### PR TITLE
[Stream] Selecting unified encodings from encoding resolvers.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -600,6 +600,12 @@ Attribute IdentityResolverAttr::getLayout(RankedTensorType type) const {
   return Encoding::IdentityAttr::get(getContext());
 }
 
+Attribute
+IdentityResolverAttr::getUnifiedEncoding(ArrayRef<Attribute> encodings) const {
+  MLIRContext *ctx = getContext();
+  return Encoding::IdentityAttr::get(ctx);
+}
+
 Type IdentityResolverAttr::convertType(Type type) const {
   using IREE::TensorExt::DispatchTensorType;
   return TypeSwitch<Type, Type>(type)
@@ -671,6 +677,12 @@ Attribute SpecializationResolverAttr::getLayout(RankedTensorType type) const {
   MLIRContext *ctx = getContext();
   return SpecializedAttr::get(ctx, getSeed(),
                               TypeAttr::get(type.dropEncoding()));
+}
+
+Attribute SpecializationResolverAttr::getUnifiedEncoding(
+    ArrayRef<Attribute> encodings) const {
+  MLIRContext *ctx = getContext();
+  return SpecializedAttr::get(ctx, getSeed(), /*type=*/nullptr);
 }
 
 } // namespace mlir::iree_compiler::IREE::Encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -278,6 +278,7 @@ def IdentityResolverAttr :
       DeclareAttrInterfaceMethods<IREEEncoding_LayoutResolverAttr, [
         "cloneWithSimplifiedConfig",
         "getLayout",
+        "getUnifiedEncoding",
       ]>,
       DeclareAttrInterfaceMethods<IREEEncoding_LayoutMaterializerAttr, [
         "convertType",
@@ -361,6 +362,7 @@ def SpecializationResolverAttr :
       DeclareAttrInterfaceMethods<IREEEncoding_LayoutResolverAttr, [
         "cloneWithSimplifiedConfig",
         "getLayout",
+        "getUnifiedEncoding",
       ]>
     ]> {
   let mnemonic = "specialization_resolver";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -69,6 +69,29 @@ def IREEEncoding_LayoutResolverAttr :
         assert(false && "unimplemented interface method");
         return {};
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns a unified encoding attribute given a list of candidate encoding
+        attributes. This is used when multiple encodings are used for the same
+        source data and need to be unified to a single encoding.
+
+        The resolver implementation can create any encoding based on
+        backend-specific heuristics. The returned encoding does not need to be
+        one of the input encodings - for example, a resolver might return an
+        identity encoding for simplicity, or synthesize a new encoding that
+        introduces less overheads in relayout.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getUnifiedEncoding",
+      /*args=*/(ins
+        "llvm::ArrayRef<::mlir::Attribute>":$encodings
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return {};
+      }]
     >
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -91,6 +91,8 @@ def IREEEncoding_LayoutResolverAttr :
       ),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
+        // TODO(hanchung): Remove the assertion once we know what to do for the
+        // default implementation.
         assert(false && "unimplemented interface method");
         return {};
       }]

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -76,6 +76,8 @@ def IREEEncoding_LayoutResolverAttr :
         attributes. This is used when multiple encodings are used for the same
         source data and need to be unified to a single encoding.
 
+        Returns nullptr if it fails to get a unified encoding.
+
         The resolver implementation can create any encoding based on
         backend-specific heuristics. The returned encoding does not need to be
         one of the input encodings - for example, a resolver might return an

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -613,8 +613,8 @@ struct UnifyEncodingForGlobalsPass
       SourceGlobalInfo sourceInfo = analyzer.getSourceGlobals(sourceName);
       // Update each encode op to use the unified encoding.
       Attribute unifiedEncoding = analyzer.getUnifiedEncoding(sourceName);
