### PR TITLE
[Encoding] Add EncodingProperties retrieval to SerializableAttr

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
@@ -68,6 +68,7 @@ iree_compiler_cc_library(
         ":EncodingInterfacesGen",
         ":EncodingOpsIncGen",
         ":EncodingTypesGen",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRTensorUtils
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -201,6 +201,18 @@ def IREEEncoding_SerializableAttr :
     /// both attributes implement SerializableAttr interface
     /// and they are compatible with each other.
     static bool areCompatible(Attribute lhs, Attribute rhs);
+
+    /// Derives encoding properties for all operands and results of an operation.
+    /// The operation is the source of truth for determining the encodings
+    /// (e.g., a linalg.matmul determines encodings for its LHS, RHS, and result).
+    ///
+    /// Returns OpEncodingProperties containing encoding properties for operands
+    /// and results. Each EncodingProperties bundles the encoding attribute with
+    /// any dynamic values needed (e.g., M, N, K dimensions).
+    ///
+    /// Returns failure if the operation is not supported for encoding derivation.
+    static FailureOr<IREE::Encoding::OpEncodingProperties>
+    getEncodingProperties(Operation *op);
   }];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -6,9 +6,13 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 
@@ -26,6 +30,101 @@ bool SerializableAttr::areCompatible(Attribute lhs, Attribute rhs) {
 
   return (!lhsEncoding || lhsEncoding.isCompatibleWith(rhsEncoding)) &&
          (!rhsEncoding || rhsEncoding.isCompatibleWith(lhsEncoding));
+}
+
+/// Given a LinalgOp and one of its OpOperands, return the element type,
+/// inferring unsignedness from the body of the LinalgOp.
+static Type getContractionInputTypeWithSignedness(OpBuilder &builder,
+                                                  linalg::LinalgOp linalgOp,
+                                                  OpOperand *operand) {
+  auto elemType = getElementTypeOrSelf(operand->get().getType());
+  // Infer if unsigned from body ops
+  Value blockArg = linalgOp.getMatchingBlockArgument(operand);
+  for (auto bodyCastOp : blockArg.getParentBlock()->getOps<arith::ExtUIOp>()) {
+    if (bodyCastOp->getOperand(0) == blockArg) {
+      return builder.getIntegerType(elemType.getIntOrFloatBitWidth(),
+                                    /*isSigned=*/false);
+    }
+  }
+  return elemType;
+}
+
+FailureOr<OpEncodingProperties>
+SerializableAttr::getEncodingProperties(Operation *op) {
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp) {
+    return failure();
+  }
+
+  MLIRContext *ctx = op->getContext();
+  OpBuilder builder(ctx);
+
+  OpEncodingProperties props;
+  SmallVector<Type> elemTypes;
+  SmallVector<AffineMap> maps = linalgOp.getIndexingMapsArray();
+  SmallVector<int64_t> iterationSizes = linalgOp.getStaticLoopRanges();
+  EncodingOpType opType;
+
+  auto addEncoding = [&](int64_t operandIndex) {
+    return EncodingProperties{EncodingAttr::get(ctx, operandIndex, opType,
+                                                elemTypes, maps,
+                                                iterationSizes),
+                              /*dynamicValues=*/{}};
+  };
+
+  // Return encoding properties for contraction operations.
+  if (linalg::isaContractionOpInterface(linalgOp)) {
+    // Get element types with signedness inference.
+    Type lhsElemType = getContractionInputTypeWithSignedness(
+        builder, linalgOp, linalgOp.getDpsInputOperand(0));
+    Type rhsElemType = getContractionInputTypeWithSignedness(
+        builder, linalgOp, linalgOp.getDpsInputOperand(1));
+    Type outElemType = getContractionInputTypeWithSignedness(
+        builder, linalgOp, linalgOp.getDpsInitOperand(0));
+
+    if (!lhsElemType || !rhsElemType || !outElemType) {
+      return failure();
+    }
+
+    elemTypes = {lhsElemType, rhsElemType, outElemType};
+    opType = EncodingOpType::matmul;
+
+    props.operands.push_back(addEncoding(MATMUL_LHS));
+    props.operands.push_back(addEncoding(MATMUL_RHS));
+    props.inits.push_back(addEncoding(MATMUL_RESULT));
+
+    return props;
+  }
+
+  // Return encoding properties for scaled contraction operations.
+  if (IREE::LinalgExt::isaScaledContractionOpInterface(linalgOp)) {
+    // Get element types for scaled matmul operands.
+    Type lhsElemType =
+        getElementTypeOrSelf(linalgOp.getDpsInputOperand(0)->get().getType());
+    Type rhsElemType =
+        getElementTypeOrSelf(linalgOp.getDpsInputOperand(1)->get().getType());
+    Type lhsScalesElemType =
+        getElementTypeOrSelf(linalgOp.getDpsInputOperand(2)->get().getType());
+    Type rhsScalesElemType =
+        getElementTypeOrSelf(linalgOp.getDpsInputOperand(3)->get().getType());
+    Type outElemType =
+        getElementTypeOrSelf(linalgOp.getDpsInitOperand(0)->get().getType());
+
+    elemTypes = {lhsElemType, rhsElemType, lhsScalesElemType, rhsScalesElemType,
+                 outElemType};
+    opType = EncodingOpType::scaled_matmul;
+
+    props.operands.push_back(addEncoding(SCALED_MATMUL_LHS));
+    props.operands.push_back(addEncoding(SCALED_MATMUL_RHS));
+    props.operands.push_back(addEncoding(SCALED_MATMUL_LHS_SCALES));
+    props.operands.push_back(addEncoding(SCALED_MATMUL_RHS_SCALES));
+    props.inits.push_back(addEncoding(SCALED_MATMUL_RESULT));
+
+    return props;
+  }
+
+  // Return failure for unsupported operations.
+  return failure();
 }
 
 std::string stringifyOperandIndex(IntegerAttr valueAttr) {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -63,6 +63,29 @@ MatmulNarrowDim getMatmulNarrowDim(linalg::LinalgOp linalgOp,
                                    int narrowThreshold);
 
 // The structs defined here because they are used by encoding_interfaces.td.
+
+/// Bundles an encoding attribute with its associated dynamic information.
+/// This is returned by interface methods that query encoding properties
+/// from operations. Dynamic values can include runtime information needed
+/// by the encoding (e.g., M, N, K dimensions for matmul encodings).
+struct EncodingProperties {
+  /// The encoding attribute for the operand/result.
+  Attribute encoding;
+  /// Dynamic values needed by the encoding. For matmul-like operations,
+  /// these typically correspond to the iteration domain dimensions (M, N, K).
+  /// TODO(#22370): Currently empty; will be populated to support dynamic
+  /// layout decisions.
+  SmallVector<Value> dynamicValues;
+};
+
+/// Bundles encoding properties for all operands and DPS init operands of an
+/// operation. This is returned by SerializableAttr::getEncodingProperties()
+/// when deriving encodings from an operation (e.g., linalg.matmul).
+struct OpEncodingProperties {
+  SmallVector<EncodingProperties> operands;
+  SmallVector<EncodingProperties> inits;
+};
+
 struct PropagationEncoding {
   SmallVector<Attribute> operandEncodings;
   SmallVector<Attribute> resultEncodings;

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -56,25 +56,6 @@ static Value unsetEncoding(OpBuilder &builder, Location loc, Value source,
       builder, loc, unsetEncodingReturnType, source, dynamicSizesVec);
 }
 
-/// Given a LinalgOp and one of its OpOperands, return the element type,
-/// inferring unsignedness from the body of the LinalgOp
-static Type getContractionInputTypeWithSignedness(OpBuilder &builder,
-                                                  linalg::LinalgOp linalgOp,
-                                                  OpOperand *operand) {
-  assert(linalg::isaContractionOpInterface(linalgOp));
-  assert(operand->getOwner() == linalgOp.getOperation());
-  auto elemType = getElementTypeOrSelf(operand->get().getType());
-  // Infer if unsigned from body ops
-  Value blockArg = linalgOp.getMatchingBlockArgument(operand);
-  for (auto bodyCastOp : blockArg.getParentBlock()->getOps<arith::ExtUIOp>()) {
-    if (bodyCastOp->getOperand(0) == blockArg) {
-      return builder.getIntegerType(elemType.getIntOrFloatBitWidth(),
-                                    /*isSigned=*/false);
-    }
-  }
-  return elemType;
-}
-
 static SmallVector<linalg::LinalgOp>
 getDataTilingCandidates(FunctionOpInterface funcOp) {
   SmallVector<linalg::LinalgOp> result;
@@ -87,65 +68,9 @@ getDataTilingCandidates(FunctionOpInterface funcOp) {
   return result;
 }
 
-/// Contains the invariant information across operands for the
-/// iree_encoding.encoding. The operand number is not included because
-/// it is not invariant across operands.
-struct GenericEncodingCommonInfo {
-  IREE::Encoding::EncodingOpType opType;
-  SmallVector<Type> elemTypes;
-  SmallVector<AffineMap> maps;
-  SmallVector<int64_t> iterationSizes;
-};
-
-/// Get the `GenericEncodingCommonInfo` for the `linalgOp` or return failure
-/// if op is not supported. Supported ops are contraction ops and scaled
-/// contraction ops.
-static FailureOr<GenericEncodingCommonInfo>
-getGenericEncodingCommonInfo(RewriterBase &rewriter,
-                             linalg::LinalgOp linalgOp) {
-  // Case 1: ContractionOpInterface
-  if (linalg::isaContractionOpInterface(linalgOp)) {
-    Type lhsElemType = getContractionInputTypeWithSignedness(
-        rewriter, linalgOp, linalgOp.getDpsInputOperand(0));
-    Type rhsElemType = getContractionInputTypeWithSignedness(
-        rewriter, linalgOp, linalgOp.getDpsInputOperand(1));
-    Type outElemType = getContractionInputTypeWithSignedness(
-        rewriter, linalgOp, linalgOp.getDpsInitOperand(0));
-    if (!lhsElemType || !rhsElemType || !outElemType) {
-      return failure();
-    }
-    return GenericEncodingCommonInfo(
-        {/*opType=*/IREE::Encoding::EncodingOpType::matmul,
-         /*elemTypes=*/{lhsElemType, rhsElemType, outElemType},
-         /*map=*/linalgOp.getIndexingMapsArray(),
-         /*iterationSizes=*/linalgOp.getStaticLoopRanges()});
-  }
-  // Case 2: Scaled ContractionOpInterface
-  if (!IREE::LinalgExt::isaScaledContractionOpInterface(linalgOp)) {
-    return failure();
-  }
-  FailureOr<IREE::LinalgExt::ScaledContractionDimensions> cDims =
-      IREE::LinalgExt::inferScaledContractionDims(
-          linalgOp.getIndexingMapsArray());
-  Type lhsElemType =
-      getElementTypeOrSelf(linalgOp.getDpsInputOperand(0)->get().getType());
-  Type rhsElemType =
-      getElementTypeOrSelf(linalgOp.getDpsInputOperand(1)->get().getType());
-  Type lhsScalesElemType =
-      getElementTypeOrSelf(linalgOp.getDpsInputOperand(2)->get().getType());
-  Type rhsScalesElemType =
-      getElementTypeOrSelf(linalgOp.getDpsInputOperand(3)->get().getType());
-  Type outElemType =
-      getElementTypeOrSelf(linalgOp.getDpsInitOperand(0)->get().getType());
-  return GenericEncodingCommonInfo(
-      {/*opType=*/IREE::Encoding::EncodingOpType::scaled_matmul,
-       /*elemTypes=*/
-       {lhsElemType, rhsElemType, lhsScalesElemType, rhsScalesElemType,
-        outElemType},
-       /*map=*/linalgOp.getIndexingMapsArray(),
-       /*iterationSizes=*/linalgOp.getStaticLoopRanges()});
-}
-
+/// Set data tiling encodings using the SerializableAttr interface.
+/// This uses SerializableAttr::getEncodingProperties() to derive encodings
+/// for all operands and results based on the operation type.
 static LogicalResult setDataTilingEncodings(RewriterBase &rewriter,
                                             linalg::LinalgOp linalgOp,
                                             EncodingOptions encodingOption) {
@@ -153,40 +78,29 @@ static LogicalResult setDataTilingEncodings(RewriterBase &rewriter,
   rewriter.setInsertionPoint(linalgOp);
   Location loc = linalgOp.getLoc();
 
-  FailureOr<GenericEncodingCommonInfo> encodingInfo =
-      getGenericEncodingCommonInfo(rewriter, linalgOp);
-  if (failed(encodingInfo)) {
+  // Use the interface to get encoding properties.
+  auto encodingResult =
+      IREE::Encoding::SerializableAttr::getEncodingProperties(linalgOp);
+  if (failed(encodingResult)) {
     return failure();
   }
-  auto setEncodingWrapper = [&](Value src, int64_t operandIndex) -> Value {
-    MLIRContext *ctx = linalgOp.getContext();
-    Attribute encoding = EncodingAttr::get(
-        ctx, operandIndex, encodingInfo->opType, encodingInfo->elemTypes,
-        encodingInfo->maps, encodingInfo->iterationSizes);
-    return setEncoding(rewriter, loc, src, encoding);
-  };
 
+  IREE::Encoding::OpEncodingProperties encProps = *encodingResult;
+
+  // Set encodings on input operands.
   SmallVector<Value> encodedInputOperands;
-  Value encodedInitOperand;
-  if (linalg::isaContractionOpInterface(linalgOp)) {
-    encodedInputOperands.push_back(setEncodingWrapper(
-        linalgOp.getDpsInputs()[0], IREE::Encoding::MATMUL_LHS));
-    encodedInputOperands.push_back(setEncodingWrapper(
-        linalgOp.getDpsInputs()[1], IREE::Encoding::MATMUL_RHS));
-    encodedInitOperand = setEncodingWrapper(linalgOp.getDpsInits()[0],
-                                            IREE::Encoding::MATMUL_RESULT);
-  } else {
-    encodedInputOperands.push_back(setEncodingWrapper(
-        linalgOp.getDpsInputs()[0], IREE::Encoding::SCALED_MATMUL_LHS));
-    encodedInputOperands.push_back(setEncodingWrapper(
-        linalgOp.getDpsInputs()[1], IREE::Encoding::SCALED_MATMUL_RHS));
-    encodedInputOperands.push_back(setEncodingWrapper(
-        linalgOp.getDpsInputs()[2], IREE::Encoding::SCALED_MATMUL_LHS_SCALES));
-    encodedInputOperands.push_back(setEncodingWrapper(
-        linalgOp.getDpsInputs()[3], IREE::Encoding::SCALED_MATMUL_RHS_SCALES));
-    encodedInitOperand = setEncodingWrapper(
-        linalgOp.getDpsInits()[0], IREE::Encoding::SCALED_MATMUL_RESULT);
+  for (auto [idx, props] : llvm::enumerate(encProps.operands)) {
+    Value src = linalgOp.getDpsInputs()[idx];
+    Value encoded = setEncoding(rewriter, loc, src, props.encoding);
+    encodedInputOperands.push_back(encoded);
   }
+
+  // Set encoding on init operand.
+  // For now, we assume single init.
+  assert(encProps.inits.size() == 1 && "Expected single init encoding");
+  Value encodedInitOperand = setEncoding(
+      rewriter, loc, linalgOp.getDpsInits()[0], encProps.inits[0].encoding);
+
   SmallVector<Value> encodedOperands(encodedInputOperands);
   encodedOperands.push_back(encodedInitOperand);
   Value opTiled =


### PR DESCRIPTION
Implements phase 1 for supporting dynamic encoding layout decisions: https://github.com/iree-org/iree/issues/22370

- **Add `EncodingProperties` struct** — Bundles encoding attribute with dynamic values (M, N, K). Returned when querying encodings from operations.
- **Extend `SerializableAttr` interface** — Add `getOperandEncodingProperties(Operation*)` that derives encodings + dynamic values for all operands. The operation is the source of truth.
- **Refactor `SetEncoding` pass** — Use the interface instead of manually constructing encodings. Initially passes zero dynamic values.