### PR TITLE
Adding iree-tokenize --json_string flag.

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -241,6 +241,7 @@ iree_runtime_cc_binary(
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/base/internal:json",
         "//runtime/src/iree/base/internal:unicode",
         "//runtime/src/iree/io:file_handle",
         "//runtime/src/iree/tokenizer",

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -265,6 +265,7 @@ iree_cc_binary(
   DEPS
     iree::base
     iree::base::internal::flags
+    iree::base::internal::json
     iree::base::internal::unicode
     iree::io::file_handle
     iree::tokenizer::tokenizer

--- a/tools/test/iree-tokenize.txt
+++ b/tools/test/iree-tokenize.txt
@@ -2,7 +2,9 @@
 // RUN:   FileCheck %s --check-prefix=BASIC
 // RUN: iree-tokenize %p/iree-tokenize.json --no_special "hello" | \
 // RUN:   FileCheck %s --check-prefix=NOSPEC
-// RUN: iree-tokenize %p/iree-tokenize.json "日本語テスト" | \
+// Unicode test: 日本語テスト (Japanese: "Japanese language test")
+// Uses --json_string with \u escapes for Windows portability.
+// RUN: iree-tokenize %p/iree-tokenize.json --json_string "\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8" | \
 // RUN:   FileCheck %s --check-prefix=UNICODE
 // RUN: iree-tokenize %p/iree-tokenize.json --info | \
 // RUN:   FileCheck %s --check-prefix=INFO


### PR DESCRIPTION
This interprets the input as a JSON-encoded string, supporting \uXXXX escape sequences. These escapes are pure ASCII and work identically across all platforms.

The test now uses:
```
iree-tokenize tokenizer.json --json_string "\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8"
```
instead of literal Japanese characters.

This reuses the existing iree_json_unescape_string() function from iree/base/internal/json.h, which already handles all RFC 8259 escape sequences including surrogate pairs for characters outside the BMP.

This was required to work around the Windows sadness sandwich of powershell/cmd/lit/python/C that all come together in the tool smoketest.