### PR TITLE
[Codegen] Add FusePCFWritesPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/BUILD.bazel
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
     srcs = [
         "ConvertForallToLoops.cpp",
         "FuseConsumers.cpp",
+        "FusePCFWrites.cpp",
         "Passes.cpp",
         "Transforms.cpp",
     ],

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
   SRCS
     "ConvertForallToLoops.cpp"
     "FuseConsumers.cpp"
+    "FusePCFWrites.cpp"
     "Passes.cpp"
     "Transforms.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FusePCFWrites.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FusePCFWrites.cpp
@@ -1,0 +1,261 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFTypes.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+
+#define DEBUG_TYPE "iree-pcf-fuse-pcf-writes"
+
+namespace mlir::iree_compiler::IREE::PCF {
+
+#define GEN_PASS_DEF_FUSEPCFWRITESPASS
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h.inc"
+
+namespace {
+
+struct FusePCFWritesPass final
+    : impl::FusePCFWritesPassBase<FusePCFWritesPass> {
+  void runOnOperation() override;
+};
+
+/// Pattern to fuse pcf.write_slice with tensor.parallel_insert_slice from
+/// scf.forall terminators.
+struct FuseWriteSliceWithParallelInsert final
+    : OpRewritePattern<PCF::WriteSliceOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(PCF::WriteSliceOp writeSliceOp,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<PCF::WriteSliceOp> newWriteSlice =
+        composeWriteSliceWithParallelInsert(rewriter, writeSliceOp);
+    if (failed(newWriteSlice)) {
+      return rewriter.notifyMatchFailure(
+          writeSliceOp,
+          "source is not an scf.forall with tensor.parallel_insert_slice");
+    }
+    return success();
+  }
+};
+
+void FusePCFWritesPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(&getContext());
+  patterns.add<FuseWriteSliceWithParallelInsert>(context);
+
+  // Forall canonicalizations to drop unused results.
+  scf::ForallOp::getCanonicalizationPatterns(patterns, &getContext());
+
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace
+
+FailureOr<PCF::WriteSliceOp>
+composeWriteSliceWithParallelInsert(RewriterBase &rewriter,
+                                    PCF::WriteSliceOp writeSliceOp) {
+  // Check if the source is produced by an scf.forall.
+  auto forallOp = writeSliceOp.getSource().getDefiningOp<scf::ForallOp>();
+  if (!forallOp) {
+    return failure();
+  }
+
+  // Get the result index being written.
+  auto forallResult = dyn_cast<OpResult>(writeSliceOp.getSource());
+  if (!forallResult) {
+    return failure();
+  }
+  unsigned resultIdx = forallResult.getResultNumber();
+
+  // Get the in_parallel terminator
+  auto inParallelOp =
+      cast<scf::InParallelOp>(forallOp.getRegion().front().getTerminator());
+
+  // Find the tensor.parallel_insert_slice for this result.
+  tensor::ParallelInsertSliceOp insertSliceOp = nullptr;
+  for (Operation &op : inParallelOp.getYieldingOps()) {
+    if (auto insertOp = dyn_cast<tensor::ParallelInsertSliceOp>(&op)) {
+      // Check if this insert targets the correct shared_out
+      auto destArg = dyn_cast<BlockArgument>(insertOp.getDest());
+      if (destArg && destArg.getOwner() == &forallOp.getRegion().front()) {
+        // Map block argument to result index
+        unsigned argIdx = destArg.getArgNumber() - forallOp.getRank();
+        if (argIdx == resultIdx) {
+          if (insertSliceOp) {
+            return rewriter.notifyMatchFailure(
+                forallOp, "unimplemented: multiple insert_slice producers");
+          }
+          insertSliceOp = insertOp;
+        }
+      }
+    }
+  }
+
+  if (!insertSliceOp) {
+    return failure();
+  }
+
+  // Collect all values used by the write_slice that are not the forall result.
+  // These need to be available inside the forall body.
+  SmallVector<Value> writeSliceOperands;
+  writeSliceOperands.push_back(writeSliceOp.getDest());
+  llvm::append_range(writeSliceOperands, writeSliceOp.getOffsets());
+  llvm::append_range(writeSliceOperands, writeSliceOp.getStrides());
+
+  // Move the definitions of these operands before the forall if they are
+  // defined after it. This can happen if the producer of an operand dominates
+  // the forall but is placed after it in the IR.
+  if (failed(moveValueDefinitions(rewriter, writeSliceOperands, forallOp))) {
+    return rewriter.notifyMatchFailure(
+        writeSliceOp,
+        "failed to move write_slice operand definitions before forall");
+  }
+
+  // Compose the offsets, sizes, and strides and insert the new write_slice
+  // before the parallel_insert_slice in the forall body.
+  // The new write_slice should use:
+  // - source: insertSlice.getSource()
+  // - dest: writeSlice.getDest()
+  // - offsets: writeSlice.offsets + insertSlice.offsets * writeSlice.strides
+  // - sizes: insertSlice.sizes
+  // - strides: writeSlice.strides * insertSlice.strides
+
+  SmallVector<OpFoldResult> composedOffsets;
+  SmallVector<OpFoldResult> composedSizes = insertSliceOp.getMixedSizes();
+  SmallVector<OpFoldResult> composedStrides;
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  // Insert before the in_parallel terminator, not inside it.
+  rewriter.setInsertionPoint(inParallelOp);
+
+  SmallVector<OpFoldResult> writeOffsets = writeSliceOp.getMixedOffsets();
+  SmallVector<OpFoldResult> insertOffsets = insertSliceOp.getMixedOffsets();
+  SmallVector<OpFoldResult> writeStrides = writeSliceOp.getMixedStrides();
+  SmallVector<OpFoldResult> insertStrides = insertSliceOp.getMixedStrides();
+
+  // Compose offsets: writeOffset + insertOffset * writeStride.
+  for (auto [writeOffset, insertOffset, writeStride] :
+       llvm::zip_equal(writeOffsets, insertOffsets, writeStrides)) {
+    Value writeOffsetVal = getValueOrCreateConstantIndexOp(
+        rewriter, insertSliceOp.getLoc(), writeOffset);
+    Value insertOffsetVal = getValueOrCreateConstantIndexOp(
+        rewriter, insertSliceOp.getLoc(), insertOffset);
+    Value writeStrideVal = getValueOrCreateConstantIndexOp(
+        rewriter, insertSliceOp.getLoc(), writeStride);
+
+    Value scaled = rewriter.createOrFold<arith::MulIOp>(
+        insertSliceOp.getLoc(), insertOffsetVal, writeStrideVal);
+    Value composed = rewriter.createOrFold<arith::AddIOp>(
+        insertSliceOp.getLoc(), writeOffsetVal, scaled);
+    composedOffsets.push_back(composed);
+  }
+
+  // Compose strides: writeStride * insertStride.
+  for (auto [writeStride, insertStride] :
+       llvm::zip_equal(writeStrides, insertStrides)) {
+    Value writeStrideVal = getValueOrCreateConstantIndexOp(
+        rewriter, insertSliceOp.getLoc(), writeStride);
+    Value insertStrideVal = getValueOrCreateConstantIndexOp(
+        rewriter, insertSliceOp.getLoc(), insertStride);
+    Value composed = rewriter.createOrFold<arith::MulIOp>(
+        insertSliceOp.getLoc(), writeStrideVal, insertStrideVal);
+    composedStrides.push_back(composed);
+  }
+
+  // Handle rank-reduced parallel_insert_slice sources.
+  // The source may have fewer dimensions than the destination sref (e.g.,
+  // tensor<1024xf32> being inserted into tensor<512x10240xf32> with sizes
+  // [1, 1024]). We need to expand the source to match the sref rank.
+  Value source = insertSliceOp.getSource();
+  auto sourceType = cast<RankedTensorType>(source.getType());
+  auto srefType = cast<ShapedRefType>(writeSliceOp.getDest().getType());
+  int64_t sourceRank = sourceType.getRank();
+  int64_t destRank = srefType.getRank();
+
+  if (sourceRank < destRank) {
+    // Build reassociation map for expand_shape.
+    // Unit dimensions (size 1) from composedSizes indicate dropped dimensions.
+    SmallVector<int64_t> expandedShape;
+    SmallVector<ReassociationIndices> reassociation;
+
+    int64_t sourceIdx = 0;
+    ReassociationIndices currentGroup;
+
+    for (int64_t i = 0; i < destRank; ++i) {
+      // Check if this dimension is a unit dimension (was dropped in rank
+      // reduction).
+      std::optional<int64_t> staticSize = getConstantIntValue(composedSizes[i]);
+      bool isUnitDim = staticSize && *staticSize == 1;
+
+      if (isUnitDim && sourceIdx < sourceRank) {
+        // This is a unit dimension, check if it matches the source.
+        int64_t sourceDimSize = sourceType.getDimSize(sourceIdx);
+        if (sourceDimSize == 1) {
+          // Source also has this as size 1, include it normally.
+          expandedShape.push_back(1);
+          currentGroup.push_back(i);
+          sourceIdx++;
+          if (sourceIdx <= sourceRank) {
+            reassociation.push_back(currentGroup);
+            currentGroup.clear();
+          }
+        } else {
+          // This is a dropped dimension, add to current group.
+          expandedShape.push_back(1);
+          currentGroup.push_back(i);
+        }
+      } else if (sourceIdx < sourceRank) {
+        // Non-unit dimension, maps to a source dimension.
+        expandedShape.push_back(sourceType.getDimSize(sourceIdx));
+        currentGroup.push_back(i);
+        sourceIdx++;
+        reassociation.push_back(currentGroup);
+        currentGroup.clear();
+      } else {
+        // Extra trailing unit dimensions.
+        expandedShape.push_back(1);
+        if (!reassociation.empty()) {
+          reassociation.back().push_back(i);
+        } else {
+          currentGroup.push_back(i);
+        }
+      }
+    }
+
+    // Handle any remaining group.
+    if (!currentGroup.empty()) {
+      reassociation.push_back(currentGroup);
+    }
+
+    auto expandedType =
+        RankedTensorType::get(expandedShape, sourceType.getElementType());
+    source = tensor::ExpandShapeOp::create(rewriter, insertSliceOp.getLoc(),
+                                           expandedType, source, reassociation)
+                 .getResult();
+  }
+
+  // Create the new write_slice before the terminator.
+  auto newWriteSlice = PCF::WriteSliceOp::create(
+      rewriter, insertSliceOp.getLoc(), source, writeSliceOp.getDest(),
+      composedOffsets, composedSizes, composedStrides);
+
+  // Erase the old write_slice.
+  rewriter.eraseOp(writeSliceOp);
+
+  return cast<PCF::WriteSliceOp>(newWriteSlice.getOperation());
+}
+
+} // namespace mlir::iree_compiler::IREE::PCF

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.td
@@ -58,4 +58,29 @@ def FuseConsumersPass : Pass<"iree-pcf-fuse-consumers", ""> {
                            "::mlir::iree_compiler::IREE::PCF::PCFDialect"];
 }
 
