### PR TITLE
[Encoding] Propagate (Un)SetEncodingOp with dynamic encoding dims

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -299,11 +299,12 @@ static Value generateEncodingTransferOps(RewriterBase &rewriter, Value src,
   Value value = src;
   if (srcType.getEncoding()) {
     value = IREE::Encoding::UnsetEncodingOp::create(
-        rewriter, src.getLoc(), srcType.dropEncoding(), value, dynamicDims);
+        rewriter, src.getLoc(), srcType.dropEncoding(), value, dynamicDims,
+        /*encodingDims=*/ValueRange{});
   }
   if (destType.getEncoding()) {
-    value = IREE::Encoding::SetEncodingOp::create(rewriter, src.getLoc(),
-                                                  destType, value);
+    value = IREE::Encoding::SetEncodingOp::create(
+        rewriter, src.getLoc(), destType, value, /*encodingDims=*/ValueRange{});
   }
   return value;
 }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -23,13 +23,19 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
     Operation to assign an encoding to a tensor. The operation does not change
     the rank or extent of a tensor. Instead it adds a LayoutResolverAttr
     attribute to the tensor type to represent a change in layout.
+
+    The optional `encoding_dims` operand carries dynamic values needed by the
+    encoding (e.g., M, N, K dimensions for matmul encodings). These values are
+    used for runtime layout selection based on problem size.
   }];
 
-  let arguments = (ins AnyRankedTensor:$source);
+  let arguments = (ins
+    AnyRankedTensor:$source,
+    Variadic<Index>:$encoding_dims);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    attr-dict $source `:` type($source) `->` type($result)
+    attr-dict $source (`encoding_dims` `{` $encoding_dims^ `}`)? `:` type($source) `->` type($result)
   }];
 
   let hasVerifier = 1;
@@ -49,21 +55,27 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
 //===----------------------------------------------------------------------===//
 
 def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
