### PR TITLE
[VM] Preserve mutability for globals and rely on fixup to update it.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -224,7 +224,6 @@ class GlobalInitializationPass
       // initial value/initializer and avoid the work entirely.
       return success();
     }
-    globalOp.setGlobalMutable(true);
     return storePrimitiveGlobal(globalOp.getLoc(), globalOp.getGlobalName(),
                                 value, builder);
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
@@ -43,6 +43,8 @@ vm.module @mutability_change {
   vm.global.i32 private mutable @g1 = 123 : i32
   // CHECK: vm.global.i32 private mutable @g2 : i32
   vm.global.i32 private @g2 : i32
+  // CHECK: vm.global.i64 private mutable @g3
+  vm.global.i64 private @g3 = 12345 : i64
 
   vm.initializer {
     %c456 = vm.const.i32 456
@@ -58,12 +60,16 @@ vm.module @mutability_change {
     vm.global.load.i32 @g1 : i32
     // CHECK: vm.global.load.i32 @g2
     vm.global.load.i32 immutable @g2 : i32
+    // CHECK: vm.global.load.i64 @g3
+    vm.global.load.i64 immutable @g3 : i64
     vm.return
   }
 
   // CHECK: vm.func private @__init() {
   // CHECK-NEXT:   %c123 = vm.const.i32 123
   // CHECK-NEXT:   vm.global.store.i32 %c123, @g1
+  // CHECK-NEXT:   %c12345 = vm.const.i64 12345
+  // CHECK-NEXT:   vm.global.store.i64 %c12345, @g3
   // CHECK-NEXT:   %c456 = vm.const.i32 456
   // CHECK-NEXT:   vm.global.store.i32 %c456, @g2
   // CHECK-NEXT:   vm.return


### PR DESCRIPTION
The pass already runs fixupGlobalMutability method after initializing all globals with initial values. If the mutability is not preserved, it triggers a bug in [the fixup method](https://github.com/iree-org/iree/blob/f4b596d5b2a8813948f6dab18a36403e768eb5e1/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp#L98-L114).

If we always set mutable for the new globals, didChange is always true. Because it at least has one store.

```cpp
  explorer.forEachGlobal([&](const Explorer::GlobalInfo *globalInfo) {
    if (globalInfo->uses.empty())
      return;
    // TODO(benvanik): verify we want this behavior - we likely want to change
    // this to be mutable only if stores exist outside of initializers.
    //
    // If there are stores mark the global as mutable. We need to update all
    // of the loads if this changes anything.
    bool hasStores = !globalInfo->getStores().empty();
    bool didChange = globalInfo->op.isGlobalMutable() != hasStores;
    if (didChange) {
      globalInfo->op.setGlobalMutable(hasStores);
      for (auto loadOp : globalInfo->getLoads()) {
        loadOp.setGlobalImmutable(!hasStores);
      }
    }
  });
```

Fixes https://github.com/iree-org/iree/issues/22880