### PR TITLE
[GPU] Account for scale operands in shared memory calculation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -20,9 +20,13 @@ struct GPUMatmulShapeType {
   SmallVector<int64_t, 2> nSizes;
   SmallVector<int64_t, 2> kSizes;
   SmallVector<int64_t, 2> batchSizes;
+
   Type aType;
   Type bType;
+  std::optional<Type> aScaleType;
+  std::optional<Type> bScaleType;
   Type cType;
+
   GemmSize gemmSize = GemmSize::NotSet;
 
   // Number of horizontally fused operations.
@@ -34,11 +38,21 @@ struct GPUMatmulShapeType {
                      int64_t numHorizontallyFusedOps = 1)
       : mSizes({m}), nSizes({n}), kSizes({k}), batchSizes({}), aType(a),
         bType(b), cType(c), numHorizontallyFusedOps(numHorizontallyFusedOps) {}
+
   GPUMatmulShapeType(ArrayRef<int64_t> m, ArrayRef<int64_t> n,
                      ArrayRef<int64_t> k, ArrayRef<int64_t> batch, Type a,
                      Type b, Type c, int64_t numHorizontallyFusedOps = 1)
       : mSizes(m), nSizes(n), kSizes(k), batchSizes(batch), aType(a), bType(b),
         cType(c), numHorizontallyFusedOps(numHorizontallyFusedOps) {}
+
+  GPUMatmulShapeType(ArrayRef<int64_t> m, ArrayRef<int64_t> n,
+                     ArrayRef<int64_t> k, ArrayRef<int64_t> batch, Type a,
+                     Type b, std::optional<Type> aScale,
+                     std::optional<Type> bScale, Type c,
+                     int64_t numHorizontallyFusedOps = 1)
+      : mSizes(m), nSizes(n), kSizes(k), batchSizes(batch), aType(a), bType(b),
+        aScaleType(aScale), bScaleType(bScale), cType(c),
+        numHorizontallyFusedOps(numHorizontallyFusedOps) {}
 };
 
 /// Struct containing information about a GPU MMA intrinsic type.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -23,9 +23,9 @@ struct GPUMatmulShapeType {
 
   Type aType;
   Type bType;
-  std::optional<Type> aScaleType;
-  std::optional<Type> bScaleType;
   Type cType;
+  Type aScaleType;
+  Type bScaleType;
 
   GemmSize gemmSize = GemmSize::NotSet;
 
@@ -41,17 +41,10 @@ struct GPUMatmulShapeType {
 
   GPUMatmulShapeType(ArrayRef<int64_t> m, ArrayRef<int64_t> n,
                      ArrayRef<int64_t> k, ArrayRef<int64_t> batch, Type a,
-                     Type b, Type c, int64_t numHorizontallyFusedOps = 1)
+                     Type b, Type c, Type aScale = nullptr,
+                     Type bScale = nullptr, int64_t numHorizontallyFusedOps = 1)
       : mSizes(m), nSizes(n), kSizes(k), batchSizes(batch), aType(a), bType(b),
-        cType(c), numHorizontallyFusedOps(numHorizontallyFusedOps) {}
-
-  GPUMatmulShapeType(ArrayRef<int64_t> m, ArrayRef<int64_t> n,
-                     ArrayRef<int64_t> k, ArrayRef<int64_t> batch, Type a,
-                     Type b, std::optional<Type> aScale,
-                     std::optional<Type> bScale, Type c,
-                     int64_t numHorizontallyFusedOps = 1)
-      : mSizes(m), nSizes(n), kSizes(k), batchSizes(batch), aType(a), bType(b),
-        aScaleType(aScale), bScaleType(bScale), cType(c),
+        cType(c), aScaleType(aScale), bScaleType(bScale),
         numHorizontallyFusedOps(numHorizontallyFusedOps) {}
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -154,7 +154,7 @@ struct GPUMMASchedule {
 FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMatmulShapeType &problem, ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
-    int64_t subgroupSize, std::optional<int64_t> cuCount,
+    int64_t subgroupSize, std::optional<int64_t> cuCount, Location loc,
     bool transposedLhs = false, bool transposedRhs = false,
     bool canUpcastAcc = false, bool mustBeAligned = true,
     bool doCPromotion = false, int64_t splitReductionTripCnt = 0);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -776,8 +776,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   Type lhsElemType = getElementTypeOrSelf(operands[0]);
   Type rhsElemType = getElementTypeOrSelf(operands[1]);
   Type initElemType = getElementTypeOrSelf(operands[2]);
