### PR TITLE
[Codegen] Add ResolveTokensPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/BUILD.bazel
@@ -41,6 +41,7 @@ iree_compiler_cc_library(
         "FusePCFWrites.cpp",
         "LowerStructuralPCF.cpp",
         "Passes.cpp",
+        "ResolveTokens.cpp",
         "Transforms.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     "FusePCFWrites.cpp"
     "LowerStructuralPCF.cpp"
     "Passes.cpp"
+    "ResolveTokens.cpp"
     "Transforms.cpp"
   DEPS
     ::PassesIncGen

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/ConversionDialectInterface.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/ConversionDialectInterface.h
@@ -16,13 +16,10 @@ class PCFConversionDialectInterface
     : public DialectInterface::Base<PCFConversionDialectInterface> {
 public:
   PCFConversionDialectInterface(Dialect *dialect) : Base(dialect) {}
-
-  // Load dialects that pcf.generic/loop lowering may produce.
+  virtual void loadSRefLoweringDependentDialects(MLIRContext *context) const {}
+  virtual void loadTokenLoweringDependentDialects(MLIRContext *context) const {}
   virtual void
   loadStructuralLoweringDependentDialects(MLIRContext *context) const {}
-
-  // Load dialects that sref to memref conversion may produce.
-  virtual void loadSRefLoweringDependentDialects(MLIRContext *context) const {}
 };
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.td
@@ -135,4 +135,23 @@ def ConvertSRefToMemRefPass : Pass<"iree-pcf-convert-sref-to-memref", ""> {
                            "::mlir::vector::VectorDialect"];
 }
 