-      LDBG() << "Unifying encodings for source global: " << sourceName
-             << " to " << unifiedEncoding;
+      LDBG() << "Unifying encodings for source global: " << sourceName << " to "
+             << unifiedEncoding;
       for (EncodedGlobalInfo &encodedInfo : sourceInfo.encodedVersions) {
         auto encodeOp = encodedInfo.encodeOp;
         auto oldResultType =

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamInterfaces.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
@@ -27,6 +28,29 @@ namespace mlir::iree_compiler::IREE::Stream {
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
 
 namespace {
+
+/// Returns a stably sorted list of dialect interfaces of T for all dialects
+/// used within the given module.
+template <typename T>
+SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
+  SmallPtrSet<const T *, 4> resultSet;
+  for (auto dialect : moduleOp.getContext()->getLoadedDialects()) {
+    auto *dialectInterface = dialect->getRegisteredInterface<T>();
+    if (!dialectInterface)
+      continue;
+    resultSet.insert(dialectInterface);
+  }
+
+  // NOTE: to ensure deterministic output we sort the result so that imports are
+  // always added in a consistent order.
+  auto results = llvm::to_vector_of<const T *>(resultSet);
+  llvm::sort(
+      results, +[](const T *a, const T *b) {
+        return a->getDialect()->getNamespace().compare(
+                   b->getDialect()->getNamespace()) < 0;
+      });
+  return results;
+}
 
 //===----------------------------------------------------------------------===//
 // Analysis.
@@ -64,13 +88,17 @@ static IREE::Util::GlobalStoreOpInterface findStoreOp(Value value) {
 }
 
 // Analyzes a module to find immutable globals that have multiple encoded
-// versions. Use run() to perform analysis, then query results with
-// getSourcesWithMultipleEncodings() or getSourceGlobals().
+// versions, and computes unified encodings for them using the layout resolver
+// from the dialect interface. Use run() to perform analysis, then query results
+// with getSourcesWithMultipleEncodings(), getSourceGlobals(), or
+// getUnifiedEncoding().
 class GlobalEncodingAnalyzer {
 public:
   explicit GlobalEncodingAnalyzer(ModuleOp moduleOp)
       : moduleOp(moduleOp), symbolTable(moduleOp), globalTable(moduleOp) {}
 
+  // Runs the full analysis: sets up resolver, collects encodings, and computes
+  // unified encodings.
   LogicalResult run();
 
   // Returns all source globals that have multiple distinct encodings.
@@ -97,7 +125,20 @@ public:
     return std::nullopt;
   }
 
+  // Returns the unified encoding for the given source global name, or
+  // std::nullopt if not found.
+  std::optional<Attribute> getUnifiedEncoding(StringRef name) const {
+    auto it = unifiedEncodings.find(name);
+    if (it != unifiedEncodings.end()) {
+      return it->second;
+    }
+    return std::nullopt;
+  }
+
 private:
+  // Sets up the layout resolver from dialect interfaces.
+  LogicalResult setupLayoutResolver();
+
   // Walks all initializers to find encoding patterns and populates
   // sourceGlobals map. Looks for patterns like:
   //   %source = util.global.load @source_global
@@ -105,6 +146,9 @@ private:
   //   util.global.store %encoded, @encoded_global
   // Only considers immutable source and encoded globals.
   LogicalResult collectGlobalEncodings();
+
+  // Computes unified encodings for all source globals with multiple encodings.
+  LogicalResult computeUnifiedEncodings();
 
   // Traces from encode op's source operand back to a source global.
   // Returns nullptr if tracing fails or source is mutable.
@@ -117,14 +161,25 @@ private:
   SymbolTable symbolTable;
   IREE::Util::GlobalTable globalTable;
 
+  // Layout resolver function from dialect interface.
+  IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr;
+
   // Maps source global name to its info. Populated by run(). The global name
   // must match the name of `sourceGlobal` inside SourceGlobalInfo. StringRef is
   // used for easier lookup, which works better with SymbolTable, etc.
   llvm::MapVector<StringRef, SourceGlobalInfo> sourceGlobals;
+
+  // Maps source global name to its unified encoding. Populated by run().
+  llvm::DenseMap<StringRef, Attribute> unifiedEncodings;
 };
 
 LogicalResult GlobalEncodingAnalyzer::run() {
   LDBG() << "=== GlobalEncodingAnalyzer::run() ===";
+
+  if (failed(setupLayoutResolver())) {
+    return failure();
+  }
+
   globalTable.rebuild();
   if (failed(collectGlobalEncodings())) {
     return failure();
@@ -137,6 +192,93 @@ LogicalResult GlobalEncodingAnalyzer::run() {
          << " encoded versions\n";
     }
   });
+
+  if (failed(computeUnifiedEncodings())) {
+    return failure();
+  }
+
+  return success();
+}
+
+LogicalResult GlobalEncodingAnalyzer::setupLayoutResolver() {
+  auto usedDialects = gatherUsedDialectInterfaces<
+      IREE::Stream::AffinityAnalysisDialectInterface>(moduleOp);
+  if (usedDialects.size() != 1) {
+    LDBG() << "Expected only one dialect implementing "
+              "AffinityAnalysisDialectInterface";
+    return failure();
+  }
+  resolveLayoutAttr = usedDialects[0]->makeLayoutAttrResolver(moduleOp);
+  return success();
+}
+
+LogicalResult GlobalEncodingAnalyzer::computeUnifiedEncodings() {
+  SmallVector<StringRef> candidates = getSourcesWithMultipleEncodings();
+  if (candidates.empty()) {
+    LDBG() << "No source globals with multiple encodings found.";
+    return success();
+  }
+
+  LDBG() << "Found " << candidates.size()
+         << " source globals with multiple encodings:";
+  for (auto name : candidates) {
+    LDBG() << "  - " << name;
+  }
+
+  // Build queries for layout resolution.
+  SmallVector<IREE::Stream::AffinityAndOpPair> queries;
+  for (StringRef sourceName : candidates) {
+    std::optional<SourceGlobalInfo> sourceInfo = getSourceGlobals(sourceName);
+    for (EncodedGlobalInfo &encodedInfo : sourceInfo->encodedVersions) {
+      queries.push_back({encodedInfo.encodeOp.getAffinityAttr(),
+                         encodedInfo.encodedGlobal});
+    }
+  }
+
+  // Resolve layout attributes for all queries.
+  llvm::DenseMap<IREE::Stream::AffinityAndOpPair, SetVector<Attribute>>
+      cachedLayoutAttrs;
+  if (failed(resolveLayoutAttr(queries, cachedLayoutAttrs))) {
+    LDBG() << "failed to resolve layouts for a query";
+    return failure();
+  }
+
+  // Compute unified encoding for each source global.
+  MLIRContext *ctx = moduleOp.getContext();
+  for (StringRef sourceName : candidates) {
+    SetVector<Attribute> layoutResolvers;
+    SmallVector<Attribute> encodingAttrVersions;
+    std::optional<SourceGlobalInfo> sourceInfo = getSourceGlobals(sourceName);
+    for (EncodedGlobalInfo &encodedInfo : sourceInfo->encodedVersions) {
+      const SetVector<Attribute> &resolvers =
+          cachedLayoutAttrs[IREE::Stream::AffinityAndOpPair(
+              encodedInfo.encodeOp.getAffinityAttr(),
+              encodedInfo.encodedGlobal)];
+      layoutResolvers.insert(resolvers.begin(), resolvers.end());
+      encodingAttrVersions.push_back(encodedInfo.encodingAttr);
+    }
+
+    // TODO: It is not clear which encoding to pick when there are multiple
+    // layout resolvers. For now, just use identity encoding for safety.
+    if (layoutResolvers.size() != 1) {
+      unifiedEncodings[sourceName] = IREE::Encoding::IdentityAttr::get(ctx);
+      continue;
+    }
+
+    // Invalid layout resolver, use identity encoding.
+    IREE::Encoding::LayoutResolverAttr layoutResolver =
+        dyn_cast<IREE::Encoding::LayoutResolverAttr>(layoutResolvers[0]);
+    if (!layoutResolver) {
+      unifiedEncodings[sourceName] = IREE::Encoding::IdentityAttr::get(ctx);
+      continue;
+    }
+
+    LDBG() << "Use encoding resolver " << layoutResolver
+           << " to unify encodings for source global: " << sourceName;
+    unifiedEncodings[sourceName] =
+        layoutResolver.getUnifiedEncoding(encodingAttrVersions);
+  }
+
   return success();
 }
 
