### PR TITLE
[Codegen][ROCDL] Improve dynamic dimension bounds handling in ROCDLConfigureBufferInstructions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
@@ -8,11 +8,9 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
-#include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/ValueBoundsOpInterface.h"
 
 namespace mlir::iree_compiler {
 
@@ -40,31 +38,6 @@ static Value skipAffineMaxZero(Value dim) {
   return *affineMax.getSymbolOperands().begin();
 }
 
-static FailureOr<int64_t> getUpperBound(Value dim,
-                                        const DataFlowSolver &solver) {
-  // Check the integer range analysis.
-  if (auto *maybeRange =
-          solver.lookupState<dataflow::IntegerValueRangeLattice>(dim)) {
-    IntegerValueRange range = maybeRange->getValue();
-    if (!range.isUninitialized() &&
-        range.getValue().smax() !=
-            IntegerValueRange::getMaxRange(dim).getValue().smax()) {
-      return range.getValue().smax().getSExtValue();
-    }
-  }
-
-  // Check the value bounds constraint set.
-  // TODO: These two analysis could be merged, but probably needs
-  // to happen usptream.
-  auto ub = ValueBoundsConstraintSet::computeConstantBound(
-      presburger::BoundType::UB, {dim, /*dim=*/std::nullopt},
-      /*stopCondition=*/nullptr, /*closedUB=*/true);
-  if (succeeded(ub)) {
-    return ub.value();
-  }
-  return failure();
-}
-
 template <typename AllocLikeOp>
 static LogicalResult padAlloc(MLIRContext *context, AllocLikeOp allocOp,
                               const DataFlowSolver &solver) {
@@ -81,7 +54,7 @@ static LogicalResult padAlloc(MLIRContext *context, AllocLikeOp allocOp,
     }
     Value dim = allocOp.getDynamicSizes()[dynamicDimIdx++];
     dim = skipAffineMaxZero(dim);
-    FailureOr<int64_t> ub = getUpperBound(dim, solver);
+    FailureOr<int64_t> ub = getDynamicUpperBound(dim, solver);
     if (failed(ub)) {
       return allocOp.emitOpError(
           "unexpected allocation without upper bound shapes");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/Support/DebugLog.h"
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
 #include "mlir/Analysis/SliceAnalysis.h"
@@ -114,6 +115,7 @@ struct ROCDLConfigureBufferInstructionsPass final
 
     // Initialize the DataFlowSolver with IntegerRangeAnalysis.
     DataFlowSolver solver;
+    solver.load<dataflow::SparseConstantPropagation>();
     solver.load<dataflow::DeadCodeAnalysis>();
     solver.load<dataflow::IntegerRangeAnalysis>();
     if (failed(solver.initializeAndRun(funcOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/configure_buffer_instructions.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/configure_buffer_instructions.mlir
@@ -123,3 +123,18 @@ func.func @assume_dyn_size() {
     : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x256xf32>>{%m.assume}
   return
 }
+
+// CHECK-LABEL: @ceildiv_dyn_size
+// CHECK: iree_gpu.use_rocdl_buffer_instructions
+// CHECK: return
+func.func @ceildiv_dyn_size() {
+  %c0 = arith.constant 0 : index
+  %m.i32 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %m = arith.index_castui %m.i32 : i32 to index
+  %m.assume = util.assume.int %m[<umin = 128, umax = 16384, udiv = 128>] : index
+  %dim = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%m.assume]
+  %bind = hal.interface.binding.subspan layout(#pipeline_layout)
+    binding(0) alignment(64) offset(%c0)
+    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x256xf32>>{%dim}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -76,6 +76,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorTransforms",
         "@llvm-project//mlir:ViewLikeInterface",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTilingInterface
     MLIRTransformUtils
+    MLIRValueBoundsOpInterface
     MLIRVectorDialect
     MLIRVectorTransforms
     MLIRViewLikeInterface

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1132,8 +1132,9 @@ FailureOr<int64_t> getDynamicUpperBound(Value value,
   auto ub = ValueBoundsConstraintSet::computeConstantBound(
       presburger::BoundType::UB, {value, std::nullopt},
       /*stopCondition=*/nullptr, /*closedUB=*/true);
-  if (succeeded(ub))
+  if (succeeded(ub)) {
     return ub.value();
+  }
   return failure();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -26,6 +26,10 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SubsetOpInterface.h"
 
+namespace mlir {
+class DataFlowSolver;
+} // namespace mlir
+
 namespace mlir::iree_compiler {
 
 static constexpr unsigned kNumMaxParallelDims = 3;
@@ -210,6 +214,17 @@ int getReductionTilingFactor(int64_t dimSize);
 // Returns the minimal element bitwidth used in the operands and results of the
 // given Linalg op.
 int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp);
+
+//===---------------------------------------------------------------------===//
+// Integer range analysis utility functions.
+//===---------------------------------------------------------------------===//
+
+/// Get the upper bound of a dynamic value. First tries IntegerRangeAnalysis
+/// (cached, efficient), then falls back to ValueBoundsConstraintSet for complex
+/// cases like affine.apply. The solver should have IntegerRangeAnalysis loaded
+/// and initialized before calling this function.
+FailureOr<int64_t> getDynamicUpperBound(Value value,
+                                        const DataFlowSolver &solver);
 
 //===---------------------------------------------------------------------===//
 // Bufferization utility functions


### PR DESCRIPTION
This change replaces the custom `getDynamicSizeMax` function with a shared utility function `getDynamicUpperBound()` which uses `IntegerRangeAnalysis` with a fallback to `ValueBoundsConstraintSet` for complex cases.

For example, with data-tiling, the dynamic dimension goes through a `ceildiv` due to packing.