### PR TITLE
[VM] Fix integer to f64 cast folding

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -1714,7 +1714,7 @@ OpFoldResult CastSI64F64Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<IntegerAttr, FloatAttr>(
       Float64Type::get(getContext()), operands.getOperand(),
       [&](const APInt &a) {
-        APFloat b = APFloat(0.0);
+        APFloat b{0.0};
         b.convertFromAPInt(a, /*IsSigned=*/true, APFloat::rmNearestTiesToAway);
         return b;
       });
@@ -1724,7 +1724,7 @@ OpFoldResult CastUI64F64Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<IntegerAttr, FloatAttr>(
       Float64Type::get(getContext()), operands.getOperand(),
       [&](const APInt &a) {
-        APFloat b = APFloat(0.0);
+        APFloat b{0.0};
         b.convertFromAPInt(a, /*IsSigned=*/false, APFloat::rmNearestTiesToAway);
         return b;
       });

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -1714,7 +1714,7 @@ OpFoldResult CastSI64F64Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<IntegerAttr, FloatAttr>(
       Float64Type::get(getContext()), operands.getOperand(),
       [&](const APInt &a) {
-        APFloat b = APFloat(0.0f);
+        APFloat b = APFloat(0.0);
         b.convertFromAPInt(a, /*IsSigned=*/true, APFloat::rmNearestTiesToAway);
         return b;
       });
@@ -1724,7 +1724,7 @@ OpFoldResult CastUI64F64Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<IntegerAttr, FloatAttr>(
       Float64Type::get(getContext()), operands.getOperand(),
       [&](const APInt &a) {
-        APFloat b = APFloat(0.0f);
+        APFloat b = APFloat(0.0);
         b.convertFromAPInt(a, /*IsSigned=*/false, APFloat::rmNearestTiesToAway);
         return b;
       });

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
@@ -205,3 +205,28 @@ vm.module @cast_ref_any_folds {
     vm.return %1 : !vm.ref<?>
   }
 }
+
+// -----
+
+// CHECK-LABEL: vm.module public @float_cast_folds
+vm.module public @float_cast_folds {
+  // CHECK-LABEL: vm.func @cast_signed_to_f64
+  vm.func @cast_signed_to_f64() -> f64 {
+    // CHECK: %[[CONST_0:.*]] = vm.const.f64
+    %cst = vm.const.i64 2147483648
+    // CHECK-NOT: vm.cast.si64.f64
+    %0 = vm.cast.si64.f64 %cst : i64 -> f64
+    // CHECK: vm.return %[[CONST_0]]
+    vm.return %0 : f64
+  }
+
+  // CHECK-LABEL: vm.func @cast_unsigned_to_f64
+  vm.func @cast_unsigned_to_f64() -> f64 {
+    // CHECK: %[[CONST_1:.*]] = vm.const.f64
+    %cst = vm.const.i64 4294967295
+    // CHECK-NOT: vm.cast.ui64.f64
+    %0 = vm.cast.ui64.f64 %cst : i64 -> f64
+    // CHECK: vm.return %[[CONST_1]]
+    vm.return %0 : f64
+  }
+}


### PR DESCRIPTION
Fix the VM dialect constant folders for integer to float64 type casts.

Incorrectly using a float(32) zero value for initialization leads to a mismatch in float semantics between initial and converted value.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22966.