### PR TITLE
[GPU] Fix data-tiling materialization for matvec/vecmat ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -640,7 +640,7 @@ func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [16, 16]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1 : i64, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [16, 16]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2 : i64, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [16, 16]>
-func.func @matvec_lowering_f16f16f32_gfx950(
+func.func @matvec_lowering_f16f16f32(
     %lhs: tensor<16x16xf16, #encoding_lhs>,
     %rhs: tensor<16xf16, #encoding_rhs>,
     %init: tensor<16xf32, #encoding_result>
@@ -654,7 +654,7 @@ func.func @matvec_lowering_f16f16f32_gfx950(
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d1)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
-// CHECK:     func.func @matvec_lowering_f16f16f32_gfx950(
+// CHECK:     func.func @matvec_lowering_f16f16f32(
 // CHECK-SAME:  %[[LHS:.+]]: tensor<1x1x4x16x8xf16>
 // CHECK-SAME:  %[[RHS:.+]]: tensor<1x4x16x8xf16>
 // CHECK-SAME:  %[[INIT:.+]]: tensor<1x4x16x4xf32>
@@ -675,7 +675,7 @@ func.func @matvec_lowering_f16f16f32_gfx950(
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [15, 20]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [15, 20]>
 
-func.func @vecmat_lowering_f32f32f32_gfx950(
+func.func @vecmat_lowering_f32f32f32(
     %lhs: tensor<20xf32, #encoding_lhs>,
     %rhs: tensor<20x15xf32, #encoding_rhs>,
     %init: tensor<15xf32, #encoding_result>
@@ -685,4 +685,17 @@ func.func @vecmat_lowering_f32f32f32_gfx950(
     outs(%init: tensor<15xf32, #encoding_result>) -> tensor<15xf32, #encoding_result>
   return %result : tensor<15xf32, #encoding_result>
 }
-
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK:     func.func @vecmat_lowering_f32f32f32(
+// CHECK-SAME:  %[[LHS:.+]]: tensor<2x4x16x4xf32>
+// CHECK-SAME:  %[[RHS:.+]]: tensor<1x2x4x16x4xf32>
+// CHECK-SAME:  %[[INIT:.+]]: tensor<1x4x16x4xf32>
+// CHECK:       %[[VECMAT:.+]] = iree_codegen.inner_tiled
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]])
+// CHECK-SAME:    outs(%[[INIT]])
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
+// CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK:       return %[[VECMAT]]

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -440,7 +440,6 @@ static Operation *lowerContractionOrScaledContractionOpToInnerTiledOp(
   }
 
   // Determine which dimensions exist in the operation by checking all operands.
-  // For matvec, the result might not have K, but the inputs do.
   bool hasBatch = false;
   bool hasM = false;
   bool hasN = false;


### PR DESCRIPTION
The previous implementation assumes that all M/N/K dimensions exist, thus there are failures in matvec lowering. The revision builds the indexing maps for InnerTiledOp by checking the corresponding encoding.

Note that this only fix matmul lowering, but not set_encoding lowering. It is a step towards https://github.com/iree-org/iree/issues/23046