### PR TITLE
[Codegen/Common] Skip generating padding scf.forall loops when padding is effectively a no-op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
 
 #define DEBUG_TYPE "iree-codegen-combine-layout-transformation"
 
@@ -357,6 +358,75 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
     scf::IfOp::create(b, loopLoc, mask, thenBuilder);
   };
 
+  auto stopConditionFn = [](Value /*v*/, std::optional<int64_t> /*dim*/,
+                            ValueBoundsConstraintSet & /*cstr*/) -> bool {
+    return false;
+  };
+
+  // Prove that range [lb, ub) is empty (lb >= ub).
+  //
+  // For high padding, we have:
+  //   lb = low + srcSize
+  //   ub = resultSize
+  // and for a well-formed pad, resultSize = srcSize + low + high, so:
+  //   ub - lb = high
+  // Therefore "lb >= ub" => "high == 0". Expressing the check in terms of lb/ub
+  // keeps it robust even when pad amount has been rewritten into a complex
+  // form.
+  auto proveEmptyRange = [&](RewriterBase &rewriter, Location loc, Value lb,
+                             Value ub) -> bool {
+    using presburger::BoundType;
+
+    // Materialize diff = ub - lb and ask for a constant upper bound on diff.
+    // If we can prove UB(diff) <= 0, then diff <= 0 => ub - lb <= 0 => lb >=
+    // ub.
+    Value diff = arith::SubIOp::create(rewriter, loc, ub, lb);
+
+    auto ubConstantBound = ValueBoundsConstraintSet::computeConstantBound(
+        BoundType::UB, ValueBoundsConstraintSet::Variable(diff),
+        /*stopCondition=*/stopConditionFn,
+        /*addConservativeSemiAffineBounds=*/true);
+
+    return succeeded(ubConstantBound) && *ubConstantBound <= 0;
+  };
+
+  // Prove v == 0 by proving both:
+  //   LB(v) == 0  and  UB(v) == 0
+  //
+  // This is intentionally strict (see stopConditionFn): if ValueBounds cannot
+  // prove either bound, it returns failure and we treat v as "not provably
+  // zero".
+  auto proveEqZero = [&](Value v) -> bool {
+    using presburger::BoundType;
+
+    // Query constant upper bound of v.
+    FailureOr<int64_t> ub = ValueBoundsConstraintSet::computeConstantBound(
+        BoundType::UB, ValueBoundsConstraintSet::Variable(v),
+        /*stopCondition=*/stopConditionFn,
+        /*addConservativeSemiAffineBounds=*/true);
+
+    // Query constant lower bound of v.
+    FailureOr<int64_t> lb = ValueBoundsConstraintSet::computeConstantBound(
+        BoundType::LB, ValueBoundsConstraintSet::Variable(v),
+        /*stopCondition=*/stopConditionFn,
+        /*addConservativeSemiAffineBounds=*/true);
+
+    return succeeded(ub) && succeeded(lb) && *ub == 0 && *lb == 0;
+  };
+
+  auto isProvablyZeroOfr = [&](OpFoldResult ofr) -> bool {
+    // static 0?
+    if (isConstantIntValue(ofr, 0)) {
+      return true;
+    }
+
+    // dynamic %v == 0?
+    if (auto v = dyn_cast<Value>(ofr)) {
+      return proveEqZero(v);
+    }
+    return false;
+  };
+
   // Distribute the padding of each dimension separately. This causes some
   // overlap of the iteration spaces across the loops, but simplifies the
   // implementation. The trade-off is expected to be okay because we expect
