### PR TITLE
[Codegen] Add index_hint op and lane hint attributes for GPU optimization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -585,4 +585,34 @@ def IREECodegen_WorkgroupCountHintOp :
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// IndexHintOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_IndexHintOp : Op<IREECodegen_Dialect, "index_hint", [Pure]> {
+  let summary = "Compiler hint providing semantic information about an index";
+  let description = [{
+    Pure pass-through operation that annotates an index value with semantic
+    information about how it varies across parallel workers (e.g., GPU lanes).
+
+    The hint attribute describes the index behavior. Common hints include:
+    - `#iree_gpu.lane_constant<N>`: Index is uniform within groups of N lanes
+    - `#iree_gpu.lane_increment<N>`: Index increments by 1 within groups of N lanes
+
+    This operation is always safe to remove (replace with input). It exists
+    purely to guide optimization passes.
+
+    Example:
+    ```mlir
+    %row = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_constant<16>} : index
+    %col = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_increment<16>} : index
+    ```
+  }];
+
+  let arguments = (ins Index:$input, AnyAttr:$hint);
+  let results = (outs Index:$result);
+
+  let assemblyFormat = "$input ` ` `{` `hint` `=` $hint `}` attr-dict `:` type($input)";
+}
+
 #endif // IREE_CODEGEN_DIALECT_IREECODEGENOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -604,15 +604,15 @@ def IREECodegen_IndexHintOp : Op<IREECodegen_Dialect, "index_hint", [Pure]> {
 
     Example:
     ```mlir
-    %row = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_constant<16>} : index
-    %col = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_increment<16>} : index
+    %row = iree_codegen.index_hint %idx(#iree_gpu.lane_constant<16>) : index
+    %col = iree_codegen.index_hint %idx(#iree_gpu.lane_increment<16>) : index
     ```
   }];
 
   let arguments = (ins Index:$input, AnyAttr:$hint);
   let results = (outs Index:$result);
 
