### PR TITLE
[Flow][Stream] Fix assertions in build function

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1333,8 +1333,8 @@ void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   }
   state.addRegion();
   if (!argAttrs.empty() || !resAttrs.empty()) {
-    assert(type.getNumInputs() == argAttrs.size());
-    assert(type.getNumResults() == resAttrs.size());
+    assert(argAttrs.empty() || (type.getNumInputs() == argAttrs.size()));
+    assert(resAttrs.empty() || (type.getNumResults() == resAttrs.size()));
     call_interface_impl::addArgAndResultAttrs(
         builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
         builder.getStringAttr("res_attrs"));

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/call_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/call_ops.mlir
@@ -53,3 +53,14 @@ util.func public @inplaceTypeChangeCall(%arg0: tensor<?x4xf32>, %dim0: index) ->
   // CHECK: util.return %[[CALL]], %[[SIZE0]]
   util.return %call : tensor<4x?xi32>
 }
+
+// -----
+
+// Externs that only have argument attributes or result attributes, but not
+// both. Here we test correct handling of the attributes.
+
+// CHECK: stream.async.func private @externArg2Attrs(%arg0: !stream.resource<*> {arg.attr0}, %arg1: i32 {arg.attr1}) -> !util.buffer
+flow.func private @externArg2Attrs(%arg0: tensor<4x?xi32> {arg.attr0}, %arg1: i32 {arg.attr1}) -> !util.buffer
+
+// CHECK: stream.async.func private @externRet1Attrs(%arg0: !hal.device, %arg1: i64) -> (!stream.resource<*> {ret.attr})
+flow.func private @externRet1Attrs(%arg0: !hal.device, %arg1: i64) -> (tensor<4x?xi32> {ret.attr})

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2928,8 +2928,8 @@ void AsyncFuncOp::build(OpBuilder &builder, OperationState &state,
   }
   state.addRegion();
   if (!argAttrs.empty() || !resAttrs.empty()) {
-    assert(type.getNumInputs() == argAttrs.size());
-    assert(type.getNumResults() == resAttrs.size());
+    assert(argAttrs.empty() || (type.getNumInputs() == argAttrs.size()));
+    assert(resAttrs.empty() || (type.getNumResults() == resAttrs.size()));
     call_interface_impl::addArgAndResultAttrs(
         builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
         builder.getStringAttr("res_attrs"));


### PR DESCRIPTION
Relaxes assertions in the `build` functions for `flow.func` and `stream.async.func`. 

The `FunctionOpTrait` only requires:
- If argument attributes are present, their number must match the number of arguments.
- If result attributes are present, their number must match the number of results.

Due to the structure of the code, the `assert`s so far required the number of argument attributes to match the number of arguments when result attributes are present, even if no argument attributes were specified (and vice versa for results).

This leads to assertion errors for legal functions which specify a full set of argument attributes but no result attributes at all, or vice versa.

This is based on bugs reported from fuzzing, it fixes https://github.com/iree-org/iree/issues/22962 and fixes https://github.com/iree-org/iree/issues/22961.