### PR TITLE
[CI] Use `build_all.sh` in clang checks

### DIFF
--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -31,29 +31,10 @@ jobs:
           submodules: true
       - name: Install Python requirements
         run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: CMake - configure
+      - name: Build IREE
         run: |
           source ./build_tools/cmake/setup_sccache.sh
-          cmake \
-            -G Ninja \
-            -B ${BUILD_DIR} \
-            -DPython3_EXECUTABLE="$(which python3)" \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DIREE_BUILD_PYTHON_BINDINGS=ON \
-            -DIREE_ENABLE_LLD=ON \
-            -DIREE_ENABLE_ASSERTIONS=ON \
-            -DIREE_ENABLE_SPLIT_DWARF=ON \
-            -DIREE_ENABLE_THIN_ARCHIVES=ON \
-            -DIREE_BUILD_DOCS=ON \
-            -DIREE_TARGET_BACKEND_CUDA=ON \
-            -DIREE_TARGET_BACKEND_ROCM=ON \
-            -DIREE_TARGET_BACKEND_WEBGPU_SPIRV=ON
-      - name: CMake - build
-        run: |
-          cmake --build ${BUILD_DIR} -- -k 0
-          cmake --build ${BUILD_DIR} --target install -- -k 0
-          cmake --build ${BUILD_DIR} --target iree-test-deps -- -k 0
-          sccache --show-stats
+          ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: Run CTest
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
         env:

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -46,23 +46,12 @@ jobs:
           submodules: true
       - name: Install Python requirements
         run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: CMake - configure
+      - name: Build IREE
+        env:
+          CMAKE_BUILD_TYPE: Debug
         run: |
           source ./build_tools/cmake/setup_sccache.sh
-          cmake \
-            -G Ninja \
-            -B ${BUILD_DIR} \
-            -DPython3_EXECUTABLE="$(which python3)" \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DIREE_BUILD_PYTHON_BINDINGS=ON \
-            -DIREE_ENABLE_LLD=ON \
-            -DIREE_ENABLE_ASSERTIONS=ON \
-            -DIREE_ENABLE_SPLIT_DWARF=ON \
-            -DIREE_ENABLE_THIN_ARCHIVES=ON
-      - name: CMake - build
-        run: |
-          cmake --build ${BUILD_DIR} -- -k 0
-          sccache --show-stats
+          ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       # We could build `iree-test-deps` or run some unit tests here, but the
       # main thing we want coverage for is the build itself and those steps
       # would add 10+ minutes to the job.

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -31,7 +31,7 @@ IREE_TARGET_BACKEND_ROCM="${IREE_TARGET_BACKEND_ROCM:-${OFF_IF_DARWIN}}"
 # developers.
 IREE_TARGET_BACKEND_WEBGPU_SPIRV="${IREE_TARGET_BACKEND_WEBGPU_SPIRV:-${OFF_IF_DARWIN}}"
 # Enable building the `iree-test-deps` target.
-IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-1}"
+IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-ON}"
 
 source build_tools/cmake/setup_build.sh
 source build_tools/cmake/setup_ccache.sh

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -31,7 +31,7 @@ IREE_TARGET_BACKEND_ROCM="${IREE_TARGET_BACKEND_ROCM:-${OFF_IF_DARWIN}}"
 # developers.
 IREE_TARGET_BACKEND_WEBGPU_SPIRV="${IREE_TARGET_BACKEND_WEBGPU_SPIRV:-${OFF_IF_DARWIN}}"
 # Enable building the `iree-test-deps` target.
-IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-ON}"
+IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-"ON"}"
 
 source build_tools/cmake/setup_build.sh
 source build_tools/cmake/setup_ccache.sh

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -31,7 +31,7 @@ IREE_TARGET_BACKEND_ROCM="${IREE_TARGET_BACKEND_ROCM:-${OFF_IF_DARWIN}}"
 # developers.
 IREE_TARGET_BACKEND_WEBGPU_SPIRV="${IREE_TARGET_BACKEND_WEBGPU_SPIRV:-${OFF_IF_DARWIN}}"
 # Enable building the `iree-test-deps` target.
-IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-"ON"}"
+IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-1}"
 
 source build_tools/cmake/setup_build.sh
 source build_tools/cmake/setup_ccache.sh


### PR DESCRIPTION
Converge on the same configure + build script as other CI checks instead of one-off cmake invocations.