### PR TITLE
[AMDGPU][LDS] Unify DMA transfer linearization based on destination contiguity

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -427,7 +427,7 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
 
     // dma_sizes is optional - if not specified, skip the size validation.
     ArrayRef<int64_t> dmaSizes;
-    if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+    if (DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes()) {
       dmaSizes = dmaSizesAttr.asArrayRef();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -109,8 +109,9 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 
   for (int64_t dmaSize : sortedDmaSizes) {
     // Calculate elements per lane for this DMA size.
-    if (dmaSize % elementBits != 0)
+    if (dmaSize % elementBits != 0) {
       continue;
+    }
     int64_t elementsPerLane = dmaSize / elementBits;
 
     // Calculate total elements per transfer (all lanes combined).
@@ -131,8 +132,9 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
       currentOffset += coveredElements;
     }
 
-    if (remainingElements == 0)
+    if (remainingElements == 0) {
       break;
+    }
   }
 
   if (remainingElements != 0) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -269,6 +269,14 @@ struct LowerCoalescedGatherDMAPattern final
     numLinearDims = std::max<int64_t>(numLinearDims, 1);
     LDBG() << "  Number of linear dims: " << numLinearDims;
 
+    // Verify all linearized dimensions are static.
+    for (int64_t i = destRank - numLinearDims; i < destRank; ++i) {
+      if (ShapedType::isDynamic(destShape[i])) {
+        return rewriter.notifyMatchFailure(
+            dmaOp, "dynamic dimension in linearized portion");
+      }
+    }
+
     // Compute total elements in the linearized portion (last numLinearDims
     // dims).
     int64_t linearSize = 1;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -5,9 +5,7 @@
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -76,9 +74,7 @@ func.func @lower_coalesced_gather_dma_multiple(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -131,9 +127,7 @@ func.func @lower_coalesced_copy_dma_basic(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -173,9 +167,7 @@ func.func @lower_coalesced_copy_dma_1d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -222,9 +214,7 @@ func.func @lower_coalesced_copy_dma_single_row_2d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -289,9 +279,7 @@ func.func @lower_coalesced_copy_dma_3d(
 #executable_target_rocm_hsaco_fb_wide = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [256, 256],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [256, 256],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -345,9 +333,7 @@ func.func @lower_coalesced_copy_dma_wide_forall_2d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -399,9 +385,7 @@ func.func @lower_coalesced_gather_dma_with_indices(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -464,9 +448,7 @@ func.func @gather_iterates_over_dest_shape_not_source(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -518,9 +500,7 @@ func.func @lower_coalesced_dma_multiple_transfers_1d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -574,9 +554,7 @@ func.func @lower_coalesced_dma_multiple_transfers_2d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -633,9 +611,7 @@ func.func @lower_coalesced_dma_mixed_sizes_1d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -703,9 +679,7 @@ func.func @lower_coalesced_dma_mixed_sizes_2d(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -769,9 +743,7 @@ func.func @lower_coalesced_dma_linearized_2_rows_per_transfer(
 #executable_target_rocm_hsaco_fb_3d = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx942", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -837,9 +809,7 @@ func.func @lower_3d_partial_contiguous(
 #executable_target_rocm_hsaco_fb_3d_mixed = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx942", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -898,9 +868,7 @@ func.func @lower_3d_partial_contiguous_mixed_dma(
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
-    compute = fp64|fp32|fp16|int64|int32|int16|int8,
-    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
-    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -587,17 +587,17 @@ func.func @lower_coalesced_dma_mixed_sizes_2d(
   // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
   scf.forall (%arg6) in (32) {
     // Linearized path: all 128-bit transfers first, then 32-bit transfers.
-    // Transfer 1: linear offset 0 → [0, 0], 128-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{.+}}], %[[DST]][%{{c0[^,]*}}, %{{.+}}] : vector<4xf32>
+    // Transfer 1: linear offset 0 → dest[0, 0], 128-bit DMA
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{.+}}], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
     //
-    // Transfer 2: linear offset 128 → [0, 128], 128-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{.+}}], %[[DST]][%{{c0[^,]*}}, %{{.+}}] : vector<4xf32>
+    // Transfer 2: linear offset 128 → dest[0, 128], 128-bit DMA
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{.+}}], %[[DST]][%{{c0[^,]*}}, %{{c128[^]]*}}] : vector<4xf32>
     //