+def FusePCFWritesPass : Pass<"iree-pcf-fuse-pcf-writes", ""> {
+  let summary = "Consolidates pcf.write_slice ops in loop bodies";
+  let description = [{
+    Test pass for composing `pcf.write_slice` operations with nested
+    `scf.forall` producers.
+
+    The input is IR containing `pcf.write_slice` ops where the source value is
+    produced by an `scf.forall` with `tensor.parallel_insert_slice` in its
+    terminator.
+
+    The pass moves each matching `pcf.write_slice` inside the `scf.forall`
+    body, composing the slice parameters:
+    - New offsets: `write_offset + insert_offset * write_stride`
+    - New sizes: from the `parallel_insert_slice`
+    - New strides: `write_stride * insert_stride`
+
+    This enables further lowering by ensuring writes happen at the granularity
+    of the inner parallel loop rather than after the entire forall completes.
+
+    The underlying pattern is exposed via `composeWriteSliceWithParallelInsert()`
+    for use in custom pipelines.
+  }];
+  let dependentDialects = ["::mlir::iree_compiler::IREE::PCF::PCFDialect"];
+}
+
 #endif // IREE_CODEGEN_DIALECT_PCF_TRANSFORMS_PASSES

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
@@ -121,6 +121,14 @@ fuseExtractSliceIntoProducerGeneric(RewriterBase &rewriter,
                                     PCF::GenericOp genericOp,
                                     tensor::ExtractSliceOp extractSliceOp);
 
