### PR TITLE
[GlobalOpt] Add a flag to enable aggressive propagation through convolutions

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -178,6 +178,8 @@ void buildGlobalOptimizationPassPipeline(
                            PropagateLinalgTransposePassOptions options;
                            options.enableAggressivePropagation =
                                transformOptions.aggressiveTransposePropagation;
+                           options.enableConvolutionPropagation =
+                               transformOptions.aggressiveTransposePropagation;
                            options.enableAttentionVTranspose =
                                clEnableAttentionVTranspose;
                            options.enableEdgeReshapePropagation =

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -29,6 +29,11 @@ static llvm::cl::opt<bool> clEnableTransposePropagation(
     llvm::cl::desc(
         "Enables propagation of transpose ops to improve fusion chances."),
     llvm::cl::init(true));
+static llvm::cl::opt<bool> clEnableConvolutionPropagation(
+    "iree-global-opt-propagate-transposes-through-conv",
+    llvm::cl::desc(
+        "Enables propagation of transpose ops through convolutions."),
+    llvm::cl::init(false));
 static llvm::cl::opt<bool> clEnableAttentionVTranspose(
     "iree-global-opt-enable-attention-v-transpose",
     llvm::cl::desc("Enables transposition of v operand of attention ops,"),
@@ -179,7 +184,7 @@ void buildGlobalOptimizationPassPipeline(
                            options.enableAggressivePropagation =
                                transformOptions.aggressiveTransposePropagation;
                            options.enableConvolutionPropagation =
-                               transformOptions.aggressiveTransposePropagation;
+                               clEnableConvolutionPropagation;
                            options.enableAttentionVTranspose =
                                clEnableAttentionVTranspose;
                            options.enableEdgeReshapePropagation =

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -857,41 +857,6 @@ public:
   }
 };
 
-// Check if we should force bubbling through a simple elementwise op that
-// follows a compute operation (contraction or convolution). This heuristic
-// enables transpose fusion with the compute op's output indexing map, which is
-// critical for performance.
-//
-// Conditions:
-// - Elementwise has single input with all identity indexing maps.
-// - Producer is a contraction or convolution.
-// - Producer has single use
-static bool
-shouldForceBubbleThroughSimpleElementwise(linalg::GenericOp genericOp) {
-  // Must be unary elementwise with all identity maps.
-  if (genericOp.getNumDpsInputs() != 1) {
-    return false;
-  }
-  if (!llvm::all_of(genericOp.getIndexingMapsArray(),
-                    [](AffineMap map) { return map.isIdentity(); })) {
-    return false;
-  }
-
-  // Check if producer is a compute op (contraction or convolution).
-  auto producer = dyn_cast<OpResult>(genericOp.getDpsInputOperand(0)->get());
-  if (!producer || !producer.hasOneUse()) {
-    return false;
-  }
-
-  auto producerLinalgOp = dyn_cast<linalg::LinalgOp>(producer.getOwner());
-  if (!producerLinalgOp) {
-    return false;
-  }
-
-  return linalg::isaContractionOpInterface(producerLinalgOp) ||
-         linalg::isaConvolutionOpInterface(producerLinalgOp);
-}
-
 // Bubbles a transpose through the init of a elementwise operation where the
 // transposition of the iteration space only affects a single input operand.
 class BubbleTransposeThroughUnaryElementwiseDpsInit
@@ -933,13 +898,6 @@ public:
     auto invPerm = invertPermutationVector(perm);
 
     auto inputOperand = getSingleTransposedInputOperand(genericOp, invPerm);
-
-    // Special case: force bubbling through simple elementwise after
-    // contractions/convolutions.
-    if (!inputOperand && shouldForceBubbleThroughSimpleElementwise(genericOp)) {
-      inputOperand = genericOp.getDpsInputOperand(0);
-    }
-
     if (!inputOperand ||
         !genericOp.getMatchingIndexingMap(inputOperand).isIdentity()) {
       return rewriter.notifyMatchFailure(


### PR DESCRIPTION
This PR fixes https://github.com/iree-org/iree/issues/22949. There is no problem with bubbling of transpose through elementwise op. However, the fusion of convolution with transpose ops is controlled by option `enableConvolutionPropagation`, which is set as `false` by default. Added a new test to validate both situations.

Now the option is controlled by a new flag `--iree-global-opt-propagate-transposes-through-conv`.
