### PR TITLE
[Stream] Handle AsyncCloneOp in UnifyEncodingForGlobals tracing.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -259,6 +259,12 @@ GlobalEncodingAnalyzer::traceToSourceGlobal(Value value) {
               // Constant is a valid leaf source.
               return true;
             })
+            .Case([&](IREE::Stream::AsyncCloneOp cloneOp) {
+              // Clone is a passthrough op, continue tracing through its source.
+              value = cloneOp.getSource();
+              shouldContinue = true;
+              return true;
+            })
             .Default([&](Operation *op) {
               LDBG() << "      Bail: unknown op " << op->getName();
               return false;


### PR DESCRIPTION
Add `stream.async.clone` to the allowlist of passthrough ops in `traceToSourceGlobal`. In real-world IR patterns, there is often a clone between the global load and the encode op:

```mlir
  %source = util.global.load @weight
  %cloned = stream.async.clone %source
  %encoded = stream.tensor.encode %cloned -> ...
```

Previously, the pass would bail on the clone op and fail to trace back to the source global, preventing encoding unification.

Updated the test to reflect this common pattern.

It is a step towards https://github.com/iree-org/iree/issues/22485