-    // Transfer 3: linear offset 256 → [1, 96], 32-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{.+}}], %[[DST]][%{{c1[^,]*}}, %{{.+}}] : vector<1xf32>
+    // Transfer 3: linear offset 256 → dest[1, 96], 32-bit DMA
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{.+}}], %[[DST]][%{{c1[^,]*}}, %{{c96[^]]*}}] : vector<1xf32>
     //
-    // Transfer 4: linear offset 288 → [1, 128], 32-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{.+}}], %[[DST]][%{{c1[^,]*}}, %{{.+}}] : vector<1xf32>
+    // Transfer 4: linear offset 288 → dest[1, 128], 32-bit DMA
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{.+}}], %[[DST]][%{{c1[^,]*}}, %{{c128[^]]*}}] : vector<1xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x160xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2x160xf32, #gpu.address_space<workgroup>>, index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -40,21 +40,29 @@ func.func @lower_coalesced_gather_dma_multiple(
     // CHECK: %[[C4:.+]] = arith.constant 4 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Row 0: source[0, offset + lane_offset], dest[0, 0]
-    // CHECK: %[[SRC_COL0:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %[[SRC_COL0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 1: linear offset 0 → [0, 0]
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
+    // CHECK: %[[SRC_COL0:.+]] = arith.addi %[[DELINEAR0]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR0]]#0, %[[SRC_COL0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<4xf32>
     //
-    // Row 1: source[1, offset + lane_offset], dest[1, 0]
-    // CHECK: %[[SRC_COL1:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %[[SRC_COL1]]], %[[DST]][%{{c1[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 2: linear offset 128 → [1, 0]
+    // CHECK: %[[C128:.+]] = arith.constant 128 : index
+    // CHECK: %[[DELINEAR128:.+]]:2 = affine.delinearize_index %[[C128]] into (4, 128)
+    // CHECK: %[[SRC_COL1:.+]] = arith.addi %[[DELINEAR128]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR128]]#0, %[[SRC_COL1]]], %[[DST]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1] : vector<4xf32>
     //
-    // Row 2: source[2, offset + lane_offset], dest[2, 0]
-    // CHECK: %[[SRC_COL2:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c2[^,]*}}, %[[SRC_COL2]]], %[[DST]][%{{c2[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 3: linear offset 256 → [2, 0]
+    // CHECK: %[[C256:.+]] = arith.constant 256 : index
+    // CHECK: %[[DELINEAR256:.+]]:2 = affine.delinearize_index %[[C256]] into (4, 128)
+    // CHECK: %[[SRC_COL2:.+]] = arith.addi %[[DELINEAR256]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR256]]#0, %[[SRC_COL2]]], %[[DST]][%[[DELINEAR256]]#0, %[[DELINEAR256]]#1] : vector<4xf32>
     //
