### PR TITLE
[LinalgExt] Simplify linearize-delinearize pairs in map_scatter

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -91,6 +91,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
         "@llvm-project//mlir:VectorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_cc_library(
     MLIRTransformDialect
     MLIRTransformUtils
     MLIRTransforms
+    MLIRValueBoundsOpInterface
     MLIRVectorDialect
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Utils

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -201,11 +201,9 @@ struct SimplifyLinearizeDelinearizePairs final
         ValueBoundsConstraintSet::Variable delinearizeVar(
             delinearizeBases[delinIdx]);
 
-        // Check equality.
         FailureOr<bool> areEqual =
             ValueBoundsConstraintSet::areEqual(productVar, delinearizeVar);
         if (succeeded(areEqual) && *areEqual) {
-          // Match found!
           newLinearizeInfos.push_back(newLinearizeInfo);
           break;
         }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
@@ -364,3 +364,37 @@ func.func @map_scatter_with_mask_on_inner_dim(
   } : vector<4x16xf4E2M1FN> into memref<8x16xf4E2M1FN>
   return
 }
+
+// -----
+
+func.func @simplify_linearize_delinearize_pair(
+    %input: vector<1x208x2x4x4x4x2x8x16xf16>,
+    %output: memref<?x53248xf16>,
+    %dim: index
+) {
+  %dim_ceildiv_128 = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%dim]
+  %dim_aligned_128 = affine.apply affine_map<()[s0] -> ((s0 ceildiv 128) * 128)>()[%dim]
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index, %idx2: index, %idx3: index, %idx4: index, %idx5: index, %idx6: index, %idx7: index, %idx8: index):
+      %mask = arith.constant true
+      %linearized_9d = affine.linearize_index disjoint [%idx0, %idx1, %idx2, %idx3, %idx4, %idx5, %idx6, %idx7, %idx8] by (%dim_ceildiv_128, 208, 2, 4, 4, 4, 2, 8, 16) : index
+      %delinearized_4d:4 = affine.delinearize_index %linearized_9d into (%dim_ceildiv_128, 208, 128, 256) : index, index, index, index
+      %linearized_4d = affine.linearize_index disjoint [%delinearized_4d#0, %delinearized_4d#2, %delinearized_4d#1, %delinearized_4d#3] by (%dim_ceildiv_128, 128, 208, 256) : index
+      %delinearized_2d:2 = affine.delinearize_index %linearized_4d into (%dim_aligned_128, 53248) : index, index
+      iree_linalg_ext.yield %delinearized_2d#0, %delinearized_2d#1, %mask : index, index, i1
+  } : vector<1x208x2x4x4x4x2x8x16xf16> into memref<?x53248xf16>
+  return
+}
+// PREPROCESSING-LABEL: func.func @simplify_linearize_delinearize_pair(
+//  PREPROCESSING-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]: vector<1x208x2x4x4x4x2x8x16xf16>
+//  PREPROCESSING-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]: memref<?x53248xf16>
+//  PREPROCESSING-SAME:     %[[DIM:[a-zA-Z0-9_]+]]: index
+//       PREPROCESSING:   %[[TRUE:.+]] = arith.constant true
+//       PREPROCESSING:   %[[DIM_CEILDIV_128:.+]] = affine.apply {{.*}}()[%[[DIM]]]
+//       PREPROCESSING:   iree_linalg_ext.map_scatter %[[INPUT]] into %[[OUTPUT]] {
+//       PREPROCESSING:     ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index, %[[IDX4:.+]]: index, %[[IDX5:.+]]: index, %[[IDX6:.+]]: index, %[[IDX7:.+]]: index, %[[IDX8:.+]]: index):
+//       PREPROCESSING:       %[[LIN_128:.+]] = affine.linearize_index disjoint [%[[IDX2]], %[[IDX3]], %[[IDX4]], %[[IDX5]]] by (2, 4, 4, 4)
+//       PREPROCESSING:       %[[LIN_256:.+]] = affine.linearize_index disjoint [%[[IDX6]], %[[IDX7]], %[[IDX8]]] by (2, 8, 16)
+//       PREPROCESSING:       %[[LIN_0:.+]] = affine.linearize_index disjoint [%[[IDX0]], %[[LIN_128]]] by (%[[DIM_CEILDIV_128]], 128)
+//       PREPROCESSING:       %[[LIN_1:.+]] = affine.linearize_index disjoint [%[[IDX1]], %[[LIN_256]]] by (208, 256)
+//       PREPROCESSING:       iree_linalg_ext.yield %[[LIN_0]], %[[LIN_1]], %[[TRUE]]


### PR DESCRIPTION
Linearize-delinearize pairs often appear inside `map_scatter`. When these operations get lowered, they can create long multiply-add and divide-remainder chains, especially when a dynamic dimension occurs.

This PR adds a pattern to simplify such operation pairs in the `DecomposeMapScatter` pass. We can optimize away the redundant operations by matching dimension products and breaking them into smaller, more efficient chunks.

This optimization helps mitigate the VGPR spilling issue observed in https://github.com/iree-org/iree/issues/21865.