### PR TITLE
[Codegen] add FoldExtractSliceOfBroadcast pattern to TileAndDistributeToWorkgroups

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -308,6 +308,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   // TODO(Max191): Replace populateSwapExtractWithExpandPattern with upstream
   // MLIR version once it is available (llvm-project/pull/126898).
   populateSwapExtractWithExpandPattern(cleanupPatterns);
+  populateFoldExtractSliceOfBroadcastPattern(cleanupPatterns);
   // When fusing pads we do not want to generate zeroSliceGuards when doing
   // workgroup tiling. In `GPUApplyTilingLevelPass` we do have an option called
   // `allowZeroSlices` that can control this but we do not want these
@@ -412,6 +413,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     populateSwapExtractWithCollapsePattern(patterns);
+    populateFoldExtractSliceOfBroadcastPattern(patterns);
     linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
     tensor::populateFoldTensorEmptyPatterns(patterns);
     context->getOrLoadDialect<tensor::TensorDialect>()

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -10,6 +10,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-common-transforms"
@@ -352,6 +353,108 @@ struct SwapExpandShapeWithSlicePattern
 
 void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns) {
   patterns.add<SwapExpandShapeWithSlicePattern>(patterns.getContext());
+}
+
+namespace {
+
+/// Pattern to fold extract_slice(broadcast) into the broadcast input when the
+/// extract_slice is rank-reducing and only extracts along the broadcasted
+/// dimensions (with size 1), leaving all non-broadcasted dimensions intact.
+/// This is valid because the broadcast only duplicates data along the
+/// broadcasted dimension, and extracting a single slice from that dimension
+/// gives back the original input.
+///
+/// Example:
+///   %broadcast = linalg.broadcast ins(%in : tensor<4x1xf16>)
+///                                 outs(%out : tensor<4x1x1xf16>) dimensions =
+///                                 [2]
+///   %extract = tensor.extract_slice %broadcast[0, 0, 0] [4, 1, 1] [1, 1, 1]
+///              : tensor<4x1x1xf16> to tensor<4x1xf16>
+/// ->
+///   %extract is replaced by %in (tensor<4x1xf16>)
+struct FoldExtractSliceOfBroadcast final
+    : OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractOp,
+                                PatternRewriter &rewriter) const override {
+    auto broadcastOp =
+        extractOp.getSource().getDefiningOp<linalg::BroadcastOp>();
+    if (!broadcastOp) {
+      return rewriter.notifyMatchFailure(
+          extractOp, "source is not a linalg.broadcast operation");
+    }
+
+    if (!extractOp.hasUnitStride()) {
+      return rewriter.notifyMatchFailure(extractOp,
+                                         "extract_slice has non-unit stride");
+    }
+
+    auto inputType =
+        dyn_cast<RankedTensorType>(broadcastOp.getInput().getType());
+    auto broadcastOutputType =
+        dyn_cast<RankedTensorType>(broadcastOp.getInit().getType());
+    auto extractResultType =
+        dyn_cast<RankedTensorType>(extractOp.getResult().getType());
+    if (!inputType || !broadcastOutputType || !extractResultType) {
+      return rewriter.notifyMatchFailure(
+          extractOp, "operand or result types are not RankedTensorType");
+    }
+
+    // Extract result type must match broadcast input type.
+    if (inputType != extractResultType) {
+      return rewriter.notifyMatchFailure(
+          extractOp, "extract result type does not match broadcast input type");
+    }
+
+    // Verify that we're extracting from offset [0, 0, ..., 0] with the same
+    // shape as the input (essentially undoing the broadcast).
+    SmallVector<OpFoldResult> offsets = extractOp.getMixedOffsets();
+    SmallVector<OpFoldResult> sizes = extractOp.getMixedSizes();
+    if (llvm::any_of(offsets, [](OpFoldResult offset) {
+          return !isConstantIntValue(offset, 0);
+        })) {
+      return rewriter.notifyMatchFailure(
+          extractOp, "extract_slice offsets are not all zeros");
+    }
+
+    // Sizes should match input dimensions (accounting for broadcast dims).
+    ArrayRef<int64_t> broadcastDims = broadcastOp.getDimensions();
+    int64_t broadcastRank = broadcastOutputType.getRank();
+
+    // Verify that for broadcast dimensions, the size is 1.
+    if (llvm::any_of(broadcastDims, [&](int64_t broadcastDim) {
+          return !isConstantIntValue(sizes[broadcastDim], 1);
+        })) {
+      return rewriter.notifyMatchFailure(
+          extractOp, "broadcast dimensions do not all have size 1");
+    }
+
+    // Collect the indices of dimensions in the broadcast output that were not
+    // broadcasted (i.e., dimensions that existed in the original input).
+    auto nonBroadcastDims = llvm::to_vector(llvm::make_filter_range(
+        llvm::seq<int64_t>(0, broadcastRank),
+        [&](int64_t i) { return !llvm::is_contained(broadcastDims, i); }));
+
+    // Verify that for non-broadcast dimensions, sizes match input shape.
+    if (llvm::any_of(llvm::enumerate(nonBroadcastDims), [&](auto pair) {
+          auto [idx, inputDim] = pair;
+          int64_t inputDimSize = inputType.getDimSize(idx);
+          return !isConstantIntValue(sizes[inputDim], inputDimSize);
+        })) {
+      return rewriter.notifyMatchFailure(
+          extractOp, "non-broadcast dimension sizes do not match input shape");
+    }
+
+    rewriter.replaceOp(extractOp, broadcastOp.getInput());
+    return success();
+  }
+};
+
+} // namespace
+
+void populateFoldExtractSliceOfBroadcastPattern(RewritePatternSet &patterns) {
+  patterns.add<FoldExtractSliceOfBroadcast>(patterns.getContext());
 }
 
 /// Note the following pattern is adapted from the upstream pattern

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -193,6 +193,10 @@ void populateReplaceSlowMinMaxOpsPatterns(RewritePatternSet &patterns);
 /// `tensor.expand_shape(tensor.extract_slice)`.
 void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns);
 
