### PR TITLE
[CI] Add MI355 e2e tests

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -58,6 +58,12 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi325')
     uses: ./.github/workflows/pkgci_test_amd_mi325.yml
 
+  test_amd_mi355:
+    name: Test AMD MI355
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi355')
+    uses: ./.github/workflows/pkgci_test_amd_mi355.yml
+
   test_amd_w7900:
     name: Test AMD W7900
     needs: [setup, build_packages]

--- a/.github/workflows/pkgci_test_amd_mi355.yml
+++ b/.github/workflows/pkgci_test_amd_mi355.yml
@@ -1,0 +1,97 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: PkgCI Test AMD MI355
+permissions:
+  contents: read
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+
+jobs:
+  test_mi355:
+    runs-on: linux-mi35x-1gpu-ossci-iree-org
+    timeout-minutes: 60
+    env:
+      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
+      BUILD_DIR: build-tests
+      VENV_DIR: ${{ github.workspace }}/.venv
+      GH_TOKEN: ${{ github.token }}
+      IREE_CPU_DISABLE: 1
+      IREE_VULKAN_DISABLE: 1
+      IREE_CUDA_ENABLE: 0
+      IREE_HIP_ENABLE: 1
+      IREE_HIP_TEST_TARGET_CHIP: "gfx950"
+    container:
+      image: rocm/dev-ubuntu-22.04:7.1.1-complete
+      options: --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git cmake ninja-build
+      - name: Configure git
+        run: git config --global --add safe.directory '*'
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: false
+      - name: Check out runtime submodules
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        if: ${{ inputs.artifact_run_id == '' }}
+        with:
+          name: linux_x86_64_release_packages
+          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Setup base venv
+        run: |
+          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
+            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
+            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Display environment info
+        run: |
+          echo "=== ROCm Version ==="
+          cat /opt/rocm/.info/version || echo "version file not found"
+          echo ""
+          echo "=== Kernel Version ==="
+          uname -r
+          echo ""
+          echo "=== rocminfo ==="
+          rocminfo || echo "rocminfo not available"
+      - name: Build tests
+        run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin
+      - name: Run GPU tests
+        env:
+          CTEST_PARALLEL_LEVEL: 2
+          IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
+          IREE_AMD_CDNA3_TESTS_DISABLE: 1
+          IREE_AMD_CDNA4_TESTS_DISABLE: 0
+          IREE_AMD_RDNA3_TESTS_DISABLE: 1
+          IREE_NVIDIA_GPU_TESTS_DISABLE: 0
+          IREE_NVIDIA_SM80_TESTS_DISABLE: 1
+          IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          # TODO: Enable HIP CTS tests (iree/hal/drivers/hip/cts)
+          IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE: "^iree/hal/drivers/hip/cts"
+        run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -44,6 +44,8 @@ export IREE_NVIDIA_SM80_TESTS_DISABLE="${IREE_NVIDIA_SM80_TESTS_DISABLE:-1}"
 export IREE_AMD_CDNA3_TESTS_DISABLE="${IREE_AMD_CDNA3_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require RDNA3 AMD GPU.
 export IREE_AMD_RDNA3_TESTS_DISABLE="${IREE_AMD_RDNA3_TESTS_DISABLE:-1}"
+# Respect the user setting, but default to skipping tests that require CDNA4 AMD GPU.
+export IREE_AMD_CDNA4_TESTS_DISABLE="${IREE_AMD_CDNA4_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require RDNA4 AMD GPU.
 export IREE_AMD_RDNA4_TESTS_DISABLE="${IREE_AMD_RDNA4_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require more than one device(GPU).
@@ -100,6 +102,9 @@ if (( IREE_NVIDIA_SM80_TESTS_DISABLE == 1 )); then
 fi
 if (( IREE_AMD_CDNA3_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-cdna3$")
+fi
+if (( IREE_AMD_CDNA4_TESTS_DISABLE == 1 )); then
+  label_exclude_args+=("^requires-gpu-cdna4$")
 fi
 if (( IREE_AMD_RDNA3_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-rdna3$")


### PR DESCRIPTION
This contains two commits, only review the last one as the first one contains a fix for a compilation issue from: https://github.com/iree-org/iree/pull/23110

**Note:** The cts tests are being skipped as they are failing on the ossci runner. They're functional locally on a MI355 machine, so this needs further debugging on the specific setup of the ossci machines. In the meantime, it's worthwhile to land this already to avoid regressions.