### PR TITLE
[GlobalOpt] Fuse transpose into matmul-looking linalg.generic

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1125,7 +1125,6 @@ static void populateNamedOpSinkingPatterns(MLIRContext *context,
   sinkingPatterns.insert<NamedOpConversion</*OpType=*/linalg::BatchMatmulOp,
                                            /*inputIdx=*/0>>(
       context, SmallVector<int64_t>{0, 2, 1});
-  // Also handle generic ops that are effectively matmul contractions.
   sinkingPatterns.insert<FuseTransposeThroughGenericContraction>(context);
 }
 
@@ -1230,7 +1229,7 @@ void PropagateLinalgTransposePass::runOnOperation() {
           // Only propagate if the immediate consumer of the reshape is a
           // transpose.
           return consumer->hasOneUse() &&
-                 llvm::isa<linalg::TransposeOp>(*(consumer->user_begin()));
+                 isa<linalg::TransposeOp>(*(consumer->user_begin()));
         };
     RewritePatternSet bubblingPatterns(context);
     linalg::populateFoldReshapeOpsByExpansionPatterns(bubblingPatterns,

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1051,7 +1051,9 @@ public:
       SmallVector<AffineExpr> newExprs =
           applyPermutation(inputMap.getResults(), invPerm);
 
-      // Only fuse if newExprs are now contiguous.
+      // Only fuse if dimension indices are in increasing order to maintain
+      // efficient memory access patterns. This should offset the fact that the
+      // transpose may have multiple uses.
       int64_t prevDim = -1;
       for (int64_t i = 0; i < newExprs.size(); ++i) {
         int64_t dim = cast<AffineDimExpr>(newExprs[i]).getPosition();

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1007,7 +1007,7 @@ private:
   SmallVector<int64_t> permutation;
 };
 
-// Sink transpose through linalg.generic that look like matmul
+// Fuse transpose through linalg.generic that look like matmul
 class FuseTransposeThroughGenericContraction
     : public OpRewritePattern<linalg::GenericOp> {
 public:

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -280,7 +280,7 @@ public:
       for (int i = 0, e = transposedMap.getNumDims(); i < e; ++i) {
         if (transposedMap.isFunctionOfDim(i)) {
           interchange.push_back(
-              llvm::cast<AffineDimExpr>(transposedMap.getResult(permIdx))
+              cast<AffineDimExpr>(transposedMap.getResult(permIdx))
                   .getPosition());
           permIdx++;
           continue;

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1007,7 +1007,24 @@ private:
   SmallVector<int64_t> permutation;
 };
 
-// Fuse transpose through linalg.generic that look like matmul
+// Returns true if the permutation swaps only the last two dimensions.
+static bool isTransposeOfLastTwoDims(ArrayRef<int64_t> perm) {
+  size_t rank = perm.size();
+  if (rank < 2)
+    return false;
+  // Check that all dims except the last two are identity.
+  for (size_t i = 0; i < rank - 2; ++i) {
+    if (perm[i] != static_cast<int64_t>(i))
+      return false;
+  }
+  // Check that the last two dims are swapped.
+  return perm[rank - 2] == static_cast<int64_t>(rank - 1) &&
+         perm[rank - 1] == static_cast<int64_t>(rank - 2);
+}
+
+// Fuses a transpose into a contraction (matmul-like) linalg.generic by
+// absorbing it into the indexing map. Only handles transposes that swap
+// the last two dimensions of an operand for now.
 class FuseTransposeThroughGenericContraction
     : public OpRewritePattern<linalg::GenericOp> {
 public:
@@ -1015,65 +1032,41 @@ public:
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
-    // Just taken from earlier (Specialize pattern)
-    if (!IREE::Flow::isNonNullAndOutsideDispatch(genericOp)) {
+    if (!IREE::Flow::isNonNullAndOutsideDispatch(genericOp))
       return failure();
-    }
 
-    auto maybeContractionDims = linalg::inferContractionDims(genericOp);
-    if (failed(maybeContractionDims)) {
+    FailureOr<linalg::ContractionDimensions> maybeContractionDims =
+        linalg::inferContractionDims(genericOp);
+    if (failed(maybeContractionDims))
       return rewriter.notifyMatchFailure(genericOp, "not a contraction");
-    }
-    auto contractionDims = *maybeContractionDims;
 
+    linalg::ContractionDimensions contractionDims =
+        std::move(*maybeContractionDims);
     if (contractionDims.m.size() != 1 || contractionDims.n.size() != 1 ||
-        contractionDims.k.size() != 1) {
+        contractionDims.k.size() != 1 || contractionDims.batch.size() > 1) {
       return rewriter.notifyMatchFailure(genericOp,
                                          "not a simple matmul contraction");
     }
 
-    // This is a suggestion from Claude. Does this make sense?
-    // Should we even care about batch vs. non-batch?
-    SmallVector<int64_t> expectedPerm;
-    if (contractionDims.batch.empty()) {
-      expectedPerm = {1, 0};
-    } else if (contractionDims.batch.size() == 1) {
-      expectedPerm = {0, 2, 1};
-    } else {
-      return rewriter.notifyMatchFailure(genericOp, "unsupported batch size");
-    }
-
-    // Does it make sense to look for and try to directly fuse the transpose?
+    // Look for a transpose on any input that swaps the last two dimensions.
     for (int64_t inputIdx = 0; inputIdx < genericOp.getNumDpsInputs();
          ++inputIdx) {
-      Value input = genericOp.getDpsInputs()[inputIdx];
-      auto transpose = input.getDefiningOp<linalg::TransposeOp>();
-      if (!transpose) {
+      auto transpose = genericOp.getDpsInputs()[inputIdx]
+                           .getDefiningOp<linalg::TransposeOp>();
+      if (!transpose || !isTransposeOfLastTwoDims(transpose.getPermutation()))
         continue;
-      }
 
-      SmallVector<int64_t> transPerm(transpose.getPermutation());
-      if (transPerm != expectedPerm) {
-        continue;
-      }
-
-      // This does the "fusion" part of the pattern.
-      // Not sure if this is actually correct way to accomplish what we want to
-      // do The other sinking patterns just replace the op with a new one
-      // basically It seems to work though; see line 66 in try.mlir (with these
-      // changes) vs/ line 66 in try-old.mlir (without these changes) After
-      // canonicalizing transpose in place (?) This is modifying the OP in order
-      // to fuse, is this what we want?
-      ArrayRef<int64_t> perm = transpose.getPermutation();
-      auto invPerm = invertPermutationVector(perm);
-
-      SmallVector<AffineMap> newIndexingMaps = genericOp.getIndexingMapsArray();
-      AffineMap inputMap = newIndexingMaps[inputIdx];
+      // Update the indexing map according to the transpose.
+      AffineMap inputMap = genericOp.getMatchingIndexingMap(
+          genericOp.getDpsInputOperand(inputIdx));
+      auto invPerm = invertPermutationVector(transpose.getPermutation());
       SmallVector<AffineExpr> newExprs =
           applyPermutation(inputMap.getResults(), invPerm);
       AffineMap transposedMap =
           AffineMap::get(inputMap.getNumDims(), inputMap.getNumSymbols(),
                          newExprs, rewriter.getContext());
+
+      SmallVector<AffineMap> newIndexingMaps = genericOp.getIndexingMapsArray();
       newIndexingMaps[inputIdx] = transposedMap;
 
       rewriter.startOpModification(genericOp);

--- a/compiler/src/iree/compiler/GlobalOptimization/test/propagate_linalg_transpose.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/propagate_linalg_transpose.mlir
@@ -846,7 +846,7 @@ util.func public @dont_sink_through_edge_expand_shape(%arg0 : tensor<2x3x4xf32>)
 
 // -----
 
-// Matmul generic transpose fusion
+// Matmul generic transpose fusion.
 #map_lhs = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_rhs = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map_out = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -884,7 +884,7 @@ util.func public @fuse_transpose_through_generic_matmul(
 
 // -----
 
-// Batch matmul generic transpose fusion
+// Batch matmul generic transpose fusion.
 #map_bmm_lhs = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map_bmm_rhs = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map_bmm_out = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
@@ -921,7 +921,7 @@ util.func public @fuse_transpose_through_generic_batch_matmul(
 //       CHECK:   util.return %[[BMM]]
 // -----
 
-// Generic reduction transpose fusion
+// Generic reduction transpose fusion.
 #map_red_in = affine_map<(d0, d1) -> (d0)>
 #map_red_rhs = affine_map<(d0, d1) -> (d1, d0)>
 #map_red_out = affine_map<(d0, d1) -> (d0)>

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_rocm.json
@@ -33,7 +33,6 @@
     "compiler_flags": [
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",
-        "--iree-opt-generalize-matmul=false",
         "--iree-opt-const-eval=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-llvmgpu-enable-prefetch",

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
@@ -4,7 +4,6 @@
         "--iree-hal-target-device=hip",
         "--iree-hip-target=gfx942",
         "--iree-opt-level=O3",
-        "--iree-opt-generalize-matmul=false",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-execution-model=async-external",


### PR DESCRIPTION
This PR adds a new pattern `FuseTransposeThroughGenericReduction` that fuses transpose operations into `linalg.generic` ops with reduction dimensions by absorbing the transpose into the indexing map. This pattern will fuse producer transposes with multiple uses (vs other patterns in this pass that look for single use transposes). Importantly, we check to make sure that the reduction op's new indexing map is contiguous, which offsets the transpose having multiple uses.


These changes are needed because `PropagateLinalgTranspose` handles named matmul ops differently than `linalg.generic` matmuls. It will fuse transposes with multiple uses into named matmuls, but not `linalg.generic` ops. CLIP's weights are transposed from NxK to KxN, so fusing the transposes means that the K dim becomes contiguous. This will allow us to remove the `--iree-opt-generalize-matmul=false` flag from CLIP benchmarks without regressions. This was generalized to all reduction ops because some of the matmuls have an M dim of 1 which means that after generalization and dropping unit dims, they don't get identified as matmuls anymore.


These changes were moved from https://github.com/iree-org/iree/pull/22790