### PR TITLE
[HAL] Avoid segfault in dealloca verifier

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1538,7 +1538,7 @@ static LogicalResult verifyDeviceQueueFences(Operation *queueOp,
                                              Value waitFence,
                                              Value signalFence) {
   if (waitFence == signalFence &&
-      !isa<IREE::Util::NullOp>(waitFence.getDefiningOp())) {
+      !isa_and_present<IREE::Util::NullOp>(waitFence.getDefiningOp())) {
     return queueOp->emitOpError() << "device queue operations cannot wait and "
                                      "signal on the same fence.";
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/invalid.mlir
@@ -77,3 +77,15 @@ hal.executable @ex_with_constants {
     }
   }
 }
+
+// -----
+
+util.func public @dealloc_same_wait_and_signal_fence(%device: !hal.device, %affinity: i64, %fence: !hal.fence, %buffer: !hal.buffer){
+  // expected-error @+1 {{device queue operations cannot wait and signal on the same fence}}
+  hal.device.queue.dealloca<%device: !hal.device>
+      affinity(%affinity)
+      wait(%fence) signal (%fence)
+      buffer(%buffer : !hal.buffer)
+      flags("None")
+  util.return
+}


### PR DESCRIPTION
Avoid segmentation fault when verifying fences in case the fence is a block argument and therefore does not have a defining operation. 

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22960.