### PR TITLE
[CI] Bump MacOS x64 version used in CI

### DIFF
--- a/.github/workflows/ci_macos_x64_clang.yml
+++ b/.github/workflows/ci_macos_x64_clang.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   macos_x64_clang:
     if: ${{ github.repository_owner == 'iree-org' || github.event_name != 'schedule' }}
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       BUILD_DIR: build-macos
     defaults:


### PR DESCRIPTION
macos-13 is retired and stopped working on Dec 9.

See https://github.com/actions/runner-images/issues/13046.

ci-extra: macos_x64_clang