### PR TITLE
Cleaning up move bit handling for disassembly/verifier/dispatch.

### DIFF
--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -80,6 +80,10 @@ def iree_c_module(
         srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
         copts = [
             "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
+            # Generated EmitC code may have unused variables from optimization
+            # barriers and other cases where an SSA value is consumed by an op
+            # that produces a new value.
+            "-Wno-unused-but-set-variable",
         ],
         deps = deps_list,
         **kwargs

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -141,8 +141,10 @@ static iree_status_t iree_vm_invoke_marshal_inputs(
       } break;
       case IREE_VM_CCONV_TYPE_REF: {
         p = iree_vm_invoke_align_ptr(p, iree_alignof(iree_vm_ref_t));
-        // TODO(benvanik): see if we can't remove this retain by instead relying
-        // on the caller still owning the list.
+        // NOTE: we assign here (not retain) for zero overhead. C++ native
+        // modules that receive refs via ParamUnpack should use borrowed
+        // pointers (T*) rather than owned refs (ref<T>) to avoid ownership
+        // issues, as ParamUnpack takes ownership and zeros the source.
         IREE_RETURN_IF_ERROR(
             iree_vm_list_get_ref_assign(inputs, arg_i, (iree_vm_ref_t*)p));
         p += sizeof(iree_vm_ref_t);

--- a/runtime/src/iree/vm/native_module_test.cc
+++ b/runtime/src/iree/vm/native_module_test.cc
@@ -463,5 +463,449 @@ INSTANTIATE_TEST_SUITE_P(ModuleImpls, VMNativeModuleAlignmentTest,
                          ::testing::Values(ModuleImpl::kC, ModuleImpl::kCpp),
                          ModuleImplName);
 
+//===----------------------------------------------------------------------===//
+// Borrowed pointer (T*) alignment tests - C++ only
+//===----------------------------------------------------------------------===//
+// These tests specifically exercise ParamUnpack<T*> which had a missing
+// alignment bug. They use actual non-null buffers to verify the data is
+// correctly read after alignment.
+
+class VMNativeModuleBorrowedPtrTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
+                                          iree_allocator_system(), &instance_));
+  }
+
+  virtual void TearDown() { iree_vm_instance_release(instance_); }
+
+  iree_vm_context_t* CreateCppContext() {
+    iree_vm_module_t* module = nullptr;
+    IREE_CHECK_OK(
+        module_cpp_create(instance_, iree_allocator_system(), &module));
+
+    iree_vm_context_t* context = NULL;
+    std::vector<iree_vm_module_t*> modules = {module};
+    IREE_CHECK_OK(iree_vm_context_create_with_modules(
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
+        iree_allocator_system(), &context));
+
+    iree_vm_module_release(module);
+    return context;
+  }
+
+  // Creates a buffer with the given length filled with zeros.
+  vm::ref<iree_vm_buffer_t> CreateBuffer(iree_host_size_t length) {
+    vm::ref<iree_vm_buffer_t> buffer;
+    IREE_CHECK_OK(iree_vm_buffer_create(
+        IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_HOST,
+        length, /*alignment=*/0, iree_allocator_system(), &buffer));
+    return buffer;
+  }
+
+  iree_vm_instance_t* instance_ = nullptr;
+};
+
+// Test borrowed ref after 4 bytes (i32) - needs alignment.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32Ref_NullBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32_ref"),
+      &function));
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 2,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(42);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  iree_vm_ref_t null_ref = iree_vm_ref_null();
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &null_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 42);  // 42 + 0 (null buffer)
+
+  iree_vm_context_release(context);
+}
+
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(10);  // 10 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 2,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(42);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 52);  // 42 + 10 (buffer length)
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref after 8 bytes (2x i32) - already aligned.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32x2Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32x2_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(5);  // 5 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 3,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(10);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  auto arg1 = iree_vm_value_make_i32(20);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 35);  // 10 + 20 + 5
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref after 12 bytes (3x i32) - THIS IS THE BUG CASE!
+// The ref needs 8-byte alignment, but 12 bytes is not aligned.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32x3Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32x3_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(7);  // 7 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 4,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(1);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  auto arg1 = iree_vm_value_make_i32(2);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  auto arg2 = iree_vm_value_make_i32(3);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg2));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 13);  // 1 + 2 + 3 + 7
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref after 16 bytes (4x i32) - already aligned.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32x4Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32x4_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(8);  // 8 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 5,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(1);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  auto arg1 = iree_vm_value_make_i32(2);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  auto arg2 = iree_vm_value_make_i32(3);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg2));
+  auto arg3 = iree_vm_value_make_i32(4);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg3));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 18);  // 1 + 2 + 3 + 4 + 8
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref after 20 bytes (5x i32) - needs alignment.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32x5Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32x5_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(11);  // 11 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 6,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(1);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  auto arg1 = iree_vm_value_make_i32(2);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  auto arg2 = iree_vm_value_make_i32(3);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg2));
+  auto arg3 = iree_vm_value_make_i32(4);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg3));
+  auto arg4 = iree_vm_value_make_i32(5);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg4));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 26);  // 1 + 2 + 3 + 4 + 5 + 11
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref/i32/ref pattern with actual buffers.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedRefI32Ref_WithBuffers) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_ref_i32_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer1 = CreateBuffer(3);   // 3 bytes
+  vm::ref<iree_vm_buffer_t> buffer2 = CreateBuffer(13);  // 13 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 3,
+                                     iree_allocator_system(), &inputs));
+  iree_vm_ref_t buffer1_ref = iree_vm_buffer_retain_ref(buffer1.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer1_ref));
+  auto arg1 = iree_vm_value_make_i32(100);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  iree_vm_ref_t buffer2_ref = iree_vm_buffer_retain_ref(buffer2.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer2_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 116);  // 3 + 100 + 13
+
+  iree_vm_context_release(context);
+}
+
+// Test two consecutive borrowed refs.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedRefRef_WithBuffers) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_ref_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer1 = CreateBuffer(17);  // 17 bytes
+  vm::ref<iree_vm_buffer_t> buffer2 = CreateBuffer(23);  // 23 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 2,
+                                     iree_allocator_system(), &inputs));
+  iree_vm_ref_t buffer1_ref = iree_vm_buffer_retain_ref(buffer1.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer1_ref));
+  iree_vm_ref_t buffer2_ref = iree_vm_buffer_retain_ref(buffer2.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer2_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 40);  // 17 + 23
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref after i64 (already aligned).
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI64Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i64_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(6);  // 6 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 2,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i64(50);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 56);  // 50 + 6
+
+  iree_vm_context_release(context);
+}
+
+// Test borrowed ref after i32+i64 (tests complex alignment).
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedI32I64Ref_WithBuffer) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_i32_i64_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer = CreateBuffer(4);  // 4 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 3,
+                                     iree_allocator_system(), &inputs));
+  auto arg0 = iree_vm_value_make_i32(10);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg0));
+  auto arg1 = iree_vm_value_make_i64(200);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  iree_vm_ref_t buffer_ref = iree_vm_buffer_retain_ref(buffer.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 214);  // 10 + 200 + 4
+
+  iree_vm_context_release(context);
+}
+
+// Test i64 between two borrowed refs.
+TEST_F(VMNativeModuleBorrowedPtrTest, BorrowedRefI64Ref_WithBuffers) {
+  iree_vm_context_t* context = CreateCppContext();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view("module_cpp.borrowed_ref_i64_ref"),
+      &function));
+
+  vm::ref<iree_vm_buffer_t> buffer1 = CreateBuffer(8);   // 8 bytes
+  vm::ref<iree_vm_buffer_t> buffer2 = CreateBuffer(12);  // 12 bytes
+
+  vm::ref<iree_vm_list_t> inputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 3,
+                                     iree_allocator_system(), &inputs));
+  iree_vm_ref_t buffer1_ref = iree_vm_buffer_retain_ref(buffer1.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer1_ref));
+  auto arg1 = iree_vm_value_make_i64(500);
+  IREE_ASSERT_OK(iree_vm_list_push_value(inputs.get(), &arg1));
+  iree_vm_ref_t buffer2_ref = iree_vm_buffer_retain_ref(buffer2.get());
+  IREE_ASSERT_OK(iree_vm_list_push_ref_move(inputs.get(), &buffer2_ref));
+
+  vm::ref<iree_vm_list_t> outputs;
+  IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 1,
+                                     iree_allocator_system(), &outputs));
+
+  IREE_ASSERT_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.get(), outputs.get(),
+                                iree_allocator_system()));
+
+  iree_vm_value_t result;
+  IREE_ASSERT_OK(iree_vm_list_get_value(outputs.get(), 0, &result));
+  EXPECT_EQ(result.i32, 520);  // 8 + 500 + 12
+
+  iree_vm_context_release(context);
+}
+
 }  // namespace
 }  // namespace iree

