### PR TITLE
[LLVMCPU] Add MaterializeTuningSpecsPass to codegen pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -659,6 +659,7 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
     addCommonTargetExecutablePreprocessingPasses(funcPassManager,
                                                  clUseSoftmaxInterFusion);
   }
+  modulePassManager.addPass(createMaterializeTuningSpecsPass());
   modulePassManager.addPass(createMaterializeUserConfigsPass());
   FunctionLikeNest(modulePassManager)
       .addPass(createMaterializeDeviceEncodingPass)


### PR DESCRIPTION
Add `MaterializeTuningSpecsPass` to LLVMCPU codegen pipeline, mirroring the LLVMGPU pipeline structure.

This enables tuning spec support for CPU targets via `--iree-codegen-tuning-spec-path`.