### PR TITLE
Disable bf16 ukernel Clang workaround on newer Clang.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_bf16.c
@@ -7,7 +7,8 @@
 #include "iree/builtins/ukernel/arch/x86_64/common_x86_64.h"
 #include "iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_internal.h"
 
-#if defined(IREE_UK_COMPILER_CLANG) && !defined(IREE_UK_COMPILER_MSVC)
+#if defined(IREE_UK_COMPILER_CLANG) && !defined(IREE_UK_COMPILER_MSVC) && \
+    !IREE_UK_COMPILER_CLANG_VERSION_AT_LEAST(20, 0)
 // This inline-asm function is a work-around for:
 // 1. https://github.com/llvm/llvm-project/issues/68117
 //    Summary: LLVM crash affecting Clang 16-17. Fixed in Clang 18.


### PR DESCRIPTION
bf16 ukernels use inline asm to work around multiple bugs in the `_mm512_dpbf16_ps` intrinsic on Clang, but the last such bug was fixed at least as far as Clang 20, so disable the workaround on newer Clang.