### PR TITLE
[Preprocessing] Convert conv2d filter layout CFHW to FHWC

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -178,3 +178,57 @@ util.func public @small_nhwc_chwf_filter_1x1(%arg0: tensor<1x16x16x4xf32>, %arg1
 
 // CHECK-FHWC-LABEL:  @small_nhwc_chwf_filter_1x1
 // CHECK-FHWC-NOT:    linalg.transpose
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d5, d2 + d6, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d3, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @conv_2d_nhwc_cfhw(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<4x16x3x3xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<1x16x16x4xf32>, tensor<4x16x3x3xf32>) outs(%arg2 : tensor<1x14x14x16xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %3 = arith.mulf %in, %in_0 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwc_cfhw
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xf32>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<4x16x3x3xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   permutation = [1, 2, 3, 0]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 + d5, d2 + d6, d3, d7)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d7, d4, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>
+util.func public @conv_2d_nhwgc_gcfhw(%arg0: tensor<2x10x10x7x4xf32>, %arg1: tensor<7x4x16x3x3xf32>, %arg2: tensor<2x8x8x7x16xf32>) -> tensor<2x8x8x7x16xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<2x10x10x7x4xf32>, tensor<7x4x16x3x3xf32>) outs(%arg2 : tensor<2x8x8x7x16xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %1 = arith.mulf %in, %in_0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<2x8x8x7x16xf32>
+  util.return %0 : tensor<2x8x8x7x16xf32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 + d5, d2 + d6, d3, d7)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d4, d5, d6, d7)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwgc_gcfhw
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<7x16x3x3x4xf32>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<7x4x16x3x3xf32>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   permutation = [0, 2, 3, 4, 1]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)


### PR DESCRIPTION
Extends the `ConvertConvFilterToChannelsLast` pass to handle generic conv `CFHW` filter layouts in addition to the existing `CHWF`, enabling transformation of both layouts to the input channels last `FHWC` format. `CFHW` layout shows up in the new torch op direct lowering for input backwards.