### PR TITLE
[Codegen] Avoid unnecessary masking in map_scatter 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -449,4 +449,3 @@ func.func @unpack_no_padding_no_masking(%dim : index, %result : memref<?x16384xf
 // DISPATCH-SCOPE-LABEL: func @unpack_no_padding_no_masking
 // DISPATCH-SCOPE: iree_linalg_ext.map_scatter
 // DISPATCH-SCOPE-NOT: arith.cmpi ult
-// DISPATCH-SCOPE: return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2428,9 +2428,9 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
   // indices are not root operations.
   llvm::SmallDenseSet<Operation *, 4> genericToSkip;
   for (Operation *op : llvm::reverse(computeOps)) {
-    if (!isa<linalg::GenericOp, linalg::FillOp, IREE::LinalgExt::ScatterOp,
-             IREE::LinalgExt::MapScatterOp, linalg::PackOp, linalg::UnPackOp>(
-            op)) {
+    if (!isa<linalg::CopyOp, linalg::GenericOp, linalg::FillOp,
+             IREE::LinalgExt::ScatterOp, IREE::LinalgExt::MapScatterOp,
+             linalg::PackOp, linalg::UnPackOp>(op)) {
       rootOperation = op;
       break;
     }
@@ -2483,7 +2483,7 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
   if (!rootOperation) {
     for (Operation *op : llvm::reverse(computeOps)) {
       if (isa<IREE::LinalgExt::ScatterOp, IREE::LinalgExt::MapScatterOp,
-              linalg::FillOp>(op)) {
+              linalg::CopyOp, linalg::FillOp>(op)) {
         rootOperation = op;
         break;
       }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/BUILD.bazel
@@ -103,6 +103,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:TilingInterface",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
         "@llvm-project//mlir:ViewLikeInterface",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -65,6 +65,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorUtils
     MLIRTilingInterface
+    MLIRValueBoundsOpInterface
     MLIRViewLikeInterface
     iree::compiler::Dialect::LinalgExt::Utils
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -765,7 +765,7 @@ bool MapScatterOp::isIdentity() {
   return true;
 }
 namespace {
-struct FoldIdentityMapScatter
+struct FoldTensorIdentityMapScatter
     : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
@@ -788,7 +788,7 @@ struct FoldIdentityMapScatter
 
 void MapScatterOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                MLIRContext *ctx) {
-  results.add<FoldIdentityMapScatter>(ctx);
+  results.add<FoldTensorIdentityMapScatter>(ctx);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -216,7 +216,7 @@ func.func public @staticize_online_attention_from_cast(%arg0: tensor<?x4096x16xf
 
 // -----
 
-func.func public @fold_identity_map_scatter(
+func.func public @convert_identity_map_scatter_into_copy(
     %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>
 ) -> tensor<?x?xf32> {
   %true = arith.constant true
@@ -226,8 +226,9 @@ func.func public @fold_identity_map_scatter(
   } : tensor<?x?xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
   return %map_scatter : tensor<?x?xf32>
 }
-//CHECK-LABEL: func public @fold_identity_map_scatter(
+//CHECK-LABEL: func public @convert_identity_map_scatter_into_copy(
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-NOT:   iree_linalg_ext.map_scatter
-//      CHECK:   return %[[ARG0]]
+//      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
+//      CHECK:   return %[[COPY]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -216,7 +216,7 @@ func.func public @staticize_online_attention_from_cast(%arg0: tensor<?x4096x16xf
 
 // -----
 
-func.func public @convert_identity_map_scatter_into_copy(
+func.func public @fold_identity_map_scatter(
     %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>
 ) -> tensor<?x?xf32> {
   %true = arith.constant true
@@ -226,9 +226,8 @@ func.func public @convert_identity_map_scatter_into_copy(
   } : tensor<?x?xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
   return %map_scatter : tensor<?x?xf32>
 }
-//CHECK-LABEL: func public @convert_identity_map_scatter_into_copy(
+//CHECK-LABEL: func public @fold_identity_map_scatter(
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-NOT:   iree_linalg_ext.map_scatter
-//      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
-//      CHECK:   return %[[COPY]]
+//      CHECK:   return %[[ARG0]]


### PR DESCRIPTION
When folding `extract_slice` operations into `map_scatter`, the current behavior is always adding masking logic, without checking whether the `extract_slice` is an identity. For static shapes, this is fine because later optimizations will remove the unnecessary masking. However, for dynamic shapes, the masking code persists and adds runtime overhead. This PR therefore avoids inserting unnecessary masking at the first place.

This PR also adjusts the priority of linalg::CopyOp in root op select, so that when identity map_scatter is canonicalized to a copy, the copy won't be incorrectly selected as the root operation over more important compute ops (e.g., inner_tiled).

This PR helps mitigate the VGPR spilling issue observed in https://github.com/iree-org/iree/issues/21865.

Depends on https://github.com/llvm/llvm-project/pull/173356.
