### PR TITLE
Adding vm.call.yieldable op to finally fix up yieldable calls.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/VM/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRAnalysis
+    MLIRControlFlowInterfaces
     MLIRIR
     MLIRSupport
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -127,6 +127,8 @@ class VM_EncStrAttr<string name> : VM_EncEncodeExpr<
     "e.encodeStrAttr(getOperation()->getAttrOfType<StringAttr>(\"" # name # "\"))">;
 class VM_EncBranch<string blockName, string operandsName, int successorIndex> : VM_EncEncodeExpr<
     "e.encodeBranch({0}(), " # operandsName # "(), " # successorIndex # ")", [blockName]>;
+class VM_EncBranchTarget<string blockName> : VM_EncEncodeExpr<
+    "e.encodeBranchTarget({0}())", [blockName]>;
 class VM_EncBranchTable<string caseBlockNames, string caseOperandsName, int baseSuccessorIndex> : VM_EncEncodeExpr<
     "e.encodeBranchTable(" # caseBlockNames # "(), " # caseOperandsName # "(), " # baseSuccessorIndex # ")">;
 class VM_EncOperand<string name, int ordinal> : VM_EncEncodeExpr<
@@ -137,6 +139,8 @@ class VM_EncResult<string name> : VM_EncEncodeExpr<
     "e.encodeResult({0}())", [name]>;
 class VM_EncVariadicResults<string name> : VM_EncEncodeExpr<
     "e.encodeResults({0}())", [name]>;
+class VM_EncBlockArgResults<string blockName> : VM_EncEncodeExpr<
+    "e.encodeBlockArgResults({0}())", [blockName]>;
 
 def VM_SerializableOpInterface : OpInterface<"VMSerializableOp"> {
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -315,6 +315,10 @@ def VM_ExtF32 : NativeOpTrait<"IREE::VM::ExtF32">;
 // Operations with this trait require the VM f64 extension.
 def VM_ExtF64 : NativeOpTrait<"IREE::VM::ExtF64">;
 
+// Operations with this trait may fail at runtime (return an error status).
+// This is used to determine which functions require stack unwinding support.
+def VM_MayFail : NativeOpTrait<"IREE::VM::MayFail">;
+
 //===----------------------------------------------------------------------===//
 // ref<T> types
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMFuncEncoder.h
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMFuncEncoder.h
@@ -80,6 +80,9 @@ public:
                                      Operation::operand_range operands,
                                      int successorIndex) = 0;
 
+  // Encodes just a branch target (PC offset) without operand mappings.
+  virtual LogicalResult encodeBranchTarget(Block *targetBlock) = 0;
+
   // Encodes a branch table.
   virtual LogicalResult encodeBranchTable(SuccessorRange caseSuccessors,
                                           OperandRangeRange caseOperands,
@@ -102,6 +105,10 @@ public:
 
   // Encodes a variable list of results (by reference), including a count.
   virtual LogicalResult encodeResults(Operation::result_range values) = 0;
+
+  // Encodes result destination registers from successor block arguments.
+  // Used for operations like CallYieldable where call results go to block args.
+  virtual LogicalResult encodeBlockArgResults(Block *targetBlock) = 0;
 
   // Returns the register allocation analysis, if available.
   // Bytecode encoder provides this; other encoders (e.g., EmitC) return

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
@@ -47,7 +47,7 @@ class VM_OPC_EnumAttr<string name, string enumName, string enumTag,
   string opcodeEnumTag = enumTag;
 }
 
-// Next available opcode: 0x87
+// Next available opcode: 0x88
 
 // Globals:
 def VM_OPC_GlobalLoadI32         : VM_OPC<0x00, "GlobalLoadI32">;
@@ -197,6 +197,7 @@ def VM_OPC_ImportResolved        : VM_OPC<0x5C, "ImportResolved">;
 
 // Async/fiber ops:
 def VM_OPC_Yield                 : VM_OPC<0x5D, "Yield">;
+def VM_OPC_CallYieldable         : VM_OPC<0x87, "CallYieldable">;
 
 // Debugging:
 def VM_OPC_Trace                 : VM_OPC<0x5E, "Trace">;
@@ -363,6 +364,7 @@ def VM_CoreOpcodeAttr :
     VM_OPC_Fail,
     VM_OPC_ImportResolved,
     VM_OPC_Yield,
+    VM_OPC_CallYieldable,
     VM_OPC_Trace,
     VM_OPC_Print,
     VM_OPC_CondBreak,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
@@ -47,7 +47,7 @@ class VM_OPC_EnumAttr<string name, string enumName, string enumTag,
   string opcodeEnumTag = enumTag;
 }
 
-// Next available opcode: 0x88
+// Next available opcode: 0x89
 
 // Globals:
 def VM_OPC_GlobalLoadI32         : VM_OPC<0x00, "GlobalLoadI32">;
@@ -198,6 +198,7 @@ def VM_OPC_ImportResolved        : VM_OPC<0x5C, "ImportResolved">;
 // Async/fiber ops:
 def VM_OPC_Yield                 : VM_OPC<0x5D, "Yield">;
 def VM_OPC_CallYieldable         : VM_OPC<0x87, "CallYieldable">;
+def VM_OPC_CallVariadicYieldable : VM_OPC<0x88, "CallVariadicYieldable">;
 
 // Debugging:
 def VM_OPC_Trace                 : VM_OPC<0x5E, "Trace">;
@@ -365,6 +366,7 @@ def VM_CoreOpcodeAttr :
     VM_OPC_ImportResolved,
     VM_OPC_Yield,
     VM_OPC_CallYieldable,
+    VM_OPC_CallVariadicYieldable,
     VM_OPC_Trace,
     VM_OPC_Print,
     VM_OPC_CondBreak,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.h
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.h
@@ -29,6 +29,14 @@ namespace mlir::iree_compiler::IREE::VM {
 /// Generic method for verifying VM fail ops.
 LogicalResult verifyFailOp(Operation *op, Value statusVal);
 
+//===----------------------------------------------------------------------===//
+// custom<ResultTypeList>
+//===----------------------------------------------------------------------===//
+// (type, type, ...)
+
+ParseResult parseResultTypeList(OpAsmParser &parser, ArrayAttr &resultTypes);
+void printResultTypeList(OpAsmPrinter &p, Operation *op, ArrayAttr resultTypes);
+
 } // namespace mlir::iree_compiler::IREE::VM
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1365,6 +1365,7 @@ def VM_BufferAllocOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemAlloc]>,
       AlwaysSpeculatable,
