### PR TITLE
[Codegen] Fix shared memory overflow for accumulating scaled matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -30,78 +31,6 @@ namespace mlir::iree_compiler {
 
 #define GEN_PASS_DEF_CONVERTACCGEMMTOGEMMPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
-
-// Get the `iree_tensor_ext.dispatch.tensor.load` that this value is
-// populated with. This could potentially walk the use-def chain to get the load
-// operation, but for now it just returns the load op if that is the defining
-// operation for `v`.
-template <typename LoadOpTy>
-std::optional<LoadOpTy> getLoadOp(Value v) {
-  auto loadOp = v.getDefiningOp<LoadOpTy>();
-  if (loadOp) {
-    return loadOp;
-  }
-  return std::nullopt;
-}
-
-// Get the `iree_tensor_ext.dispatch.tensor.store` that this value is
-// populated writes to. This could potentially walk the use-def chain of DPS
-// init operands to get the store operation, but for now it just returns the
-// store op if the result has a single use and that use is the store op.
-template <typename StoreOpTy>
-std::optional<StoreOpTy> getStoreOp(Value v) {
-  if (v.getNumUses() != 1) {
-    return std::nullopt;
-  }
-  auto storeOp = dyn_cast<StoreOpTy>(*(v.getUsers().begin()));
-  if (storeOp) {
-    return storeOp;
-  }
-  return std::nullopt;
-}
-
-// Check if the init value of the operation is read/write from the same buffer.
-// If not, it is invalid to use an accumulating GEMM operation, and convert it
-// to a non-accumulating GEMM.
-static bool isValidInPlaceAccumulatingOp(DestinationStyleOpInterface dpsOp) {
-  assert(dpsOp.getNumDpsInits() == 1 &&
-         "expected op to have a single outs operand");
-  OpOperand *initValue = dpsOp.getDpsInitOperand(0);
-
-  // Case 1. Check for the case when reading/writing from the same buffer
-  // through `iree_codegen.load_from_buffer`/`iree_codegen.store_to_buffer`.
-  {
-    std::optional<IREE::Codegen::LoadFromBufferOp> loadOp =
-        getLoadOp<IREE::Codegen::LoadFromBufferOp>(initValue->get());
-    std::optional<IREE::Codegen::StoreToBufferOp> storeOp =
-        getStoreOp<IREE::Codegen::StoreToBufferOp>(dpsOp->getResult(0));
-    if (loadOp && storeOp && loadOp->getBuffer() == storeOp->getBuffer()) {
-      return true;
-    }
-  }
-
-  // Case 2. If the `outs` operand is from a read-write buffer, and the result
-  // is writing into the same buffer, do not convert to a non-accumulating gemm.
-  // This currently would only work for very simple cases, but could be
-  // generalized further.
-  {
-    std::optional<IREE::TensorExt::DispatchTensorLoadOp> initLoadOp =
-        getLoadOp<IREE::TensorExt::DispatchTensorLoadOp>(initValue->get());
-    std::optional<IREE::TensorExt::DispatchTensorStoreOp> resultStoreOp =
-        getStoreOp<IREE::TensorExt::DispatchTensorStoreOp>(dpsOp->getResult(0));
-    if (initLoadOp && resultStoreOp && initLoadOp->getSource() &&
-        resultStoreOp->getTarget()) {
-      // Check that the source and the result have a read/write tag. If they
-      // don't then its really a bug in the way the dispatch is formed, but
-      // check here for safety.
-      if (initLoadOp->getSourceType().getAccess() ==
-          IREE::TensorExt::TensorAccess::ReadWrite) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
 
 static bool accGemmToGemmPrecondition(Operation *op) {
   if (auto innerTiledOp = dyn_cast<IREE::Codegen::InnerTiledOp>(op)) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -681,6 +681,11 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
                              transposedLhs, transposedRhs);
       int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
           schedule, lhsBitwidth, rhsBitwidth, problem.numHorizontallyFusedOps);
+      // Add accumulator/result memory when it uses shared memory (LDS):
+      // - Result needs padding in shared memory, OR
+      // - matmul_accumulate loads accumulator from global memory via shared mem
+      // For zero-initialized GEMMs without C promotion, the accumulator stays
+      // in registers and doesn't need shared memory.
       if (doCPromotion) {
         sharedMemoryUsed += calculateResultSharedMemoryUsedInBytes(
             schedule, resultBitwidth, problem.numHorizontallyFusedOps);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -141,6 +141,9 @@ struct GPUMMASchedule {
 
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
+/// When |doCPromotion| is true, the accumulator uses shared memory. This can be
+/// due to padding requirements or because the operation has an existing
+/// accumulator that needs to be loaded from global memory (matmul_accumulate).
 FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMatmulShapeType &problem, ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.h"
@@ -2216,6 +2217,77 @@ std::optional<SmallVector<int64_t>> getCopyTileSizes(linalg::CopyOp copyOp) {
     }
   }
   return tileSizes;
+}
+
+//===----------------------------------------------------------------------===//
+// Utility functions for accumulating operations
+//===----------------------------------------------------------------------===//
+
+// Get the `iree_tensor_ext.dispatch.tensor.load` that this value is
+// populated with. This could potentially walk the use-def chain to get the load
+// operation, but for now it just returns the load op if that is the defining
+// operation for `v`.
+template <typename LoadOpTy>
+static std::optional<LoadOpTy> getLoadOp(Value v) {
+  if (auto loadOp = v.getDefiningOp<LoadOpTy>()) {
+    return loadOp;
+  }
+  return std::nullopt;
+}
+
+// Get the `iree_tensor_ext.dispatch.tensor.store` that this value is
+// populated writes to. This could potentially walk the use-def chain of DPS
+// init operands to get the store operation, but for now it just returns the
+// store op if the result has a single use and that use is the store op.
+template <typename StoreOpTy>
+static std::optional<StoreOpTy> getStoreOp(Value v) {
+  if (v.getNumUses() != 1) {
+    return std::nullopt;
+  }
+  if (auto storeOp = dyn_cast<StoreOpTy>(*(v.getUsers().begin()))) {
+    return storeOp;
+  }
+  return std::nullopt;
+}
+
+bool isValidInPlaceAccumulatingOp(DestinationStyleOpInterface dpsOp) {
+  assert(dpsOp.getNumDpsInits() == 1 &&
+         "expected op to have a single outs operand");
+  OpOperand *initValue = dpsOp.getDpsInitOperand(0);
+
+  // Case 1. Check for the case when reading/writing from the same buffer
+  // through `iree_codegen.load_from_buffer`/`iree_codegen.store_to_buffer`.
+  {
+    std::optional<IREE::Codegen::LoadFromBufferOp> loadOp =
+        getLoadOp<IREE::Codegen::LoadFromBufferOp>(initValue->get());
+    std::optional<IREE::Codegen::StoreToBufferOp> storeOp =
+        getStoreOp<IREE::Codegen::StoreToBufferOp>(dpsOp->getResult(0));
+    if (loadOp && storeOp && loadOp->getBuffer() == storeOp->getBuffer()) {
+      return true;
+    }
+  }
+
+  // Case 2. If the `outs` operand is from a read-write buffer, and the result
+  // is writing into the same buffer, do not convert to a non-accumulating gemm.
+  // This currently would only work for very simple cases, but could be
+  // generalized further.
+  {
+    std::optional<IREE::TensorExt::DispatchTensorLoadOp> initLoadOp =
+        getLoadOp<IREE::TensorExt::DispatchTensorLoadOp>(initValue->get());
+    std::optional<IREE::TensorExt::DispatchTensorStoreOp> resultStoreOp =
+        getStoreOp<IREE::TensorExt::DispatchTensorStoreOp>(dpsOp->getResult(0));
+    if (initLoadOp && resultStoreOp && initLoadOp->getSource() &&
+        resultStoreOp->getTarget()) {
+      // Check that the source and the result have a read/write tag. If they
+      // don't then its really a bug in the way the dispatch is formed, but
+      // check here for safety.
+      if (initLoadOp->getSourceType().getAccess() ==
+          IREE::TensorExt::TensorAccess::ReadWrite) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -434,6 +434,21 @@ bool neverRunsSecondIteration(scf::ForOp op);
 bool hasExternalCapture(linalg::GenericOp genericOp);
 
 //===----------------------------------------------------------------------===//
+// Utility functions for accumulating operations
+//===----------------------------------------------------------------------===//
+
+/// Check if the init value of the DPS operation is read/write from the same
+/// buffer. This determines whether the operation is a valid in-place
+/// accumulating op. For GEMMs:
+/// - Returns true: The GEMM reads and writes to the same buffer
+/// (matmul_accumulate)
+///   The accumulator needs to be loaded from global memory.
+/// - Returns false: The GEMM will be converted to a non-accumulating GEMM + add
+///   by ConvertAccGEMMToGEMMPass, and the accumulator can be zero-initialized
+///   in registers.
+bool isValidInPlaceAccumulatingOp(DestinationStyleOpInterface dpsOp);
+
+//===----------------------------------------------------------------------===//
 // Utility functions for copy operations
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This resolves: https://github.com/iree-org/iree/issues/22992

We're seeing a shared memory usage failure in the e2e tests for scaled accumulating matmuls when targeting gfx950 which isn't catched as this is not checked in CI (see this PR for that: https://github.com/iree-org/iree/pull/23090). This PR fixes this by taking the shared memory usage for this into when applicable.

Sweep of failing matmul_accumulate shapes and selected tile sizes and effect on LDS allocation **(before this PR)**:

| M | N | Workgroup Tiles | Acc Size | Total Est. | Result |
|---|---|-----------------|----------|------------|--------|
| 128 | 128 | 32×32 | 4 KB | ~8 KB | ✅ OK |
| 128 | 256 | 32×32 | 4 KB | ~8 KB | ✅ OK |
| 128 | 384 | 128×128 | 64 KB | ~81 KB | ✅ OK |
| 128 | 512 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 128 | 768 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 128 | 1024 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 256 | 128 | 32×32 | 4 KB | ~8 KB | ✅ OK |
| **256** | **256** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 256 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **256** | **512** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **256** | **768** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **256** | **1024** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 384 | 128 | 128×128 | 64 KB | ~81 KB | ✅ OK |
| 384 | 256 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 384 | 384 | 128×128 | 64 KB | ~81 KB | ✅ OK |
| 384 | 512 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 384 | 768 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 384 | 1024 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 512 | 128 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **512** | **256** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 512 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **512** | **512** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **512** | **768** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **512** | **1024** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 768 | 128 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **768** | **256** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 768 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **768** | **512** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **768** | **768** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **768** | **1024** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 1024 | 128 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **1024** | **256** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| 1024 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| **1024** | **512** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **1024** | **768** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |
| **1024** | **1024** | **256×256** | **256 KB** | **~290 KB** | ❌ FAIL |

With this PR:
| M | N | Workgroup Tiles | Acc Size | Total Est. | Result |
|---|---|-----------------|----------|------------|--------|
| 128 | 128 | 32×32 | 4 KB | ~8 KB | ✅ OK |
| 128 | 256 | 32×32 | 4 KB | ~8 KB | ✅ OK |
| 128 | 384 | 128×128 | 64 KB | ~81 KB | ✅ OK |
| 128 | 512 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 128 | 768 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 128 | 1024 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 256 | 128 | 32×32 | 4 KB | ~8 KB | ✅ OK |
| 256 | 256 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 256 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 256 | 512 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 256 | 768 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 256 | 1024 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 384 | 128 | 128×128 | 64 KB | ~81 KB | ✅ OK |
| 384 | 256 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 384 | 384 | 128×128 | 64 KB | ~81 KB | ✅ OK |
| 384 | 512 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 384 | 768 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 384 | 1024 | 128×256 | 128 KB | ~153 KB | ✅ OK |
| 512 | 128 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 512 | 256 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 512 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 512 | 512 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 512 | 768 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 512 | 1024 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 768 | 128 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 768 | 256 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 768 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 768 | 512 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 768 | 768 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 768 | 1024 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 1024 | 128 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 1024 | 256 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 1024 | 384 | 256×128 | 128 KB | ~153 KB | ✅ OK |
| 1024 | 512 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 1024 | 768 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
| 1024 | 1024 | **128×256** | **128 KB** | ~153 KB | ✅ OK |
