### PR TITLE
[CI] Add ci-extra flags for scheduled builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,24 @@ jobs:
     uses: ./.github/workflows/ci_linux_x64_clang.yml
     secrets: inherit
 
+  linux_x64_gcc:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_gcc')
+    uses: ./.github/workflows/ci_linux_x64_gcc.yml
+    secrets: inherit
+
+  linux_arm64_clang:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_arm64_clang')
+    uses: ./.github/workflows/ci_linux_arm64_clang.yml
+    secrets: inherit
+
+  linux_x64_clang_debug:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_debug')
+    uses: ./.github/workflows/ci_linux_x64_clang_debug.yml
+    secrets: inherit
+
   linux_x64_clang_asan:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_asan')
@@ -245,6 +263,18 @@ jobs:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_ubsan')
     uses: ./.github/workflows/ci_linux_x64_clang_ubsan.yml
+    secrets: inherit
+
+  linux_x64_clang_tsan:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_tsan')
+    uses: ./.github/workflows/ci_linux_x64_clang_tsan.yml
+    secrets: inherit
+
+  linux_x64_clang_byollvm:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_byollvm')
+    uses: ./.github/workflows/ci_linux_x64_clang_byollvm.yml
     secrets: inherit
 
   macos_arm64_clang:
@@ -281,8 +311,13 @@ jobs:
       # Full project builds.
       - linux_x64_bazel
       - linux_x64_clang
+      - linux_x64_gcc
+      - linux_arm64_clang
+      - linux_x64_clang_debug
       - linux_x64_clang_asan
       - linux_x64_clang_ubsan
+      - linux_x64_clang_tsan
+      - linux_x64_clang_byollvm
       - macos_arm64_clang
       - macos_x64_clang
       - windows_x64_msvc

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -14,14 +14,8 @@ on:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
   workflow_dispatch:
+  workflow_call:
 
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
 
 jobs:
   linux_arm64_clang:

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -7,9 +7,6 @@
 name: CI - Linux arm64 clang
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/ci_linux_arm64_clang.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"

--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -14,14 +14,7 @@ on:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
   workflow_dispatch:
-
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   linux_x64_clang_byollvm:

--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -7,9 +7,6 @@
 name: CI - Linux x64 clang BYO LLVM
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/ci_linux_x64_clang_byollvm.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -7,9 +7,6 @@
 name: CI - Linux x64 clang debug
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/ci_linux_x64_clang_debug.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -14,14 +14,7 @@ on:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
   workflow_dispatch:
-
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   # This may run out of memory / disk space on standard GitHub-hosted runners,

--- a/.github/workflows/ci_linux_x64_clang_tsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_tsan.yml
@@ -7,9 +7,6 @@
 name: CI - Linux x64 clang TSan
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/ci_linux_x64_clang_tsan.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"

--- a/.github/workflows/ci_linux_x64_clang_tsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_tsan.yml
@@ -14,14 +14,7 @@ on:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
   workflow_dispatch:
-
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   linux_x64_clang_tsan:

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -7,9 +7,6 @@
 name: CI - Linux x64 gcc
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/ci_linux_x64_gcc.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -14,14 +14,7 @@ on:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
   workflow_dispatch:
-
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   linux_x64_gcc:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -129,6 +129,11 @@ DEFAULT_SCHEDULE_ONLY_JOBS = frozenset(
     [
         "macos_arm64_clang",
         "macos_x64_clang",
+        "linux_arm64_clang",
+        "linux_x64_clang_byollvm",
+        "linux_x64_clang_debug",
+        "linux_x64_clang_tsan",
+        "linux_x64_gcc",
     ]
 )
 

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -141,11 +141,55 @@ DEFAULT_SCHEDULE_ONLY_JOBS = frozenset(
 # Each tuple consists of the CI job name and a list of file paths to match.
 # The file paths should be specified using Unix shell-style wildcards. Sample:
 #   ("test_nvidia_a100", ["compiler/plugins/target/CUDA/*"]),
-# Note: these jobs should also be included in DEFAULT_POSTSUBMIT_ONLY_JOBS.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
     (
+        "linux_arm64_clang",
+        [".github/workflows/ci_linux_arm64_clang.yml"],
+    ),
+    (
+        "linux_x64_bazel",
+        [".github/workflows/ci_linux_x64_bazel.yml"],
+    ),
+    (
+        "linux_x64_clang_asan",
+        [".github/workflows/ci_linux_x64_clang_asan.yml"],
+    ),
+    (
+        "linux_x64_clang_byollvm",
+        [".github/workflows/ci_linux_x64_clang_byollvm.yml"],
+    ),
+    (
+        "linux_x64_clang_debug",
+        [".github/workflows/ci_linux_x64_clang_debug.yml"],
+    ),
+    (
+        "linux_x64_clang_tsan",
+        [".github/workflows/ci_linux_x64_clang_tsan.yml"],
+    ),
+    (
+        "linux_x64_clang",
+        [".github/workflows/ci_linux_x64_clang.yml"],
+    ),
+    (
+        "linux_x64_gcc",
+        [".github/workflows/ci_linux_x64_gcc.yml"],
+    ),
+    (
+        "macos_arm64_clang",
+        [".github/workflows/ci_macos_arm64_clang.yml"],
+    ),
+    (
+        "macos_x64_clang",
+        [".github/workflows/ci_macos_x64_clang.yml"],
+    ),
+    (
         "windows_x64_msvc",
-        ["*win32*", "*windows*", "*msvc*"],
+        [
+            "*win32*",
+            "*windows*",
+            "*msvc*",
+            ".github/worklflows/ci_windows_x64_msvc.yml",
+        ],
     ),
 ]
 

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -64,6 +64,21 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, all_jobs)
 
+    def test_get_enabled_jobs_modified_ci(self):
+        trailers = {}
+        all_jobs = {"job1", "job2", "job3"}
+        is_pr = True
+        is_llvm_integrate_pr = False
+        modified_paths = [".github/workflows/ci_linux_arm64_clang.yml", "runtime/file"]
+        jobs = configure_ci.get_enabled_jobs(
+            trailers,
+            all_jobs,
+            modified_paths=modified_paths,
+            is_pr=is_pr,
+            is_llvm_integrate_pr=is_llvm_integrate_pr,
+        )
+        self.assertCountEqual(jobs, all_jobs | {"linux_arm64_clang"})
+
     def test_get_enabled_jobs_postsubmit(self):
         trailers = {}
         default_jobs = {"job1", "job2", "job3"}

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -447,6 +447,12 @@ runs.
     ci-exactly: linux_x64_bazel
     ```
 
+* Opt in to the Linux arm64 build:
+
+    ``` text
+    ci-extra: linux_arm64_clang
+    ```
+
 * Opt in to the Windows compiler build and test workflow:
 
     ``` text
@@ -457,6 +463,12 @@ runs.
 
     ``` text
     ci-extra: macos_arm64_clang, macos_x64_clang
+    ```
+
+* Other opt in builds:
+
+    ``` text
+    ci-extra: linux_x64_clang_byollvm, linux_x64_clang_debug, linux_x64_clang_tsan
     ```
 
 For example, this PR opted in to running the `build_test_all_windows` job


### PR DESCRIPTION
Allows the possibility of the following workflows to be triggered by ci-extra:

* linux_arm64_clang
* linux_x64_clang_debug
* linux_x64_clang_tsan
* linux_x64_clang_byollvm
* linux_x64_gcc