### PR TITLE
runtime: allow to collect host allocator memory usage statistics

### DIFF
--- a/runtime/src/iree/base/BUILD.bazel
+++ b/runtime/src/iree/base/BUILD.bazel
@@ -56,6 +56,29 @@ iree_runtime_cc_library(
     ],
 )
 
+iree_runtime_cc_library(
+    name = "base_stats",
+    srcs = [
+        "allocator_stats.c",
+    ],
+    hdrs = ["allocator_stats.h"],
+    deps = [
+        ":base",
+        "//runtime/src/iree/base/internal:synchronization",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "base_stats_test",
+    srcs = ["allocator_stats_test.cc"],
+    deps = [
+        ":base",
+        ":base_stats",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 iree_runtime_cc_test(
     name = "bitfield_test",
     srcs = ["bitfield_test.cc"],

--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -90,6 +90,30 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    base_stats
+  HDRS
+    "allocator_stats.h"
+  SRCS
+    "allocator_stats.c"
+  DEPS
+    ::base
+    iree::base::internal::synchronization
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    base_stats_test
+  SRCS
+    "allocator_stats_test.cc"
+  DEPS
+    ::base_stats
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 iree_cc_test(
   NAME
     bitfield_test

--- a/runtime/src/iree/base/allocator_stats.c
+++ b/runtime/src/iree/base/allocator_stats.c
@@ -1,0 +1,176 @@
+#include "iree/base/allocator_stats.h"
+
+#include "iree/base/api.h"
+#include "iree/base/internal/synchronization.h"
+
+// Size of the prefix we store ahead of the user pointer.
+// Must be >= sizeof(iree_host_size_t) and a multiple of iree_max_align_t so
+// that the returned fake_ptr is still max-aligned.
+#define IREE_ALLOCATOR_STATS_PREFIX_SIZE \
+  iree_host_align(sizeof(iree_host_size_t), (iree_host_size_t)iree_max_align_t)
+
+// Records an allocation of |byte_length| bytes in |statistics|.
+static inline void iree_allocator_statistics_record_alloc(
+    iree_allocator_statistics_t* statistics, iree_host_size_t byte_length) {
+  iree_slim_mutex_lock(statistics->mutex);
+  statistics->bytes_allocated += byte_length;
+  if (statistics->bytes_allocated - statistics->bytes_freed >
+      statistics->bytes_peak) {
+    statistics->bytes_peak =
+        statistics->bytes_allocated - statistics->bytes_freed;
+  }
+  iree_slim_mutex_unlock(statistics->mutex);
+}
+
+// Records a free of |byte_length| bytes in |statistics|.
+static inline void iree_allocator_statistics_record_free(
+    iree_allocator_statistics_t* statistics, iree_host_size_t byte_length) {
+  iree_slim_mutex_lock(statistics->mutex);
+  statistics->bytes_freed += byte_length;
+  iree_slim_mutex_unlock(statistics->mutex);
+}
+
+static inline void* iree_allocator_get_real_alloc_ptr(void* fake_ptr) {
+  return (void*)((uint8_t*)fake_ptr - IREE_ALLOCATOR_STATS_PREFIX_SIZE);
+}
+
+static inline void* iree_allocator_get_fake_alloc_ptr(void* real_ptr) {
+  return (void*)((uint8_t*)real_ptr + IREE_ALLOCATOR_STATS_PREFIX_SIZE);
+}
+
+static inline iree_host_size_t iree_allocator_get_alloc_size(void* real_ptr) {
+  return *(iree_host_size_t*)real_ptr;
+}
+
+static inline void iree_allocator_set_alloc_size(void* real_ptr,
+                                                 iree_host_size_t byte_length) {
+  *(iree_host_size_t*)real_ptr = byte_length;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_allocator_stats_ctl(void* self, iree_allocator_command_t command,
+                         const void* params, void** inout_ptr) {
+  iree_allocator_with_stats_t* stats_allocator =
+      (iree_allocator_with_stats_t*)self;
+  void* base_self = stats_allocator->base_allocator.self;
+  iree_allocator_statistics_t* statistics = &stats_allocator->statistics;
+  iree_allocator_ctl_fn_t base_ctl = stats_allocator->base_allocator.ctl;
+  if (IREE_UNLIKELY(!base_ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "allocator has no control routine");
+  }
+
+  if (command == IREE_ALLOCATOR_COMMAND_FREE) {
+    if (!*inout_ptr) {
+      return iree_ok_status();
+    }
+    void* real_ptr = iree_allocator_get_real_alloc_ptr(*inout_ptr);
+    iree_host_size_t byte_length = iree_allocator_get_alloc_size(real_ptr);
+    iree_status_t status =
+        base_ctl(base_self, command, /*params=*/NULL, &real_ptr);
+    if (iree_status_is_ok(status)) {
+      iree_allocator_statistics_record_free(statistics, byte_length);
+    }
+    return status;
+  }
+
+  // Prepare adjusted allocation params to account for stored size, we need to
+  // store the size of the allocation to be able to correctly account for the
+  // memory usage of reallocs and frees
+  iree_host_size_t byte_length =
+      ((const iree_allocator_alloc_params_t*)params)->byte_length;
+  iree_allocator_alloc_params_t new_params = {
+      .byte_length = byte_length + IREE_ALLOCATOR_STATS_PREFIX_SIZE,
+  };
+
+  if (command == IREE_ALLOCATOR_COMMAND_REALLOC && *inout_ptr) {
+    void* real_ptr = iree_allocator_get_real_alloc_ptr(*inout_ptr);
+    iree_host_size_t old_byte_length = iree_allocator_get_alloc_size(real_ptr);
+    iree_status_t status = base_ctl(base_self, command, &new_params, &real_ptr);
+    if (iree_status_is_ok(status)) {
+      iree_allocator_set_alloc_size(real_ptr, byte_length);
+
+      // Check if the pointer changed if so we treat this as a free + alloc,
+      // otherwise it's either growing or shrinking the existing allocation
+      if (real_ptr != iree_allocator_get_real_alloc_ptr(*inout_ptr)) {
+        iree_allocator_statistics_record_free(statistics, old_byte_length);
+        iree_allocator_statistics_record_alloc(statistics, byte_length);
+      } else if (byte_length > old_byte_length) {
+        iree_allocator_statistics_record_alloc(statistics,
+                                               byte_length - old_byte_length);
+      } else if (byte_length < old_byte_length) {
+        iree_allocator_statistics_record_free(statistics,
+                                              old_byte_length - byte_length);
+      }
+
+      *inout_ptr = iree_allocator_get_fake_alloc_ptr(real_ptr);
+    } else {
+      // Forward any pointer value provided by the allocator on failure.
+      *inout_ptr = real_ptr;
+    }
+    return status;
+  }
+
+  // New allocation.
+  void* real_ptr = NULL;
+  iree_status_t status = base_ctl(base_self, command, &new_params, &real_ptr);
+  if (iree_status_is_ok(status)) {
+    iree_allocator_set_alloc_size(real_ptr, byte_length);
+    iree_allocator_statistics_record_alloc(statistics, byte_length);
+    *inout_ptr = iree_allocator_get_fake_alloc_ptr(real_ptr);
+  } else {
+    // Forward any pointer value provided by the allocator on failure.
+    *inout_ptr = real_ptr;
+  }
+  return status;
+}
+
+IREE_API_EXPORT iree_allocator_t
+iree_allocator_stats_init(iree_allocator_with_stats_t* stats_allocator,
+                          iree_allocator_t base_allocator) {
+  stats_allocator->base_allocator = base_allocator;
+  memset(&stats_allocator->statistics, 0, sizeof(iree_allocator_statistics_t));
+  iree_allocator_malloc(base_allocator, sizeof(iree_slim_mutex_t),
+                        (void**)&stats_allocator->statistics.mutex);
+  iree_slim_mutex_initialize(stats_allocator->statistics.mutex);
+  iree_allocator_t v = {
+      .ctl = iree_allocator_stats_ctl,
+      .self = stats_allocator,
+  };
+  return v;
+}
+
+IREE_API_EXPORT void iree_allocator_stats_deinit(
+    iree_allocator_with_stats_t* stats_allocator) {
+  iree_slim_mutex_deinitialize(stats_allocator->statistics.mutex);
+  iree_allocator_free(stats_allocator->base_allocator,
+                      stats_allocator->statistics.mutex);
+}
+
+IREE_API_EXPORT iree_status_t iree_allocator_statistics_fprint(
+    FILE* file, iree_allocator_with_stats_t* allocator) {
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(allocator->base_allocator, &builder);
+  iree_status_t status = iree_string_builder_append_cstring(
+      &builder, "[[ iree_allocator_t memory statistics ]]\n");
+
+  iree_allocator_statistics_t* stats = &allocator->statistics;
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(stats->mutex);
+    status = iree_string_builder_append_format(
+        &builder,
+        "  HOST_ALLOC: %12" PRIdsz "B peak / %12" PRIdsz
+        "B allocated / %12" PRIdsz "B freed / %12" PRIdsz "B live\n",
+        stats->bytes_peak, stats->bytes_allocated, stats->bytes_freed,
+        (stats->bytes_allocated - stats->bytes_freed));
+    iree_slim_mutex_unlock(stats->mutex);
+  }
+
+  if (iree_status_is_ok(status)) {
+    fprintf(file, "%.*s", (int)iree_string_builder_size(&builder),
+            iree_string_builder_buffer(&builder));
+  }
+
+  iree_string_builder_deinitialize(&builder);
+  return status;
+}

--- a/runtime/src/iree/base/allocator_stats.h
+++ b/runtime/src/iree/base/allocator_stats.h
@@ -1,0 +1,47 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_ALLOCATOR_STATS_H_
+#define IREE_BASE_ALLOCATOR_STATS_H_
+
+#include "iree/base/allocator.h"
+
+typedef struct iree_slim_mutex_t iree_slim_mutex_t;
+
+// Allocation statistics of the allocator
+typedef struct iree_allocator_statistics_t {
+  // Peak number of bytes allocated at any one time
+  iree_host_size_t bytes_peak;
+  // Total number of bytes allocated
+  iree_host_size_t bytes_allocated;
+  // Total number of bytes freed
+  iree_host_size_t bytes_freed;
+  // Mutex protecting the statistics
+  iree_slim_mutex_t* mutex;
+} iree_allocator_statistics_t;
+
+typedef struct iree_allocator_with_stats_t {
+  iree_allocator_t base_allocator;
+  iree_allocator_statistics_t statistics;
+} iree_allocator_with_stats_t;
+
+// Allocator control function for the system allocator with statistics enabled
+IREE_API_EXPORT iree_status_t
+iree_allocator_stats_ctl(void* self, iree_allocator_command_t command,
+                         const void* params, void** inout_ptr);
+
+IREE_API_EXPORT iree_allocator_t
+iree_allocator_stats_init(iree_allocator_with_stats_t* stats_allocator,
+                          iree_allocator_t base_allocator);
+
+IREE_API_EXPORT void iree_allocator_stats_deinit(
+    iree_allocator_with_stats_t* stats_allocator);
+
+// Prints allocator statistics to the given file, if statistics are enabled.
+IREE_API_EXPORT iree_status_t iree_allocator_statistics_fprint(
+    FILE* file, iree_allocator_with_stats_t* stats_allocator);
+
+#endif  // IREE_BASE_ALLOCATOR_STATS_H_

--- a/runtime/src/iree/base/allocator_stats_test.cc
+++ b/runtime/src/iree/base/allocator_stats_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/allocator_stats.h"
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+
+namespace iree {
+namespace {
+
+TEST(AllocatorStatsTest, CheckThatWrappingHostAllocatorTracksAllocations) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_with_stats_t stats_allocator;
+  host_allocator = iree_allocator_stats_init(&stats_allocator, host_allocator);
+
+  void* ptr1 = nullptr;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator, 128, &ptr1));
+  EXPECT_NE(ptr1, nullptr);
+  EXPECT_EQ(stats_allocator.statistics.bytes_allocated, 128);
+  EXPECT_EQ(stats_allocator.statistics.bytes_freed, 0);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 128);
+
+  void* ptr2 = nullptr;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator, 256, &ptr2));
+  EXPECT_NE(ptr2, nullptr);
+  EXPECT_EQ(stats_allocator.statistics.bytes_allocated, 384);
+  EXPECT_EQ(stats_allocator.statistics.bytes_freed, 0);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 384);
+
+  iree_allocator_free(host_allocator, ptr1);
+  EXPECT_EQ(stats_allocator.statistics.bytes_allocated, 384);
+  EXPECT_EQ(stats_allocator.statistics.bytes_freed, 128);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 384);
+
+  iree_allocator_free(host_allocator, ptr2);
+  iree_allocator_free(host_allocator, nullptr);  // should be no-op
+  EXPECT_EQ(stats_allocator.statistics.bytes_allocated, 384);
+  EXPECT_EQ(stats_allocator.statistics.bytes_freed, 384);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 384);
+
+  iree_allocator_stats_deinit(&stats_allocator);
+}
+
+TEST(AllocatorStatsTest, CheckReallocStatisticsAreCorrectlyTracked) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_with_stats_t stats_allocator;
+  host_allocator = iree_allocator_stats_init(&stats_allocator, host_allocator);
+
+  void* ptr = nullptr;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator, 128, &ptr));
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(stats_allocator.statistics.bytes_allocated, 128);
+  EXPECT_EQ(stats_allocator.statistics.bytes_freed, 0);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 128);
+
+  // Grow the allocation, this may be an alloc+free or a resize in place
+  // counting as alloc
+  IREE_CHECK_OK(iree_allocator_realloc(host_allocator, 256, &ptr));
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_GE(stats_allocator.statistics.bytes_allocated, 256);
+  EXPECT_LE(stats_allocator.statistics.bytes_allocated, 384);
+  EXPECT_GE(stats_allocator.statistics.bytes_freed, 0);
+  EXPECT_LE(stats_allocator.statistics.bytes_freed, 128);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 256);
+
+  // Shrink the allocation, this may be an alloc+free or a resize in place
+  // counting as free
+  IREE_CHECK_OK(iree_allocator_realloc(host_allocator, 64, &ptr));
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_GE(stats_allocator.statistics.bytes_allocated, 256);
+  EXPECT_LE(stats_allocator.statistics.bytes_allocated, 448);
+  EXPECT_GE(stats_allocator.statistics.bytes_freed, 192);
+  EXPECT_LE(stats_allocator.statistics.bytes_freed, 384);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 256);
+
+  iree_allocator_free(host_allocator, ptr);
+  EXPECT_GE(stats_allocator.statistics.bytes_allocated, 256);
+  EXPECT_LE(stats_allocator.statistics.bytes_allocated, 448);
+  EXPECT_GE(stats_allocator.statistics.bytes_freed, 256);
+  EXPECT_LE(stats_allocator.statistics.bytes_freed, 448);
+  EXPECT_EQ(stats_allocator.statistics.bytes_freed,
+            stats_allocator.statistics.bytes_allocated);
+  EXPECT_EQ(stats_allocator.statistics.bytes_peak, 256);
+
+  iree_allocator_stats_deinit(&stats_allocator);
+}
+
+TEST(AllocatorStatsTest, CheckAllocatorRespectsHostAlignment) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_with_stats_t stats_allocator;
+  host_allocator = iree_allocator_stats_init(&stats_allocator, host_allocator);
+
+  void* ptr = nullptr;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator, 128, &ptr));
+
+  EXPECT_TRUE(
+      iree_host_size_has_alignment((iree_host_size_t)ptr, iree_max_align_t));
+
+  iree_allocator_free(host_allocator, ptr);
+  iree_allocator_stats_deinit(&stats_allocator);
+}
+
+TEST(AllocatorStatsTest, PrintStats) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_with_stats_t stats_allocator;
+  host_allocator = iree_allocator_stats_init(&stats_allocator, host_allocator);
+
+  void* ptr = nullptr;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator, 128, &ptr));
+  iree_allocator_free(host_allocator, ptr);
+
+  ::testing::internal::CaptureStdout();
+  IREE_CHECK_OK(iree_allocator_statistics_fprint(stdout, &stats_allocator));
+
+  std::string output = ::testing::internal::GetCapturedStdout();
+  EXPECT_EQ(output,
+            "[[ iree_allocator_t memory statistics ]]\n"
+            "  HOST_ALLOC:          128B peak /          128B allocated /      "
+            "    128B freed /            0B live\n");
+
+  iree_allocator_stats_deinit(&stats_allocator);
+}
+
+}  // namespace
+}  // namespace iree