+/// Populate pattern to fold `tensor.extract_slice(linalg.broadcast)` into the
+/// broadcast input when the extract_slice undoes the broadcast.
+void populateFoldExtractSliceOfBroadcastPattern(RewritePatternSet &patterns);
+
 /// Populate pattern to convert `tensor.extract_slice(tensor.collapse_shape)` to
 /// `tensor.collapse_shape(tensor.extract_slice)`.
 void populateSwapExtractWithCollapsePattern(RewritePatternSet &patterns);

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -1364,3 +1364,60 @@ attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPU
 //       CHECK:   scf.forall.in_parallel
 //       CHECK:     tensor.parallel_insert_slice %[[RES]] into %[[OUT0]][%[[OFFSET0]], 0, %[[OFFSET1]]]
 //   CHECK: {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+func.func @arg_compare_fold_broadcast() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [128, 1, 1] subgroup_size = 64>} {
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0xFC00 : f16
+  %c-1 = arith.constant -1 : index
+  %c1336 = arith.constant 1336 : index
+  %c768 = arith.constant 768 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x128256xf16>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : memref<4x1x96xf16, #hal.descriptor_type<storage_buffer>>
+  %2 = amdgpu.fat_raw_buffer_cast %1 resetOffset : memref<4x1x96xf16, #hal.descriptor_type<storage_buffer>> to memref<4x1x96xf16, #amdgpu.address_space<fat_raw_buffer>>
+  %3 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c768) flags(Indirect) : memref<4x1x96xi32, strided<[96, 96, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+  %4 = amdgpu.fat_raw_buffer_cast %3 resetOffset : memref<4x1x96xi32, strided<[96, 96, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> to memref<4x1x96xi32, #amdgpu.address_space<fat_raw_buffer>>
+  %5 = tensor.empty() : tensor<4x1x96xi32>
+  %6 = tensor.empty() : tensor<4x1x96xf16>
+  %7 = tensor.empty() : tensor<4x1xi32>
+  %8 = tensor.empty() : tensor<4x1xf16>
+  %9 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>} ins(%cst : f16) outs(%8 : tensor<4x1xf16>) -> tensor<4x1xf16>
+  %10 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>} ins(%c0_i32 : i32) outs(%7 : tensor<4x1xi32>) -> tensor<4x1xi32>
+  %11:2 = scf.forall (%arg0) = (0) to (128256) step (1336) shared_outs(%arg1 = %6, %arg2 = %5) -> (tensor<4x1x96xf16>, tensor<4x1x96xi32>) {
+    %12 = arith.cmpi slt, %arg0, %c0 : index
+    %13 = arith.subi %c-1, %arg0 : index
+    %14 = arith.select %12, %13, %arg0 : index
+    %15 = arith.divsi %14, %c1336 : index
+    %16 = arith.subi %c-1, %15 : index
+    %17 = arith.select %12, %16, %15 : index
+    %18 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, %arg0], sizes = [4, 1, 1336], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x128256xf16>> -> tensor<4x1x1336xf16>
+    %extracted_slice = tensor.extract_slice %arg1[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1x96xf16> to tensor<4x1x1xf16>
+    %broadcasted = linalg.broadcast ins(%9 : tensor<4x1xf16>) outs(%extracted_slice : tensor<4x1x1xf16>) dimensions = [2]  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>}
+    %extracted_slice_0 = tensor.extract_slice %broadcasted[0, 0, 0] [4, 1, 1] [1, 1, 1] : tensor<4x1x1xf16> to tensor<4x1xf16>
+    %extracted_slice_1 = tensor.extract_slice %arg2[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1x96xi32> to tensor<4x1x1xi32>
+    %broadcasted_2 = linalg.broadcast ins(%10 : tensor<4x1xi32>) outs(%extracted_slice_1 : tensor<4x1x1xi32>) dimensions = [2]  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>}
+    %extracted_slice_3 = tensor.extract_slice %broadcasted_2[0, 0, 0] [4, 1, 1] [1, 1, 1] : tensor<4x1x1xi32> to tensor<4x1xi32>
+    %19 = arith.muli %17, %c1336 : index
+    %20:2 = iree_linalg_ext.arg_compare {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>} dimension(2) ins(%18 : tensor<4x1x1336xf16>) outs(%extracted_slice_0, %extracted_slice_3 : tensor<4x1xf16>, tensor<4x1xi32>) index_base(%19 : index) {
+    ^bb0(%arg3: f16, %arg4: f16):
+      %21 = arith.cmpf ogt, %arg3, %arg4 : f16
+      iree_linalg_ext.yield %21 : i1
+    } -> tensor<4x1xf16>, tensor<4x1xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %20#0 into %arg1[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1xf16> into tensor<4x1x96xf16>
+      tensor.parallel_insert_slice %20#1 into %arg2[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1xi32> into tensor<4x1x96xi32>
+    }
+  } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
+  iree_codegen.store_to_buffer %11#0, %2 : tensor<4x1x96xf16> into memref<4x1x96xf16, #amdgpu.address_space<fat_raw_buffer>>
+  iree_codegen.store_to_buffer %11#1, %4 : tensor<4x1x96xi32> into memref<4x1x96xi32, #amdgpu.address_space<fat_raw_buffer>>
+  return
+}
+// CHECK-LABEL: func.func @arg_compare_fold_broadcast
+//       CHECK:   %[[FILL_F16:.+]] = linalg.fill {{.*}} -> tensor<4x1xf16>
+//       CHECK:   %[[FILL_I32:.+]] = linalg.fill {{.*}} -> tensor<4x1xi32>
+//       CHECK:   scf.forall
+//   CHECK-NOT:     linalg.broadcast
+//       CHECK:     scf.forall {{.*}} shared_outs(%{{.*}} = %[[FILL_F16]], %{{.*}} = %[[FILL_I32]])
+//       CHECK:       iree_linalg_ext.arg_compare

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -1367,57 +1367,65 @@ attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPU
 
 // -----
 
