### PR TITLE
[Util] Generalize FoldDimOp to trace through shape-preserving ViewLikeOpInterface

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/interface_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/interface_folding.mlir
@@ -31,3 +31,37 @@ util.func public @hal_interface_binding_subspan_op_and_assume_alignment() -> ind
   // CHECK: util.return %[[C64]]
   util.return %d0 : index
 }
+
+// -----
+
+// CHECK-LABEL: @fold_dim_through_assume_alignment
+// CHECK-SAME:    %[[DIM0:[a-zA-Z0-9]+]]
+util.func public @fold_dim_through_assume_alignment(%dim0 : index) -> index {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(<
+      constants = 0, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">], flags = Indirect>)
+      binding(0) : memref<?xf32>{%dim0}
+  %assume = memref.assume_alignment %0, 64 : memref<?xf32>
+  %d0 = memref.dim %assume, %c0 : memref<?xf32>
+  // CHECK: util.return %[[DIM0]]
+  util.return %d0 : index
+}
+
+// -----
+
+// CHECK-LABEL: @fold_dim_through_assume_and_cast_chain
+// CHECK-SAME:    %[[DIM0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[DIM1:[a-zA-Z0-9]+]]
+util.func public @fold_dim_through_assume_and_cast_chain(%dim0 : index, %dim1 : index) -> (index, index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = hal.interface.binding.subspan layout(<
+      constants = 0, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">], flags = Indirect>)
+      binding(0) : memref<?x?xf32>{%dim0, %dim1}
+  %assume = memref.assume_alignment %0, 64 : memref<?x?xf32>
+  %cast = amdgpu.fat_raw_buffer_cast %assume : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %d0 = memref.dim %cast, %c0 : memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %d1 = memref.dim %cast, %c1 : memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+  // CHECK: util.return %[[DIM0]], %[[DIM1]]
+  util.return %d0, %d1 : index, index
+}


### PR DESCRIPTION
This fixes data-tiling compilation of llama 70b fp4.