### PR TITLE
[NFC] Cleanup of bytecode ISA decoding macros.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -431,7 +431,7 @@ std::optional<EncodedBytecodeFunction> BytecodeEncoder::encodeFunction(
       return std::nullopt;
     }
 
-    // From isa.h: IREE_VM_PC_BLOCK_MAX
+    // From isa.h: IREE_VM_ISA_PC_BLOCK_MAX
     static const size_t kVMMaxBlockSize = 0x00FFFFFFu;
     size_t blockLength = encoder.getOffset() - blockStart;
     if (blockLength > kVMMaxBlockSize) {

--- a/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp
@@ -63,7 +63,9 @@ void emitOpTable(const llvm::RecordKeeper &recordKeeper, const Record &tableDef,
 // Finds all opcode tables in VMBase.td and emits a enum and template table for
 // their opcode and name.
 bool emitOpTableDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
-  llvm::emitSourceFileHeader("IREE VM Operation Tables", os);
+  llvm::emitSourceFileHeader("iree-tblgen generated file; do not modify; "
+                             "change VM op .td files instead",
+                             os);
 
   auto defs = recordKeeper.getAllDerivedDefinitions("VM_OPC_EnumAttr");
   for (const auto *def : defs) {

--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -461,13 +461,23 @@ static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
        int64_t*: iree_unaligned_load_le_u64((const uint64_t*)(ptr)),           \
       uint64_t*: iree_unaligned_load_le_u64((const uint64_t*)(ptr)),           \
          float*: iree_unaligned_load_le_f32((const float*)(ptr)),              \
-        double*: iree_unaligned_load_le_f64((const double*)(ptr))              \
+        double*: iree_unaligned_load_le_f64((const double*)(ptr)),             \
+  const int8_t*: iree_unaligned_load_le_u8((const uint8_t*)(ptr)),             \
+ const uint8_t*: iree_unaligned_load_le_u8((const uint8_t*)(ptr)),             \
+ const int16_t*: iree_unaligned_load_le_u16((const uint16_t*)(ptr)),           \
+const uint16_t*: iree_unaligned_load_le_u16((const uint16_t*)(ptr)),           \
+ const int32_t*: iree_unaligned_load_le_u32((const uint32_t*)(ptr)),           \
+const uint32_t*: iree_unaligned_load_le_u32((const uint32_t*)(ptr)),           \
+ const int64_t*: iree_unaligned_load_le_u64((const uint64_t*)(ptr)),           \
+const uint64_t*: iree_unaligned_load_le_u64((const uint64_t*)(ptr)),           \
+   const float*: iree_unaligned_load_le_f32((const float*)(ptr)),              \
+  const double*: iree_unaligned_load_le_f64((const double*)(ptr))              \
   )
 
 // Dereferences |ptr| and writes the given |value|.
 // Automatically handles unaligned accesses on architectures that may not
 // support them natively (or efficiently). Memory is treated as little-endian.
-#define iree_unaligned_store(ptr, value)                                       \
+#define iree_unaligned_store_le(ptr, value)                                    \
   _Generic((ptr),                                                              \
         int8_t*: iree_unaligned_store_le_u8((uint8_t*)(ptr), value),           \
        uint8_t*: iree_unaligned_store_le_u8((uint8_t*)(ptr), value),           \

--- a/runtime/src/iree/io/memory_stream.c
+++ b/runtime/src/iree/io/memory_stream.c
@@ -263,7 +263,7 @@ static iree_status_t iree_io_memory_stream_fill(
       uint16_t* data = (uint16_t*)data_ptr;
       uint16_t value_bits = *(const uint16_t*)(pattern);
       for (iree_device_size_t i = 0; i < count; ++i) {
-        iree_unaligned_store(&data[i], value_bits);
+        iree_unaligned_store_le(&data[i], value_bits);
       }
       break;
     }
@@ -271,7 +271,7 @@ static iree_status_t iree_io_memory_stream_fill(
       uint32_t* data = (uint32_t*)data_ptr;
       uint32_t value_bits = *(const uint32_t*)(pattern);
       for (iree_device_size_t i = 0; i < count; ++i) {
-        iree_unaligned_store(&data[i], value_bits);
+        iree_unaligned_store_le(&data[i], value_bits);
       }
       break;
     }
@@ -279,7 +279,7 @@ static iree_status_t iree_io_memory_stream_fill(
       uint64_t* data = (uint64_t*)data_ptr;
       uint64_t value_bits = *(const uint64_t*)(pattern);
       for (iree_device_size_t i = 0; i < count; ++i) {
-        iree_unaligned_store(&data[i], value_bits);
+        iree_unaligned_store_le(&data[i], value_bits);
       }
       break;
     }

--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -17,7 +17,19 @@
 #include "iree/vm/ops.h"
 
 //===----------------------------------------------------------------------===//
-// Register remapping utilities
+// Ref register debug checking
+//===----------------------------------------------------------------------===//
+
+#if defined(IREE_VM_REF_DEBUG_MOVE)
+#define IREE_VM_ISA_DISPATCH_REF_DEBUG_CHECK(ptr)        \
+  IREE_ASSERT_NE((ptr)->type, IREE_VM_REF_TYPE_POISONED, \
+                 "use-after-move: ref register accessed after move")
+#else
+#define IREE_VM_ISA_DISPATCH_REF_DEBUG_CHECK(ptr) ((void)0)
+#endif  // IREE_VM_REF_DEBUG_MOVE
+
+//===----------------------------------------------------------------------===//
+// Register remapping/branch utilities
 //===----------------------------------------------------------------------===//
 
 // Remaps registers from a source set to a destination set within the same stack
@@ -35,14 +47,35 @@ static void iree_vm_bytecode_dispatch_remap_branch_registers(
     // Could write two arrays: one for prims and one for refs.
     uint16_t src_reg = remap_list->pairs[i].src_reg;
     uint16_t dst_reg = remap_list->pairs[i].dst_reg;
-    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
-      iree_vm_ref_retain_or_move(src_reg & IREE_REF_REGISTER_MOVE_BIT,
-                                 &regs_ref[src_reg & IREE_REF_REGISTER_MASK],
-                                 &regs_ref[dst_reg & IREE_REF_REGISTER_MASK]);
+    if (src_reg & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) {
+      iree_vm_ref_retain_or_move(
+          src_reg & IREE_VM_ISA_REF_REGISTER_MOVE_BIT,
+          &regs_ref[src_reg & IREE_VM_ISA_REF_REGISTER_MASK],
+          &regs_ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK]);
     } else {
       regs_i32[dst_reg] = regs_i32[src_reg];
     }
   }
+}
+
+static inline iree_vm_source_offset_t iree_vm_bytecode_dispatch_branch_to(
+    int32_t* IREE_RESTRICT regs_i32, iree_vm_ref_t* IREE_RESTRICT regs_ref,
+    iree_vm_source_offset_t target_pc,
+    const iree_vm_register_remap_list_t* IREE_RESTRICT remap_list,
+    iree_vm_source_offset_t pc_delta) {
+  if (IREE_UNLIKELY(remap_list->size > 0)) {
+    iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
+                                                     remap_list);
+  }
+  return target_pc + pc_delta;
+}
+
+static inline iree_vm_source_offset_t iree_vm_bytecode_dispatch_branch_to_block(
+    int32_t* IREE_RESTRICT regs_i32, iree_vm_ref_t* IREE_RESTRICT regs_ref,
+    iree_vm_source_offset_t block_pc,
+    const iree_vm_register_remap_list_t* IREE_RESTRICT remap_list) {
+  return iree_vm_bytecode_dispatch_branch_to(
+      regs_i32, regs_ref, block_pc, remap_list, IREE_VM_BLOCK_MARKER_SIZE);
 }
 
 // Discards ref registers in the list if they are marked move.
@@ -54,9 +87,11 @@ static void iree_vm_bytecode_dispatch_discard_registers(
   for (int i = 0; i < reg_list->size; ++i) {
     // TODO(benvanik): change encoding to avoid this branching.
     uint16_t reg = reg_list->registers[i];
-    if ((reg & (IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT)) ==
-        (IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT)) {
-      iree_vm_ref_release(&regs_ref[reg & IREE_REF_REGISTER_MASK]);
+    if ((reg & (IREE_VM_ISA_REF_REGISTER_TYPE_BIT |
+                IREE_VM_ISA_REF_REGISTER_MOVE_BIT)) ==
+        (IREE_VM_ISA_REF_REGISTER_TYPE_BIT |
+         IREE_VM_ISA_REF_REGISTER_MOVE_BIT)) {
+      iree_vm_ref_release(&regs_ref[reg & IREE_VM_ISA_REF_REGISTER_MASK]);
     }
   }
 }
@@ -151,8 +186,8 @@ static iree_status_t iree_vm_bytecode_function_enter(
   // We've verified all register storage prior to execution.
   uint32_t i32_register_count = target_descriptor->i32_register_count;
   uint32_t ref_register_count = target_descriptor->ref_register_count;
-  IREE_ASSERT_LE(i32_register_count, IREE_I32_REGISTER_MASK);
-  IREE_ASSERT_LE(ref_register_count, IREE_REF_REGISTER_MASK);
+  IREE_ASSERT_LE(i32_register_count, IREE_VM_ISA_I32_REGISTER_MASK);
+  IREE_ASSERT_LE(ref_register_count, IREE_VM_ISA_REF_REGISTER_MASK);
 
   // We need to align the ref register start to the natural machine
   // alignment in case the compiler is expecting that (it makes it easier to
@@ -246,7 +281,7 @@ static iree_status_t iree_vm_bytecode_external_enter(
         uint16_t dst_reg = ref_reg++;
         iree_vm_ref_retain(
             (iree_vm_ref_t*)p,
-            &callee_registers.ref[dst_reg & IREE_REF_REGISTER_MASK]);
+            &callee_registers.ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK]);
         p += sizeof(iree_vm_ref_t);
       } break;
     }
@@ -291,9 +326,9 @@ static iree_status_t iree_vm_bytecode_external_leave(
       case IREE_VM_CCONV_TYPE_REF: {
         p = iree_vm_bytecode_align_ptr(p, iree_alignof(iree_vm_ref_t));
         iree_vm_ref_retain_or_move(
-            src_reg & IREE_REF_REGISTER_MOVE_BIT,
-            &callee_registers->ref[src_reg & IREE_REF_REGISTER_MASK],
-            (iree_vm_ref_t*)p);
+            src_reg & IREE_VM_ISA_REF_REGISTER_MOVE_BIT,
+            &callee_registers->ref[src_reg & IREE_VM_ISA_REF_REGISTER_MASK],
+            (iree_vm_ref_t*)p);  // safe unaligned
         p += sizeof(iree_vm_ref_t);
       } break;
     }
@@ -347,14 +382,14 @@ static iree_status_t iree_vm_bytecode_internal_enter(
     // TODO(benvanik): change encoding to avoid this branching.
     // Could write two arrays: one for prims and one for refs.
     uint16_t src_reg = src_reg_list->registers[i];
-    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
+    if (src_reg & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) {
       uint16_t dst_reg = ref_reg_offset++;
-      memset(&dst_regs->ref[dst_reg & IREE_REF_REGISTER_MASK], 0,
+      memset(&dst_regs->ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK], 0,
              sizeof(iree_vm_ref_t));
       iree_vm_ref_retain_or_move(
-          src_reg & IREE_REF_REGISTER_MOVE_BIT,
-          &src_regs.ref[src_reg & IREE_REF_REGISTER_MASK],
-          &dst_regs->ref[dst_reg & IREE_REF_REGISTER_MASK]);
+          src_reg & IREE_VM_ISA_REF_REGISTER_MOVE_BIT,
+          &src_regs.ref[src_reg & IREE_VM_ISA_REF_REGISTER_MASK],
+          &dst_regs->ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK]);
     } else {
       uint16_t dst_reg = i32_reg_offset++;
       dst_regs->i32[dst_reg] = src_regs.i32[src_reg];
@@ -401,11 +436,11 @@ static iree_status_t iree_vm_bytecode_internal_leave(
     // Could write two arrays: one for prims and one for refs.
     uint16_t src_reg = src_reg_list->registers[i];
     uint16_t dst_reg = dst_reg_list->registers[i];
-    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
+    if (src_reg & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) {
       iree_vm_ref_retain_or_move(
-          src_reg & IREE_REF_REGISTER_MOVE_BIT,
-          &callee_registers.ref[src_reg & IREE_REF_REGISTER_MASK],
-          &caller_registers.ref[dst_reg & IREE_REF_REGISTER_MASK]);
+          src_reg & IREE_VM_ISA_REF_REGISTER_MOVE_BIT,
+          &callee_registers.ref[src_reg & IREE_VM_ISA_REF_REGISTER_MASK],
+          &caller_registers.ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK]);
     } else {
       caller_registers.i32[dst_reg] = callee_registers.i32[src_reg];
     }
@@ -458,9 +493,9 @@ static void iree_vm_bytecode_populate_import_cconv_arguments(
         p = iree_vm_bytecode_align_ptr(p, iree_alignof(iree_vm_ref_t));
         uint16_t src_reg = src_reg_list->registers[reg_i++];
         iree_vm_ref_retain_or_move(
-            src_reg & IREE_REF_REGISTER_MOVE_BIT,
-            &caller_registers.ref[src_reg & IREE_REF_REGISTER_MASK],
-            (iree_vm_ref_t*)p);
+            src_reg & IREE_VM_ISA_REF_REGISTER_MOVE_BIT,
+            &caller_registers.ref[src_reg & IREE_VM_ISA_REF_REGISTER_MASK],
+            (iree_vm_ref_t*)p);  // safe unaligned
         p += sizeof(iree_vm_ref_t);
       } break;
       case IREE_VM_CCONV_TYPE_SPAN_START: {
@@ -527,9 +562,10 @@ static void iree_vm_bytecode_populate_import_cconv_arguments(
                 p = iree_vm_bytecode_align_ptr(p, iree_alignof(iree_vm_ref_t));
                 uint16_t src_reg = src_reg_list->registers[reg_i++];
                 iree_vm_ref_retain_or_move(
-                    src_reg & IREE_REF_REGISTER_MOVE_BIT,
-                    &caller_registers.ref[src_reg & IREE_REF_REGISTER_MASK],
-                    (iree_vm_ref_t*)p);
+                    src_reg & IREE_VM_ISA_REF_REGISTER_MOVE_BIT,
+                    &caller_registers
+                         .ref[src_reg & IREE_VM_ISA_REF_REGISTER_MASK],
+                    (iree_vm_ref_t*)p);  // safe unaligned
                 p += sizeof(iree_vm_ref_t);
               } break;
             }
@@ -692,8 +728,8 @@ static iree_status_t iree_vm_bytecode_issue_import_call(
       case IREE_VM_CCONV_TYPE_REF:
         p = iree_vm_bytecode_align_ptr(p, iree_alignof(iree_vm_ref_t));
         iree_vm_ref_move(
-            (iree_vm_ref_t*)p,
-            &caller_registers.ref[dst_reg & IREE_REF_REGISTER_MASK]);
+            (iree_vm_ref_t*)p,  // safe unaligned
+            &caller_registers.ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK]);
         p += sizeof(iree_vm_ref_t);
         break;
     }
