### PR TITLE
[Codegen] Add pass to convert workgroup foralls to pcf

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -199,6 +199,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:KnownTargets",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
+        "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:BufferizationInterfaces",

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -88,6 +88,7 @@ iree_compiler_cc_library(
         "ConvertBf16ToUInt16Buffers.cpp",
         "ConvertToDestinationPassingStylePass.cpp",
         "ConvertUnsupportedFloatArithPass.cpp",
+        "ConvertWorkgroupForallToPCF.cpp",
         "ConvolutionToIGEMM.cpp",
         "DecomposeAffineOpsPass.cpp",
         "DecomposeConvolutionToLowerDimOps.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -233,6 +233,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::KnownTargets
     iree::compiler::Codegen::Dialect::PCF::IR
+    iree::compiler::Codegen::Dialect::PCF::Transforms
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms
     iree::compiler::Codegen::Interfaces::BufferizationInterfaces

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_cc_library(
     "ConvertBf16ToUInt16Buffers.cpp"
     "ConvertToDestinationPassingStylePass.cpp"
     "ConvertUnsupportedFloatArithPass.cpp"
+    "ConvertWorkgroupForallToPCF.cpp"
     "ConvolutionToIGEMM.cpp"
     "DecomposeAffineOpsPass.cpp"
     "DecomposeConvolutionToLowerDimOps.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertWorkgroupForallToPCF.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertWorkgroupForallToPCF.cpp
@@ -1,0 +1,79 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCF.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_CONVERTWORKGROUPFORALLTOPCFPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+struct ConvertWorkgroupForall : public OpRewritePattern<scf::ForallOp> {
+  using OpRewritePattern<scf::ForallOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(scf::ForallOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+struct ConvertWorkgroupForallToPCFPass final
+    : public impl::ConvertWorkgroupForallToPCFPassBase<
+          ConvertWorkgroupForallToPCFPass> {
+  void runOnOperation() override;
+  using Base::Base;
+};
+
+} // namespace
+
+LogicalResult
+ConvertWorkgroupForall::matchAndRewrite(scf::ForallOp op,
+                                        PatternRewriter &rewriter) const {
+  ArrayAttr mappingAttr = op.getMappingAttr();
+  if (!mappingAttr || mappingAttr.empty() ||
+      !llvm::all_of(mappingAttr,
+                    llvm::IsaPred<IREE::Codegen::WorkgroupMappingAttr>)) {
+    return failure();
+  }
+  // Linearize all ids down to 1 so that in cases when there are multiple
+  // scf.foralls with incompatible delinearization bases. This technically
+  // may be a small pessimization in very specific static cases, so if someone
+  // ever finds they care they can try doing the analysis here to figure out
+  // when it's ok not to linearize.
+  //
+  // Interface is implemented via external models hence the cast.
+  auto scope = cast<IREE::PCF::ScopeAttrInterface>(
+      IREE::Codegen::WorkgroupScopeAttr::get(rewriter.getContext(),
+                                             /*linearize=*/true));
+  FailureOr<IREE::PCF::LoopOp> res = convertForallToPCF(rewriter, op, scope, 1);
+  if (failed(res)) {
+    return failure();
+  }
+
+  // Create a workgroup count hint to launch all workgroups along x.
+  SmallVector<OpFoldResult> counts =
+      llvm::to_vector_of<OpFoldResult>(res->getCount());
+  rewriter.setInsertionPoint(*res);
+  [[maybe_unused]] LogicalResult hintRes = createWorkgroupCountHint(
+      rewriter, res->getLoc(), counts, /*maxWorkgroupParallelDims=*/1,
+      /*reverse=*/false);
+  assert(succeeded(hintRes) &&
+         "Unexpected failure to construct workgroup count hint");
+  return success();
+}
+
+void ConvertWorkgroupForallToPCFPass::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  patterns.add<ConvertWorkgroupForall>(&getContext());
+  walkAndApplyPatterns(getOperation(), std::move(patterns));
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertWorkgroupForallToPCF.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertWorkgroupForallToPCF.cpp
@@ -19,8 +19,8 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
 namespace {
-struct ConvertWorkgroupForall : public OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern<scf::ForallOp>::OpRewritePattern;
+struct ConvertWorkgroupForall : OpRewritePattern<scf::ForallOp> {
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::ForallOp op,
                                 PatternRewriter &rewriter) const override;
 };
@@ -59,8 +59,7 @@ ConvertWorkgroupForall::matchAndRewrite(scf::ForallOp op,
   }
 
   // Create a workgroup count hint to launch all workgroups along x.
-  SmallVector<OpFoldResult> counts =
-      llvm::to_vector_of<OpFoldResult>(res->getCount());
+  auto counts = llvm::to_vector_of<OpFoldResult>(res->getCount());
   rewriter.setInsertionPoint(*res);
   [[maybe_unused]] LogicalResult hintRes = createWorkgroupCountHint(
       rewriter, res->getLoc(), counts, /*maxWorkgroupParallelDims=*/1,

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -123,6 +123,26 @@ def ConvertToDestinationPassingStylePass :
   ];
 }
 
+def ConvertWorkgroupForallToPCFPass
+    : Pass<"iree-codegen-convert-workgroup-forall-to-pcf"> {
+  let summary = "Converts workgroup mapped scf.forall ops to pcf.loop";
+  let description = [{
+    Converts `scf.forall` ops with `#iree_codegen.workgroup_mapping` attributes
+    to `pcf.loop` ops with workgroup scope.
+
+    The input is IR containing `scf.forall` ops mapped to workgroups via
+    `#iree_codegen.workgroup_mapping<x/y/z>` attributes. The pass linearizes
+    all workgroup IDs down to a single dimension to handle cases where multiple
+    foralls have incompatible delinearization bases.
+
+    The output replaces each matching forall with a `pcf.loop` using
+    `#iree_codegen.workgroup_scope<linearize>` scope. Additionally, an
+    `iree_codegen.workgroup_count_hint` is inserted before each loop to
+    communicate the required workgroup count to the export's count region.
+  }];
+  let dependentDialects = ["iree_compiler::IREE::PCF::PCFDialect"];
+}
+
 def CombineLayoutTransformationPass :
     InterfacePass<"iree-codegen-combine-layout-transformation", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "convert_hal_descriptor_type_to_gpu_address_space.mlir",
             "convert_to_destination_passing_style.mlir",
             "convert_unsupported_float_arith.mlir",
+            "convert_workgroup_forall_to_pcf.mlir",
             "convolution_to_igemm.mlir",
             "convolutions.mlir",
             "erase_dead_alloc_and_stores.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "convert_hal_descriptor_type_to_gpu_address_space.mlir"
     "convert_to_destination_passing_style.mlir"
     "convert_unsupported_float_arith.mlir"
+    "convert_workgroup_forall_to_pcf.mlir"
     "convolution_to_igemm.mlir"
     "convolutions.mlir"
     "decompose_affine_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_workgroup_forall_to_pcf.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_workgroup_forall_to_pcf.mlir
@@ -1,0 +1,118 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(iree-codegen-convert-workgroup-forall-to-pcf)" \
+// RUN:  --allow-unregistered-dialect --mlir-print-local-scope --split-input-file | FileCheck %s
+
+func.func @convert_forall(%0: index, %1: index, %2: index, %3: index, %4: index, %5: index) {
+  scf.forall (%arg0, %arg1) = (%0, %1) to (%2, %3) step(%4, %5) {
+    "use"(%arg0, %arg1) : (index, index) -> ()
+  } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+  return
+}
+
+// CHECK-LABEL: @convert_forall
+//  CHECK-SAME:   %[[LBY:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[LBX:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[UBY:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[UBX:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[STEPY:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[STEPX:[A-Za-z0-9_]+]]: index
+
+//   CHECK-DAG:   %[[COUNTX:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s0 - s1) ceildiv s2)>()[%[[UBX]], %[[LBX]], %[[STEPX]]]
+//   CHECK-DAG:   %[[COUNTY:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s0 - s1) ceildiv s2)>()[%[[UBY]], %[[LBY]], %[[STEPY]]]
+//   CHECK-DAG:   %[[LINEARIZED_COUNT:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s0 - s1) ceildiv s2) * ((s3 - s4) ceildiv s5))>()[%[[UBY]], %[[LBY]], %[[STEPY]], %[[UBX]], %[[LBX]], %[[STEPX]]]
+//       CHECK:   iree_codegen.workgroup_count_hint(%[[LINEARIZED_COUNT]])
+//       CHECK:   pcf.loop scope(#iree_codegen.workgroup_scope<linearize>) count(%[[LINEARIZED_COUNT]])
+//  CHECK-NEXT:       execute[%[[LINEAR_ID:[A-Za-z0-9_]+]]: index]
+//       CHECK:     %[[DELIN:[A-Za-z0-9_]+]]:2 = affine.delinearize_index %[[LINEAR_ID]] into (%[[COUNTY]], %[[COUNTX]]) : index, index
+//   CHECK-DAG:     %[[CIDX:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELIN]]#1, %[[STEPX]], %[[LBX]]]
+//   CHECK-DAG:     %[[CIDY:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELIN]]#0, %[[STEPY]], %[[LBY]]]
+//       CHECK:     "use"(%[[CIDY]], %[[CIDX]])
+
+// -----
+
+func.func @convert_forall_reverse_mapping(%0: index, %1: index, %2: index, %3: index, %4: index, %5: index) {
+  scf.forall (%arg0, %arg1) = (%0, %1) to (%2, %3) step(%4, %5) {
+    "use"(%arg0, %arg1) : (index, index) -> ()
+  } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
+  return
+}
+
+// CHECK-LABEL: @convert_forall_reverse_mapping
+//  CHECK-SAME:   %[[LBX:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[LBY:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[UBX:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[UBY:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[STEPX:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[STEPY:[A-Za-z0-9_]+]]: index
+
+//   CHECK-DAG:   %[[COUNTX:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s0 - s1) ceildiv s2)>()[%[[UBX]], %[[LBX]], %[[STEPX]]]
+//   CHECK-DAG:   %[[COUNTY:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s0 - s1) ceildiv s2)>()[%[[UBY]], %[[LBY]], %[[STEPY]]]
+//   CHECK-DAG:   %[[LINEARIZED_COUNT:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s0 - s1) ceildiv s2) * ((s3 - s4) ceildiv s5))>()[%[[UBY]], %[[LBY]], %[[STEPY]], %[[UBX]], %[[LBX]], %[[STEPX]]]
+//       CHECK:   iree_codegen.workgroup_count_hint(%[[LINEARIZED_COUNT]])
+//       CHECK:   pcf.loop scope(#iree_codegen.workgroup_scope<linearize>) count(%[[LINEARIZED_COUNT]])
+//  CHECK-NEXT:       execute[%[[LINEAR_ID:[A-Za-z0-9_]+]]: index]
+//       CHECK:     %[[DELIN:[A-Za-z0-9_]+]]:2 = affine.delinearize_index %[[LINEAR_ID]] into (%[[COUNTY]], %[[COUNTX]]) : index, index
+//   CHECK-DAG:     %[[CIDX:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELIN]]#1, %[[STEPX]], %[[LBX]]]
+//   CHECK-DAG:     %[[CIDY:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELIN]]#0, %[[STEPY]], %[[LBY]]]
+//       CHECK:     "use"(%[[CIDX]], %[[CIDY]])
+
+// -----
+
+func.func @convert_forall_delinearize(%0: index, %1: index, %2: index, %3: index, %4: index, %5: index) {
+  scf.forall (%arg0, %arg1, %arg2, %arg3) = (3, %0, 5, %1) to (7, %2, 11, %3) step(2, %4, 1, %5) {
+    "use"(%arg0, %arg1, %arg2, %arg3) : (index, index, index, index) -> ()
+  } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<z:0>, #iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<z:1>]}
+  return
+}
+
+// CHECK-LABEL: @convert_forall_delinearize
+//  CHECK-SAME:   %[[LBZ0:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[LBZ1:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[UBZ0:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[UBZ1:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[STEPZ0:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:   %[[STEPZ1:[A-Za-z0-9_]+]]: index
+
+//   CHECK-DAG:   %[[C6:[a-zA-Z0-9_]+]] = arith.constant 6
+//   CHECK-DAG:   %[[C2:[a-zA-Z0-9_]+]] = arith.constant 2
+//   CHECK-DAG:   %[[COUNTZ0:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s0 - s1) ceildiv s2)>()[%[[UBZ0]], %[[LBZ0]], %[[STEPZ0]]]
+//   CHECK-DAG:   %[[COUNTZ1:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s0 - s1) ceildiv s2)>()[%[[UBZ1]], %[[LBZ1]], %[[STEPZ1]]]
+//   CHECK-DAG:   %[[COUNTZ:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s0 - s1) ceildiv s2) * ((s3 - s4) ceildiv s5))>()[%[[UBZ1]], %[[LBZ1]], %[[STEPZ1]], %[[UBZ0]], %[[LBZ0]], %[[STEPZ0]]]
+//       CHECK:   %{{.+}} = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> ((((s0 - s1) ceildiv s2) * ((s3 - s4) ceildiv s5)) * 2)>()[%[[UBZ1]], %[[LBZ1]], %[[STEPZ1]], %[[UBZ0]], %[[LBZ0]], %[[STEPZ0]]]
+//       CHECK:   %[[LINEARIZED_COUNT:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> ((((s0 - s1) ceildiv s2) * ((s3 - s4) ceildiv s5)) * 12)>()[%[[UBZ1]], %[[LBZ1]], %[[STEPZ1]], %[[UBZ0]], %[[LBZ0]], %[[STEPZ0]]]
+//       CHECK:   iree_codegen.workgroup_count_hint(%[[LINEARIZED_COUNT]])
+//       CHECK:   pcf.loop scope(#iree_codegen.workgroup_scope<linearize>) count(%[[LINEARIZED_COUNT]])
+//  CHECK-NEXT:       execute[%[[LINEAR_ID:[A-Za-z0-9_]+]]: index]
+//       CHECK:     %[[DELIN:[A-Za-z0-9_]+]]:4 = affine.delinearize_index %[[LINEAR_ID]] into (%[[COUNTZ1]], %[[COUNTZ0]], 2, 6) : index, index, index, index
+//   CHECK-DAG:     %[[CIDX:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0] -> (s0 + 5)>()[%[[DELIN]]#3]
+//   CHECK-DAG:     %[[CIDY:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0] -> (s0 * 2 + 3)>()[%[[DELIN]]#2]
+//   CHECK-DAG:     %[[CIDZ0:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELIN]]#1, %[[STEPZ0]], %[[LBZ0]]]
+//   CHECK-DAG:     %[[CIDZ1:[A-Za-z0-9_]+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELIN]]#0, %[[STEPZ1]], %[[LBZ1]]]
+//       CHECK:     "use"(%[[CIDY]], %[[CIDZ0]], %[[CIDX]], %[[CIDZ1]])
+
+// -----
+
+// Forall without mapping should not be converted.
+func.func @forall_no_mapping_not_converted() {
+  scf.forall (%arg0, %arg1) = (0, 0) to (32, 32) step (4, 4) {
+    "use"(%arg0, %arg1) : (index, index) -> ()
+  }
+  return
+}
+
+// CHECK-LABEL: @forall_no_mapping_not_converted
+// CHECK: scf.forall
+// CHECK-NOT: pcf.loop
+
+// -----
+
+// Forall with non-workgroup mapping (gpu.thread) should not be converted.
+func.func @forall_gpu_thread_mapping_not_converted() {
+  scf.forall (%arg0, %arg1) = (0, 0) to (32, 32) step (4, 4) {
+    "use"(%arg0, %arg1) : (index, index) -> ()
+  } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+  return
+}
+
+// CHECK-LABEL: @forall_gpu_thread_mapping_not_converted
+// CHECK: scf.forall
+// CHECK-NOT: pcf.loop

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -516,12 +516,8 @@ LogicalResult createWorkgroupCountHint(RewriterBase &rewriter, Location loc,
                                        ArrayRef<OpFoldResult> workgroupCount,
                                        int maxWorkgroupParallelDims,
                                        bool reverse) {
-  SmallVector<OpFoldResult> results;
-  if (reverse) {
-    results.append(workgroupCount.rbegin(), workgroupCount.rend());
-  } else {
-    results.append(workgroupCount.begin(), workgroupCount.end());
-  }
+  SmallVector<OpFoldResult> results =
+      llvm::to_vector(llvm::reverse_conditionally(workgroupCount, reverse));
   if (results.size() > maxWorkgroupParallelDims) {
     MutableArrayRef<OpFoldResult> resultsRef =
         llvm::MutableArrayRef<OpFoldResult>(results);

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -516,8 +516,12 @@ LogicalResult createWorkgroupCountHint(RewriterBase &rewriter, Location loc,
                                        ArrayRef<OpFoldResult> workgroupCount,
                                        int maxWorkgroupParallelDims,
                                        bool reverse) {
-  SmallVector<OpFoldResult> results(reverse ? llvm::reverse(workgroupCount)
-                                            : workgroupCount);
+  SmallVector<OpFoldResult> results;
+  if (reverse) {
+    results.append(workgroupCount.rbegin(), workgroupCount.rend());
+  } else {
+    results.append(workgroupCount.begin(), workgroupCount.end());
+  }
   if (results.size() > maxWorkgroupParallelDims) {
     MutableArrayRef<OpFoldResult> resultsRef =
         llvm::MutableArrayRef<OpFoldResult>(results);


### PR DESCRIPTION
Converts scf.forall with workgroup mappings to pcf.loop with linearized workgroup ids. This is the quick and dirty path to replacing scf.forall in codegen pipelines with pcf without needing to reimplement everything. By keeping tile + fuse intact, this pass lets us work on replacing pieces incrementally.