### PR TITLE
[CI] Upgrade to GCC 11 to fix stablehlo template instantiation error

### DIFF
--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -27,7 +27,7 @@ jobs:
   linux_x64_gcc:
     if: ${{ github.repository_owner == 'iree-org' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:78a558b999b230f7e1da376639e14b44f095f30f1777d6a272ba48c0bbdd4ccb
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:dfaf99be6f3adf3d7e404ca8e41e545f5353ab694037f627d2170f49f688504f
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -40,8 +40,8 @@ jobs:
           submodules: true
       - name: "Building IREE with gcc"
         env:
-          CC: /usr/bin/gcc-9
-          CXX: /usr/bin/g++-9
+          CC: gcc-11
+          CXX: g++-11
           CMAKE_BUILD_TYPE: Release
           IREE_TARGET_BACKEND_WEBGPU_SPIRV: OFF
           IREE_BUILD_SETUP_PYTHON_VENV: ${{ env.BUILD_DIR }}/.venv

--- a/docs/website/docs/developers/debugging/releases.md
+++ b/docs/website/docs/developers/debugging/releases.md
@@ -41,11 +41,10 @@ The Linux releases are done in a manylinux2014 docker container defined in the
 [`manylinux_x86_64.Dockerfile`](https://github.com/iree-org/base-docker-images/blob/main/dockerfiles/manylinux_x86_64.Dockerfile)
 file within the
 [iree-org/base-docker-images repository](https://github.com/iree-org/base-docker-images/).
-At the time of this writing, it has gcc 9.3.1 and Python versions 3.5 - 3.9
-under `/opt/python`. Note that this docker image approximates a 2014 era RHEL
-distro, patched with backported (newer) dev packages. It builds with gcc and
-BFD linker unless if you arrange otherwise. `yum` can be used to get some
-packages.
+At the time of this writing, it has Python versions 3.9 - 3.13 under
+`/opt/python`. Note that this docker image approximates a 2014 era RHEL distro,
+patched with backported (newer) dev packages. It builds with clang by default.
+`yum` can be used to get some packages.
 
 Get a docker shell (see exact docker image in build_package.yml workflow):
 


### PR DESCRIPTION
The GCC CI workflow was failing to build stablehlo due to a C++ template instantiation issue with GCC 9.

[StablehloAggressiveFolder.cpp](https://github.com/openxla/stablehlo/blob/4a6ea0d65a0ed97f91a04276fcda88fc516ae6de/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp#L499-L507) uses modern C++ patterns combining if constexpr with SFINAE-based type traits:
```
if constexpr (fold_unary::DirectFolderExists<Impl, APInt>::value) {
    return FoldIfImplemented<APInt>(operand); 
}
```

GCC 9 incorrectly evaluates these type traits eagerly before the if constexpr condition is resolved, causing "incomplete type" errors:
```
/__w/iree/iree/third_party/stablehlo/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp:501:48: error: no matching function for call to 'FoldIfImplemented<llvm::APInt>(llvm::APInt&)'

/__w/iree/iree/third_party/stablehlo/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp:464:78: error: incomplete type 'fold_unary::DirectFolderExists<Impl, llvm::APInt>' used in nested name specifier
```

Upgrade to GCC 11 resolves this problem.

Before: https://github.com/iree-org/iree/actions/runs/20654878139/job/59305852621

After: https://github.com/iree-org/iree/actions/runs/20660113060/job/59320617905?pr=23008