### PR TITLE
Adding iree_vm_list_get_ref_retain_or_move.

### DIFF
--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -1545,8 +1545,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "list is null");
       }
       const uint32_t index = (uint32_t)index_i32;
-      // TODO(benvanik): use result_is_move with a _retain_or_move.
-      IREE_RETURN_IF_ERROR(iree_vm_list_get_ref_retain(list, index, result));
+      IREE_RETURN_IF_ERROR(iree_vm_list_get_ref_retain_or_move(
+          list, index, result_is_move, result));
       if (result->type != IREE_VM_REF_TYPE_NULL &&
           (iree_vm_type_def_is_value(type_def) ||
            result->type != iree_vm_type_def_as_ref(type_def))) {

--- a/runtime/src/iree/vm/list.h
+++ b/runtime/src/iree/vm/list.h
@@ -7,6 +7,7 @@
 #ifndef IREE_VM_LIST_H_
 #define IREE_VM_LIST_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "iree/base/api.h"
@@ -173,6 +174,19 @@ IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_assign(
 // The ref will be retained and must be released by the caller.
 IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_retain(
     const iree_vm_list_t* list, iree_host_size_t i, iree_vm_ref_t* out_value);
+
+// Returns the ref value of the element at the given index.
+// If |is_move|=true then the ref will be moved out of the list and the list
+// element will be cleared. Otherwise the ref will be retained and must be
+// released by the caller.
+IREE_API_EXPORT iree_status_t
+iree_vm_list_get_ref_retain_or_move(iree_vm_list_t* list, iree_host_size_t i,
+                                    bool is_move, iree_vm_ref_t* out_value);
+
+// Returns the ref value of the element at the given index.
+// The ref will be moved out of the list and the list element will be cleared.
+IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_move(
+    iree_vm_list_t* list, iree_host_size_t i, iree_vm_ref_t* out_value);
 
 // Sets the ref value of the element at the given index, retaining a reference
 // in the list until the element is cleared or the list is disposed.


### PR DESCRIPTION
Allows for moves from lists in the VM.