### PR TITLE
[Dispatch Creation] Move two flags to pipeline options

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -40,19 +40,9 @@ static llvm::cl::opt<bool> clEnableEarlyTruncFusion(
         "consumers before forming dispatch regions"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clEnableFusePaddingIntoLinalgConsumerOps(
-    "iree-dispatch-creation-enable-fuse-padding-into-linalg-consumer-ops",
-    llvm::cl::desc("Enable fusing tensor.pad ops into Linalg consumer ops."),
-    llvm::cl::init(false));
-
 static llvm::cl::opt<bool> clEnableFusePaddingIntoLinalgProducerOps(
     "iree-dispatch-creation-enable-fuse-padding-into-linalg-producer-ops",
     llvm::cl::desc("Enable fusing tensor.pad ops into Linalg consumer ops."),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<bool> clEnablePadHandling(
-    "iree-flow-enable-pad-handling",
-    llvm::cl::desc("Enable native handling of tensor.pad operations."),
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool> clEnableFuseHorizontalContractions(
@@ -186,9 +176,10 @@ static void addDispatchRegionCreationPreprocessingPasses(
       //        - Split reduction using partial reduction tiling.
       .addPredicatedPass(dispatchOptions.enableSplitReduction,
                          DispatchCreation::createSetSplitReductionSizesPass)
-      .addPass([]() {
+      .addPass([&]() {
         FormSplitReductionDispatchesPassOptions options;
-        options.enableFusePad = clEnableFusePaddingIntoLinalgConsumerOps;
+        options.enableFusePad =
+            dispatchOptions.enableFusePaddingIntoLinalgConsumerOps;
         return DispatchCreation::createFormSplitReductionDispatchesPass(
             options);
       })
@@ -231,7 +222,7 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
         return DispatchCreation::createFormDispatchRegionsPass(
             FormDispatchRegionsPassOptions{
                 options.enableAggressiveFusion,
-                clEnableFusePaddingIntoLinalgConsumerOps,
+                options.enableFusePaddingIntoLinalgConsumerOps,
                 clEnableFusePaddingIntoLinalgProducerOps});
       })
       // Elementwise fuse operations that are iside a dispatch if possible.
@@ -331,12 +322,13 @@ void buildDispatchCreationPassPipeline(
 
   // Transform pad operations into linalg.fill + tensor.insert_slice.
   // This is a WAR for not having native pad handling.
-  if (!clEnablePadHandling && !clEnableFusePaddingIntoLinalgProducerOps) {
+  if (!transformOptions.enablePadHandling &&
+      !clEnableFusePaddingIntoLinalgProducerOps) {
     passManager.addPass(
         DispatchCreation::createTensorPadToTensorInsertSlicePass(
             TensorPadToTensorInsertSlicePassOptions{
                 /*skipSingleLinalgOpUses=*/
-                clEnableFusePaddingIntoLinalgConsumerOps}));
+                transformOptions.enableFusePaddingIntoLinalgConsumerOps}));
   }
 
   {

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -56,6 +56,18 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
           "shapes across reduction ops)"),
       llvm::cl::init(false),
   };
+  Option<bool> enablePadHandling{
+      *this,
+      "pad-handling",
+      llvm::cl::desc("Enable native handling of tensor.pad operations"),
+      llvm::cl::init(false),
+  };
+  Option<bool> enableFusePaddingIntoLinalgConsumerOps{
+      *this,
+      "fuse-padding-into-linalg-consumer-ops",
+      llvm::cl::desc("Enable fusing tensor.pad ops into Linalg consumer ops"),
+      llvm::cl::init(false),
+  };
   Option<bool> constExprHoisting{
       *this,
       "const-expr-hoisting",

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -346,6 +346,15 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
           "Enable aggressive reshape movement (bubbling expand/collapse "
           "shapes across reduction ops)."),
       llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-flow-enable-pad-handling", enablePadHandling,
+      llvm::cl::desc("Enable native handling of tensor.pad operations."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-dispatch-creation-enable-fuse-padding-into-linalg-consumer-ops",
+      enableFusePaddingIntoLinalgConsumerOps,
+      llvm::cl::desc("Enable fusing tensor.pad ops into Linalg consumer ops."),
+      llvm::cl::cat(category));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -239,6 +239,12 @@ struct DispatchCreationOptions {
   // across reduction ops).
   bool enableAggressiveReshapeMovement = false;
 
+  // Enables native handling of tensor.pad operations.
+  bool enablePadHandling = false;
+
+  // Enables fusing tensor.pad ops into Linalg consumer ops.
+  bool enableFusePaddingIntoLinalgConsumerOps = false;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<DispatchCreationOptions>;
 };

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -330,6 +330,10 @@ void buildIREEVMTransformPassPipeline(
         dispatchCreationOptions.enableSplitReduction;
     dispatchTransformOptions.enableAggressiveReshapeMovement =
         dispatchCreationOptions.enableAggressiveReshapeMovement;
+    dispatchTransformOptions.enablePadHandling =
+        dispatchCreationOptions.enablePadHandling;
+    dispatchTransformOptions.enableFusePaddingIntoLinalgConsumerOps =
+        dispatchCreationOptions.enableFusePaddingIntoLinalgConsumerOps;
     dispatchTransformOptions.constExprMaxSizeIncreaseThreshold =
         pipelineOptions.constExprMaxSizeIncreaseThreshold;
     dispatchTransformOptions.constExprHoisting =


### PR DESCRIPTION
Moves `--iree-flow-enable-pad-handling` and `--iree-dispatch-creation-enable-fuse-padding-into-linalg-consumer-ops` to pipeline options so that they can be bound when using the C API in Fusilli.