### PR TITLE
[CI] Drop macos job concurrency block

### DIFF
--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -13,16 +13,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   macos_arm64_clang:
+    # Prevent scheduled runs in forks (only allow for iree-org or non-schedule triggers).
     if: ${{ github.repository_owner == 'iree-org' || github.event_name != 'schedule' }}
     runs-on: macos-14
     env:

--- a/.github/workflows/ci_macos_x64_clang.yml
+++ b/.github/workflows/ci_macos_x64_clang.yml
@@ -13,16 +13,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   macos_x64_clang:
+    # Prevent scheduled runs in forks (only allow for iree-org or non-schedule triggers).
     if: ${{ github.repository_owner == 'iree-org' || github.event_name != 'schedule' }}
     runs-on: macos-15-intel
     env:


### PR DESCRIPTION
Remove `concurrency` block from macOS workflows - when called as reusable workflows, the `github.workflow` context inherits the caller's workflow name ("CI"), creating the same concurrency group as the parent workflow and causing the job to be skipped. Note that other optional checks like windows_x64_msvc don't use it either.