### PR TITLE
[LinalgExt] Add OuterReduction tiling strategy for ArgCompareOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -752,18 +752,20 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     returning both the selected value and its corresponding index. The selection
     logic is defined by a user-specified comparator region.
 
-    The operation supports two modes:
+    The operation supports three index modes for flexibility in tiling:
 
-    1. Implicit-index mode (single input): Computes (value, index) pairs from scratch.
-       Indices are implicitly computed from the reduction dimension's iteration index
-       (using linalg.index on the reduction dimension). The comparator
-       region receives two candidate values and returns a single `i1` result indicating
-       whether the first argument should be preferred.
+    1. Implicit-index without index_base (single input, no index_base):
+       Indices are computed from local position (linalg.index on reduction dimension).
+       Used for untiled operations or when global offset is not needed.
 
-    2. Explicit-index mode (two inputs): Reduces existing (value, index) pairs.
-       Indices are explicitly provided as input. The comparator region receives
-       two candidate values and returns `i1` to select the preferred value.
-       This mode is used to combine results from split-reduction operations.
+    2. Implicit-index with index_base (single input, with index_base):
+       Indices are computed as: index_base + local position.
+       Used in OuterParallel tiling where each parallel chunk has a fixed offset.
+
+    3. Explicit-index (two inputs: values + indices, no index_base):
+       Indices are provided as input tensor alongside values.
+       Used in OuterReduction tiling and merge operations where indices are
+       accumulated across iterations.
 
     The comparator region defines the sorting rule, e.g., "greater than" for argmax or
     "less than" for argmin, allowing for generalization beyond simple argmax-style

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -2013,8 +2013,7 @@ ArgCompareOp::mergeReductions(OpBuilder &b, Location loc,
       /*index_base=*/nullptr,
       /*dimension=*/reductionDim);
 
-  // Clone the comparator region from the original operRegion &targetRegion =
-  // mergeOp.getRegion();
+  // Clone the comparator region from the original operation.
   Region &targetRegion = mergeOp->getRegion(0);
   Region &sourceRegion = getRegion();
   IRMapping mapper;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1716,6 +1716,209 @@ ArgCompareOp::generateInitialTensorForPartialReduction(
                             indexBroadcastOp->getResult(0)};
 }
 
