### PR TITLE
[AMDGPU][LDS] Prefer contiguous subviews in `GPUConvertToCoalescedDMA`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -20,29 +20,30 @@ func.func @copy(%source: tensor<64x512xf32>, %init: tensor<64x512xf32>) -> tenso
     ins(%source : tensor<64x512xf32>)
     outs(%init : tensor<64x512xf32>) -> tensor<64x512xf32>
 
-  // Warp-level forall:
-  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 512) step (8, 256)
+  // Warp-level forall with contiguous subviews (columns kept whole):
+  // With 16 warps (128*512/64/64) and 64 rows: step = ceil(64/16) = 4 rows, 512 cols (whole)
+  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 512) step (4, 512)
   // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<64x512xf32>) {
-  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], %[[IV1]]] [8, 256] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<8x256xf32>
-  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], %[[IV1]]] [8, 256] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<8x256xf32>
+  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [4, 512] [1, 1]
+  // CHECK-SAME:   : tensor<64x512xf32> to tensor<4x512xf32>
+  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [4, 512] [1, 1]
+  // CHECK-SAME:   : tensor<64x512xf32> to tensor<4x512xf32>
 
   // Thread-level forall:
   // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64)
-  // CHECK-SAME:   shared_outs(%[[THREAD_INIT:.+]] = %[[SLICE_DST]]) -> (tensor<8x256xf32>) {
+  // CHECK-SAME:   shared_outs(%[[THREAD_INIT:.+]] = %[[SLICE_DST]]) -> (tensor<4x512xf32>) {
   // CHECK:     scf.forall.in_parallel {
   // CHECK:       iree_gpu.coalesced_gather_dma %[[SLICE_SRC]] into %[[THREAD_INIT]] lane(%[[LANE]])
-  // CHECK-SAME:       : tensor<8x256xf32>, tensor<8x256xf32>, index
+  // CHECK-SAME:       : tensor<4x512xf32>, tensor<4x512xf32>, index
   // CHECK:     }
 
   // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
 
   // CHECK:   scf.forall.in_parallel {
-  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], %[[IV1]]] [8, 256] [1, 1]
-  // CHECK-SAME:     : tensor<8x256xf32> into tensor<64x512xf32>
+  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [4, 512] [1, 1]
+  // CHECK-SAME:     : tensor<4x512xf32> into tensor<64x512xf32>
   // CHECK:   }
-  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  // CHECK: }
 
   // CHECK: return %[[WARP_RESULT]]
   // CHECK-NOT: linalg.copy
@@ -74,30 +75,29 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
     ins(%source, %indices : tensor<64x512xf32>, tensor<64xi32>)
     outs(%init : tensor<64x512xf32>) -> tensor<64x512xf32>
 
-  // Warp-level forall:
-  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 512) step (4, 128)
+  // Warp-level forall with contiguous subviews (columns kept whole):
+  // With 64 warps and 64 rows: step = ceil(64/64) = 1 row, 512 cols (whole)
+  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 512) step (1, 512)
   // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<64x512xf32>) {
-  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], %[[IV1]]] [4, 128] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<4x128xf32>
-  // CHECK:   %[[SLICE_INDICES:.+]] = tensor.extract_slice %[[INDICES]][%[[IV0]]] [4] [1]
-  // CHECK-SAME:   : tensor<64xi32> to tensor<4xi32>
-  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][0, %[[IV1]]] [64, 128] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<64x128xf32>
+  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [1, 512] [1, 1]
+  // CHECK-SAME:   : tensor<64x512xf32> to tensor<1x512xf32>
+  // CHECK:   %[[SLICE_INDICES:.+]] = tensor.extract_slice %[[INDICES]][%[[IV0]]] [1] [1]
+  // CHECK-SAME:   : tensor<64xi32> to tensor<1xi32>
 
   // Thread-level forall:
   // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64)
-  // CHECK-SAME:   shared_outs(%[[THREAD_INIT:.+]] = %[[SLICE_DST]]) -> (tensor<4x128xf32>) {
+  // CHECK-SAME:   shared_outs(%[[THREAD_INIT:.+]] = %[[SLICE_DST]]) -> (tensor<1x512xf32>) {
   // CHECK:     scf.forall.in_parallel {
-  // CHECK:       iree_gpu.coalesced_gather_dma %[[SLICE_SRC]][%[[SLICE_INDICES]]] into %[[THREAD_INIT]] lane(%[[LANE]])
-  // CHECK-SAME:       : tensor<64x128xf32>, tensor<4xi32>, tensor<4x128xf32>, index
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[SRC]][%[[SLICE_INDICES]]] into %[[THREAD_INIT]] lane(%[[LANE]])
+  // CHECK-SAME:       : tensor<64x512xf32>, tensor<1xi32>, tensor<1x512xf32>, index
   // CHECK:     }
   // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
 
   // CHECK:   scf.forall.in_parallel {
