### PR TITLE
[LDS] Add slice semantics to CoalescedGatherDMAOp and fix DMA lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -223,6 +223,16 @@ struct LowerCoalescedGatherDMAPattern final
     Value source = dmaOp.getSource();
     Value dest = dmaOp.getInit();
 
+    // Look through memref.cast to recover static shapes. Bufferization may
+    // insert casts that erase static type info (e.g., memref<16x64xf32> ->
+    // memref<?x?xf32>) to match the op's type signature.
+    if (auto castOp = dest.getDefiningOp<memref::CastOp>()) {
+      dest = castOp.getSource();
+    }
+    if (auto castOp = source.getDefiningOp<memref::CastOp>()) {
+      source = castOp.getSource();
+    }
+
     auto sourceType = cast<MemRefType>(source.getType());
     auto destType = cast<MemRefType>(dest.getType());
 
@@ -747,14 +757,65 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
     walkAndApplyPatterns(funcOp, std::move(patterns));
 
     // Verify all CoalescedGatherDMAOps were lowered.
-    WalkResult result = funcOp.walk([&](IREE::GPU::CoalescedGatherDMAOp op) {
-      op.emitOpError(
-          "failed to lower to gather_to_lds; possible causes: source "
-          "lacks fat_raw_buffer address space for OOB padding, destination "
-          "is not contiguous, or element sizes are incompatible with "
-          "dma_sizes");
-      return WalkResult::interrupt();
-    });
+    WalkResult result =
+        funcOp.walk([&](IREE::GPU::CoalescedGatherDMAOp op) {
+          // Diagnose the specific failure cause.
+          auto sourceType = cast<MemRefType>(op.getSource().getType());
+          auto destType = cast<MemRefType>(op.getInit().getType());
+
+          if (!destType.areTrailingDimsContiguous(1)) {
+            op.emitOpError(
+                "failed to lower to gather_to_lds: destination memref "
+                "is not contiguous");
+            return WalkResult::interrupt();
+          }
+
+          if (std::optional<ArrayAttr> inBounds = op.getInBounds()) {
+            bool hasOOB = llvm::any_of(*inBounds, [](Attribute attr) {
+              return !cast<BoolAttr>(attr).getValue();
+            });
+            if (hasOOB && !hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+              op.emitOpError(
+                  "failed to lower to gather_to_lds: source lacks "
+                  "fat_raw_buffer address space but has out-of-bounds "
+                  "dimensions (in_bounds contains false)");
+              return WalkResult::interrupt();
+            }
+          }
+
+          int64_t destRank = destType.getRank();
+          int64_t numLinearDims =
+              std::max<int64_t>(destType.getNumContiguousTrailingDims(), 1);
+          for (int64_t i = destRank - numLinearDims; i < destRank; ++i) {
+            if (ShapedType::isDynamic(destType.getShape()[i])) {
+              op.emitOpError()
+                  << "failed to lower to gather_to_lds: dynamic dimension " << i
+                  << " in destination shape";
+              return WalkResult::interrupt();
+            }
+          }
+
+          std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+          if (subgroupSize) {
+            int64_t elementBits = sourceType.getElementTypeBitWidth();
+            int64_t linearSize = 1;
+            for (int64_t i = destRank - numLinearDims; i < destRank; ++i) {
+              linearSize *= destType.getShape()[i];
+            }
+            if (failed(computeTransferSegments(linearSize, elementBits,
+                                               *subgroupSize, dmaSizes))) {
+              op.emitOpError()
+                  << "failed to lower to gather_to_lds: cannot cover "
+                  << linearSize << " elements (" << elementBits
+                  << "-bit) with available dma_sizes and subgroup size "
+                  << *subgroupSize;
+              return WalkResult::interrupt();
+            }
+          }
+
+          op.emitOpError("failed to lower to gather_to_lds");
+          return WalkResult::interrupt();
+        });
     if (result.wasInterrupted()) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1574,7 +1574,7 @@ func.func @no_lower_oob_without_fat_raw_buffer(
     attributes {hal.executable.target = #executable_target_rocm_hsaco_fb,
                 translation_info = #translation_64} {
   scf.forall (%arg6) in (64) {
-    // expected-error @+1 {{failed to lower to gather_to_lds; possible causes: source lacks fat_raw_buffer address space for OOB padding, destination is not contiguous, or element sizes are incompatible with dma_sizes}}
+    // expected-error @+1 {{failed to lower to gather_to_lds: source lacks fat_raw_buffer address space but has out-of-bounds dimensions (in_bounds contains false)}}
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [false, true] :
       memref<2x128xf32>,
       memref<4x128xf32, #gpu.address_space<workgroup>>, index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -864,14 +864,17 @@ func.func @fuse_warp_and_lane_foralls_with_coalesced_dma(%src: tensor<2x2x64xf32
 
 // CHECK-LABEL: func @fuse_warp_and_lane_foralls_with_coalesced_dma
 //  CHECK-SAME:   %[[SRC:.+]]: tensor<2x2x64xf32>
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<2x2x64xf32>
 //       CHECK:   %[[THREAD_FORALL:.+]] = scf.forall (%[[TID0:.+]], %[[TID1:.+]], %[[TID2:.+]]) in (2, 2, 64)
 //  CHECK-SAME:       shared_outs(%[[INIT_ARG:.+]] = %[[EMPTY]])
-//   CHECK-DAG:     %[[SRC_SLICE:.+]] = tensor.extract_slice %[[SRC]][%[[TID0]], %[[TID1]], 0] [1, 1, 64]
-//   CHECK-DAG:     %[[DEST_SLICE:.+]] = tensor.extract_slice %[[INIT_ARG]][%[[TID0]], %[[TID1]], 0] [1, 1, 64]
-//       CHECK:     %[[DMA_RESULT:.+]] = iree_gpu.coalesced_gather_dma %[[SRC_SLICE]] into %[[DEST_SLICE]] lane(%[[TID2]])
+//       CHECK:     %[[SRC_SLICE:.+]] = tensor.extract_slice %[[SRC]][%[[TID0]], %[[TID1]], 0] [1, 1, 64]
 //       CHECK:     scf.forall.in_parallel {
-//       CHECK:       tensor.parallel_insert_slice %[[DMA_RESULT]] into %[[INIT_ARG]][%[[TID0]], %[[TID1]], 0]
+//       CHECK:       iree_gpu.coalesced_gather_dma %[[SRC_SLICE]] into %[[INIT_ARG]]
+//  CHECK-SAME:         [%[[TID0]], %[[TID1]], %[[C0]]] [%[[C1]], %[[C1]], %[[C64]]] [%[[C1]], %[[C1]], %[[C1]]]
+//  CHECK-SAME:         lane(%[[TID2]])
 //       CHECK:     }
 //       CHECK:   } {mapping = [#gpu.thread<linear_dim_2>, #gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
 //       CHECK:   return %[[THREAD_FORALL]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -18,6 +18,9 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 
+using namespace mlir;
+using namespace mlir::iree_compiler::IREE::GPU;
+
 // clang-format off
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp.inc" // IWYU pragma: keep
@@ -219,36 +222,20 @@ Operation *CoalescedGatherDMAOp::getIteratingParent() {
 void CoalescedGatherDMAOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  // Get the OpOperand pointers for source and init
-  // Operand layout: source, indices (variadic), init, lane
-  unsigned numOperands = getOperation()->getNumOperands();
-  unsigned laneOperandIdx = numOperands - 1;
-  unsigned initOperandIdx = laneOperandIdx - 1;
-  unsigned sourceOperandIdx = 0;
-
   Value source = getSource();
   Value init = getInit();
 
-  // The operation reads from the source.
   if (isa<MemRefType>(source.getType())) {
-    effects.emplace_back(MemoryEffects::Read::get(),
-                         &getOperation()->getOpOperand(sourceOperandIdx),
+    effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
                          SideEffects::DefaultResource::get());
   }
 
-  // For memref form, the operation writes to init (side effect)
-  // For tensor form with result, the write is captured in the result value
-  // For tensor form without result (combiner case in forall.in_parallel),
-  // we must declare a write effect to prevent DCE from eliminating the op.
   if (isa<MemRefType>(init.getType())) {
-    effects.emplace_back(MemoryEffects::Write::get(),
-                         &getOperation()->getOpOperand(initOperandIdx),
+    effects.emplace_back(MemoryEffects::Write::get(), &getInitMutable(),
                          SideEffects::DefaultResource::get());
   } else if (isa<RankedTensorType>(init.getType()) &&
              getOperation()->getNumResults() == 0) {
-    // Tensor combiner case: declare write effect to prevent DCE.
-    effects.emplace_back(MemoryEffects::Write::get(),
-                         &getOperation()->getOpOperand(initOperandIdx),
+    effects.emplace_back(MemoryEffects::Write::get(), &getInitMutable(),
                          SideEffects::DefaultResource::get());
   }
 }
@@ -334,41 +321,55 @@ LogicalResult CoalescedGatherDMAOp::verify() {
     }
   }
 
-  // Verify the contiguous (non-indexed) dimensions match between source and
-  // dest, unless in_bounds allows OOB reads for that dimension.
-  std::optional<ArrayAttr> inBoundsAttr = getInBounds();
-  for (auto [dim, size] : llvm::enumerate(initShape)) {
-    if (dim >= sourceShape.size()) {
-      return emitOpError("expected source to have at least ")
-             << (dim + 1) << " dimensions when destination has rank "
-             << initShape.size();
-    }
+  // Validate slice semantics if present.
+  if (hasSliceSemantics()) {
+    size_t numOffsets = getOffsets().size();
+    size_t numSizes = getSizes().size();
+    size_t numStrides = getStrides().size();
 
-    // Skip indexed dimensions - they're validated above.
-    if (dim < indices.size()) {
-      continue;
+    if (numOffsets != initShape.size()) {
+      return emitOpError("expected ")
+             << initShape.size() << " offset values, got " << numOffsets;
     }
+    if (numSizes != initShape.size()) {
+      return emitOpError("expected ")
+             << initShape.size() << " size values, got " << numSizes;
+    }
+    if (numStrides != initShape.size()) {
+      return emitOpError("expected ")
+             << initShape.size() << " stride values, got " << numStrides;
+    }
+  } else {
+    // Without slice semantics, verify source and init shapes match.
+    std::optional<ArrayAttr> inBoundsAttr = getInBounds();
+    for (auto [dim, size] : llvm::enumerate(initShape)) {
+      if (dim >= sourceShape.size()) {
+        return emitOpError("expected source to have at least ")
+               << (dim + 1) << " dimensions when destination has rank "
+               << initShape.size();
+      }
 
-    // If in_bounds is present and this dimension allows OOB (in_bounds=false),
-    // skip the size matching check. The source may be smaller than init along
-    // this dimension, and reads beyond the source extent return zero.
-    if (inBoundsAttr) {
-      auto inBoundsArray = *inBoundsAttr;
-      if (dim < inBoundsArray.size()) {
-        bool dimInBounds = cast<BoolAttr>(inBoundsArray[dim]).getValue();
-        if (!dimInBounds) {
-          continue; // OOB allowed, skip size check
+      if (dim < indices.size()) {
+        continue;
+      }
+
+      if (inBoundsAttr) {
+        auto inBoundsArray = *inBoundsAttr;
+        if (dim < inBoundsArray.size()) {
+          bool dimInBounds = cast<BoolAttr>(inBoundsArray[dim]).getValue();
+          if (!dimInBounds) {
+            continue;
+          }
         }
       }
-    }
 
-    // Check the suffix (hidden) gathering dimensions are the same in `source`
-    // and `init`.
-    int64_t sourceDim = sourceShape[dim];
-    if (sourceDim != size) {
-      return emitOpError("expected unindexed dimension ")
-             << dim << " to have same length in source (" << sourceDim
-             << ") and destination (" << size << ')';
+      int64_t sourceDim = sourceShape[dim];
+      if (sourceDim != size && !ShapedType::isDynamic(sourceDim) &&
+          !ShapedType::isDynamic(size)) {
+        return emitOpError("expected unindexed dimension ")
+               << dim << " to have same length in source (" << sourceDim
+               << ") and destination (" << size << ')';
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -16,6 +16,7 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/ParallelCombiningOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
 
@@ -230,6 +231,7 @@ def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<ParallelCombiningOpInterface,
        ["getUpdatedDestinations", "getIteratingParent"]>]> {
@@ -336,13 +338,19 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     Variadic<RankedTensorOrVectorOrMemRefOf<[I32, Index]>>:$indices,
     AnyRankedTensorOrMemRef:$init,
     Index:$lane,
-    OptionalAttr<BoolArrayAttr>:$in_bounds
+    OptionalAttr<BoolArrayAttr>:$in_bounds,
+    Variadic<Index>:$offsets,
+    Variadic<Index>:$sizes,
+    Variadic<Index>:$strides
   );
 
   let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
 
   let assemblyFormat = [{
-    $source (`[` $indices^ `]`)? `into` $init `lane` `(` $lane `)`
+    $source (`[` $indices^ `]`)?
+    `into` $init
+    (`[` $offsets^ `]` `[` $sizes `]` `[` $strides `]`)?
+    `lane` `(` $lane `)`
     (`in_bounds` $in_bounds^)?
     attr-dict `:` type(operands) ( `->` type($result)^ )?
   }];
@@ -350,7 +358,6 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    // Get the rank of the init tensor/memref.
     unsigned getResultRank() {
       return llvm::cast<ShapedType>(getInit().getType()).getRank();
     }
@@ -358,7 +365,23 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     bool hasTensorSemantics() {
       return ::llvm::isa<RankedTensorType>(getInit().getType());
     }
+
+    bool hasSliceSemantics() {
+      return !getOffsets().empty();
+    }
   }];
+
+  let builders = [
+    // Builder without slice (backward-compatible with all existing callers).
+    OpBuilder<(ins "Type":$resultType, "Value":$source,
+                   "ValueRange":$indices, "Value":$init, "Value":$lane,
+                   "ArrayAttr":$inBounds), [{
+      build($_builder, $_state, resultType, source, indices, init, lane,
+            inBounds,
+            /*offsets=*/ValueRange{}, /*sizes=*/ValueRange{},
+            /*strides=*/ValueRange{});
+    }]>
+  ];
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREEGPUOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
@@ -88,3 +88,29 @@ func.func @bufferize_coalesced_gather_dma_in_bounds(%source: tensor<4x32xf32>,
 
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_in_bounds
 //       CHECK:   iree_gpu.coalesced_gather_dma %{{.+}} into %{{.+}} lane(%{{.+}}) in_bounds [true, false] : memref<4x32xf32{{.+}}>, memref<4x64xf32{{.+}}>, index
+
+// -----
+
+// Test bufferization with slice semantics (offsets/sizes/strides) inside forall.
+func.func @bufferize_coalesced_gather_dma_slice(%source: tensor<2x2x64xf32>) -> tensor<2x2x64xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c64 = arith.constant 64 : index
+  %empty = tensor.empty() : tensor<2x2x64xf32>
+  %result = scf.forall (%tid0, %tid1, %tid2) in (2, 2, 64) shared_outs(%init = %empty) -> tensor<2x2x64xf32> {
+    %src_slice = tensor.extract_slice %source[%tid0, %tid1, 0] [1, 1, 64] [1, 1, 1]
+      : tensor<2x2x64xf32> to tensor<1x1x64xf32>
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %src_slice into %init
+        [%tid0, %tid1, %c0] [%c1, %c1, %c64] [%c1, %c1, %c1]
+        lane(%tid2)
+        : tensor<1x1x64xf32>, tensor<2x2x64xf32>, index, index, index, index, index, index, index, index, index, index
+    }
+  } {mapping = [#gpu.thread<linear_dim_2>, #gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  return %result : tensor<2x2x64xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_slice
+//   CHECK-DAG:   %[[SRC_SUBVIEW:.+]] = memref.subview %{{.+}}[%{{.+}}, %{{.+}}, 0] [1, 1, 64] [1, 1, 1] : memref<2x2x64xf32{{.+}}> to memref<1x1x64xf32
+//   CHECK-DAG:   %[[DST_SUBVIEW:.+]] = memref.subview %{{.+}}[%{{.+}}, %{{.+}}, 0] [1, 1, 64] [1, 1, 1] : memref<2x2x64xf32> to memref<1x1x64xf32
+//       CHECK:   iree_gpu.coalesced_gather_dma %[[SRC_SUBVIEW]] into %[[DST_SUBVIEW]] lane(%{{.+}}) : memref<1x1x64xf32{{.+}}>, memref<1x1x64xf32{{.+}}>, index

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -85,6 +85,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:DialectUtils",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
@@ -443,10 +444,27 @@ struct CoalescedGatherDMAOpBufferizationInterface
       rewriter.setInsertionPoint(gatherOp);
     }
 
+    // Handle slice semantics: create a subview of the init buffer.
+    Value destBuffer = *initBuffer;
+    if (gatherOp.hasSliceSemantics()) {
+      SmallVector<OpFoldResult> offsets = llvm::map_to_vector(
+          gatherOp.getOffsets(),
+          [](Value v) -> OpFoldResult { return getAsOpFoldResult(v); });
+      SmallVector<OpFoldResult> sizes =
+          llvm::map_to_vector(gatherOp.getSizes(), [](Value v) -> OpFoldResult {
+            return getAsOpFoldResult(v);
+          });
+      SmallVector<OpFoldResult> strides = llvm::map_to_vector(
+          gatherOp.getStrides(),
+          [](Value v) -> OpFoldResult { return getAsOpFoldResult(v); });
+      destBuffer = memref::SubViewOp::create(
+          rewriter, gatherOp.getLoc(), destBuffer, offsets, sizes, strides);
+    }
+
     // Create the bufferized DMA operation with no results (memref form).
     IREE::GPU::CoalescedGatherDMAOp::create(
-        rewriter, gatherOp.getLoc(), TypeRange{}, *sourceBuffer,
-        bufferizedIndices, *initBuffer, gatherOp.getLane(),
+        rewriter, gatherOp.getLoc(), /*resultType=*/Type{}, *sourceBuffer,
+        bufferizedIndices, destBuffer, gatherOp.getLane(),
         gatherOp.getInBoundsAttr());
 
     // Replace the tensor op. If it has a result, replace with the init buffer.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_cc_library(
     MLIRAffineDialect
     MLIRAffineUtils
     MLIRArithDialect
+    MLIRArithUtils
     MLIRBufferizationDialect
     MLIRDestinationStyleOpInterface
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -312,42 +313,60 @@ LogicalResult fuseForallIntoConsumer(RewriterBase &rewriter,
     auto coalescedGather = cast<IREE::GPU::CoalescedGatherDMAOp>(
         *terminator.getYieldingOps().begin());
 
-    // Create the new CoalescedGatherDMAOp with a result outside the in_parallel
+    // Convert the combining DMA op to sequential form:
+    // 1. Create extract_slice for the DMA init (destination slice)
+    // 2. Create DMA with result (sequential, not combining)
+    // 3. Create insert_slice to write result back
     rewriter.setInsertionPoint(terminator);
+
+    SmallVector<OpFoldResult> destOffsets;
+    SmallVector<OpFoldResult> destSizes;
+    SmallVector<OpFoldResult> destStrides;
+    Value dmaInit = coalescedGather.getInit();
+
+    if (coalescedGather.hasSliceSemantics()) {
+      // DMA with slice semantics: offsets/sizes/strides are on the DMA itself.
+      // Extract the slice from the destination to use as the DMA init.
+      destOffsets =
+          llvm::map_to_vector(coalescedGather.getOffsets(),
+                              [](Value v) -> OpFoldResult { return v; });
+      destSizes =
+          llvm::map_to_vector(coalescedGather.getSizes(),
+                              [](Value v) -> OpFoldResult { return v; });
+      destStrides =
+          llvm::map_to_vector(coalescedGather.getStrides(),
+                              [](Value v) -> OpFoldResult { return v; });
+      dmaInit = tensor::ExtractSliceOp::create(
+          rewriter, loc, coalescedGather.getInit(), destOffsets, destSizes,
+          destStrides);
+    } else {
+      // DMA without slice semantics: get offsets from init's extract_slice.
+      auto extractSlice =
+          coalescedGather.getInit().getDefiningOp<tensor::ExtractSliceOp>();
+      if (extractSlice) {
+        destOffsets = extractSlice.getMixedOffsets();
+        destSizes = extractSlice.getMixedSizes();
+        destStrides = extractSlice.getMixedStrides();
+      } else {
+        auto initType = cast<ShapedType>(dmaInit.getType());
+        int64_t rank = initType.getRank();
+        destOffsets.assign(rank, rewriter.getIndexAttr(0));
+        destSizes =
+            getAsIndexOpFoldResult(rewriter.getContext(), initType.getShape());
+        destStrides.assign(rank, rewriter.getIndexAttr(1));
+      }
+    }
+
     auto newGatherOp = IREE::GPU::CoalescedGatherDMAOp::create(
-        rewriter, loc, coalescedGather.getInit().getType(),
-        coalescedGather.getSource(), coalescedGather.getIndices(),
-        coalescedGather.getInit(), coalescedGather.getLane(),
+        rewriter, loc, dmaInit.getType(), coalescedGather.getSource(),
+        coalescedGather.getIndices(), dmaInit, coalescedGather.getLane(),
         coalescedGather.getInBoundsAttr());
     Value gatherResult = newGatherOp.getResult();
-
-    // Use a tensor.insert_slice to insert the gather result back into the
-    // shared memory destination. Extract offsets from the init's extract_slice.
-    SmallVector<OpFoldResult> destIndices;
-    SmallVector<OpFoldResult> sizes;
-    SmallVector<OpFoldResult> strides;
-
-    // Get offsets, sizes, and strides from the init's extract_slice op
-    auto extractSlice =
-        coalescedGather.getInit().getDefiningOp<tensor::ExtractSliceOp>();
-    if (extractSlice) {
-      destIndices = extractSlice.getMixedOffsets();
-      sizes = extractSlice.getMixedSizes();
-      strides = extractSlice.getMixedStrides();
-    } else {
-      // Fallback: use offset 0 if init is not from an extract_slice
-      auto initType = cast<ShapedType>(coalescedGather.getInit().getType());
-      int64_t rank = initType.getRank();
-      destIndices.assign(rank, rewriter.getIndexAttr(0));
-      sizes =
-          getAsIndexOpFoldResult(rewriter.getContext(), initType.getShape());
-      strides.assign(rank, rewriter.getIndexAttr(1));
-    }
 
     // Get the destination tensor from the loop's iter_args
     Value dest = newProducer.getRegionIterArgs()[0];
     Value insertedSlice = tensor::InsertSliceOp::create(
-        rewriter, loc, gatherResult, dest, destIndices, sizes, strides);
+        rewriter, loc, gatherResult, dest, destOffsets, destSizes, destStrides);
 
     // Yield the result with the inserted slice
     scf::YieldOp::create(rewriter, loc, insertedSlice);
@@ -435,36 +454,40 @@ static void composeParallelInsertSlices(
 }
 
 /// Compose and fuse coalesced gather DMA operations with parallel insert
-/// slices. Creates a DMA op with a result, then uses parallel_insert_slice
-/// to insert the result into the forall's shared_out at the composed offsets.
+/// slices. Replaces the parallel_insert_slice with a CoalescedGatherDMAOp
+/// that has slice semantics, writing directly to the shared_out at the
+/// given offsets.
 static void composeCoalescedGatherDMA(
     RewriterBase &rewriter,
     SmallVector<std::pair<tensor::ParallelInsertSliceOp,
                           IREE::GPU::CoalescedGatherDMAOp>> &insertPairs) {
   for (auto [warpInsert, laneInsert] : insertPairs) {
     OpBuilder::InsertionGuard g(rewriter);
+    Location loc = warpInsert.getLoc();
 
-    // Create an extract_slice for the DMA's init to match the source shape.
-    // This is done outside the in_parallel region.
-    rewriter.setInsertionPoint(warpInsert->getParentOp());
-    auto destSlice = tensor::ExtractSliceOp::create(
-        rewriter, warpInsert.getLoc(), warpInsert.getDest(),
-        warpInsert.getMixedOffsets(), warpInsert.getMixedSizes(),
-        warpInsert.getMixedStrides());
+    // Materialize constants OUTSIDE the in_parallel region to avoid
+    // polluting the combining op region with non-combining ops.
+    auto *inParallelOp = warpInsert->getParentOp();
+    rewriter.setInsertionPoint(inParallelOp);
+    SmallVector<Value> offsets = llvm::map_to_vector(
+        warpInsert.getMixedOffsets(), [&](OpFoldResult ofr) {
+          return getValueOrCreateConstantIndexOp(rewriter, loc, ofr);
+        });
+    SmallVector<Value> sizes =
+        llvm::map_to_vector(warpInsert.getMixedSizes(), [&](OpFoldResult ofr) {
+          return getValueOrCreateConstantIndexOp(rewriter, loc, ofr);
+        });
+    SmallVector<Value> strides = llvm::map_to_vector(
+        warpInsert.getMixedStrides(), [&](OpFoldResult ofr) {
+          return getValueOrCreateConstantIndexOp(rewriter, loc, ofr);
+        });
 
-    // Create new CoalescedGatherDMAOp with a result (outside in_parallel).
-    auto dmaOp = IREE::GPU::CoalescedGatherDMAOp::create(
-        rewriter, warpInsert.getLoc(), destSlice.getType(),
-        laneInsert.getSource(), laneInsert.getIndices(), destSlice,
-        laneInsert.getLane(), laneInsert.getInBoundsAttr());
-
-    // Replace the warp parallel_insert_slice with one that inserts the DMA
-    // result.
     rewriter.setInsertionPoint(warpInsert);
-    rewriter.replaceOpWithNewOp<tensor::ParallelInsertSliceOp>(
-        warpInsert, dmaOp.getResult(), warpInsert.getDest(),
-        warpInsert.getMixedOffsets(), warpInsert.getMixedSizes(),
-        warpInsert.getMixedStrides());
+    rewriter.replaceOpWithNewOp<IREE::GPU::CoalescedGatherDMAOp>(
+        warpInsert,
+        /*resultType=*/Type{}, laneInsert.getSource(), laneInsert.getIndices(),
+        warpInsert.getDest(), laneInsert.getLane(),
+        laneInsert.getInBoundsAttr(), offsets, sizes, strides);
     rewriter.eraseOp(laneInsert);
   }
 }


### PR DESCRIPTION
* Extend `CoalescedGatherDMAOp` with offset/size/stride operands to support slice semantics.
* Update `composeCoalescedGatherDMA()` to place DMA directly inside `scf.forall.in_parallel` with composed offsets.
* Update bufferization to create `memref.subview` when slice semantics are used.
* Improve DMA lowering diagnostics and look through `memref.cast` to recover static shapes.

After `fuseNestedLaneAndWarpForalls`, we previously produced:
```mlir
%dma_result = iree_gpu.coalesced_gather_dma %src into %dest_slice lane(%tid)
scf.forall.in_parallel {
  tensor.parallel_insert_slice %dma_result into %init[offsets]...
}
```

With slice semantics, the DMA writes directly to the shared_out at the specified offsets:
```mlir
scf.forall.in_parallel {
  iree_gpu.coalesced_gather_dma %src into %init [offsets] [sizes] [strides] lane(%tid)
}
```