@@ -458,20 +600,17 @@ struct UnifyEncodingForGlobalsPass
           UnifyEncodingForGlobalsPass> {
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+
     GlobalEncodingAnalyzer analyzer(moduleOp);
     if (failed(analyzer.run())) {
       LDBG() << "Analysis failed, skipping.";
       return;
     }
-    auto candidates = analyzer.getSourcesWithMultipleEncodings();
+
+    SmallVector<StringRef> candidates =
+        analyzer.getSourcesWithMultipleEncodings();
     if (candidates.empty()) {
-      LDBG() << "No source globals with multiple encodings found.";
       return;
-    }
-    LDBG() << "Found " << candidates.size()
-           << " source globals with multiple encodings:";
-    for (auto name : candidates) {
-      LDBG() << "  - " << name;
     }
 
     // Unify encodings for each source global with multiple encodings, and cache
@@ -480,20 +619,13 @@ struct UnifyEncodingForGlobalsPass
     explorer.setOpAction<IREE::Stream::ExecutableOp>(TraversalAction::IGNORE);
     explorer.initialize();
     TensorEncodingUpdates tensorEncodingUpdates;
-    for (auto sourceName : candidates) {
+    for (StringRef sourceName : candidates) {
       std::optional<SourceGlobalInfo> sourceInfo =
           analyzer.getSourceGlobals(sourceName);
-      if (!sourceInfo) {
-        LDBG() << "  ERROR: source global info not found for " << sourceName;
-        continue;
-      }
-
-      // TODO(#22485): Select unified encoding via resolver. For now, use
-      // identity encoding.
-      auto unifiedEncoding =
-          IREE::Encoding::IdentityAttr::get(moduleOp.getContext());
-
       // Update each encode op to use the unified encoding.
+      Attribute unifiedEncoding = *analyzer.getUnifiedEncoding(sourceName);
+      LDBG() << "Unifying encodings for source global: " << sourceName
+             << " to " << unifiedEncoding;
       for (EncodedGlobalInfo &encodedInfo : sourceInfo->encodedVersions) {
         auto encodeOp = encodedInfo.encodeOp;
         auto oldResultType =

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -233,10 +233,10 @@ util.initializer {
 // This test also verifies that stream.async.clone between load and encode is
 // properly traced through (matching real-world patterns from input pipelines).
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
 #device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<789>]>
 
 // CHECK-LABEL: module @immutable_source_initialized_from_parameter
 //       CHECK:   util.global private @[[$DEVICE_A:.+]] =
@@ -263,8 +263,8 @@ module @immutable_source_initialized_from_parameter {
     // CHECK: %[[CLONE1:.+]] = stream.async.clone on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]]
     %cloned1 = stream.async.clone on(#hal.device.affinity<@device_a>) %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE1]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE1]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
     %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %cloned1 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
     %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
@@ -274,8 +274,8 @@ module @immutable_source_initialized_from_parameter {
     // CHECK: %[[CLONE2:.+]] = stream.async.clone on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]]
     %cloned2 = stream.async.clone on(#hal.device.affinity<@device_a>) %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE2]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE2]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
     %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %cloned2 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
     %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
@@ -330,7 +330,7 @@ module @immutable_source_initialized_from_parameter {
     %encoded = util.global.load @encoded_v1 : !stream.resource<constant>
     %encoded_size = util.global.load @encoded_v1_size : index
     // CHECK:      stream.tensor.dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %result = stream.tensor.dispatch @executable_v1::@dispatch(%encoded)
       : (tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%encoded_size})
       -> tensor<16xf32> in !stream.resource<*>{%arg0}
@@ -342,7 +342,7 @@ module @immutable_source_initialized_from_parameter {
     %encoded = util.global.load @encoded_v2 : !stream.resource<constant>
     %encoded_size = util.global.load @encoded_v2_size : index
     // CHECK:      stream.tensor.dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %result = stream.tensor.dispatch @executable_v2::@dispatch(%encoded)
       : (tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%encoded_size})
       -> tensor<16xf32> in !stream.resource<*>{%arg0}
@@ -367,8 +367,8 @@ module @immutable_source_initialized_from_parameter {
     %cloned_v2 = stream.async.clone %encoded_v2 : !stream.resource<constant>{%encoded_v2_size} -> !stream.resource<*>{%encoded_v2_size}
 
     // CHECK:      stream.tensor.dispatch @executable_both::@dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %result = stream.tensor.dispatch @executable_both::@dispatch[%c16, %c32](%cloned_v1, %c0, %cloned_v2, %c1) : (tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%encoded_v1_size}, index, tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%encoded_v2_size}, index) -> tensor<16xf32> in !stream.resource<*>{%arg0}
 
     util.return %result : !stream.resource<*>
@@ -380,10 +380,10 @@ module @immutable_source_initialized_from_parameter {
 // Test: cross-function tracking - load encoded global, pass to callee via
 // util.call, and verify dispatch site encoding is updated in callee.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
 #device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<789>]>
 
 // CHECK-LABEL: module @cross_function_tracking
 //       CHECK:   util.global private @[[$DEVICE_A:.+]] =
@@ -399,16 +399,16 @@ module @cross_function_tracking {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
     %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
     %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
     util.global.store %size1, @encoded_v1_size : index
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
     %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
     %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
@@ -435,8 +435,8 @@ module @cross_function_tracking {
   // CHECK-LABEL: util.func private @dispatch_helper
   util.func private @dispatch_helper(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) -> !stream.resource<*> {
     // CHECK:      stream.tensor.dispatch @executable_both::@dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
     %result = stream.tensor.dispatch @executable_both::@dispatch(%arg0, %arg2) : (tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%arg1}, tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%arg3}) -> tensor<16xf32> in !stream.resource<*>{%arg4}
     util.return %result : !stream.resource<*>
   }
@@ -459,11 +459,11 @@ module @cross_function_tracking {
 // When encoding changes, both operand and result encoding must change.
 // A re-encode op should be inserted after dispatch.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
 #device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-// CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+// CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<789>]>
 
 // CHECK: util.global private @[[$DEVICE_A:.+]] =
 util.global private @device_a = #device_target_local
@@ -484,15 +484,15 @@ util.initializer {
   %source = util.global.load @weight : !stream.resource<constant>
   %source_size = util.global.load @weight_size : index
 
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
   %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
   util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
   util.global.store %size1, @encoded_v1_size : index
 
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
   %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
   util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
@@ -523,12 +523,12 @@ util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.re
 
   // The dispatch has a tied result (result -> %cloned).
   // CHECK:      %[[DISPATCH:.+]] = stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @executable_tied::@dispatch_inplace
-  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
-  // CHECK-SAME:   -> tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
+  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.specialized<123>>{%[[N]], %[[M]]}
+  // CHECK-SAME:   -> tensor<?x?xf32, #iree_encoding.specialized<123>>{%[[N]], %[[M]]}
   // Re-encode sizeof and encode ops are inserted after dispatch.
   // CHECK:      stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
   // CHECK:      stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[DISPATCH]] :
-  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>
+  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.specialized<123>>
   // CHECK-SAME:   -> tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
   %result = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable_tied::@dispatch_inplace(%cloned)
     : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size})

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -3,11 +3,15 @@
 // Test: immutable source global (with initial value) with two encodings -
 // should unify to identity encoding.
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
 // CHECK-LABEL: module @immutable_source_with_initial_value
+//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @immutable_source_with_initial_value {
+  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private @encoded_v1 : !stream.resource<constant>
   util.global private @encoded_v2 : !stream.resource<constant>
@@ -18,18 +22,18 @@ module @immutable_source_with_initial_value {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
-    %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_v2 : !stream.resource<constant>
 
     util.return
@@ -43,11 +47,15 @@ module @immutable_source_with_initial_value {
 // This test also verifies that stream.async.clone between load and encode is
 // properly traced through (matching real-world patterns from input pipelines).
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
 // CHECK-LABEL: module @immutable_source_initialized_from_parameter
+//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @immutable_source_initialized_from_parameter {
+  util.global private @device_a = #device_target_local
   util.global private @weight : !stream.resource<constant>
   util.global private @weight_size : index
   util.global private @encoded_v1 : !stream.resource<constant>
@@ -57,7 +65,7 @@ module @immutable_source_initialized_from_parameter {
 
   // CHECK: util.initializer
   util.initializer {
-    %cst = stream.tensor.constant : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+    %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
     %0 = stream.resource.size %cst : !stream.resource<constant>
     util.global.store %cst, @weight : !stream.resource<constant>
     util.global.store %0, @weight_size : index
@@ -66,25 +74,25 @@ module @immutable_source_initialized_from_parameter {
     %source_size = util.global.load @weight_size : index
 
     // Clone before encode (common pattern in real pipelines).
-    // CHECK: %[[CLONE1:.+]] = stream.async.clone %[[SOURCE]]
-    %cloned1 = stream.async.clone %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
+    // CHECK: %[[CLONE1:.+]] = stream.async.clone on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]]
+    %cloned1 = stream.async.clone on(#hal.device.affinity<@device_a>) %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode %[[CLONE1]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode %cloned1 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE1]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %cloned1 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
     util.global.store %size1, @encoded_v1_size : index
 
-    // CHECK: %[[CLONE2:.+]] = stream.async.clone %[[SOURCE]]
-    %cloned2 = stream.async.clone %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
+    // CHECK: %[[CLONE2:.+]] = stream.async.clone on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]]
+    %cloned2 = stream.async.clone on(#hal.device.affinity<@device_a>) %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode %[[CLONE2]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
-    %enc2 = stream.tensor.encode %cloned2 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE2]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %cloned2 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_v2 : !stream.resource<constant>
     util.global.store %size2, @encoded_v2_size : index
 
@@ -258,9 +266,13 @@ module @cross_function_tracking {
 // -----
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
+// CHECK: util.global private @[[$DEVICE_A:.+]] =
+util.global private @device_a = #device_target_local
 util.global private @weight : !stream.resource<constant>
 util.global private @weight_size : index
 util.global private @encoded_v1 : !stream.resource<constant>
@@ -270,7 +282,7 @@ util.global private @encoded_v2_size : index
 
 // CHECK: util.initializer
 util.initializer {
-  %cst = stream.tensor.constant : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+  %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
   %0 = stream.resource.size %cst : !stream.resource<constant>
   util.global.store %cst, @weight : !stream.resource<constant>
   util.global.store %0, @weight_size : index
@@ -278,18 +290,20 @@ util.initializer {
   %source = util.global.load @weight : !stream.resource<constant>
   %source_size = util.global.load @weight_size : index
 
-  // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
-  util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+  %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+  util.global.store %const1, @encoded_v1 : !stream.resource<constant>
   util.global.store %size1, @encoded_v1_size : index
 
-  // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
-  util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+  %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+  util.global.store %const2, @encoded_v2 : !stream.resource<constant>
   util.global.store %size2, @encoded_v2_size : index
 
   util.return
@@ -319,17 +333,15 @@ util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.re
   %cloned = stream.async.clone %encoded : !stream.resource<constant>{%encoded_size} -> !stream.resource<*>{%encoded_size}
 
   // The dispatch has a tied result (result -> %cloned).
-  // CHECK:      %[[DISPATCH:.+]] = stream.tensor.dispatch @executable_tied::@dispatch_inplace
+  // CHECK:      %[[DISPATCH:.+]] = stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @executable_tied::@dispatch_inplace
   // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
   // CHECK-SAME:   -> tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
   // Re-encode sizeof and encode ops are inserted after dispatch.
-  // CHECK:      stream.tensor.sizeof tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
-  // CHECK:      stream.tensor.encode %[[DISPATCH]] :
+  // CHECK:      stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
+  // CHECK:      stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[DISPATCH]] :
   // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>
   // CHECK-SAME:   -> tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
-  %result = stream.tensor.dispatch @executable_tied::@dispatch_inplace(%cloned)
-    : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size})
-    -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
+  %result = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable_tied::@dispatch_inplace(%cloned) : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size}) -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
 
   util.return %result : !stream.resource<*>
 }
@@ -338,27 +350,31 @@ util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.re
 
 // Test: mutable source global - should be skipped, encoding unchanged.
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: module @mutable_source_skipped
+//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @mutable_source_skipped {
+  util.global private @device_a = #device_target_local
   util.global private mutable @mutable_source : !stream.resource<constant>
   util.global private @encoded : !stream.resource<constant>
 
   util.initializer {
-    %cst = stream.tensor.constant : tensor<4096x4096xf32> in !stream.resource<constant> = dense<0.0> : tensor<4096x4096xf32>
+    %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = dense<0.0> : tensor<4096x4096xf32>
     %cst_size = stream.resource.size %cst : !stream.resource<constant>
     util.global.store %cst, @mutable_source : !stream.resource<constant>
 
     %source = util.global.load @mutable_source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded : !stream.resource<constant>
 
     util.return
@@ -369,13 +385,17 @@ module @mutable_source_skipped {
 
 // Test: mutable encoded global - should be skipped, encoding unchanged.
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
 // CHECK: #[[$ENC1:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK: #[[$ENC2:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 // CHECK-LABEL: module @mutable_encoded_global_skipped
+//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @mutable_encoded_global_skipped {
+  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private mutable @encoded_mutable_v1 : !stream.resource<constant>
   util.global private mutable @encoded_mutable_v2 : !stream.resource<constant>
@@ -384,18 +404,18 @@ module @mutable_encoded_global_skipped {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC1]]>
-    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC1]]>
-    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC1]]>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC1]]>
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_mutable_v1 : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC2]]>
-    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC2]]>
-    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
-    %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC2]]>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC2]]>
+    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_mutable_v2 : !stream.resource<constant>
     util.return
   }
@@ -405,11 +425,15 @@ module @mutable_encoded_global_skipped {
 
 // Test: single encoding - not a candidate for unification, encoding unchanged.
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: module @single_encoding_no_unification
+//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @single_encoding_no_unification {
+  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private @encoded : !stream.resource<constant>
 
@@ -417,11 +441,11 @@ module @single_encoding_no_unification {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded : !stream.resource<constant>
 
     util.return
@@ -432,11 +456,15 @@ module @single_encoding_no_unification {
 
 // Test: same encoding used twice - not a candidate (only one unique encoding).
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: module @same_encoding_twice_no_unification
+//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @same_encoding_twice_no_unification {
+  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private @encoded_v1 : !stream.resource<constant>
   util.global private @encoded_v2 : !stream.resource<constant>
@@ -445,18 +473,18 @@ module @same_encoding_twice_no_unification {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
-    %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_v2 : !stream.resource<constant>
 
     util.return

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -3,15 +3,11 @@
 // Test: immutable source global (with initial value) with two encodings -
 // should unify to identity encoding.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
 // CHECK-LABEL: module @immutable_source_with_initial_value
-//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @immutable_source_with_initial_value {
-  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private @encoded_v1 : !stream.resource<constant>
   util.global private @encoded_v2 : !stream.resource<constant>
@@ -22,208 +18,22 @@ module @immutable_source_with_initial_value {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
+    %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_v2 : !stream.resource<constant>
 
     util.return
   }
-}
-
-// -----
-
-// Checks that the identity encoding is generated if no resolver is specified.
-
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<789>]>
-
-// CHECK: util.global private @[[$DEVICE_A:.+]] =
-util.global private @device_a = #device_target_local
-util.global private @weight : !stream.resource<constant>
-util.global private @weight_size : index
-util.global private @encoded_v1 : !stream.resource<constant>
-util.global private @encoded_v1_size : index
-util.global private @encoded_v2 : !stream.resource<constant>
-util.global private @encoded_v2_size : index
-
-// CHECK: util.initializer
-util.initializer {
-  %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
-  %0 = stream.resource.size %cst : !stream.resource<constant>
-  util.global.store %cst, @weight : !stream.resource<constant>
-  util.global.store %0, @weight_size : index
-  // CHECK: %[[SOURCE:.+]] = util.global.load @weight
-  %source = util.global.load @weight : !stream.resource<constant>
-  %source_size = util.global.load @weight_size : index
-
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
-  util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
-  util.global.store %size1, @encoded_v1_size : index
-
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
-  util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
-  util.global.store %size2, @encoded_v2_size : index
-
-  util.return
-}
-
-// -----
-
-// Test: multiple devices with different resolvers encoding the same source global.
-// Since different resolvers produce different encodings and they share the same source,
-// there's no common encoding - should fall back to identity encoding.
-
-#executable_target_0 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
-#executable_target_1 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<456>}>
-#device_target_local_0 = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_0]> : !hal.device
-#device_target_local_1 = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_1]> : !hal.device
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<111>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<222>]>
-
-// CHECK: util.global private @[[$DEVICE_A:.+]] =
-// CHECK: util.global private @[[$DEVICE_B:.+]] =
-util.global private @device_a = #device_target_local_0
-util.global private @device_b = #device_target_local_1
-// Single source global shared by both devices.
-util.global private @weight : !stream.resource<constant>
-util.global private @weight_size : index
-util.global private @encoded_a_v1 : !stream.resource<constant>
-util.global private @encoded_a_v2 : !stream.resource<constant>
-util.global private @encoded_b_v1 : !stream.resource<constant>
-util.global private @encoded_b_v2 : !stream.resource<constant>
-
-// CHECK: util.initializer
-util.initializer {
-  %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
-  %0 = stream.resource.size %cst : !stream.resource<constant>
-  util.global.store %cst, @weight : !stream.resource<constant>
-  util.global.store %0, @weight_size : index
-
-  // CHECK: %[[SOURCE:.+]] = util.global.load @weight
-  %source = util.global.load @weight : !stream.resource<constant>
-  %source_size = util.global.load @weight_size : index
-
-  // Device A encodes the shared source - should get identity encoding.
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
-  util.global.store %enc1, @encoded_a_v1 : !stream.resource<constant>
-
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
-  util.global.store %enc2, @encoded_a_v2 : !stream.resource<constant>
-
-  // Device B encodes the same shared source - should also get identity encoding.
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size3 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding1> : index
-  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size3}
-  util.global.store %enc3, @encoded_b_v1 : !stream.resource<constant>
-
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.identity>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
-  %size4 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding2> : index
-  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size4}
-  util.global.store %enc4, @encoded_b_v2 : !stream.resource<constant>
-
-  util.return
-}
-
-// -----
-
-// Test: multiple devices with different resolvers - each device should use its own resolver.
-
-#executable_target_0 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
-#executable_target_1 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<456>}>
-#device_target_local_0 = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_0]> : !hal.device
-#device_target_local_1 = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_1]> : !hal.device
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<111>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<222>]>
-
-// CHECK: util.global private @[[$DEVICE_A:.+]] =
-// CHECK: util.global private @[[$DEVICE_B:.+]] =
-util.global private @device_a = #device_target_local_0
-util.global private @device_b = #device_target_local_1
-// Two separate source globals - one for each device.
-util.global private @weight_a : !stream.resource<constant>
-util.global private @weight_a_size : index
-util.global private @weight_b : !stream.resource<constant>
-util.global private @weight_b_size : index
-util.global private @encoded_a_v1 : !stream.resource<constant>
-util.global private @encoded_a_v2 : !stream.resource<constant>
-util.global private @encoded_b_v1 : !stream.resource<constant>
-util.global private @encoded_b_v2 : !stream.resource<constant>
-
-// CHECK: util.initializer
-util.initializer {
-  // Initialize weight_a for device_a.
-  %cst_a = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight_a"> : tensor<4096x4096xf32>
-  %size_a = stream.resource.size %cst_a : !stream.resource<constant>
-  util.global.store %cst_a, @weight_a : !stream.resource<constant>
-  util.global.store %size_a, @weight_a_size : index
-
-  // Initialize weight_b for device_b.
-  %cst_b = stream.tensor.constant on(#hal.device.affinity<@device_b>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight_b"> : tensor<4096x4096xf32>
-  %size_b = stream.resource.size %cst_b : !stream.resource<constant>
-  util.global.store %cst_b, @weight_b : !stream.resource<constant>
-  util.global.store %size_b, @weight_b_size : index
-
-  // CHECK: %[[SOURCE_A:.+]] = util.global.load @weight_a
-  %source_a = util.global.load @weight_a : !stream.resource<constant>
-  %source_a_size = util.global.load @weight_a_size : index
-
-  // CHECK: %[[SOURCE_B:.+]] = util.global.load @weight_b
-  %source_b = util.global.load @weight_b : !stream.resource<constant>
-  %source_b_size = util.global.load @weight_b_size : index
-
-  // Device A encodes weight_a with specialization_resolver<123>.
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE_A]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
-  util.global.store %enc1, @encoded_a_v1 : !stream.resource<constant>
-
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE_A]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
-  util.global.store %enc2, @encoded_a_v2 : !stream.resource<constant>
-
-  // Device B encodes weight_b with specialization_resolver<456>.
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.specialized<456>>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE_B]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<456>>
-  %size3 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding1> : index
-  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size3}
-  util.global.store %enc3, @encoded_b_v1 : !stream.resource<constant>
-
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.specialized<456>>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE_B]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<456>>
-  %size4 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding2> : index
-  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size4}
-  util.global.store %enc4, @encoded_b_v2 : !stream.resource<constant>
-
-  util.return
 }
 
 // -----