+      VM_MayFail,
     ]> {
   let summary = [{Allocates a new zero-initialized buffer.}];
   let description = [{
@@ -1396,6 +1397,7 @@ def VM_BufferCloneOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemAlloc, MemRead]>,
       AlwaysSpeculatable,
+      VM_MayFail,
     ]> {
   let summary = [{Clones a buffer.}];
   let description = [{
@@ -1460,6 +1462,7 @@ def VM_BufferCopyOp :
     VM_Op<"buffer.copy", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead, MemWrite]>,
+      VM_MayFail,
     ]> {
   let summary = [{Copies a range of a buffer to another.}];
   let description = [{
@@ -1492,6 +1495,7 @@ def VM_BufferCompareOp :
     VM_Op<"buffer.compare", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead, MemWrite]>,
+      VM_MayFail,
     ]> {
   let summary = [{Compares a range of a buffer to another.}];
   let description = [{
@@ -1529,6 +1533,7 @@ class VM_BufferFillOp<Type type, string mnemonic, VM_OPC opcode,
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
+      VM_MayFail,
     ])> {
   let description = [{
     Fills an element range of the buffer with the given value, like memset.
@@ -1587,6 +1592,7 @@ class VM_BufferLoadOp<Type type, string mnemonic, VM_OPC opcode,
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
+      VM_MayFail,
     ])> {
   let description = [{
     Loads a value from the buffer at the given element offset.
@@ -1618,6 +1624,7 @@ class VM_BufferStoreOp<Type type, string mnemonic, VM_OPC opcode,
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
+      VM_MayFail,
     ])> {
   let description = [{
     Stores a value to the buffer at the given element offset.
@@ -1709,6 +1716,7 @@ def VM_BufferStoreF64Op :
 def VM_BufferHashOp : VM_Op<"buffer.hash", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
+      VM_MayFail,
     ]> {
   let description = [{
     Computes the SipHash-2-4 of the source buffer at the given offset for
@@ -1760,6 +1768,7 @@ def VM_ListAllocOp :
     VM_Op<"list.alloc", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemAlloc]>,
+      VM_MayFail,
     ]> {
   let summary = [{Allocates a new empty list.}];
   let description = [{
@@ -1789,6 +1798,7 @@ def VM_ListReserveOp :
     VM_Op<"list.reserve", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemAlloc, MemRead, MemWrite]>,
+      VM_MayFail,
     ]> {
   let summary = [{Reserves capacity for list growth.}];
   let description = [{
@@ -1816,6 +1826,7 @@ def VM_ListSizeOp :
     VM_Op<"list.size", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
+      VM_MayFail,
     ]> {
   let summary = [{The size of the list in elements.}];
   let description = [{
@@ -1844,6 +1855,7 @@ def VM_ListResizeOp :
     VM_Op<"list.resize", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
+      VM_MayFail,
     ]> {
   let summary = [{Resizes the list to a new count in elements.}];
   let description = [{
@@ -1873,6 +1885,7 @@ class VM_ListGetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
+      VM_MayFail,
     ])> {
   let summary = [{Primitive type element accessor.}];
   let description = [{
@@ -1904,6 +1917,7 @@ class VM_ListSetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
+      VM_MayFail,
     ])> {
   let summary = [{Primitive type element mutator.}];
   let description = [{
@@ -1957,6 +1971,7 @@ def VM_ListGetRefOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       DeclareOpInterfaceMethods<VM_RefMoveInterface>,
       MemoryEffects<[MemRead]>,
+      VM_MayFail,
     ]> {
   let summary = [{ref type element accessor.}];
   let description = [{
@@ -2004,6 +2019,7 @@ def VM_ListSetRefOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       DeclareOpInterfaceMethods<VM_RefMoveInterface>,
       MemoryEffects<[MemWrite]>,
+      VM_MayFail,
     ]> {
   let summary = [{ref type element mutator.}];
   let description = [{
@@ -4421,6 +4437,7 @@ class VM_CallBaseOp<string mnemonic, list<Trait> traits = []> :
       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
       DeclareOpInterfaceMethods<VM_RefMoveInterface>,
       CallOpInterface,
+      VM_MayFail,
     ])> {
   let extraClassDeclaration = [{
     /// Get the argument operands to the called function.
@@ -4621,6 +4638,7 @@ def VM_ReturnOp : VM_Op<"return", [
 def VM_FailOp : VM_Op<"fail", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     Terminator,
+    VM_MayFail,
   ]> {
   let summary = [{Raises a global failure.}];
   let description = [{
@@ -4673,6 +4691,7 @@ def VM_FailOp : VM_Op<"fail", [
 
 def VM_CondFailOp : VM_Op<"cond_fail", [
     VM_PseudoOp,
+    VM_MayFail,
   ]> {
   let summary = [{Raises a global failure if the condition is true.}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -4695,6 +4695,131 @@ def VM_CallYieldableOp : VM_Op<"call.yieldable", [
   let hasVerifier = 1;
 }
 
+def VM_CallVariadicYieldableOp : VM_Op<"call.variadic.yieldable", [
+    DeclareOpInterfaceMethods<BranchOpInterface>,
+    DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+    DeclareOpInterfaceMethods<VM_RefMoveInterface>,
+    CallOpInterface,
+    Terminator,
+    Util_YieldPoint,
+    VM_MayFail,
+  ]> {
+  let summary = [{Variadic call operation that may yield.}];
+  let description = [{
+    Calls a variadic VM import function that may yield. If the call yields,
+    execution resumes at the specified successor block with the call results
+    as block arguments. If the call completes synchronously, control branches
+    to the successor with the results.
+
+    Variadic arguments must be specified with a total count in the segment_sizes
+    attribute. Only imports are supported (not internal functions).
+
+    ```
+    ^bb0:
+      vm.call.variadic.yieldable @import(%a, %b, %c) {segment_sizes = dense<[1, 2]> : vector<2xi16>}
+        : (i32, i32, i32) -> ^resume(i32)
+    ^resume(%result : i32):
+      vm.return %result
+    ```
+  }];
+
+  let arguments = (ins
+    VM_FuncRefAttr:$callee,
+    SignlessIntElementsAttr<16>:$segment_sizes,
+    TypeArrayAttr:$segment_types,
+    Variadic<VM_AnyType>:$operands,
+    TypeArrayAttr:$result_types,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let successors = (successor
+    AnySuccessor:$dest
+  );
+
+  let assemblyFormat = [{
+    $callee `(` $operands `)` attr-dict `:` `(` type($operands) `)`
+    `->` $dest custom<ResultTypeList>($result_types)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_CallVariadicYieldable>,
+    VM_EncFuncAttr<"callee">,
+    VM_EncPrimitiveArrayAttr<"segment_sizes", 16>,
+    VM_EncVariadicOperands<"operands">,
+    VM_EncBranchTarget<"dest">,
+    VM_EncBlockArgResults<"dest">,
+  ];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "FlatSymbolRefAttr":$callee,
+      "ArrayRef<int16_t>":$segmentSizes,
+      "ArrayRef<Type>":$segmentTypes,
+      "ValueRange":$operands,
+      "Block *":$dest,
+      "ArrayRef<Type>":$resultTypes),
+    [{
+      $_state.addAttribute("callee", callee);
+      $_state.addAttribute("segment_sizes",
+          DenseIntElementsAttr::get(
+              VectorType::get({static_cast<int64_t>(segmentSizes.size())},
+                              $_builder.getIntegerType(16)),
+              segmentSizes));
+      $_state.addAttribute("segment_types", $_builder.getArrayAttr(
+          llvm::map_to_vector(segmentTypes, [&](Type type) {
+              return cast<Attribute>(TypeAttr::get(type));
+          })));
+      $_state.addOperands(operands);
+      $_state.addAttribute("result_types",
+          $_builder.getTypeArrayAttr(resultTypes));
+      $_state.addSuccessors(dest);
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return getOperands();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getOperandsMutable();
+    }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return getOperation()->getAttrOfType<FlatSymbolRefAttr>("callee");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", cast<SymbolRefAttr>(callee));
+    }
+
+    /// Get the result types of the call.
+    SmallVector<Type> getResultTypesVec() {
+      SmallVector<Type> types;
+      for (auto typeAttr : getResultTypes())
+        types.push_back(cast<TypeAttr>(typeAttr).getValue());
+      return types;
+    }
+
+    void setDest(Block *block);
+
+    /// RefMoveInterface: ref operands support MOVE (callee handles ownership).
+    bool isRefOperandMovable(unsigned operandIndex) {
+      return isa<IREE::VM::RefType>(getOperands()[operandIndex].getType());
+    }
+    /// RefMoveInterface: ref results support MOVE (callee transfers ownership).
+    bool isRefResultMovable(unsigned resultIndex) {
+      return isa<IREE::VM::RefType>(getResultTypesVec()[resultIndex]);
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def VM_ReturnOp : VM_Op<"return", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     DeclareOpInterfaceMethods<VM_RefMoveInterface>,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -4585,6 +4585,116 @@ def VM_CallVariadicOp : VM_CallBaseOp<"call.variadic"> {
   let hasCanonicalizer = 1;
 }
 
+def VM_CallYieldableOp : VM_Op<"call.yieldable", [
+    DeclareOpInterfaceMethods<BranchOpInterface>,
+    DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+    DeclareOpInterfaceMethods<VM_RefMoveInterface>,
+    CallOpInterface,
+    Terminator,
+    Util_YieldPoint,
+    VM_MayFail,
+  ]> {
+  let summary = [{Call operation that may yield.}];
+  let description = [{
+    Calls a VM function (internal or imported) that may yield. If the call
+    yields execution resumes at the specified successor block with the call
+    results as block arguments. If the call completes synchronously control
+    branches to the successor with the results.
+
+    This op is a terminator that combines a call with an explicit resume point,
+    making the yield/resume semantics visible in the IR.
+
+    ```
+    ^bb0:
+      vm.call.yieldable @hal.fence.await(%timeout, %fence) : (i32, !vm.ref<?>) -> ^resume(i32)
+    ^resume(%result : i32):
+      vm.return %result
+    ```
+  }];
+
+  let arguments = (ins
+    VM_FuncRefAttr:$callee,
+    Variadic<VM_AnyType>:$arguments,
+    TypeArrayAttr:$result_types,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let successors = (successor
+    AnySuccessor:$dest
+  );
+
+  let assemblyFormat = [{
+    $callee `(` $arguments `)` attr-dict `:` `(` type($arguments) `)`
+    `->` $dest custom<ResultTypeList>($result_types)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_CallYieldable>,
+    VM_EncFuncAttr<"callee">,
+    VM_EncVariadicOperands<"arguments">,
+    VM_EncBranchTarget<"dest">,
+    VM_EncBlockArgResults<"dest">,
+  ];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "FlatSymbolRefAttr":$callee,
+      "ValueRange":$arguments,
+      "Block *":$dest,
+      "ArrayRef<Type>":$resultTypes),
+    [{
+      $_state.addAttribute("callee", callee);
+      $_state.addOperands(arguments);
+      $_state.addAttribute("result_types",
+          $_builder.getTypeArrayAttr(resultTypes));
+      $_state.addSuccessors(dest);
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return getArguments();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getArgumentsMutable();
+    }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return getOperation()->getAttrOfType<FlatSymbolRefAttr>("callee");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(CallInterfaceCallable callee) {
+      (*this)->setAttr("callee", cast<SymbolRefAttr>(callee));
+    }
+
+    /// Get the result types of the call.
+    SmallVector<Type> getResultTypesVec() {
+      SmallVector<Type> types;
+      for (auto typeAttr : getResultTypes())
+        types.push_back(cast<TypeAttr>(typeAttr).getValue());
+      return types;
+    }
+
+    void setDest(Block *block);
+
+    /// RefMoveInterface: ref operands support MOVE (callee handles ownership).
+    bool isRefOperandMovable(unsigned operandIndex) {
+      return isa<IREE::VM::RefType>(getArguments()[operandIndex].getType());
+    }
+    /// RefMoveInterface: ref results support MOVE (callee transfers ownership).
+    bool isRefResultMovable(unsigned resultIndex) {
+      return isa<IREE::VM::RefType>(getResultTypesVec()[resultIndex]);
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def VM_ReturnOp : VM_Op<"return", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     DeclareOpInterfaceMethods<VM_RefMoveInterface>,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMTraits.h
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMTraits.h
@@ -68,6 +68,12 @@ public:
   }
 };
 
+template <typename ConcreteType>
+class MayFail : public OpTrait::TraitBase<ConcreteType, MayFail> {
+public:
+  static LogicalResult verifyTrait(Operation *op) { return success(); }
+};
+
 } // namespace mlir::OpTrait::IREE::VM
 
 #endif // IREE_COMPILER_DIALECT_VM_IR_VMTRAITS_H_

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
@@ -174,6 +174,19 @@ vm.module @my_module {
 
 // -----
 
+// CHECK-LABEL: @call_yieldable
+vm.module @my_module {
+  vm.import private @yieldable_fn(%arg0 : i32) -> i32 attributes {vm.yield}
+  vm.func @call_yieldable(%arg0 : i32) -> i32 {
+    // CHECK: vm.call.yieldable @yieldable_fn(%arg0) : (i32) -> ^bb1 (i32)
+    vm.call.yieldable @yieldable_fn(%arg0) : (i32) -> ^bb1(i32)
+  ^bb1(%result : i32):
+    vm.return %result : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @return_empty
 vm.module @my_module {
   vm.func @return_empty() {

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.h
@@ -34,7 +34,7 @@ struct EncodedBytecodeFunction {
 class BytecodeEncoder : public VMFuncEncoder {
 public:
   // Matches IREE_VM_BYTECODE_VERSION_MAJOR.
-  static constexpr uint32_t kVersionMajor = 16;
+  static constexpr uint32_t kVersionMajor = 17;
   // Matches IREE_VM_BYTECODE_VERSION_MINOR.
   static constexpr uint32_t kVersionMinor = 0;
   static constexpr uint32_t kVersion = (kVersionMajor << 16) | kVersionMinor;

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -297,6 +297,13 @@ static iree_vm_FeatureBits_enum_t findRequiredFeatures(Operation *rootOp) {
       result |= iree_vm_FeatureBits_EXT_F64;
     }
   });
+  // Check function-level attributes set by AnnotateFunctionsPass.
+  if (rootOp->hasAttr("vm.yield")) {
+    result |= iree_vm_FeatureBits_YIELD;
+  }
+  if (rootOp->hasAttr("vm.unwind")) {
+    result |= iree_vm_FeatureBits_UNWIND;
+  }
   return result;
 }
 
@@ -550,6 +557,9 @@ buildFlatBufferModule(IREE::VM::TargetOptions vmOptions,
     allowedFeatures |= iree_vm_FeatureBits_EXT_F32;
   if (vmOptions.f64Extension)
     allowedFeatures |= iree_vm_FeatureBits_EXT_F64;
+  // Yield/unwind are core VM semantics once supported by the runtime.
+  allowedFeatures |= iree_vm_FeatureBits_YIELD;
+  allowedFeatures |= iree_vm_FeatureBits_UNWIND;
   if ((moduleRequirements & allowedFeatures) != moduleRequirements) {
     return moduleOp.emitError()
            << "module uses features not allowed by flags (requires "

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/AnnotateFunctions.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/AnnotateFunctions.cpp
@@ -1,0 +1,202 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/IR/VMTraits.h"
+#include "iree/compiler/Dialect/VM/IR/VMTypes.h"
+#include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "llvm/ADT/SCCIterator.h"
+#include "mlir/Analysis/CallGraph.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::VM {
+
+#define GEN_PASS_DEF_ANNOTATEFUNCTIONSPASS
+#include "iree/compiler/Dialect/VM/Transforms/Passes.h.inc"
+
+namespace {
+
+// Information collected about a function in a single walk.
+struct FuncInfo {
+  bool needsYield = false;
+  bool needsUnwind = false;
+  SmallVector<Operation *> callees;
+};
+
+// Analyzes a function in a single walk to collect yield/unwind requirements
+// and callees.
+static FuncInfo analyzeFunction(IREE::VM::FuncOp funcOp,
+                                SymbolTable &symbolTable) {
+  FuncInfo info;
+
+  // Check existing attributes.
+  info.needsYield = funcOp->hasAttr("vm.yield");
+  info.needsUnwind = funcOp->hasAttr("vm.unwind");
+
+  // Check signature for refs.
+  bool hasRefs = llvm::any_of(funcOp.getArgumentTypes(),
+                              [](Type t) { return isa<IREE::VM::RefType>(t); });
+  hasRefs |= llvm::any_of(funcOp.getResultTypes(),
+                          [](Type t) { return isa<IREE::VM::RefType>(t); });
+
+  bool hasFailableOps = false;
+
+  // Single walk: collect callees, check for refs/failable ops/yield ops.
+  funcOp.walk([&](Operation *op) {
+    // Collect callees.
+    if (auto callOp = dyn_cast<IREE::VM::CallOp>(op)) {
+      if (auto callee = symbolTable.lookup(callOp.getCallee()))
+        info.callees.push_back(callee);
+    } else if (auto callOp = dyn_cast<IREE::VM::CallVariadicOp>(op)) {
+      if (auto callee = symbolTable.lookup(callOp.getCallee()))
+        info.callees.push_back(callee);
+    }
+    // Check for yield ops.
+    if (isa<IREE::VM::YieldOp>(op)) {
+      info.needsYield = true;
+    }
+    // Check for MayFail trait.
+    if (op->hasTrait<OpTrait::IREE::VM::MayFail>()) {
+      hasFailableOps = true;
+    }
+    // Check results for refs.
+    for (Value result : op->getResults()) {
+      if (isa<IREE::VM::RefType>(result.getType())) {
+        hasRefs = true;
+        break;
+      }
+    }
+  });
+
+  // Compute initial unwind requirement.
+  if (hasRefs && hasFailableOps) {
+    info.needsUnwind = true;
+  }
+
+  return info;
+}
+
+// Analyzes an import to collect yield/unwind requirements.
+static FuncInfo analyzeImport(IREE::VM::ImportOp importOp) {
+  FuncInfo info;
+  info.needsYield = importOp->hasAttr("vm.yield");
+  info.needsUnwind = importOp->hasAttr("vm.unwind");
+  // Imports have no callees.
+  return info;
+}
+
+class AnnotateFunctionsPass
+    : public IREE::VM::impl::AnnotateFunctionsPassBase<AnnotateFunctionsPass> {
+public:
+  void runOnOperation() override {
+    IREE::VM::ModuleOp moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+
+    // Map from operation to its info.
+    DenseMap<Operation *, FuncInfo> funcInfos;
+
+    // Phase 1: Analyze all functions and imports (single walk each).
+    for (auto funcOp : moduleOp.getOps<IREE::VM::FuncOp>()) {
+      funcInfos[funcOp] = analyzeFunction(funcOp, symbolTable);
+    }
+    for (auto importOp : moduleOp.getOps<IREE::VM::ImportOp>()) {
+      funcInfos[importOp] = analyzeImport(importOp);
+    }
+
+    // Phase 2: Build adjacency list for reverse graph (callee -> callers).
+    // We need to propagate from callees to callers, so we process in
+    // reverse topological order. Using the call graph directly gives us
+    // the right order with scc_iterator.
+
+    // Build the MLIR CallGraph.
+    const CallGraph callGraph(moduleOp);
+
+    // Phase 3: Process SCCs in reverse topological order (callees before
+    // callers). The scc_iterator provides SCCs in reverse post-order, which
+    // means callees are visited before callers (what we want).
+    for (auto sccIt = llvm::scc_begin(&callGraph); !sccIt.isAtEnd(); ++sccIt) {
+      const std::vector<CallGraphNode *> &scc = *sccIt;
+
+      // Collect initial bits from all nodes in this SCC.
+      bool sccYield = false;
+      bool sccUnwind = false;
+
+      for (CallGraphNode *node : scc) {
+        if (node->isExternal())
+          continue;
+        Operation *op = node->getCallableRegion()->getParentOp();
+        auto it = funcInfos.find(op);
+        if (it != funcInfos.end()) {
+          sccYield |= it->second.needsYield;
+          sccUnwind |= it->second.needsUnwind;
+        }
+      }
+
+      // Propagate from callees (already processed, outside this SCC).
+      for (CallGraphNode *node : scc) {
+        if (node->isExternal())
+          continue;
+        Operation *op = node->getCallableRegion()->getParentOp();
+        auto it = funcInfos.find(op);
+        if (it == funcInfos.end())
+          continue;
+
+        for (Operation *calleeOp : it->second.callees) {
+          auto calleeIt = funcInfos.find(calleeOp);
+          if (calleeIt == funcInfos.end())
+            continue;
+
+          // Only propagate from callees outside this SCC (they have final
+          // bits).
+          bool inScc = false;
+          for (CallGraphNode *sccNode : scc) {
+            if (!sccNode->isExternal() &&
+                sccNode->getCallableRegion()->getParentOp() == calleeOp) {
+              inScc = true;
+              break;
+            }
+          }
+          if (!inScc) {
+            sccYield |= calleeIt->second.needsYield;
+            sccUnwind |= calleeIt->second.needsUnwind;
+          }
+        }
+      }
+
+      // Apply to all nodes in this SCC.
+      for (CallGraphNode *node : scc) {
+        if (node->isExternal())
+          continue;
+        Operation *op = node->getCallableRegion()->getParentOp();
+        auto it = funcInfos.find(op);
+        if (it != funcInfos.end()) {
+          it->second.needsYield = sccYield;
+          it->second.needsUnwind = sccUnwind;
+        }
+      }
+    }
+
+    // Phase 4: Apply attributes to functions.
+    for (auto funcOp : moduleOp.getOps<IREE::VM::FuncOp>()) {
+      auto it = funcInfos.find(funcOp);
+      if (it == funcInfos.end())
+        continue;
+
+      if (it->second.needsYield && !funcOp->hasAttr("vm.yield")) {
+        funcOp->setAttr("vm.yield", UnitAttr::get(funcOp.getContext()));
+      }
+      if (it->second.needsUnwind && !funcOp->hasAttr("vm.unwind")) {
+        funcOp->setAttr("vm.unwind", UnitAttr::get(funcOp.getContext()));
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::VM

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/BUILD.bazel
@@ -20,6 +20,7 @@ package(
 iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
+        "AnnotateFunctions.cpp",
         "Conversion.cpp",
         "DeduplicateRodata.cpp",
         "DropEmptyModuleInitializers.cpp",

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/BUILD.bazel
@@ -22,6 +22,7 @@ iree_compiler_cc_library(
     srcs = [
         "AnnotateFunctions.cpp",
         "Conversion.cpp",
+        "ConvertToYieldableCalls.cpp",
         "DeduplicateRodata.cpp",
         "DropEmptyModuleInitializers.cpp",
         "DropUnusedCalls.cpp",

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
     "Passes.h"
     "Passes.h.inc"
   SRCS
+    "AnnotateFunctions.cpp"
     "Conversion.cpp"
     "DeduplicateRodata.cpp"
     "DropEmptyModuleInitializers.cpp"

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
   SRCS
     "AnnotateFunctions.cpp"
     "Conversion.cpp"
+    "ConvertToYieldableCalls.cpp"
     "DeduplicateRodata.cpp"
     "DropEmptyModuleInitializers.cpp"
     "DropUnusedCalls.cpp"

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ConvertToYieldableCalls.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ConvertToYieldableCalls.cpp
@@ -1,0 +1,105 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::VM {
+
+#define GEN_PASS_DEF_CONVERTTOYIELDABLECALLSPASS
+#include "iree/compiler/Dialect/VM/Transforms/Passes.h.inc"
+
+namespace {
+
+// Returns true if the callee is marked as yieldable (has vm.yield attribute).
+static bool isCalleeYieldable(Operation *calleeOp) {
+  return calleeOp && calleeOp->hasAttr("vm.yield");
+}
+
+class ConvertToYieldableCallsPass
+    : public IREE::VM::impl::ConvertToYieldableCallsPassBase<
+          ConvertToYieldableCallsPass> {
+public:
+  void runOnOperation() override {
+    IREE::VM::ModuleOp moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+
+    // Collect calls to convert and variadic calls to error on.
+    SmallVector<IREE::VM::CallOp> callsToConvert;
+    SmallVector<IREE::VM::CallVariadicOp> variadicCallErrors;
+    moduleOp.walk([&](Operation *op) {
+      llvm::TypeSwitch<Operation *>(op)
+          .Case<IREE::VM::CallOp>([&](auto callOp) {
+            Operation *calleeOp = symbolTable.lookup(callOp.getCallee());
+            if (isCalleeYieldable(calleeOp)) {
+              callsToConvert.push_back(callOp);
+            }
+          })
+          .Case<IREE::VM::CallVariadicOp>([&](auto callVariadicOp) {
+            Operation *calleeOp =
+                symbolTable.lookup(callVariadicOp.getCallee());
+            if (isCalleeYieldable(calleeOp)) {
+              variadicCallErrors.push_back(callVariadicOp);
+            }
+          });
+    });
+
+    // Error on variadic calls to yieldable functions (not supported).
+    for (IREE::VM::CallVariadicOp callOp : variadicCallErrors) {
+      callOp.emitError("vm.call.variadic to yieldable function not supported; "
+                       "vm.call.yieldable does not support variadic arguments");
+    }
+    if (!variadicCallErrors.empty()) {
+      return signalPassFailure();
+    }
+
+    // Convert each call.
+    for (IREE::VM::CallOp callOp : callsToConvert) {
+      if (failed(convertCallToYieldable(callOp))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+
+private:
+  LogicalResult convertCallToYieldable(IREE::VM::CallOp callOp) {
+    OpBuilder builder(callOp);
+    Location loc = callOp.getLoc();
+
+    // Split block after the call to create resume block.
+    Block *currentBlock = callOp->getBlock();
+    Block *resumeBlock = currentBlock->splitBlock(callOp->getNextNode());
+
+    // Add block arguments for call results.
+    auto resultTypes = llvm::to_vector(callOp.getResultTypes());
+    SmallVector<Location> argLocs(resultTypes.size(), loc);
+    resumeBlock->addArguments(resultTypes, argLocs);
+
+    // Replace uses of call results with block arguments.
+    for (auto [result, blockArg] :
+         llvm::zip_equal(callOp.getResults(), resumeBlock->getArguments())) {
+      result.replaceAllUsesWith(blockArg);
+    }
+
+    // Create the vm.call.yieldable op and erase the original call.
+    builder.setInsertionPoint(callOp);
+    IREE::VM::CallYieldableOp::create(
+        builder, loc, builder.getAttr<FlatSymbolRefAttr>(callOp.getCallee()),
+        callOp.getOperands(), resumeBlock, resultTypes);
+    callOp.erase();
+
+    return success();
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::VM

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -161,6 +161,11 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   // graph. This must happen after all inlining is complete.
   passManager.addNestedPass<IREE::VM::ModuleOp>(createAnnotateFunctionsPass());
 
+  // Convert calls to yieldable functions to vm.call.yieldable. This must run
+  // after AnnotateFunctionsPass which marks functions with vm.yield.
+  passManager.addNestedPass<IREE::VM::ModuleOp>(
+      createConvertToYieldableCallsPass());
+
   if (targetOptions.optimizeForStackSize) {
     passManager.addNestedPass<IREE::VM::ModuleOp>(createSinkDefiningOpsPass());
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -157,6 +157,10 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<IREE::VM::ModuleOp>(
       createDropEmptyModuleInitializersPass());
 
+  // Annotate functions with yield/unwind requirements by analyzing the call
+  // graph. This must happen after all inlining is complete.
+  passManager.addNestedPass<IREE::VM::ModuleOp>(createAnnotateFunctionsPass());
+
   if (targetOptions.optimizeForStackSize) {
     passManager.addNestedPass<IREE::VM::ModuleOp>(createSinkDefiningOpsPass());
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.td
@@ -113,6 +113,21 @@ def OrdinalAllocationPass :
   }];
 }
 
+def AnnotateFunctionsPass :
+    Pass<"iree-vm-annotate-functions", "IREE::VM::ModuleOp"> {
+  let summary = "Annotates VM functions with yield/unwind requirements.";
+  let description = [{
+    Analyzes the call graph to propagate function attributes:
+    - vm.yield: Function may yield, requires resumable execution
+    - vm.unwind: Function requires stack unwinding with ref cleanup
+
+    This pass uses SCC-based propagation for efficiency:
+    1. Single walk per function to collect initial bits and callees
+    2. Process SCCs in reverse topological order
+    3. Propagate bits from callees to callers
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Optimization passes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.td
@@ -128,6 +128,22 @@ def AnnotateFunctionsPass :
   }];
 }
 
+def ConvertToYieldableCallsPass :
+    Pass<"iree-vm-convert-to-yieldable-calls", "IREE::VM::ModuleOp"> {
+  let summary = "Converts calls to yieldable functions to vm.call.yieldable.";
+  let description = [{
+    Converts vm.call ops that target functions marked with vm.yield to
+    vm.call.yieldable ops. This makes yield points explicit in the IR,
+    enabling proper async handling in the bytecode interpreter and C export.
+
+    This pass must run after AnnotateFunctionsPass which marks functions
+    with vm.yield based on call graph analysis.
+  }];
+  let dependentDialects = [
+    "::mlir::iree_compiler::IREE::VM::VMDialect"
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Optimization passes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "annotate_functions.mlir",
+            "convert_to_yieldable_calls.mlir",
             "deduplicate_rodata.mlir",
             "drop_empty_module_initializers.mlir",
             "drop_unused_calls.mlir",

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "annotate_functions.mlir",
             "deduplicate_rodata.mlir",
             "drop_empty_module_initializers.mlir",
             "drop_unused_calls.mlir",

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "annotate_functions.mlir"
     "deduplicate_rodata.mlir"
     "drop_empty_module_initializers.mlir"
     "drop_unused_calls.mlir"

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "annotate_functions.mlir"
+    "convert_to_yieldable_calls.mlir"
     "deduplicate_rodata.mlir"
     "drop_empty_module_initializers.mlir"
     "drop_unused_calls.mlir"

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/annotate_functions.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/annotate_functions.mlir
@@ -1,0 +1,320 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(vm.module(iree-vm-annotate-functions))" \
+// RUN:   %s | FileCheck %s
+
+// vm.yield op in function body sets vm.yield attribute.
+
+// CHECK-LABEL: @yield_op_direct
+vm.module @yield_op_direct {
+  // CHECK: vm.func private @yields_directly() attributes {vm.yield}
+  vm.func private @yields_directly() {
+    vm.yield ^done
+  ^done:
+    vm.return
+  }
+}
+
+// -----
+
+// vm.yield propagates from function with vm.yield op to callers.
+
+// CHECK-LABEL: @yield_op_propagates
+vm.module @yield_op_propagates {
+  // CHECK: vm.func private @yields_directly() attributes {vm.yield}
+  vm.func private @yields_directly() {
+    vm.yield ^done
+  ^done:
+    vm.return
+  }
+  // CHECK: vm.func private @caller() attributes {vm.yield}
+  vm.func private @caller() {
+    vm.call @yields_directly() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// vm.yield propagates from import to caller.
+
+// CHECK-LABEL: @yield_from_import
+vm.module @yield_from_import {
+  vm.import private @yielding() attributes {vm.yield}
+  // CHECK: vm.func private @caller() attributes {vm.yield}
+  vm.func private @caller() {
+    vm.call @yielding() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// vm.yield propagates transitively through call graph.
+
+// CHECK-LABEL: @yield_transitive
+vm.module @yield_transitive {
+  vm.import private @yielding() attributes {vm.yield}
+  // CHECK: vm.func private @level1() attributes {vm.yield}
+  vm.func private @level1() {
+    vm.call @yielding() : () -> ()
+    vm.return
+  }
+  // CHECK: vm.func private @level2() attributes {vm.yield}
+  vm.func private @level2() {
+    vm.call @level1() : () -> ()
+    vm.return
+  }
+  // CHECK: vm.func private @level3() attributes {vm.yield}
+  vm.func private @level3() {
+    vm.call @level2() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// Function with refs and failable ops (allocation) gets vm.unwind.
+
+// CHECK-LABEL: @unwind_refs_failable
+vm.module @unwind_refs_failable {
+  // CHECK: vm.func private @needs_unwind() attributes {vm.unwind}
+  vm.func private @needs_unwind() {
+    %c128 = vm.const.i64 128
+    %c16 = vm.const.i32 16
+    %buf = vm.buffer.alloc %c128, %c16 : !vm.buffer
+    vm.return
+  }
+}
+
+// -----
+
+// Function with refs but NO failable ops does NOT get vm.unwind.
+
+// CHECK-LABEL: @no_unwind_refs_only
+vm.module @no_unwind_refs_only {
+  // CHECK: vm.func private @no_unwind
+  // CHECK-NOT: vm.unwind
+  vm.func private @no_unwind(%r: !vm.ref<?>) {
+    %nz = vm.cmp.nz.ref %r : !vm.ref<?>
+    vm.return
+  }
+}
+
+// -----
+
+// Function with failable ops but NO refs does NOT get vm.unwind.
+
+// CHECK-LABEL: @no_unwind_failable_only
+vm.module @no_unwind_failable_only {
+  vm.import private @failable()
+  // CHECK: vm.func private @no_unwind
+  // CHECK-NOT: vm.unwind
+  vm.func private @no_unwind() {
+    vm.call @failable() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// Pure integer function gets neither attribute.
+
+// CHECK-LABEL: @no_attributes
+vm.module @no_attributes {
+  // CHECK: vm.func private @pure_int
+  // CHECK-NOT: vm.yield
+  // CHECK-NOT: vm.unwind
+  vm.func private @pure_int(%val: i32) -> i32 {
+    %one = vm.const.i32 1
+    %result = vm.add.i32 %val, %one : i32
+    vm.return %result : i32
+  }
+}
+
+// -----
+
+// vm.unwind propagates from callee to caller.
+
+// CHECK-LABEL: @unwind_propagates
+vm.module @unwind_propagates {
+  // Leaf has refs and failable ops (buffer.alloc) -> needs unwind.
+  // CHECK: vm.func private @leaf() attributes {vm.unwind}
+  vm.func private @leaf() {
+    %c128 = vm.const.i64 128
+    %c16 = vm.const.i32 16
+    %buf = vm.buffer.alloc %c128, %c16 : !vm.buffer
+    vm.return
+  }
+  // Caller inherits unwind from leaf.
+  // CHECK: vm.func private @caller() attributes {vm.unwind}
+  vm.func private @caller() {
+    vm.call @leaf() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// vm.unwind from import propagates to caller.
+
+// CHECK-LABEL: @unwind_from_import
+vm.module @unwind_from_import {
+  vm.import private @unwindable() attributes {vm.unwind}
+  // CHECK: vm.func private @caller() attributes {vm.unwind}
+  vm.func private @caller() {
+    vm.call @unwindable() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// Both vm.yield and vm.unwind can be set on the same function.
+
+// CHECK-LABEL: @both_yield_and_unwind
+vm.module @both_yield_and_unwind {
+  vm.import private @yielding_unwindable() attributes {vm.yield, vm.unwind}
+  // CHECK: vm.func private @caller() attributes {vm.unwind, vm.yield}
+  vm.func private @caller() {
+    vm.call @yielding_unwindable() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// Refs in return type trigger unwind if there are failable ops.
+
+// CHECK-LABEL: @ref_return_with_failable
+vm.module @ref_return_with_failable {
+  vm.import private @create_buffer() -> !vm.buffer
+  // CHECK: vm.func private @returns_ref() -> !vm.buffer attributes {vm.unwind}
+  vm.func private @returns_ref() -> !vm.buffer {
+    %buf = vm.call @create_buffer() : () -> !vm.buffer
+    vm.return %buf : !vm.buffer
+  }
+}
+
+// -----
+
+// Explicit vm.fail op is failable.
+
+// CHECK-LABEL: @fail_op_is_failable
+vm.module @fail_op_is_failable {
+  // CHECK: vm.func private @may_fail(%{{.*}}: !vm.buffer) attributes {vm.unwind}
+  vm.func private @may_fail(%buf: !vm.buffer) {
+    %nz = vm.cmp.nz.ref %buf : !vm.buffer
+    vm.cond_br %nz, ^ok, ^fail
+  ^ok:
+    vm.return
+  ^fail:
+    %code = vm.const.i32 1
+    vm.fail %code, "buffer was null"
+  }
+}
+
+// -----
+
+// vm.cond_fail is failable.
+
+// CHECK-LABEL: @cond_fail_is_failable
+vm.module @cond_fail_is_failable {
+  // CHECK: vm.func private @may_cond_fail(%{{.*}}: !vm.buffer) attributes {vm.unwind}
+  vm.func private @may_cond_fail(%buf: !vm.buffer) {
+    %nz = vm.cmp.nz.ref %buf : !vm.buffer
+    %code = vm.const.i32 1
+    vm.cond_fail %nz, %code, "buffer was null"
+    vm.return
+  }
+}
+
+// -----
+
+// SCC: mutual recursion shares attributes.
+
+// CHECK-LABEL: @scc_mutual_recursion
+vm.module @scc_mutual_recursion {
+  vm.import private @yielding() attributes {vm.yield}
+  // Both functions in the cycle should get vm.yield.
+  // CHECK: vm.func private @func_a() attributes {vm.yield}
+  vm.func private @func_a() {
+    vm.call @func_b() : () -> ()
+    vm.return
+  }
+  // CHECK: vm.func private @func_b() attributes {vm.yield}
+  vm.func private @func_b() {
+    vm.call @yielding() : () -> ()
+    vm.call @func_a() : () -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// SCC: self-recursion with vm.unwind.
+
+// CHECK-LABEL: @scc_self_recursion
+vm.module @scc_self_recursion {
+  // CHECK: vm.func private @recursive() attributes {vm.unwind}
+  vm.func private @recursive() {
+    %c128 = vm.const.i64 128
+    %c16 = vm.const.i32 16
+    %buf = vm.buffer.alloc %c128, %c16 : !vm.buffer
+    %len = vm.buffer.length %buf : !vm.buffer -> i64
+    %zero = vm.const.i64 0
+    %cmp = vm.cmp.gt.i64.s %len, %zero : i64
+    vm.cond_br %cmp, ^recurse, ^done
+  ^recurse:
+    vm.call @recursive() : () -> ()
+    vm.br ^done
+  ^done:
+    vm.return
+  }
+}
+
+// -----
+
+// Variadic call propagates attributes.
+
+// CHECK-LABEL: @variadic_call
+vm.module @variadic_call {
+  vm.import private @variadic_yielding(%arg: i32 ...) attributes {vm.yield}
+  // CHECK: vm.func private @caller() attributes {vm.yield}
+  vm.func private @caller() {
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    vm.call.variadic @variadic_yielding([%c1, %c2]) : (i32 ...) -> ()
+    vm.return
+  }
+}
+
+// -----
+
+// Buffer load/store ops have MayFail trait.
+
+// CHECK-LABEL: @buffer_load_store_may_fail
+vm.module @buffer_load_store_may_fail {
+  // CHECK: vm.func private @buffer_ops(%{{.*}}: !vm.buffer) attributes {vm.unwind}
+  vm.func private @buffer_ops(%buf: !vm.buffer) {
+    %c0 = vm.const.i64 0
+    %val = vm.buffer.load.i32 %buf[%c0] : !vm.buffer -> i32
+    vm.buffer.store.i32 %val, %buf[%c0] : i32 -> !vm.buffer
+    vm.return
+  }
+}
+
+// -----
+
+// List ops have MayFail trait.
+
+// CHECK-LABEL: @list_ops_may_fail
+vm.module @list_ops_may_fail {
+  // CHECK: vm.func private @list_ops() attributes {vm.unwind}
+  vm.func private @list_ops() {
+    %c10 = vm.const.i32 10
+    %list = vm.list.alloc %c10 : (i32) -> !vm.list<i32>
+    %c0 = vm.const.i32 0
+    %val = vm.list.get.i32 %list, %c0 : (!vm.list<i32>, i32) -> i32
+    vm.return
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/convert_to_yieldable_calls.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/convert_to_yieldable_calls.mlir
@@ -1,0 +1,122 @@
+// RUN: iree-opt --split-input-file --iree-vm-convert-to-yieldable-calls %s | FileCheck %s
+
+// Tests that vm.call to a function with vm.yield attribute is converted to
+// vm.call.yieldable.
+
+vm.module @module {
+  // Import marked as yieldable.
+  vm.import private @yieldable_fn(%arg: i32) -> i32 attributes {vm.yield}
+  vm.import private @normal_fn(%arg: i32) -> i32
+
+  // CHECK-LABEL: @call_yieldable_import
+  vm.func @call_yieldable_import(%arg0: i32) -> i32 {
+    // CHECK: vm.call.yieldable @yieldable_fn(%arg0) : (i32) -> ^bb1 (i32)
+    // CHECK-NEXT: ^bb1(%[[RESULT:.*]]: i32):
+    // CHECK-NEXT: vm.return %[[RESULT]] : i32
+    %0 = vm.call @yieldable_fn(%arg0) : (i32) -> i32
+    vm.return %0 : i32
+  }
+
+  // CHECK-LABEL: @call_normal_import
+  vm.func @call_normal_import(%arg0: i32) -> i32 {
+    // CHECK: %[[RESULT:.*]] = vm.call @normal_fn(%arg0) : (i32) -> i32
+    // CHECK-NEXT: vm.return %[[RESULT]] : i32
+    %0 = vm.call @normal_fn(%arg0) : (i32) -> i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// Tests that internal functions with vm.yield attribute are converted.
+
+vm.module @module_internal {
+  // Internal function marked as yieldable.
+  vm.func private @yieldable_internal(%arg: i32) -> i32 attributes {vm.yield} {
+    %c1 = vm.const.i32 1
+    %result = vm.add.i32 %arg, %c1 : i32
+    vm.return %result : i32
+  }
+
+  // CHECK-LABEL: @call_yieldable_internal
+  vm.func @call_yieldable_internal(%arg0: i32) -> i32 {
+    // CHECK: vm.call.yieldable @yieldable_internal(%arg0) : (i32) -> ^bb1 (i32)
+    // CHECK-NEXT: ^bb1(%[[RESULT:.*]]: i32):
+    // CHECK-NEXT: vm.return %[[RESULT]] : i32
+    %0 = vm.call @yieldable_internal(%arg0) : (i32) -> i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// Tests conversion with multiple results.
+
+vm.module @module_multi_result {
+  vm.import private @yieldable_multi(%arg: i32) -> (i32, i32) attributes {vm.yield}
+
+  // CHECK-LABEL: @call_yieldable_multi_result
+  vm.func @call_yieldable_multi_result(%arg0: i32) -> (i32, i32) {
+    // CHECK: vm.call.yieldable @yieldable_multi(%arg0) : (i32) -> ^bb1 (i32, i32)
+    // CHECK-NEXT: ^bb1(%[[R0:.*]]: i32, %[[R1:.*]]: i32):
+    // CHECK-NEXT: vm.return %[[R0]], %[[R1]] : i32, i32
+    %0:2 = vm.call @yieldable_multi(%arg0) : (i32) -> (i32, i32)
+    vm.return %0#0, %0#1 : i32, i32
+  }
+}
+
+// -----
+
+// Tests conversion with ref types.
+
+vm.module @module_ref {
+  vm.import private @yieldable_ref(%buf: !vm.buffer) -> !vm.buffer attributes {vm.yield}
+
+  // CHECK-LABEL: @call_yieldable_ref
+  vm.func @call_yieldable_ref(%arg0: !vm.buffer) -> !vm.buffer {
+    // CHECK: vm.call.yieldable @yieldable_ref(%arg0) : (!vm.buffer) -> ^bb1 (!vm.buffer)
+    // CHECK-NEXT: ^bb1(%[[RESULT:.*]]: !vm.buffer):
+    // CHECK-NEXT: vm.return %[[RESULT]] : !vm.buffer
+    %0 = vm.call @yieldable_ref(%arg0) : (!vm.buffer) -> !vm.buffer
+    vm.return %0 : !vm.buffer
+  }
+}
+
+// -----
+
+// Tests that code after the call is preserved in the resume block.
+
+vm.module @module_code_after {
+  vm.import private @yieldable_fn(%arg: i32) -> i32 attributes {vm.yield}
+
+  // CHECK-LABEL: @call_with_code_after
+  vm.func @call_with_code_after(%arg0: i32) -> i32 {
+    // CHECK: vm.call.yieldable @yieldable_fn(%arg0) : (i32) -> ^bb1 (i32)
+    // CHECK-NEXT: ^bb1(%[[R:.*]]: i32):
+    // CHECK: %[[ADD:.*]] = vm.add.i32 %[[R]], %[[R]]
+    // CHECK-NEXT: vm.return %[[ADD]] : i32
+    %0 = vm.call @yieldable_fn(%arg0) : (i32) -> i32
+    %1 = vm.add.i32 %0, %0 : i32
+    vm.return %1 : i32
+  }
+}
+
+// -----
+
+// Tests multiple yieldable calls in sequence.
+
+vm.module @module_sequence {
+  vm.import private @yieldable_fn(%arg: i32) -> i32 attributes {vm.yield}
+
+  // CHECK-LABEL: @call_sequence
+  vm.func @call_sequence(%arg0: i32) -> i32 {
+    // CHECK: vm.call.yieldable @yieldable_fn(%arg0) : (i32) -> ^bb1 (i32)
+    // CHECK-NEXT: ^bb1(%[[R1:.*]]: i32):
+    // CHECK: vm.call.yieldable @yieldable_fn(%[[R1]]) : (i32) -> ^bb2 (i32)
+    // CHECK-NEXT: ^bb2(%[[R2:.*]]: i32):
+    // CHECK-NEXT: vm.return %[[R2]] : i32
+    %0 = vm.call @yieldable_fn(%arg0) : (i32) -> i32
+    %1 = vm.call @yieldable_fn(%0) : (i32) -> i32
+    vm.return %1 : i32
+  }
+}

--- a/runtime/src/iree/schemas/bytecode_module_def.fbs
+++ b/runtime/src/iree/schemas/bytecode_module_def.fbs
@@ -16,6 +16,15 @@ enum FeatureBits:uint32 (bit_flags) {
   EXT_F32 = 0,  // 1u << 0
   // 64-bit floating point extension.
   EXT_F64 = 1,  // 1u << 1
+  // The function may (transitively) yield and requires resumable execution.
+  // When set on function requirements callers must be able to handle
+  // IREE_STATUS_DEFERRED results and resume execution later.
+  YIELD = 2,  // 1u << 2
+  // The function (transitively) requires stack unwinding with ref cleanup.
+  // When set on function requirements callers must ensure that stack frames
+  // are entered with a cleanup callback that can release any live refs on
+  // error/unwind paths.
+  UNWIND = 3,  // 1u << 3
 }
 
 // Arbitrary key/value reflection attribute.

--- a/runtime/src/iree/vm/bytecode/BUILD.bazel
+++ b/runtime/src/iree/vm/bytecode/BUILD.bazel
@@ -69,6 +69,7 @@ iree_runtime_cc_test(
         "//runtime/src/iree/vm",
         "//runtime/src/iree/vm/test:all_bytecode_modules_c",
         "//runtime/src/iree/vm/test:async_bytecode_modules_c",
+        "//runtime/src/iree/vm/test:async_ops_test_module",
     ],
 )
 

--- a/runtime/src/iree/vm/bytecode/CMakeLists.txt
+++ b/runtime/src/iree/vm/bytecode/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_test(
     iree::vm
     iree::vm::test::all_bytecode_modules_c
     iree::vm::test::async_bytecode_modules_c
+    iree::vm::test::async_ops_test_module
 )
 
 iree_bytecode_module(

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -1686,6 +1686,27 @@ static iree_status_t iree_vm_bytecode_disassemble_op_impl(
       break;
     }
 
+    IREE_VM_ISA_EMIT_OP(CORE, CallVariadicYieldable) {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(function_ordinal);
+      // TODO(benvanik): print segment sizes.
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(segment_size_list);
+      (void)segment_size_list;
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
+      IREE_VM_ISA_DECODE_BRANCH_TARGET_PC(resume_pc);
+      IREE_VM_ISA_DECODE_VARIADIC_RESULTS(dst_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, "vm.call.variadic.yieldable @"));
+      IREE_RETURN_IF_ERROR(iree_vm_bytecode_disassembler_print_function_name(
+          module, module_state, function_ordinal, b));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "("));
+      IREE_VM_ISA_EMIT_OPERAND_REG_LIST(src_reg_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ") -> ^%08X(", resume_pc));
+      IREE_VM_ISA_EMIT_RESULT_REG_LIST(dst_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
     IREE_VM_ISA_EMIT_OP(CORE, Return) {
       IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "vm.return "));

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -1668,6 +1668,24 @@ static iree_status_t iree_vm_bytecode_disassemble_op_impl(
       break;
     }
 
+    IREE_VM_ISA_EMIT_OP(CORE, CallYieldable) {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(function_ordinal);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
+      IREE_VM_ISA_DECODE_BRANCH_TARGET_PC(resume_pc);
+      IREE_VM_ISA_DECODE_VARIADIC_RESULTS(dst_reg_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.call.yieldable @"));
+      IREE_RETURN_IF_ERROR(iree_vm_bytecode_disassembler_print_function_name(
+          module, module_state, function_ordinal, b));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "("));
+      IREE_VM_ISA_EMIT_OPERAND_REG_LIST(src_reg_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ") -> ^%08X(", resume_pc));
+      IREE_VM_ISA_EMIT_RESULT_REG_LIST(dst_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
     IREE_VM_ISA_EMIT_OP(CORE, Return) {
       IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "vm.return "));

--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -445,6 +445,9 @@ static iree_status_t iree_vm_bytecode_internal_leave(
       caller_registers.i32[dst_reg] = callee_registers.i32[src_reg];
     }
   }
+  // Clear return_registers so it's not misinterpreted as resume state by
+  // subsequent yieldable import calls in the caller frame.
+  caller_storage->return_registers = NULL;
 
   // Mark successful completion - compiler guarantees all refs are released.
   iree_vm_bytecode_frame_storage_t* callee_storage =
@@ -698,9 +701,9 @@ static iree_status_t iree_vm_bytecode_issue_import_call(
                                 iree_make_cstring_view("while calling import"));
   }
 
-  // NOTE: we don't support yielding within imported functions right now so it's
-  // safe to assume the stack is still valid here. If the called function can
-  // yield then we'll need to requery all pointers here.
+  // NOTE: this synchronous call path requires the import to complete without
+  // yielding. Functions that may yield must use vm.call.yieldable, which has
+  // its own path that handles DEFERRED status and frame pointer revalidation.
   *out_caller_frame = iree_vm_stack_current_frame(stack);
   *out_caller_registers =
       iree_vm_bytecode_get_register_storage(*out_caller_frame);
@@ -848,6 +851,114 @@ static iree_status_t iree_vm_bytecode_call_import_variadic(
       dst_reg_list, out_caller_frame, out_caller_registers);
 }
 
+// Issues a yieldable import call that supports deferral with results.
+// Uses frame->return_registers to track begin vs resume state:
+//   - NULL: Fresh call, will call begin_call and set return_registers
+//   - Non-NULL: Resume, will call resume_call
+// On DEFERRED: returns DEFERRED (PC should be set to re-execute instruction).
+// On OK: copies results to dst_reg_list, clears return_registers, returns OK.
+static iree_status_t iree_vm_bytecode_call_import_yieldable(
+    iree_vm_stack_t* stack, iree_vm_stack_frame_t* caller_frame,
+    const iree_vm_bytecode_module_state_t* module_state,
+    uint32_t import_ordinal, const iree_vm_registers_t caller_registers,
+    const iree_vm_register_list_t* IREE_RESTRICT src_reg_list,
+    const iree_vm_register_list_t* IREE_RESTRICT dst_reg_list,
+    iree_vm_registers_t* out_caller_registers) {
+  // Get frame storage to check/set return_registers for begin/resume tracking.
+  // NOTE: We must use the passed-in caller_frame, not
+  // iree_vm_stack_current_frame, because on resume the native import's frame is
+  // still on top of the stack.
+  iree_vm_bytecode_frame_storage_t* frame_storage =
+      (iree_vm_bytecode_frame_storage_t*)iree_vm_stack_frame_storage(
+          caller_frame);
+
+  // Prepare |call| by looking up the import information.
+  const iree_vm_bytecode_import_t* import = NULL;
+  IREE_RETURN_IF_ERROR(iree_vm_bytecode_verify_import(stack, module_state,
+                                                      import_ordinal, &import));
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = import->function;
+
+  // Allocate result buffer (fresh each call via alloca).
+  call.results.data_length = import->result_buffer_size;
+  call.results.data = iree_alloca(call.results.data_length);
+  memset(call.results.data, 0, call.results.data_length);
+
+  iree_status_t call_status = iree_ok_status();
+  if (frame_storage->return_registers == NULL) {
+    // Fresh call: marshal arguments and call begin_call.
+    frame_storage->return_registers = dst_reg_list;
+
+    call.arguments.data_length = import->argument_buffer_size;
+    call.arguments.data = iree_alloca(call.arguments.data_length);
+    memset(call.arguments.data, 0, call.arguments.data_length);
+    iree_vm_bytecode_populate_import_cconv_arguments(
+        import->arguments, caller_registers,
+        /*segment_size_list=*/NULL, src_reg_list, call.arguments);
+
+    call_status = call.function.module->begin_call(call.function.module->self,
+                                                   stack, call);
+
+    // Release refs in argument buffer regardless of call status.
+    iree_vm_bytecode_release_import_cconv_arguments(
+        import->arguments, /*segment_size_list=*/NULL, call.arguments);
+  } else {
+    // Resume: import already has arguments, just need results buffer.
+    call_status = call.function.module->resume_call(call.function.module->self,
+                                                    stack, call.results);
+  }
+
+  if (iree_status_is_deferred(call_status)) {
+    // Still waiting - return_registers stays set for next resume.
+    return call_status;
+  } else if (IREE_UNLIKELY(!iree_status_is_ok(call_status))) {
+    frame_storage->return_registers = NULL;  // Clear on error.
+    return iree_status_annotate(call_status,
+                                iree_make_cstring_view("while calling import"));
+  }
+
+  // Call completed. Update output registers.
+  // The bytecode frame doesn't move during import calls, so we use
+  // caller_frame.
+  *out_caller_registers = iree_vm_bytecode_get_register_storage(caller_frame);
+
+  // Get dst_reg_list from return_registers.
+  dst_reg_list = frame_storage->return_registers;
+  frame_storage->return_registers = NULL;  // Clear for next call.
+
+  // Marshal outputs from the ABI results buffer to registers.
+  iree_vm_registers_t regs = *out_caller_registers;
+  uint8_t* IREE_RESTRICT p = call.results.data;
+  iree_string_view_t cconv_results = import->results;
+  for (iree_host_size_t i = 0; i < cconv_results.size && i < dst_reg_list->size;
+       ++i) {
+    uint16_t dst_reg = dst_reg_list->registers[i];
+    switch (cconv_results.data[i]) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
+      case IREE_VM_CCONV_TYPE_I32:
+      case IREE_VM_CCONV_TYPE_F32:
+        memcpy(&regs.i32[dst_reg], p, sizeof(int32_t));
+        p += sizeof(int32_t);
+        break;
+      case IREE_VM_CCONV_TYPE_I64:
+      case IREE_VM_CCONV_TYPE_F64:
+        memcpy(&regs.i32[dst_reg], p, sizeof(int64_t));
+        p += sizeof(int64_t);
+        break;
+      case IREE_VM_CCONV_TYPE_REF:
+        iree_vm_ref_move((iree_vm_ref_t*)p,
+                         &regs.ref[dst_reg & IREE_VM_ISA_REF_REGISTER_MASK]);
+        p += sizeof(iree_vm_ref_t);
+        break;
+    }
+  }
+
+  return iree_ok_status();
+}
+
 //===----------------------------------------------------------------------===//
 // Main interpreter dispatch routine
 //===----------------------------------------------------------------------===//
@@ -898,15 +1009,28 @@ iree_status_t iree_vm_bytecode_dispatch_begin(
 iree_status_t iree_vm_bytecode_dispatch_resume(
     iree_vm_stack_t* stack, iree_vm_bytecode_module_t* module,
     iree_byte_span_t call_results) {
+  // Find the bytecode frame belonging to this module.
+  // When a yieldable import yields, the native import's frame remains on top
+  // of the bytecode frame. We need to find our bytecode frame to get the
+  // register storage and resume dispatch. The native frame(s) will be resumed
+  // by the CallYieldable handler when it re-executes.
   iree_vm_stack_frame_t* current_frame = iree_vm_stack_top(stack);
   if (IREE_UNLIKELY(!current_frame)) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "no frame at top of stack to resume");
   }
+
+  // Walk up the stack to find our bytecode frame.
+  while (current_frame && current_frame->function.module->self != module) {
+    current_frame = iree_vm_stack_parent_frame(stack);
+  }
+  if (IREE_UNLIKELY(!current_frame)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "no frame belonging to this module on stack");
+  }
+
   iree_vm_registers_t regs =
       iree_vm_bytecode_get_register_storage(current_frame);
-  // TODO(benvanik): assert the module is at the top of the frame? We should
-  // only be coming in from a call based on the current frame.
   return iree_vm_bytecode_dispatch(stack, module, current_frame, regs,
                                    call_results);
 }
@@ -1880,10 +2004,13 @@ static iree_status_t iree_vm_bytecode_dispatch(
       // TODO(benvanik): something more clever than just a high bit?
       int is_import = iree_vm_isa_function_ordinal_is_import(function_ordinal);
       if (is_import) {
-        // Call import (and possible yield).
-        IREE_RETURN_IF_ERROR(iree_vm_bytecode_call_import(
+        // Call import.
+        iree_status_t call_status = iree_vm_bytecode_call_import(
             stack, module_state, function_ordinal, regs, src_reg_list,
-            dst_reg_list, &current_frame, &regs));
+            dst_reg_list, &current_frame, &regs);
+        IREE_ASSERT(!iree_status_is_deferred(call_status),
+                    "deferred calls must use vm.call.yieldable");
+        IREE_RETURN_IF_ERROR(call_status);
       } else {
         // Switch execution to the target function and continue running in the
         // bytecode dispatcher.
@@ -1923,13 +2050,65 @@ static iree_status_t iree_vm_bytecode_dispatch(
             "variadic calls only supported for internal callees");
       }
 
-      // Call import (and possible yield).
-      IREE_RETURN_IF_ERROR(iree_vm_bytecode_call_import_variadic(
+      // Call import.
+      iree_status_t call_status = iree_vm_bytecode_call_import_variadic(
           stack, module_state, function_ordinal, regs, segment_size_list,
-          src_reg_list, dst_reg_list, &current_frame, &regs));
+          src_reg_list, dst_reg_list, &current_frame, &regs);
+      IREE_ASSERT(!iree_status_is_deferred(call_status),
+                  "deferred calls must use vm.call.yieldable");
+      IREE_RETURN_IF_ERROR(call_status);
 
       // Restore the local dispatch variables that may have changed during the
       // function call due to stack growth.
+      regs_i32 = regs.i32;
+      IREE_BUILTIN_ASSUME_ALIGNED(regs_i32, sizeof(iree_max_align_t));
+      regs_ref = regs.ref;
+      IREE_BUILTIN_ASSUME_ALIGNED(regs_ref, sizeof(iree_max_align_t));
+      pc = current_frame->pc;
+    });
+
+    IREE_VM_ISA_DISPATCH_OP(CORE, CallYieldable, {
+      // Yieldable call that may return DEFERRED.
+      // Supports both imports (via begin/resume) and internal functions
+      // (via vm.yield in the callee).
+      // Save instruction start for DEFERRED resume (pc already advanced past
+      // opcode by dispatch macro).
+      iree_vm_source_offset_t instruction_pc = pc - 1;
+      IREE_VM_ISA_DECODE_FUNC_ATTR(function_ordinal);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(src_reg_list);
+      IREE_VM_ISA_DISPATCH_DECODE_BRANCH_TARGET(resume_pc);
+      IREE_VM_ISA_DECODE_VARIADIC_RESULTS(dst_reg_list);
+
+      int is_import = iree_vm_isa_function_ordinal_is_import(function_ordinal);
+      if (is_import) {
+        // Call import (handles begin/resume via return_registers).
+        iree_status_t call_status = iree_vm_bytecode_call_import_yieldable(
+            stack, current_frame, module_state, function_ordinal, regs,
+            src_reg_list, dst_reg_list, &regs);
+        if (iree_status_is_deferred(call_status)) {
+          // Import yielded - set PC to re-execute this instruction on resume.
+          current_frame->pc = instruction_pc;
+          return call_status;
+        }
+        IREE_RETURN_IF_ERROR(call_status);
+        // Call completed - results already in dst_reg_list.
+        // Update frame PC to resume block (will be read by common code below).
+        current_frame->pc = resume_pc + IREE_VM_BLOCK_MARKER_SIZE;
+      } else {
+        // Internal function call - callee may yield via vm.yield.
+        // Set return PC to resume block (not instruction after call).
+        // When callee returns, internal_leave copies results to dst_reg_list
+        // and Return handler will continue at current_frame->pc (resume block).
+        current_frame->pc = resume_pc + IREE_VM_BLOCK_MARKER_SIZE;
+        IREE_RETURN_IF_ERROR(iree_vm_bytecode_internal_enter(
+            stack, current_frame->function.module, function_ordinal,
+            src_reg_list, dst_reg_list, &current_frame, &regs));
+        bytecode_data =
+            module->bytecode_data.data +
+            module->function_descriptor_table[function_ordinal].bytecode_offset;
+      }
+
+      // Restore dispatch state (may have changed during call/enter).
       regs_i32 = regs.i32;
       IREE_BUILTIN_ASSUME_ALIGNED(regs_i32, sizeof(iree_max_align_t));
       regs_ref = regs.ref;

--- a/runtime/src/iree/vm/bytecode/dispatch_async_test.cc
+++ b/runtime/src/iree/vm/bytecode/dispatch_async_test.cc
@@ -19,6 +19,9 @@
 // Compiled module embedded here to avoid file IO:
 #include "iree/vm/test/async_bytecode_modules.h"
 
+// Native test module for yieldable imports.
+#include "iree/vm/test/async_ops_test_module.h"
+
 namespace iree {
 namespace {
 
@@ -33,13 +36,18 @@ class VMBytecodeDispatchAsyncTest : public ::testing::Test {
     IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
                                           iree_allocator_system(), &instance_));
 
+    // Create native yieldable_test module (required by async_ops imports).
+    IREE_CHECK_OK(yieldable_test_module_create(
+        instance_, iree_allocator_system(), &native_module_));
+
     IREE_CHECK_OK(iree_vm_bytecode_module_create(
         instance_, IREE_VM_BYTECODE_MODULE_FLAG_NONE,
         iree_const_byte_span_t{reinterpret_cast<const uint8_t*>(file->data),
                                static_cast<iree_host_size_t>(file->size)},
         iree_allocator_null(), iree_allocator_system(), &bytecode_module_));
 
-    std::vector<iree_vm_module_t*> modules = {bytecode_module_};
+    // Native module first for import resolution.
+    std::vector<iree_vm_module_t*> modules = {native_module_, bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
@@ -48,12 +56,14 @@ class VMBytecodeDispatchAsyncTest : public ::testing::Test {
   void TearDown() override {
     IREE_TRACE_SCOPE();
     iree_vm_module_release(bytecode_module_);
+    iree_vm_module_release(native_module_);
     iree_vm_context_release(context_);
     iree_vm_instance_release(instance_);
   }
 
   iree_vm_instance_t* instance_ = nullptr;
   iree_vm_context_t* context_ = nullptr;
+  iree_vm_module_t* native_module_ = nullptr;
   iree_vm_module_t* bytecode_module_ = nullptr;
 };
 
@@ -149,6 +159,456 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldDivergent) {
   IREE_ASSERT_OK(
       function.module->resume_call(function.module->self, stack, call.results));
   ASSERT_EQ(ret_value, arg_values.arg1);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+//===----------------------------------------------------------------------===//
+// CallYieldable tests
+//===----------------------------------------------------------------------===//
+
+class VMBytecodeDispatchCallYieldableTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    const iree_file_toc_t* file = async_bytecode_modules_c_create();
+
+    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
+                                          iree_allocator_system(), &instance_));
+
+    // Create native yieldable_test module (required by async_ops imports).
+    IREE_CHECK_OK(yieldable_test_module_create(
+        instance_, iree_allocator_system(), &native_module_));
+
+    IREE_CHECK_OK(iree_vm_bytecode_module_create(
+        instance_, IREE_VM_BYTECODE_MODULE_FLAG_NONE,
+        iree_const_byte_span_t{reinterpret_cast<const uint8_t*>(file->data),
+                               static_cast<iree_host_size_t>(file->size)},
+        iree_allocator_null(), iree_allocator_system(), &bytecode_module_));
+
+    // Native module first for import resolution.
+    std::vector<iree_vm_module_t*> modules = {native_module_, bytecode_module_};
+    IREE_CHECK_OK(iree_vm_context_create_with_modules(
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
+        iree_allocator_system(), &context_));
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_vm_module_release(bytecode_module_);
+    iree_vm_module_release(native_module_);
+    iree_vm_context_release(context_);
+    iree_vm_instance_release(instance_);
+  }
+
+  iree_vm_instance_t* instance_ = nullptr;
+  iree_vm_context_t* context_ = nullptr;
+  iree_vm_module_t* native_module_ = nullptr;
+  iree_vm_module_t* bytecode_module_ = nullptr;
+};
+
+// Tests calling an internal function that yields 4 times via vm.call.yieldable.
+// See iree/vm/test/call_yieldable_ops.mlir > @call_yieldable_internal
+TEST_F(VMBytecodeDispatchCallYieldableTest, CallYieldableInternal) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_internal"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(nullptr, 0);  // No arguments
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // The callee yields 3 times, so we need 3 resumes.
+  // begin -> 1st yield -> DEFERRED
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  // resume -> 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> 3rd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> return -> OK
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be 4 (0 + 4 increments across 4 basic blocks)
+  ASSERT_EQ(ret_value, 4u);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+// Tests calling an internal yieldable function with an argument.
+// See iree/vm/test/call_yieldable_ops.mlir > @call_yieldable_with_arg
+TEST_F(VMBytecodeDispatchCallYieldableTest, CallYieldableWithArg) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_with_arg"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 42;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // The callee yields 1 time.
+  // 0/1
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  // 1/1
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be arg_value + 1
+  ASSERT_EQ(ret_value, arg_value + 1);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+//===----------------------------------------------------------------------===//
+// CallYieldable to Imports tests
+//===----------------------------------------------------------------------===//
+// Tests vm.call.yieldable calling native module functions that yield.
+
+class VMBytecodeDispatchCallYieldableImportTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    const iree_file_toc_t* file = async_bytecode_modules_c_create();
+
+    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
+                                          iree_allocator_system(), &instance_));
+
+    // Create native yieldable_test module.
+    IREE_CHECK_OK(yieldable_test_module_create(
+        instance_, iree_allocator_system(), &native_module_));
+
+    // Create bytecode module that imports from native module.
+    IREE_CHECK_OK(iree_vm_bytecode_module_create(
+        instance_, IREE_VM_BYTECODE_MODULE_FLAG_NONE,
+        iree_const_byte_span_t{reinterpret_cast<const uint8_t*>(file->data),
+                               static_cast<iree_host_size_t>(file->size)},
+        iree_allocator_null(), iree_allocator_system(), &bytecode_module_));
+
+    // Create context with both modules (native first for import resolution).
+    std::vector<iree_vm_module_t*> modules = {native_module_, bytecode_module_};
+    IREE_CHECK_OK(iree_vm_context_create_with_modules(
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
+        iree_allocator_system(), &context_));
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_vm_module_release(bytecode_module_);
+    iree_vm_module_release(native_module_);
+    iree_vm_context_release(context_);
+    iree_vm_instance_release(instance_);
+  }
+
+  iree_vm_instance_t* instance_ = nullptr;
+  iree_vm_context_t* context_ = nullptr;
+  iree_vm_module_t* native_module_ = nullptr;
+  iree_vm_module_t* bytecode_module_ = nullptr;
+};
+
+// Tests calling a yieldable import that yields 3 times.
+// This exercises Bug 1 fix: PC must be saved at instruction start, not after
+// decode.
+TEST_F(VMBytecodeDispatchCallYieldableImportTest, YieldableImportYields3) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_import_yields_3"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 100;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // The import yields 3 times.
+  // begin -> 1st yield -> DEFERRED
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  // resume -> 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> 3rd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> return -> OK
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be arg + 3
+  ASSERT_EQ(ret_value, arg_value + 3);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+// Tests calling a yieldable import that yields 0 times (synchronous).
+TEST_F(VMBytecodeDispatchCallYieldableImportTest, YieldableImportYields0) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_import_yields_0"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 42;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // No yields, should complete immediately.
+  IREE_ASSERT_OK(
+      function.module->begin_call(function.module->self, stack, call));
+
+  // Result should be arg + 0
+  ASSERT_EQ(ret_value, arg_value);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+// Tests calling a yieldable import after an internal function call.
+// This exercises Bug 2 fix: return_registers must be cleared after internal
+// call.
+TEST_F(VMBytecodeDispatchCallYieldableImportTest, YieldableAfterInternal) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_after_internal"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 5;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // The function:
+  // 1. Calls internal_add_10(arg) -> arg + 10
+  // 2. Calls yieldable import yield_n(arg+10, 2) which yields 2 times
+  // Expected: 2 yields, result = (arg + 10) + 2
+
+  // begin -> internal call completes, import yields 1st time -> DEFERRED
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  // resume -> 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> return -> OK
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be (arg + 10) + 2 = arg + 12
+  ASSERT_EQ(ret_value, arg_value + 12);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+// Tests two sequential yieldable import calls in the same function.
+// This catches bugs where the second call sees stale state from the first.
+TEST_F(VMBytecodeDispatchCallYieldableImportTest, YieldableImportSequential) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_import_sequential"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 10;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // First import yields 2 times, second import yields 3 times = 5 total yields.
+  // begin -> 1st import, 1st yield -> DEFERRED
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  // resume -> 1st import, 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> 1st import done, 2nd import, 1st yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> 2nd import, 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> 2nd import, 3rd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> 2nd import done, return -> OK
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be (arg + 2) + 3 = arg + 5
+  ASSERT_EQ(ret_value, arg_value + 5);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+// Tests a yieldable import nested inside an internal yieldable function.
+// This is the most complex frame stack scenario.
+TEST_F(VMBytecodeDispatchCallYieldableImportTest, YieldableImportNested) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_nested_yieldable"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 50;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // Sequence: 1 yield (internal) + 2 yields (import) + 1 yield (internal) = 4
+  // begin -> internal 1st yield -> DEFERRED
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  // resume -> import 1st yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> import 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> import done, internal 2nd yield -> DEFERRED
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
+
+  // resume -> internal done, return -> OK
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be ((arg + 1) + 2) + 1 = arg + 4
+  ASSERT_EQ(ret_value, arg_value + 4);
+
+  iree_vm_stack_deinitialize(stack);
+}
+
+// Tests a yieldable import with many yields to catch state accumulation bugs.
+TEST_F(VMBytecodeDispatchCallYieldableImportTest, YieldableImportStress) {
+  IREE_TRACE_SCOPE();
+
+  iree_vm_function_t function;
+  IREE_ASSERT_OK(iree_vm_module_lookup_function_by_name(
+      bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      IREE_SV("call_yieldable_import_stress"), &function));
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context_),
+                                  iree_allocator_system());
+
+  uint32_t arg_value = 1000;
+  uint32_t ret_value = 0;
+
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
+  call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
+
+  // 10 yields total.
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
+              StatusIs(StatusCode::kDeferred));
+
+  for (int i = 1; i < 10; ++i) {
+    ASSERT_THAT(function.module->resume_call(function.module->self, stack,
+                                             call.results),
+                StatusIs(StatusCode::kDeferred))
+        << "Expected DEFERRED at resume " << i;
+  }
+
+  // Final resume should complete.
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
+
+  // Result should be arg + 10
+  ASSERT_EQ(ret_value, arg_value + 10);
 
   iree_vm_stack_deinitialize(stack);
 }

--- a/runtime/src/iree/vm/bytecode/utils/features.c
+++ b/runtime/src/iree/vm/bytecode/utils/features.c
@@ -10,6 +10,8 @@
 static const iree_bitfield_string_mapping_t iree_vm_bytecode_feature_mappings[] = {
   {iree_vm_FeatureBits_EXT_F32, IREE_SVL("EXT_F32")},
   {iree_vm_FeatureBits_EXT_F64, IREE_SVL("EXT_F64")},
+  {iree_vm_FeatureBits_YIELD, IREE_SVL("YIELD")},
+  {iree_vm_FeatureBits_UNWIND, IREE_SVL("UNWIND")},
 };
 // clang-format on
 
@@ -28,6 +30,11 @@ iree_vm_FeatureBits_enum_t iree_vm_bytecode_available_features(void) {
 #if IREE_VM_EXT_F64_ENABLE
   result |= iree_vm_FeatureBits_EXT_F64;
 #endif  // IREE_VM_EXT_F64_ENABLE
+  // Execution and unwinding are core runtime capabilities; keep these enabled
+  // so that function requirements can communicate behavioral constraints to
+  // tools (C export/JIT/etc) without feature mismatch failures.
+  result |= iree_vm_FeatureBits_YIELD;
+  result |= iree_vm_FeatureBits_UNWIND;
   return result;
 }
 

--- a/runtime/src/iree/vm/bytecode/utils/generated/op_table.h
+++ b/runtime/src/iree/vm/bytecode/utils/generated/op_table.h
@@ -142,7 +142,7 @@ typedef enum {
   IREE_VM_OP_CORE_BufferHash = 0x84,
   IREE_VM_OP_CORE_DiscardRefs = 0x85,
   IREE_VM_OP_CORE_AssignRef = 0x86,
-  IREE_VM_OP_CORE_RSV_0x87,
+  IREE_VM_OP_CORE_CallYieldable,
   IREE_VM_OP_CORE_RSV_0x88,
   IREE_VM_OP_CORE_RSV_0x89,
   IREE_VM_OP_CORE_RSV_0x8A,

--- a/runtime/src/iree/vm/bytecode/utils/generated/op_table.h
+++ b/runtime/src/iree/vm/bytecode/utils/generated/op_table.h
@@ -143,7 +143,7 @@ typedef enum {
   IREE_VM_OP_CORE_DiscardRefs = 0x85,
   IREE_VM_OP_CORE_AssignRef = 0x86,
   IREE_VM_OP_CORE_CallYieldable,
-  IREE_VM_OP_CORE_RSV_0x88,
+  IREE_VM_OP_CORE_CallVariadicYieldable,
   IREE_VM_OP_CORE_RSV_0x89,
   IREE_VM_OP_CORE_RSV_0x8A,
   IREE_VM_OP_CORE_RSV_0x8B,

--- a/runtime/src/iree/vm/bytecode/utils/isa.h
+++ b/runtime/src/iree/vm/bytecode/utils/isa.h
@@ -23,7 +23,7 @@
 // Major bytecode version; mismatches on this will fail in either direction.
 // This allows coarse versioning of completely incompatible versions.
 // Matches BytecodeEncoder::kVersionMajor in the compiler.
-#define IREE_VM_BYTECODE_VERSION_MAJOR 16
+#define IREE_VM_BYTECODE_VERSION_MAJOR 17
 // Minor bytecode version; lower versions are allowed to enable newer runtimes
 // to load older serialized files when there are backwards-compatible changes.
 // Higher versions are disallowed as they occur when new ops are added that

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -1643,6 +1643,32 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
       verify_state->in_block = 0;  // terminator
     });
 
+    IREE_VM_ISA_VERIFY_OP(CORE, CallVariadicYieldable, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(callee_ordinal);
+      IREE_VM_ISA_DECODE_VARIADIC_OPERANDS(segment_sizes);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(dest_pc);
+      IREE_VM_ISA_VERIFY_VARIADIC_RESULTS_ANY(results);
+      if (IREE_UNLIKELY(
+              !iree_vm_isa_function_ordinal_is_import(callee_ordinal))) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "variadic yieldable calls only supported for imports");
+      }
+      callee_ordinal = iree_vm_isa_function_ordinal_as_import(callee_ordinal);
+      IREE_VM_ISA_VERIFY_IMPORT_ORDINAL(callee_ordinal);
+      iree_vm_ImportFunctionDef_table_t import_def =
+          iree_vm_ImportFunctionDef_vec_at(verify_state->imported_functions,
+                                           callee_ordinal);
+      IREE_RETURN_IF_ERROR(
+          iree_vm_bytecode_function_verify_call(
+              verify_state, iree_vm_ImportFunctionDef_signature(import_def),
+              segment_sizes, operands, results),
+          "variadic yieldable call to import '%s'",
+          iree_vm_ImportFunctionDef_full_name(import_def));
+      verify_state->in_block = 0;  // terminator
+    });
+
     IREE_VM_ISA_VERIFY_OP(CORE, Return, {
       IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
       IREE_RETURN_IF_ERROR(iree_vm_bytecode_function_verify_cconv_registers(

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -1613,6 +1613,36 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
           iree_vm_ImportFunctionDef_full_name(import_def));
     });
 
+    IREE_VM_ISA_VERIFY_OP(CORE, CallYieldable, {
+      IREE_VM_ISA_DECODE_FUNC_ATTR(callee_ordinal);
+      IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
+      IREE_VM_ISA_VERIFY_BRANCH_TARGET(dest_pc);
+      IREE_VM_ISA_VERIFY_VARIADIC_RESULTS_ANY(results);
+      if (iree_vm_isa_function_ordinal_is_import(callee_ordinal)) {
+        callee_ordinal = iree_vm_isa_function_ordinal_as_import(callee_ordinal);
+        IREE_VM_ISA_VERIFY_IMPORT_ORDINAL(callee_ordinal);
+        iree_vm_ImportFunctionDef_table_t import_def =
+            iree_vm_ImportFunctionDef_vec_at(verify_state->imported_functions,
+                                             callee_ordinal);
+        IREE_RETURN_IF_ERROR(
+            iree_vm_bytecode_function_verify_call(
+                verify_state, iree_vm_ImportFunctionDef_signature(import_def),
+                /*segment_sizes=*/NULL, operands, results),
+            "yieldable call to import '%s'",
+            iree_vm_ImportFunctionDef_full_name(import_def));
+      } else {
+        IREE_VM_ISA_VERIFY_FUNCTION_ORDINAL(callee_ordinal);
+        IREE_RETURN_IF_ERROR(
+            iree_vm_bytecode_function_verify_call(
+                verify_state,
+                iree_vm_FunctionSignatureDef_vec_at(
+                    verify_state->function_signatures, callee_ordinal),
+                /*segment_sizes=*/NULL, operands, results),
+            "yieldable call to internal function %d", callee_ordinal);
+      }
+      verify_state->in_block = 0;  // terminator
+    });
+
     IREE_VM_ISA_VERIFY_OP(CORE, Return, {
       IREE_VM_ISA_VERIFY_VARIADIC_OPERANDS_ANY(operands);
       IREE_RETURN_IF_ERROR(iree_vm_bytecode_function_verify_cconv_registers(

--- a/runtime/src/iree/vm/test/BUILD.bazel
+++ b/runtime/src/iree/vm/test/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content", "iree_runtime_cc_library")
 load("//build_tools/bazel:iree_bytecode_module.bzl", "iree_bytecode_module")
 load("//build_tools/embed_data:build_defs.bzl", "iree_c_embed_data")
 
@@ -59,6 +59,25 @@ iree_c_embed_data(
     c_file_output = "all_bytecode_modules.c",
     flatten = True,
     h_file_output = "all_bytecode_modules.h",
+)
+
+iree_c_embed_data(
+    name = "async_bytecode_modules_c",
+    srcs = [
+        ":async_ops.vmfb",
+    ],
+    c_file_output = "async_bytecode_modules.c",
+    flatten = True,
+    h_file_output = "async_bytecode_modules.h",
+)
+
+iree_runtime_cc_library(
+    name = "async_ops_test_module",
+    hdrs = ["async_ops_test_module.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/vm",
+    ],
 )
 
 iree_bytecode_module(
@@ -124,6 +143,14 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "assignment_ops_i64",
     src = "assignment_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+    ],
+)
+
+iree_bytecode_module(
+    name = "async_ops",
+    src = "async_ops.mlir",
     flags = [
         "--compile-mode=vm",
     ],
@@ -298,24 +325,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "shift_ops_i64",
     src = "shift_ops_i64.mlir",
-    flags = [
-        "--compile-mode=vm",
-    ],
-)
-
-iree_c_embed_data(
-    name = "async_bytecode_modules_c",
-    srcs = [
-        ":async_ops.vmfb",
-    ],
-    c_file_output = "async_bytecode_modules.c",
-    flatten = True,
-    h_file_output = "async_bytecode_modules.h",
-)
-
-iree_bytecode_module(
-    name = "async_ops",
-    src = "async_ops.mlir",
     flags = [
         "--compile-mode=vm",
     ],

--- a/runtime/src/iree/vm/test/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/CMakeLists.txt
@@ -55,6 +55,30 @@ iree_c_embed_data(
   PUBLIC
 )
 
+iree_c_embed_data(
+  NAME
+    async_bytecode_modules_c
+  SRCS
+    "async_ops.vmfb"
+  C_FILE_OUTPUT
+    "async_bytecode_modules.c"
+  H_FILE_OUTPUT
+    "async_bytecode_modules.h"
+  FLATTEN
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    async_ops_test_module
+  HDRS
+    "async_ops_test_module.h"
+  DEPS
+    iree::base
+    iree::vm
+  PUBLIC
+)
+
 iree_bytecode_module(
   NAME
     arithmetic_ops
@@ -134,6 +158,16 @@ iree_bytecode_module(
     assignment_ops_i64
   SRC
     "assignment_ops_i64.mlir"
+  FLAGS
+    "--compile-mode=vm"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    async_ops
+  SRC
+    "async_ops.mlir"
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -350,29 +384,6 @@ iree_bytecode_module(
     shift_ops_i64
   SRC
     "shift_ops_i64.mlir"
-  FLAGS
-    "--compile-mode=vm"
-  PUBLIC
-)
-
-iree_c_embed_data(
-  NAME
-    async_bytecode_modules_c
-  SRCS
-    "async_ops.vmfb"
-  C_FILE_OUTPUT
-    "async_bytecode_modules.c"
-  H_FILE_OUTPUT
-    "async_bytecode_modules.h"
-  FLATTEN
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    async_ops
-  SRC
-    "async_ops.mlir"
   FLAGS
     "--compile-mode=vm"
   PUBLIC

--- a/runtime/src/iree/vm/test/async_ops.mlir
+++ b/runtime/src/iree/vm/test/async_ops.mlir
@@ -1,12 +1,6 @@
 // Tested by iree/vm/bytecode/dispatch_async_test.cc.
-//
-// NOTE: we don't want to rely on vm.check.* and the main runner here for
-// testing as it makes it hard to test failure cases; a test that doesn't run
-// because we don't resume from the caller would look like a success. The test
-// runner has the other half of this code with the expectations.
 
 vm.module @async_ops {
-
   //===--------------------------------------------------------------------===//
   // vm.yield
   //===--------------------------------------------------------------------===//
@@ -50,4 +44,169 @@ vm.module @async_ops {
     vm.return %result : i32
   }
 
+  //===--------------------------------------------------------------------===//
+  // vm.call.yieldable with internal functions
+  //===--------------------------------------------------------------------===//
+
+  // Internal function that yields 4 times, incrementing a counter each time.
+  // Takes a starting value and returns starting + 4.
+  vm.func private @yield_counter(%start : i32) -> i32 {
+    %c1 = vm.const.i32 1
+    %v0 = vm.add.i32 %start, %c1 : i32
+    %v0_dno = util.optimization_barrier %v0 : i32
+    vm.yield ^y1
+  ^y1:
+    %v1 = vm.add.i32 %v0_dno, %c1 : i32
+    %v1_dno = util.optimization_barrier %v1 : i32
+    vm.yield ^y2
+  ^y2:
+    %v2 = vm.add.i32 %v1_dno, %c1 : i32
+    %v2_dno = util.optimization_barrier %v2 : i32
+    vm.yield ^y3
+  ^y3:
+    %v3 = vm.add.i32 %v2_dno, %c1 : i32
+    vm.return %v3 : i32
+  }
+
+  // Tests calling an internal yieldable function.
+  // The callee yields 4 times, so we need 4 resumes.
+  // Expects result of 0 + 4 = 4.
+  vm.export @call_yieldable_internal attributes {emitc.exclude}
+  vm.func @call_yieldable_internal() -> i32 {
+    %c0 = vm.const.i32 0
+    vm.call.yieldable @yield_counter(%c0) : (i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
+
+  // Internal function that takes an input and yields once, returning input + 1.
+  vm.func private @yield_add_one(%arg0: i32) -> i32 {
+    %c1 = vm.const.i32 1
+    %result = vm.add.i32 %arg0, %c1 : i32
+    %result_dno = util.optimization_barrier %result : i32
+    vm.yield ^done
+  ^done:
+    vm.return %result_dno : i32
+  }
+
+  // Tests calling an internal yieldable function with an argument.
+  // Expects result of %arg0 + 1.
+  vm.export @call_yieldable_with_arg attributes {emitc.exclude}
+  vm.func @call_yieldable_with_arg(%arg0: i32) -> i32 {
+    vm.call.yieldable @yield_add_one(%arg0) : (i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
+
+  //===--------------------------------------------------------------------===//
+  // vm.call.yieldable with imported functions
+  //===--------------------------------------------------------------------===//
+
+  // Import from native yieldable_test module.
+  // yield_n(arg: i32, yield_count: i32) -> i32
+  // Yields yield_count times, returns arg + yield_count.
+  vm.import private @yieldable_test.yield_n(%arg : i32, %yield_count : i32) -> i32 attributes {vm.yield}
+
+  // Test: call yieldable import with 3 yields.
+  // Expected: 3 DEFERRED returns, then OK with result = arg + 3
+  vm.export @call_yieldable_import_yields_3 attributes {emitc.exclude}
+  vm.func @call_yieldable_import_yields_3(%arg0 : i32) -> i32 {
+    %c3 = vm.const.i32 3
+    vm.call.yieldable @yieldable_test.yield_n(%arg0, %c3) : (i32, i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
+
+  // Test: call yieldable import with 0 yields (synchronous).
+  // Expected: immediate OK with result = arg
+  vm.export @call_yieldable_import_yields_0 attributes {emitc.exclude}
+  vm.func @call_yieldable_import_yields_0(%arg0 : i32) -> i32 {
+    %c0 = vm.const.i32 0
+    vm.call.yieldable @yieldable_test.yield_n(%arg0, %c0) : (i32, i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
+
+  // Test: call yieldable import after internal function call.
+  // This exercises Bug 2 fix: return_registers must be cleared after internal call.
+  vm.func private @internal_add_10(%x : i32) -> i32 {
+    %c10 = vm.const.i32 10
+    %r = vm.add.i32 %x, %c10 : i32
+    vm.return %r : i32
+  }
+
+  vm.export @call_yieldable_after_internal attributes {emitc.exclude}
+  vm.func @call_yieldable_after_internal(%arg0 : i32) -> i32 {
+    // First call an internal function (sets return_registers).
+    %v1 = vm.call @internal_add_10(%arg0) : (i32) -> i32
+    // Then call yieldable import (should see return_registers == NULL for begin).
+    %c2 = vm.const.i32 2
+    vm.call.yieldable @yieldable_test.yield_n(%v1, %c2) : (i32, i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Additional regression tests for frame tracking bugs
+  //===--------------------------------------------------------------------===//
+
+  // Test: two sequential yieldable import calls in the same function.
+  // This catches bugs where the second call sees stale state from the first.
+  // Expected: 2 yields from first call + 3 yields from second call = 5 total
+  // Result: (arg + 2) + 3 = arg + 5
+  vm.export @call_yieldable_import_sequential attributes {emitc.exclude}
+  vm.func @call_yieldable_import_sequential(%arg0 : i32) -> i32 {
+    %c2 = vm.const.i32 2
+    %c3 = vm.const.i32 3
+    // First yieldable import: yields 2 times, returns arg + 2
+    vm.call.yieldable @yieldable_test.yield_n(%arg0, %c2) : (i32, i32) -> ^after_first(i32)
+  ^after_first(%v1 : i32):
+    // Second yieldable import: yields 3 times, returns v1 + 3 = arg + 5
+    vm.call.yieldable @yieldable_test.yield_n(%v1, %c3) : (i32, i32) -> ^done(i32)
+  ^done(%result : i32):
+    vm.return %result : i32
+  }
+
+  // Test: yieldable import nested inside an internal yieldable function.
+  // The internal function yields before and after calling the import.
+  // This creates the most complex frame stack scenario.
+  vm.func private @yield_then_import_then_yield(%arg0 : i32) -> i32 {
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    // Add 1 before yield
+    %v0 = vm.add.i32 %arg0, %c1 : i32
+    %v0_dno = util.optimization_barrier %v0 : i32
+    vm.yield ^after_first_yield
+  ^after_first_yield:
+    // Call yieldable import (yields 2 times)
+    vm.call.yieldable @yieldable_test.yield_n(%v0_dno, %c2) : (i32, i32) -> ^after_import(i32)
+  ^after_import(%v1 : i32):
+    // Add 1 after import
+    %v2 = vm.add.i32 %v1, %c1 : i32
+    %v2_dno = util.optimization_barrier %v2 : i32
+    vm.yield ^final
+  ^final:
+    vm.return %v2_dno : i32
+  }
+
+  // Export that calls the nested yieldable function.
+  // Expected sequence: 1 yield (internal) + 2 yields (import) + 1 yield (internal) = 4 yields
+  // Result: ((arg + 1) + 2) + 1 = arg + 4
+  vm.export @call_nested_yieldable attributes {emitc.exclude}
+  vm.func @call_nested_yieldable(%arg0 : i32) -> i32 {
+    vm.call.yieldable @yield_then_import_then_yield(%arg0) : (i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
+
+  // Test: stress test with many yields to catch state accumulation bugs.
+  // Calls yieldable import with high yield count.
+  // Expected: 10 yields, result = arg + 10
+  vm.export @call_yieldable_import_stress attributes {emitc.exclude}
+  vm.func @call_yieldable_import_stress(%arg0 : i32) -> i32 {
+    %c10 = vm.const.i32 10
+    vm.call.yieldable @yieldable_test.yield_n(%arg0, %c10) : (i32, i32) -> ^resume(i32)
+  ^resume(%result : i32):
+    vm.return %result : i32
+  }
 }

--- a/runtime/src/iree/vm/test/async_ops_test_module.h
+++ b/runtime/src/iree/vm/test/async_ops_test_module.h
@@ -1,0 +1,135 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// A simple native module for testing vm.call.yieldable to imports.
+// Exports a single function that yields N times before returning.
+
+#include "iree/base/api.h"
+#include "iree/vm/native_module.h"
+
+//===----------------------------------------------------------------------===//
+// yieldable_test_module
+//===----------------------------------------------------------------------===//
+// Native module with a single yieldable function for testing.
+
+typedef struct yieldable_test_module_state_t {
+  iree_allocator_t allocator;
+  // Yield counter: decremented on each resume until 0.
+  int32_t yield_count;
+  // Accumulator for the result.
+  int32_t accumulator;
+} yieldable_test_module_state_t;
+
+// Shim for yield_n: (i32 arg, i32 yield_count) -> i32
+// Yields yield_count times, returns arg + yield_count.
+static iree_status_t yieldable_test_module_yield_n_shim(
+    iree_vm_stack_t* stack, iree_vm_native_function_flags_t flags,
+    iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
+    void* target_fn, void* module, void* module_state_ptr) {
+  yieldable_test_module_state_t* state =
+      (yieldable_test_module_state_t*)module_state_ptr;
+
+  if (flags == IREE_VM_NATIVE_FUNCTION_CALL_BEGIN) {
+    // Parse arguments.
+    typedef struct {
+      int32_t arg;
+      int32_t yield_count;
+    } args_t;
+    const args_t* args = (const args_t*)args_storage.data;
+
+    // Initialize state for coroutine.
+    state->yield_count = args->yield_count;
+    state->accumulator = args->arg;
+
+    if (state->yield_count > 0) {
+      state->accumulator += 1;
+      state->yield_count -= 1;
+      return iree_status_from_code(IREE_STATUS_DEFERRED);
+    }
+    // yield_count == 0: return immediately.
+    typedef struct {
+      int32_t ret;
+    } results_t;
+    results_t* results = (results_t*)rets_storage.data;
+    results->ret = state->accumulator;
+    return iree_ok_status();
+  }
+
+  // RESUME path.
+  if (state->yield_count > 0) {
+    state->accumulator += 1;
+    state->yield_count -= 1;
+    return iree_status_from_code(IREE_STATUS_DEFERRED);
+  }
+
+  // Done yielding, return result.
+  typedef struct {
+    int32_t ret;
+  } results_t;
+  results_t* results = (results_t*)rets_storage.data;
+  results->ret = state->accumulator;
+  return iree_ok_status();
+}
+
+static iree_status_t IREE_API_PTR
+yieldable_test_module_alloc_state(void* self, iree_allocator_t allocator,
+                                  iree_vm_module_state_t** out_module_state) {
+  yieldable_test_module_state_t* state = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(allocator, sizeof(*state), (void**)&state));
+  memset(state, 0, sizeof(*state));
+  state->allocator = allocator;
+  *out_module_state = (iree_vm_module_state_t*)state;
+  return iree_ok_status();
+}
+
+static void IREE_API_PTR yieldable_test_module_free_state(
+    void* self, iree_vm_module_state_t* module_state) {
+  yieldable_test_module_state_t* state =
+      (yieldable_test_module_state_t*)module_state;
+  iree_allocator_free(state->allocator, state);
+}
+
+static const iree_vm_native_export_descriptor_t
+    yieldable_test_module_exports_[] = {
+        // yield_n(arg: i32, yield_count: i32) -> i32
+        // Signature: "0ii_i" = version 0, (i32, i32) -> i32
+        {IREE_SV("yield_n"), IREE_SV("0ii_i"), 0, NULL},
+};
+static const iree_vm_native_function_ptr_t yieldable_test_module_funcs_[] = {
+    {(iree_vm_native_function_shim_t)yieldable_test_module_yield_n_shim, NULL},
+};
+static_assert(IREE_ARRAYSIZE(yieldable_test_module_funcs_) ==
+                  IREE_ARRAYSIZE(yieldable_test_module_exports_),
+              "function pointer table must be 1:1 with exports");
+
+static const iree_vm_native_module_descriptor_t
+    yieldable_test_module_descriptor_ = {
+        /*name=*/IREE_SV("yieldable_test"),
+        /*version=*/0,
+        /*attr_count=*/0,
+        /*attrs=*/NULL,
+        /*dependency_count=*/0,
+        /*dependencies=*/NULL,
+        /*import_count=*/0,
+        /*imports=*/NULL,
+        /*export_count=*/IREE_ARRAYSIZE(yieldable_test_module_exports_),
+        /*exports=*/yieldable_test_module_exports_,
+        /*function_count=*/IREE_ARRAYSIZE(yieldable_test_module_funcs_),
+        /*functions=*/yieldable_test_module_funcs_,
+};
+
+static iree_status_t yieldable_test_module_create(
+    iree_vm_instance_t* instance, iree_allocator_t allocator,
+    iree_vm_module_t** out_module) {
+  iree_vm_module_t interface;
+  IREE_RETURN_IF_ERROR(iree_vm_module_initialize(&interface, NULL));
+  interface.alloc_state = yieldable_test_module_alloc_state;
+  interface.free_state = yieldable_test_module_free_state;
+  return iree_vm_native_module_create(&interface,
+                                      &yieldable_test_module_descriptor_,
+                                      instance, allocator, out_module);
+}


### PR DESCRIPTION
**Breaking change**: bumps bytecode module version from 16 to 17.

### Summary

Introduces `vm.call.yieldable` and `vm.call.variadic.yieldable` ops for explicit handling of calls that may yield execution, along with YIELD/UNWIND feature bits in the bytecode format.

### Background

The VM needs to support calls that may yield execution (e.g., async device operations like `hal.fence.await`). Previously, this required runtime analysis to determine if functions could yield. The new approach makes yield points explicit in the IR and bytecode, enabling:

- Clean register lifetime across yield points (results flow as block arguments)
- Proper stack unwinding across module boundaries (native, bytecode, C, etc.)
- Simplified non-yieldable call implementation for the common case
- Static analysis elimination via feature bits

### Changes

**Compiler (IR + passes)**:
- New `vm.call.yieldable` op: terminator that combines a call with an explicit resume point
- New `vm.call.variadic.yieldable` op: variadic variant
- `AnnotateFunctions` pass: propagates `vm.yield`/`vm.unwind` attributes transitively
- `ConvertToYieldableCalls` pass: rewrites calls to yieldable functions
- Updated `MaterializeRefDiscards` to handle ref cleanup across yield points
- Register allocation updates for yieldable call patterns

**Runtime (bytecode)**:
- New `CallYieldable` and `CallVariadicYieldable` opcodes
- YIELD/UNWIND feature bits in bytecode module schema
- Dispatcher support for yieldable calls with proper continuation handling
- Verifier updates for new ops

**Tests**:
- Extensive lit tests for new passes and ops
- Expanded `dispatch_async_test.cc` with yielding scenarios
- New async ops tests covering yieldable call patterns

### Example

```mlir
^bb0:
  vm.call.yieldable @hal.fence.await(%timeout, %fence) : (i32, !vm.ref<?>) -> ^resume(i32)
^resume(%result : i32):
  vm.return %result
```