### PR TITLE
[Codegen] add FoldExtractSliceOfFillThroughBlockArg pattern to TileAndDistributeToWorkgroups

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -309,6 +309,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   // MLIR version once it is available (llvm-project/pull/126898).
   populateSwapExtractWithExpandPattern(cleanupPatterns);
   populateFoldExtractSliceOfBroadcastPattern(cleanupPatterns);
+  populateFoldExtractSliceOfFillThroughBlockArgPattern(cleanupPatterns);
   // When fusing pads we do not want to generate zeroSliceGuards when doing
   // workgroup tiling. In `GPUApplyTilingLevelPass` we do have an option called
   // `allowZeroSlices` that can control this but we do not want these
@@ -414,6 +415,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
     RewritePatternSet patterns(context);
     populateSwapExtractWithCollapsePattern(patterns);
     populateFoldExtractSliceOfBroadcastPattern(patterns);
+    populateFoldExtractSliceOfFillThroughBlockArgPattern(patterns);
     linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
     tensor::populateFoldTensorEmptyPatterns(patterns);
     context->getOrLoadDialect<tensor::TensorDialect>()

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -197,6 +197,12 @@ void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns);
 /// broadcast input when the extract_slice undoes the broadcast.
 void populateFoldExtractSliceOfBroadcastPattern(RewritePatternSet &patterns);
 
+/// Populate pattern to fold `tensor.extract_slice` of a `linalg.fill` through
+/// a forall's block argument. Creates a smaller tensor.empty and linalg.fill
+/// inside the loop body.
+void populateFoldExtractSliceOfFillThroughBlockArgPattern(
+    RewritePatternSet &patterns);
+
 /// Populate pattern to convert `tensor.extract_slice(tensor.collapse_shape)` to
 /// `tensor.collapse_shape(tensor.extract_slice)`.
 void populateSwapExtractWithCollapsePattern(RewritePatternSet &patterns);


### PR DESCRIPTION
## Problem
In split reduction lowering (e.g., `iree_linalg_ext.arg_compare`), `linalg.fill` operations are defined outside nested `scf.forall` loops. The existing `FoldExtractSliceOfBroadcastPattern `folds intermediate broadcast + extract_slice ops, exposing the fill result to the inner loop's shared_outs. However, inside the inner loop,` tensor.extract_slice` on the block argument still needs the fill to be materialized locally for correct bufferization.
```mlir
%fill = linalg.fill ins(%cst) outs(%empty) -> tensor<4x1xf16>          // Outside loops
scf.forall (%iv) shared_outs(%arg1 = %out_tensor) {                    // Outer loop  
  // After FoldExtractSliceOfBroadcastPattern: broadcast+extract folded away  
  // %fill is now directly available    
  scf.forall ... shared_outs(%arg5 = %fill) {                          // Inner loop    
      %slice5 = tensor.extract_slice %arg5[%i, %j] [1, ?] [1, 1]         // From block arg    
      // %slice5 traces back to %fill but needs initialization inside this loop  
  }
}
```
This causes bufferization issues because the fill is outside the inner loop, but each workgroup needs its own properly initialized tile.

## Solution

This PR adds `FoldExtractSliceOfFillThroughBlockArgPattern `which traces block arguments back to their defining linalg.fill and creates a new fill on the extracted slice inside the loop:

```mlir
// Before
%fill = linalg.fill ins(%cst) outs(%empty) -> tensor<4x16xf16>
scf.forall ... shared_outs(%out = %fill) {
  %slice = tensor.extract_slice %out[%iv0, %iv1] [1, 8] [1, 1]
  // %slice used without initialization inside loop
}

// After
scf.forall ... shared_outs(%out = %empty) {
  %slice = tensor.extract_slice %out[%iv0, %iv1] [1, 8] [1, 1]
  %filled = linalg.fill ins(%cst) outs(%slice) -> tensor<1x8xf16>
  // %filled properly initialized inside loop
}
```

## How it works with FoldExtractSliceOfBroadcastPattern

For the nested loop case in split reduction, the patterns are applied together:
1. **First**, the existing FoldExtractSliceOfBroadcastPattern simplifies extract_slice(broadcast(fill)) → directly exposes the fill result to the inner forall's shared_outs
2. **Then**, the new FoldExtractSliceOfFillThroughBlockArgPattern traces the inner loop's block argument back to the fill and creates a fill inside the innermost loop

``` mlir
// Before 
%fill = linalg.fill ins(%cst) outs(%empty)           // Outside all loops
scf.forall ... {
  %broadcast = linalg.broadcast ins(%fill) ...
  %slice0 = tensor.extract_slice %broadcast ...      
  scf.forall shared_outs(%arg5 = %slice0) {          // Traces to fill via broadcast
    %slice5 = tensor.extract_slice %arg5 ...         // Not initialized inside
    // Race condition: multiple workgroups write without proper init
  }
}
 
 // After 
 scf.forall ... shared_outs(%arg1 = %empty_out) {     // Outer loop
  scf.forall shared_outs(%arg5 = %empty_tile) {      // Inner loop  
    %slice5 = tensor.extract_slice %arg5 ...
    %filled5 = linalg.fill ins(%cst) outs(%slice5)   // Fill in innermost loop
    // Each workgroup tile properly initialized
  }
}
```
This ensures fill initialization happens at the innermost level where computation occurs, enabling correct bufferization without race conditions.

ci-extra: test_torch