### PR TITLE
[Stream] Update executables in UnifyEncodingForGlobals pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -54,12 +54,14 @@ iree_compiler_cc_library(
         "SpecializeEncodings.cpp",
         "SyncInitializers.cpp",
         "UnifyEncodingForGlobals.cpp",
+        "Utils.cpp",
         "VerifyAffinities.cpp",
         "VerifyAsyncAccessRanges.cpp",
         "VerifyLowerings.cpp",
     ],
     hdrs = [
         "Passes.h",
+        "Utils.h",
     ],
     deps = [
         ":PassesIncGen",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
     Transforms
   HDRS
     "Passes.h"
+    "Utils.h"
   SRCS
     "AnnotateAffinities.cpp"
     "AnnotateConstantTransientSize.cpp"
@@ -50,6 +51,7 @@ iree_cc_library(
     "SpecializeEncodings.cpp"
     "SyncInitializers.cpp"
     "UnifyEncodingForGlobals.cpp"
+    "Utils.cpp"
     "VerifyAffinities.cpp"
     "VerifyAsyncAccessRanges.cpp"
     "VerifyLowerings.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/Stream/IR/StreamTraits.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Utils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -36,32 +37,6 @@ namespace mlir::iree_compiler::IREE::Stream {
 
 #define GEN_PASS_DEF_SPECIALIZEENCODINGSPASS
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
-
-namespace {
-/// Returns a stably sorted list of dialect interfaces of T for all dialects
-/// used within the given module.
-template <typename T>
-SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
-  SmallPtrSet<const T *, 4> resultSet;
-  for (auto dialect : moduleOp.getContext()->getLoadedDialects()) {
-    auto *dialectInterface = dialect->getRegisteredInterface<T>();
-    if (!dialectInterface)
-      continue;
-    resultSet.insert(dialectInterface);
-  }
-
-  // NOTE: to ensure deterministic output we sort the result so that imports are
-  // always added in a consistent order.
-  auto results = llvm::to_vector_of<const T *>(resultSet);
-  llvm::sort(
-      results, +[](const T *a, const T *b) {
-        return a->getDialect()->getNamespace().compare(
-                   b->getDialect()->getNamespace()) < 0;
-      });
-  return results;
-}
-
-} // namespace
 
 /// Returns true iff the type is a RankedTensorType and it has an encoding that
 /// implements SerializableAttr.
@@ -117,272 +92,14 @@ static Type getTypeWithResolvedEncodingLayouts(
   return rankedTensorType.cloneWithEncoding(newEncoding);
 };
 
-/// Updates the bindings of function arguments with encoding layouts. It only
-/// updates the uses when the argument type is stream.binding_type. The bindings
-/// are only used by binding subspan ops that return whatever types. Today they
-/// are mostly flow tensor type. If the type implements
-/// IREE::Encoding::EncodingTypeInterface type interface, the method uses the
-/// interface methods to compute the type that has updated encodings (i.e.,
-/// encodings with layouts) and updates the type.
-static LogicalResult
-updateBindingEncodings(FunctionOpInterface funcOp,
-                       ArrayRef<Attribute> bindingLayoutTypeAttrs) {
-  Region &region = funcOp.getFunctionBody();
-  for (auto [arg, newTypeAttr] :
-       llvm::zip_equal(region.getArguments(), bindingLayoutTypeAttrs)) {
-    if (!isa<IREE::Stream::BindingType>(arg.getType())) {
-      continue;
-    }
-    auto newType =
-        dyn_cast<RankedTensorType>(cast<TypeAttr>(newTypeAttr).getValue());
-    if (!newType) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Skip, the new type is not RankedTensorType.\n");
-      continue;
-    }
-    auto encodingAttr = IREE::Encoding::getSerializableAttr(newType);
-    if (!encodingAttr) {
-      LLVM_DEBUG(llvm::dbgs() << "Skip, the binding layout attribute is not "
-                                 "SerializableAttr, which means that the type "
-                                 "does not have a valid encoding.\n");
-      continue;
-    }
-    for (auto user : arg.getUsers()) {
-      auto subspanOp = cast<IREE::Stream::BindingSubspanOp>(user);
-      auto encodingTypeInterface =
-          cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());
-      subspanOp.getResult().setType(
-          encodingTypeInterface.updateEncoding(encodingAttr));
-    }
-  }
-  return success();
-}
-
-/// Returns the operands encodings and result encodings from the `dispatchOp` in
-/// |operands| + |results| order, i.e., it returns the stripped concatenated
-/// operand encodings and result encodings. If a result is tied to an operand,
-/// the result encoding is skipped. Because it shares the same binding with the
-/// tied operands.
-///
-/// Example 1:
-///
-///   %0 = stream.tensor.dispatch ...(%arg0, %c4)
-///     : (tensor<4x?xf32, #encoding> in !resource, index)
-///     -> tensor<4x?xf32, #encoding> in !resource
-///
-/// The above dispatch op does not have tied operands. Thus, it returns
-///   |#resolved_encoding, whatever_without_encoding, #resolved_encoding|
-///
-/// Example 2:
-///
-///   %0 = stream.tensor.dispatch ...(%arg0, %c4) : tensor<4x?xf32, #encoding>
-///     -> tensor<4x?xf32, #encoding> in %arg0
-///
-/// The above dispatch op ties the result to the first operand. Thus, the result
-/// encoding is stripped. It returns
-///   |#resolved_encoding, whatever_without_encoding|
-static SmallVector<Attribute>
-getBindingLayoutAttrs(IREE::Stream::TensorDispatchOp dispatchOp) {
-  SmallVector<int64_t> tiedOperands(dispatchOp.getNumResults(),
-                                    IREE::Util::TiedOpInterface::kUntiedIndex);
-  if (std::optional<ArrayAttr> tiedOperandsAttr =
-          dispatchOp.getTiedOperands()) {
-    tiedOperands =
-        llvm::map_to_vector(tiedOperandsAttr.value(), [](Attribute intAttr) {
-          return cast<IntegerAttr>(intAttr).getInt();
-        });
-  }
-
-  SmallVector<Attribute> result(dispatchOp.getOperandEncodings().getValue());
-  for (auto [resultEncoding, tiedOperand] : llvm::zip_equal(
-           dispatchOp.getResultEncodings().getValue(), tiedOperands)) {
-    if (tiedOperand != IREE::Util::TiedOpInterface::kUntiedIndex) {
-      continue;
-    }
-    result.push_back(resultEncoding);
-  }
-
-  return result;
-}
-
-/// Duplicates stream.executables based on the operand encodings and result
-/// encodings of stream.tensor.dispatch ops. Some executables can be launched by
-/// different devices. It can produce wrong codegen artifacts when bindings
-/// types are encoded (i.e., the tensor type has an encoding attribute). Because
-/// they can result in different layouts, especially when multi-device is
-/// involved. E.g., say that device_a and device_b interpret a tensor type with
-/// encodings in different layouts, and there is an executable that can be
-/// launch with resources from either device_a or device_b. It is confusing what
-/// the input layouts for the executable because there are two possibilities. In
-/// this case, we have to duplicate the executable with updated encoding, and
-/// modify the dispatch to launch proper executable based on resolved encoding
-/// layouts.
-static LogicalResult duplicateExecutablesPerLayoutVariant(
-    ModuleOp moduleOp, SymbolTable symbolTable,
-    ArrayRef<IREE::Stream::TensorDispatchOp> candidates) {
-  MLIRContext *ctx = moduleOp.getContext();
-  IRRewriter rewriter(ctx);
-
-  //===--------------------------------------------------------------------===//
-  // Gather per-export [binding layouts] map. A function in an executable can be
-  // run with different affinities. The function arguments, where the types are
-  // `!stream.binding`, are consumed by `stream.binding.subspan` ops, and the op
-  // returns a tensor type. The binding layouts indicate the resolved layouts
-  // for those tensor types. The map records the mapping between an export op
-  // and the possible binding layouts.
-  //===--------------------------------------------------------------------===//
-  DenseMap<IREE::Stream::ExecutableExportOp, SetVector<ArrayAttr>>
-      bindingLayoutSetPerExportOp;
-
-  // Records the binding layouts for a dispatch op.
-  llvm::MapVector<IREE::Stream::TensorDispatchOp, SmallVector<Attribute>>
-      dispatchOpBindingLayouts;
-  for (auto dispatchOp : candidates) {
-    SmallVector<Attribute> bindingLayoutAttrs =
-        getBindingLayoutAttrs(dispatchOp);
-    dispatchOpBindingLayouts[dispatchOp] = bindingLayoutAttrs;
-    dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
-      auto exportOp = cast<IREE::Stream::ExecutableExportOp>(
-          symbolTable.lookupSymbolIn(moduleOp, entryPoint));
-      bindingLayoutSetPerExportOp[exportOp].insert(
-          rewriter.getArrayAttr(bindingLayoutAttrs));
-    });
-  }
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "Dump of bindingLayoutSetPerExportOp\n";
-    for (auto [exportOp, layoutSet] : bindingLayoutSetPerExportOp) {
-      llvm::dbgs() << "  ExportOp: " << exportOp.getSymName() << "\n";
-      for (auto [idx, attr] : llvm::enumerate(layoutSet)) {
-        llvm::dbgs() << "    binding_layouts #" << idx << ": " << attr << "\n ";
-      }
-    }
-  });
-
-  //===--------------------------------------------------------------------===//
-  // Duplicate executables for each unqiue binding layouts.
-  //===--------------------------------------------------------------------===//
-  // Mapping from [export op, binding layouts] to the executable op. So we can
-  // use it to update dispatch sites later on.
-  using ExportAndBindingLayouts =
-      std::pair<IREE::Stream::ExecutableExportOp, ArrayAttr>;
-  DenseMap<ExportAndBindingLayouts, IREE::Stream::ExecutableOp>
-      dispatchSiteToExecutableOp;
-  for (auto [exportOp, layoutSet] : bindingLayoutSetPerExportOp) {
-    int64_t dupId = -1;
-    auto executableOp = exportOp->getParentOfType<IREE::Stream::ExecutableOp>();
-    for (ArrayAttr bindingLayoutTypeAttrs : layoutSet) {
-      rewriter.setInsertionPointAfter(executableOp);
-      IREE::Stream::ExecutableOp dupOp = executableOp;
-      if (dupId != -1) {
-        auto symName = std::string(executableOp.getSymName());
-        symName += "_dup" + std::to_string(dupId);
-        dupOp = rewriter.cloneWithoutRegions(executableOp);
-        rewriter.modifyOpInPlace(dupOp, [&] {
-          dupOp.setSymName(symName);
-          IRMapping mapping;
-          executableOp.getRegion().cloneInto(&dupOp.getRegion(), mapping);
-        });
-      }
-
-      // Update the binding encodings within the cloned executable op.
-      auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
-          dupOp.getInnerModule(), exportOp.getSymName()));
-      if (failed(updateBindingEncodings(funcOp,
-                                        bindingLayoutTypeAttrs.getValue()))) {
-        return funcOp->emitOpError("failed to update encodings for bindings");
-      }
-      dispatchSiteToExecutableOp[ExportAndBindingLayouts(
-          exportOp, bindingLayoutTypeAttrs)] = dupOp;
-      dupId++;
-    }
-  }
-
-  //===--------------------------------------------------------------------===//
-  // Update dispatch sites, i.e., point dispatch entry points to corresponding
-  // duplicated executables.
-  //===--------------------------------------------------------------------===//
-  for (auto dispatchOp : candidates) {
-    SmallVector<Attribute> newEntryPoints;
-    SmallVector<Attribute> bindingLayoutAttrs =
-        dispatchOpBindingLayouts[dispatchOp];
-    dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
-      auto exportOp = cast<IREE::Stream::ExecutableExportOp>(
-          symbolTable.lookupSymbolIn(moduleOp, entryPoint));
-      auto info = ExportAndBindingLayouts(
-          exportOp, rewriter.getArrayAttr(bindingLayoutAttrs));
-      assert(dispatchSiteToExecutableOp.count(info));
-
-      auto executableOp = dispatchSiteToExecutableOp[info];
-      auto newSym = SymbolRefAttr::get(executableOp->getAttrOfType<StringAttr>(
-                                           SymbolTable::getSymbolAttrName()),
-                                       entryPoint.getNestedReferences());
-      newEntryPoints.push_back(newSym);
-    });
-
-    rewriter.modifyOpInPlace(dispatchOp, [&] {
-      dispatchOp.setEntryPointsAttr(rewriter.getArrayAttr(newEntryPoints));
-    });
-  }
-  return success();
-}
-
-/// Returns true iff all the entry points are recognized by the pass:
-///   - The corresponding executable is a stream.executable op.
-///   - The function arguments, where the types are !stream.binding_type, are
-///     only used by stream.binding.subspan ops. Furthermore, the result type of
-///     subspan ops have to implement IREE::Encoding::EncodingTypeInterface.
-static bool recognizeEntryPoints(ModuleOp moduleOp, SymbolTable symbolTable,
-                                 IREE::Stream::TensorDispatchOp dispatchOp) {
-  bool result = true;
-  dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
-    if (!result) {
-      return;
-    }
-    auto exportOp = dyn_cast_if_present<IREE::Stream::ExecutableExportOp>(
-        symbolTable.lookupSymbolIn(moduleOp, entryPoint));
-    if (!exportOp) {
-      result = false;
-      return;
-    }
-    auto executableOp = exportOp->getParentOfType<IREE::Stream::ExecutableOp>();
-    if (!executableOp) {
-      result = false;
-      return;
-    }
-
-    auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
-        executableOp.getInnerModule(), exportOp.getSymName()));
-    for (auto arg : funcOp.getArguments()) {
-      if (!isa<IREE::Stream::BindingType>(arg.getType())) {
-        continue;
-      }
-      for (auto user : arg.getUsers()) {
-        auto subspanOp = dyn_cast<IREE::Stream::BindingSubspanOp>(user);
-        if (!subspanOp) {
-          result = false;
-          return;
-        }
-        auto encodingTypeInterface =
-            dyn_cast<IREE::Encoding::EncodingTypeInterface>(
-                subspanOp.getType());
-        if (!encodingTypeInterface) {
-          result = false;
-          return;
-        }
-      }
-    }
-  });
-  return result;
-}
 
 /// Returns true if any of encoding types is a recognized encoding. See
 /// `isRecognizedEncodingType` method for the definition.
