### PR TITLE
[GlobalOpt] Restrict constexpr hoisting for index types

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Support/LLVM.h"
 
 namespace mlir::iree_compiler::IREE::Util {
@@ -230,7 +231,8 @@ public:
 
   const ConstExprAnalysis &getAnalysis() const { return analysis; }
 
-  ConstExprHoistingPolicy(const ConstExprAnalysis &analysis, int64_t threshold);
+  ConstExprHoistingPolicy(const ConstExprAnalysis &analysis, int64_t threshold,
+                          const DataLayout &dataLayout);
   void initialize();
   Decision *getDecision(const ConstExprAnalysis::ConstValueInfo *info) {
     return &decisions[info];
@@ -256,6 +258,9 @@ private:
   const ConstExprAnalysis &analysis;
 
   int64_t constExprMaxSizeIncreaseThreshold;
+
+  // Data layout for querying index bitwidth.
+  const DataLayout &dataLayout;
 
   // Map of ConstValueInfo * to decision structs. All are allocated at
   // initialization and then the structure is not changed.

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
@@ -52,9 +52,12 @@ static void populateEscapingProducers(Operation *parentOp,
 // types.
 static bool isLegalConstExprType(Type t) {
   // If implementing the hoistable interface just return what the interface
-  // says.
+  // says. Use a default DataLayout (which uses 64-bit index by default) since
+  // this is called during analysis when we don't have module context.
+  // The actual index bitwidth only matters for storage encoding, not for
+  // determining if a type is legal for const-expr analysis.
   if (auto hoistableType = dyn_cast<IREE::Util::HoistableTypeInterface>(t)) {
-    return hoistableType.isHoistableType();
+    return hoistableType.isHoistableType(DataLayout());
   } else if (t.isIntOrIndexOrFloat()) {
     return true;
   } else if (auto tensorType = dyn_cast<TensorType>(t)) {
@@ -161,10 +164,13 @@ bool isHoistableConstExprLeaf(const ConstExprAnalysis::ConstValueInfo *info) {
   }
 
   // If implementing the HoistableTypeInterface, at this point we can just
-  // return what the interface says.
+  // return what the interface says. Use a default DataLayout (which uses 64-bit
+  // index by default) since this is called during analysis when we don't have
+  // module context. The actual index bitwidth only matters for storage
+  // encoding, not for determining if a type is a hoistable leaf.
   if (auto hoistableType = dyn_cast<IREE::Util::HoistableTypeInterface>(
           info->constValue.getType())) {
-    return hoistableType.isHoistableLeafType();
+    return hoistableType.isHoistableLeafType(DataLayout());
   }
 
   // Never hoist sub-byte aligned values: in legal programs, these will be

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -1318,7 +1318,7 @@ def Util_HoistableType : Util_TypeInterface<"HoistableTypeInterface"> {
       }],
       /*retTy=*/"bool",
       /*methodName=*/"isHoistableType",
-      /*args=*/(ins),
+      /*args=*/(ins "const DataLayout &":$dataLayout),
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         return true;
@@ -1331,7 +1331,7 @@ def Util_HoistableType : Util_TypeInterface<"HoistableTypeInterface"> {
       }],
       /*retTy=*/"bool",
       /*methodName=*/"isHoistableLeafType",
-      /*args=*/(ins),
+      /*args=*/(ins "const DataLayout &":$dataLayout),
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         return true;
@@ -1344,7 +1344,7 @@ def Util_HoistableType : Util_TypeInterface<"HoistableTypeInterface"> {
       }],
       /*retTy=*/"mlir::Type",
       /*methodName=*/"getPreferredStorageType",
-      /*args=*/(ins),
+      /*args=*/(ins "const DataLayout &":$dataLayout),
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         return $_type;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -487,3 +487,37 @@ module @hoist_multiple_globals_ordered {
     util.return %extracted, %extracted : f32, f32
   }
 }
+
+// -----
+
+// CHECK-LABEL: @do_not_hoist_tensor_from_elements_const_index_transient
+module @do_not_hoist_tensor_from_elements_const_index_transient {
+  // CHECK-NOT: util.global
+  // CHECK-NOT: util.initializer
+  // CHECK:     util.func public @main() -> tensor<2xi64>
+  util.func public @main() -> tensor<2xi64> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cast0 = arith.index_cast %c0 : index to i64
+    %cast1 = arith.index_cast %c1 : index to i64
+    // CHECK: tensor.from_elements %{{.*}}, %{{.*}} : tensor<2xi64>
+    %0 = tensor.from_elements %cast0, %cast1 : tensor<2xi64>
+    util.return %0 : tensor<2xi64>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @do_not_hoist_tensor_from_elements_const_index_leaf
+module @do_not_hoist_tensor_from_elements_const_index_leaf {
+  // CHECK-NOT: util.global
+  // CHECK-NOT: util.initializer
+  // CHECK:     util.func public @main() -> tensor<2xindex>
+  util.func public @main() -> tensor<2xindex> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    // CHECK: tensor.from_elements %{{.*}}, %{{.*}} : tensor<2xindex>
+    %0 = tensor.from_elements %c0, %c1 : tensor<2xindex>
+    util.return %0 : tensor<2xindex>
+  }
+}

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -289,7 +289,9 @@ void HoistEncodingOpsPass::runOnOperation() {
   }
 
   const auto &constExprs = getAnalysis<IREE::Util::ConstExprAnalysis>();
-  IREE::Util::ConstExprHoistingPolicy policy(constExprs, /*threshold=*/0);
+  DataLayout dataLayout = DataLayout::closest(moduleOp);
+  IREE::Util::ConstExprHoistingPolicy policy(constExprs, /*threshold=*/0,
+                                             dataLayout);
   policy.initialize();
 
   // Each element indicates ops that are expected to be hoisted. It is valid to

--- a/compiler/src/iree/compiler/GlobalOptimization/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/hoist_into_globals.mlir
@@ -164,20 +164,14 @@ module @hoist_dialect_attrs {
 
 // -----
 
-// CHECK-LABEL: @hoist_index
-module @hoist_index {
-  // CHECK: util.global private @[[HOISTED:.*]] : i64
-  // CHECK: util.initializer
+// CHECK-LABEL: @do_not_hoist_index
+module @do_not_hoist_index {
+  // CHECK-NOT: util.global
+  // CHECK-NOT: util.initializer
+  // CHECK: util.func public @main() -> index
   // CHECK:   %[[C0:.*]] = arith.constant 0 : index
   // CHECK:   %[[CEXPR:.*]] = "iree_unregistered.const_expr"(%[[C0]])
-  // CHECK:   %[[CAST:.*]] = arith.index_cast %[[CEXPR]] : index to i64
-  // CHECK:   util.global.store %[[CAST]], @[[HOISTED]] : i64
-  // CHECK:   util.return
-
-  // CHECK: util.func public @main() -> index
-  // CHECK:   %[[GLOBAL_LD:.*]] = util.global.load immutable @[[HOISTED]] : i64
-  // CHECK:   %[[ORIG_VAL:.*]] = arith.index_cast %[[GLOBAL_LD]] : i64 to index
-  // CHECK:   util.return %[[ORIG_VAL]]
+  // CHECK:   util.return %[[CEXPR]] : index
   util.func public @main() -> (index) {
     %0 = arith.constant 0 : index
     %1 = "iree_unregistered.const_expr"(%0) : (index) -> index


### PR DESCRIPTION
Avoids crashes for operations like `tensor.dim` / `tensor.from_elements` when hoisting constant expressions. Improves index bitwidth assessment in general utilities for constexpr/hoistability analysis by propagating DataLayout information.

The only `HoistableTypeInterface`'s that are feasible to instantiate are the existing ones, for general tensors and for scalar indices. `tensor<index>` types need careful handling, as default utils for bitwidth assessment do not (and should not) assume the exact size of the index type.

For hoisting transforms that act on `ConstExprAnalsysis`, this blocks index-typed expressions altogether within `ConstExprHoistingPolicy`. This type of a transformation might cause issues if the original operation gets dispatch to a target that indexes in 64-bit, while the initializer runs on a 32-bit host, and the bounds of the hoisted constant don't get checked during materialization in the final stages of compilation.

Signed-off-by: Artem Gindinson <gindinson@roofline.ai>