-    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>, Pure
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    AttrSizedOperandSegments, Pure
   ]> {
   let summary = [{Perform unpack and extract operation on source.}];
   let description = [{
     Operation to convert a tensor with LayoutResolverAttr encoding that
     represents its data layout into a tensor with default layout
     (i.e. no encoding). For now in IREE the default layout is row-major.
+
+    The optional `encoding_dims` operand carries dynamic values needed by the
+    encoding (e.g., M, N, K dimensions for matmul encodings). These values are
+    used for runtime layout selection based on problem size.
   }];
   let arguments = (ins
     AnyRankedTensor:$source,
-    Variadic<Index>:$result_dims);
+    Variadic<Index>:$result_dims,
+    Variadic<Index>:$encoding_dims);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    attr-dict $source `:` type($source) `->` type($result) (`` `{` $result_dims^ `}`)?
+    attr-dict $source (`encoding_dims` `{` $encoding_dims^ `}`)? `:` type($source) `->` type($result) (`` `{` $result_dims^ `}`)?
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -67,14 +67,19 @@ MatmulNarrowDim getMatmulNarrowDim(linalg::LinalgOp linalgOp,
 /// Bundles an encoding attribute with its associated dynamic information.
 /// This is returned by interface methods that query encoding properties
 /// from operations. Dynamic values can include runtime information needed
-/// by the encoding (e.g., M, N, K dimensions for matmul encodings).
+/// by the encoding (e.g., Batch, M, N, K dimensions for matmul encodings).
 struct EncodingProperties {
   /// The encoding attribute for the operand/result.
   Attribute encoding;
   /// Dynamic values needed by the encoding. For matmul-like operations,
-  /// these typically correspond to the iteration domain dimensions (M, N, K).
-  /// TODO(#22370): Currently empty; will be populated to support dynamic
-  /// layout decisions.
+  /// these correspond to the dynamic entries in iteration_sizes, ordered
+  /// by loop dimension index. For example:
+  /// - matmul with iteration_sizes=[?, ?, ?] -> [M, N, K]
+  /// - batch_matmul with iteration_sizes=[?, ?, ?, ?] -> [Batch, M, N, K]
+  /// - matmul with iteration_sizes=[?, 128, ?] -> [M, K] (N is static)
+  ///
+  /// The order matches the loop dimensions as they appear in the operation's
+  /// indexing maps, filtered to only include dynamic dimensions.
   SmallVector<Value> dynamicValues;
 };
 
@@ -89,6 +94,9 @@ struct OpEncodingProperties {
 struct PropagationEncoding {
   SmallVector<Attribute> operandEncodings;
   SmallVector<Attribute> resultEncodings;
+  /// Dynamic encoding dimension values (e.g., M, N, K for matmul) that should
+  /// be carried through during propagation.
+  SmallVector<Value> encodingDims;
 };
 
 struct PropagationResult {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -259,3 +259,36 @@ func.func @identity_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf3
   return %arg0 : tensor<?x?xf32, #encoding>
 }
 //      CHECK: func.func @identity_encoding(%[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.identity>
+
+// -----
+
+#encoding = #iree_encoding.testing<>
+func.func @set_encoding_with_encoding_dims(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  return %0 : tensor<?x?xf32, #encoding>
+}
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing<>
+//      CHECK: func.func @set_encoding_with_encoding_dims
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]: index
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+
+// -----
+
+#encoding = #iree_encoding.testing<>
+func.func @unset_encoding_with_encoding_dims(
+    %arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index, %m: index, %n: index, %k: index) -> tensor<?x?xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  return %0 : tensor<?x?xf32>
+}
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing<>
+//      CHECK: func.func @unset_encoding_with_encoding_dims
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[D1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]: index
+//      CHECK:   iree_encoding.unset_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<?x?xf32, #[[ENCODING]]> -> tensor<?x?xf32>{%[[D0]], %[[D1]]}

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/BUILD.bazel
@@ -27,10 +27,12 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgUtils",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/CMakeLists.txt
@@ -21,11 +21,13 @@ iree_cc_library(
     "Utils.cpp"
   DEPS
     LLVMSupport
+    MLIRAnalysis
     MLIRArithDialect
     MLIRIR
     MLIRInferTypeOpInterface
     MLIRLinalgDialect
     MLIRLinalgUtils
+    MLIRTensorDialect
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace mlir::iree_compiler::IREE::Encoding {
 
@@ -79,6 +80,22 @@ MatmulNarrowDim getPo2MatmulNarrowDim(EncodingAttr encoding);
 /// Returns true if `encoding` represents a narrow-N matmul RESULT, e.g. the
 /// result of a matvec.
 bool isNarrowNResult(EncodingAttr encoding);
+
+/// Try to rematerialize encoding dims at the current insertion point of the
+/// builder. This is useful when propagating encodings through operations where
+/// the original encoding dims don't dominate the new insertion point.
+///
+/// Returns the rematerialized dims if successful, or failure if some dims
+/// cannot be rematerialized.
+///
+/// Recursively rematerializes operands as needed. Supports:
+/// - Values that already dominate the insertion point (used as-is)
+/// - tensor.dim ops on the propagation source (recreated from newSource)
+/// - Any pure operation (cloned with recursively rematerialized operands)
+FailureOr<SmallVector<Value>>
+rematerializeEncodingDims(RewriterBase &builder, Operation *insertionPoint,
+                          ValueRange encodingDims, Value propagationSource,
+                          Value newSource);
 
 } // namespace mlir::iree_compiler::IREE::Encoding
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
@@ -142,11 +142,12 @@ static func::FuncOp createWorkgroupFunc(IREE::Stream::TensorEncodeOp encodeOp,
   if (sourceType != destinationType) {
     if (sourceType.getEncoding()) {
       value = IREE::Encoding::UnsetEncodingOp::create(
-          builder, loc, sourceType.dropEncoding(), value, sourceDynamicDims);
+          builder, loc, sourceType.dropEncoding(), value, sourceDynamicDims,
+          /*encodingDims=*/ValueRange{});
     }
     if (destinationType.getEncoding()) {
-      value = IREE::Encoding::SetEncodingOp::create(builder, loc,
-                                                    destinationType, value);
+      value = IREE::Encoding::SetEncodingOp::create(
+          builder, loc, destinationType, value, /*encodingDims=*/ValueRange{});
     }
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -110,7 +110,7 @@ bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
     auto resType = RankedTensorType::get(
         operandType.getShape(), operandType.getElementType(), newEncoding);
     Value encodedInput = IREE::Encoding::SetEncodingOp::create(
-        rewriter, loc, resType, operand->get());
+        rewriter, loc, resType, operand->get(), /*encodingDims=*/ValueRange{});
     encodedOperands.push_back(encodedInput);
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -9,6 +9,7 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -96,6 +97,21 @@ bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
         "output map numDims do not match last encoding map numResults");
   }
 