-    // Row 3: source[3, offset + lane_offset], dest[3, 0]
-    // CHECK: %[[SRC_COL3:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c3[^,]*}}, %[[SRC_COL3]]], %[[DST]][%{{c3[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 4: linear offset 384 → [3, 0]
+    // CHECK: %[[C384:.+]] = arith.constant 384 : index
+    // CHECK: %[[DELINEAR384:.+]]:2 = affine.delinearize_index %[[C384]] into (4, 128)
+    // CHECK: %[[SRC_COL3:.+]] = arith.addi %[[DELINEAR384]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR384]]#0, %[[SRC_COL3]]], %[[DST]][%[[DELINEAR384]]#0, %[[DELINEAR384]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
       memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -101,13 +109,17 @@ func.func @lower_coalesced_copy_dma_basic(
     // CHECK: %[[C2:.+]] = arith.constant 2 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C2]]
     //
-    // Row 0: source[0, offset + lane_offset], dest[0, 0]
-    // CHECK: %[[SRC_COL0:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %[[SRC_COL0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<2xf16>
+    // Transfer 1: linear offset 0 → [0, 0]
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 64)
+    // CHECK: %[[SRC_COL0:.+]] = arith.addi %[[DELINEAR0]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR0]]#0, %[[SRC_COL0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<2xf16>
     //
