### PR TITLE
[Encoding] Add dynamic encoding dims to (Un)SetEncodingOp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -299,11 +299,12 @@ static Value generateEncodingTransferOps(RewriterBase &rewriter, Value src,
   Value value = src;
   if (srcType.getEncoding()) {
     value = IREE::Encoding::UnsetEncodingOp::create(
-        rewriter, src.getLoc(), srcType.dropEncoding(), value, dynamicDims);
+        rewriter, src.getLoc(), srcType.dropEncoding(), value, dynamicDims,
+        /*encodingDims=*/ValueRange{});
   }
   if (destType.getEncoding()) {
-    value = IREE::Encoding::SetEncodingOp::create(rewriter, src.getLoc(),
-                                                  destType, value);
+    value = IREE::Encoding::SetEncodingOp::create(
+        rewriter, src.getLoc(), destType, value, /*encodingDims=*/ValueRange{});
   }
   return value;
 }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -23,13 +23,19 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
     Operation to assign an encoding to a tensor. The operation does not change
     the rank or extent of a tensor. Instead it adds a LayoutResolverAttr
     attribute to the tensor type to represent a change in layout.
+
+    The optional `encoding_dims` operand carries dynamic values needed by the
+    encoding (e.g., M, N, K dimensions for matmul encodings). These values are
+    used for runtime layout selection based on problem size.
   }];
 
-  let arguments = (ins AnyRankedTensor:$source);
+  let arguments = (ins
+    AnyRankedTensor:$source,
+    Variadic<Index>:$encoding_dims);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    attr-dict $source `:` type($source) `->` type($result)
+    attr-dict $source (`encoding_dims` `{` $encoding_dims^ `}`)? `:` type($source) `->` type($result)
   }];
 
   let hasVerifier = 1;
@@ -49,21 +55,27 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
 //===----------------------------------------------------------------------===//
 
 def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
-    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>, Pure
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    AttrSizedOperandSegments, Pure
   ]> {
   let summary = [{Perform unpack and extract operation on source.}];
   let description = [{
     Operation to convert a tensor with LayoutResolverAttr encoding that
     represents its data layout into a tensor with default layout
     (i.e. no encoding). For now in IREE the default layout is row-major.
+
+    The optional `encoding_dims` operand carries dynamic values needed by the
+    encoding (e.g., M, N, K dimensions for matmul encodings). These values are
+    used for runtime layout selection based on problem size.
   }];
   let arguments = (ins
     AnyRankedTensor:$source,
-    Variadic<Index>:$result_dims);
+    Variadic<Index>:$result_dims,
+    Variadic<Index>:$encoding_dims);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    attr-dict $source `:` type($source) `->` type($result) (`` `{` $result_dims^ `}`)?
+    attr-dict $source (`encoding_dims` `{` $encoding_dims^ `}`)? `:` type($source) `->` type($result) (`` `{` $result_dims^ `}`)?
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -259,3 +259,36 @@ func.func @identity_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf3
   return %arg0 : tensor<?x?xf32, #encoding>
 }
 //      CHECK: func.func @identity_encoding(%[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.identity>
+
+// -----
+
+#encoding = #iree_encoding.testing<>
+func.func @set_encoding_with_encoding_dims(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  return %0 : tensor<?x?xf32, #encoding>
+}
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing<>
+//      CHECK: func.func @set_encoding_with_encoding_dims
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]: index
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+
+// -----
+
+#encoding = #iree_encoding.testing<>
+func.func @unset_encoding_with_encoding_dims(
+    %arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index, %m: index, %n: index, %k: index) -> tensor<?x?xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  return %0 : tensor<?x?xf32>
+}
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing<>
+//      CHECK: func.func @unset_encoding_with_encoding_dims
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[D1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]: index
+//      CHECK:   iree_encoding.unset_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<?x?xf32, #[[ENCODING]]> -> tensor<?x?xf32>{%[[D0]], %[[D1]]}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
@@ -142,11 +142,12 @@ static func::FuncOp createWorkgroupFunc(IREE::Stream::TensorEncodeOp encodeOp,
   if (sourceType != destinationType) {
     if (sourceType.getEncoding()) {
       value = IREE::Encoding::UnsetEncodingOp::create(
-          builder, loc, sourceType.dropEncoding(), value, sourceDynamicDims);
+          builder, loc, sourceType.dropEncoding(), value, sourceDynamicDims,
+          /*encodingDims=*/ValueRange{});
     }
     if (destinationType.getEncoding()) {
-      value = IREE::Encoding::SetEncodingOp::create(builder, loc,
-                                                    destinationType, value);
+      value = IREE::Encoding::SetEncodingOp::create(
+          builder, loc, destinationType, value, /*encodingDims=*/ValueRange{});
     }
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -110,7 +110,7 @@ bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
     auto resType = RankedTensorType::get(
         operandType.getShape(), operandType.getElementType(), newEncoding);
     Value encodedInput = IREE::Encoding::SetEncodingOp::create(
-        rewriter, loc, resType, operand->get());
+        rewriter, loc, resType, operand->get(), /*encodingDims=*/ValueRange{});
     encodedOperands.push_back(encodedInput);
   }
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -71,7 +71,8 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     }
     // Otherwise, we need to create a new set_encoding op.
     auto setEncodingOp = IREE::Encoding::SetEncodingOp::create(
-        builder, op->getLoc(), encodedOperandType, operand);
+        builder, op->getLoc(), encodedOperandType, operand,
+        /*encodingDims=*/ValueRange{});
     encodedOperands.push_back(setEncodingOp.getResult());
     result.generatedEncodingOps.push_back(setEncodingOp);
   }
@@ -100,7 +101,7 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     std::tie(std::ignore, resultDynamicDims) = decomposeMixedValues(mixedSizes);
     auto unsetEncodingOp = IREE::Encoding::UnsetEncodingOp::create(
         builder, op->getLoc(), originalResult.getType(), encodedResult,
-        resultDynamicDims);
+        resultDynamicDims, /*encodingDims=*/ValueRange{});
     result.generatedEncodingOps.push_back(unsetEncodingOp);
     result.replacements.push_back(unsetEncodingOp.getResult());
   }


### PR DESCRIPTION
Implements part 1 of phase 2 for supporting dynamic encoding layout decisions: https://github.com/iree-org/iree/issues/22370.

Adds the dynamic `encoding_dims` parameter to `SetEncodingOp` and `UnsetEncdingOp`. They are not set yet.