@@ -233,15 +43,11 @@ util.initializer {
 // This test also verifies that stream.async.clone between load and encode is
 // properly traced through (matching real-world patterns from input pipelines).
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
-#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<789>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
 // CHECK-LABEL: module @immutable_source_initialized_from_parameter
-//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @immutable_source_initialized_from_parameter {
-  util.global private @device_a = #device_target_local
   util.global private @weight : !stream.resource<constant>
   util.global private @weight_size : index
   util.global private @encoded_v1 : !stream.resource<constant>
@@ -251,7 +57,7 @@ module @immutable_source_initialized_from_parameter {
 
   // CHECK: util.initializer
   util.initializer {
-    %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+    %cst = stream.tensor.constant : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
     %0 = stream.resource.size %cst : !stream.resource<constant>
     util.global.store %cst, @weight : !stream.resource<constant>
     util.global.store %0, @weight_size : index
@@ -260,25 +66,25 @@ module @immutable_source_initialized_from_parameter {
     %source_size = util.global.load @weight_size : index
 
     // Clone before encode (common pattern in real pipelines).
-    // CHECK: %[[CLONE1:.+]] = stream.async.clone on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]]
-    %cloned1 = stream.async.clone on(#hal.device.affinity<@device_a>) %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
+    // CHECK: %[[CLONE1:.+]] = stream.async.clone %[[SOURCE]]
+    %cloned1 = stream.async.clone %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE1]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %cloned1 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode %[[CLONE1]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode %cloned1 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
     util.global.store %size1, @encoded_v1_size : index
 
-    // CHECK: %[[CLONE2:.+]] = stream.async.clone on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]]
-    %cloned2 = stream.async.clone on(#hal.device.affinity<@device_a>) %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
+    // CHECK: %[[CLONE2:.+]] = stream.async.clone %[[SOURCE]]
+    %cloned2 = stream.async.clone %source : !stream.resource<constant>{%source_size} -> !stream.resource<*>{%source_size}
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[CLONE2]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %cloned2 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK: stream.tensor.encode %[[CLONE2]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
+    %enc2 = stream.tensor.encode %cloned2 : tensor<4096x4096xf32> in !stream.resource<*>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_v2 : !stream.resource<constant>
     util.global.store %size2, @encoded_v2_size : index
 
@@ -330,7 +136,7 @@ module @immutable_source_initialized_from_parameter {
     %encoded = util.global.load @encoded_v1 : !stream.resource<constant>
     %encoded_size = util.global.load @encoded_v1_size : index
     // CHECK:      stream.tensor.dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
     %result = stream.tensor.dispatch @executable_v1::@dispatch(%encoded)
       : (tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%encoded_size})
       -> tensor<16xf32> in !stream.resource<*>{%arg0}
@@ -342,7 +148,7 @@ module @immutable_source_initialized_from_parameter {
     %encoded = util.global.load @encoded_v2 : !stream.resource<constant>
     %encoded_size = util.global.load @encoded_v2_size : index
     // CHECK:      stream.tensor.dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
     %result = stream.tensor.dispatch @executable_v2::@dispatch(%encoded)
       : (tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%encoded_size})
       -> tensor<16xf32> in !stream.resource<*>{%arg0}
@@ -367,8 +173,8 @@ module @immutable_source_initialized_from_parameter {
     %cloned_v2 = stream.async.clone %encoded_v2 : !stream.resource<constant>{%encoded_v2_size} -> !stream.resource<*>{%encoded_v2_size}
 
     // CHECK:      stream.tensor.dispatch @executable_both::@dispatch
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
+    // CHECK-SAME:   tensor<4096x4096xf32, #iree_encoding.identity>
     %result = stream.tensor.dispatch @executable_both::@dispatch[%c16, %c32](%cloned_v1, %c0, %cloned_v2, %c1) : (tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%encoded_v1_size}, index, tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%encoded_v2_size}, index) -> tensor<16xf32> in !stream.resource<*>{%arg0}
 
     util.return %result : !stream.resource<*>
@@ -452,13 +258,9 @@ module @cross_function_tracking {
 // -----
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
-// CHECK: util.global private @[[$DEVICE_A:.+]] =
-util.global private @device_a = #device_target_local
 util.global private @weight : !stream.resource<constant>
 util.global private @weight_size : index
 util.global private @encoded_v1 : !stream.resource<constant>
@@ -468,7 +270,7 @@ util.global private @encoded_v2_size : index
 
 // CHECK: util.initializer
 util.initializer {
-  %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+  %cst = stream.tensor.constant : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
   %0 = stream.resource.size %cst : !stream.resource<constant>
   util.global.store %cst, @weight : !stream.resource<constant>
   util.global.store %0, @weight_size : index
@@ -476,20 +278,18 @@ util.initializer {
   %source = util.global.load @weight : !stream.resource<constant>
   %source_size = util.global.load @weight_size : index
 
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-  %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
-  util.global.store %const1, @encoded_v1 : !stream.resource<constant>
+  // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+  %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
   util.global.store %size1, @encoded_v1_size : index
 
-  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
-  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-  %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
-  util.global.store %const2, @encoded_v2 : !stream.resource<constant>
+  // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
+  %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
   util.global.store %size2, @encoded_v2_size : index
 
   util.return
@@ -519,15 +319,17 @@ util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.re
   %cloned = stream.async.clone %encoded : !stream.resource<constant>{%encoded_size} -> !stream.resource<*>{%encoded_size}
 
   // The dispatch has a tied result (result -> %cloned).
-  // CHECK:      %[[DISPATCH:.+]] = stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @executable_tied::@dispatch_inplace
-  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.specialized<123>>{%[[N]], %[[M]]}
-  // CHECK-SAME:   -> tensor<?x?xf32, #iree_encoding.specialized<123>>{%[[N]], %[[M]]}
+  // CHECK:      %[[DISPATCH:.+]] = stream.tensor.dispatch @executable_tied::@dispatch_inplace
+  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
+  // CHECK-SAME:   -> tensor<?x?xf32, #iree_encoding.identity>{%[[N]], %[[M]]}
   // Re-encode sizeof and encode ops are inserted after dispatch.
-  // CHECK:      stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
-  // CHECK:      stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[DISPATCH]] :
-  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.specialized<123>>
+  // CHECK:      stream.tensor.sizeof tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
+  // CHECK:      stream.tensor.encode %[[DISPATCH]] :
+  // CHECK-SAME:   tensor<?x?xf32, #iree_encoding.identity>
   // CHECK-SAME:   -> tensor<?x?xf32, #[[$ENC]]>{%[[N]], %[[M]]}
-  %result = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable_tied::@dispatch_inplace(%cloned) : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size}) -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
+  %result = stream.tensor.dispatch @executable_tied::@dispatch_inplace(%cloned)
+    : (tensor<?x?xf32, #encoding1>{%N, %M} in !stream.resource<*>{%encoded_size})
+    -> tensor<?x?xf32, #encoding1>{%N, %M} in %cloned{%encoded_size}
 
   util.return %result : !stream.resource<*>
 }
@@ -536,31 +338,27 @@ util.func public @dispatch_with_tied_operand(%N: index, %M: index) -> !stream.re
 
 // Test: mutable source global - should be skipped, encoding unchanged.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: module @mutable_source_skipped
-//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @mutable_source_skipped {
-  util.global private @device_a = #device_target_local
   util.global private mutable @mutable_source : !stream.resource<constant>
   util.global private @encoded : !stream.resource<constant>
 
   util.initializer {
-    %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = dense<0.0> : tensor<4096x4096xf32>
+    %cst = stream.tensor.constant : tensor<4096x4096xf32> in !stream.resource<constant> = dense<0.0> : tensor<4096x4096xf32>
     %cst_size = stream.resource.size %cst : !stream.resource<constant>
     util.global.store %cst, @mutable_source : !stream.resource<constant>
 
     %source = util.global.load @mutable_source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded : !stream.resource<constant>
 
     util.return
@@ -571,17 +369,13 @@ module @mutable_source_skipped {
 
 // Test: mutable encoded global - should be skipped, encoding unchanged.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 #encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 
 // CHECK: #[[$ENC1:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK: #[[$ENC2:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 // CHECK-LABEL: module @mutable_encoded_global_skipped
-//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @mutable_encoded_global_skipped {
-  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private mutable @encoded_mutable_v1 : !stream.resource<constant>
   util.global private mutable @encoded_mutable_v2 : !stream.resource<constant>
@@ -590,18 +384,18 @@ module @mutable_encoded_global_skipped {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC1]]>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC1]]>
-    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC1]]>
+    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC1]]>
+    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_mutable_v1 : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC2]]>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC2]]>
-    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC2]]>
+    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC2]]>
+    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding2> : index
+    %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_mutable_v2 : !stream.resource<constant>
     util.return
   }
