### PR TITLE
[ROCM][DT] Add architecture matching to ukernel_info attribute

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -171,6 +171,19 @@ Attribute TensorUKernelProviderAttr::getDataLayoutForUKernel(
         continue;
       }
     }
+    // Match architecture if specified. Expects an ArrayAttr of StringAttr,
+    // e.g., archs = ["gfx942", "gfx950"]
+    if (auto archs = dyn_cast_if_present<ArrayAttr>(
+            info.getMatch().get(kUKernelInfoArchsName))) {
+      StringRef targetArch = targetAttr.getArch();
+      bool matched = llvm::any_of(archs, [&](Attribute attr) {
+        auto strAttr = dyn_cast<StringAttr>(attr);
+        return strAttr && strAttr.getValue() == targetArch;
+      });
+      if (!matched) {
+        continue;
+      }
+    }
     // Read the data-tiled-layout attribute.
     Attribute mma = info.getMma();
     if (!mma) {

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -172,7 +172,7 @@ Attribute TensorUKernelProviderAttr::getDataLayoutForUKernel(
       }
     }
     // Match architecture if specified. Expects an ArrayAttr of StringAttr,
-    // e.g., archs = ["gfx942", "gfx950"]
+    // e.g., archs = ["gfx942", "gfx950"].
     if (auto archs = dyn_cast_if_present<ArrayAttr>(
             info.getMatch().get(kUKernelInfoArchsName))) {
       StringRef targetArch = targetAttr.getArch();

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h
@@ -27,6 +27,7 @@ constexpr char kUKernelInfoName[] = "ukernel_info";
 constexpr char kUKernelInfoTypesName[] = "types";
 constexpr char kUKernelInfoIterationSizesConstraintsName[] =
     "iteration_sizes_constraints";
+constexpr char kUKernelInfoArchsName[] = "archs";
 
 } // namespace mlir::iree_compiler::IREE::ROCM
 

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
@@ -17,6 +17,7 @@
 util.func @pingpong_dt_large_f16(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
   ukernel_info = #rocm.ukernel_info<
     match = {
+      archs = ["gfx942"],
       types = [f16, f16, f32],
       iteration_sizes_constraints = [
         #rocm.ukernel_interation_size_constraint<

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
@@ -27,6 +27,7 @@
 util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
   ukernel_info = #rocm.ukernel_info<
     match = {
+      archs = ["gfx942"],
       types = [f8E4M3FNUZ, f8E4M3FNUZ, f32],
       iteration_sizes_constraints = [
         #rocm.ukernel_interation_size_constraint<
@@ -302,6 +303,7 @@ util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs
 util.func private @pingpong_dt_medium_f8E4M3FNUZ(%lhs_base: !m_lhs_base_ty, %rhs_base: !m_rhs_base_ty, %unused_acc: !m_acc_base_ty) -> !m_acc_base_ty attributes {
   ukernel_info = #rocm.ukernel_info<
     match = {
+      archs = ["gfx942"],
       types = [f8E4M3FNUZ, f8E4M3FNUZ, f32],
       iteration_sizes_constraints = [
         #rocm.ukernel_interation_size_constraint<

--- a/compiler/plugins/target/ROCM/test/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
         "lower_rocm_ukernel_descriptor.mlir",
         "lowering_strategy_from_tuning_spec.mlir",
         "materialize_encoding_ukernel_gfx942.mlir",
+        "materialize_encoding_ukernel_gfx950.mlir",
         "ukernel_pipeline_transform.mlir",
     ],
     cfg = "//compiler:lit.cfg.py",

--- a/compiler/plugins/target/ROCM/test/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "lower_rocm_ukernel_descriptor.mlir"
     "lowering_strategy_from_tuning_spec.mlir"
     "materialize_encoding_ukernel_gfx942.mlir"
+    "materialize_encoding_ukernel_gfx950.mlir"
     "ukernel_pipeline_transform.mlir"
   TOOLS
     FileCheck

--- a/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx950.mlir
+++ b/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx950.mlir
@@ -1,0 +1,60 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding))" %s | FileCheck %s
+
+// ===----------------------------------------------------------------------===//
+// Shared Attributes
+// ===----------------------------------------------------------------------===//
+
+// Note the ukernel provider being specified in the executable target. This should be used to determine the data tiling.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
+  abi = "hip",
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
+  iree_codegen.target_info = #iree_gpu.target<
+    arch = "gfx950",
+    features = "",
+    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+    storage =  b64|b32|b16|b8,
+    subgroup =  shuffle|arithmetic,
+    dot =  dp4xi8toi32,
+    mma = [<MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>],
+    subgroup_size_choices = [64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128,
+    simds_per_wgp = 4,
+    vgpr_space_bits = 16384>
+  >,
+  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
+  ukernels = "none"
+}>
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// ===----------------------------------------------------------------------===//
+// Tests
+// ===----------------------------------------------------------------------===//
+
+// Test that the f16 dt matmul ukernel (which has archs = ["gfx942"]) is NOT
+// matched on gfx950, demonstrating the archs filtering works correctly.
+// The ukernel has: intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4
+// gfx950 should fall back to default heuristic with different tile sizes.
+
+#encoding_lhs_f16 = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_rhs_f16 = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_result_f16 = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+
+func.func @matmul_f16_f16_f32_gfx950_no_ukernel_match(%arg0: tensor<?x?xf16, #encoding_lhs_f16>, %arg1: tensor<?x?xf16, #encoding_rhs_f16>, %arg2: tensor<?x?xf32, #encoding_result_f16>) -> tensor<?x?xf32, #encoding_result_f16> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xf16, #encoding_lhs_f16>, tensor<?x?xf16, #encoding_rhs_f16>)
+      outs(%arg2 : tensor<?x?xf32, #encoding_result_f16>)
+      -> tensor<?x?xf32, #encoding_result_f16>
+  return %0 : tensor<?x?xf32, #encoding_result_f16>
+}
+// CHECK-LABEL: matmul_f16_f16_f32_gfx950_no_ukernel_match
+// CHECK:      iree_codegen.inner_tiled
+// CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
+// CHECK-NOT:      kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_F16, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4>


### PR DESCRIPTION
The current f16 dt matmul ukernel is tuned specifically for gfx942. Without filtering by architecture, gfx950 also ends up selecting this ukernel's data layout, which can hurt performance because gfx950 generally prefers larger tile sizes.