### PR TITLE
Fix CTS CheckStatusContains to compare only message portion, ignore stack traces

### DIFF
--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ArchiveUtils.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ArchiveUtils.cpp
@@ -17,13 +17,15 @@ LogicalResult handleRuntimeError(Operation *op, iree_status_t status,
   if (iree_status_is_ok(status))
     return success();
   iree_host_size_t buffer_length = 0;
-  if (!iree_status_format(status, /*buffer_capacity=*/0,
-                          /*buffer=*/nullptr, &buffer_length))
+  if (!iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                          /*buffer_capacity=*/0, /*buffer=*/nullptr,
+                          &buffer_length))
     return op->emitError() << failureMessage;
   std::string message;
   message.reserve(buffer_length);
   message.resize(buffer_length - 1);
-  iree_status_format(status, message.capacity(), &message[0], &buffer_length);
+  iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE, message.capacity(),
+                     &message[0], &buffer_length);
   iree_status_ignore(status);
   return op->emitError() << failureMessage << "\n" << message;
 }

--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -253,11 +253,11 @@ const std::string& ErrorInstance::message() const {
     std::string buffer;
     iree_host_size_t actual_len;
     buffer.resize(1024);  // TODO: Actually reallocate to full size on trunc.
-    if (!iree_status_format(status_, buffer.size(), buffer.data(),
-                            &actual_len)) {
+    if (!iree_status_format(status_, IREE_STATUS_FORMAT_FLAG_NONE,
+                            buffer.size(), buffer.data(), &actual_len)) {
       buffer.resize(actual_len);
-      if (!iree_status_format(status_, buffer.size(), buffer.data(),
-                              &actual_len)) {
+      if (!iree_status_format(status_, IREE_STATUS_FORMAT_FLAG_NONE,
+                              buffer.size(), buffer.data(), &actual_len)) {
         actual_len = 0;
       }
     }

--- a/runtime/bindings/python/status_utils.cc
+++ b/runtime/bindings/python/status_utils.cc
@@ -30,15 +30,17 @@ PyObject* ApiStatusToPyExcClass(iree_status_t status) {
 
 std::string ApiStatusToString(iree_status_t status) {
   iree_host_size_t buffer_length = 0;
-  if (IREE_UNLIKELY(!iree_status_format(status, /*buffer_capacity=*/0,
+  if (IREE_UNLIKELY(!iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                                        /*buffer_capacity=*/0,
                                         /*buffer=*/NULL, &buffer_length))) {
     return "";
   }
   std::string result;
   result.resize(buffer_length);
   // NOTE: buffer capacity needs to be +1 for the NUL terminator in snprintf.
-  return iree_status_format(status, result.size() + 1,
-                            const_cast<char*>(result.data()), &buffer_length)
+  return iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                            result.size() + 1, const_cast<char*>(result.data()),
+                            &buffer_length)
              ? result
              : "";
 }

--- a/runtime/src/iree/base/status_cc.h
+++ b/runtime/src/iree/base/status_cc.h
@@ -117,14 +117,15 @@ class Status final {
       return "OK";
     }
     iree_host_size_t buffer_length = 0;
-    if (IREE_UNLIKELY(!iree_status_format(status, /*buffer_capacity=*/0,
+    if (IREE_UNLIKELY(!iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                                          /*buffer_capacity=*/0,
                                           /*buffer=*/NULL, &buffer_length))) {
       return "<!>";
     }
     std::string result(buffer_length, '\0');
-    if (IREE_UNLIKELY(!iree_status_format(status, result.size() + 1,
-                                          const_cast<char*>(result.data()),
-                                          &buffer_length))) {
+    if (IREE_UNLIKELY(!iree_status_format(
+            status, IREE_STATUS_FORMAT_FLAG_NONE, result.size() + 1,
+            const_cast<char*>(result.data()), &buffer_length))) {
       return "<!>";
     }
     return result;

--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -277,35 +277,23 @@ class CTSTestBase : public BaseType, public CTSTestResources {
 
   // Check that a contains b.
   // That is the codes of a and b are equal and the message of b is contained
-  // in the message of a. Note: We only compare the message portion (before
-  // "; stack:") since iree_status_clone doesn't copy payloads like stack
-  // traces, so the full formatted strings will differ.
+  // in the message of a. We exclude stack traces since iree_status_clone()
+  // captures a new stack at the clone site, so the stack traces would differ.
   void CheckStatusContains(iree_status_t a, iree_status_t b) {
     EXPECT_EQ(iree_status_code(a), iree_status_code(b));
     iree_allocator_t allocator = iree_allocator_system();
     char* a_str = NULL;
     iree_host_size_t a_str_length = 0;
-    EXPECT_TRUE(iree_status_to_string(a, &allocator, &a_str, &a_str_length));
+    EXPECT_TRUE(iree_status_to_string(a,
+                                      IREE_STATUS_FORMAT_FLAG_SKIP_STACK_TRACE,
+                                      &allocator, &a_str, &a_str_length));
     char* b_str = NULL;
     iree_host_size_t b_str_length = 0;
-    EXPECT_TRUE(iree_status_to_string(b, &allocator, &b_str, &b_str_length));
-    // Extract just the message portion (before stack trace) for comparison.
-    // iree_status_clone() captures a new stack at the clone site, so:
-    //   a_str: "CANCELLED; msg; stack: clone_site.c:42 ..."
-    //   b_str: "CANCELLED; msg; stack: original_site.c:10 ..."
-    // We only want to compare "CANCELLED; msg".
-    std::string_view a_view(a_str);
-    std::string_view b_view(b_str);
-    auto a_stack_pos = a_view.find("; stack:");
-    auto b_stack_pos = b_view.find("; stack:");
-    if (a_stack_pos != std::string_view::npos) {
-      a_view = a_view.substr(0, a_stack_pos);
-    }
-    if (b_stack_pos != std::string_view::npos) {
-      b_view = b_view.substr(0, b_stack_pos);
-    }
-    EXPECT_TRUE(a_view.find(b_view) != std::string_view::npos)
-        << "Expected '" << b_view << "' to be found in '" << a_view << "'";
+    EXPECT_TRUE(iree_status_to_string(b,
+                                      IREE_STATUS_FORMAT_FLAG_SKIP_STACK_TRACE,
+                                      &allocator, &b_str, &b_str_length));
+    EXPECT_TRUE(std::string_view(a_str).find(std::string_view(b_str)) !=
+                std::string_view::npos);
     iree_allocator_free(allocator, a_str);
     iree_allocator_free(allocator, b_str);
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -160,7 +160,8 @@ static void iree_hal_amdgpu_logical_device_error_handler(void* user_data,
   IREE_TRACE({
     char buffer[1024];
     iree_host_size_t buffer_length = 0;
-    if (iree_status_format(status, sizeof(buffer), buffer, &buffer_length)) {
+    if (iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE, sizeof(buffer),
+                           buffer, &buffer_length)) {
       IREE_TRACE_MESSAGE_DYNAMIC(ERROR, buffer, buffer_length);
     }
   });

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
@@ -254,7 +254,8 @@ static bool iree_string_builder_append_status(iree_string_builder_t* builder,
                                               iree_status_t status) {
   // Calculate total length minus the NUL terminator.
   iree_host_size_t buffer_length = 0;
-  if (IREE_UNLIKELY(!iree_status_format(status, /*buffer_capacity=*/0,
+  if (IREE_UNLIKELY(!iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                                        /*buffer_capacity=*/0,
                                         /*buffer=*/NULL, &buffer_length))) {
     return false;
   }
@@ -273,7 +274,8 @@ static bool iree_string_builder_append_status(iree_string_builder_t* builder,
   }
 
   // Format into the buffer.
-  return iree_status_format(status, buffer_length + 1, buffer, &buffer_length);
+  return iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                            buffer_length + 1, buffer, &buffer_length);
 }
 
 static bool iree_hal_amdgpu_libhsa_try_load_library_from_file(

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -63,7 +63,8 @@ static bool iree_hal_hip_try_load_dylib(const char* file_path,
 
   char* buffer = NULL;
   iree_host_size_t length = 0;
-  if (iree_status_to_string(status, &allocator, &buffer, &length)) {
+  if (iree_status_to_string(status, IREE_STATUS_FORMAT_FLAG_NONE, &allocator,
+                            &buffer, &length)) {
     iree_status_ignore(iree_string_builder_append_format(
         error_builder, "\n  Tried: %s\n    %.*s", file_path, (int)length,
         buffer));

--- a/runtime/src/iree/testing/benchmark_full.cc
+++ b/runtime/src/iree/testing/benchmark_full.cc
@@ -86,14 +86,15 @@ static std::string StatusToString(iree_status_t status) {
     return "OK";
   }
   iree_host_size_t buffer_length = 0;
-  if (IREE_UNLIKELY(!iree_status_format(status, /*buffer_capacity=*/0,
+  if (IREE_UNLIKELY(!iree_status_format(status, IREE_STATUS_FORMAT_FLAG_NONE,
+                                        /*buffer_capacity=*/0,
                                         /*buffer=*/NULL, &buffer_length))) {
     return "<!>";
   }
   std::string result(buffer_length, '\0');
-  if (IREE_UNLIKELY(!iree_status_format(status, result.size() + 1,
-                                        const_cast<char*>(result.data()),
-                                        &buffer_length))) {
+  if (IREE_UNLIKELY(!iree_status_format(
+          status, IREE_STATUS_FORMAT_FLAG_NONE, result.size() + 1,
+          const_cast<char*>(result.data()), &buffer_length))) {
     return "<!>";
   }
   return result;


### PR DESCRIPTION
This fixes the failing cts tests when run in debug build because stack traces are included:

Failing tests:
```
        1096 - iree/hal/drivers/hip/cts/hip_stream_semaphore_test (Failed)
        1097 - iree/hal/drivers/hip/cts/hip_stream_semaphore_submission_test (Failed)
        1106 - iree/hal/drivers/hip/cts/hip_graph_semaphore_test (Failed)
        1107 - iree/hal/drivers/hip/cts/hip_graph_semaphore_submission_test (Failed)
        1116 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_semaphore_test (Failed)
        1117 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_semaphore_submission_test (Failed)
        1126 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_semaphore_test (Failed)
        1127 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_semaphore_submission_test (Failed)
        1136 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_semaphore_test (Failed)
        1137 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_semaphore_submission_test (Failed)
        1146 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_semaphore_test (Failed)
        1147 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_semaphore_submission_test (Failed)
```

This is because the stack trace part differs:

**a_str:**
```
iree/runtime/src/iree/hal/cts/semaphore_test.h:440: CANCELLED; FailThenWait test.; stack:
  0x... hip_stream_semaphore_test <???> (event_semaphore.c:812)  ← clone site
  0x... hip_stream_semaphore_test <???> (semaphore.c:77)
  0x... hip_stream_semaphore_test <???> (semaphore_test.h:448)
  0x... hip_stream_semaphore_test <???> (gtest.cc:2664)
  ...
```

**b_str:**
```
iree/runtime/src/iree/hal/cts/semaphore_test.h:440: CANCELLED; FailThenWait test.; stack:
  0x... hip_stream_semaphore_test <???> (gtest.cc:2664)  ← original creation site
  0x... hip_stream_semaphore_test <???> (gtest.cc:2739)
  0x... hip_stream_semaphore_test <???> (gtest.cc:2885)
  ...
```