@@ -611,15 +405,11 @@ module @mutable_encoded_global_skipped {
 
 // Test: single encoding - not a candidate for unification, encoding unchanged.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: module @single_encoding_no_unification
-//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @single_encoding_no_unification {
-  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private @encoded : !stream.resource<constant>
 
@@ -627,11 +417,11 @@ module @single_encoding_no_unification {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded : !stream.resource<constant>
 
     util.return
@@ -642,15 +432,11 @@ module @single_encoding_no_unification {
 
 // Test: same encoding used twice - not a candidate (only one unique encoding).
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.identity_resolver}>
-#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 
 // CHECK: #[[$ENC:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: module @same_encoding_twice_no_unification
-//       CHECK:   util.global private @[[$DEVICE_A:.+]] =
 module @same_encoding_twice_no_unification {
-  util.global private @device_a = #device_target_local
   util.global private @source = #stream.parameter.named<"model"::"weight"> : !stream.resource<constant>
   util.global private @encoded_v1 : !stream.resource<constant>
   util.global private @encoded_v2 : !stream.resource<constant>
@@ -659,18 +445,18 @@ module @same_encoding_twice_no_unification {
     %source = util.global.load @source : !stream.resource<constant>
     %source_size = stream.resource.size %source : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-    %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size1 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc1 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
+    %const1 = stream.async.clone %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
     util.global.store %const1, @encoded_v1 : !stream.resource<constant>
 
-    // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #[[$ENC]]>
-    // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
-    %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-    %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size2}
-    %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
+    // CHECK: stream.tensor.sizeof tensor<4096x4096xf32, #[[$ENC]]>
+    // CHECK: stream.tensor.encode {{.*}} -> tensor<4096x4096xf32, #[[$ENC]]>
+    %size2 = stream.tensor.sizeof tensor<4096x4096xf32, #encoding1> : index
+    %enc2 = stream.tensor.encode %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size2}
+    %const2 = stream.async.clone %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
     util.global.store %const2, @encoded_v2 : !stream.resource<constant>
 
     util.return

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -71,17 +71,15 @@ util.initializer {
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-  %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
-  util.global.store %const1, @encoded_v1 : !stream.resource<constant>
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
   util.global.store %size1, @encoded_v1_size : index
 
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-  %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
-  util.global.store %const2, @encoded_v2 : !stream.resource<constant>
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
   util.global.store %size2, @encoded_v2_size : index
 
   util.return
@@ -127,31 +125,27 @@ util.initializer {
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-  %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
-  util.global.store %const1, @encoded_a_v1 : !stream.resource<constant>
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_a_v1 : !stream.resource<constant>
 
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-  %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
-  util.global.store %const2, @encoded_a_v2 : !stream.resource<constant>
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_a_v2 : !stream.resource<constant>
 
   // Device B encodes the same shared source - should also get identity encoding.
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size3 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding1> : index
-  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size3}
-  %const3 = stream.async.clone on(#hal.device.affinity<@device_b>) %enc3 : !stream.resource<*>{%size3} -> !stream.resource<constant>{%size3}
-  util.global.store %const3, @encoded_b_v1 : !stream.resource<constant>
+  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size3}
+  util.global.store %enc3, @encoded_b_v1 : !stream.resource<constant>
 
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.identity>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
   %size4 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding2> : index
-  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size4}
-  %const4 = stream.async.clone on(#hal.device.affinity<@device_b>) %enc4 : !stream.resource<*>{%size4} -> !stream.resource<constant>{%size4}
-  util.global.store %const4, @encoded_b_v2 : !stream.resource<constant>
+  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size4}
+  util.global.store %enc4, @encoded_b_v2 : !stream.resource<constant>
 
   util.return
 }
@@ -207,31 +201,27 @@ util.initializer {
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE_A]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
-  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size1}
-  %const1 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc1 : !stream.resource<*>{%size1} -> !stream.resource<constant>{%size1}
-  util.global.store %const1, @encoded_a_v1 : !stream.resource<constant>
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_a_v1 : !stream.resource<constant>
 
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE_A]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
-  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size2}
-  %const2 = stream.async.clone on(#hal.device.affinity<@device_a>) %enc2 : !stream.resource<*>{%size2} -> !stream.resource<constant>{%size2}
-  util.global.store %const2, @encoded_a_v2 : !stream.resource<constant>
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_a_v2 : !stream.resource<constant>
 
   // Device B encodes weight_b with specialization_resolver<456>.
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.specialized<456>>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE_B]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<456>>
   %size3 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding1> : index