@@ -709,7 +745,7 @@ static iree_status_t iree_vm_bytecode_verify_import(
   *out_import = NULL;
 
   // Ordinal has been checked as in-bounds during verification.
-  import_ordinal &= 0x7FFFFFFFu;
+  import_ordinal = iree_vm_isa_function_ordinal_as_import(import_ordinal);
   IREE_ASSERT(import_ordinal < module_state->import_count);
 
   const iree_vm_bytecode_import_t* import =
@@ -816,6 +852,17 @@ static iree_status_t iree_vm_bytecode_call_import_variadic(
 // Main interpreter dispatch routine
 //===----------------------------------------------------------------------===//
 
+// ISA decoding policy for dispatch.
+// NOTE: dispatch assumes verified bytecode.
+#define IREE_VM_ISA_BYTECODE_DATA bytecode_data
+#define IREE_VM_ISA_PC pc
+#define IREE_VM_ISA_REQUIRE(bytes) ((void)0)
+#define IREE_VM_ISA_LOOKUP_TYPE(type_id, out_type)             \
+  do {                                                         \
+    (out_type) = iree_vm_map_type(module, (int32_t)(type_id)); \
+  } while (0)
+#include "iree/vm/bytecode/utils/isa_decoder.inl"
+
 static iree_status_t iree_vm_bytecode_dispatch(
     iree_vm_stack_t* stack, iree_vm_bytecode_module_t* module,
     iree_vm_stack_frame_t* current_frame, iree_vm_registers_t regs,
@@ -871,7 +918,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
     iree_vm_registers_t regs, iree_byte_span_t call_results) {
   // When required emit the dispatch tables here referencing the labels we are
   // defining below.
-  DEFINE_DISPATCH_TABLES();
+  IREE_VM_ISA_DISPATCH_DEFINE_TABLES();
 
   // Primary dispatch state. This is our 'native stack frame' and really
   // just enough to make dereferencing common addresses (like the current
@@ -893,30 +940,32 @@ static iree_status_t iree_vm_bytecode_dispatch(
   IREE_BUILTIN_ASSUME_ALIGNED(regs_ref, sizeof(iree_max_align_t));
 
   iree_vm_source_offset_t pc = current_frame->pc;
-  BEGIN_DISPATCH_CORE() {
+  IREE_VM_ISA_DISPATCH_BEGIN_CORE() {
     //===------------------------------------------------------------------===//
     // Globals
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, GlobalLoadI32, {
-      uint32_t byte_offset = VM_DecGlobalAttr("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalLoadI32, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(value);
       IREE_ASSERT(byte_offset + 4 <= module_state->rwdata_storage.data_length);
-      int32_t* value = VM_DecResultRegI32("value");
       const int32_t global_value =
           vm_global_load_i32(module_state->rwdata_storage.data, byte_offset);
       *value = global_value;
     });
 
-    DISPATCH_OP(CORE, GlobalStoreI32, {
-      uint32_t byte_offset = VM_DecGlobalAttr("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalStoreI32, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value);
       IREE_ASSERT(byte_offset + 4 <= module_state->rwdata_storage.data_length);
-      int32_t value = VM_DecOperandRegI32("value");
       vm_global_store_i32(module_state->rwdata_storage.data, byte_offset,
                           value);
     });
 
-    DISPATCH_OP(CORE, GlobalLoadIndirectI32, {
-      uint32_t byte_offset = VM_DecOperandRegI32("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalLoadIndirectI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(value);
+      const uint32_t byte_offset = (uint32_t)byte_offset_i32;
       if (IREE_UNLIKELY(byte_offset + 4 >
                         module_state->rwdata_storage.data_length)) {
         return iree_make_status(
@@ -924,14 +973,15 @@ static iree_status_t iree_vm_bytecode_dispatch(
             "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
-      int32_t* value = VM_DecResultRegI32("value");
       const int32_t global_value =
           vm_global_load_i32(module_state->rwdata_storage.data, byte_offset);
       *value = global_value;
     });
 
-    DISPATCH_OP(CORE, GlobalStoreIndirectI32, {
-      uint32_t byte_offset = VM_DecOperandRegI32("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalStoreIndirectI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value);
+      const uint32_t byte_offset = (uint32_t)byte_offset_i32;
       if (IREE_UNLIKELY(byte_offset + 4 >
                         module_state->rwdata_storage.data_length)) {
         return iree_make_status(
@@ -939,30 +989,31 @@ static iree_status_t iree_vm_bytecode_dispatch(
             "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
-      int32_t value = VM_DecOperandRegI32("value");
       vm_global_store_i32(module_state->rwdata_storage.data, byte_offset,
                           value);
     });
 
-    DISPATCH_OP(CORE, GlobalLoadI64, {
-      uint32_t byte_offset = VM_DecGlobalAttr("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalLoadI64, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(value);
       IREE_ASSERT(byte_offset + 8 <= module_state->rwdata_storage.data_length);
-      int64_t* value = VM_DecResultRegI64("value");
       const int64_t global_value =
           vm_global_load_i64(module_state->rwdata_storage.data, byte_offset);
       *value = global_value;
     });
 
-    DISPATCH_OP(CORE, GlobalStoreI64, {
-      uint32_t byte_offset = VM_DecGlobalAttr("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalStoreI64, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(value);
       IREE_ASSERT(byte_offset + 8 <= module_state->rwdata_storage.data_length);
-      int64_t value = VM_DecOperandRegI64("value");
       vm_global_store_i64(module_state->rwdata_storage.data, byte_offset,
                           value);
     });
 
-    DISPATCH_OP(CORE, GlobalLoadIndirectI64, {
-      uint32_t byte_offset = VM_DecOperandRegI32("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalLoadIndirectI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(value);
+      const uint32_t byte_offset = (uint32_t)byte_offset_i32;
       if (IREE_UNLIKELY(byte_offset + 8 >
                         module_state->rwdata_storage.data_length)) {
         return iree_make_status(
@@ -970,14 +1021,15 @@ static iree_status_t iree_vm_bytecode_dispatch(
             "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
-      int64_t* value = VM_DecResultRegI64("value");
       const int64_t global_value =
           vm_global_load_i64(module_state->rwdata_storage.data, byte_offset);
       *value = global_value;
     });
 
-    DISPATCH_OP(CORE, GlobalStoreIndirectI64, {
-      uint32_t byte_offset = VM_DecOperandRegI32("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalStoreIndirectI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(value);
+      const uint32_t byte_offset = (uint32_t)byte_offset_i32;
       if (IREE_UNLIKELY(byte_offset + 8 >
                         module_state->rwdata_storage.data_length)) {
         return iree_make_status(
@@ -985,62 +1037,59 @@ static iree_status_t iree_vm_bytecode_dispatch(
             "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
-      int64_t value = VM_DecOperandRegI64("value");
       vm_global_store_i64(module_state->rwdata_storage.data, byte_offset,
                           value);
     });
 
-    DISPATCH_OP(CORE, GlobalLoadRef, {
-      uint32_t global = VM_DecGlobalAttr("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalLoadRef, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(global);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       IREE_ASSERT(global < module_state->global_ref_count);
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("value");
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("value", &result_is_move);
       iree_vm_ref_t* global_ref = &module_state->global_ref_table[global];
       IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
           result_is_move, global_ref, iree_vm_type_def_as_ref(type_def),
           result));
     });
 
-    DISPATCH_OP(CORE, GlobalStoreRef, {
-      uint32_t global = VM_DecGlobalAttr("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalStoreRef, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(global);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(value);
       IREE_ASSERT(global < module_state->global_ref_count);
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("value");
-      bool value_is_move;
-      iree_vm_ref_t* value = VM_DecOperandRegRefMove("value", &value_is_move);
       iree_vm_ref_t* global_ref = &module_state->global_ref_table[global];
       IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
           value_is_move, value, iree_vm_type_def_as_ref(type_def), global_ref));
     });
 
-    DISPATCH_OP(CORE, GlobalLoadIndirectRef, {
-      uint32_t global = VM_DecOperandRegI32("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalLoadIndirectRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(global_i32);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
+      const uint32_t global = (uint32_t)global_i32;
       if (IREE_UNLIKELY(global >= module_state->global_ref_count)) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
             "global ref ordinal out of range: %d (table=%" PRIhsz ")", global,
             module_state->global_ref_count);
       }
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("value");
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("value", &result_is_move);
       iree_vm_ref_t* global_ref = &module_state->global_ref_table[global];
       IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
           result_is_move, global_ref, iree_vm_type_def_as_ref(type_def),
           result));
     });
 
-    DISPATCH_OP(CORE, GlobalStoreIndirectRef, {
-      uint32_t global = VM_DecOperandRegI32("global");
+    IREE_VM_ISA_DISPATCH_OP(CORE, GlobalStoreIndirectRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(global_i32);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(value);
+      const uint32_t global = (uint32_t)global_i32;
       if (IREE_UNLIKELY(global >= module_state->global_ref_count)) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
             "global ref ordinal out of range: %d (table=%" PRIhsz ")", global,
             module_state->global_ref_count);
       }
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("value");
-      bool value_is_move;
-      iree_vm_ref_t* value = VM_DecOperandRegRefMove("value", &value_is_move);
       iree_vm_ref_t* global_ref = &module_state->global_ref_table[global];
       IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
           value_is_move, value, iree_vm_type_def_as_ref(type_def), global_ref));
@@ -1050,57 +1099,52 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Constants
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, ConstI32, {
-      int32_t value = VM_DecAttrI32("value");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ConstI32, {
+      IREE_VM_ISA_DECODE_ATTR_I32(value);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = value;
     });
 
-    DISPATCH_OP(CORE, ConstI32Zero, {
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ConstI32Zero, {
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = 0;
     });
 
-    DISPATCH_OP(CORE, ConstI64, {
-      int64_t value = VM_DecAttrI64("value");
-      int64_t* result = VM_DecResultRegI64("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ConstI64, {
+      IREE_VM_ISA_DECODE_ATTR_I64(value);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       *result = value;
     });
 
-    DISPATCH_OP(CORE, ConstI64Zero, {
-      int64_t* result = VM_DecResultRegI64("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ConstI64Zero, {
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       *result = 0;
     });
 
-    DISPATCH_OP(CORE, ConstRefZero, {
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+    IREE_VM_ISA_DISPATCH_OP(CORE, ConstRefZero, {
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       iree_vm_ref_release(result);
     });
 
-    DISPATCH_OP(CORE, DiscardRefs, {
-      const iree_vm_register_list_t* reg_list = VM_DecVariadicOperands("refs");
+    IREE_VM_ISA_DISPATCH_OP(CORE, DiscardRefs, {
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(reg_list);
       for (int i = 0; i < reg_list->size; ++i) {
         uint16_t reg = reg_list->registers[i];
         // All registers in this list are refs; unconditionally release.
-        iree_vm_ref_release(&regs_ref[reg & IREE_REF_REGISTER_MASK]);
+        iree_vm_ref_release(&regs_ref[reg & IREE_VM_ISA_REF_REGISTER_MASK]);
       }
     });
 
-    DISPATCH_OP(CORE, AssignRef, {
-      bool source_is_move;
-      iree_vm_ref_t* source =
-          VM_DecOperandRegRefMove("source", &source_is_move);
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+    IREE_VM_ISA_DISPATCH_OP(CORE, AssignRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(source);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       iree_vm_ref_retain_or_move(source_is_move, source, result);
     });
 
-    DISPATCH_OP(CORE, ConstRefRodata, {
-      uint32_t rodata_ordinal = VM_DecRodataAttr("rodata");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ConstRefRodata, {
+      IREE_VM_ISA_DECODE_RODATA_ATTR(rodata_ordinal);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       IREE_ASSERT(rodata_ordinal < module->rodata_ref_count);
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("value", &result_is_move);
       IREE_RETURN_IF_ERROR(
           iree_vm_ref_wrap_retain(&module->rodata_ref_table[rodata_ordinal],
                                   iree_vm_buffer_type(), result));
@@ -1110,12 +1154,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Buffers
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, BufferAlloc, {
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      iree_host_size_t alignment = VM_DecOperandRegI32("alignment");
-      bool result_is_move;
-      iree_vm_ref_t* result_ref =
-          VM_DecResultRegRefMove("result", &result_is_move);
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferAlloc, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(alignment_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result_ref);
+      const iree_host_size_t alignment = (iree_host_size_t)alignment_i32;
       iree_vm_buffer_t* buffer = NULL;
       IREE_RETURN_IF_ERROR(iree_vm_buffer_create(
           IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST,
@@ -1124,18 +1167,17 @@ static iree_status_t iree_vm_bytecode_dispatch(
           iree_vm_ref_wrap_assign(buffer, iree_vm_buffer_type(), result_ref));
     });
 
-    DISPATCH_OP(CORE, BufferClone, {
-      iree_vm_ref_t* source_ref = VM_DecOperandRegRef("source");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferClone, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(source_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(alignment_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result_ref);
       iree_vm_buffer_t* source = iree_vm_buffer_deref(*source_ref);
       if (IREE_UNLIKELY(!source)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "source is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      iree_host_size_t alignment = VM_DecOperandRegI32("alignment");
-      bool result_is_move;
-      iree_vm_ref_t* result_ref =
-          VM_DecResultRegRefMove("result", &result_is_move);
+      const iree_host_size_t alignment = (iree_host_size_t)alignment_i32;
       iree_vm_buffer_t* result = NULL;
       IREE_RETURN_IF_ERROR(iree_vm_buffer_clone(
           IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST,
@@ -1144,57 +1186,56 @@ static iree_status_t iree_vm_bytecode_dispatch(
           iree_vm_ref_wrap_assign(result, iree_vm_buffer_type(), result_ref));
     });
 
-    DISPATCH_OP(CORE, BufferLength, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLength, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result_i64);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "buffer is null");
       }
-      uint64_t* result = (uint64_t*)VM_DecResultRegI64("result");
+      uint64_t* result = (uint64_t*)result_i64;
       *result = (uint64_t)iree_vm_buffer_length(buffer);
     });
 
-    DISPATCH_OP(CORE, BufferCopy, {
-      iree_vm_ref_t* source_buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferCopy, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(source_buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(source_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(target_buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(target_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
       iree_vm_buffer_t* source_buffer =
           iree_vm_buffer_deref(*source_buffer_ref);
       if (IREE_UNLIKELY(!source_buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t source_offset =
-          VM_DecOperandRegI64HostSize("source_offset");
-      iree_vm_ref_t* target_buffer_ref = VM_DecOperandRegRef("target_buffer");
       iree_vm_buffer_t* target_buffer =
           iree_vm_buffer_deref(*target_buffer_ref);
       if (IREE_UNLIKELY(!target_buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "target_buffer is null");
       }
-      iree_host_size_t target_offset =
-          VM_DecOperandRegI64HostSize("target_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
       IREE_RETURN_IF_ERROR(iree_vm_buffer_copy_bytes(
           source_buffer, source_offset, target_buffer, target_offset, length));
     });
 
-    DISPATCH_OP(CORE, BufferCompare, {
-      iree_vm_ref_t* lhs_buffer_ref = VM_DecOperandRegRef("lhs_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferCompare, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(lhs_buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(lhs_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(rhs_buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(rhs_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_buffer_t* lhs_buffer = iree_vm_buffer_deref(*lhs_buffer_ref);
       if (IREE_UNLIKELY(!lhs_buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "lhs_buffer is null");
       }
-      iree_host_size_t lhs_offset = VM_DecOperandRegI64HostSize("lhs_offset");
-      iree_vm_ref_t* rhs_buffer_ref = VM_DecOperandRegRef("rhs_buffer");
       iree_vm_buffer_t* rhs_buffer = iree_vm_buffer_deref(*rhs_buffer_ref);
       if (IREE_UNLIKELY(!rhs_buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "rhs_buffer is null");
       }
-      iree_host_size_t rhs_offset = VM_DecOperandRegI64HostSize("rhs_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      int32_t* result = VM_DecResultRegI32("result");
       IREE_RETURN_IF_ERROR(vm_buffer_compare(lhs_buffer, lhs_offset, rhs_buffer,
                                              rhs_offset, length, result));
     });
@@ -1203,48 +1244,52 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // body - they all only vary by the length passed to fill_elements. The
     // gotcha is that on big-endian machines we'd have to flip around the bytes.
     // See VMOpcodesCore.td for more information on the encoding.
-    DISPATCH_OP(CORE, BufferFillI8, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferFillI8, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value_i32);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      uint8_t value = (uint8_t)VM_DecOperandRegI32("value");
+      const uint8_t value = (uint8_t)value_i32;
       vm_buffer_fill_i8_inline(buffer, offset, length, value);
     });
-    DISPATCH_OP(CORE, BufferFillI16, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferFillI16, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value_i32);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      uint16_t value = (uint16_t)VM_DecOperandRegI32("value");
+      const uint16_t value = (uint16_t)value_i32;
       vm_buffer_fill_i16_inline(buffer, offset, length, value);
     });
-    DISPATCH_OP(CORE, BufferFillI32, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferFillI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value_i32);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      uint32_t value = VM_DecOperandRegI32("value");
+      const uint32_t value = (uint32_t)value_i32;
       vm_buffer_fill_i32_inline(buffer, offset, length, value);
     });
-    DISPATCH_OP(CORE, BufferFillI64, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferFillI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(value_i64);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      uint64_t value = VM_DecOperandRegI64("value");
+      const uint64_t value = (uint64_t)value_i64;
       vm_buffer_fill_i64_inline(buffer, offset, length, value);
     });
 
@@ -1252,133 +1297,136 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // body - they only vary on the length and sign/zero extension mode but
     // can be packed into a single handler to reduce code-size.
     // See VMOpcodesCore.td for more information on the encoding.
-    DISPATCH_OP(CORE, BufferLoadI8U, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLoadI8U, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-      int32_t* result = VM_DecResultRegI32("result");
       vm_buffer_load_i8u_inline(buffer, offset, result);
     });
-    DISPATCH_OP(CORE, BufferLoadI8S, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLoadI8S, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-      int32_t* result = VM_DecResultRegI32("result");
       vm_buffer_load_i8s_inline(buffer, offset, result);
     });
-    DISPATCH_OP(CORE, BufferLoadI16U, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLoadI16U, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-      int32_t* result = VM_DecResultRegI32("result");
       vm_buffer_load_i16u_inline(buffer, offset, result);
     });
-    DISPATCH_OP(CORE, BufferLoadI16S, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLoadI16S, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-      int32_t* result = VM_DecResultRegI32("result");
       vm_buffer_load_i16s_inline(buffer, offset, result);
     });
-    DISPATCH_OP(CORE, BufferLoadI32, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLoadI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-      int32_t* result = VM_DecResultRegI32("result");
       vm_buffer_load_i32_inline(buffer, offset, result);
     });
-    DISPATCH_OP(CORE, BufferLoadI64, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferLoadI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-      int64_t* result = VM_DecResultRegI64("result");
       vm_buffer_load_i64_inline(buffer, offset, result);
     });
 
     // TODO(benvanik): rework dispatch so that the StoreI* ops can share the
     // same body - they only vary on the length.
     // See VMOpcodesCore.td for more information on the encoding.
-    DISPATCH_OP(CORE, BufferStoreI8, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferStoreI8, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value_i32);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "target_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      uint8_t value = (uint8_t)VM_DecOperandRegI32("value");
+      const uint8_t value = (uint8_t)value_i32;
       vm_buffer_store_i8_inline(buffer, offset, value);
     });
-    DISPATCH_OP(CORE, BufferStoreI16, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferStoreI16, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value_i32);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "target_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      uint16_t value = (uint16_t)VM_DecOperandRegI32("value");
+      const uint16_t value = (uint16_t)value_i32;
       vm_buffer_store_i16_inline(buffer, offset, value);
     });
-    DISPATCH_OP(CORE, BufferStoreI32, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferStoreI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value_i32);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "target_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      uint32_t value = VM_DecOperandRegI32("value");
+      const uint32_t value = (uint32_t)value_i32;
       vm_buffer_store_i32_inline(buffer, offset, value);
     });
-    DISPATCH_OP(CORE, BufferStoreI64, {
-      iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferStoreI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(value_i64);
       iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
       if (IREE_UNLIKELY(!buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "target_buffer is null");
       }
-      iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-      uint64_t value = (uint64_t)VM_DecOperandRegI64("value");
+      const uint64_t value = (uint64_t)value_i64;
       vm_buffer_store_i64_inline(buffer, offset, value);
     });
 
-    DISPATCH_OP(CORE, BufferHash, {
-      iree_vm_ref_t* source_buffer_ref = VM_DecOperandRegRef("source_buffer");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BufferHash, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(source_buffer_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(source_offset);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       iree_vm_buffer_t* source_buffer =
           iree_vm_buffer_deref(*source_buffer_ref);
       if (IREE_UNLIKELY(!source_buffer)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "source_buffer is null");
       }
-      iree_host_size_t source_offset =
-          VM_DecOperandRegI64HostSize("source_offset");
-      iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-      int64_t* result = VM_DecResultRegI64("result");
       IREE_RETURN_IF_ERROR(
           iree_vm_buffer_hash(source_buffer, source_offset, length, result));
     });
@@ -1387,11 +1435,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Lists
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, ListAlloc, {
-      const iree_vm_type_def_t element_type_def = VM_DecTypeOf("element_type");
-      uint32_t initial_capacity = VM_DecOperandRegI32("initial_capacity");
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListAlloc, {
+      IREE_VM_ISA_DECODE_TYPE_OF(element_type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(initial_capacity_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
+      const uint32_t initial_capacity = (uint32_t)initial_capacity_i32;
       iree_vm_list_t* list = NULL;
       IREE_RETURN_IF_ERROR(iree_vm_list_create(
           element_type_def, initial_capacity, module_state->allocator, &list));
@@ -1399,98 +1447,104 @@ static iree_status_t iree_vm_bytecode_dispatch(
           iree_vm_ref_wrap_assign(list, iree_vm_list_type(), result));
     });
 
-    DISPATCH_OP(CORE, ListReserve, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListReserve, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(minimum_capacity_i32);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t minimum_capacity = VM_DecOperandRegI32("minimum_capacity");
+      const uint32_t minimum_capacity = (uint32_t)minimum_capacity_i32;
       IREE_RETURN_IF_ERROR(iree_vm_list_reserve(list, minimum_capacity));
     });
 
-    DISPATCH_OP(CORE, ListSize, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListSize, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      int32_t* result = VM_DecResultRegI32("result");
       *result = (int32_t)iree_vm_list_size(list);
     });
 
-    DISPATCH_OP(CORE, ListResize, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListResize, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(new_size_i32);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t new_size = VM_DecOperandRegI32("new_size");
+      const uint32_t new_size = (uint32_t)new_size_i32;
       IREE_RETURN_IF_ERROR(iree_vm_list_resize(list, new_size));
     });
 
-    DISPATCH_OP(CORE, ListGetI32, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListGetI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t index = VM_DecOperandRegI32("index");
-      int32_t* result = VM_DecResultRegI32("result");
+      const uint32_t index = (uint32_t)index_i32;
       iree_vm_value_t value;
       IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
           list, index, IREE_VM_VALUE_TYPE_I32, &value));
       *result = value.i32;
     });
 
-    DISPATCH_OP(CORE, ListSetI32, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListSetI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(raw_value);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t index = VM_DecOperandRegI32("index");
-      int32_t raw_value = VM_DecOperandRegI32("raw_value");
+      const uint32_t index = (uint32_t)index_i32;
       iree_vm_value_t value = iree_vm_value_make_i32(raw_value);
       IREE_RETURN_IF_ERROR(iree_vm_list_set_value(list, index, &value));
     });
 
-    DISPATCH_OP(CORE, ListGetI64, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListGetI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t index = VM_DecOperandRegI32("index");
-      int64_t* result = VM_DecResultRegI64("result");
+      const uint32_t index = (uint32_t)index_i32;
       iree_vm_value_t value;
       IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
           list, index, IREE_VM_VALUE_TYPE_I64, &value));
       *result = value.i64;
     });
 
-    DISPATCH_OP(CORE, ListSetI64, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListSetI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(raw_value);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t index = VM_DecOperandRegI32("index");
-      int64_t raw_value = VM_DecOperandRegI64("value");
+      const uint32_t index = (uint32_t)index_i32;
       iree_vm_value_t value = iree_vm_value_make_i64(raw_value);
       IREE_RETURN_IF_ERROR(iree_vm_list_set_value(list, index, &value));
     });
 
-    DISPATCH_OP(CORE, ListGetRef, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListGetRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t index = VM_DecOperandRegI32("index");
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("result");
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+      const uint32_t index = (uint32_t)index_i32;
       // TODO(benvanik): use result_is_move with a _retain_or_move.
       IREE_RETURN_IF_ERROR(iree_vm_list_get_ref_retain(list, index, result));
       if (result->type != IREE_VM_REF_TYPE_NULL &&
@@ -1502,16 +1556,15 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(CORE, ListSetRef, {
-      iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ListSetRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(operand);
       iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
       if (IREE_UNLIKELY(!list)) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
-      uint32_t index = VM_DecOperandRegI32("index");
-      bool operand_is_move;
-      iree_vm_ref_t* operand =
-          VM_DecOperandRegRefMove("value", &operand_is_move);
+      const uint32_t index = (uint32_t)index_i32;
       if (operand_is_move) {
         IREE_RETURN_IF_ERROR(iree_vm_list_set_ref_move(list, index, operand));
       } else {
@@ -1523,35 +1576,30 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Conditional assignment
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, SelectI32, {
-      int32_t condition = VM_DecOperandRegI32("condition");
-      int32_t true_value = VM_DecOperandRegI32("true_value");
-      int32_t false_value = VM_DecOperandRegI32("false_value");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, SelectI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(true_value);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(false_value);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = vm_select_i32(condition, true_value, false_value);
     });
 
-    DISPATCH_OP(CORE, SelectI64, {
-      int32_t condition = VM_DecOperandRegI32("condition");
-      int64_t true_value = VM_DecOperandRegI64("true_value");
-      int64_t false_value = VM_DecOperandRegI64("false_value");
-      int64_t* result = VM_DecResultRegI64("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, SelectI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(true_value);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(false_value);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       *result = vm_select_i64(condition, true_value, false_value);
     });
 
-    DISPATCH_OP(CORE, SelectRef, {
-      int32_t condition = VM_DecOperandRegI32("condition");
+    IREE_VM_ISA_DISPATCH_OP(CORE, SelectRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
       // TODO(benvanik): remove the type_id and use either LHS/RHS (if both are
       // null then output is always null so no need to know the type).
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("true_value");
-      bool true_value_is_move;
-      iree_vm_ref_t* true_value =
-          VM_DecOperandRegRefMove("true_value", &true_value_is_move);
-      bool false_value_is_move;
-      iree_vm_ref_t* false_value =
-          VM_DecOperandRegRefMove("false_value", &false_value_is_move);
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(true_value);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(false_value);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       if (condition) {
         // Select LHS.
         IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
@@ -1571,12 +1619,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(CORE, SwitchI32, {
-      int32_t index = VM_DecOperandRegI32("index");
-      int32_t default_value = VM_DecOperandRegI32("default_value");
-      const iree_vm_register_list_t* value_reg_list =
-          VM_DecVariadicOperands("values");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, SwitchI32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(default_value);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(value_reg_list);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       if (index >= 0 && index < value_reg_list->size) {
         *result = regs_i32[value_reg_list->registers[index]];
       } else {
@@ -1584,12 +1631,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(CORE, SwitchI64, {
-      int32_t index = VM_DecOperandRegI32("index");
-      int64_t default_value = VM_DecOperandRegI64("default_value");
-      const iree_vm_register_list_t* value_reg_list =
-          VM_DecVariadicOperands("values");
-      int64_t* result = VM_DecResultRegI64("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, SwitchI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(default_value);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(value_reg_list);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       if (index >= 0 && index < value_reg_list->size) {
         *result = regs_i32[value_reg_list->registers[index]];
       } else {
@@ -1597,27 +1643,23 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(CORE, SwitchRef, {
-      int32_t index = VM_DecOperandRegI32("index");
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("result");
-      bool default_is_move;
-      iree_vm_ref_t* default_value =
-          VM_DecOperandRegRefMove("default_value", &default_is_move);
-      const iree_vm_register_list_t* value_reg_list =
-          VM_DecVariadicOperands("values");
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+    IREE_VM_ISA_DISPATCH_OP(CORE, SwitchRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(default_value);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(value_reg_list);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       if (index >= 0 && index < value_reg_list->size) {
-        bool is_move =
-            value_reg_list->registers[index] & IREE_REF_REGISTER_MOVE_BIT;
+        bool is_move = value_reg_list->registers[index] &
+                       IREE_VM_ISA_REF_REGISTER_MOVE_BIT;
         iree_vm_ref_t* new_value = &regs_ref[value_reg_list->registers[index] &
-                                             IREE_REF_REGISTER_MASK];
+                                             IREE_VM_ISA_REF_REGISTER_MASK];
         IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
             is_move, new_value, iree_vm_type_def_as_ref(type_def), result));
       } else {
         IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
-            default_is_move, default_value, iree_vm_type_def_as_ref(type_def),
-            result));
+            default_value_is_move, default_value,
+            iree_vm_type_def_as_ref(type_def), result));
       }
     });
 
@@ -1625,80 +1667,77 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Native integer arithmetic
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP_CORE_BINARY_I32(AddI32, vm_add_i32);
-    DISPATCH_OP_CORE_BINARY_I32(SubI32, vm_sub_i32);
-    DISPATCH_OP_CORE_BINARY_I32(MulI32, vm_mul_i32);
-    DISPATCH_OP_CORE_BINARY_I32(DivI32S, vm_div_i32s);
-    DISPATCH_OP_CORE_BINARY_I32(DivI32U, vm_div_i32u);
-    DISPATCH_OP_CORE_BINARY_I32(RemI32S, vm_rem_i32s);
-    DISPATCH_OP_CORE_BINARY_I32(RemI32U, vm_rem_i32u);
-    DISPATCH_OP_CORE_TERNARY_I32(FMAI32, vm_fma_i32);
-    DISPATCH_OP_CORE_UNARY_I32(AbsI32, vm_abs_i32);
-    DISPATCH_OP_CORE_BINARY_I32(MinI32S, vm_min_i32s);
-    DISPATCH_OP_CORE_BINARY_I32(MinI32U, vm_min_i32u);
-    DISPATCH_OP_CORE_BINARY_I32(MaxI32S, vm_max_i32s);
-    DISPATCH_OP_CORE_BINARY_I32(MaxI32U, vm_max_i32u);
-    DISPATCH_OP_CORE_UNARY_I32(NotI32, vm_not_i32);
-    DISPATCH_OP_CORE_BINARY_I32(AndI32, vm_and_i32);
-    DISPATCH_OP_CORE_BINARY_I32(OrI32, vm_or_i32);
-    DISPATCH_OP_CORE_BINARY_I32(XorI32, vm_xor_i32);
-    DISPATCH_OP_CORE_UNARY_I32(CtlzI32, vm_ctlz_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(AddI32, vm_add_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(SubI32, vm_sub_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(MulI32, vm_mul_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(DivI32S, vm_div_i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(DivI32U, vm_div_i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(RemI32S, vm_rem_i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(RemI32U, vm_rem_i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_TERNARY_I32(FMAI32, vm_fma_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(AbsI32, vm_abs_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(MinI32S, vm_min_i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(MinI32U, vm_min_i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(MaxI32S, vm_max_i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(MaxI32U, vm_max_i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(NotI32, vm_not_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(AndI32, vm_and_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(OrI32, vm_or_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(XorI32, vm_xor_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(CtlzI32, vm_ctlz_i32);
 
-    DISPATCH_OP_CORE_BINARY_I64(AddI64, vm_add_i64);
-    DISPATCH_OP_CORE_BINARY_I64(SubI64, vm_sub_i64);
-    DISPATCH_OP_CORE_BINARY_I64(MulI64, vm_mul_i64);
-    DISPATCH_OP_CORE_BINARY_I64(DivI64S, vm_div_i64s);
-    DISPATCH_OP_CORE_BINARY_I64(DivI64U, vm_div_i64u);
-    DISPATCH_OP_CORE_BINARY_I64(RemI64S, vm_rem_i64s);
-    DISPATCH_OP_CORE_BINARY_I64(RemI64U, vm_rem_i64u);
-    DISPATCH_OP_CORE_TERNARY_I64(FMAI64, vm_fma_i64);
-    DISPATCH_OP_CORE_UNARY_I64(AbsI64, vm_abs_i64);
-    DISPATCH_OP_CORE_BINARY_I64(MinI64S, vm_min_i64s);
-    DISPATCH_OP_CORE_BINARY_I64(MinI64U, vm_min_i64u);
-    DISPATCH_OP_CORE_BINARY_I64(MaxI64S, vm_max_i64s);
-    DISPATCH_OP_CORE_BINARY_I64(MaxI64U, vm_max_i64u);
-    DISPATCH_OP_CORE_UNARY_I64(NotI64, vm_not_i64);
-    DISPATCH_OP_CORE_BINARY_I64(AndI64, vm_and_i64);
-    DISPATCH_OP_CORE_BINARY_I64(OrI64, vm_or_i64);
-    DISPATCH_OP_CORE_BINARY_I64(XorI64, vm_xor_i64);
-    DISPATCH_OP_CORE_UNARY_I64(CtlzI64, vm_ctlz_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(AddI64, vm_add_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(SubI64, vm_sub_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(MulI64, vm_mul_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(DivI64S, vm_div_i64s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(DivI64U, vm_div_i64u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(RemI64S, vm_rem_i64s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(RemI64U, vm_rem_i64u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_TERNARY_I64(FMAI64, vm_fma_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I64(AbsI64, vm_abs_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(MinI64S, vm_min_i64s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(MinI64U, vm_min_i64u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(MaxI64S, vm_max_i64s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(MaxI64U, vm_max_i64u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I64(NotI64, vm_not_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(AndI64, vm_and_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(OrI64, vm_or_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(XorI64, vm_xor_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I64(CtlzI64, vm_ctlz_i64);
 
     //===------------------------------------------------------------------===//
     // Casting and type conversion/emulation
     //===------------------------------------------------------------------===//
 
     // NOTE: these all operate on 32-bit registers.
-    DISPATCH_OP_CORE_UNARY_I32(TruncI32I8, vm_trunc_i32i8);
-    DISPATCH_OP_CORE_UNARY_I32(TruncI32I16, vm_trunc_i32i16);
-    DISPATCH_OP_CORE_UNARY_I32(ExtI8I32S, vm_ext_i8i32s);
-    DISPATCH_OP_CORE_UNARY_I32(ExtI8I32U, vm_ext_i8i32u);
-    DISPATCH_OP_CORE_UNARY_I32(ExtI16I32S, vm_ext_i16i32s);
-    DISPATCH_OP_CORE_UNARY_I32(ExtI16I32U, vm_ext_i16i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(TruncI32I8, vm_trunc_i32i8);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(TruncI32I16, vm_trunc_i32i16);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(ExtI8I32S, vm_ext_i8i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(ExtI8I32U, vm_ext_i8i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(ExtI16I32S, vm_ext_i16i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(ExtI16I32U, vm_ext_i16i32u);
 
     // NOTE: 64-bit ones are actually changing register widths.
-    DISPATCH_OP(CORE, TruncI64I32, {
-      int64_t operand = VM_DecOperandRegI64("operand");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, TruncI64I32, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = vm_trunc_i64i32(operand);
     });
-    DISPATCH_OP(CORE, ExtI32I64S, {
-      int32_t operand = VM_DecOperandRegI32("operand");
-      int64_t* result = VM_DecResultRegI64("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ExtI32I64S, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       *result = vm_ext_i32i64s(operand);
     });
-    DISPATCH_OP(CORE, ExtI32I64U, {
-      int32_t operand = VM_DecOperandRegI32("operand");
-      int64_t* result = VM_DecResultRegI64("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, ExtI32I64U, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
       *result = vm_ext_i32i64u(operand);
     });
 
-    DISPATCH_OP(CORE, CastAnyRef, {
-      bool operand_is_move;
-      iree_vm_ref_t* operand =
-          VM_DecOperandRegRefMove("operand", &operand_is_move);
-      const iree_vm_type_def_t type_def = VM_DecTypeOf("result");
-      bool result_is_move;
-      iree_vm_ref_t* result = VM_DecResultRegRefMove("result", &result_is_move);
+    IREE_VM_ISA_DISPATCH_OP(CORE, CastAnyRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(operand);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(result);
       IREE_RETURN_IF_ERROR(iree_vm_ref_retain_or_move_checked(
           operand_is_move, operand, iree_vm_type_def_as_ref(type_def), result));
     });
@@ -1707,73 +1746,73 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Native bitwise shifts and rotates
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_CORE_SHIFT_I32(op_name, op_func)  \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int32_t operand = VM_DecOperandRegI32("operand"); \
-    int32_t amount = VM_DecOperandRegI32("amount");   \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = op_func(operand, amount);               \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);            \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(amount);             \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);              \
+    *result = op_func(operand, amount);                          \
   });
 
-    DISPATCH_OP_CORE_SHIFT_I32(ShlI32, vm_shl_i32);
-    DISPATCH_OP_CORE_SHIFT_I32(ShrI32S, vm_shr_i32s);
-    DISPATCH_OP_CORE_SHIFT_I32(ShrI32U, vm_shr_i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I32(ShlI32, vm_shl_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I32(ShrI32S, vm_shr_i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I32(ShrI32U, vm_shr_i32u);
 
-#define DISPATCH_OP_CORE_SHIFT_I64(op_name, op_func)  \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int64_t operand = VM_DecOperandRegI64("operand"); \
-    int32_t amount = VM_DecOperandRegI32("amount");   \
-    int64_t* result = VM_DecResultRegI64("result");   \
-    *result = op_func(operand, amount);               \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);            \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(amount);             \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);              \
+    *result = op_func(operand, amount);                          \
   });
 
-    DISPATCH_OP_CORE_SHIFT_I64(ShlI64, vm_shl_i64);
-    DISPATCH_OP_CORE_SHIFT_I64(ShrI64S, vm_shr_i64s);
-    DISPATCH_OP_CORE_SHIFT_I64(ShrI64U, vm_shr_i64u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I64(ShlI64, vm_shl_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I64(ShrI64S, vm_shr_i64s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_SHIFT_I64(ShrI64U, vm_shr_i64u);
 
     //===------------------------------------------------------------------===//
     // Comparison ops
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP_CORE_BINARY_I32(CmpEQI32, vm_cmp_eq_i32);
-    DISPATCH_OP_CORE_BINARY_I32(CmpNEI32, vm_cmp_ne_i32);
-    DISPATCH_OP_CORE_BINARY_I32(CmpLTI32S, vm_cmp_lt_i32s);
-    DISPATCH_OP_CORE_BINARY_I32(CmpLTI32U, vm_cmp_lt_i32u);
-    DISPATCH_OP_CORE_UNARY_I32(CmpNZI32, vm_cmp_nz_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(CmpEQI32, vm_cmp_eq_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(CmpNEI32, vm_cmp_ne_i32);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(CmpLTI32S, vm_cmp_lt_i32s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(CmpLTI32U, vm_cmp_lt_i32u);
+    IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(CmpNZI32, vm_cmp_nz_i32);
 
-#define DISPATCH_OP_CORE_CMP_I64(op_name, op_func)  \
-  DISPATCH_OP(CORE, op_name, {                      \
-    int64_t lhs = VM_DecOperandRegI64("lhs");       \
-    int64_t rhs = VM_DecOperandRegI64("rhs");       \
-    int32_t* result = VM_DecResultRegI32("result"); \
-    *result = op_func(lhs, rhs);                    \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_CMP_I64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                     \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(lhs);              \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(rhs);              \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);            \
+    *result = op_func(lhs, rhs);                               \
   });
 
-    DISPATCH_OP_CORE_CMP_I64(CmpEQI64, vm_cmp_eq_i64);
-    DISPATCH_OP_CORE_CMP_I64(CmpNEI64, vm_cmp_ne_i64);
-    DISPATCH_OP_CORE_CMP_I64(CmpLTI64S, vm_cmp_lt_i64s);
-    DISPATCH_OP_CORE_CMP_I64(CmpLTI64U, vm_cmp_lt_i64u);
-    DISPATCH_OP(CORE, CmpNZI64, {
-      int64_t operand = VM_DecOperandRegI64("operand");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP_CORE_CMP_I64(CmpEQI64, vm_cmp_eq_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_CMP_I64(CmpNEI64, vm_cmp_ne_i64);
+    IREE_VM_ISA_DISPATCH_OP_CORE_CMP_I64(CmpLTI64S, vm_cmp_lt_i64s);
+    IREE_VM_ISA_DISPATCH_OP_CORE_CMP_I64(CmpLTI64U, vm_cmp_lt_i64u);
+    IREE_VM_ISA_DISPATCH_OP(CORE, CmpNZI64, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = vm_cmp_nz_i64(operand);
     });
 
-    DISPATCH_OP(CORE, CmpEQRef, {
-      iree_vm_ref_t* lhs = VM_DecOperandRegRef("lhs");
-      iree_vm_ref_t* rhs = VM_DecOperandRegRef("rhs");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, CmpEQRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(lhs);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(rhs);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = vm_cmp_eq_ref(lhs, rhs);
     });
-    DISPATCH_OP(CORE, CmpNERef, {
-      iree_vm_ref_t* lhs = VM_DecOperandRegRef("lhs");
-      iree_vm_ref_t* rhs = VM_DecOperandRegRef("rhs");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, CmpNERef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(lhs);
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(rhs);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = vm_cmp_ne_ref(lhs, rhs);
     });
-    DISPATCH_OP(CORE, CmpNZRef, {
-      iree_vm_ref_t* operand = VM_DecOperandRegRef("operand");
-      int32_t* result = VM_DecResultRegI32("result");
+    IREE_VM_ISA_DISPATCH_OP(CORE, CmpNZRef, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(operand);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
       *result = vm_cmp_nz_ref(operand);
     });
 
@@ -1782,84 +1821,64 @@ static iree_status_t iree_vm_bytecode_dispatch(
     //===------------------------------------------------------------------===//
 
     // No-op in the interpreter.
-    DISPATCH_OP(CORE, Block, {});
+    IREE_VM_ISA_DISPATCH_OP(CORE, Block, {});
 
-    DISPATCH_OP(CORE, Branch, {
-      int32_t block_pc = VM_DecBranchTarget("dest");
-      const iree_vm_register_remap_list_t* remap_list =
-          VM_DecBranchOperands("operands");
-      pc = block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
-      if (IREE_UNLIKELY(remap_list->size > 0)) {
-        iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                         remap_list);
-      }
+    IREE_VM_ISA_DISPATCH_OP(CORE, Branch, {
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(remap_list);
+      pc = iree_vm_bytecode_dispatch_branch_to_block(regs_i32, regs_ref,
+                                                     block_pc, remap_list);
     });
 
-    DISPATCH_OP(CORE, CondBranch, {
-      int32_t condition = VM_DecOperandRegI32("condition");
-      int32_t true_block_pc = VM_DecBranchTarget("true_dest");
-      const iree_vm_register_remap_list_t* true_remap_list =
-          VM_DecBranchOperands("true_operands");
-      int32_t false_block_pc = VM_DecBranchTarget("false_dest");
-      const iree_vm_register_remap_list_t* false_remap_list =
-          VM_DecBranchOperands("false_operands");
+    IREE_VM_ISA_DISPATCH_OP(CORE, CondBranch, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(true_block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(true_remap_list);
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(false_block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(false_remap_list);
       if (condition) {
-        pc = true_block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
-        if (IREE_UNLIKELY(true_remap_list->size > 0)) {
-          iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                           true_remap_list);
-        }
+        pc = iree_vm_bytecode_dispatch_branch_to_block(
+            regs_i32, regs_ref, true_block_pc, true_remap_list);
       } else {
-        pc = false_block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
-        if (IREE_UNLIKELY(false_remap_list->size > 0)) {
-          iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                           false_remap_list);
-        }
+        pc = iree_vm_bytecode_dispatch_branch_to_block(
+            regs_i32, regs_ref, false_block_pc, false_remap_list);
       }
     });
 
-    DISPATCH_OP(CORE, BranchTable, {
-      int32_t index = VM_DecOperandRegI32("index");
-      int32_t default_block_pc = VM_DecBranchTarget("default_dest");
-      const iree_vm_register_remap_list_t* default_remap_list =
-          VM_DecBranchOperands("default_operands");
-      uint16_t table_size = VM_DecConstI16("table_size");
+    IREE_VM_ISA_DISPATCH_OP(CORE, BranchTable, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(default_block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(default_remap_list);
+      IREE_VM_ISA_DECODE_CONST_I16(table_size);
       if (index < 0 || index >= table_size) {
         // Out-of-bounds index; jump to default block.
-        pc = default_block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
-        if (IREE_UNLIKELY(default_remap_list->size > 0)) {
-          iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                           default_remap_list);
-        }
+        pc = iree_vm_bytecode_dispatch_branch_to_block(
+            regs_i32, regs_ref, default_block_pc, default_remap_list);
       } else {
         // In-bounds index; decode until we hit the case and branch as the
         // cases are all variable length and we can't directly index.
         for (uint16_t i = 0; i < index; ++i) {
-          (void)VM_DecBranchTarget("case_dest");
-          (void)VM_DecBranchOperands("case_operands");
+          IREE_VM_ISA_DECODE_BRANCH_TARGET_PC(skip_case_pc_u32);
+          IREE_VM_ISA_DECODE_BRANCH_OPERANDS(skip_case_operands);
+          (void)skip_case_pc_u32;
+          (void)skip_case_operands;
         }
-        int32_t case_block_pc = VM_DecBranchTarget("case_dest");
-        const iree_vm_register_remap_list_t* case_remap_list =
-            VM_DecBranchOperands("case_operands");
-        pc = case_block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
-        if (IREE_UNLIKELY(case_remap_list->size > 0)) {
-          iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                           case_remap_list);
-        }
+        IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(case_block_pc);
+        IREE_VM_ISA_DECODE_BRANCH_OPERANDS(case_remap_list);
+        pc = iree_vm_bytecode_dispatch_branch_to_block(
+            regs_i32, regs_ref, case_block_pc, case_remap_list);
       }
     });
 
-    DISPATCH_OP(CORE, Call, {
-      int32_t function_ordinal = VM_DecFuncAttr("callee");
-      const iree_vm_register_list_t* src_reg_list =
-          VM_DecVariadicOperands("operands");
-      const iree_vm_register_list_t* dst_reg_list =
-          VM_DecVariadicResults("results");
+    IREE_VM_ISA_DISPATCH_OP(CORE, Call, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(function_ordinal);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
+      IREE_VM_ISA_DECODE_VARIADIC_RESULTS(dst_reg_list);
       current_frame->pc = pc;
 
       // NOTE: we assume validation has ensured these functions exist.
       // TODO(benvanik): something more clever than just a high bit?
-      int is_import = (function_ordinal & 0x80000000u) != 0;
+      int is_import = iree_vm_isa_function_ordinal_is_import(function_ordinal);
       if (is_import) {
         // Call import (and possible yield).
         IREE_RETURN_IF_ERROR(iree_vm_bytecode_call_import(
@@ -1885,21 +1904,18 @@ static iree_status_t iree_vm_bytecode_dispatch(
       pc = current_frame->pc;
     });
 
-    DISPATCH_OP(CORE, CallVariadic, {
+    IREE_VM_ISA_DISPATCH_OP(CORE, CallVariadic, {
       // TODO(benvanik): dedupe with above or merge and always have the seg size
       // list be present (but empty) for non-variadic calls.
-      int32_t function_ordinal = VM_DecFuncAttr("callee");
-      const iree_vm_register_list_t* segment_size_list =
-          VM_DecVariadicOperands("segment_sizes");
-      const iree_vm_register_list_t* src_reg_list =
-          VM_DecVariadicOperands("operands");
-      const iree_vm_register_list_t* dst_reg_list =
-          VM_DecVariadicResults("results");
+      IREE_VM_ISA_DECODE_FUNC_ATTR(function_ordinal);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(segment_size_list);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
+      IREE_VM_ISA_DECODE_VARIADIC_RESULTS(dst_reg_list);
       current_frame->pc = pc;
 
       // NOTE: we assume validation has ensured these functions exist.
       // TODO(benvanik): something more clever than just a high bit?
-      int is_import = (function_ordinal & 0x80000000u) != 0;
+      int is_import = iree_vm_isa_function_ordinal_is_import(function_ordinal);
       if (IREE_UNLIKELY(!is_import)) {
         // Variadic calls are currently only supported for import functions.
         return iree_make_status(
@@ -1921,9 +1937,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
       pc = current_frame->pc;
     });
 
-    DISPATCH_OP(CORE, Return, {
-      const iree_vm_register_list_t* src_reg_list =
-          VM_DecVariadicOperands("operands");
+    IREE_VM_ISA_DISPATCH_OP(CORE, Return, {
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
       current_frame->pc = pc;
 
       // TODO(benvanik): faster check for escaping; this is slow (cache misses).
@@ -1951,10 +1966,10 @@ static iree_status_t iree_vm_bytecode_dispatch(
       pc = current_frame->pc;
     });
 
-    DISPATCH_OP(CORE, Fail, {
-      uint32_t status_code = VM_DecOperandRegI32("status");
-      iree_string_view_t message;
-      VM_DecStrAttr("message", &message);
+    IREE_VM_ISA_DISPATCH_OP(CORE, Fail, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(status_code_i32);
+      IREE_VM_ISA_DECODE_STRING_ATTR(message);
+      const uint32_t status_code = (uint32_t)status_code_i32;
       if (status_code != 0) {
         // TODO(benvanik): capture source information.
         return iree_status_allocate_f(status_code, "<vm>", 0, "%.*s",
@@ -1962,10 +1977,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(CORE, ImportResolved, {
-      uint32_t function_ordinal = VM_DecFuncAttr("import");
-      int32_t* result = VM_DecResultRegI32("result");
-      uint32_t import_ordinal = function_ordinal & 0x7FFFFFFFu;
+    IREE_VM_ISA_DISPATCH_OP(CORE, ImportResolved, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(function_ordinal);
+      IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
+      uint32_t import_ordinal =
+          iree_vm_isa_function_ordinal_as_import(function_ordinal);
       IREE_ASSERT(import_ordinal < module_state->import_count);
       const iree_vm_bytecode_import_t* import =
           &module_state->import_table[import_ordinal];
@@ -1976,17 +1992,13 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Async/fiber ops
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, Yield, {
+    IREE_VM_ISA_DISPATCH_OP(CORE, Yield, {
       // Perform branch before yielding; in this way we will resume at the
       // target without needing to retain any information about the yield.
-      int32_t block_pc = VM_DecBranchTarget("dest");
-      const iree_vm_register_remap_list_t* remap_list =
-          VM_DecBranchOperands("operands");
-      iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                       remap_list);
-      current_frame->pc =
-          block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
-
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(remap_list);
+      current_frame->pc = iree_vm_bytecode_dispatch_branch_to_block(
+          regs_i32, regs_ref, block_pc, remap_list);
       // Return magic status code indicating a yield.
       // This isn't an error, though callers not supporting coroutines will
       // treat it as one and propagate it up.
@@ -1997,45 +2009,37 @@ static iree_status_t iree_vm_bytecode_dispatch(
     // Debugging
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(CORE, Trace, {
-      iree_string_view_t event_name;
-      VM_DecStrAttr("event_name", &event_name);
-      const iree_vm_register_list_t* src_reg_list =
-          VM_DecVariadicOperands("operands");
+    IREE_VM_ISA_DISPATCH_OP(CORE, Trace, {
+      IREE_VM_ISA_DECODE_STRING_ATTR(event_name);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
       // TODO(benvanik): trace (if enabled).
       iree_vm_bytecode_dispatch_discard_registers(regs_ref, src_reg_list);
     });
 
-    DISPATCH_OP(CORE, Print, {
-      iree_string_view_t event_name;
-      VM_DecStrAttr("event_name", &event_name);
-      const iree_vm_register_list_t* src_reg_list =
-          VM_DecVariadicOperands("operands");
+    IREE_VM_ISA_DISPATCH_OP(CORE, Print, {
+      IREE_VM_ISA_DECODE_STRING_ATTR(event_name);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
       // TODO(benvanik): print.
       iree_vm_bytecode_dispatch_discard_registers(regs_ref, src_reg_list);
     });
 
-    DISPATCH_OP(CORE, Break, {
+    IREE_VM_ISA_DISPATCH_OP(CORE, Break, {
       // TODO(benvanik): break unconditionally.
-      int32_t block_pc = VM_DecBranchTarget("dest");
-      const iree_vm_register_remap_list_t* remap_list =
-          VM_DecBranchOperands("operands");
-      iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                       remap_list);
-      pc = block_pc;
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(remap_list);
+      pc = iree_vm_bytecode_dispatch_branch_to(regs_i32, regs_ref, block_pc,
+                                               remap_list, /*pc_delta=*/0);
     });
 
-    DISPATCH_OP(CORE, CondBreak, {
-      int32_t condition = VM_DecOperandRegI32("condition");
+    IREE_VM_ISA_DISPATCH_OP(CORE, CondBreak, {
+      IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
       if (condition) {
         // TODO(benvanik): cond break.
       }
-      int32_t block_pc = VM_DecBranchTarget("dest");
-      const iree_vm_register_remap_list_t* remap_list =
-          VM_DecBranchOperands("operands");
-      iree_vm_bytecode_dispatch_remap_branch_registers(regs_i32, regs_ref,
-                                                       remap_list);
-      pc = block_pc + IREE_VM_BLOCK_MARKER_SIZE;  // skip block marker
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(block_pc);
+      IREE_VM_ISA_DECODE_BRANCH_OPERANDS(remap_list);
+      pc = iree_vm_bytecode_dispatch_branch_to_block(regs_i32, regs_ref,
+                                                     block_pc, remap_list);
     });
 
     //===------------------------------------------------------------------===//
@@ -2043,32 +2047,34 @@ static iree_status_t iree_vm_bytecode_dispatch(
     //===------------------------------------------------------------------===//
 
 #if IREE_VM_EXT_F32_ENABLE
-    BEGIN_DISPATCH_PREFIX(PrefixExtF32, EXT_F32) {
+    IREE_VM_ISA_DISPATCH_BEGIN_PREFIX(PrefixExtF32, EXT_F32) {
       //===----------------------------------------------------------------===//
       // ExtF32: Globals
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F32, GlobalLoadF32, {
-        uint32_t byte_offset = VM_DecGlobalAttr("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, GlobalLoadF32, {
+        IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(value);
         IREE_ASSERT(byte_offset + 4 <=
                     module_state->rwdata_storage.data_length);
-        float* value = VM_DecResultRegF32("value");
         const float global_value =
             vm_global_load_f32(module_state->rwdata_storage.data, byte_offset);
         *value = global_value;
       });
 
-      DISPATCH_OP(EXT_F32, GlobalStoreF32, {
-        uint32_t byte_offset = VM_DecGlobalAttr("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, GlobalStoreF32, {
+        IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(value);
         IREE_ASSERT(byte_offset + 4 <=
                     module_state->rwdata_storage.data_length);
-        float value = VM_DecOperandRegF32("value");
         vm_global_store_f32(module_state->rwdata_storage.data, byte_offset,
                             value);
       });
 
-      DISPATCH_OP(EXT_F32, GlobalLoadIndirectF32, {
-        uint32_t byte_offset = VM_DecOperandRegI32("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, GlobalLoadIndirectF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(value);
+        const uint32_t byte_offset = (uint32_t)byte_offset_i32;
         if (IREE_UNLIKELY(byte_offset + 4 >
                           module_state->rwdata_storage.data_length)) {
           return iree_make_status(
@@ -2076,14 +2082,15 @@ static iree_status_t iree_vm_bytecode_dispatch(
               "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
-        float* value = VM_DecResultRegF32("value");
         const float global_value =
             vm_global_load_f32(module_state->rwdata_storage.data, byte_offset);
         *value = global_value;
       });
 
-      DISPATCH_OP(EXT_F32, GlobalStoreIndirectF32, {
-        uint32_t byte_offset = VM_DecOperandRegI32("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, GlobalStoreIndirectF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(value);
+        const uint32_t byte_offset = (uint32_t)byte_offset_i32;
         if (IREE_UNLIKELY(byte_offset + 4 >
                           module_state->rwdata_storage.data_length)) {
           return iree_make_status(
@@ -2091,7 +2098,6 @@ static iree_status_t iree_vm_bytecode_dispatch(
               "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
-        float value = VM_DecOperandRegF32("value");
         vm_global_store_f32(module_state->rwdata_storage.data, byte_offset,
                             value);
       });
@@ -2100,14 +2106,14 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF32: Constants
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F32, ConstF32, {
-        float value = VM_DecAttrF32("value");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, ConstF32, {
+        IREE_VM_ISA_DECODE_ATTR_F32(value);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = value;
       });
 
-      DISPATCH_OP(EXT_F32, ConstF32Zero, {
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, ConstF32Zero, {
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = 0;
       });
 
@@ -2115,28 +2121,30 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF32: Lists
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F32, ListGetF32, {
-        iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, ListGetF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
         if (IREE_UNLIKELY(!list)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
         }
-        uint32_t index = VM_DecOperandRegI32("index");
-        float* result = VM_DecResultRegF32("result");
+        const uint32_t index = (uint32_t)index_i32;
         iree_vm_value_t value;
         IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
             list, index, IREE_VM_VALUE_TYPE_F32, &value));
         *result = value.f32;
       });
 
-      DISPATCH_OP(EXT_F32, ListSetF32, {
-        iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, ListSetF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(raw_value);
         iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
         if (IREE_UNLIKELY(!list)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
         }
-        uint32_t index = VM_DecOperandRegI32("index");
-        float raw_value = VM_DecOperandRegF32("value");
+        const uint32_t index = (uint32_t)index_i32;
         iree_vm_value_t value = iree_vm_value_make_f32(raw_value);
         IREE_RETURN_IF_ERROR(iree_vm_list_set_value(list, index, &value));
       });
@@ -2145,20 +2153,19 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF32: Conditional assignment
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F32, SelectF32, {
-        int32_t condition = VM_DecOperandRegI32("condition");
-        float true_value = VM_DecOperandRegF32("true_value");
-        float false_value = VM_DecOperandRegF32("false_value");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, SelectF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(true_value);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(false_value);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_select_f32(condition, true_value, false_value);
       });
 
-      DISPATCH_OP(EXT_F32, SwitchF32, {
-        int32_t index = VM_DecOperandRegI32("index");
-        float default_value = VM_DecOperandRegF32("default_value");
-        const iree_vm_register_list_t* value_reg_list =
-            VM_DecVariadicOperands("values");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, SwitchF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(default_value);
+        IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(value_reg_list);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         if (index >= 0 && index < value_reg_list->size) {
           *result = *((float*)&regs_i32[value_reg_list->registers[index]]);
         } else {
@@ -2170,90 +2177,91 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF32: Native floating-point arithmetic
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP_EXT_F32_BINARY_F32(AddF32, vm_add_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(SubF32, vm_sub_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(MulF32, vm_mul_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(DivF32, vm_div_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(RemF32, vm_rem_f32);
-      DISPATCH_OP_EXT_F32_TERNARY_F32(FMAF32, vm_fma_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(AbsF32, vm_abs_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(NegF32, vm_neg_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(CeilF32, vm_ceil_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(FloorF32, vm_floor_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(RoundF32, vm_round_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(RoundF32Even, vm_round_f32_even);
-      DISPATCH_OP_EXT_F32_BINARY_F32(MinF32, vm_min_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(MaxF32, vm_max_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(AddF32, vm_add_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(SubF32, vm_sub_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(MulF32, vm_mul_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(DivF32, vm_div_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(RemF32, vm_rem_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_TERNARY_F32(FMAF32, vm_fma_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(AbsF32, vm_abs_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(NegF32, vm_neg_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(CeilF32, vm_ceil_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(FloorF32, vm_floor_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(RoundF32, vm_round_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(RoundF32Even,
+                                                vm_round_f32_even);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(MinF32, vm_min_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(MaxF32, vm_max_f32);
 
-      DISPATCH_OP_EXT_F32_UNARY_F32(AtanF32, vm_atan_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(Atan2F32, vm_atan2_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(CosF32, vm_cos_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(SinF32, vm_sin_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(ExpF32, vm_exp_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Exp2F32, vm_exp2_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(ExpM1F32, vm_expm1_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(LogF32, vm_log_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Log10F32, vm_log10_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Log1pF32, vm_log1p_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Log2F32, vm_log2_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(PowF32, vm_pow_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(RsqrtF32, vm_rsqrt_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(SqrtF32, vm_sqrt_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(TanhF32, vm_tanh_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(ErfF32, vm_erf_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(AtanF32, vm_atan_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(Atan2F32, vm_atan2_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(CosF32, vm_cos_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(SinF32, vm_sin_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(ExpF32, vm_exp_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(Exp2F32, vm_exp2_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(ExpM1F32, vm_expm1_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(LogF32, vm_log_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(Log10F32, vm_log10_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(Log1pF32, vm_log1p_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(Log2F32, vm_log2_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(PowF32, vm_pow_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(RsqrtF32, vm_rsqrt_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(SqrtF32, vm_sqrt_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(TanhF32, vm_tanh_f32);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(ErfF32, vm_erf_f32);
 
       //===----------------------------------------------------------------===//
       // ExtF32: Casting and type conversion/emulation
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F32, CastSI32F32, {
-        int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastSI32F32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_cast_si32f32(operand);
       });
-      DISPATCH_OP(EXT_F32, CastSI64F32, {
-        int64_t operand = (int64_t)VM_DecOperandRegI64("operand");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastSI64F32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_cast_si64f32(operand);
       });
-      DISPATCH_OP(EXT_F32, CastUI32F32, {
-        int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastUI32F32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_cast_ui32f32(operand);
       });
-      DISPATCH_OP(EXT_F32, CastUI64F32, {
-        int64_t operand = (int64_t)VM_DecOperandRegI64("operand");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastUI64F32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_cast_ui64f32(operand);
       });
-      DISPATCH_OP(EXT_F32, CastF32SI32, {
-        float operand = VM_DecOperandRegF32("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastF32SI32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_cast_f32si32(operand);
       });
-      DISPATCH_OP(EXT_F32, CastF32SI64, {
-        float operand = VM_DecOperandRegF32("operand");
-        int64_t* result = VM_DecResultRegI64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastF32SI64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
         *result = vm_cast_f32si64(operand);
       });
-      DISPATCH_OP(EXT_F32, CastF32UI32, {
-        float operand = VM_DecOperandRegF32("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastF32UI32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_cast_f32ui32(operand);
       });
-      DISPATCH_OP(EXT_F32, CastF32UI64, {
-        float operand = VM_DecOperandRegF32("operand");
-        int64_t* result = VM_DecResultRegI64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CastF32UI64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
         *result = vm_cast_f32ui64(operand);
       });
-      DISPATCH_OP(EXT_F32, BitcastI32F32, {
-        int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, BitcastI32F32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_bitcast_i32f32(operand);
       });
-      DISPATCH_OP(EXT_F32, BitcastF32I32, {
-        float operand = VM_DecOperandRegF32("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, BitcastF32I32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_bitcast_f32i32(operand);
       });
 
@@ -2261,25 +2269,25 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF32: Comparison ops
       //===----------------------------------------------------------------===//
 
-#define DISPATCH_OP_EXT_F32_CMP_F32(op_name, op_func) \
-  DISPATCH_OP(EXT_F32, op_name, {                     \
-    float lhs = VM_DecOperandRegF32("lhs");           \
-    float rhs = VM_DecOperandRegF32("rhs");           \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = op_func(lhs, rhs);                      \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F32, op_name, {                     \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(lhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(rhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);               \
+    *result = op_func(lhs, rhs);                                  \
   });
 
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpEQF32O, vm_cmp_eq_f32o);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpEQF32U, vm_cmp_eq_f32u);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpNEF32O, vm_cmp_ne_f32o);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpNEF32U, vm_cmp_ne_f32u);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpLTF32O, vm_cmp_lt_f32o);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpLTF32U, vm_cmp_lt_f32u);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpLTEF32O, vm_cmp_lte_f32o);
-      DISPATCH_OP_EXT_F32_CMP_F32(CmpLTEF32U, vm_cmp_lte_f32u);
-      DISPATCH_OP(EXT_F32, CmpNaNF32, {
-        float operand = VM_DecOperandRegF32("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpEQF32O, vm_cmp_eq_f32o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpEQF32U, vm_cmp_eq_f32u);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpNEF32O, vm_cmp_ne_f32o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpNEF32U, vm_cmp_ne_f32u);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpLTF32O, vm_cmp_lt_f32o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpLTF32U, vm_cmp_lt_f32u);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpLTEF32O, vm_cmp_lte_f32o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F32_CMP_F32(CmpLTEF32U, vm_cmp_lte_f32u);
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, CmpNaNF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_cmp_nan_f32(operand);
       });
 
@@ -2287,75 +2295,77 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF32: Buffers
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F32, BufferFillF32, {
-        iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, BufferFillF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(value);
         iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
         if (IREE_UNLIKELY(!buffer)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                   "buffer is null");
         }
-        iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-        iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-        float value = VM_DecOperandRegF32("value");
         IREE_RETURN_IF_ERROR(vm_buffer_fill_f32(buffer, offset, length, value));
       });
 
-      DISPATCH_OP(EXT_F32, BufferLoadF32, {
-        iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, BufferLoadF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
         if (IREE_UNLIKELY(!buffer)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                   "source_buffer is null");
         }
-        iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-        float* result = VM_DecResultRegF32("result");
         vm_buffer_load_f32_inline(buffer, offset, result);
       });
 
-      DISPATCH_OP(EXT_F32, BufferStoreF32, {
-        iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F32, BufferStoreF32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(value);
         iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
         if (IREE_UNLIKELY(!buffer)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                   "target_buffer is null");
         }
-        iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-        float value = VM_DecOperandRegF32("value");
         vm_buffer_store_f32_inline(buffer, offset, value);
       });
     }
-    END_DISPATCH_PREFIX();
+    IREE_VM_ISA_DISPATCH_END_PREFIX();
 #else
-    UNHANDLED_DISPATCH_PREFIX(PrefixExtF32, EXT_F32);
+    IREE_VM_ISA_DISPATCH_UNHANDLED_PREFIX(PrefixExtF32, EXT_F32);
 #endif  // IREE_VM_EXT_F32_ENABLE
 
 #if IREE_VM_EXT_F64_ENABLE
-    BEGIN_DISPATCH_PREFIX(PrefixExtF64, EXT_F64) {
+    IREE_VM_ISA_DISPATCH_BEGIN_PREFIX(PrefixExtF64, EXT_F64) {
       //===----------------------------------------------------------------===//
       // ExtF64: Globals
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F64, GlobalLoadF64, {
-        uint32_t byte_offset = VM_DecGlobalAttr("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, GlobalLoadF64, {
+        IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(value);
         IREE_ASSERT(byte_offset + 4 <=
                     module_state->rwdata_storage.data_length);
-        double* value = VM_DecResultRegF64("value");
         const double global_value =
             vm_global_load_f64(module_state->rwdata_storage.data, byte_offset);
         *value = global_value;
       });
 
-      DISPATCH_OP(EXT_F64, GlobalStoreF64, {
-        uint32_t byte_offset = VM_DecGlobalAttr("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, GlobalStoreF64, {
+        IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(value);
         IREE_ASSERT(byte_offset + 4 <=
                     module_state->rwdata_storage.data_length);
-        double value = VM_DecOperandRegF64("value");
         vm_global_store_f64(module_state->rwdata_storage.data, byte_offset,
                             value);
       });
 
-      DISPATCH_OP(EXT_F64, GlobalLoadIndirectF64, {
-        uint32_t byte_offset = VM_DecOperandRegI32("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, GlobalLoadIndirectF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(value);
+        const uint32_t byte_offset = (uint32_t)byte_offset_i32;
         if (IREE_UNLIKELY(byte_offset + 4 >
                           module_state->rwdata_storage.data_length)) {
           return iree_make_status(
@@ -2363,14 +2373,15 @@ static iree_status_t iree_vm_bytecode_dispatch(
               "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
-        double* value = VM_DecResultRegF64("value");
         const double global_value =
             vm_global_load_f64(module_state->rwdata_storage.data, byte_offset);
         *value = global_value;
       });
 
-      DISPATCH_OP(EXT_F64, GlobalStoreIndirectF64, {
-        uint32_t byte_offset = VM_DecOperandRegI32("global");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, GlobalStoreIndirectF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(value);
+        const uint32_t byte_offset = (uint32_t)byte_offset_i32;
         if (IREE_UNLIKELY(byte_offset + 4 >
                           module_state->rwdata_storage.data_length)) {
           return iree_make_status(
@@ -2378,7 +2389,6 @@ static iree_status_t iree_vm_bytecode_dispatch(
               "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
-        double value = VM_DecOperandRegF64("value");
         vm_global_store_f64(module_state->rwdata_storage.data, byte_offset,
                             value);
       });
@@ -2387,14 +2397,14 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF64: Constants
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F64, ConstF64, {
-        double value = VM_DecAttrF64("value");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, ConstF64, {
+        IREE_VM_ISA_DECODE_ATTR_F64(value);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = value;
       });
 
-      DISPATCH_OP(EXT_F64, ConstF64Zero, {
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, ConstF64Zero, {
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = 0;
       });
 
@@ -2402,28 +2412,30 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF64: Lists
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F64, ListGetF64, {
-        iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, ListGetF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
         if (IREE_UNLIKELY(!list)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
         }
-        uint32_t index = VM_DecOperandRegI32("index");
-        double* result = VM_DecResultRegF64("result");
+        const uint32_t index = (uint32_t)index_i32;
         iree_vm_value_t value;
         IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
             list, index, IREE_VM_VALUE_TYPE_F64, &value));
         *result = value.f64;
       });
 
-      DISPATCH_OP(EXT_F64, ListSetF64, {
-        iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, ListSetF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(list_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index_i32);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(raw_value);
+        const uint32_t index = (uint32_t)index_i32;
         iree_vm_list_t* list = iree_vm_list_deref(*list_ref);
         if (IREE_UNLIKELY(!list)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
         }
-        uint32_t index = VM_DecOperandRegI32("index");
-        double raw_value = VM_DecOperandRegF64("value");
         iree_vm_value_t value = iree_vm_value_make_f64(raw_value);
         IREE_RETURN_IF_ERROR(iree_vm_list_set_value(list, index, &value));
       });
@@ -2432,20 +2444,19 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF64: Conditional assignment
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F64, SelectF64, {
-        int32_t condition = VM_DecOperandRegI32("condition");
-        double true_value = VM_DecOperandRegF64("true_value");
-        double false_value = VM_DecOperandRegF64("false_value");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, SelectF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(condition);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(true_value);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(false_value);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_select_f64(condition, true_value, false_value);
       });
 
-      DISPATCH_OP(EXT_F64, SwitchF64, {
-        int32_t index = VM_DecOperandRegI32("index");
-        double default_value = VM_DecOperandRegF64("default_value");
-        const iree_vm_register_list_t* value_reg_list =
-            VM_DecVariadicOperands("values");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, SwitchF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(index);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(default_value);
+        IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(value_reg_list);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         if (index >= 0 && index < value_reg_list->size) {
           *result = *((double*)&regs_i32[value_reg_list->registers[index]]);
         } else {
@@ -2457,100 +2468,101 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF64: Native floating-point arithmetic
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP_EXT_F64_BINARY_F64(AddF64, vm_add_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(SubF64, vm_sub_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(MulF64, vm_mul_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(DivF64, vm_div_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(RemF64, vm_rem_f64);
-      DISPATCH_OP_EXT_F64_TERNARY_F64(FMAF64, vm_fma_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(AbsF64, vm_abs_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(NegF64, vm_neg_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(CeilF64, vm_ceil_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(FloorF64, vm_floor_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(RoundF64, vm_round_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(RoundF64Even, vm_round_f64_even);
-      DISPATCH_OP_EXT_F64_BINARY_F64(MinF64, vm_min_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(MaxF64, vm_max_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(AddF64, vm_add_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(SubF64, vm_sub_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(MulF64, vm_mul_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(DivF64, vm_div_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(RemF64, vm_rem_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_TERNARY_F64(FMAF64, vm_fma_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(AbsF64, vm_abs_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(NegF64, vm_neg_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(CeilF64, vm_ceil_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(FloorF64, vm_floor_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(RoundF64, vm_round_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(RoundF64Even,
+                                                vm_round_f64_even);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(MinF64, vm_min_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(MaxF64, vm_max_f64);
 
-      DISPATCH_OP_EXT_F64_UNARY_F64(AtanF64, vm_atan_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(Atan2F64, vm_atan2_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(CosF64, vm_cos_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(SinF64, vm_sin_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(ExpF64, vm_exp_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(Exp2F64, vm_exp2_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(ExpM1F64, vm_expm1_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(LogF64, vm_log_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(Log10F64, vm_log10_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(Log1pF64, vm_log1p_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(Log2F64, vm_log2_f64);
-      DISPATCH_OP_EXT_F64_BINARY_F64(PowF64, vm_pow_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(RsqrtF64, vm_rsqrt_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(SqrtF64, vm_sqrt_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(TanhF64, vm_tanh_f64);
-      DISPATCH_OP_EXT_F64_UNARY_F64(ErfF64, vm_erf_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(AtanF64, vm_atan_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(Atan2F64, vm_atan2_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(CosF64, vm_cos_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(SinF64, vm_sin_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(ExpF64, vm_exp_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(Exp2F64, vm_exp2_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(ExpM1F64, vm_expm1_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(LogF64, vm_log_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(Log10F64, vm_log10_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(Log1pF64, vm_log1p_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(Log2F64, vm_log2_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(PowF64, vm_pow_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(RsqrtF64, vm_rsqrt_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(SqrtF64, vm_sqrt_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(TanhF64, vm_tanh_f64);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(ErfF64, vm_erf_f64);
 
       //===----------------------------------------------------------------===//
       // ExtF64: Casting and type conversion/emulation
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F64, TruncF64F32, {
-        double operand = (double)VM_DecOperandRegF64("operand");
-        float* result = VM_DecResultRegF32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, TruncF64F32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);
         *result = vm_trunc_f64f32(operand);
       });
-      DISPATCH_OP(EXT_F64, ExtF32F64, {
-        float operand = (float)VM_DecOperandRegF32("operand");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, ExtF32F64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_ext_f32f64(operand);
       });
-      DISPATCH_OP(EXT_F64, CastSI32F64, {
-        int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastSI32F64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_cast_si32f64(operand);
       });
-      DISPATCH_OP(EXT_F64, CastUI32F64, {
-        int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastUI32F64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_cast_ui32f64(operand);
       });
-      DISPATCH_OP(EXT_F64, CastF64SI32, {
-        double operand = VM_DecOperandRegF64("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastF64SI32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_cast_f64si32(operand);
       });
-      DISPATCH_OP(EXT_F64, CastF64UI32, {
-        double operand = VM_DecOperandRegF64("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastF64UI32, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_cast_f64ui32(operand);
       });
-      DISPATCH_OP(EXT_F64, CastSI64F64, {
-        int64_t operand = (int64_t)VM_DecOperandRegI64("operand");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastSI64F64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_cast_si64f64(operand);
       });
-      DISPATCH_OP(EXT_F64, CastUI64F64, {
-        int64_t operand = (int64_t)VM_DecOperandRegI64("operand");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastUI64F64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_cast_ui64f64(operand);
       });
-      DISPATCH_OP(EXT_F64, CastF64SI64, {
-        double operand = VM_DecOperandRegF64("operand");
-        int64_t* result = VM_DecResultRegI64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastF64SI64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
         *result = vm_cast_f64si64(operand);
       });
-      DISPATCH_OP(EXT_F64, CastF64UI64, {
-        double operand = VM_DecOperandRegF64("operand");
-        int64_t* result = VM_DecResultRegI64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CastF64UI64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
         *result = vm_cast_f64ui64(operand);
       });
-      DISPATCH_OP(EXT_F64, BitcastI64F64, {
-        int64_t operand = (int64_t)VM_DecOperandRegI64("operand");
-        double* result = VM_DecResultRegF64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, BitcastI64F64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         *result = vm_bitcast_i64f64(operand);
       });
-      DISPATCH_OP(EXT_F64, BitcastF64I64, {
-        double operand = VM_DecOperandRegF64("operand");
-        int64_t* result = VM_DecResultRegI64("result");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, BitcastF64I64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);
         *result = vm_bitcast_f64i64(operand);
       });
 
@@ -2558,25 +2570,25 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF64: Comparison ops
       //===----------------------------------------------------------------===//
 
-#define DISPATCH_OP_EXT_F64_CMP_F64(op_name, op_func) \
-  DISPATCH_OP(EXT_F64, op_name, {                     \
-    double lhs = VM_DecOperandRegF64("lhs");          \
-    double rhs = VM_DecOperandRegF64("rhs");          \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = op_func(lhs, rhs);                      \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F64, op_name, {                     \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(lhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(rhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);               \
+    *result = op_func(lhs, rhs);                                  \
   });
 
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpEQF64O, vm_cmp_eq_f64o);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpEQF64U, vm_cmp_eq_f64u);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpNEF64O, vm_cmp_ne_f64o);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpNEF64U, vm_cmp_ne_f64u);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpLTF64O, vm_cmp_lt_f64o);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpLTF64U, vm_cmp_lt_f64u);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpLTEF64O, vm_cmp_lte_f64o);
-      DISPATCH_OP_EXT_F64_CMP_F64(CmpLTEF64U, vm_cmp_lte_f64u);
-      DISPATCH_OP(EXT_F64, CmpNaNF64, {
-        double operand = VM_DecOperandRegF64("operand");
-        int32_t* result = VM_DecResultRegI32("result");
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpEQF64O, vm_cmp_eq_f64o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpEQF64U, vm_cmp_eq_f64u);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpNEF64O, vm_cmp_ne_f64o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpNEF64U, vm_cmp_ne_f64u);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpLTF64O, vm_cmp_lt_f64o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpLTF64U, vm_cmp_lt_f64u);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpLTEF64O, vm_cmp_lte_f64o);
+      IREE_VM_ISA_DISPATCH_OP_EXT_F64_CMP_F64(CmpLTEF64U, vm_cmp_lte_f64u);
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, CmpNaNF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);
         *result = vm_cmp_nan_f64(operand);
       });
 
@@ -2584,50 +2596,50 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // ExtF64: Buffers
       //===----------------------------------------------------------------===//
 
-      DISPATCH_OP(EXT_F64, BufferFillF64, {
-        iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, BufferFillF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(length);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(value);
         iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
         if (IREE_UNLIKELY(!buffer)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                   "buffer is null");
         }
-        iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-        iree_host_size_t length = VM_DecOperandRegI64HostSize("length");
-        double value = VM_DecOperandRegF64("value");
         IREE_RETURN_IF_ERROR(vm_buffer_fill_f64(buffer, offset, length, value));
       });
 
-      DISPATCH_OP(EXT_F64, BufferLoadF64, {
-        iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("source_buffer");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, BufferLoadF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+        IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);
         iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
         if (IREE_UNLIKELY(!buffer)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                   "source_buffer is null");
         }
-        iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
-        double* result = VM_DecResultRegF64("result");
         vm_buffer_load_f64_inline(buffer, offset, result);
       });
 
-      DISPATCH_OP(EXT_F64, BufferStoreF64, {
-        iree_vm_ref_t* buffer_ref = VM_DecOperandRegRef("target_buffer");
+      IREE_VM_ISA_DISPATCH_OP(EXT_F64, BufferStoreF64, {
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(buffer_ref);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(offset);
+        IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(value);
         iree_vm_buffer_t* buffer = iree_vm_buffer_deref(*buffer_ref);
         if (IREE_UNLIKELY(!buffer)) {
           return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                   "target_buffer is null");
         }
-        iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
-        double value = VM_DecOperandRegF64("value");
         vm_buffer_store_f64_inline(buffer, offset, value);
       });
     }
-    END_DISPATCH_PREFIX();
+    IREE_VM_ISA_DISPATCH_END_PREFIX();
 #else
-    UNHANDLED_DISPATCH_PREFIX(PrefixExtF64, EXT_F64);
+    IREE_VM_ISA_DISPATCH_UNHANDLED_PREFIX(PrefixExtF64, EXT_F64);
 #endif  // IREE_VM_EXT_F64_ENABLE
 
     // NOLINTNEXTLINE(misc-static-assert)
-    DISPATCH_UNHANDLED_CORE();
+    IREE_VM_ISA_DISPATCH_UNHANDLED_CORE();
   }
-  END_DISPATCH_CORE();
+  IREE_VM_ISA_DISPATCH_END_CORE();
 }

--- a/runtime/src/iree/vm/bytecode/dispatch_util.h
+++ b/runtime/src/iree/vm/bytecode/dispatch_util.h
@@ -131,129 +131,6 @@ static inline iree_vm_type_def_t iree_vm_map_type(
 #define IREE_DISPATCH_MODE_SWITCH 1
 #endif  // IREE_VM_BYTECODE_DISPATCH_COMPUTED_GOTO_ENABLE
 
-//===----------------------------------------------------------------------===//
-// Utilities matching the tablegen op encoding scheme
-//===----------------------------------------------------------------------===//
-// These utilities match the VM_Enc* statements in VMBase.td 1:1, allowing us
-// to have the inverse of the encoding which make things easier to read.
-//
-// Each macro will increment the pc by the number of bytes read and as such must
-// be called in the same order the values are encoded.
-
-#define VM_DecConstI8(name) \
-  OP_I8(0);                 \
-  ++pc;
-#define VM_DecConstI16(name) \
-  OP_I16(0);                 \
-  pc += 2;
-#define VM_DecConstI32(name) \
-  OP_I32(0);                 \
-  pc += 4;
-#define VM_DecConstI64(name) \
-  OP_I64(0);                 \
-  pc += 8;
-#define VM_DecConstF32(name) \
-  OP_F32(0);                 \
-  pc += 4;
-#define VM_DecConstF64(name) \
-  OP_F64(0);                 \
-  pc += 8;
-#define VM_DecFuncAttr(name) VM_DecConstI32(name)
-#define VM_DecGlobalAttr(name) VM_DecConstI32(name)
-#define VM_DecRodataAttr(name) VM_DecConstI32(name)
-#define VM_DecType(name)               \
-  iree_vm_map_type(module, OP_I32(0)); \
-  pc += 4;
-#define VM_DecTypeOf(name) VM_DecType(name)
-#define VM_DecAttrI32(name) VM_DecConstI32(name)
-#define VM_DecAttrI64(name) VM_DecConstI64(name)
-#define VM_DecAttrF32(name) VM_DecConstF32(name)
-#define VM_DecAttrF64(name) VM_DecConstF64(name)
-#define VM_DecStrAttr(name, out_str)                     \
-  (out_str)->size = (iree_host_size_t)OP_I16(0);         \
-  (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
-  pc += 2 + (out_str)->size;
-#define VM_DecBranchTarget(block_name) VM_DecConstI32(name)
-#define VM_DecBranchOperands(operands_name) \
-  VM_DecBranchOperandsImpl(bytecode_data, &pc)
-static inline const iree_vm_register_remap_list_t* VM_DecBranchOperandsImpl(
-    const uint8_t* IREE_RESTRICT bytecode_data, iree_vm_source_offset_t* pc) {
-  VM_AlignPC(*pc, IREE_REGISTER_ORDINAL_SIZE);
-  const iree_vm_register_remap_list_t* list =
-      (const iree_vm_register_remap_list_t*)&bytecode_data[*pc];
-  *pc = *pc + IREE_REGISTER_ORDINAL_SIZE +
-        list->size * 2 * IREE_REGISTER_ORDINAL_SIZE;
-  return list;
-}
-#define VM_DecOperandRegI32(name) \
-  regs_i32[OP_I16(0)];            \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecOperandRegI64(name)    \
-  *((int64_t*)&regs_i32[OP_I16(0)]); \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecOperandRegI64HostSize(name) \
-  (iree_host_size_t) VM_DecOperandRegI64(name)
-#define VM_DecOperandRegF32(name)  \
-  *((float*)&regs_i32[OP_I16(0)]); \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecOperandRegF64(name)   \
-  *((double*)&regs_i32[OP_I16(0)]); \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Base macro - no MOVE bit decoding (for ops that don't support MOVE).
-#define VM_DecOperandRegRef(name)                \
-  &regs_ref[OP_I16(0) & IREE_REF_REGISTER_MASK]; \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Move variant - decodes MOVE bit (for ops that support ownership transfer).
-#if defined(IREE_VM_REF_DEBUG_MOVE)
-#define VM_DecOperandRegRefMove(name, out_is_move)                         \
-  &regs_ref[OP_I16(0) & IREE_REF_REGISTER_MASK];                           \
-  IREE_ASSERT_NE(regs_ref[OP_I16(0) & IREE_REF_REGISTER_MASK].type,        \
-                 IREE_VM_REF_TYPE_POISONED,                                \
-                 "use-after-move: ref register was accessed after being "  \
-                 "moved - the compiler incorrectly marked a non-last-use " \
-                 "as MOVE");                                               \
-  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT;                 \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#else
-#define VM_DecOperandRegRefMove(name, out_is_move)         \
-  &regs_ref[OP_I16(0) & IREE_REF_REGISTER_MASK];           \
-  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#endif  // IREE_VM_REF_DEBUG_MOVE
-#define VM_DecVariadicOperands(name) \
-  VM_DecVariadicOperandsImpl(bytecode_data, &pc)
-static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
-    const uint8_t* IREE_RESTRICT bytecode_data, iree_vm_source_offset_t* pc) {
-  VM_AlignPC(*pc, IREE_REGISTER_ORDINAL_SIZE);
-  const iree_vm_register_list_t* list =
-      (const iree_vm_register_list_t*)&bytecode_data[*pc];
-  *pc = *pc + IREE_REGISTER_ORDINAL_SIZE +
-        list->size * IREE_REGISTER_ORDINAL_SIZE;
-  return list;
-}
-#define VM_DecResultRegI32(name) \
-  &regs_i32[OP_I16(0)];          \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecResultRegI64(name)    \
-  ((int64_t*)&regs_i32[OP_I16(0)]); \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecResultRegF32(name)  \
-  ((float*)&regs_i32[OP_I16(0)]); \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecResultRegF64(name)   \
-  ((double*)&regs_i32[OP_I16(0)]); \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Base macro - no MOVE bit decoding (for ops that don't support MOVE).
-#define VM_DecResultRegRef(name)                 \
-  &regs_ref[OP_I16(0) & IREE_REF_REGISTER_MASK]; \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Move variant - decodes MOVE bit (for ops that support ownership transfer).
-#define VM_DecResultRegRefMove(name, out_is_move)          \
-  &regs_ref[OP_I16(0) & IREE_REF_REGISTER_MASK];           \
-  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_DecVariadicResults(name) VM_DecVariadicOperands(name)
-
 #define IREE_VM_BLOCK_MARKER_SIZE 1
 
 //===----------------------------------------------------------------------===//
@@ -279,83 +156,90 @@ static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
 // Because the performance difference is significant we support both here but
 // prefer the computed goto path where available. Empirical data shows them to
 // still be a win in 2019 on x64 desktops and arm32/arm64 mobile devices.
-#define BEGIN_DISPATCH_CORE()                     \
+#define IREE_VM_ISA_DISPATCH_BEGIN_CORE()         \
   goto* kDispatchTable_CORE[bytecode_data[pc++]]; \
   while (1)
-#define END_DISPATCH_CORE()
+#define IREE_VM_ISA_DISPATCH_END_CORE()
 
-#define DECLARE_DISPATCH_CORE_OPC(ordinal, name) &&_dispatch_CORE_##name,
-#define DECLARE_DISPATCH_CORE_RSV(ordinal) &&_dispatch_unhandled,
-#define DEFINE_DISPATCH_TABLE_CORE()                                    \
-  static const void* kDispatchTable_CORE[256] = {IREE_VM_OP_CORE_TABLE( \
-      DECLARE_DISPATCH_CORE_OPC, DECLARE_DISPATCH_CORE_RSV)};
+#define IREE_VM_ISA_DISPATCH_DECLARE_CORE_OPC(ordinal, name) \
+  &&_dispatch_CORE_##name,
+#define IREE_VM_ISA_DISPATCH_DECLARE_CORE_RSV(ordinal) &&_dispatch_unhandled,
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLE_CORE()                   \
+  static const void* kDispatchTable_CORE[256] = {                  \
+      IREE_VM_OP_CORE_TABLE(IREE_VM_ISA_DISPATCH_DECLARE_CORE_OPC, \
+                            IREE_VM_ISA_DISPATCH_DECLARE_CORE_RSV)};
 
-#define DECLARE_DISPATCH_EXT_RSV(ordinal) &&_dispatch_unhandled,
+#define IREE_VM_ISA_DISPATCH_DECLARE_EXT_RSV(ordinal) &&_dispatch_unhandled,
 #if IREE_VM_EXT_F32_ENABLE
-#define DECLARE_DISPATCH_EXT_F32_OPC(ordinal, name) &&_dispatch_EXT_F32_##name,
-#define DEFINE_DISPATCH_TABLE_EXT_F32()                                       \
-  static const void* kDispatchTable_EXT_F32[256] = {IREE_VM_OP_EXT_F32_TABLE( \
-      DECLARE_DISPATCH_EXT_F32_OPC, DECLARE_DISPATCH_EXT_RSV)};
+#define IREE_VM_ISA_DISPATCH_DECLARE_EXT_F32_OPC(ordinal, name) \
+  &&_dispatch_EXT_F32_##name,
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLE_EXT_F32()                      \
+  static const void* kDispatchTable_EXT_F32[256] = {                     \
+      IREE_VM_OP_EXT_F32_TABLE(IREE_VM_ISA_DISPATCH_DECLARE_EXT_F32_OPC, \
+                               IREE_VM_ISA_DISPATCH_DECLARE_EXT_RSV)};
 #else
-#define DEFINE_DISPATCH_TABLE_EXT_F32()
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLE_EXT_F32()
 #endif  // IREE_VM_EXT_F32_ENABLE
 #if IREE_VM_EXT_F64_ENABLE
-#define DECLARE_DISPATCH_EXT_F64_OPC(ordinal, name) &&_dispatch_EXT_F64_##name,
-#define DEFINE_DISPATCH_TABLE_EXT_F64()                                       \
-  static const void* kDispatchTable_EXT_F64[256] = {IREE_VM_OP_EXT_F64_TABLE( \
-      DECLARE_DISPATCH_EXT_F64_OPC, DECLARE_DISPATCH_EXT_RSV)};
+#define IREE_VM_ISA_DISPATCH_DECLARE_EXT_F64_OPC(ordinal, name) \
+  &&_dispatch_EXT_F64_##name,
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLE_EXT_F64()                      \
+  static const void* kDispatchTable_EXT_F64[256] = {                     \
+      IREE_VM_OP_EXT_F64_TABLE(IREE_VM_ISA_DISPATCH_DECLARE_EXT_F64_OPC, \
+                               IREE_VM_ISA_DISPATCH_DECLARE_EXT_RSV)};
 #else
-#define DEFINE_DISPATCH_TABLE_EXT_F64()
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLE_EXT_F64()
 #endif  // IREE_VM_EXT_F64_ENABLE
 
-#define DEFINE_DISPATCH_TABLES()   \
-  DEFINE_DISPATCH_TABLE_CORE();    \
-  DEFINE_DISPATCH_TABLE_EXT_F32(); \
-  DEFINE_DISPATCH_TABLE_EXT_F64();
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLES()   \
+  IREE_VM_ISA_DISPATCH_DEFINE_TABLE_CORE();    \
+  IREE_VM_ISA_DISPATCH_DEFINE_TABLE_EXT_F32(); \
+  IREE_VM_ISA_DISPATCH_DEFINE_TABLE_EXT_F64();
 
-#define DISPATCH_UNHANDLED_CORE()                                           \
+#define IREE_VM_ISA_DISPATCH_UNHANDLED_CORE()                               \
   _dispatch_unhandled /*verifier should prevent this*/ : {                  \
     IREE_ASSERT(0);                                                         \
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "unhandled opcode"); \
   }
-#define UNHANDLED_DISPATCH_PREFIX(op_name, ext)                    \
+#define IREE_VM_ISA_DISPATCH_UNHANDLED_PREFIX(op_name, ext)        \
   _dispatch_CORE_##op_name : {                                     \
     IREE_ASSERT(0);                                                \
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,             \
                             "unhandled dispatch extension " #ext); \
   }
 
-#define DISPATCH_OP(ext, op_name, body)                               \
-  _dispatch_##ext##_##op_name :;                                      \
-  IREE_DISPATCH_TRACE_INSTRUCTION(IREE_VM_PC_OFFSET_##ext, #op_name); \
-  body;                                                               \
+#define IREE_VM_ISA_DISPATCH_OP(ext, op_name, body)                       \
+  _dispatch_##ext##_##op_name :;                                          \
+  IREE_DISPATCH_TRACE_INSTRUCTION(IREE_VM_ISA_PC_OFFSET_##ext, #op_name); \
+  body;                                                                   \
   goto* kDispatchTable_CORE[bytecode_data[pc++]];
 
-#define BEGIN_DISPATCH_PREFIX(op_name, ext)                                   \
+#define IREE_VM_ISA_DISPATCH_BEGIN_PREFIX(op_name, ext)                       \
   _dispatch_CORE_##op_name : goto* kDispatchTable_##ext[bytecode_data[pc++]]; \
   while (1)
-#define END_DISPATCH_PREFIX() goto* kDispatchTable_CORE[bytecode_data[pc++]];
+#define IREE_VM_ISA_DISPATCH_END_PREFIX() \
+  goto* kDispatchTable_CORE[bytecode_data[pc++]];
 
 #else
 
 // Switch-based dispatch. This is strictly less efficient than the computed
 // goto approach above but is universally supported.
 
-#define BEGIN_DISPATCH_CORE() \
-  while (1) {                 \
+#define IREE_VM_ISA_DISPATCH_BEGIN_CORE() \
+  while (1) {                             \
     switch (bytecode_data[pc++])
-#define END_DISPATCH_CORE() }
+#define IREE_VM_ISA_DISPATCH_END_CORE() }
 
-#define DEFINE_DISPATCH_TABLES()
+#define IREE_VM_ISA_DISPATCH_DEFINE_TABLES()
 
-#define DISPATCH_UNHANDLED_CORE()                         \
+#define IREE_VM_ISA_DISPATCH_UNHANDLED_CORE()             \
   default: {                                              \
     IREE_ASSERT(0);                                       \
     IREE_BUILTIN_UNREACHABLE(); /* ok because verified */ \
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,    \
                             "unhandled core opcode");     \
   }
-#define UNHANDLED_DISPATCH_PREFIX(op_name, ext)                    \
+#define IREE_VM_ISA_DISPATCH_UNHANDLED_PREFIX(op_name, ext)        \
   case IREE_VM_OP_CORE_##op_name: {                                \
     IREE_ASSERT(0);                                                \
     IREE_BUILTIN_UNREACHABLE(); /* ok because verified */          \
@@ -363,117 +247,117 @@ static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
                             "unhandled dispatch extension " #ext); \
   }
 
-#define DISPATCH_OP(ext, op_name, body)                                 \
-  case IREE_VM_OP_##ext##_##op_name: {                                  \
-    IREE_DISPATCH_TRACE_INSTRUCTION(IREE_VM_PC_OFFSET_##ext, #op_name); \
-    body;                                                               \
+#define IREE_VM_ISA_DISPATCH_OP(ext, op_name, body)                         \
+  case IREE_VM_OP_##ext##_##op_name: {                                      \
+    IREE_DISPATCH_TRACE_INSTRUCTION(IREE_VM_ISA_PC_OFFSET_##ext, #op_name); \
+    body;                                                                   \
   } break;
 
-#define BEGIN_DISPATCH_PREFIX(op_name, ext) \
-  case IREE_VM_OP_CORE_##op_name: {         \
+#define IREE_VM_ISA_DISPATCH_BEGIN_PREFIX(op_name, ext) \
+  case IREE_VM_OP_CORE_##op_name: {                     \
     switch (bytecode_data[pc++])
-#define END_DISPATCH_PREFIX() \
-  break;                      \
+#define IREE_VM_ISA_DISPATCH_END_PREFIX() \
+  break;                                  \
   }
 
 #endif  // IREE_DISPATCH_MODE_COMPUTED_GOTO
 
 // Common dispatch op macros
 
-#define DISPATCH_OP_CORE_UNARY_I32(op_name, op_func)  \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int32_t operand = VM_DecOperandRegI32("operand"); \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = op_func(operand);                       \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(operand);            \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);              \
+    *result = op_func(operand);                                  \
   });
 
-#define DISPATCH_OP_CORE_UNARY_I64(op_name, op_func)  \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int64_t operand = VM_DecOperandRegI64("operand"); \
-    int64_t* result = VM_DecResultRegI64("result");   \
-    *result = op_func(operand);                       \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_UNARY_I64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(operand);            \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);              \
+    *result = op_func(operand);                                  \
   });
 
-#define DISPATCH_OP_CORE_BINARY_I32(op_name, op_func) \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int32_t lhs = VM_DecOperandRegI32("lhs");         \
-    int32_t rhs = VM_DecOperandRegI32("rhs");         \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = op_func(lhs, rhs);                      \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                        \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(lhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(rhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);               \
+    *result = op_func(lhs, rhs);                                  \
   });
 
-#define DISPATCH_OP_CORE_BINARY_I64(op_name, op_func) \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int64_t lhs = VM_DecOperandRegI64("lhs");         \
-    int64_t rhs = VM_DecOperandRegI64("rhs");         \
-    int64_t* result = VM_DecResultRegI64("result");   \
-    *result = op_func(lhs, rhs);                      \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_BINARY_I64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                        \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(lhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(rhs);                 \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);               \
+    *result = op_func(lhs, rhs);                                  \
   });
 
-#define DISPATCH_OP_CORE_TERNARY_I32(op_name, op_func) \
-  DISPATCH_OP(CORE, op_name, {                         \
-    int32_t a = VM_DecOperandRegI32("a");              \
-    int32_t b = VM_DecOperandRegI32("b");              \
-    int32_t c = VM_DecOperandRegI32("c");              \
-    int32_t* result = VM_DecResultRegI32("result");    \
-    *result = op_func(a, b, c);                        \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_TERNARY_I32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                         \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(a);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(b);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(c);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(result);                \
+    *result = op_func(a, b, c);                                    \
   });
 
-#define DISPATCH_OP_CORE_TERNARY_I64(op_name, op_func) \
-  DISPATCH_OP(CORE, op_name, {                         \
-    int64_t a = VM_DecOperandRegI64("a");              \
-    int64_t b = VM_DecOperandRegI64("b");              \
-    int64_t c = VM_DecOperandRegI64("c");              \
-    int64_t* result = VM_DecResultRegI64("result");    \
-    *result = op_func(a, b, c);                        \
+#define IREE_VM_ISA_DISPATCH_OP_CORE_TERNARY_I64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(CORE, op_name, {                         \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(a);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(b);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(c);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(result);                \
+    *result = op_func(a, b, c);                                    \
   });
 
-#define DISPATCH_OP_EXT_F32_UNARY_F32(op_name, op_func) \
-  DISPATCH_OP(EXT_F32, op_name, {                       \
-    float operand = VM_DecOperandRegF32("operand");     \
-    float* result = VM_DecResultRegF32("result");       \
-    *result = op_func(operand);                         \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F32_UNARY_F32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F32, op_name, {                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(operand);               \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);                 \
+    *result = op_func(operand);                                     \
   });
 
-#define DISPATCH_OP_EXT_F32_BINARY_F32(op_name, op_func) \
-  DISPATCH_OP(EXT_F32, op_name, {                        \
-    float lhs = VM_DecOperandRegF32("lhs");              \
-    float rhs = VM_DecOperandRegF32("rhs");              \
-    float* result = VM_DecResultRegF32("result");        \
-    *result = op_func(lhs, rhs);                         \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F32_BINARY_F32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F32, op_name, {                        \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(lhs);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(rhs);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);                  \
+    *result = op_func(lhs, rhs);                                     \
   });
 
-#define DISPATCH_OP_EXT_F32_TERNARY_F32(op_name, op_func) \
-  DISPATCH_OP(EXT_F32, op_name, {                         \
-    float a = VM_DecOperandRegF32("a");                   \
-    float b = VM_DecOperandRegF32("b");                   \
-    float c = VM_DecOperandRegF32("c");                   \
-    float* result = VM_DecResultRegF32("result");         \
-    *result = op_func(a, b, c);                           \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F32_TERNARY_F32(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F32, op_name, {                         \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(a);                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(b);                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(c);                       \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(result);                   \
+    *result = op_func(a, b, c);                                       \
   });
 
-#define DISPATCH_OP_EXT_F64_UNARY_F64(op_name, op_func) \
-  DISPATCH_OP(EXT_F64, op_name, {                       \
-    double operand = VM_DecOperandRegF64("operand");    \
-    double* result = VM_DecResultRegF64("result");      \
-    *result = op_func(operand);                         \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F64_UNARY_F64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F64, op_name, {                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(operand);               \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);                 \
+    *result = op_func(operand);                                     \
   });
 
-#define DISPATCH_OP_EXT_F64_BINARY_F64(op_name, op_func) \
-  DISPATCH_OP(EXT_F64, op_name, {                        \
-    double lhs = VM_DecOperandRegF64("lhs");             \
-    double rhs = VM_DecOperandRegF64("rhs");             \
-    double* result = VM_DecResultRegF64("result");       \
-    *result = op_func(lhs, rhs);                         \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F64_BINARY_F64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F64, op_name, {                        \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(lhs);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(rhs);                    \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);                  \
+    *result = op_func(lhs, rhs);                                     \
   });
 
-#define DISPATCH_OP_EXT_F64_TERNARY_F64(op_name, op_func) \
-  DISPATCH_OP(EXT_F64, op_name, {                         \
-    double a = VM_DecOperandRegF64("a");                  \
-    double b = VM_DecOperandRegF64("b");                  \
-    double c = VM_DecOperandRegF64("c");                  \
-    double* result = VM_DecResultRegF64("result");        \
-    *result = op_func(a, b, c);                           \
+#define IREE_VM_ISA_DISPATCH_OP_EXT_F64_TERNARY_F64(op_name, op_func) \
+  IREE_VM_ISA_DISPATCH_OP(EXT_F64, op_name, {                         \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(a);                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(b);                       \
+    IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(c);                       \
+    IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(result);                   \
+    *result = op_func(a, b, c);                                       \
   });
 
 #endif  // IREE_VM_BYTECODE_DISPATCH_UTIL_H_

--- a/runtime/src/iree/vm/bytecode/utils/BUILD.bazel
+++ b/runtime/src/iree/vm/bytecode/utils/BUILD.bazel
@@ -23,6 +23,8 @@ iree_runtime_cc_library(
         "features.h",
         "generated/op_table.h",
         "isa.h",
+        "isa_decoder.h",
+        "isa_decoder.inl",
     ],
     deps = [
         "//runtime/src/iree/base",

--- a/runtime/src/iree/vm/bytecode/utils/CMakeLists.txt
+++ b/runtime/src/iree/vm/bytecode/utils/CMakeLists.txt
@@ -18,6 +18,8 @@ iree_cc_library(
     "features.h"
     "generated/op_table.h"
     "isa.h"
+    "isa_decoder.h"
+    "isa_decoder.inl"
   SRCS
     "block_list.c"
     "features.c"

--- a/runtime/src/iree/vm/bytecode/utils/block_list.c
+++ b/runtime/src/iree/vm/bytecode/utils/block_list.c
@@ -58,10 +58,10 @@ iree_status_t iree_vm_bytecode_block_list_insert(
   IREE_ASSERT_ARGUMENT(block_list);
   *out_block = NULL;
 
-  if (IREE_UNLIKELY(pc >= IREE_VM_PC_BLOCK_MAX)) {
+  if (IREE_UNLIKELY(pc >= IREE_VM_ISA_PC_BLOCK_MAX)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "block pc %08X greater than max %08X", pc,
-                            IREE_VM_PC_BLOCK_MAX);
+                            IREE_VM_ISA_PC_BLOCK_MAX);
   }
 
   // Try to find the block or the next block greater than it in the list in case

--- a/runtime/src/iree/vm/bytecode/utils/block_list_test.cc
+++ b/runtime/src/iree/vm/bytecode/utils/block_list_test.cc
@@ -268,7 +268,7 @@ TEST(BlockListTest, OverMaxPC) {
 
   iree_vm_bytecode_block_t* block = NULL;
   EXPECT_THAT(Status(iree_vm_bytecode_block_list_insert(
-                  &block_list, IREE_VM_PC_BLOCK_MAX + 1, &block)),
+                  &block_list, IREE_VM_ISA_PC_BLOCK_MAX + 1, &block)),
               StatusIs(StatusCode::kOutOfRange));
 
   iree_vm_bytecode_block_list_deinitialize(&block_list, allocator);

--- a/runtime/src/iree/vm/bytecode/utils/isa.h
+++ b/runtime/src/iree/vm/bytecode/utils/isa.h
@@ -17,16 +17,6 @@
 #include "iree/schemas/bytecode_module_def_verifier.h"  // IWYU pragma: export
 
 //===----------------------------------------------------------------------===//
-// Misc utilities
-//===----------------------------------------------------------------------===//
-
-#define VMMAX(a, b) (((a) > (b)) ? (a) : (b))
-#define VMMIN(a, b) (((a) < (b)) ? (a) : (b))
-
-#define VM_AlignPC(pc, alignment) \
-  (pc) = ((pc) + ((alignment) - 1)) & ~((alignment) - 1)
-
-//===----------------------------------------------------------------------===//
 // Bytecode versioning
 //===----------------------------------------------------------------------===//
 
@@ -50,27 +40,45 @@
 
 // Maximum register count per bank.
 // This determines the bits required to reference registers in the VM bytecode.
-#define IREE_I32_REGISTER_COUNT 0x7FFF
-#define IREE_REF_REGISTER_COUNT 0x3FFF
+#define IREE_VM_ISA_I32_REGISTER_COUNT 0x7FFF
+#define IREE_VM_ISA_REF_REGISTER_COUNT 0x3FFF
 
-#define IREE_I32_REGISTER_MASK 0x7FFF
+#define IREE_VM_ISA_I32_REGISTER_MASK 0x7FFF
 
-#define IREE_REF_REGISTER_TYPE_BIT 0x8000
-#define IREE_REF_REGISTER_MOVE_BIT 0x4000
-#define IREE_REF_REGISTER_MASK 0x3FFF
+#define IREE_VM_ISA_REF_REGISTER_TYPE_BIT 0x8000
+#define IREE_VM_ISA_REF_REGISTER_MOVE_BIT 0x4000
+#define IREE_VM_ISA_REF_REGISTER_MASK 0x3FFF
 
 // Maximum program counter offset within in a single block.
 // This is just so that we can steal bits for flags and such. 16MB (today)
 // should be more than enough for a single basic block. If not then we should
 // compress better!
-#define IREE_VM_PC_BLOCK_MAX 0x00FFFFFFu
+#define IREE_VM_ISA_PC_BLOCK_MAX 0x00FFFFFFu
 
 // Bytecode data -offset used when looking for the start of the currently
 // dispatched instruction: `instruction_start = pc - OFFSET`
-#define IREE_VM_PC_OFFSET_CORE 1
-#define IREE_VM_PC_OFFSET_EXT_I32 2
-#define IREE_VM_PC_OFFSET_EXT_F32 2
-#define IREE_VM_PC_OFFSET_EXT_F64 2
+#define IREE_VM_ISA_PC_OFFSET_CORE 1
+#define IREE_VM_ISA_PC_OFFSET_EXT_I32 2
+#define IREE_VM_ISA_PC_OFFSET_EXT_F32 2
+#define IREE_VM_ISA_PC_OFFSET_EXT_F64 2
+
+//===----------------------------------------------------------------------===//
+// Common ordinal encodings
+//===----------------------------------------------------------------------===//
+
+// Function ordinals are tagged when referencing import functions.
+// The low bits are the ordinal in the import table; the high bit indicates
+// whether the ordinal is an import reference.
+#define IREE_VM_ISA_FUNCTION_ORDINAL_IMPORT_BIT 0x80000000u
+
+static inline bool iree_vm_isa_function_ordinal_is_import(uint32_t ordinal) {
+  return (ordinal & IREE_VM_ISA_FUNCTION_ORDINAL_IMPORT_BIT) != 0;
+}
+
+static inline uint32_t iree_vm_isa_function_ordinal_as_import(
+    uint32_t ordinal) {
+  return ordinal & ~IREE_VM_ISA_FUNCTION_ORDINAL_IMPORT_BIT;
+}
 
 // Interleaved src-dst register sets for branch register remapping.
 // This structure is an overlay for the bytecode that is serialized in a
@@ -86,18 +94,5 @@ static_assert(iree_alignof(iree_vm_register_remap_list_t) == 2,
               "Expecting byte alignment (to avoid padding)");
 static_assert(offsetof(iree_vm_register_remap_list_t, pairs) == 2,
               "Expect no padding in the struct");
-
-//===----------------------------------------------------------------------===//
-// Bytecode data reading with little-/big-endian support
-//===----------------------------------------------------------------------===//
-
-// Bytecode data access macros for reading values of a given type from a byte
-// offset within the current function.
-#define OP_I8(i) iree_unaligned_load_le((uint8_t*)&bytecode_data[pc + (i)])
-#define OP_I16(i) iree_unaligned_load_le((uint16_t*)&bytecode_data[pc + (i)])
-#define OP_I32(i) iree_unaligned_load_le((uint32_t*)&bytecode_data[pc + (i)])
-#define OP_I64(i) iree_unaligned_load_le((uint64_t*)&bytecode_data[pc + (i)])
-#define OP_F32(i) iree_unaligned_load_le((float*)&bytecode_data[pc + (i)])
-#define OP_F64(i) iree_unaligned_load_le((double*)&bytecode_data[pc + (i)])
 
 #endif  // IREE_VM_BYTECODE_UTILS_ISA_H_

--- a/runtime/src/iree/vm/bytecode/utils/isa_decoder.h
+++ b/runtime/src/iree/vm/bytecode/utils/isa_decoder.h
@@ -1,0 +1,121 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_VM_BYTECODE_UTILS_ISA_DECODER_H_
+#define IREE_VM_BYTECODE_UTILS_ISA_DECODER_H_
+
+// Shared bytecode field decoding utilities.
+//
+// This header contains small, policy-free decode helpers that operate on a
+// `(bytecode_data, pc)` stream. Bounds checks and semantic validation are
+// performed by higher-level consumers (verifier/dispatch/disassembler/etc).
+//
+// For policy-substituted macros that build on these helpers, see
+// `isa_decoder.inl`.
+
+#include "iree/vm/bytecode/utils/isa.h"
+
+//===----------------------------------------------------------------------===//
+// Decoding utilities
+//===----------------------------------------------------------------------===//
+
+static inline iree_vm_source_offset_t iree_vm_isa_align_pc(
+    iree_vm_source_offset_t pc, int alignment) {
+  return (pc + (alignment - 1)) & ~(alignment - 1);
+}
+
+//===----------------------------------------------------------------------===//
+// Primitive field decoding (unchecked)
+//===----------------------------------------------------------------------===//
+
+static inline uint8_t iree_vm_isa_decode_u8(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  return data[(*pc)++];
+}
+
+static inline uint16_t iree_vm_isa_decode_u16(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  const uint16_t v = iree_unaligned_load_le((const uint16_t*)&data[*pc]);
+  *pc += 2;
+  return v;
+}
+
+static inline uint32_t iree_vm_isa_decode_u32(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  const uint32_t v = iree_unaligned_load_le((const uint32_t*)&data[*pc]);
+  *pc += 4;
+  return v;
+}
+
+static inline uint64_t iree_vm_isa_decode_u64(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  const uint64_t v = iree_unaligned_load_le((const uint64_t*)&data[*pc]);
+  *pc += 8;
+  return v;
+}
+
+static inline float iree_vm_isa_decode_f32(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  const float v = iree_unaligned_load_le((const float*)&data[*pc]);
+  *pc += 4;
+  return v;
+}
+
+static inline double iree_vm_isa_decode_f64(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  const double v = iree_unaligned_load_le((const double*)&data[*pc]);
+  *pc += 8;
+  return v;
+}
+
+static inline iree_string_view_t iree_vm_isa_decode_string_view(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  const uint16_t n = iree_vm_isa_decode_u16(data, pc);
+  iree_string_view_t v = iree_make_string_view((const char*)&data[*pc], n);
+  *pc += n;
+  return v;
+}
+
+//===----------------------------------------------------------------------===//
+// Aggregate field decoding helpers (unchecked)
+//===----------------------------------------------------------------------===//
+
+// Decodes a variadic register list encoded in the bytecode stream.
+// The returned pointer aliases |data| and is only valid as long as |data| is.
+static inline const iree_vm_register_list_t*
+iree_vm_isa_decode_register_list_unchecked(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  *pc = iree_vm_isa_align_pc(*pc, IREE_REGISTER_ORDINAL_SIZE);
+  const iree_vm_register_list_t* list =
+      (const iree_vm_register_list_t*)&data[*pc];
+  *pc = *pc + IREE_REGISTER_ORDINAL_SIZE +
+        list->size * IREE_REGISTER_ORDINAL_SIZE;
+  return list;
+}
+
+// Decodes an interleaved src-dst remap list encoded in the bytecode stream.
+// The returned pointer aliases |data| and is only valid as long as |data| is.
+static inline const iree_vm_register_remap_list_t*
+iree_vm_isa_decode_register_remap_list_unchecked(
+    const uint8_t* IREE_RESTRICT data,
+    iree_vm_source_offset_t* IREE_RESTRICT pc) {
+  *pc = iree_vm_isa_align_pc(*pc, IREE_REGISTER_ORDINAL_SIZE);
+  const iree_vm_register_remap_list_t* list =
+      (const iree_vm_register_remap_list_t*)&data[*pc];
+  *pc = *pc + IREE_REGISTER_ORDINAL_SIZE +
+        list->size * 2 * IREE_REGISTER_ORDINAL_SIZE;
+  return list;
+}
+
+#endif  // IREE_VM_BYTECODE_UTILS_ISA_DECODER_H_

--- a/runtime/src/iree/vm/bytecode/utils/isa_decoder.inl
+++ b/runtime/src/iree/vm/bytecode/utils/isa_decoder.inl
@@ -1,0 +1,410 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Policy-substituted ISA decoding macros.
+//
+// This file intentionally has no include guard so that it can be included with
+// different policy configurations (though most users include it once per TU).
+//
+// Required configuration (define before including):
+// - IREE_VM_ISA_BYTECODE_DATA: expression yielding `const uint8_t*`.
+// - IREE_VM_ISA_PC: lvalue of type `iree_vm_source_offset_t`.
+//
+// Optional policy hooks (define before including; defaults are no-ops):
+// - IREE_VM_ISA_REQUIRE(bytes): statement that ensures `pc + bytes` is in
+//   range (may `return` on failure).
+// - IREE_VM_ISA_VALIDATE_*: statements that validate decoded fields (may
+//   `return` on failure).
+// - IREE_VM_ISA_TYPE_T: type used for decoded type defs (defaults to
+//   `iree_vm_type_def_t`).
+// - IREE_VM_ISA_LOOKUP_TYPE(type_id, out_type): statement mapping a type ID to
+//   an `IREE_VM_ISA_TYPE_T` lvalue (required for `IREE_VM_ISA_DECODE_TYPE*`).
+//
+// Example (dispatch-style, unchecked):
+//   #define IREE_VM_ISA_BYTECODE_DATA bytecode_data
+//   #define IREE_VM_ISA_PC pc
+//   #define IREE_VM_ISA_REQUIRE(bytes) ((void)0)
+//   #define IREE_VM_ISA_LOOKUP_TYPE(type_id, out_type) \
+//     do { (out_type) = iree_vm_map_type(module, (int32_t)(type_id)); } while
+//     (0)
+//   #include "iree/vm/bytecode/utils/isa_decoder.inl"
+
+#include "iree/vm/bytecode/utils/isa_decoder.h"
+
+#if !defined(IREE_VM_ISA_BYTECODE_DATA)
+#error \
+    "IREE_VM_ISA_BYTECODE_DATA must be defined before including isa_decoder.inl"
+#endif  // !IREE_VM_ISA_BYTECODE_DATA
+
+#if !defined(IREE_VM_ISA_PC)
+#error "IREE_VM_ISA_PC must be defined before including isa_decoder.inl"
+#endif  // !IREE_VM_ISA_PC
+
+//===----------------------------------------------------------------------===//
+// Policy defaults
+//===----------------------------------------------------------------------===//
+
+#if !defined(IREE_VM_ISA_REQUIRE)
+#define IREE_VM_ISA_REQUIRE(bytes) ((void)0)
+#endif  // !IREE_VM_ISA_REQUIRE
+
+#if !defined(IREE_VM_ISA_TYPE_T)
+#define IREE_VM_ISA_TYPE_T iree_vm_type_def_t
+#endif  // !IREE_VM_ISA_TYPE_T
+
+#if !defined(IREE_VM_ISA_VALIDATE_TYPE_ID)
+#define IREE_VM_ISA_VALIDATE_TYPE_ID(type_id) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_TYPE_ID
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_I32)
+#define IREE_VM_ISA_VALIDATE_REG_I32(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_I32
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_I64)
+#define IREE_VM_ISA_VALIDATE_REG_I64(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_I64
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_F32)
+#define IREE_VM_ISA_VALIDATE_REG_F32(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_F32
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_F64)
+#define IREE_VM_ISA_VALIDATE_REG_F64(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_F64
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_REF_ALLOW_MOVE)
+#define IREE_VM_ISA_VALIDATE_REG_REF_ALLOW_MOVE(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_REF_ALLOW_MOVE
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_REF_NO_MOVE)
+#define IREE_VM_ISA_VALIDATE_REG_REF_NO_MOVE(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_REF_NO_MOVE
+
+#if !defined(IREE_VM_ISA_VALIDATE_REG_ANY)
+#define IREE_VM_ISA_VALIDATE_REG_ANY(ordinal) ((void)0)
+#endif  // !IREE_VM_ISA_VALIDATE_REG_ANY
+
+//===----------------------------------------------------------------------===//
+// Internal helpers
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_IMPL_READ_U8(out_value)                                \
+  do {                                                                     \
+    IREE_VM_ISA_REQUIRE(1);                                                \
+    (out_value) =                                                          \
+        iree_vm_isa_decode_u8(IREE_VM_ISA_BYTECODE_DATA, &IREE_VM_ISA_PC); \
+  } while (0)
+
+#define IREE_VM_ISA_IMPL_READ_U16(out_value)                                \
+  do {                                                                      \
+    IREE_VM_ISA_REQUIRE(2);                                                 \
+    (out_value) =                                                           \
+        iree_vm_isa_decode_u16(IREE_VM_ISA_BYTECODE_DATA, &IREE_VM_ISA_PC); \
+  } while (0)
+
+#define IREE_VM_ISA_IMPL_READ_U32(out_value)                                \
+  do {                                                                      \
+    IREE_VM_ISA_REQUIRE(4);                                                 \
+    (out_value) =                                                           \
+        iree_vm_isa_decode_u32(IREE_VM_ISA_BYTECODE_DATA, &IREE_VM_ISA_PC); \
+  } while (0)
+
+#define IREE_VM_ISA_IMPL_READ_U64(out_value)                                \
+  do {                                                                      \
+    IREE_VM_ISA_REQUIRE(8);                                                 \
+    (out_value) =                                                           \
+        iree_vm_isa_decode_u64(IREE_VM_ISA_BYTECODE_DATA, &IREE_VM_ISA_PC); \
+  } while (0)
+
+#define IREE_VM_ISA_IMPL_READ_F32(out_value)                                \
+  do {                                                                      \
+    IREE_VM_ISA_REQUIRE(4);                                                 \
+    (out_value) =                                                           \
+        iree_vm_isa_decode_f32(IREE_VM_ISA_BYTECODE_DATA, &IREE_VM_ISA_PC); \
+  } while (0)
+
+#define IREE_VM_ISA_IMPL_READ_F64(out_value)                                \
+  do {                                                                      \
+    IREE_VM_ISA_REQUIRE(8);                                                 \
+    (out_value) =                                                           \
+        iree_vm_isa_decode_f64(IREE_VM_ISA_BYTECODE_DATA, &IREE_VM_ISA_PC); \
+  } while (0)
+
+//===----------------------------------------------------------------------===//
+// Core fields
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_DECODE_ALIGN_PC(alignment) \
+  IREE_VM_ISA_PC = iree_vm_isa_align_pc(IREE_VM_ISA_PC, (alignment))
+
+#define IREE_VM_ISA_DECODE_OPCODE(opcode) \
+  uint8_t opcode = 0;                     \
+  IREE_VM_ISA_IMPL_READ_U8(opcode)
+
+//===----------------------------------------------------------------------===//
+// Constants and attributes
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_DECODE_CONST_I8(name) \
+  uint8_t name = 0;                       \
+  IREE_VM_ISA_IMPL_READ_U8(name)
+#define IREE_VM_ISA_DECODE_CONST_I16(name) \
+  uint16_t name = 0;                       \
+  IREE_VM_ISA_IMPL_READ_U16(name)
+#define IREE_VM_ISA_DECODE_CONST_I32(name) \
+  uint32_t name = 0;                       \
+  IREE_VM_ISA_IMPL_READ_U32(name)
+#define IREE_VM_ISA_DECODE_CONST_I64(name) \
+  uint64_t name = 0;                       \
+  IREE_VM_ISA_IMPL_READ_U64(name)
+#define IREE_VM_ISA_DECODE_CONST_F32(name) \
+  float name = 0.0f;                       \
+  IREE_VM_ISA_IMPL_READ_F32(name)
+#define IREE_VM_ISA_DECODE_CONST_F64(name) \
+  double name = 0.0;                       \
+  IREE_VM_ISA_IMPL_READ_F64(name)
+
+#define IREE_VM_ISA_DECODE_ATTR_I32(name) \
+  int32_t name = 0;                       \
+  do {                                    \
+    uint32_t __u32 = 0;                   \
+    IREE_VM_ISA_IMPL_READ_U32(__u32);     \
+    name = (int32_t)__u32;                \
+    ((void)name);                         \
+  } while (0)
+#define IREE_VM_ISA_DECODE_ATTR_I64(name) \
+  int64_t name = 0;                       \
+  do {                                    \
+    uint64_t __u64 = 0;                   \
+    IREE_VM_ISA_IMPL_READ_U64(__u64);     \
+    name = (int64_t)__u64;                \
+    ((void)name);                         \
+  } while (0)
+#define IREE_VM_ISA_DECODE_ATTR_F32(name) \
+  float name = 0.0f;                      \
+  IREE_VM_ISA_IMPL_READ_F32(name)
+#define IREE_VM_ISA_DECODE_ATTR_F64(name) \
+  double name = 0.0;                      \
+  IREE_VM_ISA_IMPL_READ_F64(name)
+
+#define IREE_VM_ISA_DECODE_FUNC_ATTR(name) IREE_VM_ISA_DECODE_CONST_I32(name)
+#define IREE_VM_ISA_DECODE_GLOBAL_ATTR(name) IREE_VM_ISA_DECODE_CONST_I32(name)
+#define IREE_VM_ISA_DECODE_RODATA_ATTR(name) IREE_VM_ISA_DECODE_CONST_I32(name)
+
+#define IREE_VM_ISA_DECODE_STRING_ATTR(name)                   \
+  uint16_t name##_length = 0;                                  \
+  IREE_VM_ISA_IMPL_READ_U16(name##_length);                    \
+  IREE_VM_ISA_REQUIRE(name##_length);                          \
+  iree_string_view_t name = iree_make_string_view(             \
+      (const char*)&IREE_VM_ISA_BYTECODE_DATA[IREE_VM_ISA_PC], \
+      (iree_host_size_t)name##_length);                        \
+  ((void)name);                                                \
+  IREE_VM_ISA_PC += (iree_vm_source_offset_t)name##_length
+
+//===----------------------------------------------------------------------===//
+// Types
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_DECODE_TYPE_ID(name) \
+  uint32_t name = 0;                     \
+  IREE_VM_ISA_IMPL_READ_U32(name);       \
+  IREE_VM_ISA_VALIDATE_TYPE_ID(name)
+
+#if !defined(IREE_VM_ISA_LOOKUP_TYPE)
+#define IREE_VM_ISA_LOOKUP_TYPE(type_id, out_type) \
+  static_assert(                                   \
+      0,                                           \
+      "IREE_VM_ISA_LOOKUP_TYPE must be defined for IREE_VM_ISA_DECODE_TYPE*")
+#endif  // !IREE_VM_ISA_LOOKUP_TYPE
+
+#define IREE_VM_ISA_DECODE_TYPE(name)            \
+  IREE_VM_ISA_DECODE_TYPE_ID(name##_type_id);    \
+  IREE_VM_ISA_TYPE_T name;                       \
+  IREE_VM_ISA_LOOKUP_TYPE(name##_type_id, name); \
+  (void)(name##_type_id)
+
+#define IREE_VM_ISA_DECODE_TYPE_OF(name) IREE_VM_ISA_DECODE_TYPE(name)
+
+//===----------------------------------------------------------------------===//
+// Register ordinals
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_DECODE_OPERAND_I32(name) \
+  uint16_t name = 0;                         \
+  IREE_VM_ISA_IMPL_READ_U16(name);           \
+  IREE_VM_ISA_VALIDATE_REG_I32(name)
+
+#define IREE_VM_ISA_DECODE_OPERAND_I64(name) \
+  uint16_t name = 0;                         \
+  IREE_VM_ISA_IMPL_READ_U16(name);           \
+  IREE_VM_ISA_VALIDATE_REG_I64(name)
+
+#define IREE_VM_ISA_DECODE_OPERAND_F32(name) \
+  uint16_t name = 0;                         \
+  IREE_VM_ISA_IMPL_READ_U16(name);           \
+  IREE_VM_ISA_VALIDATE_REG_F32(name)
+
+#define IREE_VM_ISA_DECODE_OPERAND_F64(name) \
+  uint16_t name = 0;                         \
+  IREE_VM_ISA_IMPL_READ_U16(name);           \
+  IREE_VM_ISA_VALIDATE_REG_F64(name)
+
+#define IREE_VM_ISA_DECODE_RESULT_I32(name) IREE_VM_ISA_DECODE_OPERAND_I32(name)
+#define IREE_VM_ISA_DECODE_RESULT_I64(name) IREE_VM_ISA_DECODE_OPERAND_I64(name)
+#define IREE_VM_ISA_DECODE_RESULT_F32(name) IREE_VM_ISA_DECODE_OPERAND_F32(name)
+#define IREE_VM_ISA_DECODE_RESULT_F64(name) IREE_VM_ISA_DECODE_OPERAND_F64(name)
+
+// Ref operand/result - rejects MOVE bit (for ops that don't support MOVE).
+// Defines:
+// - `<name>_ordinal`: raw encoded ordinal (includes type/move bits)
+// - `<name>`: masked ordinal index for regs_ref[]
+#define IREE_VM_ISA_DECODE_OPERAND_REF(name)                      \
+  uint16_t name##_ordinal = 0;                                    \
+  IREE_VM_ISA_IMPL_READ_U16(name##_ordinal);                      \
+  IREE_VM_ISA_VALIDATE_REG_REF_NO_MOVE(name##_ordinal);           \
+  const uint16_t name =                                           \
+      (uint16_t)(name##_ordinal & IREE_VM_ISA_REF_REGISTER_MASK); \
+  ((void)name)
+
+#define IREE_VM_ISA_DECODE_RESULT_REF(name) IREE_VM_ISA_DECODE_OPERAND_REF(name)
+
+// Ref operand/result - allows MOVE bit (for ops that support ownership
+// transfer). Defines:
+// - `<name>_ordinal`: raw encoded ordinal (includes type/move bits)
+// - `<name>_is_move`: bool indicating MOVE bit
+// - `<name>`: masked ordinal index for regs_ref[]
+#define IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(name)                 \
+  uint16_t name##_ordinal = 0;                                    \
+  IREE_VM_ISA_IMPL_READ_U16(name##_ordinal);                      \
+  IREE_VM_ISA_VALIDATE_REG_REF_ALLOW_MOVE(name##_ordinal);        \
+  const bool name##_is_move =                                     \
+      (name##_ordinal & IREE_VM_ISA_REF_REGISTER_MOVE_BIT) != 0;  \
+  ((void)name##_is_move);                                         \
+  const uint16_t name =                                           \
+      (uint16_t)(name##_ordinal & IREE_VM_ISA_REF_REGISTER_MASK); \
+  ((void)name)
+
+#define IREE_VM_ISA_DECODE_RESULT_REF_MOVE(name) \
+  IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(name)
+
+//===----------------------------------------------------------------------===//
+// Variadic aggregates
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(name)               \
+  IREE_VM_ISA_DECODE_ALIGN_PC(IREE_REGISTER_ORDINAL_SIZE);       \
+  IREE_VM_ISA_REQUIRE(IREE_REGISTER_ORDINAL_SIZE);               \
+  const iree_vm_register_list_t* name =                          \
+      (const iree_vm_register_list_t*)&IREE_VM_ISA_BYTECODE_DATA \
+          [IREE_VM_ISA_PC];                                      \
+  IREE_VM_ISA_PC += IREE_REGISTER_ORDINAL_SIZE;                  \
+  IREE_VM_ISA_REQUIRE((name)->size* IREE_REGISTER_ORDINAL_SIZE); \
+  IREE_VM_ISA_PC += (name)->size * IREE_REGISTER_ORDINAL_SIZE
+
+#define IREE_VM_ISA_DECODE_VARIADIC_RESULTS(name) \
+  IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(name)
+
+//===----------------------------------------------------------------------===//
+// Branch metadata
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_DECODE_BRANCH_TARGET_PC(name) \
+  IREE_VM_ISA_DECODE_CONST_I32(name)
+
+#define IREE_VM_ISA_DECODE_BRANCH_OPERANDS(name)                       \
+  IREE_VM_ISA_DECODE_ALIGN_PC(IREE_REGISTER_ORDINAL_SIZE);             \
+  IREE_VM_ISA_REQUIRE(IREE_REGISTER_ORDINAL_SIZE);                     \
+  const iree_vm_register_remap_list_t* name =                          \
+      (const iree_vm_register_remap_list_t*)&IREE_VM_ISA_BYTECODE_DATA \
+          [IREE_VM_ISA_PC];                                            \
+  IREE_VM_ISA_PC += IREE_REGISTER_ORDINAL_SIZE;                        \
+  IREE_VM_ISA_REQUIRE((name)->size * 2 * IREE_REGISTER_ORDINAL_SIZE);  \
+  IREE_VM_ISA_PC += (name)->size * 2 * IREE_REGISTER_ORDINAL_SIZE
+
+//===----------------------------------------------------------------------===//
+// Operand/result mapping
+//===----------------------------------------------------------------------===//
+
+// NOTE: these macros assume locals:
+//   int32_t* IREE_RESTRICT regs_i32;
+//   iree_vm_ref_t* IREE_RESTRICT regs_ref;
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(name) \
+  IREE_VM_ISA_DECODE_OPERAND_I32(name##_reg);         \
+  const int32_t name = regs_i32[name##_reg];          \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(name)   \
+  IREE_VM_ISA_DECODE_RESULT_I32(name##_reg);           \
+  int32_t* IREE_RESTRICT name = &regs_i32[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(name)    \
+  IREE_VM_ISA_DECODE_OPERAND_I64(name##_reg);            \
+  const int64_t name = *(int64_t*)&regs_i32[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(name)             \
+  IREE_VM_ISA_DECODE_RESULT_I64(name##_reg);                     \
+  int64_t* IREE_RESTRICT name = (int64_t*)&regs_i32[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(name) \
+  IREE_VM_ISA_DECODE_OPERAND_F32(name##_reg);         \
+  const float name = *(float*)&regs_i32[name##_reg];  \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(name)         \
+  IREE_VM_ISA_DECODE_RESULT_F32(name##_reg);                 \
+  float* IREE_RESTRICT name = (float*)&regs_i32[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(name)  \
+  IREE_VM_ISA_DECODE_OPERAND_F64(name##_reg);          \
+  const double name = *(double*)&regs_i32[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(name)           \
+  IREE_VM_ISA_DECODE_RESULT_F64(name##_reg);                   \
+  double* IREE_RESTRICT name = (double*)&regs_i32[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64_HOST_SIZE(name) \
+  IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(name##_i64);          \
+  const iree_host_size_t name = (iree_host_size_t)name##_i64;   \
+  ((void)name##_i64)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF(name)        \
+  IREE_VM_ISA_DECODE_OPERAND_REF(name##_reg);                \
+  iree_vm_ref_t* IREE_RESTRICT name = &regs_ref[name##_reg]; \
+  IREE_VM_ISA_DISPATCH_REF_DEBUG_CHECK(name);                \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF(name)         \
+  IREE_VM_ISA_DECODE_RESULT_REF(name##_reg);                 \
+  iree_vm_ref_t* IREE_RESTRICT name = &regs_ref[name##_reg]; \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_OPERAND_REF_MOVE(name)   \
+  IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(name##_reg);           \
+  const bool name##_is_move = name##_reg##_is_move;          \
+  ((void)name##_is_move);                                    \
+  iree_vm_ref_t* IREE_RESTRICT name = &regs_ref[name##_reg]; \
+  IREE_VM_ISA_DISPATCH_REF_DEBUG_CHECK(name);                \
+  ((void)name##_reg)
+
+#define IREE_VM_ISA_DISPATCH_DECODE_RESULT_REF_MOVE(name)    \
+  IREE_VM_ISA_DECODE_RESULT_REF_MOVE(name##_reg);            \
+  const bool name##_is_move = name##_reg##_is_move;          \
+  ((void)name##_is_move);                                    \
+  iree_vm_ref_t* IREE_RESTRICT name = &regs_ref[name##_reg]; \
+  ((void)name##_reg)
+
+// Branch target encoded as a PC (u32) converted to source offset.
+#define IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(name)                        \
+  IREE_VM_ISA_DECODE_BRANCH_TARGET_PC(name##_pc_u32);                          \
+  const iree_vm_source_offset_t name = (iree_vm_source_offset_t)name##_pc_u32; \
+  ((void)name##_pc_u32)

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -209,8 +209,10 @@ iree_status_t iree_vm_bytecode_module_flatbuffer_verify(
                               i, function_descriptor->bytecode_offset,
                               flatbuffers_uint8_vec_len(bytecode_data));
     }
-    if (function_descriptor->i32_register_count > IREE_I32_REGISTER_COUNT ||
-        function_descriptor->ref_register_count > IREE_REF_REGISTER_COUNT) {
+    if (function_descriptor->i32_register_count >
+            IREE_VM_ISA_I32_REGISTER_COUNT ||
+        function_descriptor->ref_register_count >
+            IREE_VM_ISA_REF_REGISTER_COUNT) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
           "functions[%zu] descriptor register count out of range", i);
@@ -268,8 +270,8 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     iree_vm_bytecode_verify_state_t* verify_state,
     iree_vm_FunctionSignatureDef_table_t function_signature,
     iree_vm_FunctionDescriptor_struct_t function_descriptor,
-    iree_const_byte_span_t bytecode_data, uint32_t pc, uint32_t max_pc,
-    uint32_t* out_next_pc);
+    iree_const_byte_span_t bytecode_data, iree_vm_source_offset_t pc,
+    iree_vm_source_offset_t max_pc, iree_vm_source_offset_t* out_next_pc);
 
 // NOTE: by the time this is called we have the module created and can assume
 // all information on it has been verified. The only thing this verifies is
@@ -334,11 +336,13 @@ iree_status_t iree_vm_bytecode_function_verify(
   // Ensure the register storage (rounded to the nearest power of 2) won't
   // exceed the maximum allowed registers.
   verify_state.i32_register_count = iree_math_round_up_to_pow2_u32(
-      VMMAX(1, function_descriptor->i32_register_count));
+      iree_max(1, function_descriptor->i32_register_count));
   verify_state.ref_register_count = iree_math_round_up_to_pow2_u32(
-      VMMAX(1, function_descriptor->ref_register_count));
-  if (IREE_UNLIKELY(verify_state.i32_register_count > IREE_I32_REGISTER_MASK) ||
-      IREE_UNLIKELY(verify_state.ref_register_count > IREE_REF_REGISTER_MASK)) {
+      iree_max(1, function_descriptor->ref_register_count));
+  if (IREE_UNLIKELY(verify_state.i32_register_count >
+                    IREE_VM_ISA_I32_REGISTER_MASK) ||
+      IREE_UNLIKELY(verify_state.ref_register_count >
+                    IREE_VM_ISA_REF_REGISTER_MASK)) {
     // Register count overflow. A valid compiler should never produce files that
     // hit this.
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
@@ -366,7 +370,8 @@ iree_status_t iree_vm_bytecode_function_verify(
   iree_const_byte_span_t bytecode_data = iree_make_const_byte_span(
       module->bytecode_data.data + function_descriptor->bytecode_offset,
       function_descriptor->bytecode_length);
-  const uint32_t max_pc = (uint32_t)function_descriptor->bytecode_length;
+  const iree_vm_source_offset_t max_pc =
+      (iree_vm_source_offset_t)function_descriptor->bytecode_length;
 
   // Reserve the block list. As we walk the bytecode we'll declare/define blocks
   // and then afterward verify all were found.
@@ -378,8 +383,10 @@ iree_status_t iree_vm_bytecode_function_verify(
   // Perform bytecode verification by performing a single-pass walk of all
   // function bytecode.
   iree_status_t status = iree_ok_status();
-  for (uint32_t pc = 0; pc < bytecode_data.data_length - 1;) {
-    uint32_t start_pc = pc;
+  const iree_vm_source_offset_t end_pc =
+      (iree_vm_source_offset_t)bytecode_data.data_length - 1;
+  for (iree_vm_source_offset_t pc = 0; pc < end_pc;) {
+    iree_vm_source_offset_t start_pc = pc;
     status = iree_vm_bytecode_function_verify_bytecode_op(
         module, &verify_state, function_signature_def, function_descriptor,
         bytecode_data, start_pc, max_pc, &pc);
@@ -398,11 +405,11 @@ iree_status_t iree_vm_bytecode_function_verify(
         status = iree_status_annotate_f(status, "at %.*s.%.*s+%08X",
                                         (int)module_name.size, module_name.data,
                                         (int)function_name.size,
-                                        function_name.data, start_pc);
+                                        function_name.data, (uint32_t)start_pc);
       } else {
         status = iree_status_annotate_f(status, "at %.*s@%u+%08X",
                                         (int)module_name.size, module_name.data,
-                                        function_ordinal, start_pc);
+                                        function_ordinal, (uint32_t)start_pc);
       }
 #endif  // IREE_STATUS_MODE
       break;
@@ -456,11 +463,8 @@ iree_status_t iree_vm_bytecode_function_verify(
   }
 
 // Bails if the register ordinal for the given register type is out of bounds.
-#define IREE_VM_VERIFY_REG_ORDINAL(name)                            \
-  IREE_VM_VERIFY_PC_RANGE(pc + IREE_REGISTER_ORDINAL_SIZE, max_pc); \
-  const uint32_t name = OP_I16(0);
 #define IREE_VM_VERIFY_REG_ORDINAL_X32(ordinal, category)                      \
-  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) != 0)) {          \
+  if (IREE_UNLIKELY(((ordinal) & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) != 0)) {   \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                      \
                             category                                           \
                             " register required but ref register %u provided", \
@@ -471,7 +475,7 @@ iree_status_t iree_vm_bytecode_function_verify(
                             (ordinal), verify_state->i32_register_count);      \
   }
 #define IREE_VM_VERIFY_REG_ORDINAL_X64(ordinal, category)                      \
-  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) != 0)) {          \
+  if (IREE_UNLIKELY(((ordinal) & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) != 0)) {   \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                      \
                             category                                           \
                             " register required but ref register %u provided", \
@@ -496,19 +500,19 @@ iree_status_t iree_vm_bytecode_function_verify(
 #define IREE_VM_VERIFY_REG_F64(ordinal) \
   IREE_VM_VERIFY_REG_ORDINAL_X64(ordinal, "f64");
 #define IREE_VM_VERIFY_REG_REF(ordinal)                                      \
-  if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_TYPE_BIT) == 0)) {        \
+  if (IREE_UNLIKELY(((ordinal) & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) == 0)) { \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                    \
                             "ref register required but non-ref %u provided", \
                             (ordinal));                                      \
-  } else if (IREE_UNLIKELY(((ordinal) & IREE_REF_REGISTER_MASK) >=           \
+  } else if (IREE_UNLIKELY(((ordinal) & IREE_VM_ISA_REF_REGISTER_MASK) >=    \
                            verify_state->ref_register_count)) {              \
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,                        \
                             "ref register ordinal %u out of range %u",       \
                             (ordinal), verify_state->ref_register_count);    \
   }
 #define IREE_VM_VERIFY_REG_ANY(ordinal)                                       \
-  if (((ordinal) & IREE_REF_REGISTER_TYPE_BIT) != 0) {                        \
-    int32_t ref_ordinal = (ordinal) & IREE_REF_REGISTER_MASK;                 \
+  if (((ordinal) & IREE_VM_ISA_REF_REGISTER_TYPE_BIT) != 0) {                 \
+    int32_t ref_ordinal = (ordinal) & IREE_VM_ISA_REF_REGISTER_MASK;          \
     if (IREE_UNLIKELY(ref_ordinal >= verify_state->ref_register_count)) {     \
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,                       \
                               "ref register ordinal %u out of range %u",      \
@@ -520,41 +524,130 @@ iree_status_t iree_vm_bytecode_function_verify(
                             (ordinal), verify_state->i32_register_count);     \
   }
 
-#define VM_VerifyConstI8(name)             \
-  IREE_VM_VERIFY_PC_RANGE(pc + 1, max_pc); \
-  uint8_t name = OP_I8(0);                 \
-  (void)(name);                            \
-  ++pc;
-#define VM_VerifyConstI16(name)            \
-  IREE_VM_VERIFY_PC_RANGE(pc + 2, max_pc); \
-  uint32_t name = OP_I16(0);               \
-  (void)(name);                            \
-  pc += 2;
-#define VM_VerifyConstI32(name)            \
-  IREE_VM_VERIFY_PC_RANGE(pc + 4, max_pc); \
-  uint32_t name = OP_I32(0);               \
-  (void)(name);                            \
-  pc += 4;
-#define VM_VerifyConstI64(name)            \
-  IREE_VM_VERIFY_PC_RANGE(pc + 8, max_pc); \
-  uint64_t name = OP_I64(0);               \
-  (void)(name);                            \
-  pc += 8;
-#define VM_VerifyConstF32(name)            \
-  IREE_VM_VERIFY_PC_RANGE(pc + 4, max_pc); \
-  float name = OP_F32(0);                  \
-  (void)(name);                            \
-  pc += 4;
-#define VM_VerifyConstF64(name)            \
-  IREE_VM_VERIFY_PC_RANGE(pc + 8, max_pc); \
-  double name = OP_F64(0);                 \
-  (void)(name);                            \
-  pc += 8;
+//===----------------------------------------------------------------------===//
+// ISA decoding (verifier policy)
+//===----------------------------------------------------------------------===//
 
-#define VM_VerifyFuncAttr(name) VM_VerifyConstI32(name)
-#define VM_IsImportOrdinal(name) (((name) & 0x80000000u) != 0)
-#define VM_UnmaskImportOrdinal(name) name &= ~0x80000000u
-#define VM_VerifyImportOrdinal(name)                                          \
+#define IREE_VM_ISA_BYTECODE_DATA bytecode_data
+#define IREE_VM_ISA_PC pc
+#define IREE_VM_ISA_REQUIRE(bytes) IREE_VM_VERIFY_PC_RANGE(pc + (bytes), max_pc)
+
+// Verifier wants strict bounds checks on type IDs.
+#define IREE_VM_ISA_VERIFY_TYPE_ID(type_id)                       \
+  do {                                                            \
+    if (IREE_UNLIKELY((type_id) >= module->type_count)) {         \
+      return iree_make_status(                                    \
+          IREE_STATUS_OUT_OF_RANGE,                               \
+          "type id ordinal out of range: %u (table=%" PRIhsz ")", \
+          (uint32_t)(type_id), module->type_count);               \
+    }                                                             \
+  } while (0)
+
+// Type lookups in the verifier use pointers into the module type table.
+#define IREE_VM_ISA_TYPE_T const iree_vm_type_def_t*
+#define IREE_VM_ISA_LOOKUP_TYPE(type_id, out_type) \
+  do {                                             \
+    (out_type) = &module->type_table[(type_id)];   \
+  } while (0)
+
+// Register validation uses the verifier's current register-count limits.
+#define IREE_VM_ISA_VERIFY_REG_I32(ordinal) \
+  do {                                      \
+    IREE_VM_VERIFY_REG_I32(ordinal);        \
+  } while (0)
+#define IREE_VM_ISA_VERIFY_REG_I64(ordinal) \
+  do {                                      \
+    IREE_VM_VERIFY_REG_I64(ordinal);        \
+  } while (0)
+#define IREE_VM_ISA_VERIFY_REG_F32(ordinal) \
+  do {                                      \
+    IREE_VM_VERIFY_REG_F32(ordinal);        \
+  } while (0)
+#define IREE_VM_ISA_VERIFY_REG_F64(ordinal) \
+  do {                                      \
+    IREE_VM_VERIFY_REG_F64(ordinal);        \
+  } while (0)
+#define IREE_VM_ISA_VERIFY_REG_ANY(ordinal) \
+  do {                                      \
+    IREE_VM_VERIFY_REG_ANY(ordinal);        \
+  } while (0)
+
+// Ref register validation differs based on whether the op supports MOVE.
+#define IREE_VM_ISA_VERIFY_REG_REF_ALLOW_MOVE(ordinal) \
+  do {                                                 \
+    IREE_VM_VERIFY_REG_REF(ordinal);                   \
+  } while (0)
+#define IREE_VM_ISA_VERIFY_REG_REF_NO_MOVE(ordinal)                        \
+  do {                                                                     \
+    IREE_VM_VERIFY_REG_REF(ordinal);                                       \
+    if (IREE_UNLIKELY((ordinal) & IREE_VM_ISA_REF_REGISTER_MOVE_BIT)) {    \
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                \
+                              "ref register has MOVE bit but op does not " \
+                              "support MOVE");                             \
+    }                                                                      \
+  } while (0)
+
+#include "iree/vm/bytecode/utils/isa_decoder.inl"
+
+//===----------------------------------------------------------------------===//
+// Verifier-specific helpers for decoded aggregates
+//===----------------------------------------------------------------------===//
+
+#define IREE_VM_ISA_VERIFY_BRANCH_TARGET(name)             \
+  IREE_VM_ISA_DECODE_BRANCH_TARGET_PC(name);               \
+  iree_vm_bytecode_block_t* name##_block = NULL;           \
+  IREE_RETURN_IF_ERROR(iree_vm_bytecode_block_list_insert( \
+      &verify_state->block_list, (name), &name##_block));  \
+  (void)(name##_block)
+
+#define IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(name)        \
+  IREE_VM_ISA_DECODE_BRANCH_OPERANDS(name);             \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {   \
+    IREE_VM_VERIFY_REG_ANY((name)->pairs[__i].src_reg); \
+    IREE_VM_VERIFY_REG_ANY((name)->pairs[__i].dst_reg); \
+  }
+
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name) \
+  IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(name)
+#define IREE_VM_ISA_VERIFY_VARIADIC_RESULTS(name) \
+  IREE_VM_ISA_DECODE_VARIADIC_RESULTS(name)
+
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_I32(name) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name);          \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {  \
+    IREE_VM_VERIFY_REG_I32((name)->registers[__i]);    \
+  }
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_I64(name) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name);          \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {  \
+    IREE_VM_VERIFY_REG_I64((name)->registers[__i]);    \
+  }
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_F32(name) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name);          \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {  \
+    IREE_VM_VERIFY_REG_F32((name)->registers[__i]);    \
+  }
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_F64(name) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name);          \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {  \
+    IREE_VM_VERIFY_REG_F64((name)->registers[__i]);    \
+  }
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_REF(name, type_def) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name);                    \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {            \
+    IREE_VM_VERIFY_REG_REF((name)->registers[__i]);              \
+  }                                                              \
+  (void)(type_def)
+#define IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(name) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS(name);          \
+  for (uint16_t __i = 0; __i < (name)->size; ++__i) {  \
+    IREE_VM_VERIFY_REG_ANY((name)->registers[__i]);    \
+  }
+
+#define IREE_VM_ISA_VERIFY_VARIADIC_RESULTS_ANY(name) \
+  IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(name)
+
+#define IREE_VM_ISA_VERIFY_IMPORT_ORDINAL(name)                               \
   if (IREE_UNLIKELY((name) >= iree_vm_ImportFunctionDef_vec_len(              \
                                   verify_state->imported_functions))) {       \
     return iree_make_status(                                                  \
@@ -562,7 +655,7 @@ iree_status_t iree_vm_bytecode_function_verify(
         name,                                                                 \
         iree_vm_ImportFunctionDef_vec_len(verify_state->imported_functions)); \
   }
-#define VM_VerifyFunctionOrdinal(name)                                      \
+#define IREE_VM_ISA_VERIFY_FUNCTION_ORDINAL(name)                           \
   if (IREE_UNLIKELY((name)) >= iree_vm_FunctionDescriptor_vec_len(          \
                                    verify_state->function_descriptors)) {   \
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                   \
@@ -570,8 +663,7 @@ iree_status_t iree_vm_bytecode_function_verify(
                             iree_vm_FunctionDescriptor_vec_len(             \
                                 verify_state->function_descriptors));       \
   }
-#define VM_VerifyGlobalAttr(name) VM_VerifyConstI32(name)
-#define VM_VerifyRwdataOffset(name, access_length)                          \
+#define IREE_VM_ISA_VERIFY_RWDATA_OFFSET(name, access_length)               \
   if (IREE_UNLIKELY(((name) + (access_length)) >                            \
                     verify_state->rwdata_storage_size)) {                   \
     return iree_make_status(                                                \
@@ -579,250 +671,102 @@ iree_status_t iree_vm_bytecode_function_verify(
         "global byte_offset out of range: %d (rwdata=%" PRIhsz ")", (name), \
         verify_state->rwdata_storage_size);                                 \
   }
-#define VM_VerifyGlobalRefOrdinal(name)                                    \
+#define IREE_VM_ISA_VERIFY_GLOBAL_REF_ORDINAL(name)                        \
   if (IREE_UNLIKELY((name) >= verify_state->global_ref_count)) {           \
     return iree_make_status(                                               \
         IREE_STATUS_OUT_OF_RANGE,                                          \
         "global ref ordinal out of range: %d (table=%" PRIhsz ")", (name), \
         verify_state->global_ref_count);                                   \
   }
-#define VM_VerifyRodataAttr(name) VM_VerifyConstI32(name)
-#define VM_VerifyRodataOrdinal(name)                                       \
+#define IREE_VM_ISA_VERIFY_RODATA_ORDINAL(name)                            \
   if (IREE_UNLIKELY((name) >= verify_state->rodata_ref_count)) {           \
     return iree_make_status(                                               \
         IREE_STATUS_OUT_OF_RANGE,                                          \
         "rodata ref ordinal out of range: %d (table=%" PRIhsz ")", (name), \
         verify_state->rodata_ref_count);                                   \
   }
-#define VM_VerifyType(name)                                                    \
-  IREE_VM_VERIFY_PC_RANGE(pc + 4, max_pc);                                     \
-  uint32_t name##_id = OP_I32(0);                                              \
-  if (IREE_UNLIKELY(name##_id >= module->type_count)) {                        \
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,                          \
-                            "type id ordinal out of range: %d (table=%" PRIhsz \
-                            ")",                                               \
-                            name##_id, module->type_count);                    \
-  }                                                                            \
-  const iree_vm_type_def_t* name = &module->type_table[name##_id];             \
-  (void)(name);                                                                \
-  pc += 4;
-#define VM_VerifyTypeOf(name) VM_VerifyType(name)
-#define VM_VerifyAttrI32(name) VM_VerifyConstI32(name)
-#define VM_VerifyAttrI64(name) VM_VerifyConstI64(name)
-#define VM_VerifyAttrF32(name) VM_VerifyConstF32(name)
-#define VM_VerifyAttrF64(name) VM_VerifyConstF64(name)
-#define VM_VerifyStrAttr(name, out_str)                      \
-  IREE_VM_VERIFY_PC_RANGE(pc + 2, max_pc);                   \
-  (out_str)->size = (iree_host_size_t)OP_I16(0);             \
-  IREE_VM_VERIFY_PC_RANGE(pc + 2 + (out_str)->size, max_pc); \
-  (out_str)->data = (const char*)&bytecode_data[pc + 2];     \
-  pc += 2 + (out_str)->size;
-
-#define VM_VerifyBranchTarget(name)                        \
-  VM_VerifyConstI32(name##_pc);                            \
-  iree_vm_bytecode_block_t* name = NULL;                   \
-  IREE_RETURN_IF_ERROR(iree_vm_bytecode_block_list_insert( \
-      &verify_state->block_list, name##_pc, &name));
-#define VM_VerifyBranchOperands(name)                                         \
-  VM_AlignPC(pc, IREE_REGISTER_ORDINAL_SIZE);                                 \
-  IREE_VM_VERIFY_PC_RANGE(pc + IREE_REGISTER_ORDINAL_SIZE, max_pc);           \
-  const iree_vm_register_remap_list_t* name =                                 \
-      (const iree_vm_register_remap_list_t*)&bytecode_data[pc];               \
-  pc += IREE_REGISTER_ORDINAL_SIZE;                                           \
-  IREE_VM_VERIFY_PC_RANGE(pc + (name)->size * 2 * IREE_REGISTER_ORDINAL_SIZE, \
-                          max_pc);                                            \
-  pc += (name)->size * 2 * IREE_REGISTER_ORDINAL_SIZE;                        \
-  for (uint16_t i = 0; i < name->size; ++i) {                                 \
-    IREE_VM_VERIFY_REG_ANY(name->pairs[i].src_reg);                           \
-    IREE_VM_VERIFY_REG_ANY(name->pairs[i].dst_reg);                           \
-  }
-
-#define VM_VerifyOperandRegI32(name)          \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_I32(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyOperandRegI64(name)          \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_I64(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyOperandRegI64HostSize(name) VM_VerifyOperandRegI64(name)
-#define VM_VerifyOperandRegF32(name)          \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_F32(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyOperandRegF64(name)          \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_F32(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Operand ref - rejects MOVE bit (default, for ops that don't support MOVE).
-#define VM_VerifyOperandRegRef(name)                                     \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal);                            \
-  IREE_VM_VERIFY_REG_REF(name##_ordinal);                                \
-  if (IREE_UNLIKELY((name##_ordinal) & IREE_REF_REGISTER_MOVE_BIT)) {    \
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                \
-                            "ref register has MOVE bit but op does not " \
-                            "support MOVE");                             \
-  }                                                                      \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Operand ref - allows MOVE bit (for ops that support ownership transfer).
-#define VM_VerifyOperandRegRefMove(name)      \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_REF(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyVariadicOperands(name)                                   \
-  VM_AlignPC(pc, IREE_REGISTER_ORDINAL_SIZE);                             \
-  IREE_VM_VERIFY_PC_RANGE(pc + IREE_REGISTER_ORDINAL_SIZE, max_pc);       \
-  const iree_vm_register_list_t* name =                                   \
-      (const iree_vm_register_list_t*)&bytecode_data[pc];                 \
-  pc += IREE_REGISTER_ORDINAL_SIZE;                                       \
-  IREE_VM_VERIFY_PC_RANGE(pc + (name)->size * IREE_REGISTER_ORDINAL_SIZE, \
-                          max_pc);                                        \
-  pc += (name)->size * IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyVariadicOperandsI32(name)            \
-  VM_VerifyVariadicOperands(name);                    \
-  for (uint16_t __i = 0; __i < (name)->size; ++__i) { \
-    IREE_VM_VERIFY_REG_I32((name)->registers[__i]);   \
-  }
-#define VM_VerifyVariadicOperandsI64(name)            \
-  VM_VerifyVariadicOperands(name);                    \
-  for (uint16_t __i = 0; __i < (name)->size; ++__i) { \
-    IREE_VM_VERIFY_REG_I64((name)->registers[__i]);   \
-  }
-#define VM_VerifyVariadicOperandsF32(name)            \
-  VM_VerifyVariadicOperands(name);                    \
-  for (uint16_t __i = 0; __i < (name)->size; ++__i) { \
-    IREE_VM_VERIFY_REG_F32((name)->registers[__i]);   \
-  }
-#define VM_VerifyVariadicOperandsF64(name)            \
-  VM_VerifyVariadicOperands(name);                    \
-  for (uint16_t __i = 0; __i < (name)->size; ++__i) { \
-    IREE_VM_VERIFY_REG_F64((name)->registers[__i]);   \
-  }
-#define VM_VerifyVariadicOperandsRef(name, type_def)  \
-  VM_VerifyVariadicOperands(name);                    \
-  for (uint16_t __i = 0; __i < (name)->size; ++__i) { \
-    IREE_VM_VERIFY_REG_REF((name)->registers[__i]);   \
-  }
-#define VM_VerifyVariadicOperandsAny(name)            \
-  VM_VerifyVariadicOperands(name);                    \
-  for (uint16_t __i = 0; __i < (name)->size; ++__i) { \
-    IREE_VM_VERIFY_REG_ANY((name)->registers[__i]);   \
-  }
-#define VM_VerifyResultRegI32(name)           \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_I32(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyResultRegI64(name)           \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_I64(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyResultRegF32(name)           \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_F32(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyResultRegF64(name)           \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_F64(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Result ref - rejects MOVE bit (default, for ops that don't support MOVE).
-#define VM_VerifyResultRegRef(name)                                      \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal);                            \
-  IREE_VM_VERIFY_REG_REF(name##_ordinal);                                \
-  if (IREE_UNLIKELY((name##_ordinal) & IREE_REF_REGISTER_MOVE_BIT)) {    \
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                \
-                            "ref register has MOVE bit but op does not " \
-                            "support MOVE");                             \
-  }                                                                      \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-// Result ref - allows MOVE bit (for ops that support ownership transfer).
-#define VM_VerifyResultRegRefMove(name)       \
-  IREE_VM_VERIFY_REG_ORDINAL(name##_ordinal); \
-  IREE_VM_VERIFY_REG_REF(name##_ordinal);     \
-  pc += IREE_REGISTER_ORDINAL_SIZE;
-#define VM_VerifyVariadicResultsAny(name) VM_VerifyVariadicOperandsAny(name)
-
-#define VERIFY_OP_CORE_UNARY_I32(op_name) \
-  VERIFY_OP(CORE, op_name, {              \
-    VM_VerifyOperandRegI32(operand);      \
-    VM_VerifyResultRegI32(result);        \
+#define IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {              \
+    IREE_VM_ISA_DECODE_OPERAND_I32(operand);          \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);            \
   });
 
-#define VERIFY_OP_CORE_UNARY_I64(op_name) \
-  VERIFY_OP(CORE, op_name, {              \
-    VM_VerifyOperandRegI64(operand);      \
-    VM_VerifyResultRegI64(result);        \
+#define IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {              \
+    IREE_VM_ISA_DECODE_OPERAND_I64(operand);          \
+    IREE_VM_ISA_DECODE_RESULT_I64(result);            \
   });
 
-#define VERIFY_OP_CORE_BINARY_I32(op_name) \
-  VERIFY_OP(CORE, op_name, {               \
-    VM_VerifyOperandRegI32(lhs);           \
-    VM_VerifyOperandRegI32(rhs);           \
-    VM_VerifyResultRegI32(result);         \
+#define IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {               \
+    IREE_VM_ISA_DECODE_OPERAND_I32(lhs);               \
+    IREE_VM_ISA_DECODE_OPERAND_I32(rhs);               \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);             \
   });
 
-#define VERIFY_OP_CORE_BINARY_I64(op_name) \
-  VERIFY_OP(CORE, op_name, {               \
-    VM_VerifyOperandRegI64(lhs);           \
-    VM_VerifyOperandRegI64(rhs);           \
-    VM_VerifyResultRegI64(result);         \
+#define IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {               \
+    IREE_VM_ISA_DECODE_OPERAND_I64(lhs);               \
+    IREE_VM_ISA_DECODE_OPERAND_I64(rhs);               \
+    IREE_VM_ISA_DECODE_RESULT_I64(result);             \
   });
 
-#define VERIFY_OP_CORE_TERNARY_I32(op_name) \
-  VERIFY_OP(CORE, op_name, {                \
-    VM_VerifyOperandRegI32(a);              \
-    VM_VerifyOperandRegI32(b);              \
-    VM_VerifyOperandRegI32(c);              \
-    VM_VerifyResultRegI32(result);          \
+#define IREE_VM_ISA_VERIFY_OP_CORE_TERNARY_I32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {                \
+    IREE_VM_ISA_DECODE_OPERAND_I32(a);                  \
+    IREE_VM_ISA_DECODE_OPERAND_I32(b);                  \
+    IREE_VM_ISA_DECODE_OPERAND_I32(c);                  \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);              \
   });
 
-#define VERIFY_OP_CORE_TERNARY_I64(op_name) \
-  VERIFY_OP(CORE, op_name, {                \
-    VM_VerifyOperandRegI64(a);              \
-    VM_VerifyOperandRegI64(b);              \
-    VM_VerifyOperandRegI64(c);              \
-    VM_VerifyResultRegI64(result);          \
+#define IREE_VM_ISA_VERIFY_OP_CORE_TERNARY_I64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {                \
+    IREE_VM_ISA_DECODE_OPERAND_I64(a);                  \
+    IREE_VM_ISA_DECODE_OPERAND_I64(b);                  \
+    IREE_VM_ISA_DECODE_OPERAND_I64(c);                  \
+    IREE_VM_ISA_DECODE_RESULT_I64(result);              \
   });
 
-#define VERIFY_OP_EXT_F32_UNARY_F32(op_name) \
-  VERIFY_OP(EXT_F32, op_name, {              \
-    VM_VerifyOperandRegF32(operand);         \
-    VM_VerifyResultRegF32(result);           \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F32, op_name, {              \
+    IREE_VM_ISA_DECODE_OPERAND_F32(operand);             \
+    IREE_VM_ISA_DECODE_RESULT_F32(result);               \
   });
 
-#define VERIFY_OP_EXT_F32_BINARY_F32(op_name) \
-  VERIFY_OP(EXT_F32, op_name, {               \
-    VM_VerifyOperandRegF32(lhs);              \
-    VM_VerifyOperandRegF32(rhs);              \
-    VM_VerifyResultRegF32(result);            \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F32, op_name, {               \
+    IREE_VM_ISA_DECODE_OPERAND_F32(lhs);                  \
+    IREE_VM_ISA_DECODE_OPERAND_F32(rhs);                  \
+    IREE_VM_ISA_DECODE_RESULT_F32(result);                \
   });
 
-#define VERIFY_OP_EXT_F32_TERNARY_F32(op_name) \
-  VERIFY_OP(EXT_F32, op_name, {                \
-    VM_VerifyOperandRegF32(a);                 \
-    VM_VerifyOperandRegF32(b);                 \
-    VM_VerifyOperandRegF32(c);                 \
-    VM_VerifyResultRegF32(result);             \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F32_TERNARY_F32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F32, op_name, {                \
+    IREE_VM_ISA_DECODE_OPERAND_F32(a);                     \
+    IREE_VM_ISA_DECODE_OPERAND_F32(b);                     \
+    IREE_VM_ISA_DECODE_OPERAND_F32(c);                     \
+    IREE_VM_ISA_DECODE_RESULT_F32(result);                 \
   });
 
-#define VERIFY_OP_EXT_F64_UNARY_F64(op_name) \
-  VERIFY_OP(EXT_F64, op_name, {              \
-    VM_VerifyOperandRegF64(operand);         \
-    VM_VerifyResultRegF64(result);           \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F64, op_name, {              \
+    IREE_VM_ISA_DECODE_OPERAND_F64(operand);             \
+    IREE_VM_ISA_DECODE_RESULT_F64(result);               \
   });
 
-#define VERIFY_OP_EXT_F64_BINARY_F64(op_name) \
-  VERIFY_OP(EXT_F64, op_name, {               \
-    VM_VerifyOperandRegF64(lhs);              \
-    VM_VerifyOperandRegF64(rhs);              \
-    VM_VerifyResultRegF64(result);            \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F64, op_name, {               \
+    IREE_VM_ISA_DECODE_OPERAND_F64(lhs);                  \
+    IREE_VM_ISA_DECODE_OPERAND_F64(rhs);                  \
+    IREE_VM_ISA_DECODE_RESULT_F64(result);                \
   });
 
-#define VERIFY_OP_EXT_F64_TERNARY_F64(op_name) \
-  VERIFY_OP(EXT_F64, op_name, {                \
-    VM_VerifyOperandRegF64(a);                 \
-    VM_VerifyOperandRegF64(b);                 \
-    VM_VerifyOperandRegF64(c);                 \
-    VM_VerifyResultRegF64(result);             \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F64_TERNARY_F64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F64, op_name, {                \
+    IREE_VM_ISA_DECODE_OPERAND_F64(a);                     \
+    IREE_VM_ISA_DECODE_OPERAND_F64(b);                     \
+    IREE_VM_ISA_DECODE_OPERAND_F64(c);                     \
+    IREE_VM_ISA_DECODE_RESULT_F64(result);                 \
   });
 
 //===----------------------------------------------------------------------===//
@@ -1021,9 +965,9 @@ static iree_status_t iree_vm_bytecode_function_verify_call(
 // Bytecode verification
 //===----------------------------------------------------------------------===//
 
-#define VERIFY_OP(ext, op_name, body)  \
-  case IREE_VM_OP_##ext##_##op_name: { \
-    body;                              \
+#define IREE_VM_ISA_VERIFY_OP(ext, op_name, body) \
+  case IREE_VM_OP_##ext##_##op_name: {            \
+    body;                                         \
   } break;
 
 #define BEGIN_VERIFY_PREFIX(op_name, ext)    \
@@ -1050,10 +994,10 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     iree_vm_bytecode_verify_state_t* verify_state,
     iree_vm_FunctionSignatureDef_table_t function_signature,
     iree_vm_FunctionDescriptor_struct_t function_descriptor,
-    iree_const_byte_span_t function_bytecode, uint32_t start_pc,
-    uint32_t max_pc, uint32_t* out_next_pc) {
+    iree_const_byte_span_t function_bytecode, iree_vm_source_offset_t start_pc,
+    iree_vm_source_offset_t max_pc, iree_vm_source_offset_t* out_next_pc) {
   *out_next_pc = 0;
-  uint32_t pc = start_pc;
+  iree_vm_source_offset_t pc = start_pc;
   const uint8_t* bytecode_data = function_bytecode.data;
 
   // NOTE: we keep this as simple as possible so that we can one day auto
@@ -1067,14 +1011,14 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     // If not in a block then the next opcode must be a block.
     if (bytecode_data[pc] != IREE_VM_OP_CORE_Block) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "op at pc %08X is not in a block", pc);
+                              "op at pc %08" PRIX64 " is not in a block", pc);
     }
   } else {
     // If in a block then the next opcode must not be a block.
     if (bytecode_data[pc] == IREE_VM_OP_CORE_Block) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "op at pc %08X is a block while still in a block",
-                              pc);
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "op at pc %08" PRIX64 " is a block while still in a block", pc);
     }
   }
 
@@ -1084,497 +1028,502 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     // Globals
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, GlobalLoadI32, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 4);
-      VM_VerifyResultRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalLoadI32, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_DECODE_RESULT_I32(value);
     });
 
-    VERIFY_OP(CORE, GlobalStoreI32, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 4);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalStoreI32, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
     });
 
-    VERIFY_OP(CORE, GlobalLoadIndirectI32, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalLoadIndirectI32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyResultRegI32(value);
+      IREE_VM_ISA_DECODE_RESULT_I32(value);
     });
 
-    VERIFY_OP(CORE, GlobalStoreIndirectI32, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalStoreIndirectI32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyOperandRegI32(value);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
     });
 
-    VERIFY_OP(CORE, GlobalLoadI64, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 8);
-      VM_VerifyResultRegI64(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalLoadI64, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 8);
+      IREE_VM_ISA_DECODE_RESULT_I64(value);
     });
 
-    VERIFY_OP(CORE, GlobalStoreI64, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 8);
-      VM_VerifyOperandRegI64(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalStoreI64, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 8);
+      IREE_VM_ISA_DECODE_OPERAND_I64(value);
     });
 
-    VERIFY_OP(CORE, GlobalLoadIndirectI64, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalLoadIndirectI64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyResultRegI64(value);
+      IREE_VM_ISA_DECODE_RESULT_I64(value);
     });
 
-    VERIFY_OP(CORE, GlobalStoreIndirectI64, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalStoreIndirectI64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyOperandRegI64(value);
+      IREE_VM_ISA_DECODE_OPERAND_I64(value);
     });
 
-    VERIFY_OP(CORE, GlobalLoadRef, {
-      VM_VerifyGlobalAttr(global);
-      VM_VerifyGlobalRefOrdinal(global);
-      VM_VerifyTypeOf(type_def);
-      VM_VerifyResultRegRefMove(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalLoadRef, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(global);
+      IREE_VM_ISA_VERIFY_GLOBAL_REF_ORDINAL(global);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(value);
     });
 
-    VERIFY_OP(CORE, GlobalStoreRef, {
-      VM_VerifyGlobalAttr(global);
-      VM_VerifyGlobalRefOrdinal(global);
-      VM_VerifyTypeOf(type_def);
-      VM_VerifyOperandRegRefMove(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalStoreRef, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(global);
+      IREE_VM_ISA_VERIFY_GLOBAL_REF_ORDINAL(global);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(value);
     });
 
-    VERIFY_OP(CORE, GlobalLoadIndirectRef, {
-      VM_VerifyOperandRegI32(global);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalLoadIndirectRef, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(global);
       // NOTE: we have to verify the ordinal at runtime.
-      VM_VerifyTypeOf(type_def);
-      VM_VerifyResultRegRefMove(value);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(value);
     });
 
-    VERIFY_OP(CORE, GlobalStoreIndirectRef, {
-      VM_VerifyOperandRegI32(global);
+    IREE_VM_ISA_VERIFY_OP(CORE, GlobalStoreIndirectRef, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(global);
       // NOTE: we have to verify the ordinal at runtime.
-      VM_VerifyTypeOf(type_def);
-      VM_VerifyOperandRegRefMove(value);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(value);
     });
 
     //===------------------------------------------------------------------===//
     // Constants
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, ConstI32, {
-      VM_VerifyAttrI32(value);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ConstI32, {
+      IREE_VM_ISA_DECODE_ATTR_I32(value);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, ConstI32Zero, { VM_VerifyResultRegI32(result); });
+    IREE_VM_ISA_VERIFY_OP(CORE, ConstI32Zero,
+                          { IREE_VM_ISA_DECODE_RESULT_I32(result); });
 
-    VERIFY_OP(CORE, ConstI64, {
-      VM_VerifyAttrI64(value);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ConstI64, {
+      IREE_VM_ISA_DECODE_ATTR_I64(value);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
-    VERIFY_OP(CORE, ConstI64Zero, { VM_VerifyResultRegI64(result); });
+    IREE_VM_ISA_VERIFY_OP(CORE, ConstI64Zero,
+                          { IREE_VM_ISA_DECODE_RESULT_I64(result); });
 
-    VERIFY_OP(CORE, ConstRefZero, { VM_VerifyResultRegRefMove(result); });
+    IREE_VM_ISA_VERIFY_OP(CORE, ConstRefZero,
+                          { IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result); });
 
-    VERIFY_OP(CORE, DiscardRefs, { VM_VerifyVariadicOperandsAny(refs); });
+    IREE_VM_ISA_VERIFY_OP(CORE, DiscardRefs,
+                          { IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(refs); });
 
-    VERIFY_OP(CORE, AssignRef, {
-      VM_VerifyOperandRegRefMove(source);
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, AssignRef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(source);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
-    VERIFY_OP(CORE, ConstRefRodata, {
-      VM_VerifyRodataAttr(rodata);
-      VM_VerifyRodataOrdinal(rodata);
-      VM_VerifyResultRegRefMove(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, ConstRefRodata, {
+      IREE_VM_ISA_DECODE_RODATA_ATTR(rodata);
+      IREE_VM_ISA_VERIFY_RODATA_ORDINAL(rodata);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(value);
     });
 
     //===------------------------------------------------------------------===//
     // Buffers
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, BufferAlloc, {
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegI32(alignment);
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferAlloc, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_I32(alignment);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
-    VERIFY_OP(CORE, BufferClone, {
-      VM_VerifyOperandRegRef(source);  // Source buffer - no MOVE.
-      VM_VerifyOperandRegI64HostSize(offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegI32(alignment);
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferClone, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source);  // Source buffer - no MOVE.
+      IREE_VM_ISA_DECODE_OPERAND_I64(offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_I32(alignment);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
-    VERIFY_OP(CORE, BufferLength, {
-      VM_VerifyOperandRegRef(buffer);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLength, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(buffer);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
-    VERIFY_OP(CORE, BufferCopy, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferCopy, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
     });
 
-    VERIFY_OP(CORE, BufferCompare, {
-      VM_VerifyOperandRegRef(lhs_buffer);
-      VM_VerifyOperandRegI64HostSize(lhs_offset);
-      VM_VerifyOperandRegRef(rhs_buffer);
-      VM_VerifyOperandRegI64HostSize(rhs_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferCompare, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(lhs_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(lhs_offset);
+      IREE_VM_ISA_DECODE_OPERAND_REF(rhs_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(rhs_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, BufferFillI8, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferFillI8, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
     });
-    VERIFY_OP(CORE, BufferFillI16, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferFillI16, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
     });
-    VERIFY_OP(CORE, BufferFillI32, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferFillI32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
     });
-    VERIFY_OP(CORE, BufferFillI64, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegI64(value);
-    });
-
-    VERIFY_OP(CORE, BufferLoadI8U, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegI32(result);
-    });
-    VERIFY_OP(CORE, BufferLoadI8S, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegI32(result);
-    });
-    VERIFY_OP(CORE, BufferLoadI16U, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegI32(result);
-    });
-    VERIFY_OP(CORE, BufferLoadI16S, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegI32(result);
-    });
-    VERIFY_OP(CORE, BufferLoadI32, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegI32(result);
-    });
-    VERIFY_OP(CORE, BufferLoadI64, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferFillI64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_I64(value);
     });
 
-    VERIFY_OP(CORE, BufferStoreI8, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLoadI8U, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, BufferStoreI16, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLoadI8S, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, BufferStoreI32, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI32(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLoadI16U, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, BufferStoreI64, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLoadI16S, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, BufferHash, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLoadI32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
+    });
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferLoadI64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
+    });
+
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferStoreI8, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
+    });
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferStoreI16, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
+    });
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferStoreI32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I32(value);
+    });
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferStoreI64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(value);
+    });
+    IREE_VM_ISA_VERIFY_OP(CORE, BufferHash, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
     //===------------------------------------------------------------------===//
     // Lists
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, ListAlloc, {
-      VM_VerifyTypeOf(element_type);
-      VM_VerifyOperandRegI32(initial_capacity);
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListAlloc, {
+      IREE_VM_ISA_DECODE_TYPE_OF(element_type);
+      IREE_VM_ISA_DECODE_OPERAND_I32(initial_capacity);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
-    VERIFY_OP(CORE, ListReserve, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(minimum_capacity);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListReserve, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(minimum_capacity);
     });
 
-    VERIFY_OP(CORE, ListSize, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListSize, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, ListResize, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(new_size);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListResize, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(new_size);
     });
 
-    VERIFY_OP(CORE, ListGetI32, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListGetI32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, ListSetI32, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegI32(raw_value);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListSetI32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_I32(raw_value);
     });
 
-    VERIFY_OP(CORE, ListGetI64, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListGetI64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
-    VERIFY_OP(CORE, ListSetI64, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegI64(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListSetI64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_I64(value);
     });
 
-    VERIFY_OP(CORE, ListGetRef, {
-      VM_VerifyOperandRegRef(list);  // List operand - no MOVE.
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyTypeOf(type_def);
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListGetRef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);  // List operand - no MOVE.
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
-    VERIFY_OP(CORE, ListSetRef, {
-      VM_VerifyOperandRegRef(list);  // List operand - no MOVE.
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegRefMove(value);
+    IREE_VM_ISA_VERIFY_OP(CORE, ListSetRef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);  // List operand - no MOVE.
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(value);
     });
 
     //===------------------------------------------------------------------===//
     // Conditional assignment
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, SelectI32, {
-      VM_VerifyOperandRegI32(condition);
-      VM_VerifyOperandRegI32(true_value);
-      VM_VerifyOperandRegI32(false_value);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, SelectI32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DECODE_OPERAND_I32(true_value);
+      IREE_VM_ISA_DECODE_OPERAND_I32(false_value);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, SelectI64, {
-      VM_VerifyOperandRegI32(condition);
-      VM_VerifyOperandRegI64(true_value);
-      VM_VerifyOperandRegI64(false_value);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, SelectI64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DECODE_OPERAND_I64(true_value);
+      IREE_VM_ISA_DECODE_OPERAND_I64(false_value);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
-    VERIFY_OP(CORE, SelectRef, {
-      VM_VerifyOperandRegI32(condition);
+    IREE_VM_ISA_VERIFY_OP(CORE, SelectRef, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
       // TODO(benvanik): remove the type_id and use either LHS/RHS (if both are
       // null then output is always null so no need to know the type).
-      VM_VerifyTypeOf(true_value_type_def);
-      VM_VerifyOperandRegRefMove(true_value);
-      VM_VerifyOperandRegRefMove(false_value);
-      VM_VerifyResultRegRefMove(result);
+      IREE_VM_ISA_DECODE_TYPE_OF(true_value_type_def);
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(true_value);
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(false_value);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
-    VERIFY_OP(CORE, SwitchI32, {
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegI32(default_value);
-      VM_VerifyVariadicOperandsI32(values);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, SwitchI32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_I32(default_value);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_I32(values);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, SwitchI64, {
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegI64(default_value);
-      VM_VerifyVariadicOperandsI64(values);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, SwitchI64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_I64(default_value);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_I64(values);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
-    VERIFY_OP(CORE, SwitchRef, {
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyTypeOf(type_def);
-      VM_VerifyOperandRegRefMove(default_value);
-      VM_VerifyVariadicOperandsRef(values,
-                                   type_def);  // TODO: add Move variant.
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, SwitchRef, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_TYPE_OF(type_def);
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(default_value);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_REF(
+          values,
+          type_def);  // TODO: add Move variant.
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
     //===------------------------------------------------------------------===//
     // Native integer arithmetic
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP_CORE_BINARY_I32(AddI32);
-    VERIFY_OP_CORE_BINARY_I32(SubI32);
-    VERIFY_OP_CORE_BINARY_I32(MulI32);
-    VERIFY_OP_CORE_BINARY_I32(DivI32S);
-    VERIFY_OP_CORE_BINARY_I32(DivI32U);
-    VERIFY_OP_CORE_BINARY_I32(RemI32S);
-    VERIFY_OP_CORE_BINARY_I32(RemI32U);
-    VERIFY_OP_CORE_TERNARY_I32(FMAI32);
-    VERIFY_OP_CORE_UNARY_I32(AbsI32);
-    VERIFY_OP_CORE_BINARY_I32(MinI32S);
-    VERIFY_OP_CORE_BINARY_I32(MinI32U);
-    VERIFY_OP_CORE_BINARY_I32(MaxI32S);
-    VERIFY_OP_CORE_BINARY_I32(MaxI32U);
-    VERIFY_OP_CORE_UNARY_I32(NotI32);
-    VERIFY_OP_CORE_BINARY_I32(AndI32);
-    VERIFY_OP_CORE_BINARY_I32(OrI32);
-    VERIFY_OP_CORE_BINARY_I32(XorI32);
-    VERIFY_OP_CORE_UNARY_I32(CtlzI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(AddI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(SubI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(MulI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(DivI32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(DivI32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(RemI32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(RemI32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_TERNARY_I32(FMAI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(AbsI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(MinI32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(MinI32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(MaxI32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(MaxI32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(NotI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(AndI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(OrI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(XorI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(CtlzI32);
 
-    VERIFY_OP_CORE_BINARY_I64(AddI64);
-    VERIFY_OP_CORE_BINARY_I64(SubI64);
-    VERIFY_OP_CORE_BINARY_I64(MulI64);
-    VERIFY_OP_CORE_BINARY_I64(DivI64S);
-    VERIFY_OP_CORE_BINARY_I64(DivI64U);
-    VERIFY_OP_CORE_BINARY_I64(RemI64S);
-    VERIFY_OP_CORE_BINARY_I64(RemI64U);
-    VERIFY_OP_CORE_TERNARY_I64(FMAI64);
-    VERIFY_OP_CORE_UNARY_I64(AbsI64);
-    VERIFY_OP_CORE_BINARY_I64(MinI64S);
-    VERIFY_OP_CORE_BINARY_I64(MinI64U);
-    VERIFY_OP_CORE_BINARY_I64(MaxI64S);
-    VERIFY_OP_CORE_BINARY_I64(MaxI64U);
-    VERIFY_OP_CORE_UNARY_I64(NotI64);
-    VERIFY_OP_CORE_BINARY_I64(AndI64);
-    VERIFY_OP_CORE_BINARY_I64(OrI64);
-    VERIFY_OP_CORE_BINARY_I64(XorI64);
-    VERIFY_OP_CORE_UNARY_I64(CtlzI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(AddI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(SubI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(MulI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(DivI64S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(DivI64U);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(RemI64S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(RemI64U);
+    IREE_VM_ISA_VERIFY_OP_CORE_TERNARY_I64(FMAI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I64(AbsI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(MinI64S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(MinI64U);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(MaxI64S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(MaxI64U);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I64(NotI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(AndI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(OrI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I64(XorI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I64(CtlzI64);
 
     //===------------------------------------------------------------------===//
     // Casting and type conversion/emulation
     //===------------------------------------------------------------------===//
 
     // NOTE: these all operate on 32-bit registers.
-    VERIFY_OP_CORE_UNARY_I32(TruncI32I8);
-    VERIFY_OP_CORE_UNARY_I32(TruncI32I16);
-    VERIFY_OP_CORE_UNARY_I32(ExtI8I32S);
-    VERIFY_OP_CORE_UNARY_I32(ExtI8I32U);
-    VERIFY_OP_CORE_UNARY_I32(ExtI16I32S);
-    VERIFY_OP_CORE_UNARY_I32(ExtI16I32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(TruncI32I8);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(TruncI32I16);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(ExtI8I32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(ExtI8I32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(ExtI16I32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(ExtI16I32U);
 
     // NOTE: 64-bit ones are actually changing register widths.
-    VERIFY_OP(CORE, TruncI64I32, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, TruncI64I32, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, ExtI32I64S, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ExtI32I64S, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
-    VERIFY_OP(CORE, ExtI32I64U, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, ExtI32I64U, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
-    VERIFY_OP(CORE, CastAnyRef, {
-      VM_VerifyOperandRegRefMove(operand);
-      VM_VerifyTypeOf(result);
-      VM_VerifyResultRegRefMove(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, CastAnyRef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF_MOVE(operand);
+      IREE_VM_ISA_DECODE_TYPE_OF(result_type);
+      IREE_VM_ISA_DECODE_RESULT_REF_MOVE(result);
     });
 
     //===------------------------------------------------------------------===//
     // Native bitwise shifts and rotates
     //===------------------------------------------------------------------===//
 
-#define VERIFY_OP_CORE_SHIFT_I32(op_name) \
-  VERIFY_OP(CORE, op_name, {              \
-    VM_VerifyOperandRegI32(operand);      \
-    VM_VerifyOperandRegI32(amount);       \
-    VM_VerifyResultRegI32(result);        \
+#define IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {              \
+    IREE_VM_ISA_DECODE_OPERAND_I32(operand);          \
+    IREE_VM_ISA_DECODE_OPERAND_I32(amount);           \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);            \
   });
 
-    VERIFY_OP_CORE_SHIFT_I32(ShlI32);
-    VERIFY_OP_CORE_SHIFT_I32(ShrI32S);
-    VERIFY_OP_CORE_SHIFT_I32(ShrI32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I32(ShlI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I32(ShrI32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I32(ShrI32U);
 
-#define VERIFY_OP_CORE_SHIFT_I64(op_name) \
-  VERIFY_OP(CORE, op_name, {              \
-    VM_VerifyOperandRegI64(operand);      \
-    VM_VerifyOperandRegI32(amount);       \
-    VM_VerifyResultRegI64(result);        \
+#define IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {              \
+    IREE_VM_ISA_DECODE_OPERAND_I64(operand);          \
+    IREE_VM_ISA_DECODE_OPERAND_I32(amount);           \
+    IREE_VM_ISA_DECODE_RESULT_I64(result);            \
   });
 
-    VERIFY_OP_CORE_SHIFT_I64(ShlI64);
-    VERIFY_OP_CORE_SHIFT_I64(ShrI64S);
-    VERIFY_OP_CORE_SHIFT_I64(ShrI64U);
+    IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I64(ShlI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I64(ShrI64S);
+    IREE_VM_ISA_VERIFY_OP_CORE_SHIFT_I64(ShrI64U);
 
     //===------------------------------------------------------------------===//
     // Comparison ops
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP_CORE_BINARY_I32(CmpEQI32);
-    VERIFY_OP_CORE_BINARY_I32(CmpNEI32);
-    VERIFY_OP_CORE_BINARY_I32(CmpLTI32S);
-    VERIFY_OP_CORE_BINARY_I32(CmpLTI32U);
-    VERIFY_OP_CORE_UNARY_I32(CmpNZI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(CmpEQI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(CmpNEI32);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(CmpLTI32S);
+    IREE_VM_ISA_VERIFY_OP_CORE_BINARY_I32(CmpLTI32U);
+    IREE_VM_ISA_VERIFY_OP_CORE_UNARY_I32(CmpNZI32);
 
-#define VERIFY_OP_CORE_CMP_I64(op_name) \
-  VERIFY_OP(CORE, op_name, {            \
-    VM_VerifyOperandRegI64(lhs);        \
-    VM_VerifyOperandRegI64(rhs);        \
-    VM_VerifyResultRegI32(result);      \
+#define IREE_VM_ISA_VERIFY_OP_CORE_CMP_I64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(CORE, op_name, {            \
+    IREE_VM_ISA_DECODE_OPERAND_I64(lhs);            \
+    IREE_VM_ISA_DECODE_OPERAND_I64(rhs);            \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);          \
   });
 
-    VERIFY_OP_CORE_CMP_I64(CmpEQI64);
-    VERIFY_OP_CORE_CMP_I64(CmpNEI64);
-    VERIFY_OP_CORE_CMP_I64(CmpLTI64S);
-    VERIFY_OP_CORE_CMP_I64(CmpLTI64U);
-    VERIFY_OP(CORE, CmpNZI64, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP_CORE_CMP_I64(CmpEQI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_CMP_I64(CmpNEI64);
+    IREE_VM_ISA_VERIFY_OP_CORE_CMP_I64(CmpLTI64S);
+    IREE_VM_ISA_VERIFY_OP_CORE_CMP_I64(CmpLTI64U);
+    IREE_VM_ISA_VERIFY_OP(CORE, CmpNZI64, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
-    VERIFY_OP(CORE, CmpEQRef, {
-      VM_VerifyOperandRegRef(lhs);
-      VM_VerifyOperandRegRef(rhs);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, CmpEQRef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(lhs);
+      IREE_VM_ISA_DECODE_OPERAND_REF(rhs);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, CmpNERef, {
-      VM_VerifyOperandRegRef(lhs);
-      VM_VerifyOperandRegRef(rhs);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, CmpNERef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(lhs);
+      IREE_VM_ISA_DECODE_OPERAND_REF(rhs);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(CORE, CmpNZRef, {
-      VM_VerifyOperandRegRef(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(CORE, CmpNZRef, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
     //===------------------------------------------------------------------===//
     // Control flow
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, Block, {
+    IREE_VM_ISA_VERIFY_OP(CORE, Block, {
       // Define the new block in the block list. It may already be declared from
       // a prior branch.
       iree_vm_bytecode_block_t* block = NULL;
@@ -1584,40 +1533,40 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
       verify_state->in_block = 1;
     });
 
-    VERIFY_OP(CORE, Branch, {
-      VM_VerifyBranchTarget(dest_pc);
-      VM_VerifyBranchOperands(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, Branch, {
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(dest_pc);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(operands);
       verify_state->in_block = 0;  // terminator
     });
 
-    VERIFY_OP(CORE, CondBranch, {
-      VM_VerifyOperandRegI32(condition);
-      VM_VerifyBranchTarget(true_dest_pc);
-      VM_VerifyBranchOperands(true_operands);
-      VM_VerifyBranchTarget(false_dest_pc);
-      VM_VerifyBranchOperands(false_operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, CondBranch, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(true_dest_pc);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(true_operands);
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(false_dest_pc);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(false_operands);
       verify_state->in_block = 0;  // terminator
     });
 
-    VERIFY_OP(CORE, BranchTable, {
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyBranchTarget(default_dest_pc);
-      VM_VerifyBranchOperands(default_operands);
-      VM_VerifyConstI16(table_size);
+    IREE_VM_ISA_VERIFY_OP(CORE, BranchTable, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(default_dest_pc);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(default_operands);
+      IREE_VM_ISA_DECODE_CONST_I16(table_size);
       for (uint16_t i = 0; i < table_size; ++i) {
-        VM_VerifyBranchTarget(case_dest_pc);
-        VM_VerifyBranchOperands(case_operands);
+        IREE_VM_ISA_VERIFY_BRANCH_TARGET(case_dest_pc);
+        IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(case_operands);
       }
       verify_state->in_block = 0;  // terminator
     });
 
-    VERIFY_OP(CORE, Call, {
-      VM_VerifyFuncAttr(callee_ordinal);
-      VM_VerifyVariadicOperandsAny(operands);
-      VM_VerifyVariadicResultsAny(results);
-      if (VM_IsImportOrdinal(callee_ordinal)) {
-        VM_UnmaskImportOrdinal(callee_ordinal);
-        VM_VerifyImportOrdinal(callee_ordinal);
+    IREE_VM_ISA_VERIFY_OP(CORE, Call, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(callee_ordinal);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
+      IREE_VM_ISA_VERIFY_VARIADIC_RESULTS_ANY(results);
+      if (iree_vm_isa_function_ordinal_is_import(callee_ordinal)) {
+        callee_ordinal = iree_vm_isa_function_ordinal_as_import(callee_ordinal);
+        IREE_VM_ISA_VERIFY_IMPORT_ORDINAL(callee_ordinal);
         iree_vm_ImportFunctionDef_table_t import_def =
             iree_vm_ImportFunctionDef_vec_at(verify_state->imported_functions,
                                              callee_ordinal);
@@ -1628,7 +1577,7 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
             "call to import '%s'",
             iree_vm_ImportFunctionDef_full_name(import_def));
       } else {
-        VM_VerifyFunctionOrdinal(callee_ordinal);
+        IREE_VM_ISA_VERIFY_FUNCTION_ORDINAL(callee_ordinal);
         IREE_RETURN_IF_ERROR(
             iree_vm_bytecode_function_verify_call(
                 verify_state,
@@ -1639,19 +1588,20 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
       }
     });
 
-    VERIFY_OP(CORE, CallVariadic, {
-      VM_VerifyFuncAttr(callee_ordinal);
-      VM_VerifyVariadicOperands(segment_sizes);
-      VM_VerifyVariadicOperandsAny(operands);
-      VM_VerifyVariadicResultsAny(results);
-      if (IREE_UNLIKELY(!VM_IsImportOrdinal(callee_ordinal))) {
+    IREE_VM_ISA_VERIFY_OP(CORE, CallVariadic, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(callee_ordinal);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(segment_sizes);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
+      IREE_VM_ISA_VERIFY_VARIADIC_RESULTS_ANY(results);
+      if (IREE_UNLIKELY(
+              !iree_vm_isa_function_ordinal_is_import(callee_ordinal))) {
         // Variadic calls are currently only supported for import functions.
         return iree_make_status(
             IREE_STATUS_FAILED_PRECONDITION,
             "variadic calls only supported for internal callees");
       }
-      VM_UnmaskImportOrdinal(callee_ordinal);
-      VM_VerifyImportOrdinal(callee_ordinal);
+      callee_ordinal = iree_vm_isa_function_ordinal_as_import(callee_ordinal);
+      IREE_VM_ISA_VERIFY_IMPORT_ORDINAL(callee_ordinal);
       iree_vm_ImportFunctionDef_table_t import_def =
           iree_vm_ImportFunctionDef_vec_at(verify_state->imported_functions,
                                            callee_ordinal);
@@ -1663,40 +1613,40 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
           iree_vm_ImportFunctionDef_full_name(import_def));
     });
 
-    VERIFY_OP(CORE, Return, {
-      VM_VerifyVariadicOperandsAny(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, Return, {
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
       IREE_RETURN_IF_ERROR(iree_vm_bytecode_function_verify_cconv_registers(
           verify_state, verify_state->cconv_results, /*segment_sizes=*/NULL,
           operands));
       verify_state->in_block = 0;  // terminator
     });
 
-    VERIFY_OP(CORE, Fail, {
-      VM_VerifyOperandRegI32(status);
-      iree_string_view_t message;
-      VM_VerifyStrAttr(message, &message);
+    IREE_VM_ISA_VERIFY_OP(CORE, Fail, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(status);
+      IREE_VM_ISA_DECODE_STRING_ATTR(message);
       verify_state->in_block = 0;  // terminator
     });
 
-    VERIFY_OP(CORE, ImportResolved, {
-      VM_VerifyFuncAttr(import_ordinal);
-      if (IREE_UNLIKELY(!VM_IsImportOrdinal(import_ordinal))) {
+    IREE_VM_ISA_VERIFY_OP(CORE, ImportResolved, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(import_ordinal);
+      if (IREE_UNLIKELY(
+              !iree_vm_isa_function_ordinal_is_import(import_ordinal))) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "function ordinal %u is not an import ordinal",
                                 import_ordinal);
       }
-      VM_UnmaskImportOrdinal(import_ordinal);
-      VM_VerifyImportOrdinal(import_ordinal);
-      VM_VerifyResultRegI32(result);
+      import_ordinal = iree_vm_isa_function_ordinal_as_import(import_ordinal);
+      IREE_VM_ISA_VERIFY_IMPORT_ORDINAL(import_ordinal);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
     //===------------------------------------------------------------------===//
     // Async/fiber ops
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, Yield, {
-      VM_VerifyBranchTarget(dest_pc);
-      VM_VerifyBranchOperands(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, Yield, {
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(dest_pc);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(operands);
       verify_state->in_block = 0;  // terminator
     });
 
@@ -1704,28 +1654,26 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     // Debugging
     //===------------------------------------------------------------------===//
 
-    VERIFY_OP(CORE, Trace, {
-      iree_string_view_t event_name;
-      VM_VerifyStrAttr(event_name, &event_name);
-      VM_VerifyVariadicOperandsAny(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, Trace, {
+      IREE_VM_ISA_DECODE_STRING_ATTR(event_name);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
     });
 
-    VERIFY_OP(CORE, Print, {
-      iree_string_view_t event_name;
-      VM_VerifyStrAttr(event_name, &event_name);
-      VM_VerifyVariadicOperandsAny(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, Print, {
+      IREE_VM_ISA_DECODE_STRING_ATTR(event_name);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
     });
 
-    VERIFY_OP(CORE, Break, {
-      VM_VerifyBranchTarget(dest_pc);
-      VM_VerifyBranchOperands(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, Break, {
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(dest_pc);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(operands);
       verify_state->in_block = 0;  // terminator
     });
 
-    VERIFY_OP(CORE, CondBreak, {
-      VM_VerifyOperandRegI32(condition);
-      VM_VerifyBranchTarget(dest);
-      VM_VerifyBranchOperands(operands);
+    IREE_VM_ISA_VERIFY_OP(CORE, CondBreak, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(dest);
+      IREE_VM_ISA_VERIFY_BRANCH_OPERANDS(operands);
       verify_state->in_block = 0;  // terminator
     });
 
@@ -1740,201 +1688,202 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     // ExtF32: Globals
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F32, GlobalLoadF32, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 4);
-      VM_VerifyResultRegF32(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, GlobalLoadF32, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_DECODE_RESULT_F32(value);
     });
 
-    VERIFY_OP(EXT_F32, GlobalStoreF32, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 4);
-      VM_VerifyOperandRegF32(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, GlobalStoreF32, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_DECODE_OPERAND_F32(value);
     });
 
-    VERIFY_OP(EXT_F32, GlobalLoadIndirectF32, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, GlobalLoadIndirectF32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyResultRegF32(value);
+      IREE_VM_ISA_DECODE_RESULT_F32(value);
     });
 
-    VERIFY_OP(EXT_F32, GlobalStoreIndirectF32, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, GlobalStoreIndirectF32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyOperandRegF32(value);
+      IREE_VM_ISA_DECODE_OPERAND_F32(value);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF32: Constants
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F32, ConstF32, {
-      VM_VerifyAttrF32(value);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, ConstF32, {
+      IREE_VM_ISA_DECODE_ATTR_F32(value);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
 
-    VERIFY_OP(EXT_F32, ConstF32Zero, { VM_VerifyResultRegF32(result); });
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, ConstF32Zero,
+                          { IREE_VM_ISA_DECODE_RESULT_F32(result); });
 
     //===----------------------------------------------------------------===//
     // ExtF32: Lists
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F32, ListGetF32, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, ListGetF32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
 
-    VERIFY_OP(EXT_F32, ListSetF32, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegF32(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, ListSetF32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_F32(value);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF32: Conditional assignment
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F32, SelectF32, {
-      VM_VerifyOperandRegI32(condition);
-      VM_VerifyOperandRegF32(true_value);
-      VM_VerifyOperandRegF32(false_value);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, SelectF32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DECODE_OPERAND_F32(true_value);
+      IREE_VM_ISA_DECODE_OPERAND_F32(false_value);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
 
-    VERIFY_OP(EXT_F32, SwitchF32, {
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegF32(default_value);
-      VM_VerifyVariadicOperandsF32(values);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, SwitchF32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_F32(default_value);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_F32(values);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF32: Native floating-point arithmetic
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP_EXT_F32_BINARY_F32(AddF32);
-    VERIFY_OP_EXT_F32_BINARY_F32(SubF32);
-    VERIFY_OP_EXT_F32_BINARY_F32(MulF32);
-    VERIFY_OP_EXT_F32_BINARY_F32(DivF32);
-    VERIFY_OP_EXT_F32_BINARY_F32(RemF32);
-    VERIFY_OP_EXT_F32_TERNARY_F32(FMAF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(AbsF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(NegF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(CeilF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(FloorF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(RoundF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(RoundF32Even);
-    VERIFY_OP_EXT_F32_BINARY_F32(MinF32);
-    VERIFY_OP_EXT_F32_BINARY_F32(MaxF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(AddF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(SubF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(MulF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(DivF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(RemF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_TERNARY_F32(FMAF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(AbsF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(NegF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(CeilF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(FloorF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(RoundF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(RoundF32Even);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(MinF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(MaxF32);
 
-    VERIFY_OP_EXT_F32_UNARY_F32(AtanF32);
-    VERIFY_OP_EXT_F32_BINARY_F32(Atan2F32);
-    VERIFY_OP_EXT_F32_UNARY_F32(CosF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(SinF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(ExpF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(Exp2F32);
-    VERIFY_OP_EXT_F32_UNARY_F32(ExpM1F32);
-    VERIFY_OP_EXT_F32_UNARY_F32(LogF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(Log10F32);
-    VERIFY_OP_EXT_F32_UNARY_F32(Log1pF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(Log2F32);
-    VERIFY_OP_EXT_F32_BINARY_F32(PowF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(RsqrtF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(SqrtF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(TanhF32);
-    VERIFY_OP_EXT_F32_UNARY_F32(ErfF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(AtanF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(Atan2F32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(CosF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(SinF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(ExpF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(Exp2F32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(ExpM1F32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(LogF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(Log10F32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(Log1pF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(Log2F32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_BINARY_F32(PowF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(RsqrtF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(SqrtF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(TanhF32);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_UNARY_F32(ErfF32);
 
     //===----------------------------------------------------------------===//
     // ExtF32: Casting and type conversion/emulation
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F32, CastSI32F32, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastSI32F32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
-    VERIFY_OP(EXT_F32, CastSI64F32, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastSI64F32, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
-    VERIFY_OP(EXT_F32, CastUI32F32, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastUI32F32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
-    VERIFY_OP(EXT_F32, CastUI64F32, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastUI64F32, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
-    VERIFY_OP(EXT_F32, CastF32SI32, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastF32SI32, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(EXT_F32, CastF32SI64, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastF32SI64, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
-    VERIFY_OP(EXT_F32, CastF32UI32, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastF32UI32, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(EXT_F32, CastF32UI64, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CastF32UI64, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
-    VERIFY_OP(EXT_F32, BitcastI32F32, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, BitcastI32F32, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
-    VERIFY_OP(EXT_F32, BitcastF32I32, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, BitcastF32I32, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF32: Comparison ops
     //===----------------------------------------------------------------===//
 
-#define VERIFY_OP_EXT_F32_CMP_F32(op_name) \
-  VERIFY_OP(EXT_F32, op_name, {            \
-    VM_VerifyOperandRegF32(lhs);           \
-    VM_VerifyOperandRegF32(rhs);           \
-    VM_VerifyResultRegI32(result);         \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F32, op_name, {            \
+    IREE_VM_ISA_DECODE_OPERAND_F32(lhs);               \
+    IREE_VM_ISA_DECODE_OPERAND_F32(rhs);               \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);             \
   });
 
-    VERIFY_OP_EXT_F32_CMP_F32(CmpEQF32O);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpEQF32U);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpNEF32O);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpNEF32U);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpLTF32O);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpLTF32U);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpLTEF32O);
-    VERIFY_OP_EXT_F32_CMP_F32(CmpLTEF32U);
-    VERIFY_OP(EXT_F32, CmpNaNF32, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpEQF32O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpEQF32U);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpNEF32O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpNEF32U);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpLTF32O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpLTF32U);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpLTEF32O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F32_CMP_F32(CmpLTEF32U);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, CmpNaNF32, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF32: Buffers
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F32, BufferFillF32, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegF32(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, BufferFillF32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_F32(value);
     });
 
-    VERIFY_OP(EXT_F32, BufferLoadF32, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, BufferLoadF32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
 
-    VERIFY_OP(EXT_F32, BufferStoreF32, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegF32(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F32, BufferStoreF32, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_F32(value);
     });
 
     END_VERIFY_PREFIX(PrefixExtF32, iree_vm_FeatureBits_EXT_F32);
@@ -1949,209 +1898,210 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     // ExtF64: Globals
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F64, GlobalLoadF64, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 4);
-      VM_VerifyResultRegF64(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, GlobalLoadF64, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_DECODE_RESULT_F64(value);
     });
 
-    VERIFY_OP(EXT_F64, GlobalStoreF64, {
-      VM_VerifyGlobalAttr(byte_offset);
-      VM_VerifyRwdataOffset(byte_offset, 4);
-      VM_VerifyOperandRegF64(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, GlobalStoreF64, {
+      IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_DECODE_OPERAND_F64(value);
     });
 
-    VERIFY_OP(EXT_F64, GlobalLoadIndirectF64, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, GlobalLoadIndirectF64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyResultRegF64(value);
+      IREE_VM_ISA_DECODE_RESULT_F64(value);
     });
 
-    VERIFY_OP(EXT_F64, GlobalStoreIndirectF64, {
-      VM_VerifyOperandRegI32(byte_offset);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, GlobalStoreIndirectF64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(byte_offset);
       // NOTE: we have to verify the offset at runtime.
-      VM_VerifyOperandRegF64(value);
+      IREE_VM_ISA_DECODE_OPERAND_F64(value);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF64: Constants
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F64, ConstF64, {
-      VM_VerifyAttrF64(value);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, ConstF64, {
+      IREE_VM_ISA_DECODE_ATTR_F64(value);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
 
-    VERIFY_OP(EXT_F64, ConstF64Zero, { VM_VerifyResultRegF64(result); });
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, ConstF64Zero,
+                          { IREE_VM_ISA_DECODE_RESULT_F64(result); });
 
     //===----------------------------------------------------------------===//
     // ExtF64: Lists
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F64, ListGetF64, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, ListGetF64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
 
-    VERIFY_OP(EXT_F64, ListSetF64, {
-      VM_VerifyOperandRegRef(list);
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegF64(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, ListSetF64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(list);
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_F64(value);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF64: Conditional assignment
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F64, SelectF64, {
-      VM_VerifyOperandRegI32(condition);
-      VM_VerifyOperandRegF64(true_value);
-      VM_VerifyOperandRegF64(false_value);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, SelectF64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(condition);
+      IREE_VM_ISA_DECODE_OPERAND_F64(true_value);
+      IREE_VM_ISA_DECODE_OPERAND_F64(false_value);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
 
-    VERIFY_OP(EXT_F64, SwitchF64, {
-      VM_VerifyOperandRegI32(index);
-      VM_VerifyOperandRegF64(default_value);
-      VM_VerifyVariadicOperandsF64(values);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, SwitchF64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(index);
+      IREE_VM_ISA_DECODE_OPERAND_F64(default_value);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_F64(values);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF64: Native floating-point arithmetic
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP_EXT_F64_BINARY_F64(AddF64);
-    VERIFY_OP_EXT_F64_BINARY_F64(SubF64);
-    VERIFY_OP_EXT_F64_BINARY_F64(MulF64);
-    VERIFY_OP_EXT_F64_BINARY_F64(DivF64);
-    VERIFY_OP_EXT_F64_BINARY_F64(RemF64);
-    VERIFY_OP_EXT_F64_TERNARY_F64(FMAF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(AbsF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(NegF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(CeilF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(FloorF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(RoundF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(RoundF64Even);
-    VERIFY_OP_EXT_F64_BINARY_F64(MinF64);
-    VERIFY_OP_EXT_F64_BINARY_F64(MaxF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(AddF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(SubF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(MulF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(DivF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(RemF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_TERNARY_F64(FMAF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(AbsF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(NegF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(CeilF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(FloorF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(RoundF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(RoundF64Even);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(MinF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(MaxF64);
 
-    VERIFY_OP_EXT_F64_UNARY_F64(AtanF64);
-    VERIFY_OP_EXT_F64_BINARY_F64(Atan2F64);
-    VERIFY_OP_EXT_F64_UNARY_F64(CosF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(SinF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(ExpF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(Exp2F64);
-    VERIFY_OP_EXT_F64_UNARY_F64(ExpM1F64);
-    VERIFY_OP_EXT_F64_UNARY_F64(LogF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(Log10F64);
-    VERIFY_OP_EXT_F64_UNARY_F64(Log1pF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(Log2F64);
-    VERIFY_OP_EXT_F64_BINARY_F64(PowF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(RsqrtF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(SqrtF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(TanhF64);
-    VERIFY_OP_EXT_F64_UNARY_F64(ErfF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(AtanF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(Atan2F64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(CosF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(SinF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(ExpF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(Exp2F64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(ExpM1F64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(LogF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(Log10F64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(Log1pF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(Log2F64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_BINARY_F64(PowF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(RsqrtF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(SqrtF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(TanhF64);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_UNARY_F64(ErfF64);
 
     //===----------------------------------------------------------------===//
     // ExtF64: Casting and type conversion/emulation
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F64, TruncF64F32, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegF32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, TruncF64F32, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_F32(result);
     });
-    VERIFY_OP(EXT_F64, ExtF32F64, {
-      VM_VerifyOperandRegF32(operand);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, ExtF32F64, {
+      IREE_VM_ISA_DECODE_OPERAND_F32(operand);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
-    VERIFY_OP(EXT_F64, CastSI32F64, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastSI32F64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
-    VERIFY_OP(EXT_F64, CastUI32F64, {
-      VM_VerifyOperandRegI32(operand);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastUI32F64, {
+      IREE_VM_ISA_DECODE_OPERAND_I32(operand);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
-    VERIFY_OP(EXT_F64, CastF64SI32, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastF64SI32, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(EXT_F64, CastF64UI32, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastF64UI32, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
-    VERIFY_OP(EXT_F64, CastSI64F64, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastSI64F64, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
-    VERIFY_OP(EXT_F64, CastUI64F64, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastUI64F64, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
-    VERIFY_OP(EXT_F64, CastF64SI64, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastF64SI64, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
-    VERIFY_OP(EXT_F64, CastF64UI64, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CastF64UI64, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
-    VERIFY_OP(EXT_F64, BitcastI64F64, {
-      VM_VerifyOperandRegI64(operand);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, BitcastI64F64, {
+      IREE_VM_ISA_DECODE_OPERAND_I64(operand);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
-    VERIFY_OP(EXT_F64, BitcastF64I64, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegI64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, BitcastF64I64, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I64(result);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF64: Comparison ops
     //===----------------------------------------------------------------===//
 
-#define VERIFY_OP_EXT_F64_CMP_F64(op_name) \
-  VERIFY_OP(EXT_F64, op_name, {            \
-    VM_VerifyOperandRegF64(lhs);           \
-    VM_VerifyOperandRegF64(rhs);           \
-    VM_VerifyResultRegI32(result);         \
+#define IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(op_name) \
+  IREE_VM_ISA_VERIFY_OP(EXT_F64, op_name, {            \
+    IREE_VM_ISA_DECODE_OPERAND_F64(lhs);               \
+    IREE_VM_ISA_DECODE_OPERAND_F64(rhs);               \
+    IREE_VM_ISA_DECODE_RESULT_I32(result);             \
   });
 
-    VERIFY_OP_EXT_F64_CMP_F64(CmpEQF64O);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpEQF64U);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpNEF64O);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpNEF64U);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpLTF64O);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpLTF64U);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpLTEF64O);
-    VERIFY_OP_EXT_F64_CMP_F64(CmpLTEF64U);
-    VERIFY_OP(EXT_F64, CmpNaNF64, {
-      VM_VerifyOperandRegF64(operand);
-      VM_VerifyResultRegI32(result);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpEQF64O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpEQF64U);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpNEF64O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpNEF64U);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpLTF64O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpLTF64U);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpLTEF64O);
+    IREE_VM_ISA_VERIFY_OP_EXT_F64_CMP_F64(CmpLTEF64U);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, CmpNaNF64, {
+      IREE_VM_ISA_DECODE_OPERAND_F64(operand);
+      IREE_VM_ISA_DECODE_RESULT_I32(result);
     });
 
     //===----------------------------------------------------------------===//
     // ExtF64: Buffers
     //===----------------------------------------------------------------===//
 
-    VERIFY_OP(EXT_F64, BufferFillF64, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegI64HostSize(length);
-      VM_VerifyOperandRegF64(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, BufferFillF64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_I64(length);
+      IREE_VM_ISA_DECODE_OPERAND_F64(value);
     });
 
-    VERIFY_OP(EXT_F64, BufferLoadF64, {
-      VM_VerifyOperandRegRef(source_buffer);
-      VM_VerifyOperandRegI64HostSize(source_offset);
-      VM_VerifyResultRegF64(result);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, BufferLoadF64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(source_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(source_offset);
+      IREE_VM_ISA_DECODE_RESULT_F64(result);
     });
 
-    VERIFY_OP(EXT_F64, BufferStoreF64, {
-      VM_VerifyOperandRegRef(target_buffer);
-      VM_VerifyOperandRegI64HostSize(target_offset);
-      VM_VerifyOperandRegF64(value);
+    IREE_VM_ISA_VERIFY_OP(EXT_F64, BufferStoreF64, {
+      IREE_VM_ISA_DECODE_OPERAND_REF(target_buffer);
+      IREE_VM_ISA_DECODE_OPERAND_I64(target_offset);
+      IREE_VM_ISA_DECODE_OPERAND_F64(value);
     });
 
     END_VERIFY_PREFIX(PrefixExtF64, iree_vm_FeatureBits_EXT_F64);

--- a/runtime/src/iree/vm/ref.c
+++ b/runtime/src/iree/vm/ref.c
@@ -33,7 +33,7 @@ static void iree_vm_ref_trace(const char* msg, iree_vm_ref_t* ref) {
   if (!ref->ptr) return;
   iree_atomic_ref_count_t* counter = iree_vm_get_ref_counter_ptr(ref);
   iree_string_view_t name = iree_vm_ref_type_name(ref->type);
-  fprintf(stderr, "%s %.*s 0x%p %d\n", msg, (int)name.size, name.data, ref->ptr,
+  fprintf(stderr, "%s %.*s %p %d\n", msg, (int)name.size, name.data, ref->ptr,
           iree_atomic_ref_count_load(counter));
   IREE_DEBUG_PRINT_BACKTRACE_HERE(msg);
 }
@@ -42,7 +42,7 @@ static void iree_vm_ref_ptr_trace(const char* msg, void* ptr,
   if (!ptr) return;
   iree_atomic_ref_count_t* counter = iree_vm_get_raw_counter_ptr(ptr, type);
   iree_string_view_t name = iree_vm_ref_type_name(type);
-  fprintf(stderr, "%s %.*s 0x%p %d\n", msg, (int)name.size, name.data, ptr,
+  fprintf(stderr, "%s %.*s %p %d\n", msg, (int)name.size, name.data, ptr,
           iree_atomic_ref_count_load(counter));
   IREE_DEBUG_PRINT_BACKTRACE_HERE(msg);
 }


### PR DESCRIPTION
This fixes ancient misnamings and duplication to make the bytecode interpreter/disassembler/verifier share the same style. Future C export/JIT/etc will reuse these as well.