### PR TITLE
[NFC] Add tablegen_compile_commands.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ imgui.ini
 
 # Source indexing files
 compile_commands.json
+tablegen_compile_commands.yml
 .cache/clangd
 
 # Language server configuration files


### PR DESCRIPTION
The tablegen LSP has a tablegen_compile_commands.yml analogous to the compile_commands.json for C++. Since people may want to link it into their source tree for similar reasons to compile_commands.json, add it to .gitignore as well.