### PR TITLE
Trying things out

### DIFF
--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_w7900:
-    runs-on: [Linux, X64, iree-w7900]
+    runs-on: [self-hosted, Linux, X64, iree-w7900]
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -46,11 +46,11 @@ jobs:
           - name: amdgpu_hip_rdna3_O3
             numprocesses: 1
             config-file: onnx_ops_gpu_hip_rdna3_O3.json
-            runs-on: [Linux, X64, gfx1100]
+            runs-on: [self-hosted, Linux, X64, gfx1100]
           - name: amdgpu_vulkan_O0
             numprocesses: 1
             config-file: onnx_ops_gpu_vulkan_O0.json
-            runs-on: [Linux, X64, rdna3]
+            runs-on: [self-hosted, Linux, X64, rdna3]
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -36,11 +36,11 @@ jobs:
             runs-on: ubuntu-24.04
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
-            runs-on: [Linux, X64, gfx1100]
+            runs-on: [self-hosted, Linux, X64, gfx1100]
           - name: amdgpu_vulkan_O3
             config-file: torch_ops_gpu_vulkan_O3.json
             # TODO(#22579): Remove `shark10-ci` label. There are vulkan driver issues on other runners.
-            runs-on: [Linux, X64, rdna3, shark10-ci]
+            runs-on: [self-hosted, Linux, X64, rdna3, shark10-ci]
           - name: amdgpu_rocm_mi300_gfx942_O3
             config-file: torch_ops_gpu_hip_gfx942_O3.json
             runs-on: linux-mi325-1gpu-ossci-iree-org


### PR DESCRIPTION
> we recommend providing an array of labels that begins with self-hosted (this must be listed first) and then includes additional labels as needed

https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-self-hosted-runners