-  std::optional<Type> lhsScaleType, rhsScaleType;
-
+  Type lhsScaleType = nullptr;
+  Type rhsScaleType = nullptr;
   if (scaled) {
     assert(llvm::all_of(operands,
                         [](Value a) { return isa<ShapedType>(a.getType()); }) &&
@@ -800,9 +800,9 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              getDimBoundsNoPad(batchDims),
                              lhsElemType,
                              rhsElemType,
+                             initElemType,
                              lhsScaleType,
-                             rhsScaleType,
-                             initElemType};
+                             rhsScaleType};
 
   // Accumulator needs shared memory if:
   // - Padding requires C promotion, OR

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -330,12 +330,12 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // First try to find a schedule with an exactly matching intrinsic.
   FailureOr<GPUMMASchedule> schedule =
       deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                        targetSubgroupSize, wgpCount);
+                        targetSubgroupSize, wgpCount, op.getLoc());
   if (failed(schedule)) {
     // Then try again by allowing upcasting accumulator.
     schedule =
         deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                          targetSubgroupSize, wgpCount,
+                          targetSubgroupSize, wgpCount, op.getLoc(),
                           /*transposedLhs*/ false, /*transposedRhs*/ false,
                           /*canUpcastAcc=*/true);
   }
@@ -589,13 +589,13 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // First try to find a schedule with an exactly matching intrinsic.
   std::optional<GPUMMASchedule> schedule =
       deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                        targetSubgroupSize, wgpCount);
+                        targetSubgroupSize, wgpCount, op.getLoc());
   if (!schedule) {
     // Then try again by allowing upcasting accumulator.
-    schedule = deduceMMASchedule(problem, intrinsics, seeds,
-                                 maxSharedMemoryBytes, targetSubgroupSize,
-                                 wgpCount, transposedLhs, transposedRhs,
-                                 /*canUpcastAcc=*/true);
+    schedule =
+        deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
+                          targetSubgroupSize, wgpCount, op.getLoc(),
+                          transposedLhs, transposedRhs, /*canUpcastAcc=*/true);
   }
 
   if (!schedule) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -515,9 +515,16 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // all instances of schedule->m/nSubgroupCounts[0],
   // schedule->m/n/kTileSizes[0] and schedule->m/n/kSizes[0] need to use the
   // full list of sizes instead of just the first element.
-  GPUMatmulShapeType problem{
-      {bounds[mDim]}, {bounds[nDim]}, {bounds[kDim]}, getDimBounds(batchDims),
-      lhsElemType,    rhsElemType,    initElemType,   numHorizontallyFusedOps};
+  GPUMatmulShapeType problem{{bounds[mDim]},
+                             {bounds[nDim]},
+                             {bounds[kDim]},
+                             getDimBounds(batchDims),
+                             lhsElemType,
+                             rhsElemType,
+                             initElemType,
+                             /*aScaleType=*/nullptr,
+                             /*bScaleType=*/nullptr,
+                             numHorizontallyFusedOps};
 
   // Helper fn to store mma information.
   auto storeMmaInfo = [](IREE::GPU::MmaInterfaceAttr mma,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -926,9 +926,9 @@ setCooperativeMatrixConfig(IREE::GPU::TargetAttr target, linalg::LinalgOp op,
   bool transposedRhs =
       nIndex != cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
 
-  FailureOr<GPUMMASchedule> schedule =
-      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimitInBytes,
-                        subgroupSize, transposedLhs, transposedRhs);
+  FailureOr<GPUMMASchedule> schedule = deduceMMASchedule(
+      problem, intrinsics, seeds, sharedMemoryLimitInBytes, subgroupSize,
+      /*cuCount=*/std::nullopt, op.getLoc(), transposedLhs, transposedRhs);
   if (failed(schedule))
     return failure();
   assert(schedule->hasSingleDimensions() && "expected single M/N/K dimension");


### PR DESCRIPTION
This PR fixes the shared memory calculation for scaled matmul operations by properly accounting for scale operands in the GPU heuristics.