+// Composes a pcf.write_slice with a tensor.parallel_insert_slice from an
+// scf.forall terminator. The write_slice's destination must be produced by the
+// forall op, and the parallel_insert_slice must be inserting into that result.
+// Returns the newly created write_slice op on success.
+FailureOr<PCF::WriteSliceOp>
+composeWriteSliceWithParallelInsert(RewriterBase &rewriter,
+                                    PCF::WriteSliceOp writeSliceOp);
+
 } // namespace mlir::iree_compiler::IREE::PCF
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_PCF_TRANSFORMS_TRANSFORMS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "convert_forall_to_loops.mlir",
             "fuse_consumers.mlir",
+            "fuse_pcf_writes.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "convert_forall_to_loops.mlir"
     "fuse_consumers.mlir"
+    "fuse_pcf_writes.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/fuse_pcf_writes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/fuse_pcf_writes.mlir
@@ -1,0 +1,184 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(iree-pcf-fuse-pcf-writes)" --split-input-file | FileCheck %s
+
+func.func @fuse_write_slice_with_parallel_insert(%init: tensor<32x64xf32>, %dest: !pcf.sref<32x64xf32, sync(#pcf.sequential)>) {
+  %result = scf.forall (%i, %j) in (4, 8) shared_outs(%iter = %init) -> tensor<32x64xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %tile into %iter[%i, %j] [8, 8] [1, 1] : tensor<8x8xf32> into tensor<32x64xf32>
+    }
+  }
+  pcf.write_slice %result into %dest[0, 0] [32, 64] [1, 1] : tensor<32x64xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+  return
+}
+
+// CHECK-LABEL: @fuse_write_slice_with_parallel_insert(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+
+//       CHECK:   scf.forall (%[[I:.+]], %[[J:.+]]) in (4, 8) {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     pcf.write_slice %[[TILE]] into %[[DEST]][%[[I]], %[[J]]] [8, 8] [1, 1]
+//       CHECK:   }
+//       CHECK-NOT:   pcf.write_slice
+//       CHECK:   return
+
+// -----
+
+func.func @fuse_with_offset(%init: tensor<32x64xf32>, %dest: !pcf.sref<32x64xf32, sync(#pcf.sequential)>) {
+  %result = scf.forall (%i, %j) in (4, 8) shared_outs(%iter = %init) -> tensor<32x64xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %tile into %iter[%i, %j] [8, 8] [1, 1] : tensor<8x8xf32> into tensor<32x64xf32>
+    }
+  }
+  %c16 = arith.constant 16 : index
+  pcf.write_slice %result into %dest[%c16, 0] [32, 64] [1, 1] : tensor<32x64xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+  return
+}
+
+// CHECK-LABEL: @fuse_with_offset(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+
+//   CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
+//       CHECK:   scf.forall (%[[I:.+]], %[[J:.+]]) in (4, 8) {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     %[[COMPOSED_OFFSET:.+]] = arith.addi %[[I]], %[[C16]]
+//       CHECK:     pcf.write_slice %[[TILE]] into %[[DEST]][%[[COMPOSED_OFFSET]], %[[J]]] [8, 8] [1, 1]
+//       CHECK:   }
+//       CHECK-NOT:   pcf.write_slice
+//       CHECK:   return
+
+// -----
+
+func.func @fuse_with_stride(%init: tensor<32x64xf32>, %dest: !pcf.sref<64x128xf32, sync(#pcf.sequential)>) {
+  %result = scf.forall (%i, %j) in (4, 8) shared_outs(%iter = %init) -> tensor<32x64xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %tile into %iter[%i, %j] [8, 8] [1, 1] : tensor<8x8xf32> into tensor<32x64xf32>
+    }
+  }
+  pcf.write_slice %result into %dest[0, 0] [32, 64] [2, 2] : tensor<32x64xf32> into !pcf.sref<64x128xf32, sync(#pcf.sequential)>
+  return
+}
+
+// CHECK-LABEL: @fuse_with_stride(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: !pcf.sref<64x128xf32, sync(#pcf.sequential)>
+
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//       CHECK:   scf.forall (%[[I:.+]], %[[J:.+]]) in (4, 8) {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//   CHECK-DAG:     %[[OFFSET_0:.+]] = arith.muli %[[I]], %[[C2]]
+//   CHECK-DAG:     %[[OFFSET_1:.+]] = arith.muli %[[J]], %[[C2]]
+//       CHECK:     pcf.write_slice %[[TILE]] into %[[DEST]][%[[OFFSET_0]], %[[OFFSET_1]]] [8, 8] [2, 2]
+//       CHECK:   }
+//       CHECK-NOT:   pcf.write_slice
+//       CHECK:   return
+
+// -----
+
+func.func @no_fusion_different_source(%init: tensor<32x64xf32>, %other: tensor<32x64xf32>, %dest: !pcf.sref<32x64xf32, sync(#pcf.sequential)>) {
+  %result = scf.forall (%i, %j) in (4, 8) shared_outs(%iter = %init) -> tensor<32x64xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %tile into %iter[%i, %j] [8, 8] [1, 1] : tensor<8x8xf32> into tensor<32x64xf32>
+    }
+  }
+  // Write from a different source, not the forall result
+  pcf.write_slice %other into %dest[0, 0] [32, 64] [1, 1] : tensor<32x64xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+  return
+}
+
+// CHECK-LABEL: @no_fusion_different_source(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[OTHER:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+
+//       CHECK:   pcf.write_slice %[[OTHER]] into %[[DEST]][0, 0] [32, 64] [1, 1]
+//       CHECK:   return
+
+// -----
+
+func.func @fuse_with_offset_after_forall(%init: tensor<32x64xf32>, %dest: !pcf.sref<32x64xf32, sync(#pcf.sequential)>, %offset_base: index) {
+  %result = scf.forall (%i, %j) in (4, 8) shared_outs(%iter = %init) -> tensor<32x64xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %tile into %iter[%i, %j] [8, 8] [1, 1] : tensor<8x8xf32> into tensor<32x64xf32>
+    }
+  }
+  // Define the offset after the forall - this should be moved before it
+  %c16 = arith.constant 16 : index
+  %offset = arith.addi %c16, %offset_base : index
+  pcf.write_slice %result into %dest[%offset, 0] [32, 64] [1, 1] : tensor<32x64xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+  return
+}
+
+// CHECK-LABEL: @fuse_with_offset_after_forall(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+//  CHECK-SAME:   %[[OFFSET_BASE:[A-Za-z0-9_]+]]: index
+
+//   CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
+//   CHECK-DAG:   %[[OFFSET:.+]] = arith.addi %[[OFFSET_BASE]], %[[C16]]
+//       CHECK:   scf.forall (%[[I:.+]], %[[J:.+]]) in (4, 8) {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     %[[COMPOSED_OFFSET:.+]] = arith.addi %[[OFFSET]], %[[I]]
+//       CHECK:     pcf.write_slice %[[TILE]] into %[[DEST]][%[[COMPOSED_OFFSET]], %[[J]]] [8, 8] [1, 1]
+//       CHECK:   }
+//       CHECK-NOT:   pcf.write_slice
+//       CHECK:   return
+
+// -----
+
+// Test case for rank-reduced parallel_insert_slice sources.
+// The source tensor<1024xf32> is rank-1, but the destination sref is rank-2.
+// The pass should expand the source to match the dest rank.
+func.func @fuse_with_rank_reduction(%init: tensor<512x10240xf32>, %dest: !pcf.sref<512x10240xf32, sync(#pcf.sequential)>) {
+  %result = scf.forall (%i) in (512) shared_outs(%iter = %init) -> tensor<512x10240xf32> {
+    %c0 = arith.constant 0.0 : f32
+    // Rank-1 tile that will be inserted into rank-2 tensor
+    %tile = tensor.generate {
+    ^bb0(%ii: index):
+      tensor.yield %c0 : f32
+    } : tensor<1024xf32>
+    scf.forall.in_parallel {
+      // Rank-reducing insert: tensor<1024xf32> into tensor<512x10240xf32>[%i, 0] [1, 1024]
+      tensor.parallel_insert_slice %tile into %iter[%i, 0] [1, 1024] [1, 1] : tensor<1024xf32> into tensor<512x10240xf32>
+    }
+  }
+  pcf.write_slice %result into %dest[0, 0] [512, 10240] [1, 1] : tensor<512x10240xf32> into !pcf.sref<512x10240xf32, sync(#pcf.sequential)>
+  return
+}
+
+// CHECK-LABEL: @fuse_with_rank_reduction(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<512x10240xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: !pcf.sref<512x10240xf32, sync(#pcf.sequential)>
+
+//       CHECK:   scf.forall (%[[I:.+]]) in (512) {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     %[[EXPANDED:.+]] = tensor.expand_shape %[[TILE]] {{\[\[}}0, 1{{\]\]}} output_shape [1, 1024] : tensor<1024xf32> into tensor<1x1024xf32>
+//       CHECK:     pcf.write_slice %[[EXPANDED]] into %[[DEST]][%[[I]], 0] [1, 1024] [1, 1]
+//       CHECK:   }
+//       CHECK-NOT:   pcf.write_slice
+//       CHECK:   return


### PR DESCRIPTION
Adds the FusePCFWritesPass which consolidates pcf.write_slice ops in loop bodies by fusing them with tensor.parallel_insert_slice operations from scf.forall terminators.

When a pcf.write_slice writes to an sref that is produced by an scf.forall result, this pass composes the offsets, sizes, and strides of both operations to create a single write_slice inside the forall body.

The implementation is exposed through the helper
composeWriteSliceWithParallelInsert for use within larger passes.