@@ -392,8 +462,8 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
   // computation in order to have a more simplified kernel.
   for (auto [idx, low, high] :
        llvm::enumerate(padOp.getMixedLowPad(), padOp.getMixedHighPad())) {
-    // Create a distributed loop for the low padding
-    if (!isConstantIntValue(low, 0)) {
+    // Create a distributed loop for the low padding if low pad is non-zero
+    if (!isProvablyZeroOfr(low)) {
       SmallVector<OpFoldResult> ubs(padResultSizes);
       SmallVector<OpFoldResult> lbs(ubs.size(), rewriter.getIndexAttr(0));
       SmallVector<int64_t> shape(padOp.getSourceType().getShape());
@@ -404,15 +474,41 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
       buildNestedDistributionLoops(rewriter, loc, /*distributionLevel=*/0, lbs,
                                    ubs, distConfigs, innerLoopBuilder);
     }
-    // Create a distributed loop for the high padding
-    if (isConstantIntValue(high, 0)) {
+
+    // If the pad amount is provably zero, skip generating loops.
+    // This reduces IR bloat and avoids degenerate scf.forall bounds for
+    // padding.
+    if (isProvablyZeroOfr(high)) {
       continue;
     }
+
+    // Create a distributed loop for the high padding
     SmallVector<OpFoldResult> ubs(padResultSizes);
     SmallVector<OpFoldResult> lbs(ubs.size(), rewriter.getIndexAttr(0));
     SmallVector<int64_t> shape(padOp.getSourceType().getShape());
     shape[idx] = padOp.getStaticHigh()[idx];
     lbs[idx] = IREE::LinalgExt::addOfrs(rewriter, loc, low, padSrcSizes[idx]);
+    // ubs[idx] is padResultSizes[idx] already (since ubs initialized from
+    // padResultSizes)
+
+    // Fallback: Even if we couldn't prove the pad amount is exactly 0, the
+    // derived half-open iteration space [lb, ub) may still be empty. For
+    // well-formed pads this typically means lb == ub (i.e., the high pad is 0),
+    // but we phrase it as the general condition lb >= ub for half-open ranges.
+    // If it's empty, skip generating this loop nest.
+    {
+      Value lbV = getValueOrCreateConstantIndexOp(rewriter, loc, lbs[idx]);
+      Value ubV = getValueOrCreateConstantIndexOp(rewriter, loc, ubs[idx]);
+
+      if (lbV == ubV) {
+        continue;
+      }
+
+      if (proveEmptyRange(rewriter, loc, lbV, ubV)) {
+        continue;
+      }
+    }
+
     SmallVector<DistributionConfig> distConfigs =
         padDistributionConfigFn(shape, rewriter.getContext());
     buildNestedDistributionLoops(rewriter, loc, /*distributionLevel=*/0, lbs,
@@ -593,6 +689,24 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
   // ops like pack and unpack into simpler supported ops.
   IRRewriter rewriter(ctx);
   simplifyComplexRelayoutOps(rewriter, funcOp);
+
+  // Resolve dims aggressively and canonicalize to simplify and deduplicate the
+  // IR. This improves pattern matching and makes it easier for subsequent
+  // rewrites/proofs to recognize identity/no-op cases.
+  {
+    RewritePatternSet dimResolve(ctx);
+    memref::populateResolveRankedShapedTypeResultDimsPatterns(dimResolve);
+    if (failed(applyPatternsGreedily(funcOp, std::move(dimResolve)))) {
+      return failure();
+    }
+
+    PassManager pm(ctx);
+    pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
+    if (failed(pm.run(funcOp))) {
+      return failure();
+    }
+  }
 
   // Combine relayout operations into new the map_scatter ops.
   RewritePatternSet relayoutCombinationPatterns(ctx);

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -427,7 +427,7 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
   for (auto [idx, low, high] :
        llvm::enumerate(padOp.getMixedLowPad(), padOp.getMixedHighPad())) {
     // Create a distributed loop for the low padding.
-    if (!(isConstantIntValue(low, 0))) {
+    if (!isConstantIntValue(low, 0)) {
       SmallVector<OpFoldResult> ubs(padResultSizes);
       SmallVector<OpFoldResult> lbs(ubs.size(), rewriter.getIndexAttr(0));
       SmallVector<int64_t> shape(padOp.getSourceType().getShape());

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -170,6 +170,7 @@ def CombineLayoutTransformationPass :
   ];
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
+    "iree_compiler::IREE::Util::UtilDialect",
     "scf::SCFDialect",
     "tensor::TensorDialect"
   ];

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -449,3 +449,47 @@ func.func @unpack_no_padding_no_masking(%dim : index, %result : memref<?x16384xf
 // DISPATCH-SCOPE-LABEL: func @unpack_no_padding_no_masking
 // DISPATCH-SCOPE: iree_linalg_ext.map_scatter
 // DISPATCH-SCOPE-NOT: arith.cmpi ult
+
+// -----
+
+// Tests that no padding scf.forall loops are emitted when
+// padding in linalg.pack is effectively a no-op
+
+func.func @pack_dynamic_dim_tile_size_1_no_pad_loop(%source : tensor<16x?x128xf16>, %result : memref<16x8x?x16x1xf16>) {
+  %cst = arith.constant 0.000000e+00 : f16
+  %cst_1 = arith.constant 1 : index
+  %dim = tensor.dim %source, %cst_1 : tensor<16x?x128xf16>
+  %dest = tensor.empty(%dim) : tensor<16x8x?x16x1xf16>
+  %pack = linalg.pack %source padding_value(%cst : f16)
+    outer_dims_perm = [0, 2, 1]
+    inner_dims_pos = [2, 1]
+    inner_tiles = [16, 1]
+    into %dest : tensor<16x?x128xf16> -> tensor<16x8x?x16x1xf16>
+  iree_codegen.store_to_buffer %pack, %result : tensor<16x8x?x16x1xf16> into memref<16x8x?x16x1xf16>
+  return
+}
+// DISPATCH-SCOPE-LABEL: @pack_dynamic_dim_tile_size_1_no_pad_loop
+//       DISPATCH-SCOPE:   iree_linalg_ext.map_scatter
+// Verify no padding loops are generated
+//   DISPATCH-SCOPE-NOT:   scf.forall
+//       DISPATCH-SCOPE:   iree_codegen.store_to_buffer
+
+// -----
+
+func.func @pack_divisible_static_dim_tile_size_8_no_pad_loop(%source : tensor<16x?xf16>, %result : memref<2x?x8x1xf16>) {
+  %cst = arith.constant 0.000000e+00 : f16
+  %cst_1 = arith.constant 1 : index
+  %dim = tensor.dim %source, %cst_1 : tensor<16x?xf16>
+  %dest = tensor.empty(%dim) : tensor<2x?x8x1xf16>
+  %pack = linalg.pack %source padding_value(%cst : f16)
+    inner_dims_pos = [0, 1]
+    inner_tiles = [8, 1]
+    into %dest : tensor<16x?xf16> -> tensor<2x?x8x1xf16>
+  iree_codegen.store_to_buffer %pack, %result : tensor<2x?x8x1xf16> into memref<2x?x8x1xf16>
+  return
+}
+// DISPATCH-SCOPE-LABEL: @pack_divisible_static_dim_tile_size_8_no_pad_loop
+//       DISPATCH-SCOPE:   iree_linalg_ext.map_scatter
+// Verify no padding loops are generated
+//   DISPATCH-SCOPE-NOT:   scf.forall
+//       DISPATCH-SCOPE:   iree_codegen.store_to_buffer

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -453,7 +453,7 @@ func.func @unpack_no_padding_no_masking(%dim : index, %result : memref<?x16384xf
 // -----
 
 // Tests that no padding scf.forall loops are emitted when
-// padding in linalg.pack is effectively a no-op
+// padding in linalg.pack is effectively a no-op.
 
 func.func @pack_dynamic_dim_tile_size_1_no_pad_loop(%source : tensor<16x?x128xf16>, %result : memref<16x8x?x16x1xf16>) {
   %cst = arith.constant 0.000000e+00 : f16
@@ -470,7 +470,7 @@ func.func @pack_dynamic_dim_tile_size_1_no_pad_loop(%source : tensor<16x?x128xf1
 }
 // DISPATCH-SCOPE-LABEL: @pack_dynamic_dim_tile_size_1_no_pad_loop
 //       DISPATCH-SCOPE:   iree_linalg_ext.map_scatter
-// Verify no padding loops are generated
+// Verify no padding loops are generated.
 //   DISPATCH-SCOPE-NOT:   scf.forall
 //       DISPATCH-SCOPE:   iree_codegen.store_to_buffer
 
@@ -490,6 +490,6 @@ func.func @pack_divisible_static_dim_tile_size_8_no_pad_loop(%source : tensor<16
 }
 // DISPATCH-SCOPE-LABEL: @pack_divisible_static_dim_tile_size_8_no_pad_loop
 //       DISPATCH-SCOPE:   iree_linalg_ext.map_scatter
-// Verify no padding loops are generated
+// Verify no padding loops are generated.
 //   DISPATCH-SCOPE-NOT:   scf.forall
 //       DISPATCH-SCOPE:   iree_codegen.store_to_buffer


### PR DESCRIPTION
Fixes #23016

### TL;DR

Avoid generating padding materialization loops during `linalg.pack` lowering when the padding iteration space is provably empty, using `ValueBoundsOpInterface`.

### What changed?

- Use **ValueBounds** to prove padding is a no-op by proving that the derived half-open padding range `[lb, ub)` is empty (i.e., `lb >= ub`)
- Add helper predicate for “provably empty range”.
- Improve dimension canonicalization/resolution so no-op padding patterns are detected reliably.
- Skip emitting padding `scf.forall` when proven empty.
- Add tests where padding loops are not emitted when it's 0.

### How to test?

- Run

```
iree-opt compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir --pass-pipeline="builtin.module(func.func(iree-codegen-combine-layout-transformation{scope=dispatch}, canonicalize, cse))" --split-input-file
```

- The tests check no padding `scf.forall` is emitted when it isn't required

### Why?

Eliminating empty/degenerate padding loops:

- reduces IR bloat
- avoids issues from degenerate/empty iteration spaces (e.g., `scf.forall` with `lb == ub`) that can later materialize as invalid bases during index delinearization, causing failures in downstream passes.
- helps dynamic-shape cases where `ValueBounds` can prove padding is unnecessary even when static analysis can’t.