### PR TITLE
[LLVMGPU] Remove fold unit extent dims from vector distribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -825,29 +825,8 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createLLVMGPUConfigureTensorLayoutsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
 
-  // Generalize all named ops so that we can fold away unit extent dims. By this
-  // point, all tiling is finished so the tiling configurations on those ops can
-  // be safely dropped. This additionally allows vectorization of convolution to
-  // `vector.contract` as filter dimensions are expected to be tiled to 1 by
-  // this point.
-  funcPassManager.addPass(createLinalgGeneralizeNamedOpsPass());
-  {
-    IREE::LinalgExt::FoldUnitExtentDimsPassOptions options;
-    options.useReshapes = false;
-    funcPassManager.addPass(
-        IREE::LinalgExt::createFoldUnitExtentDimsPass(options));
-  }
-  funcPassManager.addPass(
-      IREE::VectorExt::createVectorExtFoldUnitExtentDimsPass());
-  {
-    LinalgFoldUnitExtentDimsPassOptions options;
-    options.useRankReducingSlices = true;
-    funcPassManager.addPass(mlir::createLinalgFoldUnitExtentDimsPass(options));
-    funcPassManager.addPass(createCanonicalizerPass());
-    funcPassManager.addPass(createCSEPass());
-    funcPassManager.addPass(tensor::createFoldTensorSubsetOpsPass());
-  }
-
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
 
   // Linalg -> Vector

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -828,6 +828,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
+  funcPassManager.addPass(tensor::createFoldTensorSubsetOpsPass());
 
   // Linalg -> Vector
   funcPassManager.addPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -871,7 +871,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
-// CHECK-SAME: -> (vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x4x1x1x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x2x4x1x1x1x1x1x4xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>)
 // CHECK-COUNT-48:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
