### PR TITLE
[bindings] Link CAPIAMDGPU into libIREECompiler

### DIFF
--- a/compiler/src/iree/compiler/API/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/BUILD.bazel
@@ -38,6 +38,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/API/Internal:IREEReduceToolEntryPoint",
         "//compiler/src/iree/compiler/API/Internal:LLDToolEntryPoint",
         "//llvm-external-projects/iree-dialects:CAPI",
+        "@llvm-project//mlir:CAPIAMDGPU",
         "@llvm-project//mlir:CAPIDebug",
         "@llvm-project//mlir:CAPIGPU",
         "@llvm-project//mlir:CAPIIR",

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
     StaticImpl
   DEPS
     IREEDialectsCAPI
+    MLIRCAPIAMDGPU
     MLIRCAPIDebug
     MLIRCAPIGPU
     MLIRCAPIIR
@@ -70,6 +71,7 @@ iree_cc_library(
 ################################################################################
 
 set(_EXPORT_OBJECT_LIBS
+  obj.MLIRCAPIAMDGPU
   obj.IREEDialectsCAPI
   obj.MLIRCAPIDebug
   obj.MLIRCAPIIR


### PR DESCRIPTION
resolves a linker issue encountered in https://github.com/iree-org/iree/pull/22925