--- a/runtime/src/iree/base/status_cc.h
+++ b/runtime/src/iree/base/status_cc.h
@@ -20,8 +20,8 @@
 #include <type_traits>
 #include <utility>
 
-#include "iree/base/api.h"
 #include "iree/base/attributes.h"
+#include "iree/base/status.h"
 #include "iree/base/target_platform.h"
 
 namespace iree {

--- a/runtime/src/iree/tooling/BUILD.bazel
+++ b/runtime/src/iree/tooling/BUILD.bazel
@@ -218,6 +218,7 @@ iree_runtime_cc_library(
         ":function_util",
         ":instrument_util",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/base:base_stats",
         "//runtime/src/iree/base/internal:flags",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/io:stream",

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -251,6 +251,7 @@ iree_cc_library(
     ::function_util
     ::instrument_util
     iree::base
+    iree::base::base_stats
     iree::base::internal::flags
     iree::hal
     iree::io::stream

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -45,6 +45,7 @@ iree_runtime_cc_binary(
     srcs = ["iree-benchmark-module-main.cc"],
     deps = [
         "//runtime/src/iree/base",
+        "//runtime/src/iree/base:base_stats",
         "//runtime/src/iree/base/internal:flags",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/modules/hal:types",

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -91,6 +91,7 @@ iree_cc_binary(
   DEPS
     benchmark
     iree::base
+    iree::base::base_stats
     iree::base::internal::flags
     iree::hal
     iree::modules::hal::types


### PR DESCRIPTION
This is a first PR to increase the visibility of memory usage by the IREE runtime.

It adds optional reporting for host allocation statistics to iree-run-module and iree-benchmark-module:
```
[[ iree_allocator_t memory statistics ]]
  HOST_ALLOC:     92504575B peak /   1623823585B allocated /   1531383426B freed /     92440159B live
[[ iree_hal_allocator_t memory statistics ]]
  HOST_LOCAL:            0B peak /            0B allocated /            0B freed /            0B live
DEVICE_LOCAL:        28640B peak /   1428451680B allocated /   1428451680B freed /            0B live
```