-static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable symbolTable,
+static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable &symbolTable,
                                   Operation *op) {
   return TypeSwitch<Operation *, bool>(op)
-      .Case<IREE::Stream::TensorDispatchOp>([&](auto op) {
-        if (!recognizeEntryPoints(moduleOp, symbolTable, op)) {
+      .Case<TensorDispatchOp>([&](auto op) {
+        if (!recognizeDispatchEntryPoints(moduleOp, symbolTable, op)) {
           return false;
         }
         for (TypeAttr typeAttr : llvm::concat<TypeAttr>(
@@ -429,7 +146,7 @@ static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable symbolTable,
 /// a stream affinity indicates the kind of enviroment the ops are expected run
 /// in.
 static SmallVector<IREE::Stream::AffinityOpInterface>
-collectStreamTensorOps(ModuleOp moduleOp, SymbolTable symbolTable,
+collectStreamTensorOps(ModuleOp moduleOp, SymbolTable &symbolTable,
                        FunctionOpInterface funcOp) {
   SmallVector<IREE::Stream::AffinityOpInterface> result;
   funcOp.walk([&](IREE::Stream::AffinityOpInterface affinityOp) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -92,7 +92,6 @@ static Type getTypeWithResolvedEncodingLayouts(
   return rankedTensorType.cloneWithEncoding(newEncoding);
 };
 
-
 /// Returns true if any of encoding types is a recognized encoding. See
 /// `isRecognizedEncodingType` method for the definition.
 static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable &symbolTable,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Utils.h"
 #include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
 #include "iree/compiler/Dialect/Util/Analysis/GlobalTable.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
@@ -28,29 +29,6 @@ namespace mlir::iree_compiler::IREE::Stream {
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
 
 namespace {
-
-/// Returns a stably sorted list of dialect interfaces of T for all dialects
-/// used within the given module.
-template <typename T>
-SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
-  SmallPtrSet<const T *, 4> resultSet;
-  for (Dialect *dialect : moduleOp.getContext()->getLoadedDialects()) {
-    const T *dialectInterface = dialect->getRegisteredInterface<T>();
-    if (!dialectInterface)
-      continue;
-    resultSet.insert(dialectInterface);
-  }
-
-  // NOTE: to ensure deterministic output we sort the result so that imports are
-  // always added in a consistent order.
-  auto results = llvm::to_vector_of<const T *>(resultSet);
-  llvm::sort(
-      results, +[](const T *a, const T *b) {
-        return a->getDialect()->getNamespace().compare(
-                   b->getDialect()->getNamespace()) < 0;
-      });
-  return results;
-}
 
 //===----------------------------------------------------------------------===//
 // Analysis.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -646,7 +646,51 @@ struct UnifyEncodingForGlobalsPass
     // Apply all tensor encoding updates in one shot.
     applyTensorEncodingUpdates(tensorEncodingUpdates);
 
-    // TODO(#22485): Update executables.
+    // Collect dispatch ops that need executable updates. Only include those
+    // with recognizable entry points (executable exists with proper binding
+    // subspans).
+    // TODO(hanchung): This currently does not work with if export op is not
+    // Stream op. E.g., it could be authored by external users. We need to
+    // filter such global out or re-encode before the dispatch op properly.
+    SymbolTable symbolTable(moduleOp);
+    SmallVector<TensorDispatchOp> dispatchOpsForExecutableUpdate;
+    for (auto &[op, operandUpdates] : tensorEncodingUpdates) {
+      auto dispatchOp = dyn_cast<TensorDispatchOp>(op);
+      if (!dispatchOp) {
+        continue;
+      }
+      if (!recognizeDispatchEntryPoints(moduleOp, symbolTable, dispatchOp)) {
+        LDBG() << "  Skipping executable update for dispatch (entry points not "
+                  "recognized): "
+               << dispatchOp;
+        continue;
+      }
+      dispatchOpsForExecutableUpdate.push_back(dispatchOp);
+    }
+
+    // Sort by affinity string for deterministic executable duplication order.
+    llvm::sort(dispatchOpsForExecutableUpdate,
+               [](TensorDispatchOp a, TensorDispatchOp b) {
+                 std::string aStr, bStr;
+                 llvm::raw_string_ostream aStream(aStr), bStream(bStr);
+                 if (auto aAffinity = a.getAffinityAttr())
+                   aStream << aAffinity;
+                 if (auto bAffinity = b.getAffinityAttr())
+                   bStream << bAffinity;
+                 return aStr < bStr;
+               });
+
+    // Duplicate executables for dispatch ops that have different binding
+    // layouts. This handles the case where the same executable is used by
+    // dispatch sites with different unified encodings (e.g., multi-device).
+    if (!dispatchOpsForExecutableUpdate.empty()) {
+      if (failed(duplicateExecutablesPerLayoutVariant(
+              moduleOp, symbolTable, dispatchOpsForExecutableUpdate))) {
+        moduleOp.emitError("failed to duplicate executables for unified "
+                           "encoding variants");
+        return signalPassFailure();
+      }
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
@@ -73,7 +73,8 @@ bool recognizeDispatchEntryPoints(ModuleOp moduleOp, SymbolTable &symbolTable,
           return;
         }
         auto encodingTypeInterface =
-            dyn_cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());
+            dyn_cast<IREE::Encoding::EncodingTypeInterface>(
+                subspanOp.getType());
         if (!encodingTypeInterface) {
           result = false;
           return;
@@ -133,7 +134,8 @@ duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp,
   // for those tensor types. The map records the mapping between an export op
   // and the possible binding layouts.
   //===--------------------------------------------------------------------===//
-  DenseMap<ExecutableExportOp, SetVector<ArrayAttr>> bindingLayoutSetPerExportOp;
+  DenseMap<ExecutableExportOp, SetVector<ArrayAttr>>
+      bindingLayoutSetPerExportOp;
 
   // Records the binding layouts for a dispatch op.
   llvm::MapVector<TensorDispatchOp, SmallVector<Attribute>>
@@ -187,8 +189,8 @@ duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp,
       // Update the binding encodings within the cloned executable op.
       auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
           dupOp.getInnerModule(), exportOp.getSymName()));
-      if (failed(
-              updateBindingEncodings(funcOp, bindingLayoutTypeAttrs.getValue()))) {
+      if (failed(updateBindingEncodings(funcOp,
+                                        bindingLayoutTypeAttrs.getValue()))) {
         return funcOp->emitOpError("failed to update encodings for bindings");
       }
       dispatchSiteToExecutableOp[ExportAndBindingLayouts(
@@ -208,14 +210,14 @@ duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp,
     dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
       auto exportOp = cast<ExecutableExportOp>(
           symbolTable.lookupSymbolIn(moduleOp, entryPoint));
-      auto info = ExportAndBindingLayouts(exportOp,
-                                          rewriter.getArrayAttr(bindingLayoutAttrs));
+      auto info = ExportAndBindingLayouts(
+          exportOp, rewriter.getArrayAttr(bindingLayoutAttrs));
       assert(dispatchSiteToExecutableOp.count(info));
 
       auto executableOp = dispatchSiteToExecutableOp[info];
-      auto newSym = SymbolRefAttr::get(
-          executableOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()),
-          entryPoint.getNestedReferences());
+      auto newSym = SymbolRefAttr::get(executableOp->getAttrOfType<StringAttr>(
+                                           SymbolTable::getSymbolAttrName()),
+                                       entryPoint.getNestedReferences());
       newEntryPoints.push_back(newSym);
     });
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
@@ -1,0 +1,229 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Stream/Transforms/Utils.h"
+
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+
+#define DEBUG_TYPE "iree-stream-transforms-utils"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+SmallVector<Attribute> getBindingLayoutAttrs(TensorDispatchOp dispatchOp) {
+  SmallVector<int64_t> tiedOperands(dispatchOp.getNumResults(),
+                                    IREE::Util::TiedOpInterface::kUntiedIndex);
+  if (std::optional<ArrayAttr> tiedOperandsAttr =
+          dispatchOp.getTiedOperands()) {
+    tiedOperands =
+        llvm::map_to_vector(tiedOperandsAttr.value(), [](Attribute intAttr) {
+          return cast<IntegerAttr>(intAttr).getInt();
+        });
+  }
+
+  SmallVector<Attribute> result(dispatchOp.getOperandEncodings().getValue());
+  for (auto [resultEncoding, tiedOperand] : llvm::zip_equal(
+           dispatchOp.getResultEncodings().getValue(), tiedOperands)) {
+    if (tiedOperand != IREE::Util::TiedOpInterface::kUntiedIndex) {
+      continue;
+    }
+    result.push_back(resultEncoding);
+  }
+
+  return result;
+}
+
+bool recognizeDispatchEntryPoints(ModuleOp moduleOp, SymbolTable &symbolTable,
+                                  TensorDispatchOp dispatchOp) {
+  bool result = true;
+  dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
+    if (!result) {
+      return;
+    }
+    auto exportOp = dyn_cast_if_present<ExecutableExportOp>(
+        symbolTable.lookupSymbolIn(moduleOp, entryPoint));
+    if (!exportOp) {
+      result = false;
+      return;
+    }
+    auto executableOp = exportOp->getParentOfType<ExecutableOp>();
+    if (!executableOp) {
+      result = false;
+      return;
+    }
+
+    auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
+        executableOp.getInnerModule(), exportOp.getSymName()));
+    for (auto arg : funcOp.getArguments()) {
+      if (!isa<BindingType>(arg.getType())) {
+        continue;
+      }
+      for (auto user : arg.getUsers()) {
+        auto subspanOp = dyn_cast<BindingSubspanOp>(user);
+        if (!subspanOp) {
+          result = false;
+          return;
+        }
+        auto encodingTypeInterface =
+            dyn_cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());
+        if (!encodingTypeInterface) {
+          result = false;
+          return;
+        }
+      }
+    }
+  });
+  return result;
+}
+
+LogicalResult
+updateBindingEncodings(FunctionOpInterface funcOp,
+                       ArrayRef<Attribute> bindingLayoutTypeAttrs) {
+  Region &region = funcOp.getFunctionBody();
+  for (auto [arg, newTypeAttr] :
+       llvm::zip_equal(region.getArguments(), bindingLayoutTypeAttrs)) {
+    if (!isa<BindingType>(arg.getType())) {
+      continue;
+    }
+    auto newType =
+        dyn_cast<RankedTensorType>(cast<TypeAttr>(newTypeAttr).getValue());
+    if (!newType) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Skip, the new type is not RankedTensorType.\n");
+      continue;
+    }
+    auto encodingAttr = IREE::Encoding::getSerializableAttr(newType);
+    if (!encodingAttr) {
+      LLVM_DEBUG(llvm::dbgs() << "Skip, the binding layout attribute is not "
+                                 "SerializableAttr, which means that the type "
+                                 "does not have a valid encoding.\n");
+      continue;
+    }
+    for (auto user : arg.getUsers()) {
+      auto subspanOp = cast<BindingSubspanOp>(user);
+      auto encodingTypeInterface =
+          cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());
+      subspanOp.getResult().setType(
+          encodingTypeInterface.updateEncoding(encodingAttr));
+    }
+  }
+  return success();
+}
+
+LogicalResult
+duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp,
+                                     SymbolTable &symbolTable,
+                                     ArrayRef<TensorDispatchOp> candidates) {
+  MLIRContext *ctx = moduleOp.getContext();
+  IRRewriter rewriter(ctx);
+
+  //===--------------------------------------------------------------------===//
+  // Gather per-export [binding layouts] map. A function in an executable can be
+  // run with different affinities. The function arguments, where the types are
+  // `!stream.binding`, are consumed by `stream.binding.subspan` ops, and the op
+  // returns a tensor type. The binding layouts indicate the resolved layouts
+  // for those tensor types. The map records the mapping between an export op
+  // and the possible binding layouts.
+  //===--------------------------------------------------------------------===//
+  DenseMap<ExecutableExportOp, SetVector<ArrayAttr>> bindingLayoutSetPerExportOp;
+
+  // Records the binding layouts for a dispatch op.
+  llvm::MapVector<TensorDispatchOp, SmallVector<Attribute>>
+      dispatchOpBindingLayouts;
+  for (auto dispatchOp : candidates) {
+    SmallVector<Attribute> bindingLayoutAttrs =
+        getBindingLayoutAttrs(dispatchOp);
+    dispatchOpBindingLayouts[dispatchOp] = bindingLayoutAttrs;
+    dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
+      auto exportOp = cast<ExecutableExportOp>(
+          symbolTable.lookupSymbolIn(moduleOp, entryPoint));
+      bindingLayoutSetPerExportOp[exportOp].insert(
+          rewriter.getArrayAttr(bindingLayoutAttrs));
+    });
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Dump of bindingLayoutSetPerExportOp\n";
+    for (auto [exportOp, layoutSet] : bindingLayoutSetPerExportOp) {
+      llvm::dbgs() << "  ExportOp: " << exportOp.getSymName() << "\n";
+      for (auto [idx, attr] : llvm::enumerate(layoutSet)) {
+        llvm::dbgs() << "    binding_layouts #" << idx << ": " << attr << "\n ";
+      }
+    }
+  });
+
+  //===--------------------------------------------------------------------===//
+  // Duplicate executables for each unique binding layouts.
+  //===--------------------------------------------------------------------===//
+  // Mapping from [export op, binding layouts] to the executable op. So we can
+  // use it to update dispatch sites later on.
+  using ExportAndBindingLayouts = std::pair<ExecutableExportOp, ArrayAttr>;
+  DenseMap<ExportAndBindingLayouts, ExecutableOp> dispatchSiteToExecutableOp;
+  for (auto [exportOp, layoutSet] : bindingLayoutSetPerExportOp) {
+    int64_t dupId = -1;
+    auto executableOp = exportOp->getParentOfType<ExecutableOp>();
+    for (ArrayAttr bindingLayoutTypeAttrs : layoutSet) {
+      rewriter.setInsertionPointAfter(executableOp);
+      ExecutableOp dupOp = executableOp;
+      if (dupId != -1) {
+        auto symName = std::string(executableOp.getSymName());
+        symName += "_dup" + std::to_string(dupId);
+        dupOp = rewriter.cloneWithoutRegions(executableOp);
+        rewriter.modifyOpInPlace(dupOp, [&] {
+          dupOp.setSymName(symName);
+          IRMapping mapping;
+          executableOp.getRegion().cloneInto(&dupOp.getRegion(), mapping);
+        });
+      }
+
+      // Update the binding encodings within the cloned executable op.
+      auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
+          dupOp.getInnerModule(), exportOp.getSymName()));
+      if (failed(
+              updateBindingEncodings(funcOp, bindingLayoutTypeAttrs.getValue()))) {
+        return funcOp->emitOpError("failed to update encodings for bindings");
+      }
+      dispatchSiteToExecutableOp[ExportAndBindingLayouts(
+          exportOp, bindingLayoutTypeAttrs)] = dupOp;
+      dupId++;
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Update dispatch sites, i.e., point dispatch entry points to corresponding
+  // duplicated executables.
+  //===--------------------------------------------------------------------===//
+  for (auto dispatchOp : candidates) {
+    SmallVector<Attribute> newEntryPoints;
+    SmallVector<Attribute> bindingLayoutAttrs =
+        dispatchOpBindingLayouts[dispatchOp];
+    dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
+      auto exportOp = cast<ExecutableExportOp>(
+          symbolTable.lookupSymbolIn(moduleOp, entryPoint));
+      auto info = ExportAndBindingLayouts(exportOp,
+                                          rewriter.getArrayAttr(bindingLayoutAttrs));
+      assert(dispatchSiteToExecutableOp.count(info));
+
+      auto executableOp = dispatchSiteToExecutableOp[info];
+      auto newSym = SymbolRefAttr::get(
+          executableOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()),
+          entryPoint.getNestedReferences());
+      newEntryPoints.push_back(newSym);
+    });
+
+    rewriter.modifyOpInPlace(dispatchOp, [&] {
+      dispatchOp.setEntryPointsAttr(rewriter.getArrayAttr(newEntryPoints));
+    });
+  }
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
@@ -1,0 +1,92 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_STREAM_TRANSFORMS_UTILS_H_
+#define IREE_COMPILER_DIALECT_STREAM_TRANSFORMS_UTILS_H_
+
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+//===----------------------------------------------------------------------===//
+// Dialect Interface Utilities
+//===----------------------------------------------------------------------===//
+
+/// Returns a stably sorted list of dialect interfaces of T for all dialects
+/// used within the given module.
+template <typename T>
+SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
+  SmallPtrSet<const T *, 4> resultSet;
+  for (auto dialect : moduleOp.getContext()->getLoadedDialects()) {
+    auto *dialectInterface = dialect->getRegisteredInterface<T>();
+    if (!dialectInterface)
+      continue;
+    resultSet.insert(dialectInterface);
+  }
+
+  // NOTE: to ensure deterministic output we sort the result so that imports are
+  // always added in a consistent order.
+  auto results = llvm::to_vector_of<const T *>(resultSet);
+  llvm::sort(
+      results, +[](const T *a, const T *b) {
+        return a->getDialect()->getNamespace().compare(
+                   b->getDialect()->getNamespace()) < 0;
+      });
+  return results;
+}
+
+//===----------------------------------------------------------------------===//
+// Executable Encoding Utilities
+//===----------------------------------------------------------------------===//
+
+/// Returns the operands encodings and result encodings from the `dispatchOp` in
+/// |operands| + |results| order, i.e., it returns the stripped concatenated
+/// operand encodings and result encodings. If a result is tied to an operand,
+/// the result encoding is skipped because it shares the same binding with the
+/// tied operand.
+SmallVector<Attribute> getBindingLayoutAttrs(TensorDispatchOp dispatchOp);
+
+/// Returns true iff all the entry points are recognized by the pass:
+///   - The corresponding executable is a stream.executable op.
+///   - The function arguments, where the types are !stream.binding_type, are
+///     only used by stream.binding.subspan ops. Furthermore, the result type of
+///     subspan ops have to implement IREE::Encoding::EncodingTypeInterface.
+bool recognizeDispatchEntryPoints(ModuleOp moduleOp, SymbolTable &symbolTable,
+                                  TensorDispatchOp dispatchOp);
+
+/// Updates the bindings of function arguments with encoding layouts. It only
+/// updates the uses when the argument type is stream.binding_type. The bindings
+/// are only used by binding subspan ops that return whatever types. Today they
+/// are mostly flow tensor type. If the type implements
+/// IREE::Encoding::EncodingTypeInterface type interface, the method uses the
+/// interface methods to compute the type that has updated encodings (i.e.,
+/// encodings with layouts) and updates the type.
+LogicalResult updateBindingEncodings(FunctionOpInterface funcOp,
+                                     ArrayRef<Attribute> bindingLayoutTypeAttrs);
+
+/// Duplicates stream.executables based on the operand encodings and result
+/// encodings of stream.tensor.dispatch ops. Some executables can be launched by
+/// different devices. It can produce wrong codegen artifacts when bindings
+/// types are encoded (i.e., the tensor type has an encoding attribute). Because
+/// they can result in different layouts, especially when multi-device is
+/// involved. E.g., say that device_a and device_b interpret a tensor type with
+/// encodings in different layouts, and there is an executable that can be
+/// launch with resources from either device_a or device_b. It is confusing what
+/// the input layouts for the executable because there are two possibilities. In
+/// this case, we have to duplicate the executable with updated encoding, and
+/// modify the dispatch to launch proper executable based on resolved encoding
+/// layouts.
+LogicalResult
+duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp,
+                                     SymbolTable &symbolTable,
+                                     ArrayRef<TensorDispatchOp> candidates);
+
+} // namespace mlir::iree_compiler::IREE::Stream
+
+#endif // IREE_COMPILER_DIALECT_STREAM_TRANSFORMS_UTILS_H_

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
@@ -50,9 +50,27 @@ SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 /// operand encodings and result encodings. If a result is tied to an operand,
 /// the result encoding is skipped because it shares the same binding with the
 /// tied operand.
