### PR TITLE
Revert "[Codegen][ROCDL] Improve dynamic dimension bounds handling in ROCDLConfigureBufferInstructions (#22892)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/configure_buffer_instructions.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/configure_buffer_instructions.mlir
@@ -123,18 +123,3 @@ func.func @assume_dyn_size() {
     : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x256xf32>>{%m.assume}
   return
 }
-
-// CHECK-LABEL: @ceildiv_dyn_size
-// CHECK: iree_gpu.use_rocdl_buffer_instructions
-// CHECK: return
-func.func @ceildiv_dyn_size() {
-  %c0 = arith.constant 0 : index
-  %m.i32 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-  %m = arith.index_castui %m.i32 : i32 to index
-  %m.assume = util.assume.int %m[<umin = 128, umax = 16384, udiv = 128>] : index
-  %dim = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%m.assume]
-  %bind = hal.interface.binding.subspan layout(#pipeline_layout)
-    binding(0) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x256xf32>>{%dim}
-  return
-}

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -76,7 +76,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:TransformUtils",
-        "@llvm-project//mlir:ValueBoundsOpInterface",
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorTransforms",
         "@llvm-project//mlir:ViewLikeInterface",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -55,7 +55,6 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTilingInterface
     MLIRTransformUtils
-    MLIRValueBoundsOpInterface
     MLIRVectorDialect
     MLIRVectorTransforms
     MLIRViewLikeInterface

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -20,8 +20,6 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/DebugLog.h"
-#include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
-#include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -40,7 +38,6 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/TilingInterface.h"
-#include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/RegionUtils.h"
 
@@ -1111,32 +1108,6 @@ int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp) {
   }
   return bitwidth;
 };
-
-//===---------------------------------------------------------------------===//
-// Integer range analysis utility functions
-//===---------------------------------------------------------------------===//
-
-FailureOr<int64_t> getDynamicUpperBound(Value value,
-                                        const DataFlowSolver &solver) {
-  // First try IntegerRangeAnalysis (cached, efficient).
-  if (auto *maybeRange =
-          solver.lookupState<dataflow::IntegerValueRangeLattice>(value)) {
-    IntegerValueRange range = maybeRange->getValue();
-    if (!range.isUninitialized() &&
-        range.getValue().smax() !=
-            IntegerValueRange::getMaxRange(value).getValue().smax()) {
-      return range.getValue().smax().getSExtValue();
-    }
-  }
-  // Fallback to ValueBoundsConstraintSet for complex cases.
-  auto ub = ValueBoundsConstraintSet::computeConstantBound(
-      presburger::BoundType::UB, {value, std::nullopt},
-      /*stopCondition=*/nullptr, /*closedUB=*/true);
-  if (succeeded(ub)) {
-    return ub.value();
-  }
-  return failure();
-}
 
 //===---------------------------------------------------------------------===//
 // Bufferization utility functions

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -26,10 +26,6 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SubsetOpInterface.h"
 
-namespace mlir {
-class DataFlowSolver;
-} // namespace mlir
-
 namespace mlir::iree_compiler {
 
 static constexpr unsigned kNumMaxParallelDims = 3;
@@ -214,17 +210,6 @@ int getReductionTilingFactor(int64_t dimSize);
 // Returns the minimal element bitwidth used in the operands and results of the
 // given Linalg op.
 int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp);
-
-//===---------------------------------------------------------------------===//
-// Integer range analysis utility functions.
-//===---------------------------------------------------------------------===//
-
-/// Get the upper bound of a dynamic value. First tries IntegerRangeAnalysis
-/// (cached, efficient), then falls back to ValueBoundsConstraintSet for complex
-/// cases like affine.apply. The solver should have IntegerRangeAnalysis loaded
-/// and initialized before calling this function.
-FailureOr<int64_t> getDynamicUpperBound(Value value,
-                                        const DataFlowSolver &solver);
 
 //===---------------------------------------------------------------------===//
 // Bufferization utility functions


### PR DESCRIPTION
This reverts commit 085a594e93738b579806936f52d91f4b9d2698e3, due to numeric issues on llama model (https://github.com/iree-org/iree/pull/22892#issuecomment-3700005179).