+  // Get encoding_dims from the original SetEncodingOp and try to rematerialize
+  // them at the new insertion point (before the genericOp).
+  // For identity output map, we can remap tensor.dim from output to inputs.
+  Value genericOutput = encodingOp.getSource();
+  Value firstInput = genericOp.getDpsInputOperand(0)->get();
+  FailureOr<SmallVector<Value>> rematerializedDims =
+      IREE::Encoding::rematerializeEncodingDims(rewriter, genericOp,
+                                                encodingOp.getEncodingDims(),
+                                                genericOutput, firstInput);
+  if (failed(rematerializedDims)) {
+    return rewriter.notifyMatchFailure(encodingOp,
+                                       "cannot rematerialize encoding_dims");
+  }
+  ValueRange encodingDims = *rematerializedDims;
+
   // Set encodings on each input
   Location loc = genericOp->getLoc();
   SmallVector<Value> encodedOperands;
@@ -110,7 +126,7 @@ bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
     auto resType = RankedTensorType::get(
         operandType.getShape(), operandType.getElementType(), newEncoding);
     Value encodedInput = IREE::Encoding::SetEncodingOp::create(
-        rewriter, loc, resType, operand->get(), /*encodingDims=*/ValueRange{});
+        rewriter, loc, resType, operand->get(), encodingDims);
     encodedOperands.push_back(encodedInput);
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/PropagateEncodings.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/PropagateEncodings.cpp
@@ -46,6 +46,9 @@ bubbleUpSetEncodingOp(RewriterBase &rewriter, OpOperand *propagationSource,
                                        "not able to determine propagation "
                                        "attributes for operands and results");
   }
