### PR TITLE
[LLVMCPU][AArch64] New heuristic for matmul vector tile sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1559,8 +1559,6 @@ static void getMatmulVectorSizesUsingFillRegisterFileHeuristic(
   }
 
   // Find the output element type of the matmul.
-  assert(op->getResultTypes().size() == 1 &&
-         "Expected single output type for matmul op");
   Type outputEltType = getElementTypeOrSelf(op->getResultTypes()[0]);
   if (!outputEltType.isSignlessIntOrFloat()) {
     return;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1549,6 +1549,14 @@ static void getMatmulVectorSizesUsingFillRegisterFileHeuristic(
     SmallVectorImpl<bool> &scalableSizeFlags) {
   assert(sizes.empty() && "Pre-condition enforced by caller");
 
+  // Check we have a matrix multiplication.
+  FailureOr<linalg::ContractionDimensions> cDims =
+      linalg::inferContractionDims(op);
+  if (failed(cDims) || cDims->m.size() != 1 || cDims->n.size() != 1 ||
+      cDims->k.size() != 1) {
+    return;
+  }
+
   // Find the output element type of the matmul.
   assert(op->getResultTypes().size() == 1 &&
          "Expected single output type for matmul op");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1577,8 +1577,8 @@ static void getMatmulVectorSizesUsingFillRegisterFileHeuristic(
   // Numbers picked experimentally for a range of element types.
   constexpr int64_t m = 8, n = 2, k = 1;
 
-  // Multiply "horizontal" extents by the number of elements that fit in a vector
-  // register.
+  // Multiply "horizontal" extents by the number of elements that fit in a
+  // vector register.
   sizes.append({m, n * outNumElements, k * outNumElements});
 
   // Mark N dimension as scalable, if doing scalable vectorization.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1553,7 +1553,8 @@ static void getMatmulVectorSizesUsingFillRegisterFileHeuristic(
   FailureOr<linalg::ContractionDimensions> cDims =
       linalg::inferContractionDims(op);
   if (failed(cDims) || cDims->m.size() != 1 || cDims->n.size() != 1 ||
-      cDims->k.size() != 1) {
+      cDims->k.size() != 1 || cDims->m[0] != 0 || cDims->n[0] != 1 ||
+      cDims->k[0] != 2) {
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1549,12 +1549,17 @@ static void getMatmulVectorSizesUsingFillRegisterFileHeuristic(
     SmallVectorImpl<bool> &scalableSizeFlags) {
   assert(sizes.empty() && "Pre-condition enforced by caller");
 
-  // Check we have a matrix multiplication.
+  // Check we have a (batch) matrix multiplication.
   FailureOr<linalg::ContractionDimensions> cDims =
       linalg::inferContractionDims(op);
   if (failed(cDims) || cDims->m.size() != 1 || cDims->n.size() != 1 ||
-      cDims->k.size() != 1 || cDims->m[0] != 0 || cDims->n[0] != 1 ||
-      cDims->k[0] != 2) {
+      cDims->k.size() != 1) {
+    return;
+  }
+  if ((cDims->batch.size() == 0 &&
+       (cDims->m[0] != 0 || cDims->n[0] != 1 || cDims->k[0] != 2)) ||
+      (cDims->batch.size() == 1 &&
+       (cDims->m[0] != 1 || cDims->n[0] != 2 || cDims->k[0] != 3))) {
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -8,9 +8,39 @@ func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
   return %10 : tensor<?x?xf32>
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [4, [16], 0], vector_reduction = [0, 0, 1]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //       CHECK: func.func @matmul_tensors(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// Check tile sizes depend on output element type - altering output element type changes tile sizes.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_f16(%7: tensor<?x?xf16>, %8: tensor<?x?xf16>, %9: tensor<?x?xf16>) -> tensor<?x?xf16> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf16>, tensor<?x?xf16>) outs(%9 : tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %10 : tensor<?x?xf16>
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 8]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
+//       CHECK: func.func @matmul_tensors_f16(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// Check tile sizes depend on output element type - keeping output element type keeps tile sizes.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_i8i8_i32(%7: tensor<?x?xi8>, %8: tensor<?x?xi8>, %9: tensor<?x?xi32>) -> tensor<?x?xi32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xi8>, tensor<?x?xi8>) outs(%9 : tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %10 : tensor<?x?xi32>
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
+//       CHECK: func.func @matmul_tensors_i8i8_i32(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -22,7 +52,7 @@ func.func @static_tensors_non_pow_two_sizes(%3: tensor<15x14xf32>, %4: tensor<14
   %6 = linalg.matmul ins(%3, %4 : tensor<15x14xf32>, tensor<14x7xf32>) outs(%5 : tensor<15x7xf32>) -> tensor<15x7xf32>
   return %6 : tensor<15x7xf32>
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [5, 7, 0], vector_common_parallel = [5, [8], 0], vector_reduction = [0, 0, 1]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [5, 7, 0], vector_common_parallel = [5, [8], 0], vector_reduction = [0, 0, 2]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //       CHECK: func.func @static_tensors_non_pow_two_sizes(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -50,7 +80,7 @@ func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
   return %10 : tensor<?x?xf32>
 }
-//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [4, [16], 0], vector_reduction = [0, 0, 1]>
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
 //  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      DISABLE-ARM-SME: func.func @matmul_tensors(
 //  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
@@ -85,8 +115,8 @@ func.func @matmul_with_fill(%15: tensor<1024x256xi8>, %16: tensor<256x256xi8>, %
    } -> tensor<1024x256xf32>
    return %23 : tensor<1024x256xf32>
 }
-// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [4, [16]]>
-// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [4, [16], 0], vector_reduction = [0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [8, [8]]>
+// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 // CHECK:      func.func @matmul_with_fill(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -7,9 +7,39 @@ func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
   return %10 : tensor<?x?xf32>
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, [16], 0], vector_reduction = [0, 0, 1]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert, {{\{}}enable_loop_peeling}>
 //       CHECK: func.func @matmul_tensors(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// Check tile sizes depend on output element type - altering output element type changes tile sizes.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_f16(%7: tensor<?x?xf16>, %8: tensor<?x?xf16>, %9: tensor<?x?xf16>) -> tensor<?x?xf16> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf16>, tensor<?x?xf16>) outs(%9 : tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %10 : tensor<?x?xf16>
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, [16], 0], vector_reduction = [0, 0, 8]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert, {{\{}}enable_loop_peeling}>
+//       CHECK: func.func @matmul_tensors_f16(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// Check tile sizes depend on output element type - keeping output element type keeps tile sizes.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_i8i8_i32(%7: tensor<?x?xi8>, %8: tensor<?x?xi8>, %9: tensor<?x?xi32>) -> tensor<?x?xi32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xi8>, tensor<?x?xi8>) outs(%9 : tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %10 : tensor<?x?xi32>
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert, {{\{}}enable_loop_peeling}>
+//       CHECK: func.func @matmul_tensors_i8i8_i32(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -21,7 +51,7 @@ func.func @static_tensors_non_pow_two_sizes(%3: tensor<15x14xf32>, %4: tensor<14
   %6 = linalg.matmul ins(%3, %4 : tensor<15x14xf32>, tensor<14x7xf32>) outs(%5 : tensor<15x7xf32>) -> tensor<15x7xf32>
   return %6 : tensor<15x7xf32>
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [5, 7, 0], distribution = [5, 7, 0], vector_common_parallel = [8, [16], 0], vector_reduction = [0, 0, 1]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [5, 7, 0], distribution = [5, 7, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert, {{\{}}enable_loop_peeling}>
 //       CHECK: func.func @static_tensors_non_pow_two_sizes(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -36,7 +66,7 @@ func.func @static_tensors_1x1(%3: tensor<1x1xf32>, %4: tensor<1x1xf32>, %5: tens
   return %6 : tensor<1x1xf32>
 }
 // TODO: FIXME - scalable "16" ([16]) for just 1 element
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 0, 0], vector_common_parallel = [1, [16], 0], vector_reduction = [0, 0, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 0, 0], vector_common_parallel = [1, [8], 0], vector_reduction = [0, 0, 4]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @static_tensors_1x1(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
Compute vector tile sizes using a heuristic that aims to keep the entire
ACC/OUT tile in registers, leave a few registers for LHS/RHS columns
or rows, and all that while not exceeding the number of available
registers.  The rationale is that a matrix multiplication typically
lowers to a loop nest in which the ACC/OUT tile remains live across all
iterations of the innermost loop, whereas the LHS and RHS operands live
for a single iteration and do not require the entire tiles to be
simultaneously resident in registers.

The base element type used is the element type of the output vector
under the assumption the operand types with smaller bitwidths
will be promoted to the output type and thus require more registers
for the same number of elements.

We have observed improvements in performance for on AArch64 targets
(Neoverse-V1 and Neoverse-V2 cores) for Neon and SVE configurations
without data tiling and peeling vector preprocessing strategy,
for example:
  * Neon, `batch.matmul`, f32: ~46% improvement (less time)
  * Neon, GPT2, f32: ~31% improvement

Signed-off-by: Momchil Velikov <momchil.velikov@arm.com>
