### PR TITLE
Integrate LLVM at 60e7c47

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -88,4 +88,15 @@ use_repo(
 # Configure LLVM using the llvm-raw repo (creates llvm-project)
 llvm_configure = use_repo_rule("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
 
-llvm_configure(name = "llvm-project")
+llvm_configure(
+    name = "llvm-project",
+    targets = [
+        "AArch64",
+        "AMDGPU",
+        "ARM",
+        "NVPTX",
+        "RISCV",
+        "WebAssembly",
+        "X86",
+    ],
+)


### PR DESCRIPTION
Integrate https://github.com/llvm/llvm-project/commit/60e7c4709cb728b024a94ab918cc9ca481160fac

Local change: set explicit LLVM target list in the Bazel build. Previously we were deferring to the upstream configure.bzl which set a long list of [DEFAULT_TARGETS](https://github.com/llvm/llvm-project/blob/59da50c77140c5a4909d4fe5accd3bd83b20854f/utils/bazel/configure.bzl#L7-L29). The trigger was that earlier today, Xtensa was added to that list of targets, breaking our build for some reason. But long before that, we had been wasting cycles by building dozens of unnecessary targets. The timing was good for this change, as the new MODULE.bazel with the llvm_configure repository rule makes this easy.

Existing local reverts carried forward:
* Local revert of https://github.com/llvm/llvm-project/pull/169614 due to https://github.com/llvm/llvm-project/issues/172932.