### PR TITLE
[LLVMGPU] Add pass to lower vector loads to amdgpu.transpose_load

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -822,7 +822,7 @@ createTransposeLoadIndexHint(OpBuilder &builder, Location loc,
   auto laneConstantAttr =
       IREE::GPU::LaneConstantAttr::get(builder.getContext(), groupSize);
   auto laneIncrementAttr = IREE::GPU::LaneIncrementAttr::get(
-      builder.getContext(), groupSize, /*step=*/1);
+      builder.getContext(), groupSize, /*step=*/1, /*aligned=*/true);
 
   SmallVector<Value> results;
   for (auto [i, value] : llvm::enumerate(delinearizedLaneId)) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -1091,10 +1091,20 @@ def IREEGPU_LaneIncrementAttr : AttrDef<IREEGPU_Dialect, "LaneIncrement"> {
     groups of N consecutive lanes. For example, with group_size=16 and a base
     value B, lane i has value `B + (i % 16) * step`.
 
+    The `aligned` flag indicates that the base value (at lane 0 within each
+    group) is guaranteed to be a multiple of `group_size`. This is important
+    for propagating hints through operations like `affine.delinearize_index`,
+    where alignment ensures the delinearization doesn't cause wrap-around
+    within a lane group.
+
     This hint is used to guide optimizations like transpose load lowering,
     where the column index must increment by 1 across consecutive lanes.
   }];
-  let parameters = (ins "int64_t":$group_size, "int64_t":$step);
+  let parameters = (ins
+    "int64_t":$group_size,
+    "int64_t":$step,
+    DefaultValuedParameter<"bool", "false">:$aligned
+  );
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -207,3 +207,21 @@ module {
 }
 // CHECK-LABEL: func @test_lane_increment_with_step
 //  CHECK-SAME:   lane_increment = #iree_gpu.lane_increment<16, step = 2>
+
+module {
+  func.func @test_lane_increment_aligned() attributes {
+      lane_increment = #iree_gpu.lane_increment<64, aligned>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_lane_increment_aligned
+//  CHECK-SAME:   lane_increment = #iree_gpu.lane_increment<64, aligned>
+
+module {
+  func.func @test_lane_increment_step_and_aligned() attributes {
+      lane_increment = #iree_gpu.lane_increment<64, step = 2, aligned>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_lane_increment_step_and_aligned
+//  CHECK-SAME:   lane_increment = #iree_gpu.lane_increment<64, step = 2, aligned>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_inner_tiled.mlir
@@ -36,7 +36,7 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   scf.forall (%[[LANE_ID:.+]]) in (64) shared_outs(%[[ITER_ARG:.+]] = %[[ACC]]) -> (tensor<2x2x16x16xf32>)
 //       CHECK:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANE_ID]] into (4, 16)
 //       CHECK:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//       CHECK:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//       CHECK:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //       CHECK:     %[[ID1:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (4, 4)
 //       CHECK:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[COL]], %[[ID1]]]
 //  CHECK-SAME:       [2, 2, 1, 4] [1, 1, 1, 1] : tensor<2x2x16x16xf16> to tensor<2x2x1x4xf16>
@@ -90,7 +90,7 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   scf.forall (%[[LANE_ID:.+]]) in (64) shared_outs(%[[ITER_ARG:.+]] = %[[ACC]]) -> (tensor<2x2x16x16xi32>)
 //       CHECK:     %[[ID:.+]]:3  = affine.delinearize_index %[[LANE_ID]] into (4, 16)
 //       CHECK:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//       CHECK:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//       CHECK:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //       CHECK:     %[[ID1:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (4, 8)
 //       CHECK:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[COL]], %[[ID1]]]
 //  CHECK-SAME:       [2, 2, 1, 8] [1, 1, 1, 1] : tensor<2x2x16x32xi8> to tensor<2x2x1x8xi8>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -98,7 +98,7 @@ module {
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<2x2x4x8x32xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 32)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<32>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[COL]], %[[IDY]]] [2, 8, 1, 4]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[COL]], %[[IDY]]] [8, 2, 1, 4]
@@ -140,7 +140,7 @@ module {
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<2x2x32x4x8xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 32)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<32>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[COL]], %[[IDY]]] [2, 8, 1, 4]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[COL]], %[[IDY]]] [8, 2, 1, 4]
@@ -182,7 +182,7 @@ module {
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<2x2x4x8x32xi32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 32)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<32>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[COL]], %[[IDY]]] [2, 8, 1, 4]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[COL]], %[[IDY]]] [8, 2, 1, 4]
@@ -223,12 +223,12 @@ module {
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<8x2x16x16xf16>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<2x2x8x2x16xf32>)
 //   CHECK-DAG:     %[[ID_1:.+]]:2 = affine.delinearize_index %[[LANEID]] into (16)
-//   CHECK-DAG:     %[[ROW_1:.+]] = iree_codegen.index_hint %[[ID_1]]#1(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[ROW_1:.+]] = iree_codegen.index_hint %[[ID_1]]#1(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[ROW_1]], 0] [2, 8, 1, 16]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[ROW_1]], 0] [8, 2, 1, 16]
 //   CHECK-DAG:     %[[ID_2:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
 //   CHECK-DAG:     %[[ROW_2:.+]] = iree_codegen.index_hint %[[ID_2]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL_2:.+]] = iree_codegen.index_hint %[[ID_2]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL_2:.+]] = iree_codegen.index_hint %[[ID_2]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   Note: ID_2#1 and I_2#2 should not be delinearize outputs once we move to linearized indexing
 //   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, 0, %[[ROW_2]], %[[COL_2]]] [2, 2, 8, 1, 1]
 //       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]]) outs(%[[ACC_SLICE]])
@@ -261,7 +261,7 @@ func.func @distribute_MFMA_F32_16x16x4_F32(%lhs: tensor<16x4xf32>, %rhs: tensor<
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[COL]], %[[ROW]]] [1, 1]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][%[[ROW]], %[[COL]]] [1, 1]
 //   CHECK-DAG:     %[[IDZ:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (4, 4)
@@ -295,7 +295,7 @@ func.func @distribute_F32_16x16x32_F8E4M3FNUZ(%lhs: tensor<16x32xf8E4M3FNUZ>, %r
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (4, 8)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[COL]], %[[IDY]]] [1, 8]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][%[[IDY]], %[[COL]]] [8, 1]
@@ -330,7 +330,7 @@ func.func @distribute_I32_32x32x16_I8(%lhs: tensor<32x16xi8>, %rhs: tensor<16x32
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<4x8x32xi32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 32)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<32>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<32, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 8)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[COL]], %[[IDY]]] [1, 8]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][%[[IDY]], %[[COL]]] [8, 1]
@@ -364,7 +364,7 @@ func.func @distribute_WMMAR3_F16_16x16x16_F16(%lhs: tensor<16x16xf16>, %rhs: ten
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<16x16xf16>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x8x2xf16>)
 //   CHECK-DAG:     %[[ID:.+]]:2 = affine.delinearize_index %[[LANEID]] into (16)
-//   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[ROW]], 0] [1, 16]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, %[[ROW]]] [16, 1]
@@ -404,12 +404,12 @@ module {
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<8x2x16x16xi8>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<2x2x8x2x16xi32>)
 //   CHECK-DAG:     %[[ID:.+]]:2 = affine.delinearize_index %[[LANEID]] into (16)
-//   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[ROW]], 0] [2, 8, 1, 16]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[ROW]], 0] [8, 2, 1, 16]
 //   CHECK-DAG:     %[[ID_ACC:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
 //   CHECK-DAG:     %[[ROW_ACC:.+]] = iree_codegen.index_hint %[[ID_ACC]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL_ACC:.+]] = iree_codegen.index_hint %[[ID_ACC]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL_ACC:.+]] = iree_codegen.index_hint %[[ID_ACC]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, 0, %[[ROW_ACC]], %[[COL_ACC]]] [2, 2, 8, 1, 1]
 //       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]]) outs(%[[ACC_SLICE]])
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
@@ -441,7 +441,7 @@ func.func @distribute_WMMAR4_F16_16x16x16_F16(%lhs: tensor<16x16xf16>, %rhs: ten
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x16xf16>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 8)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[COL]], %[[IDY]]] [1, 8]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][%[[IDY]], %[[COL]]] [8, 1]
@@ -482,7 +482,7 @@ module {
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<2x2x16x16xi32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 8)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[COL]], %[[IDY]]] [2, 8, 1, 8]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[COL]], %[[IDY]]] [8, 2, 1, 8]
@@ -517,7 +517,7 @@ func.func @distribute_WMMA_F32_16x16x4_F32(%lhs: tensor<16x4xf32>, %rhs: tensor<
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[IDX:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 2)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[COL]], %[[IDX]]] [1, 2]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][%[[IDX]], %[[COL]]] [2, 1]
@@ -552,7 +552,7 @@ func.func @distribute_WMMA_F32_16x16x128_F8E4M3FN(%lhs: tensor<16x128xf8E4M3FN>,
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[IDX:.+]] = affine.linearize_index disjoint [%[[ROW]], %c0] by (2, 64)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[COL]], %[[IDX]]] [1, 64]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][%[[IDX]], %[[COL]]] [64, 1]
@@ -1116,7 +1116,7 @@ func.func @scaled_matmul_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x1x16x4x32xf4
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
 //   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %[[ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[COL]], %[[ROW]], 0] [3, 5, 1, 1, 1, 32]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ROW]], 0, %[[COL]]] [5, 1, 7, 1, 32, 1]
 //   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[COL]], %[[ROW]]] [3, 5, 1, 1]