-  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], %[[IV1]]] [4, 128] [1, 1]
-  // CHECK-SAME:     : tensor<4x128xf32> into tensor<64x512xf32>
+  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [1, 512] [1, 1]
+  // CHECK-SAME:     : tensor<1x512xf32> into tensor<64x512xf32>
   // CHECK:   }
-  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  // CHECK: }
 
   // CHECK: return %[[WARP_RESULT]]
   // CHECK-NOT: iree_linalg_ext.gather
@@ -136,4 +136,67 @@ func.func @copy_small_innermost_dim(%source: tensor<64x32xf32>, %init: tensor<64
   // CHECK-NOT: iree_gpu.coalesced_gather_dma
 
   return %result : tensor<64x32xf32>
+}
+
+// -----
+
+// Test: Prefer contiguous subviews when tiling would split the innermost dimension.
+// With 64x128 tensor, workgroup_size=[256,1,1], subgroup_size=64:
+// - 4 warps available (256/64)
+// - Default tiling would split 128 columns into 2x64, creating non-contiguous subviews
+// - Instead, we should tile rows to 16 (64/4) and keep columns whole (128)
+// This ensures subviews are contiguous in memory.
+
+#gpu_target_contiguous = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_contiguous = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_contiguous}>
+#translation_contiguous = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_prefer_contiguous_subview
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x128xf32>
+// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x128xf32>
+func.func @copy_prefer_contiguous_subview(%source: tensor<64x128xf32>, %init: tensor<64x128xf32>) -> tensor<64x128xf32>
+  attributes {hal.executable.target = #exec_target_contiguous, translation_info = #translation_contiguous} {
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%source : tensor<64x128xf32>)
+    outs(%init : tensor<64x128xf32>) -> tensor<64x128xf32>
+
+  // With 4 warps and 64x128 tensor:
+  // - Rows are tiled: step = 64/4 = 16
+  // - Columns are NOT tiled (step = 128, full dimension) to ensure contiguous subviews
+  // Warp-level forall iterates over rows with step 16, columns with step 128 (whole):
+  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 128) step (16, 128)
+  // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<64x128xf32>) {
+
+  // Key check: subviews are 16x128 (contiguous) not 64x64 (non-contiguous)
+  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [16, 128] [1, 1]
+  // CHECK-SAME:   : tensor<64x128xf32> to tensor<16x128xf32>
+  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [16, 128] [1, 1]
+  // CHECK-SAME:   : tensor<64x128xf32> to tensor<16x128xf32>
+
+  // Thread-level forall distributes across lanes:
+  // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK-SAME:   shared_outs(%[[THREAD_INIT:.+]] = %[[SLICE_DST]]) -> (tensor<16x128xf32>) {
+  // CHECK:     scf.forall.in_parallel {
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[SLICE_SRC]] into %[[THREAD_INIT]] lane(%[[LANE]])
+  // CHECK-SAME:       : tensor<16x128xf32>, tensor<16x128xf32>, index
+  // CHECK:     }
+  // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
+
+  // CHECK:   scf.forall.in_parallel {
+  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [16, 128] [1, 1]
+  // CHECK-SAME:     : tensor<16x128xf32> into tensor<64x128xf32>
+  // CHECK:   }
+  // CHECK: }
+
+  // CHECK: return %[[WARP_RESULT]]
+  // CHECK-NOT: linalg.copy
+
+  return %result : tensor<64x128xf32>
 }


### PR DESCRIPTION
* When tiling for coalesced DMA operations, prefer keeping the innermost dimension whole to ensure contiguous memory access patterns.
* Redistributes warps to outer dimensions when default tiling would split the innermost dimension.
* Prevents generation of non-contiguous `memref.subview` operations with inefficient strided access.

## Example:
Previously, the pass would tile based on workgroup dimensions without considering memory contiguity. For a `64x128` tensor with 4 warps, default tiling would create `64x64` tiles, resulting in a strided subview:
```
memref.subview ... [64, 64] [1, 1] : memref<64x128xf32> to memref<64x64xf32, strided<[128, 1]>>
```

Instead, detect when tiling would split the innermost dimension and instead redistribute warps to outer dimensions:
Before: step (64, 64) → 64x64 non-contiguous subviews
After: step (16, 128) → 16x128 contiguous subviews
This ensures LDS subviews maintain the full innermost dimension for efficient coalesced memory access.