### PR TITLE
[CI][Torch Models] Tighten golden times 

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 7.8
+    "golden_time_ms": 7.48
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 275.55
+    "golden_time_ms": 266.2
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 8.26
+    "golden_time_ms": 7.7
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 31.35
+    "golden_time_ms": 27.1
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 181.5
+    "golden_time_ms": 173.8
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 221.65
+    "golden_time_ms": 187
 }


### PR DESCRIPTION
Tighten golden times for benchmarks that exhibit significant % improvement over current goldens. The new values are those that have reasonable absolute margins and are derived from the average times of the 3 most recent passing commits with a 1.1x multiplier. 