+def ResolveTokensPass : Pass<"iree-pcf-resolve-tokens", ""> {
+  let summary = "Resolves synchronization scopes on `pcf.sref` types.";
+  let description = [{
+    Resolves synchronization scopes attached to `pcf.sref` types by expanding
+    them to their concrete representations. This pass should run before
+    `iree-pcf-convert-sref-to-memref`.
+
+    The input is IR containing `pcf.sref` types with sync scope attributes.
+    The pass expands `pcf.sref<..., sync_scope>` types into a `pcf.sref`
+    without sync scope plus any concrete types required by the sync scope
+    attribute. For shaped refs with `sync_on_return` scope, the parent
+    `pcf.generic` or `pcf.loop` op has its `sync_on_return` flag set to true,
+    ensuring a barrier is inserted when the op is lowered.
+
+    Write operations (`pcf.write_slice`) are updated to enqueue writes through
+    the sync scope's interface methods.
+  }];
+}
+
 #endif // IREE_CODEGEN_DIALECT_PCF_TRANSFORMS_PASSES

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/ResolveTokens.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/ResolveTokens.cpp
@@ -1,0 +1,342 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCF.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFTypes.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/ConversionDialectInterface.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#define DEBUG_TYPE "iree-pcf-resolve-tokens"
+
+namespace mlir::iree_compiler::IREE::PCF {
+
+#define GEN_PASS_DEF_RESOLVETOKENSPASS
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h.inc"
+
+namespace {
+
+class LoadDependentDialectExtension : public DialectExtensionBase {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LoadDependentDialectExtension)
+
+  LoadDependentDialectExtension() : DialectExtensionBase(/*dialectNames=*/{}) {}
+
+  void apply(MLIRContext *context,
+             MutableArrayRef<Dialect *> dialects) const final {
+    for (Dialect *dialect : dialects) {
+      auto *iface = dyn_cast<PCFConversionDialectInterface>(dialect);
+      if (!iface) {
+        continue;
+      }
+      iface->loadTokenLoweringDependentDialects(context);
+    }
+  }
+
+  /// Return a copy of this extension.
+  std::unique_ptr<DialectExtensionBase> clone() const final {
+    return std::make_unique<LoadDependentDialectExtension>(*this);
+  }
+};
+
+struct ResolveTokensPass final
+    : impl::ResolveTokensPassBase<ResolveTokensPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.addExtensions<LoadDependentDialectExtension>();
+  }
+  void runOnOperation() override;
+};
+
+/// Flatten the given value ranges into a single vector of values.
+static SmallVector<Value> flattenValues(ArrayRef<ValueRange> values) {
+  SmallVector<Value> result;
+  for (ValueRange vals : values) {
+    llvm::append_range(result, vals);
+  }
+  return result;
+}
+
+/// Helper function for converting branch ops. This function converts the
+/// signature of the given block. If the new block signature is different from
+/// `expectedTypes`, returns "failure".
+static FailureOr<Block *> getConvertedBlock(ConversionPatternRewriter &rewriter,
+                                            const TypeConverter *converter,
+                                            Operation *branchOp, Block *block,
+                                            TypeRange expectedTypes) {
+  assert(converter && "expected non-null type converter");
+  assert(!block->isEntryBlock() && "entry blocks have no predecessors");
+
+  // There is nothing to do if the types already match.
+  if (block->getArgumentTypes() == expectedTypes) {
+    return block;
+  }
+
+  // Compute the new block argument types and convert the block.
+  std::optional<TypeConverter::SignatureConversion> conversion =
+      converter->convertBlockSignature(block);
+  if (!conversion) {
+    return rewriter.notifyMatchFailure(branchOp,
+                                       "could not compute block signature");
+  }
+  if (expectedTypes != conversion->getConvertedTypes()) {
+    return rewriter.notifyMatchFailure(
+        branchOp,
+        "mismatch between adaptor operand types and computed block signature");
+  }
+  return rewriter.applySignatureConversion(block, *conversion, converter);
+}
+
+struct ConvertGenericOp final : OpConversionPattern<PCF::GenericOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(PCF::GenericOp genericOp, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    bool madeChange = false;
+    if (llvm::any_of(genericOp.getRegionRefArgs(), [](BlockArgument b) {
+          return cast<PCF::ShapedRefType>(b.getType()).isReturnOnlySync();
+        })) {
+      genericOp.setSyncOnReturn(true);
+      madeChange = true;
+    }
+
+    SmallVector<Block *> blocksToConvert = llvm::map_to_vector(
+        genericOp.getRegion().getBlocks(), [](Block &b) { return &b; });
+    for (Block *block : blocksToConvert) {
+      std::optional<TypeConverter::SignatureConversion> signatureConverter =
+          getTypeConverter()->convertBlockSignature(block);
+      if (signatureConverter) {
+        madeChange = true;
+        rewriter.applySignatureConversion(block, signatureConverter.value(),
+                                          getTypeConverter());
+      }
+    }
+    return success(madeChange);
+  }
+};
+
+struct ConvertLoopOp final : OpConversionPattern<PCF::LoopOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(PCF::LoopOp loopOp, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    bool madeChange = false;
+    if (llvm::any_of(loopOp.getRegionRefArgs(), [](BlockArgument b) {
+          return cast<PCF::ShapedRefType>(b.getType()).isReturnOnlySync();
+        })) {
+      loopOp.setSyncOnReturn(true);
+      madeChange = true;
+    }
+
+    std::optional<TypeConverter::SignatureConversion> signatureConverter =
+        getTypeConverter()->convertBlockSignature(loopOp.getBody());
+    if (signatureConverter) {
+      madeChange = true;
+      rewriter.applySignatureConversion(
+          loopOp.getBody(), signatureConverter.value(), getTypeConverter());
+    }
+    return success(madeChange);
+  }
+};
+
+struct ConvertAllocOp final : OpConversionPattern<PCF::AllocOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(PCF::AllocOp allocOp, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(getTypeConverter()->convertType(allocOp.getResultType(),
+                                               resultTypes))) {
+      return failure();
+    }
+
+    auto syncScope = cast_if_present<PCF::SyncScopeAttrInterface>(
+        allocOp.getResultType().getSyncScope());
+    SmallVector<Value> replacements;
+    if (syncScope) {
+      replacements = syncScope.allocate(rewriter);
+    }
+    auto newAlloc =
+        PCF::AllocOp::create(rewriter, allocOp.getLoc(),
+                             cast<PCF::ShapedRefType>(resultTypes.front()),
+                             allocOp.getDynamicSizes());
+    replacements.insert(replacements.begin(), newAlloc.getResult());
+    rewriter.replaceOp(allocOp, replacements);
+    return success();
+  }
+};
+
+struct ConvertWriteSliceOp final : OpConversionPattern<PCF::WriteSliceOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(PCF::WriteSliceOp writeOp, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Replace the destination with the unscoped sref.
+    ValueRange splitDest = adaptor.getDest();
+
+    rewriter.startOpModification(writeOp);
+    writeOp.getDestMutable().assign(splitDest.front());
+
+    // Enqueue the write via the attribute interface immediately after it.
+    auto syncScope = cast_if_present<PCF::SyncScopeAttrInterface>(
+        writeOp.getDestType().getSyncScope());
+    if (syncScope) {
+      rewriter.setInsertionPointAfter(writeOp);
+      syncScope.enqueueWrite(rewriter, splitDest.drop_front(), writeOp);
+    }
+    rewriter.finalizeOpModification(writeOp);
+    return success();
+  }
+};
+
+/// Convert the destination block signature if necessary.
+struct ConvertBranchOp final : OpConversionPattern<cf::BranchOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(cf::BranchOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const TypeConverter *typeConverter = getTypeConverter();
+    if (llvm::all_of(op->getOperandTypes(),
+                     [&](Type t) { return typeConverter->isLegal(t); })) {
+      // Nothing to do.
+      return failure();
+    }
+    SmallVector<Value> flattenedAdaptor = flattenValues(adaptor.getOperands());
+    FailureOr<Block *> convertedBlock =
+        getConvertedBlock(rewriter, typeConverter, op, op.getSuccessor(),
+                          TypeRange(ValueRange(flattenedAdaptor)));
+    if (failed(convertedBlock)) {
+      return failure();
+    }
+    op.getDestOperandsMutable().assign(flattenedAdaptor);
+    return success();
+  }
+};
+
+struct ConvertOptimizationBarrier final
+    : OpConversionPattern<Util::OptimizationBarrierOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(Util::OptimizationBarrierOp barrier, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<Util::OptimizationBarrierOp>(
+        barrier, flattenValues(adaptor.getOperands()));
+    return success();
+  }
+};
+
+void ResolveTokensPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+
+  TypeConverter typeConverter;
+  ConversionTarget target(*context);
+  RewritePatternSet patterns(context);
+
+  // Passthrough converter for everything else. Type conversions are iterated
+  // in reverse, meaning this will be checked after subsequently added
+  // specialized variants.
+  typeConverter.addConversion(
+      [](Type type, SmallVectorImpl<Type> &resultTypes) -> LogicalResult {
+        resultTypes.push_back(type);
+        return success();
+      });
+
+  // Expand shaped refs into one without sync scope and the scope's concrete
+  // types.
+  typeConverter.addConversion(
+      [=](PCF::ShapedRefType type,
+          SmallVectorImpl<Type> &resultTypes) -> std::optional<LogicalResult> {
+        auto syncScope =
+            cast_if_present<PCF::SyncScopeAttrInterface>(type.getSyncScope());
+        if (!syncScope) {
+          resultTypes.push_back(type);
+          return success();
+        }
+
+        auto newRefType =
+            PCF::ShapedRefType::get(type.getContext(), type.getShape(),
+                                    type.getElementType(), type.getScope());
+        resultTypes.push_back(newRefType);
+        for (Type expandedType :
+             syncScope.getConcreteTypes(type.getContext())) {
+          resultTypes.push_back(expandedType);
+        }
+        return success();
+      });
+
+  patterns
+      .add<ConvertGenericOp, ConvertLoopOp, ConvertAllocOp, ConvertWriteSliceOp,
+           ConvertOptimizationBarrier, ConvertBranchOp>(typeConverter, context);
+
+  // Verify that all operand, result, and region argument types have been
+  // converted.
+  auto isLegallyTypedOp = [&](Operation *op) -> bool {
+    for (Type type : op->getResultTypes()) {
+      if (!typeConverter.isLegal(type)) {
+        return false;
+      }
+    }
+    for (Type type : op->getOperandTypes()) {
+      if (!typeConverter.isLegal(type)) {
+        return false;
+      }
+    }
+    for (Region &region : op->getRegions()) {
+      for (Type type : region.getArgumentTypes()) {
+        if (!typeConverter.isLegal(type)) {
+          return false;
+        }
+      }
+    }
+    if (auto funcInterface = dyn_cast<FunctionOpInterface>(op)) {
+      if (llvm::any_of(funcInterface.getArgumentTypes(),
+                       [&](Type t) { return !typeConverter.isLegal(t); })) {
+        return false;
+      }
+      if (llvm::any_of(funcInterface.getResultTypes(),
+                       [&](Type t) { return !typeConverter.isLegal(t); })) {
+        return false;
+      }
+    }
+    return true;
+  };
+  target.markUnknownOpDynamicallyLegal(isLegallyTypedOp);
+
+  scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter, patterns,
+                                                       target);
+  populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
+                                                                 typeConverter);
+  populateCallOpTypeConversionPattern(patterns, typeConverter);
+  populateReturnOpTypeConversionPattern(patterns, typeConverter);
+
+  ConversionConfig config;
+  config.allowPatternRollback = false;
+  if (failed(applyFullConversion(getOperation(), target, std::move(patterns),
+                                 config))) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::PCF

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "fuse_consumers.mlir",
             "fuse_pcf_writes.mlir",
             "lower_structural_pcf.mlir",