@@ -938,7 +938,7 @@ hal.executable private @attention_multiple_m_transpose {
 
 // CHECK-LABEL: func.func @attention_multiple_m_transpose()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c64
-// CHECK-SAME: -> (vector<1x1x2x1x1x1x1x1x1xf32>, vector<1x1x2x1x1x1x1x1x1xf32>, vector<1x1x2x4x1x1x1x1x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x2x4x1x1x1x1x1x1x1x4xf32>, vector<1x1x2x1x1x1x1x1x1xf32>, vector<1x1x2x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-96:  amdgpu.mfma 16x16x16 {{.*}}blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
@@ -1005,7 +1005,7 @@ hal.executable private @attention_mfma_32x32x8 {
 
 // CHECK-LABEL: func.func @attention_mfma_32x32x8()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c32
-// CHECK-SAME: -> (vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-24:  amdgpu.mfma 32x32x8 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
 // CHECK: scf.yield
 
@@ -1083,7 +1083,7 @@ hal.executable private @online_attention_split_k2 {
 
 // CHECK-LABEL: func.func @online_attention_split_k2()
 // CHECK: scf.for %{{.*}} = %c0 to %c256 step %c32
-// CHECK-SAME: -> (vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x4x1x1x1x1x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x1x4x1x1x1x1x1x1x1x4xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-16:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -153,13 +153,13 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 //          CHECK: func @expanded_matmul_transpose_b
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
 // prefetching, we have one iteration peeled of so upper bound is 2048 - 128 = 1920.
-//          CHECK:   scf.for {{.*}} = %c0 to %c1920 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<4x1x1x1x4x1xf16>)
-//          CHECK:     arith.extf %[[ARG]] : vector<4x1x1x1x4x1xf16> to vector<4x1x1x1x4x1xf32>
+//          CHECK:   scf.for {{.*}} = %c0 to %c1920 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<1x1x4x1x1x1x1x1x1x1x4x1xf16>)
+//          CHECK:     arith.extf %[[ARG]] : vector<1x1x4x1x1x1x1x1x1x1x4x1xf16> to vector<1x1x4x1x1x1x1x1x1x1x4x1xf32>
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<4x1x1x1x4x1xf32> to vector<4x1x1x1x4x1xf16>
-//          CHECK:     scf.yield %[[TRUNC]] : vector<4x1x1x1x4x1xf16>
+//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<1x1x4x1x1x1x1x1x1x1x4x1xf32> to vector<1x1x4x1x1x1x1x1x1x1x4x1xf16>
+//          CHECK:     scf.yield %[[TRUNC]] : vector<1x1x4x1x1x1x1x1x1x1x4x1xf16>
 // CHECK-COUNT-32:   amdgpu.mfma
-//  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
 
 // -----
 
@@ -207,7 +207,7 @@ hal.executable @matmul_multiple_k {
 // CHECK:            affine.delinearize_index %[[IV]] into (128, 16)
 // CHECK-COUNT-32:   amdgpu.mfma
 // CHECK:            scf.yield
-// CHECK-COUNT-4:  vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-COUNT-4:  vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
 
 // -----
 
@@ -432,11 +432,11 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //    CHECK-LABEL: func.func @conv_nhwc
-//          CHECK:   scf.for {{.*}} = %c0 to %c215 step %c1 iter_args({{.*}}) -> (vector<2x4x1x1x4x1xf32>)
+//          CHECK:   scf.for {{.*}} = %c0 to %c215 step %c1 iter_args({{.*}}) -> (vector<1x1x2x4x1x1x1x1x1x1x4x1xf32>)
 // CHECK-COUNT-16:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 //          CHECK:     scf.yield
 // CHECK-COUNT-16:   amdgpu.mfma
-//  CHECK-COUNT-8:   vector.transfer_write {{.+}} : vector<4x1xf32>, memref<2x256x512x256xf32, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-COUNT-8:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf32>, memref<2x256x512x256xf32, #amdgpu.address_space<fat_raw_buffer>>
 
 // -----
 
@@ -495,13 +495,13 @@ hal.executable public @main_dispatch_expanded_matmul {
 //    CHECK-LABEL: func.func @generic_2x1024x20x64x1280_f16
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
 // prefetching, we have one iteration peeled of so upper bound is 1280 - 128 = 1152.
-//          CHECK:   scf.for {{.*}} = %c0 to %c1152 step %c128 iter_args({{.*}}) -> (vector<2x2x1x1x4x1xf16>)
+//          CHECK:   scf.for {{.*}} = %c0 to %c1152 step %c128 iter_args({{.*}}) -> (vector<1x2x1x2x1x1x1x1x1x4x1x1xf16>)
 // Each subgroup handles 2 * 2 tiles, and for each tile we accumulate 8 times
 // along the K dimension. So in total 32 mfma ops.
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     scf.yield %{{.+}} : vector<2x2x1x1x4x1xf16>
+//          CHECK:     scf.yield %{{.+}} : vector<1x2x1x2x1x1x1x1x1x4x1x1xf16>
 // CHECK-COUNT-32:   amdgpu.mfma
-//  CHECK-COUNT-4:   vector.transfer_write {{.+}} : vector<4x1xf16>
+//  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x4x1x1xf16>, memref<2x1024x20x64xf16, #amdgpu.address_space<fat_raw_buffer>>
 
 // -----
 
@@ -552,11 +552,11 @@ hal.executable public @contract_schedule_considering_read_layout {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK-LABEL: func.func @contract_schedule_considering_read_layout()
-// CHECK-DAG:     %[[RHS_SHARED:.+]] = memref.alloc() : memref<128x132xf16, #gpu.address_space<workgroup>>
-// CHECK-DAG:     memref.subview %[[RHS_SHARED]][0, 0] [128, 128] [1, 1]
-// CHECK-DAG:     %[[LHS_SHARED:.+]] = memref.alloc() : memref<16x132xf16, #gpu.address_space<workgroup>>
-// CHECK-DAG:     memref.subview %[[LHS_SHARED]][0, 0] [16, 128] [1, 1]
-// CHECK:   scf.for {{.*}} = %c0 to %c1408 step %c128 iter_args({{.*}}) -> (vector<1x2x1x1x4x1xf16>)
+// CHECK-DAG:     %[[RHS_SHARED:.+]] = memref.alloc() : memref<1x128x132xf16, #gpu.address_space<workgroup>>
+// CHECK-DAG:     memref.subview %[[RHS_SHARED]][0, 0, 0] [1, 128, 128] [1, 1, 1]
+// CHECK-DAG:     %[[LHS_SHARED:.+]] = memref.alloc() : memref<1x16x132xf16, #gpu.address_space<workgroup>>
+// CHECK-DAG:     memref.subview %[[LHS_SHARED]][0, 0, 0] [1, 16, 128] [1, 1, 1]
+// CHECK:   scf.for {{.*}} = %c0 to %c1408 step %c128 iter_args({{.*}}) -> (vector<1x1x2x1x1x1x1x4x1xf16>)
 // CHECK-COUNT-16:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK:     scf.yield
 // CHECK-COUNT-16:   amdgpu.mfma
@@ -871,7 +871,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
-// CHECK-SAME: -> (vector<2x1x1xf32>, vector<2x1x1xf32>, vector<2x4x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x4x1x1x1x1x1x4xf32>)
 // CHECK-COUNT-48:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
@@ -938,7 +938,7 @@ hal.executable private @attention_multiple_m_transpose {
 
 // CHECK-LABEL: func.func @attention_multiple_m_transpose()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c64
-// CHECK-SAME: -> (vector<2x1x1xf32>, vector<2x1x1xf32>, vector<2x4x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x2x1x1x1x1x1x1xf32>, vector<1x1x2x1x1x1x1x1x1xf32>, vector<1x1x2x4x1x1x1x1x1x1x1x4xf32>)
 // CHECK-COUNT-96:  amdgpu.mfma 16x16x16 {{.*}}blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
@@ -1005,7 +1005,7 @@ hal.executable private @attention_mfma_32x32x8 {
 
 // CHECK-LABEL: func.func @attention_mfma_32x32x8()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c32
-// CHECK-SAME: -> (vector<1x1x1xf32>, vector<1x1x1xf32>, vector<1x2x1x4x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>)
 // CHECK-COUNT-24:  amdgpu.mfma 32x32x8 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
 // CHECK: scf.yield
 
@@ -1083,7 +1083,7 @@ hal.executable private @online_attention_split_k2 {
 
 // CHECK-LABEL: func.func @online_attention_split_k2()
 // CHECK: scf.for %{{.*}} = %c0 to %c256 step %c32
-// CHECK-SAME: -> (vector<1x1x1xf32>, vector<1x1x1xf32>, vector<1x4x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x4x1x1x1x1x1x1x1x4xf32>)
 // CHECK-COUNT-16:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
@@ -1157,7 +1157,7 @@ module {
 // CHECK-LABEL: func.func @attention_gather_k
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
 // CHECK:      vector.gather
-// CHECK-SAME: into vector<4x1x1x1x1x8xf16>
+// CHECK-SAME: into vector<1x1x4x1x1x1x1x1x1x1x1x8xf16>
 // CHECK: scf.yield
 
 // MEMORY-LABEL: func.func @attention_gather_k

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
@@ -457,7 +457,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c128
-// CHECK-SAME: -> (vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x4x1x1x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x2x4x1x1x1x1x1x4xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>)
 // CHECK-COUNT-32:  amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<4xf32>
 // CHECK-COUNT-16:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
@@ -525,7 +525,7 @@ hal.executable private @attention_mfma_32x32x16 {
 
 // CHECK-LABEL: func.func @attention_mfma_32x32x16()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c64
-// CHECK-SAME: -> (vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-16:  amdgpu.mfma 32x32x16 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<16xf32>
 // CHECK-COUNT-8:  amdgpu.mfma 32x32x8 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
 // CHECK: scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
@@ -153,13 +153,13 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 //    CHECK-LABEL: func @expanded_matmul_transpose_b
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
 // prefetching, we have one iteration peeled of so upper bound is 2048 - 256 = 1792.
-//          CHECK:   scf.for {{.*}} = %c0 to %c1792 step %c256 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<4x1x1x1x4x1xf16>)
-//          CHECK:     arith.extf %[[ARG]] : vector<4x1x1x1x4x1xf16> to vector<4x1x1x1x4x1xf32>
+//          CHECK:   scf.for {{.*}} = %c0 to %c1792 step %c256 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<1x1x4x1x1x1x1x1x1x1x4x1xf16>)
+//          CHECK:     arith.extf %[[ARG]] : vector<1x1x4x1x1x1x1x1x1x1x4x1xf16> to vector<1x1x4x1x1x1x1x1x1x1x4x1xf32>
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<4xf32>
-//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<4x1x1x1x4x1xf32> to vector<4x1x1x1x4x1xf16>
-//          CHECK:     scf.yield %[[TRUNC]] : vector<4x1x1x1x4x1xf16>
+//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<1x1x4x1x1x1x1x1x1x1x4x1xf32> to vector<1x1x4x1x1x1x1x1x1x1x4x1xf16>
+//          CHECK:     scf.yield %[[TRUNC]] : vector<1x1x4x1x1x1x1x1x1x1x4x1xf16>
 // CHECK-COUNT-32:   amdgpu.mfma
-//  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
 
 // -----
 
@@ -207,7 +207,7 @@ hal.executable @matmul_multiple_k {
 // CHECK:            affine.delinearize_index %[[IV]] into (128, 16)
 // CHECK-COUNT-32:   amdgpu.mfma
 // CHECK:            scf.yield
-// CHECK-COUNT-4:  vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-COUNT-4:  vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf16>, memref<2x10x64x64xf16, #amdgpu.address_space<fat_raw_buffer>>
 
 // -----
 
@@ -457,7 +457,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c128
-// CHECK-SAME: -> (vector<2x1x1xf32>, vector<2x1x1xf32>, vector<2x4x1x1x1x4xf32>)
+// CHECK-SAME: -> (vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x4x1x1x1x1x1x4xf32>)
 // CHECK-COUNT-32:  amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<4xf32>
 // CHECK-COUNT-16:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
@@ -525,7 +525,7 @@ hal.executable private @attention_mfma_32x32x16 {
 
 // CHECK-LABEL: func.func @attention_mfma_32x32x16()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c64
-// CHECK-SAME: -> (vector<1x1x1xf32>, vector<1x1x1xf32>, vector<1x2x1x4x1x4xf32>)
+// CHECK-SAME: -> (vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>)
 // CHECK-COUNT-16:  amdgpu.mfma 32x32x16 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<16xf32>
 // CHECK-COUNT-8:  amdgpu.mfma 32x32x8 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
 // CHECK: scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -575,7 +575,7 @@ hal.executable private @attention_4xDx1x32x128xf16 {
 
 //     CHECK-LABEL: func.func @attention_4xDx1x32x128xf16
 //           CHECK:   scf.forall ({{.*}}) in (4)
-//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x16x1x1x1x1x1x1x1x1x1x1x1x8xf32>) {
+//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x16x1x1x1x1x1x1x1x1x1x1x1x8xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>) {
 //       CHECK-NOT:       gpu.subgroup_reduce
 //           CHECK:       scf.yield
 //

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -51,7 +51,7 @@ hal.executable private @matvec_fp16 {
 //     CHECK-LABEL: func.func @matvec_fp16
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
+//     CHECK-SAME:      vector<1x1x1x1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1x1x1x1xf16>
 //          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
 //          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
 
@@ -108,7 +108,7 @@ hal.executable private @matvec_fp16_parallel_subgroup {
 //     CHECK-LABEL: func.func @matvec_fp16_parallel_subgroup
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c512
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
+//     CHECK-SAME:      vector<1x1x1x1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1x1x1x1xf16>
 //          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
 //          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
 
@@ -169,7 +169,7 @@ hal.executable private @matvec_fp16_promote_rhs {
 //          CHECK:      %[[RHS_SHARED_READ:.+]] = vector.transfer_read %alloc
 //          CHECK:      %[[RHS_INSERT:.+]] = vector.insert_strided_slice %[[RHS_SHARED_READ]]
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      %{{.*}}, %[[RHS_INSERT]], %{{.*}} : vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
+//     CHECK-SAME:      %{{.*}}, %[[RHS_INSERT]], %{{.*}} : vector<1x1x1x1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1x1x1x1xf16>
 //          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
 //          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
 
@@ -255,7 +255,7 @@ hal.executable private @attention_20x1x64x4096x64 {
 // CHECK:         scf.for %{{.*}} = %c0 to %c4096 step %c128
 // QK Matmul
 // CHECK:           vector.contract
-// CHECK-SAME:      vector<1x1x32xf16>, vector<1x1x1x1x4x32xf16> into vector<1x1x4xf32>
+// CHECK-SAME:      vector<1x1x1x1x1x1x1x1x32xf16>, vector<1x1x1x1x1x1x1x4x32xf16> into vector<1x1x1x1x1x1x1x1x4xf32>
 // CHECK-COUNT-4:   gpu.subgroup_reduce  add
 
 // QK Max
@@ -349,7 +349,7 @@ hal.executable private @attention_20x1x64x4096x64 {
 // CHECK:         scf.for %{{.*}} = %c0 to %c4096 step %c128
 // QK Matmul
 // CHECK:           vector.contract
-// CHECK-SAME:      vector<1x1x32xf16>, vector<1x1x1x1x4x32xf16> into vector<1x1x4xf32>
+// CHECK-SAME:      vector<1x1x1x1x1x1x1x1x32xf16>, vector<1x1x1x1x1x1x1x4x32xf16> into vector<1x1x1x1x1x1x1x4x1xf32>
 // CHECK-COUNT-4:   gpu.subgroup_reduce  add
 
 // No subgroup reduction in the loop other than QK reductions
@@ -361,13 +361,13 @@ hal.executable private @attention_20x1x64x4096x64 {
 // CHECK-COUNT-1:   gpu.subgroup_reduce  maximumf
 
 // Sum
-// CHECK:           vector.contract
-// CHECK-SAME:      vector<1x1x4xf32>, vector<1x1x4xf32> into f32
+// CHECK:           vector.multi_reduction <add>
+// CHECK-SAME:      vector<1x1x1x1x1x1x4x1x1xf32> to vector<1x1x1x1x1x1xf32>
 // CHECK-COUNT-1:   gpu.subgroup_reduce  add
 
 // PV Matmul
-// CHECK:           vector.contract
-// CHECK-SAME:      vector<1x1x4xf32>, vector<1x2x1x1x4x4xf32> into vector<2x1x4xf32>
+// CHECK:           vector.multi_reduction
+// CHECK-SAME:      vector<1x1x1x2x1x1x1x1x4x1x1x4xf32> to vector<1x1x2x1x1x1x1x1x4xf32>
 // CHECK-COUNT-8:   gpu.subgroup_reduce  add
 
 
@@ -420,7 +420,7 @@ hal.executable private @matvec_fp16 {
 //     CHECK-LABEL: func.func @matvec_fp16_subgroup_reduction
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      vector<1x1x4xf16>, vector<1x1x1x1x1x4xf16> into vector<1x1x1xf16>
+//     CHECK-SAME:      vector<1x1x1x1x1x4xf16>, vector<1x1x1x1x1x4xf16> into vector<1x1x1x1x1x1xf16>
 //          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
 //          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
 //          CHECK:        gpu.barrier memfence [#gpu.address_space<workgroup>]
@@ -575,7 +575,7 @@ hal.executable private @attention_4xDx1x32x128xf16 {
 
 //     CHECK-LABEL: func.func @attention_4xDx1x32x128xf16
 //           CHECK:   scf.forall ({{.*}}) in (4)
-//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1xf32>, vector<1x1x16x1x1x1x1x1x8xf32>) {
+//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x16x1x1x1x1x1x1x1x1x1x1x1x8xf32>) {
 //       CHECK-NOT:       gpu.subgroup_reduce
 //           CHECK:       scf.yield
 //

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -37,19 +37,18 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @warp_reduction_dispatch()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
-//     CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x4xf32>
-//     CHECK-DAG:    %[[CST_ACC:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1xf32>
+//     CHECK-DAG:    %[[CST_ACC:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x1xf32>
 //     CHECK-DAG:    gpu.thread_id  x
-//         CHECK:    %[[R0:.+]] = scf.for %{{.*}} = %c0 to %c2560 step %c256 iter_args(%[[A0:.+]] = %[[CST_ACC]]) -> (vector<1x1x1xf32>) {
+//         CHECK:    %[[R0:.+]] = scf.for %{{.*}} = %c0 to %c2560 step %c256 iter_args(%[[A0:.+]] = %[[CST_ACC]]) -> (vector<1x1x1x1x1x1xf32>) {
 //         CHECK:      memref.expand_shape {{.*}} : memref<1x1024xf32, {{.*}}> into memref<1x256x4xf32, {{.*}}>
-//         CHECK:      %[[V:.+]] = vector.transfer_read {{.*}} : memref<1x256x4xf32, {{.*}}>, vector<1x4xf32>
-//         CHECK:      %[[STRIDED:.+]] = vector.insert_strided_slice %[[V]], {{.*}} : vector<1x4xf32> into vector<1x1x1x1x1x4xf32>
-//         CHECK:      %[[REDUCE:.+]] = vector.multi_reduction <add>, %[[STRIDED]], %[[CST_ACC]] [1, 3, 5] : vector<1x1x1x1x1x4xf32> to vector<1x1x1xf32>
-//         CHECK:      %[[ADD:.+]] = arith.addf %[[REDUCE]], %[[A0]] : vector<1x1x1xf32>
-//         CHECK:      scf.yield %[[ADD]] : vector<1x1x1xf32>
+//         CHECK:      %[[V:.+]] = vector.transfer_read {{.*}} : memref<1x256x4xf32, {{.*}}>, vector<1x1x4xf32>
+//         CHECK:      %[[STRIDED:.+]] = vector.insert_strided_slice %[[V]], {{.*}} : vector<1x1x4xf32> into vector<1x1x1x1x1x1x1x1x4xf32>
+//         CHECK:      %[[REDUCE:.+]] = vector.multi_reduction <add>, %[[STRIDED]], %[[CST_ACC]] [2, 5, 8] : vector<1x1x1x1x1x1x1x1x4xf32> to vector<1x1x1x1x1x1xf32>
+//         CHECK:      %[[ADD:.+]] = arith.addf %[[REDUCE]], %[[A0]] : vector<1x1x1x1x1x1xf32>
+//         CHECK:      scf.yield %[[ADD]] : vector<1x1x1x1x1x1xf32>
 //         CHECK:    }
 //         CHECK:    gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
-//         CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<10xf32, #gpu.address_space<workgroup>>
+//         CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<1x10xf32, #gpu.address_space<workgroup>>
 //         CHECK:    gpu.barrier memfence [#gpu.address_space<workgroup>]
 //         CHECK:    vector.transfer_read %[[ALLOC]]{{.*}}
 //         CHECK:    gpu.subgroup_reduce  add {{.*}} cluster(size = 8) : (f32) -> f32
@@ -104,15 +103,15 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @warp_reduction_broadcast_dispatch()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
-//         CHECK:    scf.for {{.*}} -> (vector<1x1x1xf32>) {
+//         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1xf32>) {
 //         CHECK:      memref.expand_shape {{.*}} : memref<1x1024xf32, {{.*}}> into memref<1x256x4xf32, {{.*}}>
-//         CHECK:      vector.transfer_read {{.*}} : memref<1x256x4xf32, {{.*}}>, vector<1x4xf32>
-//         CHECK:      vector.multi_reduction <add>, {{.*}} [1, 3, 5] : vector<1x1x1x1x1x4xf32> to vector<1x1x1xf32>
-//         CHECK:      arith.addf {{.*}} : vector<1x1x1xf32>
+//         CHECK:      vector.transfer_read {{.*}} : memref<1x256x4xf32, {{.*}}>, vector<1x1x4xf32>
+//         CHECK:      vector.multi_reduction <add>, {{.*}} [2, 5, 8] : vector<1x1x1x1x1x1x1x1x4xf32> to vector<1x1x1x1x1x1xf32>
+//         CHECK:      arith.addf {{.*}} : vector<1x1x1x1x1x1xf32>
 //         CHECK:      scf.yield
 //         CHECK:    gpu.subgroup_reduce
 //         CHECK:    gpu.subgroup_reduce
-//         CHECK:    arith.divf {{.*}} : vector<f32>
+//         CHECK:    arith.divf {{.*}} : vector<1x1x1xf32>
 //         CHECK:    return
 
 // -----
@@ -145,16 +144,16 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @softmax()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
-//         CHECK:    scf.for {{.*}} -> (vector<1x1x1xf32>) {
+//         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1xf32>) {
 //         CHECK:      memref.expand_shape {{.*}} : memref<1x1x4096xf32, {{.*}}> into memref<1x1x1024x4xf32, {{.*}}>
-//         CHECK:      vector.transfer_read {{.*}} : memref<1x1x1024x4xf32, {{.*}}>, vector<1x4xf32>
-//         CHECK:      vector.multi_reduction <maxnumf>, {{.*}} {{.*}} : vector<1x1x1x1x1x4xf32> to vector<1x1x1xf32>
-//         CHECK:      arith.maxnumf {{.*}} : vector<1x1x1xf32>
+//         CHECK:      vector.transfer_read {{.*}} : memref<1x1x1024x4xf32, {{.*}}>, vector<1x1x1x4xf32>
+//         CHECK:      vector.multi_reduction <maxnumf>, {{.*}} {{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf32> to vector<1x1x1x1x1x1x1x1x1xf32>
+//         CHECK:      arith.maxnumf {{.*}} : vector<1x1x1x1x1x1x1x1x1xf32>
 //         CHECK:      scf.yield
 //         CHECK:    gpu.subgroup_reduce  maxnumf
 //         CHECK:    gpu.barrier memfence [#gpu.address_space<workgroup>]
 //         CHECK:    gpu.subgroup_reduce  maxnumf
-//         CHECK:    scf.for {{.*}} -> (vector<1x1x1xf32>) {
+//         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1xf32>) {
 //         CHECK:      vector.transfer_read
 //         CHECK:      arith.subf
 //         CHECK:      math.exp
@@ -203,15 +202,15 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @softmax_singlesubgroup()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
-//         CHECK:    scf.for {{.*}} -> (vector<1x1x1xf32>) {
+//         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1xf32>) {
 //         CHECK:      memref.expand_shape {{.*}} : memref<1x1x128xf32, {{.*}}> into memref<1x1x32x4xf32, {{.*}}>
-//         CHECK:      vector.transfer_read {{.*}} : memref<1x1x32x4xf32, {{.*}}>, vector<1x4xf32>
-//         CHECK:      vector.multi_reduction <maxnumf>, {{.*}} {{.*}} : vector<1x1x1x1x1x4xf32> to vector<1x1x1xf32>
-//         CHECK:      arith.maxnumf {{.*}} : vector<1x1x1xf32>
+//         CHECK:      vector.transfer_read {{.*}} : memref<1x1x32x4xf32, {{.*}}>, vector<1x1x1x4xf32>
+//         CHECK:      vector.multi_reduction <maxnumf>, {{.*}} {{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf32> to vector<1x1x1x1x1x1x1x1x1xf32>
+//         CHECK:      arith.maxnumf {{.*}} : vector<1x1x1x1x1x1x1x1x1xf32>
 //         CHECK:      scf.yield
 //         CHECK:    gpu.subgroup_reduce  maxnumf
-//         CHECK:    vector.broadcast %{{.*}} : f32 to vector<1x1x1x1x1x4xf32>
-//         CHECK:    scf.for {{.*}} -> (vector<1x1x1xf32>) {
+//         CHECK:    vector.broadcast %{{.*}} : f32 to vector<1x1x1x1x1x1x1x1x1x1x1x4xf32>
+//         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1xf32>) {
 //         CHECK:      vector.transfer_read
 //         CHECK:      arith.subf
 //         CHECK:      math.exp
@@ -520,16 +519,16 @@ hal.executable private @i4_dequant_matvec {
 //     CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //     CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//     CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1xf16>
-//         CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<1x1x1xf16>)
+//     CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x1x1x1x1xf16>
+//         CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<1x1x1x1x1x1x1x1x1xf16>)
 //         CHECK:     memref.expand_shape {{.*}} : memref<1x128xf16, {{.*}}> into memref<1x32x4xf16, {{.*}}>
+//         CHECK:     vector.transfer_read {{.*}} : memref<1x32x4xf16, {{.*}}>, vector<1x1x4xf16>
 //         CHECK:     memref.expand_shape {{.*}} : memref<1x1x128xi4, {{.*}}> into memref<1x1x32x4xi4, {{.*}}>
-//         CHECK:     vector.transfer_read {{.*}} : memref<1x32x4xf16, {{.*}}>, vector<1x4xf16>
-//         CHECK:     vector.transfer_read {{.*}} : memref<1x1x32x4xi4, {{.*}}>, vector<1x4xi4>
-//         CHECK:     arith.extui %{{.*}} : vector<1x1x1x1x1x4xi4> to vector<1x1x1x1x1x4xi32>
-//         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x4xi32> to vector<1x1x1x1x1x4xf16>
-//         CHECK:     arith.subf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x4xf16>
-//         CHECK:     arith.mulf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x4xf16>
-//         CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x4xf16>, vector<1x1x1x1x1x4xf16> into vector<1x1x1xf16>
+//         CHECK:     vector.transfer_read {{.*}} : memref<1x1x32x4xi4, {{.*}}>, vector<1x1x1x4xi4>
+//         CHECK:     arith.extui %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<1x1x1x1x1x1x1x1x1x1x1x4xi32>
+//         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xi32> to vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     arith.subf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     arith.mulf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<1x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<1x1x1x1x1x1x1x1x1xf16>
 
-//         CHECK:   vector.extract {{.*}} : f16 from vector<1x1x1xf16>
+//         CHECK:   vector.shape_cast %{{.*}} : vector<1x1x1x1x1x1x1x1x1xf16> to vector<1x1x1xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -138,16 +138,16 @@ hal.executable private @i4_dequant_matvec {
 //     RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //     RDNA3-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //     RDNA3-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//     RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x1xf16>
-//         RDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x1xf16>)
+//     RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x1x1x1x1xf16>
+//         RDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x1x1x1x1xf16>)
 //         RDNA3:   memref.expand_shape {{.*}} : memref<4x1x128xi4, {{.*}}> into memref<4x1x32x4xi4, {{.*}}>
-//         RDNA3:   %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x4xi32>
-//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x4xi32> to vector<4x1x1x1x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x4xf16>
-//         RDNA3:   vector.contract {{.*}} : vector<1x1x1x1x1x4xf16>, vector<4x1x1x1x1x1x1x1x4xf16> into vector<4x1x1x1x1x1xf16>
+//         RDNA3:   %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x1x1x1x4xi32>
+//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xi32> to vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<4x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<4x1x1x1x1x1x1x1x1xf16>
 
-//         RDNA3:   vector.shape_cast %{{.*}} : vector<4x1x1x1x1x1xf16> to vector<4x1x1xf16>
+//         RDNA3:   vector.shape_cast %{{.*}} : vector<4x1x1x1x1x1x1x1x1xf16> to vector<4x1x1xf16>
 
 // -----
 
@@ -253,12 +253,12 @@ hal.executable private @matvec_fp16 {
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //      CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-//      CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8x1x1x1x1x1xf16>
-//          CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C64]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<8x1x1x1x1x1xf16>)
+//      CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x8x1x1x1x1x1x1x1xf16>
+//          CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C64]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<1x8x1x1x1x1x1x1x1xf16>)
 //          CHECK:     memref.expand_shape {{.*}} : memref<8x512xf16, {{.*}}> into memref<8x64x8xf16, {{.*}}>
-//          CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x8xf16>, vector<8x1x1x1x1x1x1x1x8xf16> into vector<8x1x1x1x1x1xf16>
+//          CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x8xf16>, vector<8x1x1x1x1x1x1x1x8xf16> into vector<1x8x1x1x1x1x1x1x1xf16>
 
-//          CHECK: vector.shape_cast %{{.*}} : vector<8x1x1x1x1x1xf16> to vector<8x1x1xf16>
+//          CHECK: vector.shape_cast %{{.*}} : vector<1x8x1x1x1x1x1x1x1xf16> to vector<1x8x1x1x1x1xf16>
 
 // -----
 
@@ -306,12 +306,12 @@ hal.executable private @matvec_fp16 {
 //      RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      RDNA3-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //      RDNA3-DAG:   %[[C32:.+]] = arith.constant 32 : index
-//      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x1xf16>
-//          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C32]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<4x1x1x1x1x1xf16>)
+//      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x4x1x1x1x1x1x1x1xf16>
+//          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C32]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<1x4x1x1x1x1x1x1x1xf16>)
 //          RDNA3:     memref.expand_shape {{.*}} : memref<4x256xf16, {{.*}}> into memref<4x32x8xf16, {{.*}}>
-//          RDNA3:     vector.contract {{.*}} : vector<1x1x1x1x1x8xf16>, vector<4x1x1x1x1x1x1x1x8xf16> into vector<4x1x1x1x1x1xf16>
+//          RDNA3:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x8xf16>, vector<4x1x1x1x1x1x1x1x8xf16> into vector<1x4x1x1x1x1x1x1x1xf16>
 
-//          RDNA3: vector.shape_cast %{{.*}} : vector<4x1x1x1x1x1xf16> to vector<4x1x1xf16>
+//          RDNA3: vector.shape_cast %{{.*}} : vector<1x4x1x1x1x1x1x1x1xf16> to vector<1x4x1x1x1x1xf16>
 
 // -----
 


### PR DESCRIPTION
This unit dim folding was added early on when the pipeline was created. It helps reduce some cognitive load in tests, but adds a lot of implementation overhead for each new codegen op to implement unit dim extent folding. Vectorization completly fails if this unit dim folding doesn't work.

Remove unit dim folding from the codegen pipeline and handle it in vector distribute properly. We can drop a lot of code for droppping unit dims for codegen ops after this patch.

Eventually, this work will lead to dropping `outer_tile` from the layout, which will eventually reduce the number of final vector dimensions.

ci-extra: test_torch