-    // Row 1: source[1, offset + lane_offset], dest[1, 0]
-    // CHECK: %[[SRC_COL1:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %[[SRC_COL1]]], %[[DST]][%{{c1[^,]*}}, %{{c0[^]]*}}] : vector<2xf16>
+    // Transfer 2: linear offset 64 → [1, 0]
+    // CHECK: %[[C64:.+]] = arith.constant 64 : index
+    // CHECK: %[[DELINEAR64:.+]]:2 = affine.delinearize_index %[[C64]] into (2, 64)
+    // CHECK: %[[SRC_COL1:.+]] = arith.addi %[[DELINEAR64]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR64]]#0, %[[SRC_COL1]]], %[[DST]][%[[DELINEAR64]]#0, %[[DELINEAR64]]#1] : vector<2xf16>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x64xf16, #amdgpu.address_space<fat_raw_buffer>>, memref<2x64xf16, #gpu.address_space<workgroup>>, index
   } {mapping = [#gpu.thread<linear_dim_0>]}
@@ -193,21 +205,29 @@ func.func @lower_coalesced_copy_dma_3d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Tile [0, 0, 0]: source[0, 0, col+lane_offset], dest[0, 0, 0]
-    // CHECK: %[[SRC_IDX_0:[a-zA-Z0-9_]+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{c0[^,]*}}, %[[SRC_IDX_0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 1: linear offset 0 → [0, 0, 0]
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:3 = affine.delinearize_index %[[C0]] into (2, 2, 128)
+    // CHECK: %[[SRC_IDX_0:[a-zA-Z0-9_]+]] = arith.addi %[[DELINEAR0]]#2, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1, %[[SRC_IDX_0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1, %[[DELINEAR0]]#2] : vector<4xf32>
     //
-    // Tile [0, 1, 0]: source[0, 1, col+lane_offset], dest[0, 1, 0]
-    // CHECK: %[[SRC_IDX_1:[a-zA-Z0-9_]+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{c1[^,]*}}, %[[SRC_IDX_1]]], %[[DST]][%{{c0[^,]*}}, %{{c1[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 2: linear offset 128 → [0, 1, 0]
+    // CHECK: %[[C128:.+]] = arith.constant 128 : index
+    // CHECK: %[[DELINEAR128:.+]]:3 = affine.delinearize_index %[[C128]] into (2, 2, 128)
+    // CHECK: %[[SRC_IDX_1:[a-zA-Z0-9_]+]] = arith.addi %[[DELINEAR128]]#2, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1, %[[SRC_IDX_1]]], %[[DST]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1, %[[DELINEAR128]]#2] : vector<4xf32>
     //
-    // Tile [1, 0, 0]: source[1, 0, col+lane_offset], dest[1, 0, 0]
-    // CHECK: %[[SRC_IDX_2:[a-zA-Z0-9_]+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{c0[^,]*}}, %[[SRC_IDX_2]]], %[[DST]][%{{c1[^,]*}}, %{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 3: linear offset 256 → [1, 0, 0]
+    // CHECK: %[[C256:.+]] = arith.constant 256 : index
+    // CHECK: %[[DELINEAR256:.+]]:3 = affine.delinearize_index %[[C256]] into (2, 2, 128)
+    // CHECK: %[[SRC_IDX_2:[a-zA-Z0-9_]+]] = arith.addi %[[DELINEAR256]]#2, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR256]]#0, %[[DELINEAR256]]#1, %[[SRC_IDX_2]]], %[[DST]][%[[DELINEAR256]]#0, %[[DELINEAR256]]#1, %[[DELINEAR256]]#2] : vector<4xf32>
     //
-    // Tile [1, 1, 0]: source[1, 1, col+lane_offset], dest[1, 1, 0]
-    // CHECK: %[[SRC_IDX_3:[a-zA-Z0-9_]+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{c1[^,]*}}, %[[SRC_IDX_3]]], %[[DST]][%{{c1[^,]*}}, %{{c1[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 4: linear offset 384 → [1, 1, 0]
+    // CHECK: %[[C384:.+]] = arith.constant 384 : index
+    // CHECK: %[[DELINEAR384:.+]]:3 = affine.delinearize_index %[[C384]] into (2, 2, 128)
+    // CHECK: %[[SRC_IDX_3:[a-zA-Z0-9_]+]] = arith.addi %[[DELINEAR384]]#2, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR384]]#0, %[[DELINEAR384]]#1, %[[SRC_IDX_3]]], %[[DST]][%[[DELINEAR384]]#0, %[[DELINEAR384]]#1, %[[DELINEAR384]]#2] : vector<4xf32>
     //
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x2x128xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2x2x128xf32, #gpu.address_space<workgroup>>, index
@@ -249,18 +269,22 @@ func.func @lower_coalesced_copy_dma_wide_forall_2d(
     translation_info = #translation_256_wide} {
   // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (256)
   scf.forall (%arg6) in (256) {
-    // elementsPerTransfer = 1024 / 256 = 4
+    // elementsPerTransfer = 256 * 4 = 1024 = 1 row
     // laneOffset is precomputed once and reused across all rows.
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Row 0: source[0, offset + lane_offset], dest[0, 0]
-    // CHECK: %[[SRC_COL0:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %[[SRC_COL0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 1: linear offset 0, source[0, lane_offset], dest[0, 0]
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 1024)
+    // CHECK: %[[SRC_COL0:.+]] = arith.addi %[[DELINEAR0]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR0]]#0, %[[SRC_COL0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<4xf32>
     //
-    // Row 1: source[1, offset + lane_offset], dest[1, 0]
-    // CHECK: %[[SRC_COL1:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %[[SRC_COL1]]], %[[DST]][%{{c1[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 2: linear offset 1024, source[1, lane_offset], dest[1, 0]
+    // CHECK: %[[C1024:.+]] = arith.constant 1024 : index
+    // CHECK: %[[DELINEAR1024:.+]]:2 = affine.delinearize_index %[[C1024]] into (2, 1024)
+    // CHECK: %[[SRC_COL1:.+]] = arith.addi %[[DELINEAR1024]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR1024]]#0, %[[SRC_COL1]]], %[[DST]][%[[DELINEAR1024]]#0, %[[DELINEAR1024]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x1024xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2x1024xf32, #gpu.address_space<workgroup>>, index
   } {mapping = [#gpu.thread<linear_dim_0>]}
@@ -302,15 +326,19 @@ func.func @lower_coalesced_gather_dma_with_indices(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Row 0: load row_indices[0], then gather source[loaded_idx, col+lane_offset]
-    // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%{{c0[^]]*}}]
-    // CHECK: %[[SRC_COL0:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_COL0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 1: linear offset 0, load row_indices[0], gather source[loaded_idx, col+lane_offset]
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 128)
+    // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%[[DELINEAR0]]#0]
+    // CHECK: %[[SRC_COL0:.+]] = arith.addi %[[DELINEAR0]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_COL0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<4xf32>
     //
-    // Row 1: load row_indices[1], then gather source[loaded_idx, col+lane_offset]
-    // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%{{c1[^]]*}}]
-    // CHECK: %[[SRC_COL1:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_COL1]]], %[[DST]][%{{c1[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 2: linear offset 128, load row_indices[1], gather source[loaded_idx, col+lane_offset]
+    // CHECK: %[[C128:.+]] = arith.constant 128 : index
+    // CHECK: %[[DELINEAR128:.+]]:2 = affine.delinearize_index %[[C128]] into (2, 128)
+    // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%[[DELINEAR128]]#0]
+    // CHECK: %[[SRC_COL1:.+]] = arith.addi %[[DELINEAR128]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_COL1]]], %[[DST]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source[%row_indices] into %dest lane(%arg6) : memref<1024x128xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2xindex>, memref<2x128xf32, #gpu.address_space<workgroup>>, index
   } {mapping = [#gpu.thread<linear_dim_0>]}
@@ -355,20 +383,26 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Row 0: load row_indices[0], gather source[loaded_idx, col+lane_offset]
-    // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%{{c0[^]]*}}]
-    // CHECK: %[[SRC_COL0:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_COL0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 1: linear offset 0, load row_indices[0], gather source[loaded_idx, col+lane_offset]
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (3, 128)
+    // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%[[DELINEAR0]]#0]
+    // CHECK: %[[SRC_COL0:.+]] = arith.addi %[[DELINEAR0]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_COL0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<4xf32>
     //
-    // Row 1: load row_indices[1], gather source[loaded_idx, col+lane_offset]
-    // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%{{c1[^]]*}}]
-    // CHECK: %[[SRC_COL1:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_COL1]]], %[[DST]][%{{c1[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 2: linear offset 128, load row_indices[1], gather source[loaded_idx, col+lane_offset]
+    // CHECK: %[[C128:.+]] = arith.constant 128 : index
+    // CHECK: %[[DELINEAR128:.+]]:2 = affine.delinearize_index %[[C128]] into (3, 128)
+    // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%[[DELINEAR128]]#0]
+    // CHECK: %[[SRC_COL1:.+]] = arith.addi %[[DELINEAR128]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_COL1]]], %[[DST]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1] : vector<4xf32>
     //
-    // Row 2: load row_indices[2], gather source[loaded_idx, col+lane_offset]
-    // CHECK: %[[LOADED_ROW2:.+]] = memref.load %[[IDX]][%{{c2[^]]*}}]
-    // CHECK: %[[SRC_COL2:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW2]], %[[SRC_COL2]]], %[[DST]][%{{c2[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // Transfer 3: linear offset 256, load row_indices[2], gather source[loaded_idx, col+lane_offset]
+    // CHECK: %[[C256:.+]] = arith.constant 256 : index
+    // CHECK: %[[DELINEAR256:.+]]:2 = affine.delinearize_index %[[C256]] into (3, 128)
+    // CHECK: %[[LOADED_ROW2:.+]] = memref.load %[[IDX]][%[[DELINEAR256]]#0]
+    // CHECK: %[[SRC_COL2:.+]] = arith.addi %[[DELINEAR256]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW2]], %[[SRC_COL2]]], %[[DST]][%[[DELINEAR256]]#0, %[[DELINEAR256]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source[%row_indices] into %dest lane(%arg6) : memref<256x128xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<3xindex>, memref<3x128xf32, #gpu.address_space<workgroup>>, index
@@ -587,17 +621,27 @@ func.func @lower_coalesced_dma_mixed_sizes_2d(
   // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
   scf.forall (%arg6) in (32) {
     // Linearized path: all 128-bit transfers first, then 32-bit transfers.
+    // Uses affine.delinearize_index to convert linear offsets to multi-dim indices.
+    //
     // Transfer 1: linear offset 0 → dest[0, 0], 128-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{.+}}], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 160)
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR0]]#0, %{{.+}}], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<4xf32>
     //
     // Transfer 2: linear offset 128 → dest[0, 128], 128-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %{{.+}}], %[[DST]][%{{c0[^,]*}}, %{{c128[^]]*}}] : vector<4xf32>
+    // CHECK: %[[C128:.+]] = arith.constant 128 : index
+    // CHECK: %[[DELINEAR128:.+]]:2 = affine.delinearize_index %[[C128]] into (2, 160)
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR128]]#0, %{{.+}}], %[[DST]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1] : vector<4xf32>
     //
     // Transfer 3: linear offset 256 → dest[1, 96], 32-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{.+}}], %[[DST]][%{{c1[^,]*}}, %{{c96[^]]*}}] : vector<1xf32>
+    // CHECK: %[[C256:.+]] = arith.constant 256 : index
+    // CHECK: %[[DELINEAR256:.+]]:2 = affine.delinearize_index %[[C256]] into (2, 160)
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR256]]#0, %{{.+}}], %[[DST]][%[[DELINEAR256]]#0, %[[DELINEAR256]]#1] : vector<1xf32>
     //
     // Transfer 4: linear offset 288 → dest[1, 128], 32-bit DMA
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c1[^,]*}}, %{{.+}}], %[[DST]][%{{c1[^,]*}}, %{{c128[^]]*}}] : vector<1xf32>
+    // CHECK: %[[C288:.+]] = arith.constant 288 : index
+    // CHECK: %[[DELINEAR288:.+]]:2 = affine.delinearize_index %[[C288]] into (2, 160)
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR288]]#0, %{{.+}}], %[[DST]][%[[DELINEAR288]]#0, %[[DELINEAR288]]#1] : vector<1xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x160xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2x160xf32, #gpu.address_space<workgroup>>, index
@@ -653,13 +697,17 @@ func.func @lower_coalesced_dma_linearized_2_rows_per_transfer(
     //
     // Transfer 1: linear offset 0, multi-dim [0, 0]
     // Covers rows 0-1 (elements 0-127)
-    // CHECK: %[[SRC_COL0:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c0[^,]*}}, %[[SRC_COL0]]], %[[DST]][%{{c0[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[DELINEAR0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 64)
+    // CHECK: %[[SRC_COL0:.+]] = arith.addi %[[DELINEAR0]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR0]]#0, %[[SRC_COL0]]], %[[DST]][%[[DELINEAR0]]#0, %[[DELINEAR0]]#1] : vector<4xf32>
     //
     // Transfer 2: linear offset 128, multi-dim [2, 0] (128 / 64 = 2, 128 % 64 = 0)
     // Covers rows 2-3 (elements 128-255)
-    // CHECK: %[[SRC_COL1:.+]] = arith.addi %{{.+}}, %[[LANE_OFFSET]]
-    // CHECK: amdgpu.gather_to_lds %[[SRC]][%{{c2[^,]*}}, %[[SRC_COL1]]], %[[DST]][%{{c2[^,]*}}, %{{c0[^]]*}}] : vector<4xf32>
+    // CHECK: %[[C128:.+]] = arith.constant 128 : index
+    // CHECK: %[[DELINEAR128:.+]]:2 = affine.delinearize_index %[[C128]] into (4, 64)
+    // CHECK: %[[SRC_COL1:.+]] = arith.addi %[[DELINEAR128]]#1, %[[LANE_OFFSET]]
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[DELINEAR128]]#0, %[[SRC_COL1]]], %[[DST]][%[[DELINEAR128]]#0, %[[DELINEAR128]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<4x64xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<4x64xf32, #gpu.address_space<workgroup>>, index


### PR DESCRIPTION
This PR refactors the `AMDGPULowerCoalescedDMAToGatherLDS` pass to use an unified and optimized approach for DMA transfers based on destination memref contiguity. Previously, the pass treated transfers row-by-row. 

This PR extends the transfer to cover multiple inner dimensions if it satisfy the contiguity condition. By doing so we can utilize larger DMA transfer sizes which will not be feasible previously.

