### PR TITLE
[NFC][PCF] Drop clear method from fusion struct

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp
@@ -44,8 +44,10 @@ struct FuseIntoGenericOp : public OpRewritePattern<IREE::PCF::GenericOp> {
     TilingInterface fusionTarget;
     for (Operation *user : genericOp->getUsers()) {
       fusionTarget = dyn_cast<TilingInterface>(user);
+      ConsumerFusionParams tempParams;
       if (fusionTarget && succeeded(matchTilableConsumer(
-                              rewriter, genericOp, fusionTarget, params))) {
+                              rewriter, genericOp, fusionTarget, tempParams))) {
+        std::swap(params, tempParams);
         break;
       }
       fusionTarget = TilingInterface();
@@ -67,8 +69,10 @@ struct FuseIntoLoopOp : public OpRewritePattern<IREE::PCF::LoopOp> {
     TilingInterface fusionTarget;
     for (Operation *user : loopOp->getUsers()) {
       fusionTarget = dyn_cast<TilingInterface>(user);
+      ConsumerFusionParams tempParams;
       if (fusionTarget && succeeded(matchTilableConsumer(
-                              rewriter, loopOp, fusionTarget, params))) {
+                              rewriter, loopOp, fusionTarget, tempParams))) {
+        std::swap(params, tempParams);
         break;
       }
       fusionTarget = TilingInterface();
@@ -878,22 +882,14 @@ LogicalResult matchTilableConsumer(RewriterBase &rewriter,
                                    PCF::GenericOp producerOp,
                                    TilingInterface target,
                                    ConsumerFusionParams &params) {
-  if (failed(matchTilableConsumerImpl(rewriter, producerOp, target, params))) {
-    params.clear();
-    return failure();
-  }
-  return success();
+  return matchTilableConsumerImpl(rewriter, producerOp, target, params);
 }
 
 LogicalResult matchTilableConsumer(RewriterBase &rewriter,
                                    PCF::LoopOp producerOp,
                                    TilingInterface target,
                                    ConsumerFusionParams &params) {
-  if (failed(matchTilableConsumerImpl(rewriter, producerOp, target, params))) {
-    params.clear();
-    return failure();
-  }
-  return success();
+  return matchTilableConsumerImpl(rewriter, producerOp, target, params);
 }
 
 void fuseTilableConsumer(RewriterBase &rewriter, PCF::GenericOp producerOp,

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
@@ -52,12 +52,6 @@ struct ConsumerFusionParams {
   // In the first case, slices[0] is the most dominant slice (and thus the
   // insertion point for the fused op).
   SmallVector<PCF::WriteSliceOp> slices;
-
-  void clear() {
-    operands.clear();
-    results.clear();
-    slices.clear();
-  }
 };
 
 // Helpers to match a consumer as fusable into a producer. There are two
@@ -68,8 +62,8 @@ struct ConsumerFusionParams {
 //   1. The tilable |target| consumes multiple results of the producer but only
 //      a single writing op constructs each consumed result.
 // Populates |params| with the matched information needed to perform a fusion
-// upon success. On failure |params| is cleared and a different tilable consumer
-// may be matched against.
+// upon success. On failure |params| may be partially populated. It is the
+// caller's responsibility to pass an empty struct on subsequent matches.
 //
 // Note that currently multiple producers split across block/region boundaries
 // is unsupported. We need to guarantee the existence of a point in


### PR DESCRIPTION
Missed comment on PR #22912, drops the clear method and updates uses of the matcher accordingly.