+  // Carry through the encoding dims from the original set_encoding op.
+  propagationEncodings->encodingDims =
+      llvm::to_vector(encodingOp.getEncodingDims());
   Operation *targetOp = target.getOwner();
   if (!IREE::Flow::isNonNullAndOutsideDispatch(encodingOp) ||
       !IREE::Flow::isNonNullAndOutsideDispatch(targetOp)) {

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
@@ -537,3 +537,175 @@ util.func public @dont_propagate_non_projected_permutation(%arg0: tensor<?x4096x
 // CHECK:         iree_encoding.unset_encoding
 // CHECK:         tensor.empty
 // CHECK:         linalg.generic
+
+// -----
+
+// Test that bubble-up works with encoding_dims when they dominate the genericOp.
+// Here, the encoding_dims are function arguments, so they always dominate.
+
+#map_bubble = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map_bubble1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map_bubble2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_bubble3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_bubble4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#encoding_bubble = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_bubble2, #map_bubble3, #map_bubble4]>
+util.func public @bubble_through_dequant_with_encoding_dims(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>,
+    %m: index, %n: index, %k: index) -> tensor<2x11008x128xf32, #encoding_bubble> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_bubble>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map_bubble, #map_bubble1, #map_bubble1, #map_bubble],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    %13 = iree_encoding.set_encoding %11 encoding_dims{%m, %n, %k} : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding_bubble>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding_bubble>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding_bubble>
+}
+
+// CHECK-DAG:   #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[$ENCODING_IBMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP3]]], #[[MAP2]]]>
+// CHECK-DAG:   #[[$ENCODING_BMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP4]]], #[[MAP2]]]>
+// CHECK-LABEL: @bubble_through_dequant_with_encoding_dims
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>,
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<2x11008xf32>, %[[ARG2:.+]]: tensor<2x11008xf32>,
+// CHECK-SAME:    %[[M:.+]]: index, %[[N:.+]]: index, %[[K:.+]]: index
+// CHECK-DAG:   %[[SET_ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<2x11008x128xi8> -> tensor<2x11008x128xi8, #[[$ENCODING_IBMAP]]>
+// CHECK-DAG:   %[[SET_ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<2x11008xf32> -> tensor<2x11008xf32, #[[$ENCODING_BMAP]]>
+// CHECK-DAG:   %[[SET_ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<2x11008xf32> -> tensor<2x11008xf32, #[[$ENCODING_BMAP]]>
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32, #[[$ENCODING]]>
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING0]], %[[SET_ENCODING1]], %[[SET_ENCODING2]] : {{.*}} outs(%[[INIT]] :
+// CHECK:         flow.return %[[DEQUANT]]
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]]
+
+// -----
+
+// Test that bubble-up works with encoding_dims that need rematerialization.
+// The encoding_dims are computed from the generic output via tensor.dim, but
+// can be rematerialized as tensor.dim on the inputs (which fold to constants
+// for static dimensions).
+
+#map_remat = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map_remat1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map_remat2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_remat3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_remat4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#encoding_remat = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_remat2, #map_remat3, #map_remat4]>
+util.func public @bubble_with_rematerialized_encoding_dims(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>) -> tensor<2x11008x128xf32, #encoding_remat> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_remat>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map_remat, #map_remat1, #map_remat1, #map_remat],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    // encoding_dims are computed from the output, but can be rematerialized
+    // from the first input (which then fold to constants).
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %m = tensor.dim %11, %c0 : tensor<2x11008x128xf32>
+    %n = tensor.dim %11, %c1 : tensor<2x11008x128xf32>
+    %k = tensor.dim %11, %c2 : tensor<2x11008x128xf32>
+    %13 = iree_encoding.set_encoding %11 encoding_dims{%m, %n, %k} : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding_remat>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding_remat>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding_remat>
+}
+
+// The tensor.dim ops are rematerialized from the first input, folding to constants.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32]
+// CHECK-LABEL: @bubble_with_rematerialized_encoding_dims
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>,
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<2x11008xf32>, %[[ARG2:.+]]: tensor<2x11008xf32>
+// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:   %[[C11008:.+]] = arith.constant 11008 : index
+// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:   %[[SET_ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[C2]], %[[C11008]], %[[C128]]}
+// CHECK-DAG:   %[[SET_ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] encoding_dims{%[[C2]], %[[C11008]], %[[C128]]}
+// CHECK-DAG:   %[[SET_ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] encoding_dims{%[[C2]], %[[C11008]], %[[C128]]}
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32, #[[$ENCODING]]>
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING0]], %[[SET_ENCODING1]], %[[SET_ENCODING2]] : {{.*}} outs(%[[INIT]] :
+// CHECK:         flow.return %[[DEQUANT]]
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]]
+
+// -----
+
+// Test that bubble-up through generic works with recursive rematerialization
+// when encoding_dims use tensor.dim on a dominating tensor. The set_encoding
+// moves to the inputs but stays inside the dispatch region (encoding dims
+// are computed inside).
+
+#map_dom = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map_dom1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map_dom2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_dom3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_dom4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#encoding_dom = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_dom2, #map_dom3, #map_dom4]>
+util.func public @bubble_with_recursive_rematerialization(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>,
+    %dominating: tensor<?x?xf32>) -> tensor<2x11008x128xf32, #encoding_dom> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_dom>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map_dom, #map_dom1, #map_dom1, #map_dom],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    // encoding_dim uses tensor.dim on a dominating tensor - can be rematerialized
+    %c0 = arith.constant 0 : index
+    %m = tensor.dim %dominating, %c0 : tensor<?x?xf32>
+    %c11008 = arith.constant 11008 : index
+    %c128 = arith.constant 128 : index
+    %13 = iree_encoding.set_encoding %11 encoding_dims{%m, %c11008, %c128} : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding_dom>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding_dom>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding_dom>
+}
+
+// The set_encoding is bubbled through the generic. The ops stay inside dispatch
+// because the encoding_dims (tensor.dim result) are computed inside.
+// CHECK-LABEL: @bubble_with_recursive_rematerialization
+// CHECK:       flow.dispatch.region
+// CHECK:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK:         %[[DIM:.+]] = tensor.dim %{{.*}}, %[[C0]]
+// CHECK:         %[[SET0:.+]] = iree_encoding.set_encoding %{{.*}} encoding_dims{%[[DIM]]
+// CHECK:         %[[SET1:.+]] = iree_encoding.set_encoding %{{.*}} encoding_dims{%[[DIM]]
+// CHECK:         %[[SET2:.+]] = iree_encoding.set_encoding %{{.*}} encoding_dims{%[[DIM]]
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32,
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic {{.*}} ins(%[[SET0]], %[[SET1]], %[[SET2]]
+// CHECK:         flow.return %[[DEQUANT]]
+// CHECK:       }

--- a/compiler/src/iree/compiler/DispatchCreation/test/propagate_encodings.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/propagate_encodings.mlir
@@ -29,3 +29,169 @@ util.func @dont_propagate_unserialized_layout(%src: tensor<1024x?xf16>) -> tenso
 // CHECK:         %[[CAST:.+]] = tensor.cast %[[SRC]] : tensor<1024x?xf16> to tensor<?x512xf16>
 // CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[CAST]] : tensor<?x512xf16> -> tensor<?x512xf16, #[[$ENCODING]]>
 // CHECK:         util.return %[[SET_ENCODING]]
+
+// -----
+
+// Test that propagation works with encoding_dims when they dominate the insertion point.
+// The encoding_dims are function arguments, so they always dominate.
+
+#encoding_with_dims = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_encoding_with_encoding_dims(%src: tensor<1024x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x512xf16, #encoding_with_dims> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%m, %n, %k} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_with_dims>
+  util.return %0 : tensor<?x512xf16, #encoding_with_dims>
+}
+
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_encoding_with_encoding_dims(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-SAME:    %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:    %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:    %[[K:[a-zA-Z0-9]+]]: index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works with encoding_dims that need rematerialization.
+// Here, the encoding_dims are computed from the cast result, but can be
+// rematerialized as tensor.dim on the cast source (which then folds to constants
+// for static dimensions).
+
+#encoding_remat = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_rematerialized_encoding_dims(%src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding_remat> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %c0 = arith.constant 0 : index
+  // This dim is computed from %cast, but can be rematerialized from %src
+  %m = tensor.dim %cast, %c0 : tensor<?x512xf16>
+  %c512 = arith.constant 512 : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%m, %c512} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_remat>
+  util.return %0 : tensor<?x512xf16, #encoding_remat>
+}
+
+// The tensor.dim is rematerialized as tensor.dim on %src, which folds to constant 1024.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_rematerialized_encoding_dims(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[C512:.+]] = arith.constant 512 : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[C1024]], %[[C512]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works when encoding_dims use tensor.dim on the
+// propagation source. The dim is rematerialized from the new source tensor.
+
+#encoding_dim_on_source = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_dim_on_propagation_source(
+    %src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding_dim_on_source> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %c0 = arith.constant 0 : index
+  // This dim depends on the cast result (propagation source).
+  // It gets rematerialized to use the new source (src).
+  %m = tensor.dim %cast, %c0 : tensor<?x512xf16>
+  %c512 = arith.constant 512 : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%m, %c512} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_dim_on_source>
+  util.return %0 : tensor<?x512xf16, #encoding_dim_on_source>
+}
+
+// Propagation succeeds because tensor.dim on propagation source (cast) is
+// rematerialized to use the new source (src). Since dim 0 is statically known
+// (1024), a constant is created instead of tensor.dim.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_dim_on_propagation_source(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-DAG:     %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[C512:.+]] = arith.constant 512 : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[C1024]], %[[C512]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]]
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works when encoding_dims are arithmetic ops with
+// dominating operands. The arith.addi can be cloned since its operands
+// (function arguments) dominate the new insertion point.
+
+#encoding_arith = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_arith_encoding_dims(
+    %src: tensor<1024x?xf16>, %m: index, %n: index) -> tensor<?x512xf16, #encoding_arith> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  // This arith.addi can be cloned since %m and %n dominate the cast
+  %sum = arith.addi %m, %n : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%sum} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_arith>
+  util.return %0 : tensor<?x512xf16, #encoding_arith>
+}
+
+// The arith.addi is cloned at the new insertion point.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_arith_encoding_dims(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-SAME:    %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:    %[[N:[a-zA-Z0-9]+]]: index
+// CHECK:         %[[SUM:.+]] = arith.addi %[[M]], %[[N]] : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[SUM]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works when encoding_dims use tensor.dim on a tensor
+// that already dominates (not the propagation source). The tensor.dim on %src
+// already dominates the cast, so no rematerialization is needed.
+
+#encoding_dim_dominates = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_dim_on_dominating_tensor(
+    %src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding_dim_dominates> {
+  %c1 = arith.constant 1 : index
+  // tensor.dim on %src - this dominates the cast already
+  %dynamic_dim = tensor.dim %src, %c1 : tensor<1024x?xf16>
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%dynamic_dim} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_dim_dominates>
+  util.return %0 : tensor<?x512xf16, #encoding_dim_dominates>
+}
+
+// The tensor.dim on %src already dominates, so it's used directly.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_dim_on_dominating_tensor(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         %[[DIM:.+]] = tensor.dim %[[SRC]], %[[C1]]
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[DIM]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that recursive rematerialization works for arith ops with operands
+// that can be recursively rematerialized. The arith.muli uses %dim which is
+// computed from %cast. Since %dim is a tensor.dim on the propagation source,
+// it gets rematerialized from %src, and then arith.muli is cloned.
+
+#encoding_arith_recursive = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_recursive_rematerialization(
+    %src: tensor<1024x?xf16>, %multiplier: index) -> tensor<?x512xf16, #encoding_arith_recursive> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %c0 = arith.constant 0 : index
+  // %dim depends on %cast
+  %dim = tensor.dim %cast, %c0 : tensor<?x512xf16>
+  // arith.muli can be cloned after recursively rematerializing %dim from %src.
+  %product = arith.muli %dim, %multiplier : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%product} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_arith_recursive>
+  util.return %0 : tensor<?x512xf16, #encoding_arith_recursive>
+}
+
+// Propagation succeeds with recursive rematerialization of tensor.dim and arith.muli.
+// Since dim 0 of src (1024) is static, a constant is created instead of tensor.dim.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_recursive_rematerialization(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-SAME:    %[[MULT:[a-zA-Z0-9]+]]: index
+// CHECK:         %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK:         %[[PRODUCT:.+]] = arith.muli %[[MULT]], %[[C1024]] : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[PRODUCT]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
+        "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Encoding::IR
+    iree::compiler::Dialect::Encoding::Utils
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -71,7 +71,8 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     }
     // Otherwise, we need to create a new set_encoding op.
     auto setEncodingOp = IREE::Encoding::SetEncodingOp::create(
-        builder, op->getLoc(), encodedOperandType, operand);
+        builder, op->getLoc(), encodedOperandType, operand,
+        /*encodingDims=*/ValueRange{});
     encodedOperands.push_back(setEncodingOp.getResult());
     result.generatedEncodingOps.push_back(setEncodingOp);
   }