-  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%size3}
-  %const3 = stream.async.clone on(#hal.device.affinity<@device_b>) %enc3 : !stream.resource<*>{%size3} -> !stream.resource<constant>{%size3}
-  util.global.store %const3, @encoded_b_v1 : !stream.resource<constant>
+  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size3}
+  util.global.store %enc3, @encoded_b_v1 : !stream.resource<constant>
 
   // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.specialized<456>>
   // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE_B]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<456>>
   %size4 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding2> : index
-  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%size4}
-  %const4 = stream.async.clone on(#hal.device.affinity<@device_b>) %enc4 : !stream.resource<*>{%size4} -> !stream.resource<constant>{%size4}
-  util.global.store %const4, @encoded_b_v2 : !stream.resource<constant>
+  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size4}
+  util.global.store %enc4, @encoded_b_v2 : !stream.resource<constant>
 
   util.return
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -42,6 +42,192 @@ module @immutable_source_with_initial_value {
 
 // -----
 
+// Checks that the identity encoding is generated if no resolver is specified.
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {}>
+#device_target_local = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<789>]>
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] =
+util.global private @device_a = #device_target_local
+util.global private @weight : !stream.resource<constant>
+util.global private @weight_size : index
+util.global private @encoded_v1 : !stream.resource<constant>
+util.global private @encoded_v1_size : index
+util.global private @encoded_v2 : !stream.resource<constant>
+util.global private @encoded_v2_size : index
+
+// CHECK: util.initializer
+util.initializer {
+  %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+  %0 = stream.resource.size %cst : !stream.resource<constant>
+  util.global.store %cst, @weight : !stream.resource<constant>
+  util.global.store %0, @weight_size : index
+  // CHECK: %[[SOURCE:.+]] = util.global.load @weight
+  %source = util.global.load @weight : !stream.resource<constant>
+  %source_size = util.global.load @weight_size : index
+
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_v1 : !stream.resource<constant>
+  util.global.store %size1, @encoded_v1_size : index
+
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_v2 : !stream.resource<constant>
+  util.global.store %size2, @encoded_v2_size : index
+
+  util.return
+}
+
+// -----
+
+// Test: multiple devices with different resolvers encoding the same source global.
+// Since different resolvers produce different encodings and they share the same source,
+// there's no common encoding - should fall back to identity encoding.
+
+#executable_target_0 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
+#executable_target_1 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<456>}>
+#device_target_local_0 = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_0]> : !hal.device
+#device_target_local_1 = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_1]> : !hal.device
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<111>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<222>]>
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] =
+// CHECK: util.global private @[[$DEVICE_B:.+]] =
+util.global private @device_a = #device_target_local_0
+util.global private @device_b = #device_target_local_1
+// Single source global shared by both devices.
+util.global private @weight : !stream.resource<constant>
+util.global private @weight_size : index
+util.global private @encoded_a_v1 : !stream.resource<constant>
+util.global private @encoded_a_v2 : !stream.resource<constant>
+util.global private @encoded_b_v1 : !stream.resource<constant>
+util.global private @encoded_b_v2 : !stream.resource<constant>
+
+// CHECK: util.initializer
+util.initializer {
+  %cst = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight"> : tensor<4096x4096xf32>
+  %0 = stream.resource.size %cst : !stream.resource<constant>
+  util.global.store %cst, @weight : !stream.resource<constant>
+  util.global.store %0, @weight_size : index
+
+  // CHECK: %[[SOURCE:.+]] = util.global.load @weight
+  %source = util.global.load @weight : !stream.resource<constant>
+  %source_size = util.global.load @weight_size : index
+
+  // Device A encodes the shared source - should get identity encoding.
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_a_v1 : !stream.resource<constant>
+
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_a_v2 : !stream.resource<constant>
+
+  // Device B encodes the same shared source - should also get identity encoding.
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size3 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding1> : index
+  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size3}
+  util.global.store %enc3, @encoded_b_v1 : !stream.resource<constant>
+
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.identity>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.identity>
+  %size4 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding2> : index
+  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source : tensor<4096x4096xf32> in !stream.resource<constant>{%source_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size4}
+  util.global.store %enc4, @encoded_b_v2 : !stream.resource<constant>
+
+  util.return
+}
+
+// -----
+
+// Test: multiple devices with different resolvers - each device should use its own resolver.
+
+#executable_target_0 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
+#executable_target_1 = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.specialization_resolver<456>}>
+#device_target_local_0 = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_0]> : !hal.device
+#device_target_local_1 = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_1]> : !hal.device
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<111>]>
+#encoding2 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<222>]>
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] =
+// CHECK: util.global private @[[$DEVICE_B:.+]] =
+util.global private @device_a = #device_target_local_0
+util.global private @device_b = #device_target_local_1
+// Two separate source globals - one for each device.
+util.global private @weight_a : !stream.resource<constant>
+util.global private @weight_a_size : index
+util.global private @weight_b : !stream.resource<constant>
+util.global private @weight_b_size : index
+util.global private @encoded_a_v1 : !stream.resource<constant>
+util.global private @encoded_a_v2 : !stream.resource<constant>
+util.global private @encoded_b_v1 : !stream.resource<constant>
+util.global private @encoded_b_v2 : !stream.resource<constant>
+
+// CHECK: util.initializer
+util.initializer {
+  // Initialize weight_a for device_a.
+  %cst_a = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight_a"> : tensor<4096x4096xf32>
+  %size_a = stream.resource.size %cst_a : !stream.resource<constant>
+  util.global.store %cst_a, @weight_a : !stream.resource<constant>
+  util.global.store %size_a, @weight_a_size : index
+
+  // Initialize weight_b for device_b.
+  %cst_b = stream.tensor.constant on(#hal.device.affinity<@device_b>) : tensor<4096x4096xf32> in !stream.resource<constant> = #stream.parameter.named<"model"::"weight_b"> : tensor<4096x4096xf32>
+  %size_b = stream.resource.size %cst_b : !stream.resource<constant>
+  util.global.store %cst_b, @weight_b : !stream.resource<constant>
+  util.global.store %size_b, @weight_b_size : index
+
+  // CHECK: %[[SOURCE_A:.+]] = util.global.load @weight_a
+  %source_a = util.global.load @weight_a : !stream.resource<constant>
+  %source_a_size = util.global.load @weight_a_size : index
+
+  // CHECK: %[[SOURCE_B:.+]] = util.global.load @weight_b
+  %source_b = util.global.load @weight_b : !stream.resource<constant>
+  %source_b_size = util.global.load @weight_b_size : index
+
+  // Device A encodes weight_a with specialization_resolver<123>.
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE_A]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+  %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding1> : index
+  %enc1 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size1}
+  util.global.store %enc1, @encoded_a_v1 : !stream.resource<constant>
+
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_A]]>) tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_A]]>) %[[SOURCE_A]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<123>>
+  %size2 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<4096x4096xf32, #encoding2> : index
+  %enc2 = stream.tensor.encode on(#hal.device.affinity<@device_a>) %source_a : tensor<4096x4096xf32> in !stream.resource<constant>{%source_a_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size2}
+  util.global.store %enc2, @encoded_a_v2 : !stream.resource<constant>
+
+  // Device B encodes weight_b with specialization_resolver<456>.
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.specialized<456>>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE_B]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<456>>
+  %size3 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding1> : index
+  %enc3 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%size3}
+  util.global.store %enc3, @encoded_b_v1 : !stream.resource<constant>
+
+  // CHECK: stream.tensor.sizeof on(#hal.device.affinity<@[[$DEVICE_B]]>) tensor<4096x4096xf32, #iree_encoding.specialized<456>>
+  // CHECK: stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE_B]]>) %[[SOURCE_B]] : {{.*}} -> tensor<4096x4096xf32, #iree_encoding.specialized<456>>
+  %size4 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<4096x4096xf32, #encoding2> : index
+  %enc4 = stream.tensor.encode on(#hal.device.affinity<@device_b>) %source_b : tensor<4096x4096xf32> in !stream.resource<constant>{%source_b_size} -> tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%size4}
+  util.global.store %enc4, @encoded_b_v2 : !stream.resource<constant>
+
+  util.return
+}
+
+// -----
+
 // Test: immutable source global (initialized from parameter in initializer) with
 // two encodings - should unify to identity encoding.
 // This test also verifies that stream.async.clone between load and encode is


### PR DESCRIPTION
Add a new `getUnifiedEncoding` method to the `LayoutResolverAttr` interface that returns a unified encoding given multiple candidate encodings. This is used by the UnifyEncodingForGlobals pass to select an appropriate encoding when the same source data has multiple encoded versions.

Also refactor GlobalEncodingAnalyzer to:
- Set up the layout resolver from dialect interfaces internally
- Compute unified encodings as part of the analysis phase
- Provide a `getUnifiedEncoding(name)` getter for querying results

This simplifies the pass by moving analysis-related logic into the analyzer class, making the pass focused on applying transformations.

Update lit tests to include device definitions and affinity attributes on stream.tensor.* ops, which are required for the pass to resolve layout attributes properly. It also switches identity_resolver to specialization_resolver, which improves the test quality. Identity encoding is used in fallback solution.

It is a step towards https://github.com/iree-org/iree/issues/22485