@@ -1168,7 +1168,7 @@ func.func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x4x16x4x3
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x16x4xf8E8M0FNU>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x16x16xf32>)
 //   CHECK-DAG:     iree_codegen.index_hint {{.*}}(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     iree_codegen.index_hint {{.*}}(#iree_gpu.lane_increment<16>) : index
+//   CHECK-DAG:     iree_codegen.index_hint {{.*}}(#iree_gpu.lane_increment<16, aligned>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]{{.*}} [3, 5, 4, 1, 1, 32]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]{{.*}} [5, 4, 7, 1, 1, 32]
 //   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]]{{.*}} [3, 5, 1, 1]
@@ -1214,7 +1214,7 @@ func.func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8(%lhs: tensor<3x5x1x32x2x32
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x32x2xf8E8M0FNU>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x4x8x32xf32>)
 //   CHECK-DAG:     iree_codegen.index_hint {{.*}}(#iree_gpu.lane_constant<32>) : index
-//   CHECK-DAG:     iree_codegen.index_hint {{.*}}(#iree_gpu.lane_increment<32>) : index
+//   CHECK-DAG:     iree_codegen.index_hint {{.*}}(#iree_gpu.lane_increment<32, aligned>) : index
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]{{.*}} [3, 5, 1, 1, 1, 32]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]{{.*}} [5, 1, 7, 1, 1, 32]
 //   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]]{{.*}} [3, 5, 1, 1]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -113,6 +113,7 @@ iree_compiler_cc_library(
         "ROCDLAnnotateKernelForTranslation.cpp",
         "ROCDLBufferInstructionsOptimization.cpp",
         "ROCDLConfigureBufferInstructions.cpp",
+        "ROCDLLoadToTransposeLoad.cpp",
         "ROCDLLowerExecutableTarget.cpp",
         "ROCDLPrefetching.cpp",
         "Verifiers.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_cc_library(
     "ROCDLAnnotateKernelForTranslation.cpp"
     "ROCDLBufferInstructionsOptimization.cpp"
     "ROCDLConfigureBufferInstructions.cpp"
+    "ROCDLLoadToTransposeLoad.cpp"
     "ROCDLLowerExecutableTarget.cpp"
     "ROCDLPrefetching.cpp"
     "Verifiers.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -585,6 +585,9 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createFlattenSwizzleHintAllocsPass());
   funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
+  if (forROCDL) {
+    funcPassManager.addPass(createROCDLLoadToTransposeLoadPass());
+  }
   funcPassManager.addPass(createUnrollAnnotatedLoopsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
   if (pipelineOptions.enableReduceSharedMemoryBankConflicts) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -585,9 +585,6 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createFlattenSwizzleHintAllocsPass());
   funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