-func.func @arg_compare_fold_broadcast() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [128, 1, 1] subgroup_size = 64>} {
-  %c0_i32 = arith.constant 0 : i32
+func.func @arg_compare_fold_broadcast(
+    %input : tensor<4x1x128256xf16>,
+    %init_f16 : tensor<4x1xf16>,
+    %init_i32 : tensor<4x1xi32>,
+    %out_init_f16 : tensor<4x1x96xf16>,
+    %out_init_i32 : tensor<4x1x96xi32>)
+    -> (tensor<4x1x96xf16>, tensor<4x1x96xi32>) {
   %c0 = arith.constant 0 : index
-  %cst = arith.constant 0xFC00 : f16
   %c-1 = arith.constant -1 : index
   %c1336 = arith.constant 1336 : index
-  %c768 = arith.constant 768 : index
-  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x128256xf16>>
-  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : memref<4x1x96xf16, #hal.descriptor_type<storage_buffer>>
-  %2 = amdgpu.fat_raw_buffer_cast %1 resetOffset : memref<4x1x96xf16, #hal.descriptor_type<storage_buffer>> to memref<4x1x96xf16, #amdgpu.address_space<fat_raw_buffer>>
-  %3 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c768) flags(Indirect) : memref<4x1x96xi32, strided<[96, 96, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-  %4 = amdgpu.fat_raw_buffer_cast %3 resetOffset : memref<4x1x96xi32, strided<[96, 96, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> to memref<4x1x96xi32, #amdgpu.address_space<fat_raw_buffer>>
-  %5 = tensor.empty() : tensor<4x1x96xi32>
-  %6 = tensor.empty() : tensor<4x1x96xf16>
-  %7 = tensor.empty() : tensor<4x1xi32>
-  %8 = tensor.empty() : tensor<4x1xf16>
-  %9 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>} ins(%cst : f16) outs(%8 : tensor<4x1xf16>) -> tensor<4x1xf16>
-  %10 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>} ins(%c0_i32 : i32) outs(%7 : tensor<4x1xi32>) -> tensor<4x1xi32>
-  %11:2 = scf.forall (%arg0) = (0) to (128256) step (1336) shared_outs(%arg1 = %6, %arg2 = %5) -> (tensor<4x1x96xf16>, tensor<4x1x96xi32>) {
-    %12 = arith.cmpi slt, %arg0, %c0 : index
-    %13 = arith.subi %c-1, %arg0 : index
-    %14 = arith.select %12, %13, %arg0 : index
-    %15 = arith.divsi %14, %c1336 : index
-    %16 = arith.subi %c-1, %15 : index
-    %17 = arith.select %12, %16, %15 : index
-    %18 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, %arg0], sizes = [4, 1, 1336], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x128256xf16>> -> tensor<4x1x1336xf16>
-    %extracted_slice = tensor.extract_slice %arg1[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1x96xf16> to tensor<4x1x1xf16>
-    %broadcasted = linalg.broadcast ins(%9 : tensor<4x1xf16>) outs(%extracted_slice : tensor<4x1x1xf16>) dimensions = [2]  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>}
-    %extracted_slice_0 = tensor.extract_slice %broadcasted[0, 0, 0] [4, 1, 1] [1, 1, 1] : tensor<4x1x1xf16> to tensor<4x1xf16>
-    %extracted_slice_1 = tensor.extract_slice %arg2[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1x96xi32> to tensor<4x1x1xi32>
-    %broadcasted_2 = linalg.broadcast ins(%10 : tensor<4x1xi32>) outs(%extracted_slice_1 : tensor<4x1x1xi32>) dimensions = [2]  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>}
-    %extracted_slice_3 = tensor.extract_slice %broadcasted_2[0, 0, 0] [4, 1, 1] [1, 1, 1] : tensor<4x1x1xi32> to tensor<4x1xi32>
-    %19 = arith.muli %17, %c1336 : index
-    %20:2 = iree_linalg_ext.arg_compare {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>} dimension(2) ins(%18 : tensor<4x1x1336xf16>) outs(%extracted_slice_0, %extracted_slice_3 : tensor<4x1xf16>, tensor<4x1xi32>) index_base(%19 : index) {
-    ^bb0(%arg3: f16, %arg4: f16):
-      %21 = arith.cmpf ogt, %arg3, %arg4 : f16
-      iree_linalg_ext.yield %21 : i1
+  %result:2 = scf.forall (%iv) = (0) to (128256) step (1336)
+      shared_outs(%out_f16 = %out_init_f16, %out_i32 = %out_init_i32)
+      -> (tensor<4x1x96xf16>, tensor<4x1x96xi32>) {
+    %cmp = arith.cmpi slt, %iv, %c0 : index
+    %neg_iv = arith.subi %c-1, %iv : index
+    %abs_iv = arith.select %cmp, %neg_iv, %iv : index
+    %idx = arith.divsi %abs_iv, %c1336 : index
+    %neg_idx = arith.subi %c-1, %idx : index
+    %final_idx = arith.select %cmp, %neg_idx, %idx : index
+    %in_slice = tensor.extract_slice %input[0, 0, %iv] [4, 1, 1336] [1, 1, 1]
+        : tensor<4x1x128256xf16> to tensor<4x1x1336xf16>
+    %slice_f16 = tensor.extract_slice %out_f16[0, 0, %final_idx] [4, 1, 1] [1, 1, 1]
+        : tensor<4x1x96xf16> to tensor<4x1x1xf16>
+    %bcast_f16 = linalg.broadcast ins(%init_f16 : tensor<4x1xf16>)
+        outs(%slice_f16 : tensor<4x1x1xf16>) dimensions = [2]
+    %extract_f16 = tensor.extract_slice %bcast_f16[0, 0, 0] [4, 1, 1] [1, 1, 1]
+        : tensor<4x1x1xf16> to tensor<4x1xf16>
+    %slice_i32 = tensor.extract_slice %out_i32[0, 0, %final_idx] [4, 1, 1] [1, 1, 1]
+        : tensor<4x1x96xi32> to tensor<4x1x1xi32>
+    %bcast_i32 = linalg.broadcast ins(%init_i32 : tensor<4x1xi32>)
+        outs(%slice_i32 : tensor<4x1x1xi32>) dimensions = [2]
+    %extract_i32 = tensor.extract_slice %bcast_i32[0, 0, 0] [4, 1, 1] [1, 1, 1]
+        : tensor<4x1x1xi32> to tensor<4x1xi32>
+    %index_base = arith.muli %final_idx, %c1336 : index
+    %compare:2 = iree_linalg_ext.arg_compare
+        {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 128]]>}
+        dimension(2) ins(%in_slice : tensor<4x1x1336xf16>)
+        outs(%extract_f16, %extract_i32 : tensor<4x1xf16>, tensor<4x1xi32>)
+        index_base(%index_base : index) {
+      ^bb0(%lhs: f16, %rhs: f16):
+        %cmp_result = arith.cmpf ogt, %lhs, %rhs : f16
+        iree_linalg_ext.yield %cmp_result : i1
     } -> tensor<4x1xf16>, tensor<4x1xi32>
     scf.forall.in_parallel {
-      tensor.parallel_insert_slice %20#0 into %arg1[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1xf16> into tensor<4x1x96xf16>
-      tensor.parallel_insert_slice %20#1 into %arg2[0, 0, %17] [4, 1, 1] [1, 1, 1] : tensor<4x1xi32> into tensor<4x1x96xi32>
+      tensor.parallel_insert_slice %compare#0 into %out_f16[0, 0, %final_idx] [4, 1, 1] [1, 1, 1]
+          : tensor<4x1xf16> into tensor<4x1x96xf16>
+      tensor.parallel_insert_slice %compare#1 into %out_i32[0, 0, %final_idx] [4, 1, 1] [1, 1, 1]
+          : tensor<4x1xi32> into tensor<4x1x96xi32>
     }
   } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
