### PR TITLE
[Codegen] Fix ConvertAccGemmToGemm to handle read-write arguments correctly.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
@@ -92,8 +92,8 @@ static bool isValidInPlaceAccumulatingOp(DestinationStyleOpInterface dpsOp) {
     if (initLoadOp && resultStoreOp && initLoadOp->getSource() &&
         resultStoreOp->getTarget()) {
       // Check that the source and the result have a read/write tag. If they
-      // don't then its really a bug in the way the dispatch is formed, but check
-      // here for safety.
+      // don't then its really a bug in the way the dispatch is formed, but
+      // check here for safety.
       if (initLoadOp->getSourceType().getAccess() ==
           IREE::TensorExt::TensorAccess::ReadWrite) {
         return true;


### PR DESCRIPTION
The current pass unconditionally converts from an accumulating GEMM to a non-accumulating GEMM. This transformation is only required when the `outs` arguments is coming from a read-only buffer. When coming from a read-write buffer, the accumulating gemm can be handled as is, and it does not need to converted to a non-accumulating gemm.

For a function input like

```
func.func @acc_gemm(%lhs : tensor<?x?xf32>, %rhs: tensor<?x?xf32>,
    %init : tensor<?x?xf32> {iree.abi.output = 0}) -> tensor<?x?xf32> {
  %0 = linalg.matmul ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
      outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
  return %0 : tensor<?x?xf32>
}
```

The dispatch sees an single `init` binding that is read-write. In those cases we dont need to convert the `linalg.matmul` into a non-accumulating GEMM. This case can be (and is currently) handled natively.

ci-extra: test_torch