### PR TITLE
Update shark/SHARK to amd-shark/AMD-SHARK in documentation and URLs in IREE

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -71,7 +71,7 @@ jobs:
       #   https://github.com/iree-org/iree
       #   https://github.com/iree-org/iree-turbine
       # Ecosystem projects for consideration:
-      #   https://github.com/nod-ai/shark-ai
+      #   https://github.com/nod-ai/amd-shark-ai
       #   https://github.com/openxla/stablehlo
       #   https://github.com/llvm/torch-mlir (see below)
       #   https://github.com/llvm/torch-mlir-release

--- a/docs/website/docs/community/index.md
+++ b/docs/website/docs/community/index.md
@@ -2,17 +2,18 @@
 
 Projects built by community members:
 
-* The [SHARK-Studio](https://github.com/nod-ai/SHARK-Studio) project offers user
-  interfaces for running a large corpus of machine learning programs.
+* The [AMD-SHARK-Studio](https://github.com/nod-ai/AMD-SHARK-Studio) project
+  offers user interfaces for running a large corpus of machine learning
+  programs.
 
-* The [shark-ai](https://github.com/nod-ai/shark-ai) project
+* The [amd-shark-ai](https://github.com/nod-ai/amd-shark-ai) project
   contains modeling and serving libraries.
 
-* The [SHARK-ModelDev](https://github.com/nod-ai/SHARK-ModelDev) project is an
-  integration repository for various model bringup activities. Several parts
-  of SHARK-ModelDev graduated to
+* The [AMD-SHARK-ModelDev](https://github.com/nod-ai/AMD-SHARK-ModelDev)
+  project is an integration repository for various model bringup activities.
+  Several parts of AMD-SHARK-ModelDev graduated to
   [iree-turbine](https://github.com/iree-org/iree-turbine) and
-  [shark-ai](https://github.com/nod-ai/shark-ai).
+  [amd-shark-ai](https://github.com/nod-ai/amd-shark-ai).
 
 * The [IREE C++ Template](https://github.com/iml130/iree-template-cpp) *(archived)*
   showed one way to integrate IREE's runtime into a project with CMake.

--- a/docs/website/docs/developers/debugging/model-development.md
+++ b/docs/website/docs/developers/debugging/model-development.md
@@ -9,9 +9,9 @@ icon: octicons/bug-16
 
 Bringing up new models or diagnosing regressions in existing models written
 using one of IREE's supported [ML frameworks](../../guides/ml-frameworks/index.md)
-or downstream projects like [shark-ai](https://github.com/nod-ai/shark-ai) can
-involve debugging up and down the tech stack. Here are some tips to make that
-process easier.
+or downstream projects like
+[amd-shark-ai](https://github.com/nod-ai/amd-shark-ai) can involve debugging
+up and down the tech stack. Here are some tips to make that process easier.
 
 ## Helpful build settings
 
@@ -147,6 +147,6 @@ Some existing test suites can be found at these locations:
 
 * <https://github.com/iree-org/iree/tree/main/tests/e2e>
 * <https://github.com/iree-org/iree-test-suites>
-* <https://github.com/nod-ai/SHARK-TestSuite/tree/main/e2eshark/onnx/operators>
-* <https://github.com/nod-ai/SHARK-TestSuite/tree/main/e2eshark/pytorch/operators>
+* <https://github.com/nod-ai/AMD-SHARK-TestSuite/tree/main/e2eamdshark/onnx/operators>
+* <https://github.com/nod-ai/AMD-SHARK-TestSuite/tree/main/e2eamdshark/pytorch/operators>
 * <https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret>

--- a/docs/website/docs/developers/general/release-management.md
+++ b/docs/website/docs/developers/general/release-management.md
@@ -42,7 +42,7 @@ in scope:
 
 * [iree-org/iree](https://github.com/iree-org/iree)
 * [iree-org/iree-turbine](https://github.com/iree-org/iree-turbine)
-* [nod-ai/shark-ai](https://github.com/nod-ai/shark-ai)
+* [nod-ai/amd-shark-ai](https://github.com/nod-ai/amd-shark-ai)
 
 !!! info
 
@@ -174,7 +174,7 @@ Stable release history:
 
 | Project | Package | Release status |
 | -- | -- | -- |
-| [nod-ai/shark-ai](https://github.com/nod-ai/shark-ai) | GitHub release (stable) | [![GitHub Release](https://img.shields.io/github/v/release/nod-ai/shark-ai)](https://github.com/nod-ai/shark-ai/releases/latest) |
+| [nod-ai/amd-shark-ai](https://github.com/nod-ai/amd-shark-ai) | GitHub release (stable) | [![GitHub Release](https://img.shields.io/github/v/release/nod-ai/amd-shark-ai)](https://github.com/nod-ai/amd-shark-ai/releases/latest) |
 | | `shark-ai` | [![PyPI version](https://badge.fury.io/py/shark-ai.svg)](https://pypi.org/project/shark-ai) |
 | | `sharktank` | [![PyPI version](https://badge.fury.io/py/sharktank.svg)](https://pypi.org/project/sharktank) |
 | | `shortfin` | [![PyPI version](https://badge.fury.io/py/shortfin.svg)](https://pypi.org/project/shortfin) |
@@ -187,7 +187,7 @@ Stable release history:
 | | `iree-runtime` | [![PyPI version](https://badge.fury.io/py/iree-runtime.svg)](https://pypi.org/project/iree-runtime) | Renamed to `iree-base-runtime`
 | | `iree-runtime-instrumented` | [![PyPI version](https://badge.fury.io/py/iree-runtime-instrumented.svg)](https://pypi.org/project/iree-runtime-instrumented) | Merged into `iree[-base]-runtime`
 | | `iree-tools-xla` | [![PyPI version](https://badge.fury.io/py/iree-tools-xla.svg)](https://pypi.org/project/iree-tools-xla) | Merged into `iree-tools-tf`
-| [nod-ai/SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) | `shark-turbine` | [![PyPI version](https://badge.fury.io/py/shark-turbine.svg)](https://pypi.org/project/shark-turbine) | Renamed to `iree-turbine`
+| [nod-ai/AMD-SHARK-ModelDev](https://github.com/nod-ai/AMD-SHARK-ModelDev) | `shark-turbine` | [![PyPI version](https://badge.fury.io/py/shark-turbine.svg)](https://pypi.org/project/shark-turbine) | Renamed to `iree-turbine`
 
 ## :material-hammer-wrench: Release mechanics
 

--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -521,9 +521,9 @@ tests nightly in
 
 Tests for small scale versions of Large Language Models (LLMs)
 and other Generative AI (GenAI) programs exported using the
-[sharktank package](https://github.com/nod-ai/shark-ai/tree/main/sharktank)
-built as part of the [shark-ai project](https://github.com/nod-ai/shark-ai) are
-included at
+[sharktank package](https://github.com/nod-ai/amd-shark-ai/tree/main/amdsharktank)
+built as part of the
+[amd-shark-ai project](https://github.com/nod-ai/amd-shark-ai) are included at
 [`sharktank_models/`](https://github.com/iree-org/iree-test-suites/tree/main/sharktank_models)
 in the
 [iree-org/iree-test-suites](https://github.com/iree-org/iree-test-suites)
@@ -544,10 +544,10 @@ Detailed steps on how to update the golden output in SDXL may be found [here](..
 
 ### SHARK-TestSuite
 
-The [nod-ai/SHARK-TestSuite](https://github.com/nod-ai/SHARK-TestSuite)
+The [nod-ai/AMD-SHARK-TestSuite](https://github.com/nod-ai/AMD-SHARK-TestSuite)
 repository also contains tests using IREE,
 [llvm/torch-mlir](https://github.com/llvm/torch-mlir), and
-[nod-ai/shark-ai](https://github.com/nod-ai/shark-ai).
+[nod-ai/amd-shark-ai](https://github.com/nod-ai/amd-shark-ai).
 
 Some test coverage may overlap between SHARK-TestSuite and iree-test-suites,
 though some tests are planned to be migrated into

--- a/docs/website/docs/developers/update-sdxl-golden-outputs.md
+++ b/docs/website/docs/developers/update-sdxl-golden-outputs.md
@@ -18,7 +18,7 @@ re-running CI.
 
 Before updating golden outputs, first confirm your change maintains acceptable
 accuracy. Follow the steps
-[outlined](https://github.com/nod-ai/SHARK-MLPERF/blob/dev/code/stable-diffusion-xl/development.md#test-accuracy-only).
+[outlined](https://github.com/nod-ai/AMD-SHARK-MLPERF/blob/dev/code/stable-diffusion-xl/development.md#test-accuracy-only).
 Use the offline variant of the `precompile_model_shortfin.sh` script for your
 platform. On MI300X use the one for MI325X.
 

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -110,7 +110,7 @@ or from pip:
 | -- | -- |
 Generated op tests | [iree-test-suites `onnx_ops`](https://github.com/iree-org/iree-test-suites/tree/main/onnx_ops)
 Public model tests | [iree-test-suites `onnx_models`](https://github.com/iree-org/iree-test-suites/tree/main/onnx_models)
-Curated op and model tests | SHARK-TestSuite [`e2eshark/onnx`](https://github.com/nod-ai/SHARK-TestSuite/tree/main/e2eshark/onnx) and [`alt_e2eshark/onnx_tests`](https://github.com/nod-ai/SHARK-TestSuite/tree/main/alt_e2eshark/onnx_tests)
+Curated op and model tests | AMD-SHARK-TestSuite [`e2eshark/onnx`](https://github.com/nod-ai/AMD-SHARK-TestSuite/tree/main/e2eamdshark/onnx) and [`alt_e2eshark/onnx_tests`](https://github.com/nod-ai/AMD-SHARK-TestSuite/tree/main/alt_e2eamdshark/onnx_tests)
 Importer tests | [torch-mlir `test/python/onnx_importer`](https://github.com/llvm/torch-mlir/tree/main/test/python/onnx_importer)
 
 ## :octicons-question-16: Troubleshooting
@@ -118,7 +118,7 @@ Importer tests | [torch-mlir `test/python/onnx_importer`](https://github.com/llv
 Support for a broad set of [ONNX operators](https://onnx.ai/onnx/operators/)
 and [data types](https://onnx.ai/onnx/intro/concepts.html#supported-types)
 is an active investment area. See the
-[ONNX Op Support tracking issue](https://github.com/nod-ai/SHARK-ModelDev/issues/215)
+[ONNX Op Support tracking issue](https://github.com/nod-ai/AMD-SHARK-ModelDev/issues/215)
 for the latest status.
 
 ### Failed to legalize operation that was explicitly marked illegal
@@ -138,7 +138,7 @@ There are several possible scenarios:
 1. The operator is not implemented, or the implementation is missing a case.
    Search for a matching issue in one of these places:
      * <https://github.com/llvm/torch-mlir/issues>
-     * <https://github.com/nod-ai/SHARK-ModelDev/issues>
+     * <https://github.com/nod-ai/AMD-SHARK-ModelDev/issues>
 2. The operator is implemented but only for a more recent ONNX version. You can
    try upgrading your .onnx file using the
    [ONNX Version Converter](https://github.com/onnx/onnx/blob/main/docs/VersionConverter.md):

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -482,6 +482,6 @@ PyTorch dynamic shapes notebook | [![Open In Colab](https://colab.research.googl
 AOT unit tests | [iree-turbine `tests/aot/`](https://github.com/iree-org/iree-turbine/tree/main/tests/aot)
 
 The sharktank project hosted at
-<https://github.com/nod-ai/shark-ai/tree/main/sharktank> also uses
+<https://github.com/nod-ai/amd-shark-ai/tree/main/amdsharktank> also uses
 `iree-turbine` heavily to provide inference-optimized ops, layers, and models
 for popular gen-ai applications.

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -42,17 +42,17 @@ graph LR;
 ### :octicons-book-16: Overview
 
 While tuning can be done manually, the
-[SHARK Tuner](https://github.com/nod-ai/shark-ai/tree/main/sharktuner) tool
-can automatically search through possible knob values for individual
+[AMDSHARK Tuner](https://github.com/nod-ai/amd-shark-ai/tree/main/amdsharktuner)
+tool can automatically search through possible knob values for individual
 dispatches to improve overall program performance. Dispatches are blocks of
 code that are created as part of IREE's compilation flow by splitting the
 input program into blocks that can be executed concurrently and atomically.
 For further information on dispatches see the sections below.
 
 !!! info
-    For more information about SHARK Tuner, see its source in the
-    [shark-ai GitHub repository](https://github.com/nod-ai/shark-ai/tree/main/sharktuner)
-    and the [Model Tuner example](https://github.com/nod-ai/shark-ai/tree/main/sharktuner/model_tuner).
+    For more information about AMDSHARK Tuner, see its source in the
+    [amd-shark-ai GitHub repository](https://github.com/nod-ai/amd-shark-ai/tree/main/amdsharktuner)
+    and the [Model Tuner example](https://github.com/nod-ai/amd-shark-ai/tree/main/amdsharktuner/model_tuner).
 
 In our experience, using the SHARK Tuner can provide **meaningful speedup** of
 model execution.

--- a/samples/colab/pytorch_huggingface_whisper.ipynb
+++ b/samples/colab/pytorch_huggingface_whisper.ipynb
@@ -231,7 +231,7 @@
         "See also:\n",
         "\n",
         "* Model card: https://huggingface.co/docs/transformers/model_doc/whisper\n",
-        "* Test case in [SHARK-TestSuite](https://github.com/nod-ai/SHARK-TestSuite/): [`pytorch/models/whisper-small/model.py`](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/pytorch/models/whisper-small/model.py)"
+        "* Test case in [AMD-SHARK-TestSuite](https://github.com/nod-ai/AMD-SHARK-TestSuite/): [`pytorch/models/whisper-small/model.py`](https://github.com/nod-ai/AMD-SHARK-TestSuite/blob/main/e2eamdshark/pytorch/models/whisper-small/model.py)"
       ],
       "metadata": {
         "id": "94Ji4URLT_xM"
@@ -250,7 +250,7 @@
         "tokenizer = AutoTokenizer.from_pretrained(modelname)\n",
         "\n",
         "# Some of the options here affect how the model is exported. See the test cases\n",
-        "# at https://github.com/nod-ai/SHARK-TestSuite/tree/main/e2eshark/pytorch/models\n",
+        "# at https://github.com/nod-ai/AMD-SHARK-TestSuite/tree/main/e2eamdshark/pytorch/models\n",
         "# for other options that may be useful to set.\n",
         "model = AutoModelForCausalLM.from_pretrained(\n",
         "    modelname,\n",


### PR DESCRIPTION
This PR updates repository URLs and references throughout the IREE codebase to use correct naming conventions for SHARK-related projects, adding "amd-" or "AMD-" prefixes.

Test suite JSON files are excluded from updates to avoid breaking data fetching from existing blob storage URLs.

ci-extra: test_torch, windows_x64_msvc