-  if (forROCDL) {
-    funcPassManager.addPass(createROCDLLoadToTransposeLoadPass());
-  }
   funcPassManager.addPass(createUnrollAnnotatedLoopsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
   if (pipelineOptions.enableReduceSharedMemoryBankConflicts) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -1,0 +1,831 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-rocdl-load-to-transpose-load"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_ROCDLLOADTOTRANSPOSELOADPASS
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h.inc"
+
+namespace {
+
+constexpr int64_t kTransposeLoadLaneGroupSize = 16;
+constexpr amdgpu::Chipset kGfx950 = amdgpu::Chipset(9, 5, 0);
+constexpr llvm::StringLiteral kPassLocalHintAttr = "__pass_local_hint";
+
+//===----------------------------------------------------------------------===//
+// Validation Helpers
+//===----------------------------------------------------------------------===//
+
+/// Returns true if the given memory space is workgroup (LDS) memory.
+static bool isWorkgroupMemory(MemRefType memrefType) {
+  Attribute memSpace = memrefType.getMemorySpace();
+  if (!memSpace) {
+    return false;
+  }
+  if (auto intMemSpace = dyn_cast<IntegerAttr>(memSpace)) {
+    return intMemSpace.getInt() == 3;
+  }
+  if (auto gpuMemSpace = dyn_cast<gpu::AddressSpaceAttr>(memSpace)) {
+    return gpuMemSpace.getValue() == gpu::AddressSpace::Workgroup;
+  }
+  return false;
+}
+
+/// Returns the required vector size for transpose_load given an element type.
+/// Returns std::nullopt if the element type is not supported.
+/// TODO(Max191): Add and test 4-bit and 6-bit element type support.
+static std::optional<int64_t> getTransposeLoadVectorSize(Type elementType) {
+  unsigned bitWidth = elementType.getIntOrFloatBitWidth();
+  switch (bitWidth) {
+  case 8:
+    return 8;
+  case 16:
+    return 4;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// Given a permutation map, find which memref dimension corresponds to the
+/// specified result index in the permutation map.
+/// For example, for affine_map<(d0, d1) -> (d0, d1)> with resultIdx=1,
+/// returns 1 (d1's position).
+/// Asserts that the permutation map is valid and resultIdx is in bounds.
+static int64_t getMemrefDimFromMapResult(AffineMap permMap,
+                                         unsigned resultIdx) {
+  assert(resultIdx < permMap.getNumResults() &&
+         "resultIdx out of bounds for permutation map");
+
+  AffineExpr expr = permMap.getResult(resultIdx);
+  auto dimExpr = dyn_cast<AffineDimExpr>(expr);
+  assert(dimExpr && "permutation map result is not a dimension expression");
+
+  return dimExpr.getPosition();
+}
+
+/// Check if the specified memref dimension has stride 1 (is contiguous).
+static bool isDimensionContiguous(MemRefType memrefType, int64_t dim) {
+  assert(dim >= 0 && dim < memrefType.getRank() &&
+         "dim must be a valid memref dimension");
+
+  // getStridesAndOffset handles all standard layouts including identity.
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (failed(memrefType.getStridesAndOffset(strides, offset))) {
+    // For layouts where strides cannot be computed, be conservative.
+    return false;
+  }
+
+  return strides[dim] == 1;
+}
+
+/// Checks if a row index value is uniform across lanes in a 16-lane group.
+/// A row index is uniform if it comes only from:
+/// - Constants
+/// - index_hint ops with lane_constant attribute (uniform across lanes)
+/// - Arithmetic/affine operations on these values
+///
+/// This function assumes that hint propagation has already been done, so all
+/// relevant thread_id ops should already have index_hint users with appropriate
+/// lane attributes.
+static bool isRowIndexUniform(Value rowIndex) {
+  LLVM_DEBUG(llvm::dbgs() << "isRowIndexUniform: checking value: " << rowIndex
+                          << "\n");
+  // Verify that the rowIndex is some function of constants and hint ops.
+  // Use SetVector as worklist to avoid revisiting the same value.
+  llvm::SetVector<Value> worklist;
+  worklist.insert(rowIndex);
+  while (!worklist.empty()) {
+    Value currentVal = worklist.pop_back_val();
+    LLVM_DEBUG(llvm::dbgs()
+               << "  checking worklist item: " << currentVal << "\n");
+    auto opResult = dyn_cast<OpResult>(currentVal);
+    if (!opResult) {
+      LLVM_DEBUG(llvm::dbgs() << "  FAIL: value is not an OpResult (likely a "
+                                 "block argument)\n");
+      return false;
+    }
+    Operation *definingOp = opResult.getOwner();
+    LLVM_DEBUG(llvm::dbgs() << "  defining op: " << *definingOp << "\n");
+    if (matchPattern(definingOp, m_Constant())) {
+      LLVM_DEBUG(llvm::dbgs() << "  OK: is a constant\n");
+      continue;
+    }
+    // Check for index_hint op with lane attributes.
+    if (auto indexHintOp = dyn_cast<IREE::Codegen::IndexHintOp>(definingOp)) {
+      Attribute hint = indexHintOp.getHint();
+      if (auto laneConstant = dyn_cast<IREE::GPU::LaneConstantAttr>(hint)) {
+        // lane_constant means uniform across lanes within group_size lanes.
+        // For transpose_load, we need uniformity within 16-lane groups.
+        // The group_size must be a multiple of 16 for proper alignment.
+        if (laneConstant.getGroupSize() % kTransposeLoadLaneGroupSize == 0) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "  OK: index_hint with lane_constant, group_size="
+                     << laneConstant.getGroupSize() << " is multiple of 16\n");
+          continue;
+        }
+        LLVM_DEBUG(llvm::dbgs()
+                   << "  FAIL: index_hint with lane_constant, group_size="
+                   << laneConstant.getGroupSize()
+                   << " is not a multiple of 16\n");
+        return false;
+      }
+      if (isa<IREE::GPU::LaneIncrementAttr>(hint)) {
+        // lane_increment means varying across lanes - NOT OK for row index.
+        LLVM_DEBUG(llvm::dbgs()
+                   << "  FAIL: index_hint with lane_increment attribute "
+                      "(column index, not uniform)\n");
+        return false;
+      }
+      // Unknown hint type - be conservative and fail.
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  FAIL: index_hint with unknown hint attribute type\n");
+      return false;
+    }
+    // Use a whitelist of arith/affine ops to be conservative for non-leaf ops.
+    // Other ops may be valid, but they are not common, and allowing arbitrary
+    // ops is unsafe when the semantics of the ops are unknown.
+    if (!isa<arith::ArithDialect, affine::AffineDialect>(
+            definingOp->getDialect())) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  FAIL: op is not from arith or affine dialect (dialect: "
+                 << definingOp->getDialect()->getNamespace() << ")\n");
+      return false;
+    }
+    LLVM_DEBUG(llvm::dbgs()
+               << "  OK: arith/affine op, adding "
+               << definingOp->getNumOperands() << " operands to worklist\n");
+    for (Value operand : definingOp->getOperands()) {
+      worklist.insert(operand);
+    }
+  }
+  LLVM_DEBUG(
+      llvm::dbgs() << "isRowIndexUniform: SUCCESS - all values uniform\n");
+  return true;
+}
+
+/// Analysis result for a transfer_read that can be transformed.
+struct TransposeLoadAnalysis {
+  int64_t columnMemrefDim; // Which memref dimension is the column
+  SmallVector<int64_t>
+      rowMemrefDims;             // Memref dims for rows (ordered by vector dim)
+  SmallVector<int64_t> rowSizes; // Vector sizes for row dims (same order)
+  int64_t totalRowSize;          // Product of rowSizes
+  int64_t intrinsicVectorSize;   // Required size per transpose_load
+  int64_t unrollCount;           // Number of transpose_loads needed
+};
+
+/// Analyzes a transfer_read to determine if it can be lowered to
+/// transpose_load. Returns analysis result if the transfer_read is suitable,
+/// std::nullopt otherwise.
+///
+/// Requirements:
+/// - Source must be workgroup (LDS) memory
+/// - Innermost vector dimension must have size 1 (the column dimension)
+/// - Column index must come from an index_hint with lane_increment attribute
+/// - Column memref dimension must be contiguous (stride 1)
+/// - All row indices must be uniform across lanes (derived from constants or
+///   index_hint ops with lane_constant attribute)
+static std::optional<TransposeLoadAnalysis>
+analyzeTransferReadForTransposeLoad(vector::TransferReadOp transferOp) {
+  VectorType vecType = transferOp.getVectorType();
+
+  // Vector must have at least 1 dimension.
+  if (vecType.getRank() < 1) {
+    return std::nullopt;
+  }
+
+  // Innermost vector dimension must have size 1 (this is the column).
+  if (vecType.getDimSize(vecType.getRank() - 1) != 1) {
+    return std::nullopt;
+  }
+
+  AffineMap permMap = transferOp.getPermutationMap();
+
+  // Permutation map must have same number of results as vector rank
+  // and must be a projected permutation.
+  if (permMap.getNumResults() != static_cast<unsigned>(vecType.getRank()) ||
+      !permMap.isProjectedPermutation()) {
+    return std::nullopt;
+  }
+
+  // Column dimension is the last result in the permutation map
+  // (corresponds to innermost vector dimension).
+  int64_t columnMemrefDim =
+      getMemrefDimFromMapResult(permMap, vecType.getRank() - 1);
+  Value columnIndex = transferOp.getIndices()[columnMemrefDim];
+
+  // Check if the column index comes from an index_hint with lane_increment.
+  auto opResult = dyn_cast<OpResult>(columnIndex);
+  if (!opResult) {
+    return std::nullopt;
+  }
+  auto indexHintOp = dyn_cast<IREE::Codegen::IndexHintOp>(opResult.getOwner());
+  if (!indexHintOp) {
+    return std::nullopt;
+  }
+
+  // Validate the lane_increment attribute:
+  // - Must be lane_increment (not lane_constant)
+  // - group_size must be >= 16 (transpose_load operates on 16-lane groups)
+  // - step must be 1 (column indices must be consecutive)
+  auto laneIncrement =
+      dyn_cast<IREE::GPU::LaneIncrementAttr>(indexHintOp.getHint());
+  if (!laneIncrement) {
+    return std::nullopt;
+  }
+  // The group_size must be a multiple of 16 for proper alignment.
+  if (laneIncrement.getGroupSize() % kTransposeLoadLaneGroupSize != 0) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Column index lane_increment group_size "
+               << laneIncrement.getGroupSize() << " is not a multiple of "
+               << kTransposeLoadLaneGroupSize << "\n");
+    return std::nullopt;
+  }
+  if (laneIncrement.getStep() != 1) {
+    LLVM_DEBUG(llvm::dbgs() << "Column index lane_increment step "
+                            << laneIncrement.getStep() << " != 1\n");
+    return std::nullopt;
+  }
+
+  TransposeLoadAnalysis analysis;
+  analysis.columnMemrefDim = columnMemrefDim;
+
+  // 1. Validate element type and get intrinsic size.
+  Type elementType = vecType.getElementType();
+  std::optional<int64_t> intrinsicSize =
+      getTransposeLoadVectorSize(elementType);
+  if (!intrinsicSize) {
+    LLVM_DEBUG(llvm::dbgs() << "Unsupported element type\n");
+    return std::nullopt;
+  }
+  analysis.intrinsicVectorSize = *intrinsicSize;
+
+  // 2. Collect row dimensions and compute total row size.
+  // Row dimensions are all vector dimensions except the innermost (column).
+  // We iterate in vector dimension order to maintain correct linearization.
+  analysis.totalRowSize = 1;
+  for (int64_t vecDim = 0; vecDim < vecType.getRank() - 1; ++vecDim) {
+    int64_t size = vecType.getDimSize(vecDim);
+    int64_t memrefDim = getMemrefDimFromMapResult(permMap, vecDim);
+
+    // Only include dimensions with size > 1 in row computation.
+    // Dimensions with size 1 don't contribute to the row product.
+    if (size > 1) {
+      analysis.rowMemrefDims.push_back(memrefDim);
+      analysis.rowSizes.push_back(size);
+      analysis.totalRowSize *= size;
+    }
+  }
+
+  // 3. Validate total row size is a multiple of intrinsic size.
+  if (analysis.totalRowSize % analysis.intrinsicVectorSize != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "Total row size " << analysis.totalRowSize
+                            << " is not a multiple of intrinsic size "
+                            << analysis.intrinsicVectorSize << "\n");
+    return std::nullopt;
+  }
+
+  analysis.unrollCount = analysis.totalRowSize / analysis.intrinsicVectorSize;
+
+  // 4. Validate column dimension is contiguous (stride 1).
+  MemRefType memrefType = cast<MemRefType>(transferOp.getBase().getType());
+  if (!isDimensionContiguous(memrefType, analysis.columnMemrefDim)) {
+    LLVM_DEBUG(llvm::dbgs() << "Column dimension is not contiguous\n");
+    return std::nullopt;
+  }
+
+  // 5. Validate all row indices are uniform across lanes.
+  for (int64_t memrefDim : analysis.rowMemrefDims) {
+    Value rowIndex = transferOp.getIndices()[memrefDim];
+    if (!isRowIndexUniform(rowIndex)) {
+      LLVM_DEBUG(llvm::dbgs() << "Row index for memref dim " << memrefDim
+                              << " is not uniform across lanes\n");
+      return std::nullopt;
+    }
+  }
+
+  return analysis;
+}
+
+//===----------------------------------------------------------------------===//
+// Transformation Logic
+//===----------------------------------------------------------------------===//
+
+/// Delinearize a linear element index into N-D indices.
+/// Given sizes [S_0, S_1, ..., S_k] and a linear index, returns indices
+/// [Idx_0, Idx_1, ..., Idx_k] such that:
+///   linearIdx = Idx_0 * (S_1 * S_2 * ... * S_k) + Idx_1 * (S_2 * ... * S_k) +
+///   ... + Idx_k
+static SmallVector<Value> delinearizeIndex(Value linearIdx,
+                                           ArrayRef<int64_t> sizes,
+                                           RewriterBase &rewriter,
+                                           Location loc) {
+  if (sizes.empty()) {
+    return {};
+  }
+
+  SmallVector<Value> indices(sizes.size());
+  Value remaining = linearIdx;
+
+  // Process from innermost to outermost dimension
+  for (int64_t i = sizes.size() - 1; i >= 0; --i) {
+    Value size = arith::ConstantIndexOp::create(rewriter, loc, sizes[i]);
+    indices[i] = arith::RemUIOp::create(rewriter, loc, remaining, size);
+    if (i > 0) {
+      remaining = arith::DivUIOp::create(rewriter, loc, remaining, size);
+    }
+  }
+
+  return indices;
+}
+
+/// Computes all memref indices for a single transpose_load op during unrolling.
+///
+/// The transformation converts implicit vector element indices into explicit
+/// offset additions. For each unroll iteration:
+///   linearElemIdx = unrollIndex * intrinsicSize + rowGroupIdx
+///   delinearize to get {Idx_0, Idx_1, ...} for row dimensions
+///   newOffset_i = originalOffset_i + Idx_i
+///
+/// Column index uses lane-based remapping (unchanged from 2D case).
+///
+/// Returns all memref indices for the transpose_load.
+static SmallVector<Value> computeTransposeLoadIndices(
+    vector::TransferReadOp transferOp, const TransposeLoadAnalysis &analysis,
+    int64_t unrollIndex, Value rowGroupIdx, Value newColIdx,
+    RewriterBase &rewriter, Location loc) {
+  OperandRange originalIndices = transferOp.getIndices();
+  int64_t intrinsicSize = analysis.intrinsicVectorSize;
+
+  // Compute linear element index for this unroll iteration
+  // linearElemIdx = unrollIndex * intrinsicSize + rowGroupIdx
+  Value cUnrollBase = arith::ConstantIndexOp::create(
+      rewriter, loc, unrollIndex * intrinsicSize);
+  Value linearElemIdx =
+      arith::AddIOp::create(rewriter, loc, cUnrollBase, rowGroupIdx);
+
+  // Delinearize to get indices for each row dimension
+  SmallVector<Value> rowIndices =
+      delinearizeIndex(linearElemIdx, analysis.rowSizes, rewriter, loc);
+
+  // Build the full index list for the memref
+  // Start with original indices, then update row and column dimensions
+  SmallVector<Value> newIndices(originalIndices.begin(), originalIndices.end());
+
+  // Update row dimension indices: newOffset = originalOffset + delinearizedIdx
+  for (auto [i, memrefDim] : llvm::enumerate(analysis.rowMemrefDims)) {
+    Value originalIdx = originalIndices[memrefDim];
+    newIndices[memrefDim] =
+        arith::AddIOp::create(rewriter, loc, originalIdx, rowIndices[i]);
+  }
+
+  // Update column dimension index
+  newIndices[analysis.columnMemrefDim] = newColIdx;
+
+  return newIndices;
+}
+
+/// Computes the column index for transpose_load using lane-based remapping.
+/// This is shared across all unroll iterations.
+static Value computeColumnIndex(Value originalColIdx, Value laneInGroup,
+                                int64_t intrinsicSize, RewriterBase &rewriter,
+                                Location loc) {
+  int64_t loadsPerColumn = kTransposeLoadLaneGroupSize / intrinsicSize;
+
+  // Column index remapping:
+  // 1. Compute baseColOffset = originalColIdx - laneInGroup
+  Value baseColOffset =
+      arith::SubIOp::create(rewriter, loc, originalColIdx, laneInGroup);
+
+  // 2. Compute colGroupIdx = laneInGroup % loadsPerColumn
+  Value cLoadsPerCol =
+      arith::ConstantIndexOp::create(rewriter, loc, loadsPerColumn);
+  Value colGroupIdx =
+      arith::RemUIOp::create(rewriter, loc, laneInGroup, cLoadsPerCol);
+
+  // 3. Compute offset within column group = colGroupIdx * intrinsicSize
+  Value cIntrinsicSize =
+      arith::ConstantIndexOp::create(rewriter, loc, intrinsicSize);
+  Value colOffset =
+      arith::MulIOp::create(rewriter, loc, colGroupIdx, cIntrinsicSize);
+
+  // 4. newColIdx = baseColOffset + colOffset
+  return arith::AddIOp::create(rewriter, loc, baseColOffset, colOffset);
+}
+
+/// Generates the transpose_load ops and combines results into a 1D vector,
+/// then reshapes to the original N-D vector shape.
+static Value generateTransposeLoads(vector::TransferReadOp transferOp,
+                                    const TransposeLoadAnalysis &analysis,
+                                    RewriterBase &rewriter) {
+  Location loc = transferOp.getLoc();
+  VectorType resultType = transferOp.getVectorType();
+  Type elementType = resultType.getElementType();
+  int64_t intrinsicSize = analysis.intrinsicVectorSize;
+  int64_t unrollCount = analysis.unrollCount;
+  int64_t totalRowSize = analysis.totalRowSize;
+  Value source = transferOp.getBase();
+
+  // The intrinsic produces a 1D vector
+  VectorType intrinsicVecType = VectorType::get({intrinsicSize}, elementType);
+
+  // Compute lane ID and derived values (shared across all unrolls)
+  Value laneId = gpu::LaneIdOp::create(rewriter, loc, /*upper_bound=*/nullptr);
+  Value cLaneGroupSize = arith::ConstantIndexOp::create(
+      rewriter, loc, kTransposeLoadLaneGroupSize);
+  Value laneInGroup =
+      arith::RemUIOp::create(rewriter, loc, laneId, cLaneGroupSize);
+
+  // Compute rowGroupIdx = laneInGroup / loadsPerColumn (shared across unrolls)
+  int64_t loadsPerColumn = kTransposeLoadLaneGroupSize / intrinsicSize;
+  Value cLoadsPerCol =
+      arith::ConstantIndexOp::create(rewriter, loc, loadsPerColumn);
+  Value rowGroupIdx =
+      arith::DivUIOp::create(rewriter, loc, laneInGroup, cLoadsPerCol);
+
+  // Compute column index (shared across all unrolls)
+  Value originalColIdx = transferOp.getIndices()[analysis.columnMemrefDim];
+  Value newColIdx = computeColumnIndex(originalColIdx, laneInGroup,
+                                       intrinsicSize, rewriter, loc);
+
+  // Generate transpose_load ops for each unroll iteration
+  SmallVector<Value> results;
+  for (int64_t i = 0; i < unrollCount; ++i) {
+    // Compute all memref indices for this transpose_load
+    SmallVector<Value> indices = computeTransposeLoadIndices(
+        transferOp, analysis, i, rowGroupIdx, newColIdx, rewriter, loc);
+
+    // Create transpose_load op with all indices
+    auto transposeLoadOp = amdgpu::TransposeLoadOp::create(
+        rewriter, loc, intrinsicVecType, source, indices);
+
+    results.push_back(transposeLoadOp.getResult());
+  }
+
+  // Combine results into a 1D vector
+  VectorType flat1DType = VectorType::get({totalRowSize}, elementType);
+
+  Value combined;
+  if (results.size() == 1) {
+    // Single result - just use it directly (already 1D)
+    combined = results[0];
+  } else {
+    // Multiple results - concatenate into 1D vector
+    combined = arith::ConstantOp::create(rewriter, loc, flat1DType,
+                                         rewriter.getZeroAttr(flat1DType));
+
+    for (auto [idx, result] : llvm::enumerate(results)) {
+      // Insert at offset [idx * intrinsicSize]
+      SmallVector<int64_t> offsets = {static_cast<int64_t>(idx) *
+                                      intrinsicSize};
+      SmallVector<int64_t> strides = {1};
+      combined = vector::InsertStridedSliceOp::create(
+          rewriter, loc, result, combined, offsets, strides);
+    }
+  }
+
+  // Reshape from 1D to original N-D shape
+  return vector::ShapeCastOp::create(rewriter, loc, resultType, combined);
+}
+
+//===----------------------------------------------------------------------===//
+// Preprocessing: Seed and Propagate Lane Hints
+//===----------------------------------------------------------------------===//
+
+/// Injects lane hints on gpu.thread_id ops based on workgroup size.
+///
+/// The hints describe how thread IDs vary across consecutive lanes (threads
+/// with consecutive linear IDs within a workgroup):
+/// - thread_id x: lane_increment<wgSizeX, 1> - increments by 1, wraps at
+/// wgSizeX
+/// - thread_id y: lane_constant<wgSizeX> - constant within groups of wgSizeX
+/// lanes
+/// - thread_id z: lane_constant<wgSizeX*wgSizeY> - constant within groups of
+///   wgSizeX*wgSizeY lanes
+///
+/// For transpose_load optimization, row indices must be uniform within 16-lane
+/// groups. This is satisfied when the group_size >= 16 (i.e., wgSizeX >= 16
+/// for thread_id y, or wgSizeX*wgSizeY >= 16 for thread_id z).
+///
+/// Note: getWorkgroupSize() typically returns a 3-element vector for GPU
+/// workgroups. This function only uses elements 0 (x) and 1 (y).
+static void seedThreadIdHints(FunctionOpInterface funcOp, IRRewriter &rewriter,
+                              ArrayRef<int64_t> workgroupSize) {
+  assert(workgroupSize.size() >= 2 &&
+         "workgroupSize must have at least 2 elements (x, y)");
+  int64_t wgSizeX = workgroupSize[0];
+  int64_t wgSizeY = workgroupSize[1];
+
+  // Collect ops first to avoid modifying IR during walk.
+  SmallVector<gpu::ThreadIdOp> threadIdOps;
+  funcOp.walk([&](gpu::ThreadIdOp threadIdOp) {
+    // Skip if already has a hint user.
+    for (Operation *user : threadIdOp.getResult().getUsers()) {
+      if (isa<IREE::Codegen::IndexHintOp>(user)) {
+        return;
+      }
+    }
+    threadIdOps.push_back(threadIdOp);
+  });
+
+  for (gpu::ThreadIdOp threadIdOp : threadIdOps) {
+    Value result = threadIdOp.getResult();
+    rewriter.setInsertionPointAfter(threadIdOp);
+
+    Attribute hintAttr;
+    switch (threadIdOp.getDimension()) {
+    case gpu::Dimension::x:
+      // x varies across lanes. Thread IDs start at 0 which is always aligned.
+      hintAttr = IREE::GPU::LaneIncrementAttr::get(
+          rewriter.getContext(), wgSizeX, /*step=*/1, /*aligned=*/true);
+      break;
+    case gpu::Dimension::y:
+      // y is constant within groups of wgSizeX consecutive lanes.
+      hintAttr =
+          IREE::GPU::LaneConstantAttr::get(rewriter.getContext(), wgSizeX);
+      break;
+    case gpu::Dimension::z:
+      // z is constant within groups of wgSizeX*wgSizeY consecutive lanes.
+      hintAttr = IREE::GPU::LaneConstantAttr::get(rewriter.getContext(),
+                                                  wgSizeX * wgSizeY);
+      break;
+    }
+    assert(hintAttr && "all gpu::Dimension cases should set hintAttr");
+
+    auto hintOp = IREE::Codegen::IndexHintOp::create(
+        rewriter, threadIdOp.getLoc(), result, hintAttr);
+    hintOp->setAttr(kPassLocalHintAttr, rewriter.getUnitAttr());
+    result.replaceAllUsesExcept(hintOp.getResult(), hintOp);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Hint Propagation Patterns
+//===----------------------------------------------------------------------===//
+
+/// Propagates lane hints through affine.delinearize_index operations.
+///
+/// For an input with lane_increment<N>:
+///   - Results 0 to K-2 get lane_constant<product of bases after that position>
+///   - Result K-1 (last) gets lane_increment<innermost_basis>
+///
+/// For an input with lane_constant<N>:
+///   - All results get lane_constant<N> (constant propagates through)
+///
+/// The pattern fails if any result already has an index_hint user, ensuring
+/// hints are only propagated once.
+struct PropagateHintThroughDelinearize
+    : OpRewritePattern<affine::AffineDelinearizeIndexOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineDelinearizeIndexOp op,
+                                PatternRewriter &rewriter) const override {
+    auto hintOp =
+        op.getLinearIndex().getDefiningOp<IREE::Codegen::IndexHintOp>();
+    if (!hintOp) {
+      return failure();
+    }
+
+    // Check for existing hints to provide a stop condition for the greedy
+    // driver and avoid infinite loops from re-propagating hints.
+    for (Value result : op.getResults()) {
+      for (Operation *user : result.getUsers()) {
+        if (isa<IREE::Codegen::IndexHintOp>(user)) {
+          return failure();
+        }
+      }
+    }
+
+    ArrayRef<int64_t> basis = op.getStaticBasis();
+    Attribute inputHint = hintOp.getHint();
+    rewriter.setInsertionPointAfter(op);
+
+    return llvm::TypeSwitch<Attribute, LogicalResult>(inputHint)
+        // Case 1: lane_constant propagates to all results unchanged.
+        // Dynamic basis is allowed since we don't need basis values.
+        .Case<IREE::GPU::LaneConstantAttr>([&](auto laneConstant) {
+          for (Value result : op.getResults()) {
+            if (result.use_empty()) {
+              continue;
+            }
+            auto newHint = IREE::Codegen::IndexHintOp::create(
+                rewriter, op.getLoc(), result, laneConstant);
+            newHint->setAttr(kPassLocalHintAttr, rewriter.getUnitAttr());
+            result.replaceAllUsesExcept(newHint.getResult(), newHint);
+          }
+          return success();
+        })
+        // Case 2: lane_increment splits across results based on basis.
+        // We process from innermost to outermost, computing group sizes from
+        // static bases. Dynamic bases are pessimized to 1 (their minimum
+        // value).
+        .Case<IREE::GPU::LaneIncrementAttr>([&](auto laneIncrement) {
+          if (basis.empty()) {
+            return failure();
+          }
+
+          // Innermost basis must be static for lane_increment propagation.
+          if (ShapedType::isDynamic(basis.back())) {
+            return failure();
+          }
+
+          // If the input is not aligned, we cannot safely propagate the hint
+          // through delinearize. The modulo operation in delinearize can cause
+          // wrap-around within a lane group if the base is not aligned.
+          if (!laneIncrement.getAligned()) {
+            return failure();
+          }
+
+          int64_t originalGroupSize = laneIncrement.getGroupSize();
+
+          // Compute group sizes from innermost to outermost.
+          // groupSizes[i] = product of static bases from position i+1 to end.
+          //
+          // When originalGroupSize is not divisible by currentGroupSize, we
+          // inherit the group size from the next inner result. This works
+          // because for the outer dim to increment, the inner dim must have
+          // incremented, which means it changed by a multiple of its group
+          // size.
+          //
+          // When a dynamic dimension is hit, the currentGroupSize is
+          // invalidated, so the remaining results inherit the last valid group
+          // size.
+          SmallVector<int64_t> groupSizes(basis.size());
+          int64_t currentGroupSize = 1;
+          int64_t lastValidGroupSize = 1;
+          for (int64_t i = basis.size() - 1; i >= 0; --i) {
+            if (originalGroupSize % currentGroupSize == 0) {
+              groupSizes[i] = currentGroupSize;
+              lastValidGroupSize = currentGroupSize;
+            } else {
+              // Not evenly divisible - inherit from inner result.
+              groupSizes[i] = lastValidGroupSize;
+            }
+            // Only grow currentGroupSize for static bases.
+            if (!ShapedType::isDynamic(basis[i])) {
+              currentGroupSize *= basis[i];
+            }
+          }
+
+          for (unsigned i = 0; i < op.getNumResults(); ++i) {
+            Value result = op.getResult(i);
+            if (result.use_empty()) {
+              continue;
+            }
+
+            Attribute hintAttr;
+            if (i == op.getNumResults() - 1) {
+              // Last result gets lane_increment with innermost basis.
+              // Since the input was aligned and delinearize starts from 0,
+              // the innermost result is also aligned.
+              hintAttr = IREE::GPU::LaneIncrementAttr::get(
+                  getContext(), basis.back(), /*step=*/1, /*aligned=*/true);
+            } else {
+              // Other results get lane_constant with computed group size.
+              hintAttr =
+                  IREE::GPU::LaneConstantAttr::get(getContext(), groupSizes[i]);
+            }
+
+            auto newHint = IREE::Codegen::IndexHintOp::create(
+                rewriter, op.getLoc(), result, hintAttr);
+            newHint->setAttr(kPassLocalHintAttr, rewriter.getUnitAttr());
+            result.replaceAllUsesExcept(newHint.getResult(), newHint);
+          }
+          return success();
+        })
+        .Default([](auto) { return failure(); });
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Transfer Read to Transpose Load Pattern
+//===----------------------------------------------------------------------===//
+
+/// Converts vector.transfer_read operations to amdgpu.transpose_load when
+/// profitable.
+///
+/// This pattern is designed to run in the same greedy driver as hint
+/// propagation patterns, allowing hints to propagate incrementally and
+/// transpose_load lowering to fire as soon as hints are available.
+///
+/// The pattern requires hints to already be present on the column index (via
+/// seedThreadIdHints + PropagateHintThroughDelinearize). The greedy driver
+/// iterates until fixpoint, so hints will propagate through all delinearize
+/// ops before this pattern can match.
+struct TransferReadToTransposeLoad : OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp transferOp,
+                                PatternRewriter &rewriter) const override {
+    LLVM_DEBUG(llvm::dbgs() << "TransferReadToTransposeLoad: checking "
+                            << transferOp << "\n");
+
+    // Validate memory space.
+    auto memrefType = cast<MemRefType>(transferOp.getBase().getType());
+    if (!isWorkgroupMemory(memrefType)) {
+      LLVM_DEBUG(llvm::dbgs() << "  -> Source is not workgroup memory\n");
+      return failure();
+    }
+
+    // Analyze and validate access pattern.
+    std::optional<TransposeLoadAnalysis> analysis =
+        analyzeTransferReadForTransposeLoad(transferOp);
+    if (!analysis) {
+      LLVM_DEBUG(llvm::dbgs() << "  -> Access pattern analysis failed\n");
+      return failure();
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "  -> Transforming to transpose_load (unroll="
+                            << analysis->unrollCount << ")\n");
+
+    // Generate transpose_load ops.
+    rewriter.setInsertionPoint(transferOp);
+    Value result = generateTransposeLoads(transferOp, *analysis, rewriter);
+
+    // Replace the original transfer_read.
+    rewriter.replaceOp(transferOp, result);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+/// Pass to lower vector.transfer_read operations to amdgpu.transpose_load
+/// operations when profitable, based on iree_codegen.index_hint annotations
+/// with lane_constant and lane_increment attributes.
+///
+/// The pass operates in two phases:
+/// 1. Seeding: Inject lane hints on gpu.thread_id ops based on workgroup size
+/// 2. Pattern-based transformation: Run hint propagation and transpose_load
+///    lowering patterns together in a single greedy driver
+struct ROCDLLoadToTransposeLoadPass final
+    : impl::ROCDLLoadToTransposeLoadPassBase<ROCDLLoadToTransposeLoadPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+
+    // Check if target supports transpose_load (gfx950 only)
+    IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+    if (!target) {
+      return;
+    }
+    FailureOr<amdgpu::Chipset> chipset =
+        amdgpu::Chipset::parse(target.getArch());
+    if (failed(chipset) || *chipset != kGfx950) {
+      return;
+    }
+
+    IRRewriter rewriter(funcOp.getContext());
+
+    // Phase 1: Seed hints on gpu.thread_id ops
+    std::optional<SmallVector<int64_t>> workgroupSize =
+        getWorkgroupSize(funcOp);
+    if (workgroupSize) {
+      seedThreadIdHints(funcOp, rewriter, *workgroupSize);
+    }
+
+    // Phase 2: Propagate hints and lower transfer_reads via greedy patterns
+    RewritePatternSet patterns(funcOp.getContext());
+    patterns.add<PropagateHintThroughDelinearize>(funcOp.getContext());
+    patterns.add<TransferReadToTransposeLoad>(funcOp.getContext());
+
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    // Phase 3: Remove pass-local index_hint ops for IR cleanliness
+    funcOp.walk([&](IREE::Codegen::IndexHintOp hintOp) {
+      if (hintOp->hasAttr(kPassLocalHintAttr)) {
+        rewriter.replaceAllUsesWith(hintOp.getResult(), hintOp.getOperand());
+        rewriter.eraseOp(hintOp);
+      }
+    });
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -349,8 +349,7 @@ static SmallVector<Value> computeTransposeLoadIndices(
   auto delinOp = affine::AffineDelinearizeIndexOp::create(
       rewriter, loc, linearElemIdx, analysis.rowSizes,
       /*hasOuterBound=*/true);
-  rowIndices.assign(delinOp.getResults().begin(),
-                    delinOp.getResults().end());
+  rowIndices.assign(delinOp.getResults().begin(), delinOp.getResults().end());
 
   // Build the full index list for the memref
   // Start with original indices, then update row and column dimensions

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -56,4 +56,23 @@ def ROCDLLowerExecutableTargetPass : InterfacePass<
                 "pass pipeline";
 }
 
+def ROCDLLoadToTransposeLoadPass :
+    InterfacePass<"iree-rocdl-load-to-transpose-load", "mlir::FunctionOpInterface"> {
+  let summary = "Lower vector.transfer_read to amdgpu.transpose_load when profitable";
+  let description = [{
+    This pass analyzes vector.transfer_read operations that are fed by
+    iree_codegen.index_hint operations (with lane_constant and lane_increment
+    attributes) and converts them to amdgpu.transpose_load operations when
+    the access pattern matches the requirements for transpose load instructions.
+
+    This pass is ROCDL-specific as transpose_load is an AMD GPU feature
+    (available on CDNA architectures like gfx950+).
+  }];
+  let dependentDialects = [
+    "amdgpu::AMDGPUDialect",
+    "::mlir::iree_compiler::IREE::Codegen::IREECodegenDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 #endif // IREE_CODEGEN_LLVMGPU_ROCDLPASSES

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -65,6 +65,10 @@ def ROCDLLoadToTransposeLoadPass :
     attributes) and converts them to amdgpu.transpose_load operations when
     the access pattern matches the requirements for transpose load instructions.
 
+    This pass relies on shape information from memrefs to verify and perform the
+    transformation, so this pass should be run before any memref flattening,
+    and before fully unrolling non-contiguous vector loads into scalar loads.
+
     This pass is ROCDL-specific as transpose_load is an AMD GPU feature
     (available on CDNA architectures like gfx950+).
   }];

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -56,6 +56,7 @@ iree_lit_test_suite(
             "reduction_pipeline_rocm.mlir",
             "reduction_pipeline_softmax_rocm.mlir",
             "reuse_shared_memory_allocs.mlir",
+            "rocdl_load_to_transpose_load.mlir",
             "rocdl_pipeline_test.mlir",
             "sort_pipeline_test.mlir",
             "tensorcore_vectorization.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_lit_test_suite(
     "reduction_pipeline_rocm.mlir"
     "reduction_pipeline_softmax_rocm.mlir"
     "reuse_shared_memory_allocs.mlir"
+    "rocdl_load_to_transpose_load.mlir"
     "rocdl_pipeline_test.mlir"
     "sort_pipeline_test.mlir"
     "tensorcore_vectorization.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
@@ -26,7 +26,8 @@ func.func @no_transform_global_memory(%src: memref<128x256xf16>) -> vector<4x1xf
 // CHECK-LABEL: func.func @no_transform_column_hint_unused
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_column_hint_unused(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @no_transform_column_hint_unused() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %c5 = arith.constant 5 : index
   %tid = gpu.thread_id x
@@ -46,7 +47,8 @@ func.func @no_transform_column_hint_unused(%src: memref<128x256xf16, #gpu.addres
 // CHECK-LABEL: func.func @no_transform_column_size_not_1
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_column_size_not_1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x2xf16> {
+func.func @no_transform_column_size_not_1() -> vector<4x2xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -64,7 +66,8 @@ func.func @no_transform_column_size_not_1(%src: memref<128x256xf16, #gpu.address
 // CHECK-LABEL: func.func @no_transform_f32
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_f32(%src: memref<128x256xf32, #gpu.address_space<workgroup>>) -> vector<4x1xf32> {
+func.func @no_transform_f32() -> vector<4x1xf32> {
+  %src = memref.alloc() : memref<128x256xf32, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -82,7 +85,8 @@ func.func @no_transform_f32(%src: memref<128x256xf32, #gpu.address_space<workgro
 // CHECK-LABEL: func.func @no_transform_non_multiple_row_size
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_non_multiple_row_size(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<3x1xf16> {
+func.func @no_transform_non_multiple_row_size() -> vector<3x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -101,7 +105,8 @@ func.func @no_transform_non_multiple_row_size(%src: memref<128x256xf16, #gpu.add
 // CHECK-LABEL: func.func @no_transform_column_step_not_1
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_column_step_not_1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @no_transform_column_step_not_1() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -121,7 +126,8 @@ func.func @no_transform_column_step_not_1(%src: memref<128x256xf16, #gpu.address
 // CHECK-LABEL: func.func @no_transform_column_group_size_too_small
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_column_group_size_too_small(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @no_transform_column_group_size_too_small() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -141,7 +147,8 @@ func.func @no_transform_column_group_size_too_small(%src: memref<128x256xf16, #g
 // CHECK-LABEL: func.func @no_transform_row_group_size_not_multiple
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_row_group_size_not_multiple(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @no_transform_row_group_size_not_multiple() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   // Row hint has group_size=20, which is not a multiple of 16
@@ -164,7 +171,8 @@ func.func @no_transform_row_group_size_not_multiple(%src: memref<128x256xf16, #g
 // CHECK-LABEL: func.func @no_transform_row_from_column_hint
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_row_from_column_hint(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @no_transform_row_from_column_hint() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -183,7 +191,8 @@ func.func @no_transform_row_from_column_hint(%src: memref<128x256xf16, #gpu.addr
 // CHECK-LABEL: func.func @no_transform_row_from_block_arg
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_row_from_block_arg(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %row_arg: index) -> vector<4x1xf16> {
+func.func @no_transform_row_from_block_arg(%row_arg: index) -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
@@ -192,6 +201,50 @@ func.func @no_transform_row_from_block_arg(%src: memref<128x256xf16, #gpu.addres
   %0 = vector.transfer_read %src[%row_arg, %col], %cst
        {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
        : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Memref from function argument (not from alloc) - should NOT transform
+// CHECK-LABEL: func.func @no_transform_memref_from_arg
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_memref_from_arg(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Subview of allocation - should NOT transform
+// Subview may introduce offsets that violate the access pattern requirements.
+// CHECK-LABEL: func.func @no_transform_subview
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_subview() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<256x512xf16, #gpu.address_space<workgroup>>
+  %tid_y = gpu.thread_id y
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %subview = memref.subview %src[%tid_y, 0][128, 256][1, 1]
+      : memref<256x512xf16, #gpu.address_space<workgroup>>
+      to memref<128x256xf16, strided<[512, 1], offset: ?>, #gpu.address_space<workgroup>>
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %subview[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, strided<[512, 1], offset: ?>, #gpu.address_space<workgroup>>, vector<4x1xf16>
   return %0 : vector<4x1xf16>
 }
 
@@ -221,7 +274,8 @@ func.func @no_transform_row_from_block_arg(%src: memref<128x256xf16, #gpu.addres
 // CHECK: %[[LOAD:.+]] = amdgpu.transpose_load %{{.*}}[%[[NEW_ROW]], %[[NEW_COL]]] : memref<128x256xf16, #gpu.address_space<workgroup>> -> vector<4xf16>
 // CHECK: %[[CAST:.+]] = vector.shape_cast %[[LOAD]] : vector<4xf16> to vector<4x1xf16>
 // CHECK: return %[[CAST]]
-func.func @transform_basic_f16_4x1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @transform_basic_f16_4x1() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -240,7 +294,8 @@ func.func @transform_basic_f16_4x1(%src: memref<128x256xf16, #gpu.address_space<
 // CHECK: gpu.lane_id
 // CHECK: amdgpu.transpose_load
 // CHECK: vector.shape_cast
-func.func @transform_row_hint_plus_constant(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @transform_row_hint_plus_constant() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c10 = arith.constant 10 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c10(#iree_gpu.lane_constant<16>) : index
@@ -262,7 +317,8 @@ func.func @transform_row_hint_plus_constant(%src: memref<128x256xf16, #gpu.addre
 // CHECK: gpu.lane_id
 // CHECK: amdgpu.transpose_load
 // CHECK: vector.shape_cast
-func.func @transform_row_affine_apply(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+func.func @transform_row_affine_apply() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c10 = arith.constant 10 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c10(#iree_gpu.lane_constant<16>) : index
@@ -298,7 +354,8 @@ func.func @transform_row_affine_apply(%src: memref<128x256xf16, #gpu.address_spa
 // CHECK: %[[NEW_ROW:.+]] = arith.addi %[[ROW]], %[[DIV2]] : index
 // CHECK: %[[LOAD:.+]] = amdgpu.transpose_load %{{.*}}[%[[NEW_ROW]], %[[NEW_COL]]] : memref<128x256xi8, #gpu.address_space<workgroup>> -> vector<8xi8>
 // CHECK: vector.shape_cast %[[LOAD]] : vector<8xi8> to vector<8x1xi8>
-func.func @transform_i8_8x1(%src: memref<128x256xi8, #gpu.address_space<workgroup>>) -> vector<8x1xi8> {
+func.func @transform_i8_8x1() -> vector<8x1xi8> {
+  %src = memref.alloc() : memref<128x256xi8, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -336,7 +393,8 @@ func.func @transform_i8_8x1(%src: memref<128x256xi8, #gpu.address_space<workgrou
 // CHECK: vector.insert_strided_slice %[[L0]], {{.*}} {offsets = [0], strides = [1]}
 // CHECK: vector.insert_strided_slice %[[L1]], {{.*}} {offsets = [4], strides = [1]}
 // CHECK: vector.shape_cast {{.*}} : vector<8xf16> to vector<8x1xf16>
-func.func @transform_unroll_f16_8x1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<8x1xf16> {
+func.func @transform_unroll_f16_8x1() -> vector<8x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %tid = gpu.thread_id x
   %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
@@ -361,8 +419,9 @@ func.func @transform_unroll_f16_8x1(%src: memref<128x256xf16, #gpu.address_space
 // CHECK-LABEL: func.func @preprocess_delinearize_3d
 // CHECK: amdgpu.transpose_load
 // CHECK: vector.shape_cast
-func.func @preprocess_delinearize_3d(%src: memref<64x128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16>
+func.func @preprocess_delinearize_3d() -> vector<4x1xf16>
     attributes {translation_info = #translation_128} {
+  %src = memref.alloc() : memref<64x128x256xf16, #gpu.address_space<workgroup>>
   %tid = gpu.thread_id x
   // Delinearize into (2, 4, 16): outer results get lane_constant, final gets lane_increment
   %indices:3 = affine.delinearize_index %tid into (2, 4, 16) : index, index, index
@@ -382,7 +441,8 @@ func.func @preprocess_delinearize_3d(%src: memref<64x128x256xf16, #gpu.address_s
 // CHECK-LABEL: func.func @preprocess_delinearize_preexisting_hint
 // CHECK: amdgpu.transpose_load
 // CHECK: vector.shape_cast
-func.func @preprocess_delinearize_preexisting_hint(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %arg: index) -> vector<4x1xf16> {
+func.func @preprocess_delinearize_preexisting_hint(%arg: index) -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   // Pre-existing aligned lane_increment hint on a function argument
   // The pattern should propagate hints through delinearize when aligned=true
   %arg_hinted = iree_codegen.index_hint %arg(#iree_gpu.lane_increment<64, aligned>) : index
@@ -404,7 +464,8 @@ func.func @preprocess_delinearize_preexisting_hint(%src: memref<128x256xf16, #gp
 // CHECK-LABEL: func.func @no_transform_delinearize_nonaligned_hint
 // CHECK-NOT: amdgpu.transpose_load
 // CHECK: vector.transfer_read
-func.func @no_transform_delinearize_nonaligned_hint(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %arg: index) -> vector<4x1xf16> {
+func.func @no_transform_delinearize_nonaligned_hint(%arg: index) -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
   // lane_increment<64> without aligned:
   // - Cannot propagate safely through delinearize
   // - Pattern fails, no hints propagated, blocking transformation
@@ -412,6 +473,37 @@ func.func @no_transform_delinearize_nonaligned_hint(%src: memref<128x256xf16, #g
   %indices:2 = affine.delinearize_index %arg_hinted into (4, 16) : index, index
   %cst = arith.constant 0.0 : f16
   %0 = vector.transfer_read %src[%indices#0, %indices#1], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Tests for reshape operations on allocations
+//===----------------------------------------------------------------------===//
+
+// Test: expand_shape and collapse_shape on allocation - should transform
+// These ops preserve the full view of the allocation, just changing the shape.
+// CHECK-LABEL: func.func @transform_expand_collapse_shape
+// CHECK: amdgpu.transpose_load
+// CHECK: vector.shape_cast
+func.func @transform_expand_collapse_shape() -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
+  %expanded = memref.expand_shape %src [[0, 1], [2]]
+      output_shape [4, 32, 256]
+      : memref<128x256xf16, #gpu.address_space<workgroup>>
+      into memref<4x32x256xf16, #gpu.address_space<workgroup>>
+  %collapsed = memref.collapse_shape %expanded [[0, 1], [2]]
+      : memref<4x32x256xf16, #gpu.address_space<workgroup>>
+      into memref<128x256xf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %collapsed[%row, %col], %cst
        {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
        : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
   return %0 : vector<4x1xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
@@ -1,0 +1,371 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline='builtin.module(func.func(iree-rocdl-load-to-transpose-load))' %s | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Tests for cases where transformation doesn't apply
+//===----------------------------------------------------------------------===//
+
+// Test: Global memory - no transformation (only workgroup memory supported)
+// CHECK-LABEL: func.func @no_transform_global_memory
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_global_memory(%src: memref<128x256xf16>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Column index not from lane_increment hint - no transformation
+// CHECK-LABEL: func.func @no_transform_column_hint_unused
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_column_hint_unused(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %c5 = arith.constant 5 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  // Using constant for column instead of col - NOT valid
+  %0 = vector.transfer_read %src[%row, %c5], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Innermost vector dimension != 1 - no transformation
+// CHECK-LABEL: func.func @no_transform_column_size_not_1
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_column_size_not_1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x2xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x2xf16>
+  return %0 : vector<4x2xf16>
+}
+
+// -----
+
+// Test: Unsupported element type (f32) - no transformation
+// CHECK-LABEL: func.func @no_transform_f32
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_f32(%src: memref<128x256xf32, #gpu.address_space<workgroup>>) -> vector<4x1xf32> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f32
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf32, #gpu.address_space<workgroup>>, vector<4x1xf32>
+  return %0 : vector<4x1xf32>
+}
+
+// -----
+
+// Test: Row size not multiple of intrinsic size - no transformation
+// CHECK-LABEL: func.func @no_transform_non_multiple_row_size
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_non_multiple_row_size(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<3x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<3x1xf16>
+  return %0 : vector<3x1xf16>
+}
+
+// -----
+
+// Test: Column index with lane_increment step > 1 - no transformation
+// transpose_load requires column indices to be consecutive (step=1)
+// CHECK-LABEL: func.func @no_transform_column_step_not_1
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_column_step_not_1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  // Column hint has step=2, which is not supported for transpose_load
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, step = 2, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Column index with lane_increment group_size < 16 - no transformation
+// transpose_load operates on 16-lane groups, so group_size must be >= 16
+// CHECK-LABEL: func.func @no_transform_column_group_size_too_small
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_column_group_size_too_small(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  // Column hint has group_size=8, which is too small for transpose_load
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<8, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Row index with lane_constant group_size not a multiple of 16 - no transformation
+// transpose_load requires row uniformity within 16-lane groups
+// CHECK-LABEL: func.func @no_transform_row_group_size_not_multiple
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_row_group_size_not_multiple(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  // Row hint has group_size=20, which is not a multiple of 16
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<20>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Tests for row index validation - row index must be uniform across 16 lanes
+//===----------------------------------------------------------------------===//
+
+// Test: Row index from lane_increment hint (varies across lanes) - should NOT transform
+// CHECK-LABEL: func.func @no_transform_row_from_column_hint
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_row_from_column_hint(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  // Row from col (lane_increment - varies across lanes) - INVALID
+  %0 = vector.transfer_read %src[%col, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Row index from block argument (unknown provenance) - should NOT transform
+// CHECK-LABEL: func.func @no_transform_row_from_block_arg
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_row_from_block_arg(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %row_arg: index) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  // Row from function argument - could vary per thread
+  %0 = vector.transfer_read %src[%row_arg, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Tests for successful transformation
+//===----------------------------------------------------------------------===//
+
+// Test: Basic f16 4x1 transformation - row from lane_constant, column from lane_increment
+// CHECK-LABEL: func.func @transform_basic_f16_4x1
+// CHECK: %[[LOAD:.+]] = amdgpu.transpose_load %{{.*}}[%{{.*}}] : memref<128x256xf16, #gpu.address_space<workgroup>> -> vector<4xf16>
+// CHECK: %[[CAST:.+]] = vector.shape_cast %[[LOAD]] : vector<4xf16> to vector<4x1xf16>
+// CHECK: return %[[CAST]]
+func.func @transform_basic_f16_4x1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Row index through arith ops (hint + constant) - should transform
+// CHECK-LABEL: func.func @transform_row_hint_plus_constant
+// CHECK: gpu.lane_id
+// CHECK: amdgpu.transpose_load
+// CHECK: vector.shape_cast
+func.func @transform_row_hint_plus_constant(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c10 = arith.constant 10 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c10(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  // Row is row + constant offset
+  %c5 = arith.constant 5 : index
+  %row_plus = arith.addi %row, %c5 : index
+  %0 = vector.transfer_read %src[%row_plus, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Row index through affine.apply - should transform
+// CHECK-LABEL: func.func @transform_row_affine_apply
+// CHECK: gpu.lane_id
+// CHECK: amdgpu.transpose_load
+// CHECK: vector.shape_cast
+func.func @transform_row_affine_apply(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16> {
+  %c10 = arith.constant 10 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c10(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  // Row uses affine.apply on row
+  %row_affine = affine.apply affine_map<(d0) -> (d0 * 4 + 8)>(%row)
+  %0 = vector.transfer_read %src[%row_affine, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: i8 8x1 transformation (intrinsic size 8 for 8-bit types)
+// CHECK-LABEL: func.func @transform_i8_8x1
+// CHECK: amdgpu.transpose_load
+// CHECK-SAME: -> vector<8xi8>
+// CHECK: vector.shape_cast
+func.func @transform_i8_8x1(%src: memref<128x256xi8, #gpu.address_space<workgroup>>) -> vector<8x1xi8> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %c0_i8 = arith.constant 0 : i8
+  %0 = vector.transfer_read %src[%row, %col], %c0_i8
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xi8, #gpu.address_space<workgroup>>, vector<8x1xi8>
+  return %0 : vector<8x1xi8>
+}
+
+// -----
+
+// Test: f16 8x1 unrolling (2x transpose_load when row size > intrinsic size)
+// CHECK-LABEL: func.func @transform_unroll_f16_8x1
+// CHECK: %[[L0:.+]] = amdgpu.transpose_load {{.*}} -> vector<4xf16>
+// CHECK: %[[L1:.+]] = amdgpu.transpose_load {{.*}} -> vector<4xf16>
+// CHECK: vector.insert_strided_slice %[[L0]], {{.*}} {offsets = [0], strides = [1]}
+// CHECK: vector.insert_strided_slice %[[L1]], {{.*}} {offsets = [4], strides = [1]}
+// CHECK: vector.shape_cast {{.*}} : vector<8xf16> to vector<8x1xf16>
+func.func @transform_unroll_f16_8x1(%src: memref<128x256xf16, #gpu.address_space<workgroup>>) -> vector<8x1xf16> {
+  %c0 = arith.constant 0 : index
+  %tid = gpu.thread_id x
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %col = iree_codegen.index_hint %tid(#iree_gpu.lane_increment<16, aligned>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<8x1xf16>
+  return %0 : vector<8x1xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Tests for preprocessing: seeding hints on thread_id and propagating through delinearize
+//===----------------------------------------------------------------------===//
+
+// Test: 3-element delinearize_index from thread_id gets hints with correct group sizes
+// With workgroup_size = [128, 1, 1], thread_id x gets lane_increment<128>
+// For basis (2, 4, 16): result #0 gets lane_constant<64>, result #1 gets lane_constant<16>, result #2 gets lane_increment<16>
+#translation_128 = #iree_codegen.translation_info<pipeline = LLVMGPUDefault workgroup_size = [128, 1, 1]>
+// CHECK-LABEL: func.func @preprocess_delinearize_3d
+// CHECK: amdgpu.transpose_load
+// CHECK: vector.shape_cast
+func.func @preprocess_delinearize_3d(%src: memref<64x128x256xf16, #gpu.address_space<workgroup>>) -> vector<4x1xf16>
+    attributes {translation_info = #translation_128} {
+  %tid = gpu.thread_id x
+  // Delinearize into (2, 4, 16): outer results get lane_constant, final gets lane_increment
+  %indices:3 = affine.delinearize_index %tid into (2, 4, 16) : index, index, index
+  %cst = arith.constant 0.0 : f16
+  // Row indices are first two results (uniform), col is third result (varies)
+  %0 = vector.transfer_read %src[%indices#0, %indices#1, %indices#2], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>}
+       : memref<64x128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Pre-existing aligned lane_increment hint on non-thread_id value with delinearize
+// This tests the pattern propagation when hints come from sources other than seeding.
+// The hint must have `aligned` for propagation to produce useful hints.
+// CHECK-LABEL: func.func @preprocess_delinearize_preexisting_hint
+// CHECK: amdgpu.transpose_load
+// CHECK: vector.shape_cast
+func.func @preprocess_delinearize_preexisting_hint(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %arg: index) -> vector<4x1xf16> {
+  // Pre-existing aligned lane_increment hint on a function argument
+  // The pattern should propagate hints through delinearize when aligned=true
+  %arg_hinted = iree_codegen.index_hint %arg(#iree_gpu.lane_increment<64, aligned>) : index
+  %indices:2 = affine.delinearize_index %arg_hinted into (4, 16) : index, index
+  %cst = arith.constant 0.0 : f16
+  // After propagation: result #0 gets lane_constant<16>, result #1 gets lane_increment<16, aligned>
+  %0 = vector.transfer_read %src[%indices#0, %indices#1], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
+// Test: Non-aligned lane_increment hint blocks propagation
+// When lane_increment does NOT have `aligned`, we cannot safely propagate
+// through delinearize because the modulo may cause wrap-around within a lane
+// group. The pattern returns failure, leaving the original hints unchanged.
+// CHECK-LABEL: func.func @no_transform_delinearize_nonaligned_hint
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_delinearize_nonaligned_hint(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %arg: index) -> vector<4x1xf16> {
+  // lane_increment<64> without aligned:
+  // - Cannot propagate safely through delinearize
+  // - Pattern fails, no hints propagated, blocking transformation
+  %arg_hinted = iree_codegen.index_hint %arg(#iree_gpu.lane_increment<64>) : index
+  %indices:2 = affine.delinearize_index %arg_hinted into (4, 16) : index, index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%indices#0, %indices#1], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}


### PR DESCRIPTION
This pass identifies contiguous vector loads that can benefit from AMD's transpose load instruction, which provides better memory access patterns for certain GPU workloads.

The pass works in two phases:
1. Hint injection: Seeds thread ID values with lane hints and propagates these hints through arithmetic operations. Just affine.delinearize_index ops for now, but could be extended in the future.
2. Load transformation: Analyzes load operations to determine if indices follow a pattern suitable for transpose loads (consecutive lanes accessing consecutive memory with appropriate strides).

For now, this is not enabled for 6 bit or 4 bit types, since we have no real usecase for them and they would not be tested. However, the logic should work the same for those types. We just need use cases to test with.

Key components:
- LaneIncrementAttr: Indicates an index value that increments by a fixed amount within lane groups, with optional step and aligned parameters
- LaneConstantAttr: Indicates an index value that is constant within lane groups
- Pattern-based hint propagation through various ops including arith.addi, arith.muli, arith.divui/divsi, arith.remui/remsi, and affine.delinearize_index
- Validation of lane hint parameters (group_size, step must be positive and powers of 2)

The aligned field on LaneIncrementAttr tracks whether the base value at lane 0 is guaranteed to be a multiple of the group size, which is required for safe propagation through delinearize operations.