### PR TITLE
[Stream] Handle tied operand result encodings in UnifyEncodingForGlobals 3/n

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -283,9 +283,9 @@ using TensorEncodingUpdates =
     llvm::DenseMap<Operation *, OperandEncodingUpdates>;
 
 // Updates encoding attributes for a TensorDispatchOp.
-static void
-updateTensorDispatchOp(TensorDispatchOp dispatchOp,
-                       const OperandEncodingUpdates &operandUpdates) {
+static void updateTensorDispatchOp(TensorDispatchOp dispatchOp,
+                                   const OperandEncodingUpdates &operandUpdates,
+                                   IRRewriter &rewriter) {
   // Update operand encodings.
   // The operand_encodings attribute has the same length as getMixedOperands().
   // For non-affinity types (e.g., index), the encoding is just the type.
@@ -312,14 +312,92 @@ updateTensorDispatchOp(TensorDispatchOp dispatchOp,
   }
   dispatchOp.setOperandEncodingsAttr(
       ArrayAttr::get(dispatchOp.getContext(), newOperandEncodings));
+
+  // Update result encodings for tied operands and track which results need
+  // re-encoding for downstream users.
+  //
+  // NOTE: This is a rare case that exists primarily for correctness as a safe
+  // fallback. In practice, tied operands with encodings that need unification
+  // are uncommon. The re-encode op inserted here ensures downstream users see
+  // the original encoding they expect, even though the dispatch internally
+  // uses the unified encoding.
+  auto tiedOp = cast<IREE::Util::TiedOpInterface>(dispatchOp.getOperation());
+
+  // Collect old encodings and build new result encodings.
+  SmallVector<Type> newResultEncodings;
+  SmallVector<std::pair<OpResult, RankedTensorType>> resultsToReencode;
+  for (auto [result, typeAttr] :
+       llvm::zip_equal(dispatchOp.getResults(),
+                       dispatchOp.getResultEncodings().getValue())) {
+    Type type = cast<TypeAttr>(typeAttr).getValue();
+    if (!isa<IREE::Stream::ResourceType>(result.getType())) {
+      newResultEncodings.push_back(type);
+      continue;
+    }
+    OpOperand *tiedOperand = tiedOp.getTiedResultOpOperand(result);
+    if (!tiedOperand) {
+      newResultEncodings.push_back(type);
+      continue;
+    }
+    if (!operandUpdates.contains(tiedOperand->getOperandNumber())) {
+      newResultEncodings.push_back(type);
+      continue;
+    }
+    // Track old encoding for re-encode op insertion.
+    auto rankedTensorType = cast<RankedTensorType>(type);
+    resultsToReencode.push_back({result, rankedTensorType});
+    newResultEncodings.push_back(rankedTensorType.cloneWithEncoding(
+        operandUpdates.lookup(tiedOperand->getOperandNumber())));
+  }
+  dispatchOp.setResultEncodingsAttr(
+      rewriter.getTypeArrayAttr(newResultEncodings));
+
+  // Insert re-encode ops after the dispatch for results that were updated.
+  // This converts results back to the original encoding for downstream users.
+  if (resultsToReencode.empty()) {
+    return;
+  }
+
+  // Build a map from result index to its encoding dims by iterating through
+  // the flattened result_encoding_dims list.
+  SmallVector<ValueRange> resultEncodingDimsMap(newResultEncodings.size());
+  ValueRange remainingDims = dispatchOp.getResultEncodingDims();
+  for (auto [idx, encodingType] : llvm::enumerate(newResultEncodings)) {
+    auto shapedType = cast<ShapedType>(encodingType);
+    int64_t dynamicDimCount = shapedType.getNumDynamicDims();
+    resultEncodingDimsMap[idx] = remainingDims.take_front(dynamicDimCount);
+    remainingDims = remainingDims.drop_front(dynamicDimCount);
+  }
+
+  rewriter.setInsertionPointAfter(dispatchOp);
+  for (auto [result, oldType] : resultsToReencode) {
+    unsigned resultIdx = result.getResultNumber();
+    Value resultSize = dispatchOp.getResultSize(resultIdx);
+    auto newType = cast<RankedTensorType>(newResultEncodings[resultIdx]);
+    ValueRange encodingDims = resultEncodingDimsMap[resultIdx];
+    Value oldSize = TensorSizeOfOp::create(
+        rewriter, dispatchOp.getLoc(), rewriter.getIndexType(),
+        TypeAttr::get(oldType), encodingDims, dispatchOp.getAffinityAttr());
+    auto reencodeOp =
+        TensorEncodeOp::create(rewriter, dispatchOp.getLoc(), result.getType(),
+                               result, TypeAttr::get(newType),
+                               /*source_encoding_dims=*/encodingDims,
+                               resultSize, TypeAttr::get(oldType),
+                               /*result_encoding_dims=*/encodingDims, oldSize,
+                               dispatchOp.getAffinityAttr());
+    rewriter.replaceAllUsesExcept(result, reencodeOp.getResult(), reencodeOp);
+    LDBG() << "  Inserted re-encode op for result " << resultIdx << ": "
+           << reencodeOp;
+  }
 }
 
 // Applies all cached encoding updates to tensor ops.
 static void applyTensorEncodingUpdates(TensorEncodingUpdates &updates) {
   for (auto &[op, operandUpdates] : updates) {
+    IRRewriter rewriter(op->getContext());
     // TODO: Handle other TensorPhaseOp ops (TensorFillOp, etc.) via TypeSwitch.
     if (auto dispatchOp = dyn_cast<TensorDispatchOp>(op)) {
-      updateTensorDispatchOp(dispatchOp, operandUpdates);
+      updateTensorDispatchOp(dispatchOp, operandUpdates, rewriter);
     }
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -369,6 +369,7 @@ static void updateTensorDispatchOp(TensorDispatchOp dispatchOp,
     remainingDims = remainingDims.drop_front(dynamicDimCount);
   }
 
+  OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointAfter(dispatchOp);
   for (auto [result, oldType] : resultsToReencode) {
     unsigned resultIdx = result.getResultNumber();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -257,6 +257,85 @@ module @cross_function_tracking {
 
 // -----
 
+// CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+
+util.global private @weight : !stream.resource<constant>
+util.global private @weight_size : index
+util.global private @encoded_v1 : !stream.resource<constant>
+util.global private @encoded_v1_size : index
+util.global private @encoded_v2 : !stream.resource<constant>
+util.global private @encoded_v2_size : index
+
+// CHECK: util.initializer
+util.initializer {
+  %cst = stream.tensor.constant : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+  %0 = stream.resource.size %cst : !stream.resource<constant>
+  util.global.store %cst, @weight : !stream.resource<constant>
+  util.global.store %0, @weight_size : index
+  // CHECK: %[[SOURCE:.+]] = util.global.load @weight
+  %source = util.global.load @weight : !stream.resource<constant>
+  %source_size = util.global.load @weight_size : index
+
+  // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+  %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+  %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+  util.global.store %const1, @encoded_v1 : !stream.resource<constant>
+  util.global.store %size1, @encoded_v1_size : index
+
+  // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
+  %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+  %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+  util.global.store %const2, @encoded_v2 : !stream.resource<constant>
+  util.global.store %size2, @encoded_v2_size : index
+
+  util.return
+}
+
+// Executable with tied operand for in-place update.
+stream.executable private @executable_tied {
+  stream.executable.export public @dispatch_inplace
+  builtin.module {
+    func.func @dispatch_inplace(%arg0: !stream.binding) {
+      %c0 = arith.constant 0 : index
+      %0 = stream.binding.subspan %arg0[%c0] : !stream.binding -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32, #encoding1>>
+      return
+    }
+  }
+}
+
+// Test tied operand: dispatch result tied to input operand.
+// When encoding changes, both operand and result encoding must change.
+// A re-encode op should be inserted after dispatch.
+// CHECK-LABEL: util.func public @dispatch_with_tied_operand
+// CHECK-SAME:    %[[N:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
+util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.resource<*> {
+  %encoded = util.global.load @encoded_v1 : !stream.resource<constant>
+  %encoded_size = util.global.load @encoded_v1_size : index
+  %cloned = stream.async.clone %encoded : !stream.resource<constant>{%encoded_size} -> !stream.resource<*>{%encoded_size}
+
+  // The dispatch has a tied result (result -> %cloned).
+  // CHECK:      %[[DISPATCH:.+]] = stream.tensor.dispatch @executable_tied::@dispatch_inplace
+  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
+  // CHECK-SAME:   -> tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
+  // Re-encode sizeof and encode ops are inserted after dispatch.
+  // CHECK:      stream.tensor.sizeof tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
+  // CHECK:      stream.tensor.encode %[[DISPATCH]] :
+  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>
+  // CHECK-SAME:   -> tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
+  %result = stream.tensor.dispatch @executable_tied::@dispatch_inplace(%cloned) : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size}) -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
+
+  util.return %result : !stream.resource<*>
+}
+
+// -----
+
 // Test: mutable source global - should be skipped, encoding unchanged.
 
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -281,17 +281,15 @@ util.initializer {
   // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-  %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
-  util.global.store %const1, @encoded_v1 : !stream.resource<constant>
+  %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
   util.global.store %size1, @encoded_v1_size : index
 
   // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-  %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
-  util.global.store %const2, @encoded_v2 : !stream.resource<constant>
+  %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
   util.global.store %size2, @encoded_v2_size : index
 
   util.return
@@ -329,7 +327,9 @@ util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.re
   // CHECK:      stream.tensor.encode %[[DISPATCH]] :
   // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>
   // CHECK-SAME:   -> tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
-  %result = stream.tensor.dispatch @executable_tied::@dispatch_inplace(%cloned) : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size}) -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
+  %result = stream.tensor.dispatch @executable_tied::@dispatch_inplace(%cloned)
+    : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size})
+    -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
 
   util.return %result : !stream.resource<*>
 }


### PR DESCRIPTION
When a dispatch has a tied operand whose encoding is being unified, the result encoding must also be updated to match (verifier requirement). Additionally, insert a re-encode op after the dispatch to convert the result back to the original encoding for downstream users.

This is a rare case that exists primarily for correctness as a safe fallback. In practice, tied operands with encodings that need unification are uncommon.

I decide to not bail out the case in the first place because it'd add much more complex to the implementation, while the fallback can be easy: just add re-encode ops. It may result in the amount of memory footprint, but it is a rare case.

It is a step towards https://github.com/iree-org/iree/issues/22485