+// Helper function to create a tiled operation for the OuterReduction strategy.
+//
+// OuterReduction uses scf.for with iter_args to accumulate results across
+// iterations. Within each iteration, we perform element-wise comparisons (not
+// reductions), so we always use linalg.generic. The only difference between
+// explicit and implicit-index modes is whether indices come from the input
+// tensor or are computed from the tile offset.
+static std::pair<Operation *, SmallVector<Operation *>>
+createTiledOpForOuterReduction(ArgCompareOp op, OpBuilder &b, Location loc,
+                               ValueRange init, ArrayRef<OpFoldResult> offsets,
+                               SmallVector<Value> &tiledOperands,
+                               int64_t reductionDim, int64_t rank,
+                               bool isExplicitIndexMode) {
+  SmallVector<Operation *> slices;
+  Value initValResult = init[0];
+  Value initIdxResult = init[1];
+
+  SmallVector<Type, 2> resultTypes;
+  if (op.hasPureTensorSemantics()) {
+    resultTypes = {initValResult.getType(), initIdxResult.getType()};
+  }
+
+  // For OuterReduction, we always use linalg.generic to perform element-wise
+  // comparison, regardless of index mode. The difference is just how we obtain
+  // the indices: from input (explicit) or computed (implicit).
+  AffineMap identityMap = b.getMultiDimIdentityMap(rank);
+
+  // Base setup: input_value, accum_value, accum_index.
+  SmallVector<AffineMap> indexingMaps = {identityMap, identityMap, identityMap};
+  SmallVector<Value> inputs = {tiledOperands[0]};
+
+  if (isExplicitIndexMode) {
+    // Explicit-index mode: Also read indices from the sliced input_index
+    // tensor.
+    indexingMaps.push_back(identityMap);
+    inputs.push_back(tiledOperands[1]);
+  }
+
+  SmallVector<utils::IteratorType> iterators(rank,
+                                             utils::IteratorType::parallel);
+
+  auto genericOp = linalg::GenericOp::create(
+      b, loc, TypeRange{initValResult.getType(), initIdxResult.getType()},
+      inputs, ValueRange{initValResult, initIdxResult}, indexingMaps, iterators,
+      [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
+        Value newVal, accVal, accIdx, newIdx;
+
+        newVal = args[0];
+        if (isExplicitIndexMode) {
+          // Args: [input_value, input_index, accum_value, accum_index].
+          newIdx = args[1];
+          accVal = args[2];
+          accIdx = args[3];
+        } else {
+          // Args: [input_value, accum_value, accum_index].
+          accVal = args[1];
+          accIdx = args[2];
+
+          // Compute the global index for this element.
+          Value localIdx =
+              linalg::IndexOp::create(nestedBuilder, nestedLoc, reductionDim);
+          Value offsetValue = getValueOrCreateConstantIndexOp(
+              nestedBuilder, nestedLoc, offsets[reductionDim]);
+          Value globalIdx = arith::AddIOp::create(nestedBuilder, nestedLoc,
+                                                  offsetValue, localIdx);
+
+          if (Value indexBase = op.getIndexBase()) {
+            globalIdx = arith::AddIOp::create(nestedBuilder, nestedLoc,
+                                              indexBase, globalIdx);
+          }
+
+          // Cast to match the output index tensor's element type.
+          Type idxElemType = accIdx.getType();
+          newIdx = globalIdx;
+          if (!isa<IndexType>(idxElemType)) {
+            newIdx = arith::IndexCastOp::create(nestedBuilder, nestedLoc,
+                                                idxElemType, globalIdx);
+          }
+        }
+
+        // Clone the user's comparison logic to decide whether to update.
+        Block &originalBlock = op.getRegion().front();
+        IRMapping mapper;
+        mapper.map(originalBlock.getArgument(0), newVal);
+        mapper.map(originalBlock.getArgument(1), accVal);
+        for (Operation &innerOp : originalBlock) {
+          if (innerOp.hasTrait<OpTrait::IsTerminator>()) {
+            break;
+          }
+          nestedBuilder.clone(innerOp, mapper);
+        }
+
+        Value predicate =
+            mapper.lookup(originalBlock.getTerminator()->getOperand(0));
+        Value selectedVal = arith::SelectOp::create(nestedBuilder, nestedLoc,
+                                                    predicate, newVal, accVal);
+        Value selectedIdx = arith::SelectOp::create(nestedBuilder, nestedLoc,
+                                                    predicate, newIdx, accIdx);
+        linalg::YieldOp::create(nestedBuilder, nestedLoc,
+                                ValueRange{selectedVal, selectedIdx});
+      });
+
+  return {genericOp, slices};
+}
+
+// Helper function to create a tiled operation for the OuterParallel strategy.
+//
+// OuterParallel uses scf.forall with parallel_insert_slice where each parallel
+// iteration handles an independent chunk of the reduction dimension. Each chunk
+// performs a complete reduction and writes its result to a specific slot in the
+// output. Unlike OuterReduction, we can use ArgCompareOp for both index modes
+// because each chunk has a fixed offset that can be baked into index_base.
+static std::pair<Operation *, SmallVector<Operation *>>
+createTiledOpForOuterParallel(ArgCompareOp op, OpBuilder &b, Location loc,
+                              ValueRange init, ArrayRef<OpFoldResult> offsets,
+                              ArrayRef<OpFoldResult> sizes,
+                              ArrayRef<OpFoldResult> splitReductionIvs,
+                              SmallVector<Value> &tiledOperands,
+                              int64_t reductionDim, int64_t rank,
+                              bool isExplicitIndexMode) {
+  SmallVector<Operation *> slices;
+
+  // Extract a slice of the output for this parallel chunk.
+  SmallVector<OpFoldResult> initOffsets, initSizes, initStrides;
+  for (int64_t i = 0; i < rank; ++i) {
+    if (i == reductionDim) {
+      initOffsets.push_back(splitReductionIvs[0]);
+      initSizes.push_back(b.getIndexAttr(1));
+    } else {
+      initOffsets.push_back(offsets[i]);
+      initSizes.push_back(sizes[i]);
+    }
+    initStrides.push_back(b.getIndexAttr(1));
+  }
+
+  SmallVector<int64_t> resultValShape, resultIdxShape;
+  for (int64_t i = 0; i < rank; ++i) {
+    if (i == reductionDim) {
+      continue;
+    }
+    int64_t size =
+        getConstantIntValue(initSizes[i]).value_or(ShapedType::kDynamic);
+    resultValShape.push_back(size);
+    resultIdxShape.push_back(size);
+  }
+
+  auto sliceValResultType = RankedTensorType::get(
+      resultValShape, op.getOutputValueType().getElementType());
+  auto sliceIdxResultType =
+      RankedTensorType::get(resultIdxShape, op.getOutputIndexElementType());
+
+  auto initValSlice = tensor::ExtractSliceOp::create(
+      b, loc, sliceValResultType, init[0], initOffsets, initSizes, initStrides);
+  slices.push_back(initValSlice);
+
+  auto initIdxSlice = tensor::ExtractSliceOp::create(
+      b, loc, sliceIdxResultType, init[1], initOffsets, initSizes, initStrides);
+  slices.push_back(initIdxSlice);
+
+  Value initValResult = initValSlice.getResult();
+  Value initIdxResult = initIdxSlice.getResult();
+
+  tiledOperands.push_back(initValResult);
+  tiledOperands.push_back(initIdxResult);
+
+  SmallVector<Type, 2> resultTypes;
+  if (op.hasPureTensorSemantics()) {
+    resultTypes = {initValResult.getType(), initIdxResult.getType()};
+  }
+
+  ArgCompareOp tiledArgmaxOp;
+  if (isExplicitIndexMode) {
+    // Indices are provided as input, no index_base needed.
+    tiledArgmaxOp = ArgCompareOp::create(
+        b, loc, resultTypes,
+        /*inputs=*/ValueRange{tiledOperands[0], tiledOperands[1]},
+        /*outputs=*/ValueRange{tiledOperands[2], tiledOperands[3]},
+        /*index_base=*/nullptr, /*dimension=*/reductionDim);
+  } else {
+    // Compute index_base for this chunk so that generated indices correspond
+    // to positions in the original tensor. We use tileIndex * tileSize to get
+    // the starting offset of this chunk in the reduction dimension.
+    Value tileIndex =
+        getValueOrCreateConstantIndexOp(b, loc, splitReductionIvs[0]);
+    Value tileSize =
+        getValueOrCreateConstantIndexOp(b, loc, sizes[reductionDim]);
+    Value newIndexBase = arith::MulIOp::create(b, loc, tileIndex, tileSize);
+
+    if (Value globalIndexBase = op.getIndexBase()) {
+      newIndexBase =
+          arith::AddIOp::create(b, loc, globalIndexBase, newIndexBase);
+    }
+
+    tiledArgmaxOp = ArgCompareOp::create(
+        b, loc, resultTypes,
+        /*inputs=*/tiledOperands[0],
+        /*outputs=*/ValueRange{tiledOperands[1], tiledOperands[2]},
+        /*index_base=*/newIndexBase, /*dimension=*/reductionDim);
+  }
+
+  return {tiledArgmaxOp, slices};
+}
+
 FailureOr<TilingResult> ArgCompareOp::tileToPartialReduction(
     OpBuilder &b, Location loc, ReductionTilingStrategy strategy,
     ValueRange init, ArrayRef<OpFoldResult> offsets,
@@ -1757,240 +1960,62 @@ FailureOr<TilingResult> ArgCompareOp::tileToPartialReduction(
     slices.push_back(inputIndexSlice);
   }
 
-  // The two strategies handle partial results differently. For arg_compare on
-  // tensor<64x4096xf32> with reduction dim=1 and tile_size=128 (32 chunks):
-  // - OuterReduction: Partial results are tensor<64x128xf32>,
-  // tensor<64x128xi32>
-  //   (tile shape). Uses scf.for iter_args to accumulate across iterations.
-  // - OuterParallel: Partial results are tensor<64x32xf32>, tensor<64x32xi32>
-  //   (one slot per chunk). Uses scf.forall with parallel_insert_slice.
-  Value initValResult, initIdxResult;
+  // Dispatch to appropriate helper based on strategy.
+  // The two strategies handle partial results differently:
+  // - OuterReduction: Uses scf.for iter_args to accumulate across iterations.
+  // - OuterParallel: Uses scf.forall with parallel_insert_slice for parallel
+  // chunks.
+  Operation *tiledOp;
+  SmallVector<Operation *> strategySlices;
   if (strategy == ReductionTilingStrategy::PartialReductionOuterReduction) {
-    initValResult = init[0];
-    initIdxResult = init[1];
+    auto [op, extraSlices] = createTiledOpForOuterReduction(
+        *this, b, loc, init, offsets, tiledOperands, reductionDim, rank,
+        isExplicitIndexMode);
+    tiledOp = op;
+    strategySlices = std::move(extraSlices);
   } else {
-    SmallVector<OpFoldResult> initOffsets, initSizes, initStrides;
-    for (int64_t i = 0; i < rank; ++i) {
-      if (i == reductionDim) {
-        initOffsets.push_back(splitReductionIvs[0]);
-        initSizes.push_back(b.getIndexAttr(1));
-      } else {
-        initOffsets.push_back(offsets[i]);
-        initSizes.push_back(sizes[i]);
-      }
-      initStrides.push_back(b.getIndexAttr(1));
-    }
-
-    SmallVector<int64_t> resultShape;
-    for (int64_t i = 0; i < rank; ++i) {
-      if (i == reductionDim) {
-        continue;
-      }
-      if (auto constantSize = getConstantIntValue(initSizes[i])) {
-        resultShape.push_back(*constantSize);
-      } else {
-        resultShape.push_back(ShapedType::kDynamic);
-      }
-    }
-
-    auto sliceValResultType =
-        cast<RankedTensorType>(getOutputValueType().clone(resultShape));
-    auto sliceIdxResultType =
-        cast<RankedTensorType>(getOutputIndexType().clone(resultShape));
-
-    auto initValSlice =
-        tensor::ExtractSliceOp::create(b, loc, sliceValResultType, init[0],
-                                       initOffsets, initSizes, initStrides);
-    initValResult = initValSlice.getResult();
-    slices.push_back(initValSlice);
-
-    auto initIdxSlice =
-        tensor::ExtractSliceOp::create(b, loc, sliceIdxResultType, init[1],
-                                       initOffsets, initSizes, initStrides);
-    initIdxResult = initIdxSlice.getResult();
-    slices.push_back(initIdxSlice);
+    auto [op, extraSlices] = createTiledOpForOuterParallel(
+        *this, b, loc, init, offsets, sizes, splitReductionIvs, tiledOperands,
+        reductionDim, rank, isExplicitIndexMode);
+    tiledOp = op;
+    strategySlices = std::move(extraSlices);
   }
 
-  // OuterReduction requires a different IR structure than OuterParallel. We
-  // cannot use a tiled ArgCompareOp because each iteration must compare the
-  // new tile against the accumulated result, not perform an independent
-  // reduction. Instead, we emit a linalg.generic that applies the comparator
-  // elementwise and updates both value and index accumulators.
-  if (strategy == ReductionTilingStrategy::PartialReductionOuterReduction) {
-    Value tileInput = tiledOperands[0];
+  slices.insert(slices.end(), strategySlices.begin(), strategySlices.end());
 
-    // For explicit-index mode with OuterReduction, we can directly use a
-    // tiled ArgCompareOp since indices are provided explicitly.
-    if (isExplicitIndexMode) {
-      tiledOperands.push_back(initValResult);
-      tiledOperands.push_back(initIdxResult);
-
-      SmallVector<Type, 2> resultTypes;
-      if (hasPureTensorSemantics()) {
-        resultTypes = {initValResult.getType(), initIdxResult.getType()};
-      }
-
-      // Explicit-index mode: 2 inputs (value + index), no index_base.
-      ArgCompareOp tiledArgmaxOp = ArgCompareOp::create(
-          b, loc, resultTypes,
-          /*inputs=*/ValueRange{tiledOperands[0], tiledOperands[1]},
-          /*outputs=*/ValueRange{tiledOperands[2], tiledOperands[3]},
-          /*indexBase=*/nullptr, /*dimension=*/reductionDim);
-
-      Region &targetRegion = tiledArgmaxOp.getRegion();
-      Region &sourceRegion = getRegion();
-      IRMapping mapper;
-      sourceRegion.cloneInto(&targetRegion, mapper);
-
-      return TilingResult{
-          {tiledArgmaxOp}, SmallVector<Value>(tiledArgmaxOp->getResults()),
-          slices};
-    }
-
-    // For implicit-index mode with OuterReduction, we emit a linalg.generic
-    // that applies the comparator elementwise and updates both value and
-    // index accumulators.
-    // All operands use identity maps: 1 input + 2 outputs (value, index).
-    auto identityMap = AffineMap::getMultiDimIdentityMap(rank, b.getContext());
-    SmallVector<AffineMap> indexingMaps(3, identityMap);
-    SmallVector<utils::IteratorType> iterators(rank,
-                                               utils::IteratorType::parallel);
-
-    auto genericOp = linalg::GenericOp::create(
-        b, loc, TypeRange{initValResult.getType(), initIdxResult.getType()},
-        ValueRange{tileInput}, ValueRange{initValResult, initIdxResult},
-        indexingMaps, iterators,
-        [this, reductionDim, &offsets](OpBuilder &nestedBuilder,
-                                       Location nestedLoc, ValueRange args) {
-          Value newVal = args[0];
-          Value accVal = args[1];
-          Value accIdx = args[2];
-
-          // Track the global index for each element so we can record which
-          // position held the selected value.
-          auto localIdx =
-              linalg::IndexOp::create(nestedBuilder, nestedLoc, reductionDim);
-          Value offsetVal = getValueOrCreateConstantIndexOp(
-              nestedBuilder, nestedLoc, offsets[reductionDim]);
-          auto globalIdx = arith::AddIOp::create(nestedBuilder, nestedLoc,
-                                                 offsetVal, localIdx);
-
-          if (Value indexBase = getIndexBase()) {
-            globalIdx = arith::AddIOp::create(nestedBuilder, nestedLoc,
-                                              indexBase, globalIdx);
-          }
-
-          // The index type in the output may differ from the index type used
-          // internally, so cast if necessary.
-          Type idxElemType = accIdx.getType();
-          Value newIdx = globalIdx;
-          if (!idxElemType.isIndex()) {
-            auto castedIdx = arith::IndexCastOp::create(
-                nestedBuilder, nestedLoc, idxElemType, globalIdx);
-            newIdx = castedIdx;
-          }
-
-          // Apply the user-defined comparison logic to decide whether the new
-          // value should replace the accumulated value.
-          Block &originalBlock = getRegion().front();
-          IRMapping mapper;
-          mapper.map(originalBlock.getArgument(0), newVal);
-          mapper.map(originalBlock.getArgument(1), accVal);
-
-          for (Operation &op : originalBlock) {
-            if (op.hasTrait<OpTrait::IsTerminator>()) {
-              break;
-            }
-            nestedBuilder.clone(op, mapper);
-          }
-
-          Value predicate =
-              mapper.lookup(originalBlock.getTerminator()->getOperand(0));
-
-          auto selectedVal = arith::SelectOp::create(nestedBuilder, nestedLoc,
-                                                     predicate, newVal, accVal);
-          auto selectedIdx = arith::SelectOp::create(nestedBuilder, nestedLoc,
-                                                     predicate, newIdx, accIdx);
-
-          linalg::YieldOp::create(nestedBuilder, nestedLoc,
-                                  ValueRange{selectedVal, selectedIdx});
-        });
-
-    return TilingResult{
-        {genericOp}, SmallVector<Value>(genericOp->getResults()), slices};
+  // Clone the user's comparison region into the tiled operation. This is only
+  // needed for OuterParallel which creates ArgCompareOp; OuterReduction uses
+  // linalg.generic which already has its region fully defined.
+  if (strategy == ReductionTilingStrategy::PartialReductionOuterParallel) {
+    auto argCompareOp = cast<ArgCompareOp>(tiledOp);
+    Region &targetRegion = argCompareOp.getRegion();
+    Region &sourceRegion = getRegion();
+    IRMapping mapper;
+    sourceRegion.cloneInto(&targetRegion, mapper);
   }
-
-  // OuterParallel: both explicit and implicit index modes can use a regular
-  // tiled ArgCompareOp since each chunk performs an independent reduction.
-  tiledOperands.push_back(initValResult);
-  tiledOperands.push_back(initIdxResult);
-  SmallVector<Type, 2> resultTypes;
-  if (hasPureTensorSemantics()) {
-    resultTypes = {initValResult.getType(), initIdxResult.getType()};
-  }
-
-  // Handle OuterParallel for both explicit and implicit index modes.
-  ArgCompareOp tiledArgmaxOp;
-  if (isExplicitIndexMode) {
-    // Explicit-index mode: 2 inputs (value + index), no index_base.
-    // tiledOperands layout: [value_slice, index_slice, init_val, init_idx].
-    tiledArgmaxOp = ArgCompareOp::create(
-        b, loc, resultTypes,
-        /*inputs=*/ValueRange{tiledOperands[0], tiledOperands[1]},
-        /*outputs=*/ValueRange{tiledOperands[2], tiledOperands[3]},
-        /*indexBase=*/nullptr, /*dimension=*/reductionDim);
-  } else {
-    // Implicit-index mode: 1 input (value) + index_base.
-    // Create index_base for this chunk. We adjust index_base so the indices
-    // in each chunk reflect their position in the original tensor.
-    Value tileIndex =
-        getValueOrCreateConstantIndexOp(b, loc, splitReductionIvs[0]);
-    Value tileSize =
-        getValueOrCreateConstantIndexOp(b, loc, sizes[reductionDim]);
-    Value newIndexBase = arith::MulIOp::create(b, loc, tileIndex, tileSize);
-
-    if (Value globalIndexBase = getIndexBase()) {
-      // Add chunk start to existing index_base.
-      newIndexBase =
-          arith::AddIOp::create(b, loc, globalIndexBase, newIndexBase);
-    }
-
-    // tiledOperands layout: [value_slice, init_val, init_idx].
-    tiledArgmaxOp = ArgCompareOp::create(
-        b, loc, resultTypes,
-        /*inputs=*/tiledOperands[0],
-        /*outputs=*/ValueRange{tiledOperands[1], tiledOperands[2]},
-        /*indexBase=*/newIndexBase, /*dimension=*/reductionDim);
-  }
-
-  Region &targetRegion = tiledArgmaxOp->getRegion(0);
-  Region &sourceRegion = getRegion();
-  IRMapping mapper;
-  sourceRegion.cloneInto(&targetRegion, mapper);
 
   return TilingResult{
-      {tiledArgmaxOp}, SmallVector<Value>(tiledArgmaxOp->getResults()), slices};
+      {tiledOp}, SmallVector<Value>(tiledOp->getResults()), slices};
 }
 
 FailureOr<MergeResult>
 ArgCompareOp::mergeReductions(OpBuilder &b, Location loc,
                               ValueRange partialReduce,
                               const llvm::SetVector<unsigned> &reductionDims) {
-  int64_t reductionDim = getDimension();
+  int64_t reductionDim = reductionDims.front();
 
   // Create arg_compare in explicit-index mode to merge the partial results.
   // Explicit-index mode: 2 inputs (value + index), no index_base.
   ArgCompareOp mergeOp = ArgCompareOp::create(
-      b, loc,
-      hasPureTensorSemantics() ? TypeRange(getDpsInits().getTypes())
-                               : TypeRange{},
+      b, loc, hasPureTensorSemantics() ? TypeRange(getDpsInits()) : TypeRange{},
       /*inputs=*/partialReduce,
       /*outputs=*/getDpsInits(),
-      /*indexBase=*/nullptr,
+      /*index_base=*/nullptr,
       /*dimension=*/reductionDim);
 
-  // Clone the comparator region from the original operation.
-  Region &targetRegion = mergeOp.getRegion();
+  // Clone the comparator region from the original operRegion &targetRegion =
+  // mergeOp.getRegion();
+  Region &targetRegion = mergeOp->getRegion(0);
   Region &sourceRegion = getRegion();
   IRMapping mapper;
   sourceRegion.cloneInto(&targetRegion, mapper);
@@ -2013,7 +2038,7 @@ LogicalResult ArgCompareOp::getPartialResultTilePosition(
   bool isOuterReduction =
       tilingStrategy == ReductionTilingStrategy::PartialReductionOuterReduction;
 
-  for (auto [i, offset, size] : llvm::enumerate(offsets, sizes)) {
+  for (auto [i, size, offset] : llvm::enumerate(sizes, offsets)) {
     if (i == reductionDim) {
       // OuterReduction accumulates in place, always writing to offset 0.
       // OuterParallel writes each chunk to a separate slot indexed by chunkIdx.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -3047,33 +3047,38 @@ func.func @arg_compare_outer_reduction(%arg0: tensor<4x1x129024xf16>, %out_val: 
 }
 
 // CHECK-LABEL: func.func @arg_compare_outer_reduction
-// CHECK-SAME: (%[[ARG0:.+]]: tensor<4x1x129024xf16>, %[[OUT_VAL:.+]]: tensor<4x1xf16>, %[[OUT_IDX:.+]]: tensor<4x1xi32>)
+// CHECK-SAME:    (%[[ARG0:.+]]: tensor<4x1x129024xf16>, %[[OUT_VAL:.+]]: tensor<4x1xf16>, %[[OUT_IDX:.+]]: tensor<4x1xi32>)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C2048:.+]] = arith.constant 2048 : index
+// CHECK-DAG:     %[[C129024:.+]] = arith.constant 129024 : index
+// CHECK-DAG:     %[[PARTIAL_VAL_EMPTY:.+]] = tensor.empty() : tensor<4x1x2048xf16>
+// CHECK-DAG:     %[[PARTIAL_IDX_EMPTY:.+]] = tensor.empty() : tensor<4x1x2048xi32>
+// CHECK-DAG:     %[[BROADCAST_VAL:.+]] = linalg.broadcast ins(%[[OUT_VAL]] : tensor<4x1xf16>) outs(%[[PARTIAL_VAL_EMPTY]] : tensor<4x1x2048xf16>) dimensions = [2]
+// CHECK-DAG:     %[[BROADCAST_IDX:.+]] = linalg.broadcast ins(%[[OUT_IDX]] : tensor<4x1xi32>) outs(%[[PARTIAL_IDX_EMPTY]] : tensor<4x1x2048xi32>) dimensions = [2]
 
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-DAG: %[[C129024:.+]] = arith.constant 129024 : index
+// OuterReduction uses scf.for with iter_args.
+// CHECK:         %[[ITER:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C129024]] step %[[C2048]] iter_args(%[[VAL_ARG:.+]] = %[[BROADCAST_VAL]], %[[IDX_ARG:.+]] = %[[BROADCAST_IDX]]) -> (tensor<4x1x2048xf16>, tensor<4x1x2048xi32>)
+// CHECK:           %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[IV]]] [4, 1, 2048] [1, 1, 1] : tensor<4x1x129024xf16> to tensor<4x1x2048xf16>
 
-// CHECK-DAG: %[[PARTIAL_VAL_EMPTY:.+]] = tensor.empty() : tensor<4x1x2048xf16>
-// CHECK-DAG: %[[PARTIAL_IDX_EMPTY:.+]] = tensor.empty() : tensor<4x1x2048xi32>
+// linalg.generic computes element-wise comparison with index computation.
+// CHECK:           %[[RESULT:.+]]:2 = linalg.generic {{.*}} ins(%[[INPUT_SLICE]] : tensor<4x1x2048xf16>) outs(%[[VAL_ARG]], %[[IDX_ARG]] : tensor<4x1x2048xf16>, tensor<4x1x2048xi32>)
+// CHECK:             ^bb0(%[[IN:.+]]: f16, %[[OUT:.+]]: f16, %[[OUT_I:.+]]: i32):
+// CHECK:               %[[IDX:.+]] = linalg.index 2
+// CHECK:               %[[GLOBAL_IDX:.+]] = arith.addi %[[IV]], %[[IDX]]
+// CHECK:               %[[CAST_IDX:.+]] = arith.index_cast %[[GLOBAL_IDX]] : index to i32
+// CHECK:               %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[OUT]] : f16
+// CHECK:               %[[SEL_VAL:.+]] = arith.select %[[CMP]], %[[IN]], %[[OUT]] : f16
+// CHECK:               %[[SEL_IDX:.+]] = arith.select %[[CMP]], %[[CAST_IDX]], %[[OUT_I]] : i32
+// CHECK:               linalg.yield %[[SEL_VAL]], %[[SEL_IDX]] : f16, i32
+// CHECK:           scf.yield
 
-// CHECK-DAG: %[[BROADCAST_VAL:.+]] = linalg.broadcast ins(%[[OUT_VAL]] : tensor<4x1xf16>) outs(%[[PARTIAL_VAL_EMPTY]] : tensor<4x1x2048xf16>) dimensions = [2]
-// CHECK-DAG: %[[BROADCAST_IDX:.+]] = linalg.broadcast ins(%[[OUT_IDX]] : tensor<4x1xi32>) outs(%[[PARTIAL_IDX_EMPTY]] : tensor<4x1x2048xi32>) dimensions = [2]
-
-// CHECK: %[[ITER:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C129024]] step %[[C2048]] iter_args(%[[VAL_ARG:.+]] = %[[BROADCAST_VAL]], %[[IDX_ARG:.+]] = %[[BROADCAST_IDX]]) -> (tensor<4x1x2048xf16>, tensor<4x1x2048xi32>)
-// CHECK:   %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[IV]]] [4, 1, 2048] [1, 1, 1]
-// CHECK:   %[[RESULT:.+]]:2 = linalg.generic {{.*}} ins(%[[INPUT_SLICE]] : tensor<4x1x2048xf16>) outs(%[[VAL_ARG]], %[[IDX_ARG]] : tensor<4x1x2048xf16>, tensor<4x1x2048xi32>)
-// CHECK:       linalg.index 2
-// CHECK:       arith.addi %[[IV]]
-// CHECK:       arith.index_cast
-// CHECK:       arith.cmpf ogt
-// CHECK:       arith.select
-// CHECK:       arith.select
-// CHECK:       linalg.yield
-// CHECK:   scf.yield
-
-// CHECK: iree_linalg_ext.arg_compare
-// CHECK:     arith.cmpf ogt
-// CHECK:     iree_linalg_ext.yield
+// Merge reduction uses arg_compare in explicit-index mode.
+// CHECK:         %[[REDUCED:.+]]:2 = iree_linalg_ext.arg_compare dimension(2) ins(%[[ITER]]#0, %[[ITER]]#1 : tensor<4x1x2048xf16>, tensor<4x1x2048xi32>) outs(%[[OUT_VAL]], %[[OUT_IDX]] : tensor<4x1xf16>, tensor<4x1xi32>)
+// CHECK:           ^bb0(%[[IN:.+]]: f16, %[[INIT:.+]]: f16):
+// CHECK:             %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[INIT]] : f16
+// CHECK:             iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:           } -> tensor<4x1xf16>, tensor<4x1xi32>
+// CHECK:         return %[[REDUCED]]#0, %[[REDUCED]]#1 : tensor<4x1xf16>, tensor<4x1xi32>
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
@@ -3099,25 +3104,39 @@ func.func @arg_compare_outer_reduction_with_base(%arg0: tensor<2x64x1024xf32>, %
 }
 
 // CHECK-LABEL: func.func @arg_compare_outer_reduction_with_base
-// CHECK-SAME: (%[[ARG0:.+]]: tensor<2x64x1024xf32>, %[[BASE:.+]]: index, %[[OUT_VAL:.+]]: tensor<2x64xf32>, %[[OUT_IDX:.+]]: tensor<2x64xi32>)
+// CHECK-SAME:    (%[[ARG0:.+]]: tensor<2x64x1024xf32>, %[[BASE:.+]]: index, %[[OUT_VAL:.+]]: tensor<2x64xf32>, %[[OUT_IDX:.+]]: tensor<2x64xi32>)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:     %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[PARTIAL_VAL_EMPTY:.+]] = tensor.empty() : tensor<2x64x128xf32>
+// CHECK-DAG:     %[[PARTIAL_IDX_EMPTY:.+]] = tensor.empty() : tensor<2x64x128xi32>
+// CHECK-DAG:     %[[BROADCAST_VAL:.+]] = linalg.broadcast ins(%[[OUT_VAL]] : tensor<2x64xf32>) outs(%[[PARTIAL_VAL_EMPTY]] : tensor<2x64x128xf32>) dimensions = [2]
+// CHECK-DAG:     %[[BROADCAST_IDX:.+]] = linalg.broadcast ins(%[[OUT_IDX]] : tensor<2x64xi32>) outs(%[[PARTIAL_IDX_EMPTY]] : tensor<2x64x128xi32>) dimensions = [2]
 
-// CHECK: linalg.broadcast
-// CHECK: linalg.broadcast
+// OuterReduction uses scf.for with iter_args.
+// CHECK:         %[[ITER:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C1024]] step %[[C128]] iter_args(%[[VAL_ARG:.+]] = %[[BROADCAST_VAL]], %[[IDX_ARG:.+]] = %[[BROADCAST_IDX]]) -> (tensor<2x64x128xf32>, tensor<2x64x128xi32>)
+// CHECK:           %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[IV]]] [2, 64, 128] [1, 1, 1] : tensor<2x64x1024xf32> to tensor<2x64x128xf32>
 
-// CHECK: scf.for
-// CHECK:   linalg.generic
-// CHECK:       linalg.index 2
-// CHECK:       arith.addi
-// CHECK:       arith.addi %[[BASE]]
-// CHECK:       arith.cmpf ogt
-// CHECK:       arith.select
-// CHECK:       arith.select
-// CHECK:       linalg.yield
-// CHECK:   scf.yield
+// linalg.generic computes element-wise comparison with index computation including index_base.
+// CHECK:           %[[RESULT:.+]]:2 = linalg.generic {{.*}} ins(%[[INPUT_SLICE]] : tensor<2x64x128xf32>) outs(%[[VAL_ARG]], %[[IDX_ARG]] : tensor<2x64x128xf32>, tensor<2x64x128xi32>)
+// CHECK:             ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32, %[[OUT_I:.+]]: i32):
+// CHECK:               %[[IDX:.+]] = linalg.index 2
+// CHECK:               %[[LOCAL_IDX:.+]] = arith.addi %[[IV]], %[[IDX]]
+// CHECK:               %[[GLOBAL_IDX:.+]] = arith.addi %[[BASE]], %[[LOCAL_IDX]]
+// CHECK:               %[[CAST_IDX:.+]] = arith.index_cast %[[GLOBAL_IDX]] : index to i32
+// CHECK:               %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[OUT]] : f32
+// CHECK:               %[[SEL_VAL:.+]] = arith.select %[[CMP]], %[[IN]], %[[OUT]] : f32
+// CHECK:               %[[SEL_IDX:.+]] = arith.select %[[CMP]], %[[CAST_IDX]], %[[OUT_I]] : i32
+// CHECK:               linalg.yield %[[SEL_VAL]], %[[SEL_IDX]] : f32, i32
+// CHECK:           scf.yield
 
-// CHECK: iree_linalg_ext.arg_compare
-// CHECK:     arith.cmpf ogt
-// CHECK:     iree_linalg_ext.yield
+// Merge reduction uses arg_compare in explicit-index mode.
+// CHECK:         %[[REDUCED:.+]]:2 = iree_linalg_ext.arg_compare dimension(2) ins(%[[ITER]]#0, %[[ITER]]#1 : tensor<2x64x128xf32>, tensor<2x64x128xi32>) outs(%[[OUT_VAL]], %[[OUT_IDX]] : tensor<2x64xf32>, tensor<2x64xi32>)
+// CHECK:           ^bb0(%[[IN:.+]]: f32, %[[INIT:.+]]: f32):
+// CHECK:             %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[INIT]] : f32
+// CHECK:             iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:           } -> tensor<2x64xf32>, tensor<2x64xi32>
+// CHECK:         return %[[REDUCED]]#0, %[[REDUCED]]#1 : tensor<2x64xf32>, tensor<2x64xi32>
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
@@ -3142,32 +3161,98 @@ func.func @arg_compare_outer_reduction_index_type(%arg0: tensor<2x64x1024xf32>, 
 }
 
 // CHECK-LABEL: func.func @arg_compare_outer_reduction_index_type
-// CHECK-SAME: (%[[ARG0:.+]]: tensor<2x64x1024xf32>, %[[OUT_VAL:.+]]: tensor<2x64xf32>, %[[OUT_IDX:.+]]: tensor<2x64xindex>)
+// CHECK-SAME:    (%[[ARG0:.+]]: tensor<2x64x1024xf32>, %[[OUT_VAL:.+]]: tensor<2x64xf32>, %[[OUT_IDX:.+]]: tensor<2x64xindex>)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:     %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[PARTIAL_VAL_EMPTY:.+]] = tensor.empty() : tensor<2x64x128xf32>
+// CHECK-DAG:     %[[PARTIAL_IDX_EMPTY:.+]] = tensor.empty() : tensor<2x64x128xindex>
+// CHECK-DAG:     %[[BROADCAST_VAL:.+]] = linalg.broadcast ins(%[[OUT_VAL]] : tensor<2x64xf32>) outs(%[[PARTIAL_VAL_EMPTY]] : tensor<2x64x128xf32>) dimensions = [2]
+// CHECK-DAG:     %[[BROADCAST_IDX:.+]] = linalg.broadcast ins(%[[OUT_IDX]] : tensor<2x64xindex>) outs(%[[PARTIAL_IDX_EMPTY]] : tensor<2x64x128xindex>) dimensions = [2]
 
-// CHECK: linalg.broadcast
-// CHECK: linalg.broadcast
+// OuterReduction uses scf.for with iter_args.
+// CHECK:         %[[ITER:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C1024]] step %[[C128]] iter_args(%[[VAL_ARG:.+]] = %[[BROADCAST_VAL]], %[[IDX_ARG:.+]] = %[[BROADCAST_IDX]]) -> (tensor<2x64x128xf32>, tensor<2x64x128xindex>)
+// CHECK:           %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, 0, %[[IV]]] [2, 64, 128] [1, 1, 1] : tensor<2x64x1024xf32> to tensor<2x64x128xf32>
 
-// Verify OuterReduction uses scf.for with iter_args
-// CHECK: scf.for
-// CHECK:   linalg.generic
-// Verify index computation with index type (no index_cast needed since output uses index type)
-// CHECK:       linalg.index 2
-// CHECK:       arith.addi
-// CHECK:       arith.cmpf ogt
-// CHECK:       arith.select
-// CHECK:       arith.select
-// CHECK:       linalg.yield
-// CHECK:   scf.yield
+// linalg.generic computes element-wise comparison (no index_cast needed since output uses index type).
+// CHECK:           %[[RESULT:.+]]:2 = linalg.generic {{.*}} ins(%[[INPUT_SLICE]] : tensor<2x64x128xf32>) outs(%[[VAL_ARG]], %[[IDX_ARG]] : tensor<2x64x128xf32>, tensor<2x64x128xindex>)
+// CHECK:             ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32, %[[OUT_I:.+]]: index):
+// CHECK:               %[[IDX:.+]] = linalg.index 2
+// CHECK:               %[[GLOBAL_IDX:.+]] = arith.addi %[[IV]], %[[IDX]]
+// CHECK:               %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[OUT]] : f32
+// CHECK:               %[[SEL_VAL:.+]] = arith.select %[[CMP]], %[[IN]], %[[OUT]] : f32
+// CHECK:               %[[SEL_IDX:.+]] = arith.select %[[CMP]], %[[GLOBAL_IDX]], %[[OUT_I]] : index
+// CHECK:               linalg.yield %[[SEL_VAL]], %[[SEL_IDX]] : f32, index
+// CHECK:           scf.yield
 
-// Verify merge uses arg_compare in explicit-index mode
-// CHECK: iree_linalg_ext.arg_compare
-// CHECK:     arith.cmpf ogt
-// CHECK:     iree_linalg_ext.yield
+// Merge reduction uses arg_compare in explicit-index mode.
+// CHECK:         %[[REDUCED:.+]]:2 = iree_linalg_ext.arg_compare dimension(2) ins(%[[ITER]]#0, %[[ITER]]#1 : tensor<2x64x128xf32>, tensor<2x64x128xindex>) outs(%[[OUT_VAL]], %[[OUT_IDX]] : tensor<2x64xf32>, tensor<2x64xindex>)
+// CHECK:           ^bb0(%[[IN:.+]]: f32, %[[INIT:.+]]: f32):
+// CHECK:             %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[INIT]] : f32
+// CHECK:             iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:           } -> tensor<2x64xf32>, tensor<2x64xindex>
+// CHECK:         return %[[REDUCED]]#0, %[[REDUCED]]#1 : tensor<2x64xf32>, tensor<2x64xindex>
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %arg_compare_op = transform.structured.match ops{["iree_linalg_ext.arg_compare"]} in %module_op : (!transform.any_op) -> !transform.any_op
     %fill_op:2, %split_op, %combining_op, %for_op = transform.structured.tile_reduction_using_for %arg_compare_op by tile_sizes = [0, 0, 128] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+func.func @arg_compare_outer_reduction_explicit_index(%arg0: tensor<8x4096xf32>, %arg1: tensor<8x4096xi32>, %out_val: tensor<8xf32>, %out_idx: tensor<8xi32>) -> (tensor<8xf32>, tensor<8xi32>) {
+  %0:2 = iree_linalg_ext.arg_compare
+      dimension(1)
+      ins(%arg0, %arg1 : tensor<8x4096xf32>, tensor<8x4096xi32>) outs(%out_val, %out_idx : tensor<8xf32>, tensor<8xi32>) {
+    ^bb0(%in: f32, %init_val: f32):
+      %cmp = arith.cmpf ogt, %in, %init_val : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<8xf32>, tensor<8xi32>
+
+  return %0#0, %0#1 : tensor<8xf32>, tensor<8xi32>
+}
+
+// CHECK-LABEL: func.func @arg_compare_outer_reduction_explicit_index
+// CHECK-SAME:    (%[[VALUES:.+]]: tensor<8x4096xf32>, %[[INDICES:.+]]: tensor<8x4096xi32>, %[[OUT_VAL:.+]]: tensor<8xf32>, %[[OUT_IDX:.+]]: tensor<8xi32>)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:     %[[C4096:.+]] = arith.constant 4096 : index
+// CHECK-DAG:     %[[PARTIAL_VAL_EMPTY:.+]] = tensor.empty() : tensor<8x128xf32>
+// CHECK-DAG:     %[[PARTIAL_IDX_EMPTY:.+]] = tensor.empty() : tensor<8x128xi32>
+// CHECK-DAG:     %[[BROADCAST_VAL:.+]] = linalg.broadcast ins(%[[OUT_VAL]] : tensor<8xf32>) outs(%[[PARTIAL_VAL_EMPTY]] : tensor<8x128xf32>) dimensions = [1]
+// CHECK-DAG:     %[[BROADCAST_IDX:.+]] = linalg.broadcast ins(%[[OUT_IDX]] : tensor<8xi32>) outs(%[[PARTIAL_IDX_EMPTY]] : tensor<8x128xi32>) dimensions = [1]
+
+// OuterReduction uses scf.for with iter_args.
+// CHECK:         %[[ITER:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C4096]] step %[[C128]] iter_args(%[[VAL_ARG:.+]] = %[[BROADCAST_VAL]], %[[IDX_ARG:.+]] = %[[BROADCAST_IDX]]) -> (tensor<8x128xf32>, tensor<8x128xi32>)
+
+// Explicit-index mode slices BOTH inputs (values + indices).
+// CHECK-DAG:       %[[VALUE_SLICE:.+]] = tensor.extract_slice %[[VALUES]][0, %[[IV]]] [8, 128] [1, 1] : tensor<8x4096xf32> to tensor<8x128xf32>
+// CHECK-DAG:       %[[INDEX_SLICE:.+]] = tensor.extract_slice %[[INDICES]][0, %[[IV]]] [8, 128] [1, 1] : tensor<8x4096xi32> to tensor<8x128xi32>
+
+// linalg.generic computes element-wise comparison with explicit indices (no index computation).
+// CHECK:           %[[RESULT:.+]]:2 = linalg.generic {{.*}} ins(%[[VALUE_SLICE]], %[[INDEX_SLICE]] : tensor<8x128xf32>, tensor<8x128xi32>) outs(%[[VAL_ARG]], %[[IDX_ARG]] : tensor<8x128xf32>, tensor<8x128xi32>)
+// CHECK:             ^bb0(%[[IN:.+]]: f32, %[[IN_I:.+]]: i32, %[[OUT:.+]]: f32, %[[OUT_I:.+]]: i32):
+// CHECK:               %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[OUT]] : f32
+// CHECK:               %[[SEL_VAL:.+]] = arith.select %[[CMP]], %[[IN]], %[[OUT]] : f32
+// CHECK:               %[[SEL_IDX:.+]] = arith.select %[[CMP]], %[[IN_I]], %[[OUT_I]] : i32
+// CHECK:               linalg.yield %[[SEL_VAL]], %[[SEL_IDX]] : f32, i32
+// CHECK:           scf.yield
+
+// Merge reduction uses arg_compare in explicit-index mode.
+// CHECK:         %[[REDUCED:.+]]:2 = iree_linalg_ext.arg_compare dimension(1) ins(%[[ITER]]#0, %[[ITER]]#1 : tensor<8x128xf32>, tensor<8x128xi32>) outs(%[[OUT_VAL]], %[[OUT_IDX]] : tensor<8xf32>, tensor<8xi32>)
+// CHECK:           ^bb0(%[[IN:.+]]: f32, %[[INIT:.+]]: f32):
+// CHECK:             %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[INIT]] : f32
+// CHECK:             iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:           } -> tensor<8xf32>, tensor<8xi32>
+// CHECK:         return %[[REDUCED]]#0, %[[REDUCED]]#1 : tensor<8xf32>, tensor<8xi32>
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %arg_compare_op = transform.structured.match ops{["iree_linalg_ext.arg_compare"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %fill_op:2, %split_op, %combining_op, %for_op = transform.structured.tile_reduction_using_for %arg_compare_op by tile_sizes = [0, 128] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }


### PR DESCRIPTION
This PR extends ArgCompareOp's PartialReductionOpInterface to support the OuterReduction tiling strategy in addition to the existing OuterParallel (Split-Reduction) strategy.

## Example
For `arg_compare` on `tensor<64x4096xf32>` with reduction `dim=1` and `tile_size=128`:

**OuterParallel** (existing) - each chunk writes to a separate slot:
```mlir
// Partial results: tensor<64x32xf32>, tensor<64x32xi32> (32 chunks)
%results:2 = scf.forall (%chunk_idx) = (0) to (4096) step (128)
    shared_outs(%val = %init_val, %idx = %init_idx) {
  %slice = tensor.extract_slice %input[0, %chunk_idx] [64, 128] [1, 1]
  %partial:2 = iree_linalg_ext.arg_compare dim(1) ins(%slice) outs(...)
  scf.forall.in_parallel {
    tensor.parallel_insert_slice %partial#0 into %val[0, %chunk_idx] [64, 1]
    tensor.parallel_insert_slice %partial#1 into %idx[0, %chunk_idx] [64, 1]
  }
}
%final:2 = linalg.reduce ins(%results#0, %results#1) dims=[1]
```
`OuterReduction `(this PR) - accumulates in place each iteration:
```mlir
// Partial results: tensor<64x128xf32>, tensor<64x128xi32> (tile shape)
%results:2 = scf.for %iv = 0 to 4096 step 128
    iter_args(%val = %init_val, %idx = %init_idx) {
  %slice = tensor.extract_slice %input[0, %iv] [64, 128] [1, 1]
  %updated:2 = linalg.generic ins(%slice) outs(%val, %idx) {
    ^bb0(%new: f32, %acc_val: f32, %acc_idx: i32):
      %global_idx = arith.addi %iv, %local_idx  // track position
      %cmp = arith.cmpf ogt, %new, %acc_val
      %sel_val = arith.select %cmp, %new, %acc_val
      %sel_idx = arith.select %cmp, %global_idx, %acc_idx
      linalg.yield %sel_val, %sel_idx
  }
  scf.yield %updated#0, %updated#1
}
%final:2 = linalg.reduce ins(%results#0, %results#1) dims=[1]
```

This is one necessary step for plumbing through ArgCompare along VectorDistribute pipeline. 

Issue: #23005