### PR TITLE
[CI] Allow macos checks to be triggered with ci-extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,18 @@ jobs:
     uses: ./.github/workflows/ci_linux_x64_clang_ubsan.yml
     secrets: inherit
 
+  macos_arm64_clang:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'macos_arm64_clang')
+    uses: ./.github/workflows/ci_macos_arm64_clang.yml
+    secrets: inherit
+
+  macos_x64_clang:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'macos_x64_clang')
+    uses: ./.github/workflows/ci_macos_x64_clang.yml
+    secrets: inherit
+
   windows_x64_msvc:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'windows_x64_msvc')
@@ -271,6 +283,8 @@ jobs:
       - linux_x64_clang
       - linux_x64_clang_asan
       - linux_x64_clang_ubsan
+      - macos_arm64_clang
+      - macos_x64_clang
       - windows_x64_msvc
     uses: ./.github/workflows/workflow_summary.yml
     secrets: inherit

--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_macos_x64_clang.yml
+++ b/.github/workflows/ci_macos_x64_clang.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -118,9 +118,17 @@ CONTROL_JOB_REGEXES = frozenset(
 # They may also run on presubmit only under certain conditions.
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
-        # None.
         "windows_x64_msvc",
         "test_torch",
+    ]
+)
+
+# Jobs to only run on schedule or when explicitly requested via ci-extra.
+# These are excluded from both presubmit and postsubmit by default.
+DEFAULT_SCHEDULE_ONLY_JOBS = frozenset(
+    [
+        "macos_arm64_clang",
+        "macos_x64_clang",
     ]
 )
 
@@ -404,10 +412,10 @@ def get_enabled_jobs(
     """
     if not is_pr:
         print(
-            "Running all jobs because run was not triggered by a pull request event.",
+            "Running default postsubmit jobs (excluding schedule-only jobs).",
             file=sys.stderr,
         )
-        return all_jobs
+        return all_jobs - DEFAULT_SCHEDULE_ONLY_JOBS
     if is_llvm_integrate_pr:
         print(
             "Running all jobs because run was triggered by an LLVM integrate pull request event.",
@@ -456,7 +464,7 @@ def get_enabled_jobs(
             f" '{Trailer.EXTRA_JOBS}', but found {ambiguous_jobs}"
         )
 
-    enabled_jobs = all_jobs - DEFAULT_POSTSUBMIT_ONLY_JOBS
+    enabled_jobs = all_jobs - DEFAULT_POSTSUBMIT_ONLY_JOBS - DEFAULT_SCHEDULE_ONLY_JOBS
 
     if not modifies_non_skip_paths(modified_paths):
         print(

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -453,6 +453,12 @@ runs.
     ci-extra: windows_x64_msvc
     ```
 
+* Opt in to the MacOS build and test workflows:
+
+    ``` text
+    ci-extra: macos_arm64_clang, macos_x64_clang
+    ```
+
 For example, this PR opted in to running the `build_test_all_windows` job
 (which was renamed to `windows_x64_msvc`):
 


### PR DESCRIPTION
This makes it easier to see if these are working, without having to push changes to a branch under iree-org/iree. We already have support for this for windows_x64_msvc and torch_ops.

ci-extra: macos_arm64_clang, macos_x64_clang