### PR TITLE
[GPU] C promote (I)GEMM when there is elementwise with additonal operands

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -34,6 +34,12 @@
 
 #define DEBUG_TYPE "iree-gpu-config-utils"
 
+llvm::cl::opt<bool> clGPUTestCpromotion(
+    "iree-codegen-test-c-promtion",
+    llvm::cl::desc("C promote in specific case of elemetwise operations that "
+                   "codegen cant yet support without it if also doing padding"),
+    llvm::cl::init(true));
+
 namespace mlir::iree_compiler::IREE::GPU {
 
 constexpr int64_t kCacheLineSizeBits = 128 * 8;
@@ -574,6 +580,34 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
+/// Helper to check if a linalg operation has elementwise users that have
+/// additional operands beyond the result of the linalg operation.
+/// This function a workaround until we have map_gather op that
+/// can allow us to codegen without c promotion for such elementwise ops
+/// we will track progress of this in
+/// https://github.com/iree-org/iree/issues/23038
+static bool checkForElementwiseUsersWithNewOperands(linalg::LinalgOp linalgOp) {
+  // Iterate through all users of the linalg operation's results
+  for (OpResult result : linalgOp->getResults()) {
+    for (Operation *user : result.getUsers()) {
+      // All elementwise operations are expected to be linalg at this stage.
+      auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
+      if (!linalgUser) {
+        continue;
+      }
+      // Check if the linalg user has operands other than the result from
+      // linalgOp.
+      for (Value operand : linalgUser.getDpsInputs()) {
+        // If the operand is not from this linalg operation, return true.
+        if (operand.getDefiningOp() != linalgOp.getOperation()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 /// Create a lowering config for matmul or IGEMM convolution based on iteration
 /// bounds and indexing maps for a given target. This function computes
 /// contraction dimensions and deduces an MMA intrinsic schedule to choose tile
@@ -586,6 +620,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     ArrayRef<int64_t> bounds, ArrayRef<AffineMap> maps,
     ArrayRef<Value> operands, IREE::GPU::TargetAttr target, bool useDirectLoad,
     bool isGemm, bool scaled, int64_t splitReductionTripCnt,
+    bool CpromoteIfPadding,
     std::optional<ConvToIgemmInfo> convToIgemmInfo = std::nullopt) {
   if (target.getWgp().getMma().empty()) {
     return failure();
@@ -764,7 +799,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   std::optional<GPUMMASchedule> schedule = getMmaScheduleFromProblemAndTarget(
       target, problem, transposedLhs, transposedRhs, isGemm,
       /*mustBeAligned=*/true,
-      /*doCPromotion=*/false, scaled, splitReductionTripCnt);
+      /*doCPromotion=*/couldNeedPadding && CpromoteIfPadding, scaled,
+      splitReductionTripCnt);
 
   // TODO (nirvedhmeshram, qedawkins): The performance with this will be bad if
   // the GEMM is accumulating (i.e., doesn't have a zero fill dpsInit) as that
@@ -775,7 +811,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     mustBeAligned = false;
     schedule = getMmaScheduleFromProblemAndTarget(
         target, problem, transposedLhs, transposedRhs, isGemm, mustBeAligned,
-        /*doCPromotion=*/false, scaled, splitReductionTripCnt);
+        /*doCPromotion=*/CpromoteIfPadding, scaled, splitReductionTripCnt);
   }
 
   if (!schedule) {
@@ -856,12 +892,20 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
   SmallVector<Attribute> promotionArray = {useGlobalDma, useGlobalDma};
   SmallVector<int64_t> promotionList = {0, 1};
+  bool mustCpromote = (!mustBeAligned || couldNeedPadding) && CpromoteIfPadding;
+  if (mustCpromote) {
+    promotionList.push_back(2);
+  }
   if (scaled) {
     // TODO(#22119): We don't use global load DMA for scaled matmuls, because
     // compilation doesn't support it. Once this is fixed, we should use global
     // load DMA here when possible.
     promotionArray = {};
-    promotionList.append({2, 3});
+    if (mustCpromote) {
+      promotionList.append({3, 4});
+    } else {
+      promotionList.append({2, 3});
+    }
   }
   ArrayRef<Attribute> promotionTypes = useDirectLoad
                                            ? ArrayRef<Attribute>(promotionArray)
@@ -971,11 +1015,16 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
   SmallVector<int64_t> igemmLoopBounds =
       igemmGenericConvDetails->igemmLoopBounds;
   SmallVector<Value> igemmOperands = igemmGenericConvDetails->igemmOperands;
+  bool CPromoteIfPadding = false;
+  if (clGPUTestCpromotion) {
+    CPromoteIfPadding = checkForElementwiseUsersWithNewOperands(linalgOp);
+  }
   FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
       getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           igemmLoopBounds, igemmContractionMaps, igemmOperands, target,
           useDirectLoad, /*isGemm=*/false,
-          /*scaled=*/false, splitReductionTripCnt, convToIgemmInfo);
+          /*scaled=*/false, splitReductionTripCnt,
+          /*CPromoteIfPadding=*/CPromoteIfPadding, convToIgemmInfo);
   if (failed(configAndWgSize)) {
     return failure();
   }
@@ -1018,11 +1067,14 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
   const int64_t splitReductionTripCnt = getSplitReductionTripCount(entryPoint);
 
   LDBG() << "Matmul TileAndFuse Config";
-
+  bool CPromoteIfPadding = false;
+  if (clGPUTestCpromotion) {
+    CPromoteIfPadding = checkForElementwiseUsersWithNewOperands(linalgOp);
+  }
   FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
       getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           bounds, maps, operands, target, useDirectLoad, /*isGemm=*/true,
-          /*scaled=*/false, splitReductionTripCnt);
+          /*scaled=*/false, splitReductionTripCnt, CPromoteIfPadding);
 
   // TODO (muzasyed) : add generalization for scaled and nonscaled versions of
   // matmul lowering.
@@ -1032,7 +1084,7 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
     useDirectLoad = true;
     configAndWgSize = getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
         bounds, maps, operands, target, useDirectLoad, /*isGemm=*/true,
-        /*scaled=*/true, splitReductionTripCnt);
+        /*scaled=*/true, splitReductionTripCnt, CPromoteIfPadding);
   }
 
   if (failed(configAndWgSize)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -313,3 +313,48 @@ func.func @conv_nhwc_small_channel_size(%arg0: tensor<16x26x19x3xf16>, %arg1: te
 //     CHECK-LABEL:  func.func @conv_nhwc_small_channel_size
 // PAD-CONV-GFX942:     padding = [1, 4, 32, 64, 32]
 // PAD-CONV-GFX942:     padding_conv = [1, 4, 32, 64, 0, 0, 0]
+
+// -----
+// This test is to check that we c promote in such cases since we have codegen issues with this case
+// see https://github.com/iree-org/iree/issues/23038
+func.func @nhwc_conv_mfma_biasadd(%3: tensor<2x35x35x128xf32>, %4: tensor<3x3x128x64xf32>, %5 : tensor<2x33x33x64xf32>) -> tensor<2x33x33x64xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<2x33x33x64xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x33x33x64xf32>) -> tensor<2x33x33x64xf32>
+  %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%3, %4 : tensor<2x35x35x128xf32>, tensor<3x3x128x64xf32>) outs(%empty : tensor<2x33x33x64xf32>) -> tensor<2x33x33x64xf32>
+  %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+                                        iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%7, %5 : tensor<2x33x33x64xf32>, tensor<2x33x33x64xf32>) outs(%empty : tensor<2x33x33x64xf32>)   {
+      ^bb0(%in: f32, %in_0: f32, %out: f32):
+        %18 = arith.addf %in, %in_0 : f32
+        linalg.yield %18 : f32
+      }  -> tensor<2x33x33x64xf32>
+  return %7 : tensor<2x33x33x64xf32>
+}
+
+//     CHECK-LABEL: nhwc_conv_mfma_biasadd
+//           CHECK: promote_operands = [0, 1, 2]
+
+// -----
+// Check that we dont c promote if there is no additonal operand
+func.func @nhwc_conv_mfma_truncf(%3: tensor<2x35x35x128xf32>, %4: tensor<3x3x128x64xf32>, %5 : tensor<2x33x33x64xf32>) -> tensor<2x33x33x64xf16> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<2x33x33x64xf32>
+  %empty2 = tensor.empty() : tensor<2x33x33x64xf16>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x33x33x64xf32>) -> tensor<2x33x33x64xf32>
+  %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%3, %4 : tensor<2x35x35x128xf32>, tensor<3x3x128x64xf32>) outs(%empty : tensor<2x33x33x64xf32>) -> tensor<2x33x33x64xf32>
+  %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+                      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+       ins(%7 : tensor<2x33x33x64xf32>) outs(%empty2 : tensor<2x33x33x64xf16>)   {
+       ^bb0(%in: f32, %out: f16):
+         %18 = arith.truncf %in : f32 to f16
+        linalg.yield %18 : f16
+       }  -> tensor<2x33x33x64xf16>
+  return %8 : tensor<2x33x33x64xf16>
+}
+
+//     CHECK-LABEL: nhwc_conv_mfma_truncf
+//           CHECK: promote_operands = [0, 1]


### PR DESCRIPTION
We have trouble with fusion of operands to elementwise operations without c promotion. We have work in progress for proper support of this as per https://github.com/iree-org/iree/issues/23038

However in the time being we have several issues blocked by this so we will just enable c promotion for this specific case, which is using padding AND has an elementwise with operands other than the (I)GEMM itself. 

We have a dev flag (default true) so that we can continue the work on map_gather while observing the problem with `--iree-codegen-test-c-promtion=false`

Fixes :  https://github.com/iree-org/iree/issues/22919
Fixes : https://github.com/iree-org/iree/issues/22986