--- a/runtime/src/iree/vm/test/call_ops.mlir
+++ b/runtime/src/iree/vm/test/call_ops.mlir
@@ -132,8 +132,9 @@ vm.module @call_ops {
   }
 
   vm.func @_v_v_fail() attributes {inlining_policy = #util.inline.never} {
-    %c2 = vm.const.i32 2
-    vm.fail %c2
+    // FAILED_PRECONDITION
+    %c9 = vm.const.i32 9
+    vm.fail %c9
   }
 
 }

--- a/runtime/src/iree/vm/test/ref_ops.mlir
+++ b/runtime/src/iree/vm/test/ref_ops.mlir
@@ -1,7 +1,18 @@
 vm.module @ref_ops {
 
-  vm.rodata private @buffer_i8 dense<[1, 2, 3]> : tensor<3xi8>
-  vm.rodata private @buffer_i32 dense<[1, 2, 3]> : tensor<3xi32>
+  //===--------------------------------------------------------------------===//
+  // Test data
+  //===--------------------------------------------------------------------===//
+
+  vm.rodata private @buffer_a dense<[1, 2, 3]> : tensor<3xi8>
+  vm.rodata private @buffer_b dense<[4, 5, 6]> : tensor<3xi8>
+  vm.rodata private @buffer_c dense<[7, 8, 9]> : tensor<3xi8>
+
+  vm.global.ref private mutable @global_ref : !vm.buffer
+
+  //===--------------------------------------------------------------------===//
+  // Basic ref comparisons
+  //===--------------------------------------------------------------------===//
 
   vm.export @test_zero_ref_eq
   vm.func @test_zero_ref_eq() {
@@ -18,9 +29,9 @@ vm.module @ref_ops {
   // barrier op.
   vm.export @test_ref_eq attributes {emitc.exclude}
   vm.func @test_ref_eq() {
-    %ref_1 = vm.const.ref.rodata @buffer_i8 : !vm.buffer
+    %ref_1 = vm.const.ref.rodata @buffer_a : !vm.buffer
     %ref_1_dno = util.optimization_barrier %ref_1 : !vm.buffer
-    %ref_2 = vm.const.ref.rodata @buffer_i8 : !vm.buffer
+    %ref_2 = vm.const.ref.rodata @buffer_a : !vm.buffer
     %ref_2_dno = util.optimization_barrier %ref_2 : !vm.buffer
     vm.check.eq %ref_1_dno, %ref_2_dno : !vm.buffer
     vm.return
@@ -28,19 +39,514 @@ vm.module @ref_ops {
 
   vm.export @test_ref_ne
   vm.func @test_ref_ne() {
-    %ref_i8 = vm.const.ref.rodata @buffer_i8 : !vm.buffer
-    %ref_i8_dno = util.optimization_barrier %ref_i8 : !vm.buffer
-    %ref_i32 = vm.const.ref.rodata @buffer_i32 : !vm.buffer
-    %ref_i32_dno = util.optimization_barrier %ref_i32 : !vm.buffer
-    vm.check.ne %ref_i8_dno, %ref_i32_dno : !vm.buffer
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    vm.check.ne %ref_a_dno, %ref_b_dno : !vm.buffer
     vm.return
   }
 
   vm.export @test_ref_nz
   vm.func @test_ref_nz() {
-    %ref = vm.const.ref.rodata @buffer_i8 : !vm.buffer
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
     %ref_dno = util.optimization_barrier %ref : !vm.buffer
     vm.check.nz %ref_dno : !vm.buffer
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Ref lifetime through calls
+  // These tests verify refs survive being passed to callees.
+  //===--------------------------------------------------------------------===//
+
+  // Pass ref to callee, verify caller's ref is still valid after return.
+  vm.export @test_ref_survives_call attributes {emitc.exclude}
+  vm.func @test_ref_survives_call() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    vm.check.nz %ref_dno, "ref valid before call" : !vm.buffer
+    vm.call @_consume_ref(%ref_dno) : (!vm.buffer) -> ()
+    // Ref should still be valid after the call.
+    vm.check.nz %ref_dno, "ref valid after call" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_consume_ref(%arg : !vm.buffer)
+      attributes {inlining_policy = #util.inline.never} {
+    %arg_dno = util.optimization_barrier %arg : !vm.buffer
+    vm.check.nz %arg_dno, "ref valid in callee" : !vm.buffer
+    vm.return
+  }
+
+  // Pass same ref multiple times to same call.
+  vm.export @test_same_ref_multiple_args attributes {emitc.exclude}
+  vm.func @test_same_ref_multiple_args() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    vm.call @_consume_two_refs(%ref_dno, %ref_dno) : (!vm.buffer, !vm.buffer) -> ()
+    // Ref should still be valid after the call.
+    vm.check.nz %ref_dno, "ref valid after call with same ref twice" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_consume_two_refs(%arg0 : !vm.buffer, %arg1 : !vm.buffer)
+      attributes {inlining_policy = #util.inline.never} {
+    %arg0_dno = util.optimization_barrier %arg0 : !vm.buffer
+    %arg1_dno = util.optimization_barrier %arg1 : !vm.buffer
+    vm.check.nz %arg0_dno, "first arg valid" : !vm.buffer
+    vm.check.nz %arg1_dno, "second arg valid" : !vm.buffer
+    vm.check.eq %arg0_dno, %arg1_dno, "both args are same ref" : !vm.buffer
+    vm.return
+  }
+
+  // Return ref from callee, verify it's valid in caller.
+  vm.export @test_ref_returned_from_call attributes {emitc.exclude}
+  vm.func @test_ref_returned_from_call() {
+    %ref = vm.call @_return_ref() : () -> !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    vm.check.nz %ref_dno, "returned ref is valid" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_return_ref() -> !vm.buffer
+      attributes {inlining_policy = #util.inline.never} {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    vm.return %ref : !vm.buffer
+  }
+
+  // Pass ref, callee returns the same ref.
+  vm.export @test_ref_passthrough attributes {emitc.exclude}
+  vm.func @test_ref_passthrough() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %returned = vm.call @_passthrough_ref(%ref_dno) : (!vm.buffer) -> !vm.buffer
+    %returned_dno = util.optimization_barrier %returned : !vm.buffer
+    vm.check.eq %ref_dno, %returned_dno, "passthrough returns same ref" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_passthrough_ref(%arg : !vm.buffer) -> !vm.buffer
+      attributes {inlining_policy = #util.inline.never} {
+    vm.return %arg : !vm.buffer
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Ref lifetime in control flow
+  //===--------------------------------------------------------------------===//
+
+  // Ref passed to both branches of cond_br.
+  vm.export @test_ref_cond_br_both_paths attributes {emitc.exclude}
+  vm.func @test_ref_cond_br_both_paths() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %c1 = vm.const.i32 1
+    %c1_dno = util.optimization_barrier %c1 : i32
+    vm.cond_br %c1_dno, ^bb1(%ref_dno : !vm.buffer), ^bb2(%ref_dno : !vm.buffer)
+  ^bb1(%arg1 : !vm.buffer):
+    vm.check.nz %arg1, "ref valid in bb1" : !vm.buffer
+    vm.check.eq %arg1, %ref_dno, "bb1 got same ref" : !vm.buffer
+    vm.return
+  ^bb2(%arg2 : !vm.buffer):
+    vm.check.nz %arg2, "ref valid in bb2" : !vm.buffer
+    vm.check.eq %arg2, %ref_dno, "bb2 got same ref" : !vm.buffer
+    vm.return
+  }
+
+  // Ref passed to one branch, not the other.
+  vm.export @test_ref_cond_br_one_path attributes {emitc.exclude}
+  vm.func @test_ref_cond_br_one_path() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %c1 = vm.const.i32 1
+    %c1_dno = util.optimization_barrier %c1 : i32
+    vm.cond_br %c1_dno, ^bb1(%ref_dno : !vm.buffer), ^bb2
+  ^bb1(%arg1 : !vm.buffer):
+    vm.check.nz %arg1, "ref valid in bb1" : !vm.buffer
+    vm.return
+  ^bb2:
+    vm.return
+  }
+
+  // Ref used in loop body (back-edge liveness).
+  vm.export @test_ref_in_loop attributes {emitc.exclude}
+  vm.func @test_ref_in_loop() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c3 = vm.const.i32 3
+    vm.br ^loop(%c0, %ref_dno : i32, !vm.buffer)
+  ^loop(%i : i32, %loop_ref : !vm.buffer):
+    // Verify ref is valid on each iteration.
+    vm.check.nz %loop_ref, "ref valid in loop" : !vm.buffer
+    %i_next = vm.add.i32 %i, %c1 : i32
+    %cmp = vm.cmp.lt.i32.s %i_next, %c3 : i32
+    vm.cond_br %cmp, ^loop(%i_next, %loop_ref : i32, !vm.buffer), ^exit
+  ^exit:
+    vm.return
+  }
+
+  // Multiple different refs through loop.
+  vm.export @test_multiple_refs_in_loop attributes {emitc.exclude}
+  vm.func @test_multiple_refs_in_loop() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c3 = vm.const.i32 3
+    vm.br ^loop(%c0, %ref_a_dno, %ref_b_dno : i32, !vm.buffer, !vm.buffer)
+  ^loop(%i : i32, %loop_ref_a : !vm.buffer, %loop_ref_b : !vm.buffer):
+    vm.check.nz %loop_ref_a, "ref_a valid in loop" : !vm.buffer
+    vm.check.nz %loop_ref_b, "ref_b valid in loop" : !vm.buffer
+    vm.check.ne %loop_ref_a, %loop_ref_b, "refs are different" : !vm.buffer
+    %i_next = vm.add.i32 %i, %c1 : i32
+    %cmp = vm.cmp.lt.i32.s %i_next, %c3 : i32
+    vm.cond_br %cmp, ^loop(%i_next, %loop_ref_a, %loop_ref_b : i32, !vm.buffer, !vm.buffer), ^exit
+  ^exit:
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Ref with globals
+  //===--------------------------------------------------------------------===//
+
+  // Store ref to global, load back, verify equality.
+  vm.export @test_global_store_load_ref attributes {emitc.exclude}
+  vm.func @test_global_store_load_ref() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    vm.global.store.ref %ref_dno, @global_ref : !vm.buffer
+    %loaded = vm.global.load.ref @global_ref : !vm.buffer
+    %loaded_dno = util.optimization_barrier %loaded : !vm.buffer
+    vm.check.eq %ref_dno, %loaded_dno, "loaded ref equals stored ref" : !vm.buffer
+    vm.return
+  }
+
+  // Store ref to global, use original ref after.
+  vm.export @test_ref_valid_after_global_store attributes {emitc.exclude}
+  vm.func @test_ref_valid_after_global_store() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    vm.check.nz %ref_dno, "ref valid before store" : !vm.buffer
+    vm.global.store.ref %ref_dno, @global_ref : !vm.buffer
+    // Original ref should still be valid after storing to global.
+    vm.check.nz %ref_dno, "ref valid after store to global" : !vm.buffer
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Ref with lists
+  //===--------------------------------------------------------------------===//
+
+  // Store ref in list, retrieve, verify equality.
+  // Uses variant list (!vm.list<?>) since typed lists require type registration.
+  vm.export @test_list_set_get_ref attributes {emitc.exclude}
+  vm.func @test_list_set_get_ref() {
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %list = vm.list.alloc %c1 : (i32) -> !vm.list<?>
+    vm.list.resize %list, %c1 : (!vm.list<?>, i32)
+    vm.list.set.ref %list, %c0, %ref_dno : (!vm.list<?>, i32, !vm.buffer)
+    %retrieved = vm.list.get.ref %list, %c0 : (!vm.list<?>, i32) -> !vm.buffer
+    %retrieved_dno = util.optimization_barrier %retrieved : !vm.buffer
+    vm.check.eq %ref_dno, %retrieved_dno, "retrieved ref equals set ref" : !vm.buffer
+    vm.return
+  }
+
+  // Multiple refs in same list.
+  vm.export @test_list_multiple_refs attributes {emitc.exclude}
+  vm.func @test_list_multiple_refs() {
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %list = vm.list.alloc %c2 : (i32) -> !vm.list<?>
+    vm.list.resize %list, %c2 : (!vm.list<?>, i32)
+    vm.list.set.ref %list, %c0, %ref_a_dno : (!vm.list<?>, i32, !vm.buffer)
+    vm.list.set.ref %list, %c1, %ref_b_dno : (!vm.list<?>, i32, !vm.buffer)
+    %retrieved_a = vm.list.get.ref %list, %c0 : (!vm.list<?>, i32) -> !vm.buffer
+    %retrieved_a_dno = util.optimization_barrier %retrieved_a : !vm.buffer
+    %retrieved_b = vm.list.get.ref %list, %c1 : (!vm.list<?>, i32) -> !vm.buffer
+    %retrieved_b_dno = util.optimization_barrier %retrieved_b : !vm.buffer
+    vm.check.eq %ref_a_dno, %retrieved_a_dno, "retrieved ref_a equals set ref_a" : !vm.buffer
+    vm.check.eq %ref_b_dno, %retrieved_b_dno, "retrieved ref_b equals set ref_b" : !vm.buffer
+    vm.check.ne %retrieved_a_dno, %retrieved_b_dno, "refs are different" : !vm.buffer
+    vm.return
+  }
+
+  // Get ref from list, use multiple times.
+  vm.export @test_list_get_ref_multiple_uses attributes {emitc.exclude}
+  vm.func @test_list_get_ref_multiple_uses() {
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %list = vm.list.alloc %c1 : (i32) -> !vm.list<?>
+    vm.list.resize %list, %c1 : (!vm.list<?>, i32)
+    vm.list.set.ref %list, %c0, %ref_dno : (!vm.list<?>, i32, !vm.buffer)
+    %retrieved = vm.list.get.ref %list, %c0 : (!vm.list<?>, i32) -> !vm.buffer
+    %retrieved_dno = util.optimization_barrier %retrieved : !vm.buffer
+    // Use retrieved ref multiple times.
+    vm.check.nz %retrieved_dno, "retrieved ref valid (use 1)" : !vm.buffer
+    vm.check.nz %retrieved_dno, "retrieved ref valid (use 2)" : !vm.buffer
+    vm.check.eq %ref_dno, %retrieved_dno, "retrieved ref equals original" : !vm.buffer
+    vm.return
+  }
+
+  // Ref survives after being stored in list.
+  vm.export @test_ref_valid_after_list_set attributes {emitc.exclude}
+  vm.func @test_ref_valid_after_list_set() {
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    vm.check.nz %ref_dno, "ref valid before list set" : !vm.buffer
+    %list = vm.list.alloc %c1 : (i32) -> !vm.list<?>
+    vm.list.resize %list, %c1 : (!vm.list<?>, i32)
+    vm.list.set.ref %list, %c0, %ref_dno : (!vm.list<?>, i32, !vm.buffer)
+    // Original ref should still be valid.
+    vm.check.nz %ref_dno, "ref valid after list set" : !vm.buffer
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Select operations
+  //===--------------------------------------------------------------------===//
+
+  // vm.select.ref with both refs valid.
+  vm.export @test_select_ref_true attributes {emitc.exclude}
+  vm.func @test_select_ref_true() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %c1 = vm.const.i32 1
+    %c1_dno = util.optimization_barrier %c1 : i32
+    %result = vm.select.ref %c1_dno, %ref_a_dno, %ref_b_dno : !vm.buffer
+    %result_dno = util.optimization_barrier %result : !vm.buffer
+    vm.check.eq %result_dno, %ref_a_dno, "select true returns first ref" : !vm.buffer
+    vm.return
+  }
+
+  vm.export @test_select_ref_false attributes {emitc.exclude}
+  vm.func @test_select_ref_false() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %c0 = vm.const.i32 0
+    %c0_dno = util.optimization_barrier %c0 : i32
+    %result = vm.select.ref %c0_dno, %ref_a_dno, %ref_b_dno : !vm.buffer
+    %result_dno = util.optimization_barrier %result : !vm.buffer
+    vm.check.eq %result_dno, %ref_b_dno, "select false returns second ref" : !vm.buffer
+    vm.return
+  }
+
+  // vm.select.ref with one ref used after select.
+  vm.export @test_select_ref_input_survives attributes {emitc.exclude}
+  vm.func @test_select_ref_input_survives() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %c1 = vm.const.i32 1
+    %c1_dno = util.optimization_barrier %c1 : i32
+    %result = vm.select.ref %c1_dno, %ref_a_dno, %ref_b_dno : !vm.buffer
+    %result_dno = util.optimization_barrier %result : !vm.buffer
+    // Both input refs should still be valid after select.
+    vm.check.nz %ref_a_dno, "ref_a valid after select" : !vm.buffer
+    vm.check.nz %ref_b_dno, "ref_b valid after select" : !vm.buffer
+    vm.check.nz %result_dno, "result valid" : !vm.buffer
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Complex multi-use patterns
+  //===--------------------------------------------------------------------===//
+
+  // Same ref used in multiple operations sequentially.
+  vm.export @test_ref_multiple_sequential_uses attributes {emitc.exclude}
+  vm.func @test_ref_multiple_sequential_uses() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    // Use 1: check nz
+    vm.check.nz %ref_dno, "use 1" : !vm.buffer
+    // Use 2: pass to call
+    vm.call @_consume_ref(%ref_dno) : (!vm.buffer) -> ()
+    // Use 3: check nz again
+    vm.check.nz %ref_dno, "use 3" : !vm.buffer
+    // Use 4: store to global
+    vm.global.store.ref %ref_dno, @global_ref : !vm.buffer
+    // Use 5: final check
+    vm.check.nz %ref_dno, "use 5" : !vm.buffer
+    vm.return
+  }
+
+  // Chain of calls passing same ref.
+  vm.export @test_ref_call_chain attributes {emitc.exclude}
+  vm.func @test_ref_call_chain() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %result = vm.call @_call_chain_a(%ref_dno) : (!vm.buffer) -> !vm.buffer
+    %result_dno = util.optimization_barrier %result : !vm.buffer
+    vm.check.eq %ref_dno, %result_dno, "chain returns same ref" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_call_chain_a(%arg : !vm.buffer) -> !vm.buffer
+      attributes {inlining_policy = #util.inline.never} {
+    %result = vm.call @_call_chain_b(%arg) : (!vm.buffer) -> !vm.buffer
+    vm.return %result : !vm.buffer
+  }
+
+  vm.func private @_call_chain_b(%arg : !vm.buffer) -> !vm.buffer
+      attributes {inlining_policy = #util.inline.never} {
+    vm.return %arg : !vm.buffer
+  }
+
+  // Return multiple refs.
+  vm.export @test_return_multiple_refs attributes {emitc.exclude}
+  vm.func @test_return_multiple_refs() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %results:2 = vm.call @_return_two_refs(%ref_a_dno, %ref_b_dno)
+        : (!vm.buffer, !vm.buffer) -> (!vm.buffer, !vm.buffer)
+    vm.check.eq %results#0, %ref_a_dno, "first result is ref_a" : !vm.buffer
+    vm.check.eq %results#1, %ref_b_dno, "second result is ref_b" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_return_two_refs(%a : !vm.buffer, %b : !vm.buffer)
+      -> (!vm.buffer, !vm.buffer)
+      attributes {inlining_policy = #util.inline.never} {
+    vm.return %a, %b : !vm.buffer, !vm.buffer
+  }
+
+  // Return refs in swapped order.
+  vm.export @test_return_refs_swapped attributes {emitc.exclude}
+  vm.func @test_return_refs_swapped() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %results:2 = vm.call @_return_refs_swapped(%ref_a_dno, %ref_b_dno)
+        : (!vm.buffer, !vm.buffer) -> (!vm.buffer, !vm.buffer)
+    vm.check.eq %results#0, %ref_b_dno, "first result is ref_b (swapped)" : !vm.buffer
+    vm.check.eq %results#1, %ref_a_dno, "second result is ref_a (swapped)" : !vm.buffer
+    vm.return
+  }
+
+  vm.func private @_return_refs_swapped(%a : !vm.buffer, %b : !vm.buffer)
+      -> (!vm.buffer, !vm.buffer)
+      attributes {inlining_policy = #util.inline.never} {
+    vm.return %b, %a : !vm.buffer, !vm.buffer
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Edge case: Nested loops with refs
+  //===--------------------------------------------------------------------===//
+
+  // Outer loop carries ref, inner loop doesn't touch it.
+  vm.export @test_nested_loop_outer_ref attributes {emitc.exclude}
+  vm.func private @test_nested_loop_outer_ref() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    vm.br ^outer(%c0, %ref_dno : i32, !vm.buffer)
+  ^outer(%outer_i : i32, %outer_ref : !vm.buffer):
+    // Verify ref valid on each outer iteration.
+    vm.check.nz %outer_ref, "ref valid in outer loop" : !vm.buffer
+    vm.br ^inner(%c0 : i32)
+  ^inner(%inner_i : i32):
+    // Inner loop doesn't touch ref.
+    %inner_next = vm.add.i32 %inner_i, %c1 : i32
+    %inner_cmp = vm.cmp.lt.i32.s %inner_next, %c2 : i32
+    vm.cond_br %inner_cmp, ^inner(%inner_next : i32), ^outer_check
+  ^outer_check:
+    %outer_next = vm.add.i32 %outer_i, %c1 : i32
+    %outer_cmp = vm.cmp.lt.i32.s %outer_next, %c2 : i32
+    vm.cond_br %outer_cmp, ^outer(%outer_next, %outer_ref : i32, !vm.buffer), ^exit
+  ^exit:
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Edge case: Ref swap (ping-pong) in loop
+  //===--------------------------------------------------------------------===//
+
+  // Loop swaps two refs on each iteration.
+  vm.export @test_ping_pong_swap attributes {emitc.exclude}
+  vm.func private @test_ping_pong_swap() {
+    %ref_a = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_a_dno = util.optimization_barrier %ref_a : !vm.buffer
+    %ref_b = vm.const.ref.rodata @buffer_b : !vm.buffer
+    %ref_b_dno = util.optimization_barrier %ref_b : !vm.buffer
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c3 = vm.const.i32 3
+    vm.br ^loop(%c0, %ref_a_dno, %ref_b_dno : i32, !vm.buffer, !vm.buffer)
+  ^loop(%i : i32, %x : !vm.buffer, %y : !vm.buffer):
+    // Verify both refs valid.
+    vm.check.nz %x, "x valid in loop" : !vm.buffer
+    vm.check.nz %y, "y valid in loop" : !vm.buffer
+    vm.check.ne %x, %y, "x and y are different" : !vm.buffer
+    %i_next = vm.add.i32 %i, %c1 : i32
+    %cmp = vm.cmp.lt.i32.s %i_next, %c3 : i32
+    // SWAP: x->y_arg, y->x_arg
+    vm.cond_br %cmp, ^loop(%i_next, %y, %x : i32, !vm.buffer, !vm.buffer), ^exit
+  ^exit:
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Edge case: Diamond with asymmetric use
+  //===--------------------------------------------------------------------===//
+
+  // One path uses the ref, other doesn't. Both should work.
+  vm.export @test_diamond_asymmetric_use attributes {emitc.exclude}
+  vm.func private @test_diamond_asymmetric_use() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %c1 = vm.const.i32 1
+    %c1_dno = util.optimization_barrier %c1 : i32
+    vm.cond_br %c1_dno, ^use_path(%ref_dno : !vm.buffer), ^nouse_path(%ref_dno : !vm.buffer)
+  ^use_path(%r1 : !vm.buffer):
+    vm.check.nz %r1, "ref valid in use_path" : !vm.buffer
+    vm.br ^merge
+  ^nouse_path(%r2 : !vm.buffer):
+    // Don't use r2 - just forward.
+    vm.br ^merge
+  ^merge:
+    vm.return
+  }
+
+  // Same test but with condition false - takes nouse_path.
+  vm.export @test_diamond_asymmetric_nouse attributes {emitc.exclude}
+  vm.func private @test_diamond_asymmetric_nouse() {
+    %ref = vm.const.ref.rodata @buffer_a : !vm.buffer
+    %ref_dno = util.optimization_barrier %ref : !vm.buffer
+    %c0 = vm.const.i32 0
+    %c0_dno = util.optimization_barrier %c0 : i32
+    vm.cond_br %c0_dno, ^use_path(%ref_dno : !vm.buffer), ^nouse_path(%ref_dno : !vm.buffer)
+  ^use_path(%r1 : !vm.buffer):
+    vm.check.nz %r1, "ref valid in use_path" : !vm.buffer
+    vm.br ^merge
+  ^nouse_path(%r2 : !vm.buffer):
+    // Don't use r2 - just forward. Should still be released properly.
+    vm.br ^merge
+  ^merge:
     vm.return
   }
 

--- a/samples/custom_module/basic/module.cc
+++ b/samples/custom_module/basic/module.cc
@@ -122,7 +122,7 @@ class CustomModuleState final {
   }
 
   // Returns the length of the string in characters.
-  StatusOr<int64_t> StringLength(const vm::ref<iree_custom_string_t> string) {
+  StatusOr<int64_t> StringLength(iree_custom_string_t* string) {
     if (!string) {
       // Passed in refs may be null.
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null string arg");
@@ -135,7 +135,7 @@ class CustomModuleState final {
   }
 
   // Prints the contents of the string to stdout.
-  Status StringPrint(const vm::ref<iree_custom_string_t> string) {
+  Status StringPrint(iree_custom_string_t* string) {
     if (!string) return OkStatus();  // no-op
     fprintf(stdout, "PRINT %.*s\n", static_cast<int>(string->value.size),
             string->value.data);
@@ -144,9 +144,9 @@ class CustomModuleState final {
   }
 
   // Prints the contents of the string; only exported in debug mode.
-  Status StringDPrint(const vm::ref<iree_custom_string_t> string) {
+  Status StringDPrint(iree_custom_string_t* string) {
     if (!string) return OkStatus();  // no-op
-    return StringPrint(std::move(string));
+    return StringPrint(string);
   }
 
  private:

--- a/samples/custom_module/dynamic/module.cc
+++ b/samples/custom_module/dynamic/module.cc
@@ -122,11 +122,11 @@ class CustomModuleState final {
   // Creates a new string with a copy of the given string data.
   // No NUL terminator is required.
   StatusOr<vm::ref<iree_custom_string_t>> StringFromTensor(
-      vm::ref<iree_hal_buffer_view_t> buffer_view) {
+      iree_hal_buffer_view_t* buffer_view) {
     char string_buffer[512];
     iree_host_size_t string_length = 0;
     IREE_RETURN_IF_ERROR(iree_hal_buffer_view_format(
-        buffer_view.get(), 128, IREE_ARRAYSIZE(string_buffer), string_buffer,
+        buffer_view, 128, IREE_ARRAYSIZE(string_buffer), string_buffer,
         &string_length));
 
     vm::ref<iree_custom_string_t> string;
@@ -140,7 +140,7 @@ class CustomModuleState final {
   }
 
   // Prints the contents of the string to stdout.
-  Status StringPrint(const vm::ref<iree_custom_string_t> string) {
+  Status StringPrint(iree_custom_string_t* string) {
     if (!string) return OkStatus();  // no-op
     fprintf(stdout, "PRINT %.*s\n", static_cast<int>(string->value.size),
             string->value.data);

--- a/samples/custom_module/static/module.cc
+++ b/samples/custom_module/static/module.cc
@@ -121,11 +121,11 @@ class CustomModuleState final {
   // Creates a new string with a copy of the given string data.
   // No NUL terminator is required.
   StatusOr<vm::ref<iree_sample_string_t>> StringFromTensor(
-      vm::ref<iree_hal_buffer_view_t> buffer_view) {
+      iree_hal_buffer_view_t* buffer_view) {
     char string_buffer[512];
     iree_host_size_t string_length = 0;
     IREE_RETURN_IF_ERROR(iree_hal_buffer_view_format(
-        buffer_view.get(), 128, IREE_ARRAYSIZE(string_buffer), string_buffer,
+        buffer_view, 128, IREE_ARRAYSIZE(string_buffer), string_buffer,
         &string_length));
 
     vm::ref<iree_sample_string_t> string;
@@ -139,7 +139,7 @@ class CustomModuleState final {
   }
 
   // Prints the contents of the string to stdout.
-  Status StringPrint(const vm::ref<iree_sample_string_t> string) {
+  Status StringPrint(iree_sample_string_t* string) {
     if (!string) return OkStatus();  // no-op
     fprintf(stdout, "PRINT %.*s\n", static_cast<int>(string->value.size),
             string->value.data);


### PR DESCRIPTION
This splits between operands/results that support moves and those that don't, which makes things much less confusing to read and allows us to verify program correctness.