@@ -100,7 +101,7 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     std::tie(std::ignore, resultDynamicDims) = decomposeMixedValues(mixedSizes);
     auto unsetEncodingOp = IREE::Encoding::UnsetEncodingOp::create(
         builder, op->getLoc(), originalResult.getType(), encodedResult,
-        resultDynamicDims);
+        resultDynamicDims, /*encodingDims=*/ValueRange{});
     result.generatedEncodingOps.push_back(unsetEncodingOp);
     result.replacements.push_back(unsetEncodingOp.getResult());
   }


### PR DESCRIPTION
Stacked on top of: https://github.com/iree-org/iree/pull/22907.

This PR adds support for propagating dynamic encoding_dims through encoding operations during dispatch creation:
- **`EncodingTypes.cpp`**: Extract dynamic dimension values (Batch, M, N, K) from contractions, only for dimensions that are dynamic in iteration_sizes
-  **`Utils.cpp`**: Add rematerializeEncodingDims helper to recreate encoding dims at new insertion points during propagation (handles dominance, tensor.dim remapping, pure op cloning)
-  **`HoistEncodingOps.cpp`**: Rematerialize encoding dims when bubbling up set_encoding through generic ops
-  **`EncodingExternalModels.cpp`**: Rematerialize encoding dims when propagating through tensor.cast and similar ops