### PR TITLE
[GlobalOpt] Move conv propagation flag to pipeline options

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -29,11 +29,6 @@ static llvm::cl::opt<bool> clEnableTransposePropagation(
     llvm::cl::desc(
         "Enables propagation of transpose ops to improve fusion chances."),
     llvm::cl::init(true));
-static llvm::cl::opt<bool> clEnableConvolutionPropagation(
-    "iree-global-opt-propagate-transposes-through-conv",
-    llvm::cl::desc(
-        "Enables propagation of transpose ops through convolutions."),
-    llvm::cl::init(false));
 static llvm::cl::opt<bool> clEnableAttentionVTranspose(
     "iree-global-opt-enable-attention-v-transpose",
     llvm::cl::desc("Enables transposition of v operand of attention ops,"),
@@ -184,7 +179,7 @@ void buildGlobalOptimizationPassPipeline(
                            options.enableAggressivePropagation =
                                transformOptions.aggressiveTransposePropagation;
                            options.enableConvolutionPropagation =
-                               clEnableConvolutionPropagation;
+                               transformOptions.propagateTransposesThroughConv;
                            options.enableAttentionVTranspose =
                                clEnableAttentionVTranspose;
                            options.enableEdgeReshapePropagation =

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -64,6 +64,13 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
           "ops, rewriting named ops as fused generics."),
       llvm::cl::init(false),
   };
+  Option<bool> propagateTransposesThroughConv{
+      *this,
+      "propagate-transposes-through-conv",
+      llvm::cl::desc(
+          "Enables propagation of transpose ops through convolutions"),
+      llvm::cl::init(false),
+  };
   Option<bool> outerDimConcat{
       *this,
       "outer-dim-concat",

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -177,6 +177,12 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
           "Propagates transposes to named ops even when the resulting op will "
           "be a linalg.generic"),
       llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-global-opt-propagate-transposes-through-conv",
+      propagateTransposesThroughConv,
+      llvm::cl::desc(
+          "Enables propagation of transpose ops through convolutions."),
+      llvm::cl::cat(category));
   binder.opt<bool>("iree-opt-outer-dim-concat", outerDimConcat,
                    {init_at_opt(llvm::OptimizationLevel::O0, false),
                     init_at_opt(llvm::OptimizationLevel::O1, true)},

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -132,6 +132,9 @@ struct GlobalOptimizationOptions {
   // rewriting named ops as fused generics.
   bool aggressiveTransposePropagation = false;
 
+  // Enables propagation of transpose ops through convolutions.
+  bool propagateTransposesThroughConv = false;
+
   // Enables transposing all concatenations to the outer most dimension.
   bool outerDimConcat = false;
 

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -189,6 +189,8 @@ void buildIREEPrecompileTransformPassPipeline(
       globalOptimizationOptions.parameterSplatExportFile;
   globalTransformOptions.aggressiveTransposePropagation =
       globalOptimizationOptions.aggressiveTransposePropagation;
+  globalTransformOptions.propagateTransposesThroughConv =
+      globalOptimizationOptions.propagateTransposesThroughConv;
   globalTransformOptions.outerDimConcat =
       globalOptimizationOptions.outerDimConcat;
   // The pipeline option has higher priority.


### PR DESCRIPTION
Moves `iree-global-opt-propagate-transposes-through-conv` to pipeline options so that it can be bound when using the C API in Fusilli. 

Similar to https://github.com/iree-org/iree/pull/23067