### PR TITLE
Support float type conversion between f32 and f64 in VM lists.

### DIFF
--- a/runtime/src/iree/vm/list.c
+++ b/runtime/src/iree/vm/list.c
@@ -615,6 +615,22 @@ static void iree_vm_list_convert_value_type(
         default:
           return;
       }
+    case IREE_VM_VALUE_TYPE_F32:
+      switch (target_value_type) {
+        case IREE_VM_VALUE_TYPE_F64:
+          out_value->f64 = (double)source_value->f32;
+          return;
+        default:
+          return;
+      }
+    case IREE_VM_VALUE_TYPE_F64:
+      switch (target_value_type) {
+        case IREE_VM_VALUE_TYPE_F32:
+          out_value->f32 = (float)source_value->f64;
+          return;
+        default:
+          return;
+      }
   }
 }
 


### PR DESCRIPTION
I had an issue where passing an f64 where an f32 was expected would result in a zero value, and this fixes it.