+///
+/// Example 1:
+///
+///   %0 = stream.tensor.dispatch ...(%arg0, %c4)
+///     : (tensor<4x?xf32, #encoding> in !resource, index)
+///     -> tensor<4x?xf32, #encoding> in !resource
+///
+/// The above dispatch op does not have tied operands. Thus, it returns
+///   |#resolved_encoding, whatever_without_encoding, #resolved_encoding|
+///
+/// Example 2:
+///
+///   %0 = stream.tensor.dispatch ...(%arg0, %c4) : tensor<4x?xf32, #encoding>
+///     -> tensor<4x?xf32, #encoding> in %arg0
+///
+/// The above dispatch op ties the result to the first operand. Thus, the result
+/// encoding is stripped. It returns
+///   |#resolved_encoding, whatever_without_encoding|
 SmallVector<Attribute> getBindingLayoutAttrs(TensorDispatchOp dispatchOp);
 
-/// Returns true iff all the entry points are recognized by the pass:
+/// Returns true iff all the entry points are recognized:
 ///   - The corresponding executable is a stream.executable op.
 ///   - The function arguments, where the types are !stream.binding_type, are
 ///     only used by stream.binding.subspan ops. Furthermore, the result type of

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
@@ -85,8 +85,9 @@ bool recognizeDispatchEntryPoints(ModuleOp moduleOp, SymbolTable &symbolTable,
 /// IREE::Encoding::EncodingTypeInterface type interface, the method uses the
 /// interface methods to compute the type that has updated encodings (i.e.,
 /// encodings with layouts) and updates the type.
-LogicalResult updateBindingEncodings(FunctionOpInterface funcOp,
-                                     ArrayRef<Attribute> bindingLayoutTypeAttrs);
+LogicalResult
+updateBindingEncodings(FunctionOpInterface funcOp,
+                       ArrayRef<Attribute> bindingLayoutTypeAttrs);
 
 /// Duplicates stream.executables based on the operand encodings and result
 /// encodings of stream.tensor.dispatch ops. Some executables can be launched by

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/unify_encoding_for_globals.mlir
@@ -262,38 +262,28 @@ stream.executable private @ex {
 util.func public @multi_device_with_executable_duplication(%arg0: index) {
   %encoded_a_v1 = util.global.load immutable @encoded_a_v1 : !stream.resource<constant>
   %encoded_a_v1_size = util.global.load immutable @encoded_a_v1_size : index
-  %operand_a_0 = stream.async.clone on(#hal.device.affinity<@device_a>)
-    %encoded_a_v1 : !stream.resource<constant>{%encoded_a_v1_size}
-    -> !stream.resource<*>{%encoded_a_v1_size}
   %encoded_a_v2 = util.global.load immutable @encoded_a_v2 : !stream.resource<constant>
   %encoded_a_v2_size = util.global.load immutable @encoded_a_v2_size : index
-  %operand_a_1 = stream.async.clone on(#hal.device.affinity<@device_a>)
-    %encoded_a_v2 : !stream.resource<constant>{%encoded_a_v2_size}
-    -> !stream.resource<*>{%encoded_a_v2_size}
   // CHECK: stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX]]::@dispatch
   // CHECK-SAME: tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   // CHECK-SAME: tensor<4096x4096xf32, #iree_encoding.specialized<123>>
   %dispatch_a = stream.tensor.dispatch on(#hal.device.affinity<@device_a>)
-    @ex::@dispatch(%operand_a_0, %operand_a_1) : (tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%encoded_a_v1_size},
-                                                  tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%encoded_a_v2_size}
+    @ex::@dispatch(%encoded_a_v1, %encoded_a_v2)
+    : (tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%encoded_a_v1_size},
+       tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%encoded_a_v2_size}
     ) -> tensor<4096x4096xf32> in !stream.resource<*>{%arg0}
 
   %encoded_b_v1 = util.global.load immutable @encoded_b_v1 : !stream.resource<constant>
   %encoded_b_v1_size = util.global.load immutable @encoded_b_v1_size : index
-  %operand_b_0 = stream.async.clone on(#hal.device.affinity<@device_b>)
-    %encoded_b_v1 : !stream.resource<constant>{%encoded_b_v1_size}
-    -> !stream.resource<*>{%encoded_b_v1_size}
   %encoded_b_v2 = util.global.load immutable @encoded_b_v2 : !stream.resource<constant>
   %encoded_b_v2_size = util.global.load immutable @encoded_b_v2_size : index
-  %operand_b_1 = stream.async.clone on(#hal.device.affinity<@device_b>)
-    %encoded_b_v2 : !stream.resource<constant>{%encoded_b_v2_size}
-    -> !stream.resource<*>{%encoded_b_v2_size}
   // CHECK: stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX_DUP]]::@dispatch
   // CHECK-SAME: tensor<4096x4096xf32, #iree_encoding.specialized<456>>
   // CHECK-SAME: tensor<4096x4096xf32, #iree_encoding.specialized<456>>
   %dispatch_b = stream.tensor.dispatch on(#hal.device.affinity<@device_b>)
-    @ex::@dispatch(%operand_b_0, %operand_b_1) : (tensor<4096x4096xf32, #encoding1> in !stream.resource<*>{%encoded_b_v1_size},
-                                                  tensor<4096x4096xf32, #encoding2> in !stream.resource<*>{%encoded_b_v2_size}
+    @ex::@dispatch(%encoded_b_v1, %encoded_b_v2)
+    : (tensor<4096x4096xf32, #encoding1> in !stream.resource<constant>{%encoded_b_v1_size},
+       tensor<4096x4096xf32, #encoding2> in !stream.resource<constant>{%encoded_b_v2_size}
     ) -> tensor<4096x4096xf32> in !stream.resource<*>{%arg0}
 
   util.return


### PR DESCRIPTION
When the same executable is used by dispatch sites targeting different devices with different unified encodings (e.g., multi-device scenarios), the executable may have to be duplicated so each device gets bindings with its own encoding. If they result in the same encodings, duplication is not needed.

The revision also refacotrs reusable executable handling utilities from
SpecializeEncodings into Utils.h/Utils.cpp:
 - gatherUsedDialectInterfaces<T>()
 - getBindingLayoutAttrs()
 - recognizeDispatchEntryPoints()
 - updateBindingEncodings()
 - duplicateExecutablesPerLayoutVariant()

It is not a pure copy-paste refactoring. There are two minor changes:
- Function rename: recognizeEntryPoints → recognizeDispatchEntryPoints (to be more explicit about what it recognizes)
- Parameter change: SymbolTable symbolTable → SymbolTable &symbolTable (pass by reference instead of by value)

It is a step towards https://github.com/iree-org/iree/issues/22940