### PR TITLE
[LinalgExt] Enable tensor map_scatter lowering

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -395,8 +395,8 @@ static LogicalResult decomposeToScatter(MapScatterOp mapScatterOp,
   return success();
 }
 
-/// Decompose an `iree_linalg_ext.map_scatter` op with vector input and memref
-/// output. This is the main dispatch function that analyzes the `map_scatter`
+/// Decompose an `iree_linalg_ext.map_scatter` op with vector input.
+/// This is the main dispatch function that analyzes the `map_scatter`
 /// operation and chooses the most appropriate decomposition strategy.
 ///
 /// Decomposition strategies (in order of preference):
@@ -461,9 +461,7 @@ struct DecomposeMapScatterPass final
       return;
     }
 
-    // Decomposition is only supported for map_scatter ops that are both
-    // vectorized and bufferized. Bufferization is a requirement because
-    // vector.scatter only takes memref destinations.
+    // Decomposition is only supported for map_scatter ops that are vectorized.
     SmallVector<MapScatterOp> candidates;
     funcOp->walk([&](MapScatterOp op) {
       if (isa<VectorType>(op.getInputType())) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
@@ -57,6 +57,28 @@ func.func @identity_map_scatter_tensor(
 
 // -----
 
+func.func @identity_map_scatter_tensor(
+    %input: vector<4x16xf32>, %output: tensor<?x?xf32>
+) -> tensor<?x?xf32> {
+  %res = iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
+  return %res : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: func.func @identity_map_scatter_tensor(
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[CST_TRUE:.+]] = arith.constant dense<true> : vector<64xi1>
+//   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = tensor.collapse_shape %[[OUTPUT]] {{.*}} tensor<?x?xf32> into tensor<?xf32>
+//       CHECK:   %[[SCATTER:.+]] = vector.scatter
+//       CHECK:   %[[RESULT:.+]] = tensor.expand_shape %[[SCATTER]] {{.*}} : tensor<?xf32> into tensor<?x?xf32>
+//       CHECK:   return %[[RESULT]] : tensor<?x?xf32>
+
+// -----
+
 // This test checks all index and mask computations for the `map_scatter` to `vector.scatter` path.
 // Other tests shouldn't check this to avoid maintenance burden.
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
@@ -33,6 +33,30 @@ func.func @identity_map_scatter(
 
 // -----
 
+func.func @identity_map_scatter_tensor(
+    %input: vector<4x16xf32>, %output: tensor<4x16xf32>
+) -> tensor<4x16xf32> {
+  %res = iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf32> into tensor<4x16xf32> -> tensor<4x16xf32>
+  return %res : tensor<4x16xf32>
+}
+
+// CHECK-LABEL: func.func @identity_map_scatter_tensor(
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant dense<16> : vector<4x16xindex>
+//   CHECK-DAG:   %[[CST_TRUE:.+]] = arith.constant dense<true> : vector<64xi1>
+//   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = tensor.collapse_shape %[[OUTPUT]] {{.*}} tensor<4x16xf32> into tensor<64xf32>
+//       CHECK:   %[[SCATTER:.+]] = vector.scatter
+//       CHECK:   %[[RESULT:.+]] = tensor.expand_shape %[[SCATTER]] {{.*}} : tensor<64xf32> into tensor<4x16xf32>
+//       CHECK:   return %[[RESULT]] : tensor<4x16xf32>
+
+
+// -----
+
 // This test checks all index and mask computations for the `map_scatter` to `vector.scatter` path.
 // Other tests shouldn't check this to avoid maintenance burden.
 


### PR DESCRIPTION
Previously, vector.scatter didn’t support tensor outputs. Upstream changes added that support, so DecomposeMapScatter now handles the tensor case as well.

Closes https://github.com/iree-org/iree/issues/22697