### PR TITLE
Flatbuffers: do not canonicalize empty strings to null string

### DIFF
--- a/compiler/src/iree/compiler/Utils/FlatbufferUtils.h
+++ b/compiler/src/iree/compiler/Utils/FlatbufferUtils.h
@@ -52,8 +52,6 @@ public:
 
   // Creates a string with the given string contents (including zeros).
   flatbuffers_string_ref_t createString(StringRef value) {
-    if (value.empty())
-      return 0;
     return flatbuffers_string_create(*this, value.data(), value.size());
   }
 


### PR DESCRIPTION
This was causing assertion failures in flatbuffers serialization when serializing debug info with a Name location that was empty. 
```
iree-compile: iree/third_party/flatcc/src/runtime/builder.c:1492: flatcc_builder_ref_t _create_offset_vector_direct(flatcc_builder_t *, flatcc_builder_ref_t *, size_t, const flatbuffers_utype_t *): Assertion `types[i] == 0' failed.
Stack dump:
#12 0x00007fca8696f35b _create_offset_vector_direct /tmp/xx/iree/third_party/flatcc/src/runtime/builder.c:1498:12
#13 0x00007fca8696fcce flatcc_builder_create_union_vector_direct /tmp/xx/iree/third_party/flatcc/src/runtime/builder.c:1618:29
#14 0x00007fca8696fcce flatcc_builder_create_union_vector /tmp/xx/iree/third_party/flatcc/src/runtime/builder.c:1606:13
#15 0x00007fca817ffcfe iree_vm_LocationTypeDef_vec_create(flatcc_builder*, flatcc_builder_union_ref const*, unsigned long) /tmp/xx/iree-build/runtime/src/iree/schemas/bytecode_module_def_builder.h:299:1
#16 0x00007fca817ffcfe mlir::iree_compiler::IREE::VM::LocationTable::finish() /tmp/xx/iree/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.cpp:99:12
#17 0x00007fca817ffcfe mlir::iree_compiler::IREE::VM::DebugDatabaseBuilder::build(mlir::iree_compiler::FlatbufferBuilder&) /tmp/xx/iree/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.cpp:131:41
```

The actual assertion message is somehow not printed above, but is describes the issue more explicitly:
https://github.com/dvidelabs/flatcc/blob/e3e44836c5f625b5532586ddce895f8b5e36a212/src/runtime/builder.c#L1495

```c++
if (vec[i] != 0) {
         ...
        } else {
            if (types) {
                check(types[i] == 0, "union vector cannot have null element without type NONE");
```

So the summary is that inside a union, each value must be either non-null or NONE.  A null-string is thus illegal in an union.