-  let assemblyFormat = "$input ` ` `{` `hint` `=` $hint `}` attr-dict `:` type($input)";
+  let assemblyFormat = "$input `(` $hint `)` attr-dict `:` type($input)";
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREECODEGENOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -86,34 +86,21 @@ func.func @fusion_barrier(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 // -----
 
 func.func @index_hint_lane_constant(%idx: index) -> index {
-  %hinted = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_constant<16>} : index
+  %hinted = iree_codegen.index_hint %idx(#iree_gpu.lane_constant<16>) : index
   return %hinted : index
 }
 // CHECK-LABEL: func.func @index_hint_lane_constant(
 // CHECK-SAME:    %[[IDX:[a-zA-Z0-9_]+]]: index
-// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]] {hint = #iree_gpu.lane_constant<16>} : index
+// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]](#iree_gpu.lane_constant<16>) : index
 // CHECK:         return %[[HINT]]
 
 // -----
 
 func.func @index_hint_lane_increment(%idx: index) -> index {
-  %hinted = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_increment<16>} : index
+  %hinted = iree_codegen.index_hint %idx(#iree_gpu.lane_increment<16>) : index
   return %hinted : index
 }
 // CHECK-LABEL: func.func @index_hint_lane_increment(
 // CHECK-SAME:    %[[IDX:[a-zA-Z0-9_]+]]: index
-// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]] {hint = #iree_gpu.lane_increment<16>} : index
+// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]](#iree_gpu.lane_increment<16>) : index
 // CHECK:         return %[[HINT]]
-
-// -----
-
-func.func @index_hint_multiple(%idx0: index, %idx1: index, %idx2: index) -> (index, index, index) {
-  %row0 = iree_codegen.index_hint %idx0 {hint = #iree_gpu.lane_constant<16>} : index
-  %row1 = iree_codegen.index_hint %idx1 {hint = #iree_gpu.lane_constant<16>} : index
-  %col = iree_codegen.index_hint %idx2 {hint = #iree_gpu.lane_increment<16>} : index
-  return %row0, %row1, %col : index, index, index
-}
-// CHECK-LABEL: func.func @index_hint_multiple(
-// CHECK:         iree_codegen.index_hint {{.*}} {hint = #iree_gpu.lane_constant<16>} : index
-// CHECK:         iree_codegen.index_hint {{.*}} {hint = #iree_gpu.lane_constant<16>} : index
-// CHECK:         iree_codegen.index_hint {{.*}} {hint = #iree_gpu.lane_increment<16>} : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -82,3 +82,38 @@ func.func @fusion_barrier(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK-LABEL: func.func @fusion_barrier(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?xf32>
 // CHECK:         iree_codegen.fusion_barrier %[[ARG0]] : tensor<?xf32>
+
+// -----
+
+func.func @index_hint_lane_constant(%idx: index) -> index {
+  %hinted = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_constant<16>} : index
+  return %hinted : index
+}
+// CHECK-LABEL: func.func @index_hint_lane_constant(
+// CHECK-SAME:    %[[IDX:[a-zA-Z0-9_]+]]: index
+// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]] {hint = #iree_gpu.lane_constant<16>} : index
+// CHECK:         return %[[HINT]]
+
+// -----
+
+func.func @index_hint_lane_increment(%idx: index) -> index {
+  %hinted = iree_codegen.index_hint %idx {hint = #iree_gpu.lane_increment<16>} : index
+  return %hinted : index
+}
+// CHECK-LABEL: func.func @index_hint_lane_increment(
+// CHECK-SAME:    %[[IDX:[a-zA-Z0-9_]+]]: index
+// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]] {hint = #iree_gpu.lane_increment<16>} : index
+// CHECK:         return %[[HINT]]
+
+// -----
+
+func.func @index_hint_multiple(%idx0: index, %idx1: index, %idx2: index) -> (index, index, index) {
+  %row0 = iree_codegen.index_hint %idx0 {hint = #iree_gpu.lane_constant<16>} : index
+  %row1 = iree_codegen.index_hint %idx1 {hint = #iree_gpu.lane_constant<16>} : index
+  %col = iree_codegen.index_hint %idx2 {hint = #iree_gpu.lane_increment<16>} : index
+  return %row0, %row1, %col : index, index, index
+}
+// CHECK-LABEL: func.func @index_hint_multiple(
+// CHECK:         iree_codegen.index_hint {{.*}} {hint = #iree_gpu.lane_constant<16>} : index
+// CHECK:         iree_codegen.index_hint {{.*}} {hint = #iree_gpu.lane_constant<16>} : index
+// CHECK:         iree_codegen.index_hint {{.*}} {hint = #iree_gpu.lane_increment<16>} : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -85,22 +85,11 @@ func.func @fusion_barrier(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 
 // -----
 
-func.func @index_hint_lane_constant(%idx: index) -> index {
-  %hinted = iree_codegen.index_hint %idx(#iree_gpu.lane_constant<16>) : index
+func.func @index_hint(%idx: index) -> index {
+  %hinted = iree_codegen.index_hint %idx([]) : index
   return %hinted : index
 }
-// CHECK-LABEL: func.func @index_hint_lane_constant(
+// CHECK-LABEL: func.func @index_hint(
 // CHECK-SAME:    %[[IDX:[a-zA-Z0-9_]+]]: index
-// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]](#iree_gpu.lane_constant<16>) : index
-// CHECK:         return %[[HINT]]
-
-// -----
-
-func.func @index_hint_lane_increment(%idx: index) -> index {
-  %hinted = iree_codegen.index_hint %idx(#iree_gpu.lane_increment<16>) : index
-  return %hinted : index
-}
-// CHECK-LABEL: func.func @index_hint_lane_increment(
-// CHECK-SAME:    %[[IDX:[a-zA-Z0-9_]+]]: index
-// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]](#iree_gpu.lane_increment<16>) : index
+// CHECK:         %[[HINT:.+]] = iree_codegen.index_hint %[[IDX]]([]) : index
 // CHECK:         return %[[HINT]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2309,6 +2309,35 @@ GPUPipelineOptionsAttr GPUPipelineOptionsAttr::get(
 }
 
 //===----------------------------------------------------------------------===//
+// Index Hint Attributes
+//===----------------------------------------------------------------------===//
+
+// Custom parser/printer to make the step optional. When the step is 1, the step
+// field will be ommited.
+Attribute IREE::GPU::LaneIncrementAttr::parse(AsmParser &parser, Type) {
+  int64_t groupSize = 0;
+  if (failed(parser.parseLess()) || failed(parser.parseInteger(groupSize))) {
+    return {};
+  }
+  int64_t step = 1;
+  if (succeeded(parser.parseOptionalComma())) {
+    if (failed(parser.parseKeyword("step")) || failed(parser.parseEqual()) ||
+        failed(parser.parseInteger(step))) {
+      return {};
+    }
+  }
+  return LaneIncrementAttr::get(parser.getContext(), groupSize, step);
+}
+
+void IREE::GPU::LaneIncrementAttr::print(AsmPrinter &printer) const {
+  printer << "<" << getGroupSize();
+  if (getStep() != 1) {
+    printer << ", step = " << getStep();
+  }
+  printer << ">";
+}
+
+//===----------------------------------------------------------------------===//
 // Attribute Registration
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -986,15 +986,15 @@ def IREEGPU_LaneIncrementAttr : AttrDef<IREEGPU_Dialect, "LaneIncrement"> {
   let summary = "Index increments by 1 within groups of N lanes";
   let description = [{
     This attribute is intended to be attached to the iree_codegen.index_hint op,
-    on which it indicates that the index value increments by 1 within groups
-    of N consecutive lanes. For example, with group_size=16 and a base value B,
-    lane i has value B + (i % 16).
+    on which it indicates that the index value increments by `step` within
+    groups of N consecutive lanes. For example, with group_size=16 and a base
+    value B, lane i has value `B + (i % 16) * step`.
 
     This hint is used to guide optimizations like transpose load lowering,
     where the column index must increment by 1 across consecutive lanes.
   }];
-  let parameters = (ins "int64_t":$group_size);
-  let assemblyFormat = "`<` $group_size `>`";
+  let parameters = (ins "int64_t":$group_size, "int64_t":$step);
+  let hasCustomAssemblyFormat = 1;
 }
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -968,9 +968,10 @@ def IREEGPU_LaneConstantAttr : AttrDef<IREEGPU_Dialect, "LaneConstant"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
   let summary = "Index is constant within groups of N lanes";
   let description = [{
-    This attribute indicates that an index value is constant (uniform) across
-    groups of N consecutive lanes. For example, with group_size=16, lanes 0-15
-    all have the same value, lanes 16-31 all have the same value, etc.
+    This attribute is intended to be attached to the iree_codegen.index_hint op,
+    on which it attribute indicates that the index value is constant (uniform)
+    across groups of N consecutive lanes. For example, with group_size=16, lanes
+    0-15 all have the same value, lanes 16-31 all have the same value, etc.
 
     This hint is used to guide optimizations like transpose load lowering,
     where row indices must be uniform within a 16-lane group.
@@ -984,7 +985,8 @@ def IREEGPU_LaneIncrementAttr : AttrDef<IREEGPU_Dialect, "LaneIncrement"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
   let summary = "Index increments by 1 within groups of N lanes";
   let description = [{
-    This attribute indicates that an index value increments by 1 within groups
+    This attribute is intended to be attached to the iree_codegen.index_hint op,
+    on which it indicates that the index value increments by 1 within groups
     of N consecutive lanes. For example, with group_size=16 and a base value B,
     lane i has value B + (i % 16).
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -959,4 +959,40 @@ def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOption
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Lane Index Hint Attributes
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_LaneConstantAttr : AttrDef<IREEGPU_Dialect, "LaneConstant"> {
+  let mnemonic = "lane_constant";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+  let summary = "Index is constant within groups of N lanes";
+  let description = [{
+    This attribute indicates that an index value is constant (uniform) across
+    groups of N consecutive lanes. For example, with group_size=16, lanes 0-15
+    all have the same value, lanes 16-31 all have the same value, etc.
+
+    This hint is used to guide optimizations like transpose load lowering,
+    where row indices must be uniform within a 16-lane group.
+  }];
+  let parameters = (ins "int64_t":$group_size);
+  let assemblyFormat = "`<` $group_size `>`";
+}
+
+def IREEGPU_LaneIncrementAttr : AttrDef<IREEGPU_Dialect, "LaneIncrement"> {
+  let mnemonic = "lane_increment";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+  let summary = "Index increments by 1 within groups of N lanes";
+  let description = [{
+    This attribute indicates that an index value increments by 1 within groups
+    of N consecutive lanes. For example, with group_size=16 and a base value B,
+    lane i has value B + (i % 16).
+
+    This hint is used to guide optimizations like transpose load lowering,
+    where the column index must increment by 1 across consecutive lanes.
+  }];
+  let parameters = (ins "int64_t":$group_size);
+  let assemblyFormat = "`<` $group_size `>`";
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -180,3 +180,30 @@ module {
 }
 // CHECK-LABEL: func @test_cache_swizzle_promotion
 //  CHECK-SAME:   promotion_types = [#iree_gpu.promote_with_cache_swizzle<#iree_gpu.derived_thread_config>]
+
+module {
+  func.func @test_lane_constant() attributes {
+      lane_constant = #iree_gpu.lane_constant<16>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_lane_constant
+//  CHECK-SAME:   lane_constant = #iree_gpu.lane_constant<16>
+
+module {
+  func.func @test_lane_increment() attributes {
+      lane_increment = #iree_gpu.lane_increment<16>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_lane_increment
+//  CHECK-SAME:   lane_increment = #iree_gpu.lane_increment<16>
+
+module {
+  func.func @test_lane_increment_with_step() attributes {
+      lane_increment = #iree_gpu.lane_increment<16, step = 2>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_lane_increment_with_step
+//  CHECK-SAME:   lane_increment = #iree_gpu.lane_increment<16, step = 2>


### PR DESCRIPTION
Add an op to annotate index values with semantic information about how they vary across GPU lanes. This enables later optimization opportunities that have index pattern requirements like transpose loads.

The `iree_codegen.index_hint` op is a pure pass-through that wraps an index with a hint attribute. Two GPU-specific hint attributes are added:
- `#iree_gpu.lane_constant<N>`: index is uniform within N-lane groups
- `#iree_gpu.lane_increment<N>`: index increments by 1 within N-lane groups

These hints are always safe to remove and serve purely as optimization guides. The immediate use case is enabling `amdgpu.transpose_load` lowering, where row indices must be uniform and column indices must increment across lanes within 16-lane groups.

This is the final state of the index hint op proposed in https://github.com/iree-org/iree/issues/22700.