-  iree_codegen.store_to_buffer %11#0, %2 : tensor<4x1x96xf16> into memref<4x1x96xf16, #amdgpu.address_space<fat_raw_buffer>>
-  iree_codegen.store_to_buffer %11#1, %4 : tensor<4x1x96xi32> into memref<4x1x96xi32, #amdgpu.address_space<fat_raw_buffer>>
-  return
+  return %result#0, %result#1 : tensor<4x1x96xf16>, tensor<4x1x96xi32>
 }
 // CHECK-LABEL: func.func @arg_compare_fold_broadcast
-//       CHECK:   %[[FILL_F16:.+]] = linalg.fill {{.*}} -> tensor<4x1xf16>
-//       CHECK:   %[[FILL_I32:.+]] = linalg.fill {{.*}} -> tensor<4x1xi32>
+//  CHECK-SAME:     %[[INPUT:.+]]: tensor<4x1x128256xf16>
+//  CHECK-SAME:     %[[INIT_F16:.+]]: tensor<4x1xf16>
+//  CHECK-SAME:     %[[INIT_I32:.+]]: tensor<4x1xi32>
+//  CHECK-SAME:     %[[OUT_F16:.+]]: tensor<4x1x96xf16>
+//  CHECK-SAME:     %[[OUT_I32:.+]]: tensor<4x1x96xi32>
 //       CHECK:   scf.forall
 //   CHECK-NOT:     linalg.broadcast
-//       CHECK:     scf.forall {{.*}} shared_outs(%{{.*}} = %[[FILL_F16]], %{{.*}} = %[[FILL_I32]])
+//       CHECK:     scf.forall {{.*}} shared_outs(%{{.*}} = %[[INIT_F16]], %{{.*}} = %[[INIT_I32]])
 //       CHECK:       iree_linalg_ext.arg_compare

--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
     deps = [
         ":PassHeaders",
         ":PassesIncGen",
+        "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -86,6 +86,7 @@ iree_cc_library(
     MLIRTransformDialectTransforms
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Codegen::Common
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Encoding::Utils


### PR DESCRIPTION
This PR adds the FoldExtractSliceOfBroadcast pattern to TileAndDistributeToWorkgroupsUsingForall. This avoids mishandling of broadcasts with unit dimensions during this pass, which previously caused bufferization issues and subsequent numerical correctness problems.

ci-extra: test_torch