+            "resolve_tokens.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "fuse_consumers.mlir"
     "fuse_pcf_writes.mlir"
     "lower_structural_pcf.mlir"
+    "resolve_tokens.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/resolve_tokens.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/resolve_tokens.mlir
@@ -1,0 +1,111 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(iree-pcf-resolve-tokens)" --split-input-file | FileCheck %s
+
+func.func @convert_generic(%arg0: memref<?x?xi32>) {
+  pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %arg0)[%id: index, %n: index]
+         : (!pcf.sref<?x?xi32, sync(#pcf.test_scope)>)
+        -> (memref<?x?xi32>) {
+    util.optimization_barrier %ref : !pcf.sref<?x?xi32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @convert_generic
+//       CHECK:   pcf.generic sync true
+//  CHECK-NEXT:     execute(%[[REF:.+]] = %{{.*}})
+//  CHECK-NEXT:          : (!pcf.sref<?x?xi32, #pcf.test_scope>)
+//       CHECK:       util.optimization_barrier %[[REF]]
+
+// -----
+
+func.func @convert_generic_block_args(%arg0: memref<?x?xi32>) {
+  pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %arg0)[%id: index, %n: index]
+         : (!pcf.sref<?x?xi32, sync(#pcf.test_scope)>)
+        -> (memref<?x?xi32>) {
+    cf.br ^bb1(%ref : !pcf.sref<?x?xi32, sync(#pcf.test_scope)>)
+   ^bb1(%ref_0: !pcf.sref<?x?xi32, sync(#pcf.test_scope)>):
+    util.optimization_barrier %ref_0 : !pcf.sref<?x?xi32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @convert_generic_block_args
+//       CHECK:   pcf.generic sync true
+//  CHECK-NEXT:     execute(%[[REF:.+]] = %{{.*}})
+//  CHECK-NEXT:          : (!pcf.sref<?x?xi32, #pcf.test_scope>)
+//       CHECK:     cf.br ^bb1(%[[REF]]
+//       CHECK:    ^bb1(%[[BRANCH:.+]]: !pcf.sref<?x?xi32, #pcf.test_scope>):
+//       CHECK:       util.optimization_barrier %[[BRANCH]]
+
+// -----
+
+func.func @do_not_sync_no_result_generic() {
+  pcf.generic scope(#pcf.test_scope)
+    execute[%id: index, %count: index] {
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @do_not_sync_no_result_generic
+//       CHECK:   pcf.generic scope
+
+// -----
+
+func.func @convert_loop(%arg0: memref<?x?xi32>, %n: index) {
+  pcf.loop scope(#pcf.test_scope) count(%n)
+    execute(%ref = %arg0)[%id: index]
+            : (!pcf.sref<?x?xi32, sync(#pcf.test_scope)>)
+           -> (memref<?x?xi32>) {
+    util.optimization_barrier %ref : !pcf.sref<?x?xi32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @convert_loop
+//       CHECK:   pcf.loop sync true
+//  CHECK-NEXT:     execute(%[[REF:.+]] = %{{.*}})
+//  CHECK-NEXT:          : (!pcf.sref<?x?xi32, #pcf.test_scope>)
+//       CHECK:       util.optimization_barrier %[[REF]]
+
+// -----
+
+func.func @do_not_sync_no_result_loop(%n: index) {
+  pcf.loop scope(#pcf.test_scope) count(%n)
+    execute[%id: index] {
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @do_not_sync_no_result_loop
+//       CHECK:   pcf.loop scope
+
+// -----
+
+func.func @convert_write_slice(%arg0: memref<3x4xi32>, %ref: !pcf.sref<?x?xi32, sync(#pcf.test_scope)>) {
+  pcf.write_slice %arg0 into %ref[1, 2] [3, 4] [1, 1] : memref<3x4xi32> into !pcf.sref<?x?xi32, sync(#pcf.test_scope)>
+  return
+}
+
+// CHECK-LABEL: @convert_write_slice
+//  CHECK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: memref<3x4xi32>
+//  CHECK-SAME:   %[[ARG1:[A-Za-z0-9]+]]: !pcf.sref<?x?xi32, #pcf.test_scope>
+//       CHECK:   pcf.write_slice %[[ARG0]] into %[[ARG1]][1, 2] [3, 4] [1, 1]
+//  CHECK-SAME:    : memref<3x4xi32> into !pcf.sref<?x?xi32, #pcf.test_scope>
+
+// -----
+
+func.func @convert_alloc(%d0: index) -> !pcf.sref<?x5xi32, sync(#pcf.test_scope)> {
+  %0 = pcf.alloc(%d0) : !pcf.sref<?x5xi32, sync(#pcf.test_scope)>
+  return %0 : !pcf.sref<?x5xi32, sync(#pcf.test_scope)>
+}
+
+// CHECK-LABEL: @convert_alloc
+//  CHECK-SAME:   %[[D0:[A-Za-z0-9]+]]: index
+//       CHECK:   %[[ALLOC:.+]] = pcf.alloc(%[[D0]]) : !pcf.sref<?x5xi32, #pcf.test_scope>
+//       CHECK:   return %[[ALLOC]] : !pcf.sref<?x5xi32, #pcf.test_scope>


### PR DESCRIPTION
Adds the ResolveTokensPass which resolves synchronization scopes attached to `pcf.sref` types by expanding them to a sync_scope-less sref + concrete token types.

The pass:
- Expands `pcf.sref<..., sync_scope>` types into a `pcf.sref` without sync scope plus any concrete types required by the sync scope attribute
- Sets the `sync_on_return` flag on parent `pcf.generic` or `pcf.loop` ops for shaped refs with `sync_on_return` scope
- Updates write operations (`pcf.write_slice`) to enqueue writes through the sync scope's interface methods

This pass runs before `iree-pcf-convert-sref-to-memref` and uses the PCFConversionDialectInterface to load dependent dialects via the new `loadTokenLoweringDependentDialects` method.