### PR TITLE
[LinalgExt] Fix map_scatter verifier

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -636,10 +636,11 @@ LogicalResult MapScatterOp::verify() {
                     llvm::IsaPred<IndexType>)) {
     return emitOpError("expected block arguments to be index types");
   }
-  if (!transformBody.mightHaveTerminator() ||
-      !isa<IREE::LinalgExt::YieldOp>(transformBody.getTerminator())) {
-    return emitOpError("expected transformation_region to have a terminator");
-  }
+  return success();
+}
+
+LogicalResult MapScatterOp::verifyRegions() {
+  Block &transformBody = getTransformationRegion().getBlocks().front();
   auto yieldOp = cast<IREE::LinalgExt::YieldOp>(transformBody.getTerminator());
   if (yieldOp->getNumOperands() != getOutputRank() + 1) {
     return yieldOp.emitOpError("expected transformation_region to yield a "

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -636,6 +636,10 @@ LogicalResult MapScatterOp::verify() {
                     llvm::IsaPred<IndexType>)) {
     return emitOpError("expected block arguments to be index types");
   }
+  if (!transformBody.mightHaveTerminator() ||
+      !isa<IREE::LinalgExt::YieldOp>(transformBody.getTerminator())) {
+    return emitOpError("expected transformation_region to have a terminator");
+  }
   auto yieldOp = cast<IREE::LinalgExt::YieldOp>(transformBody.getTerminator());
   if (yieldOp->getNumOperands() != getOutputRank() + 1) {
     return yieldOp.emitOpError("expected transformation_region to yield a "

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -305,6 +305,7 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_Op<"map_scatter",
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$transformation_region);
   let hasVerifier = 1;
+  let hasRegionVerifier = 1;
   let hasCanonicalizer = 1;
   let assemblyFormat = [{
     attr-dict $input `into` $output

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -555,6 +555,19 @@ func.func @map_scatter_wrong_mask_type(
 
 // -----
 
+func.func @map_scatter_no_terminator(
+    %input: memref<4xf32>, %output: memref<4xf32>
+){
+  // expected-error@+1 {{expected transformation_region to have a terminator}}
+  "iree_linalg_ext.map_scatter"(%input, %output) ({
+  ^bb0(%idx0: index):
+    %0 = "arith.constant"() <{value = true}> : () -> i1
+  }) : (memref<4xf32>, memref<4xf32>) -> ()
+  return
+}
+
+// -----
+
 func.func @map_scatter_wrong_num_yielded_values(
     %input: memref<4xf32>, %output: memref<4xf32>
 ) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -558,9 +558,9 @@ func.func @map_scatter_wrong_mask_type(
 func.func @map_scatter_no_terminator(
     %input: memref<4xf32>, %output: memref<4xf32>
 ){
-  // expected-error@+1 {{expected transformation_region to have a terminator}}
   "iree_linalg_ext.map_scatter"(%input, %output) ({
   ^bb0(%idx0: index):
+    // expected-error@+1 {{block with no terminator}}
     %0 = "arith.constant"() <{value = true}> : () -> i1
   }) : (memref<4xf32>, memref<4xf32>) -> ()
   return

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -555,6 +555,8 @@ func.func @map_scatter_wrong_mask_type(
 
 // -----
 
+// This test uses generic format, because the custom parser would otherwise
+// insert a terminator due to the SingleBlockImplicitTerminator trait.
 func.func @map_scatter_no_terminator(
     %input: memref<4xf32>, %output: memref<4xf32>
 ){


### PR DESCRIPTION
Fix verification of the `iree_linalg_ext.map_scatter` operation for the case where the `transformation_region` does not have a terminator. So far, we tried to verify the nested `yield` operation before region traits, after this change, this check happens in `verifyRegions` as required.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22965.