### PR TITLE
[CI] update onnx_model ci to use huggingface token

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -204,3 +204,5 @@ jobs:
               --timeout=120 \
               --durations=0 \
               --test-config-file=${CONFIG_FILE_PATH}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
Add a huggingface token to env to authenticate requests made to huggingface, avoiding unnecessary rate limitations. This will be used in onnx_model tests after https://github.com/iree-org/iree-test-suites/pull/142/ is merged.