### PR TITLE
[CI] Reclaim disk space on macos arm runners

### DIFF
--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -46,6 +46,15 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+      - name: "Reclaim disk space"
+        # GitHub-hosted runners have 14GB of disk space -- reclaim some by removing SDKs
+        # we don't need.
+        run: |
+          echo "Free space before"
+          df -h
+          sudo rm -rf /Users/runner/Library/Android/sdk
+          echo "Free space after"
+          df -h
       - name: "Installing Python packages"
         run: pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Installing requirements"


### PR DESCRIPTION
Our macos arm builds started failing with out-of-disk-space errors on Nov 17: https://github.com/iree-org/iree/actions/runs/19424581074.

Reclaim some disk space by deleting the Android SDK. Inspired by https://github.com/nodejs/node/pull/54658/changes.