### PR TITLE
Update iree-test-suites

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17a391dc3882f136e567bf2687806ef6af46ad64
+          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
           path: iree-test-suites
       - name: Install ONNX ops test suite requirements
         run: |
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17a391dc3882f136e567bf2687806ef6af46ad64
+          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
           path: iree-test-suites
       - name: Install ONNX models test suite requirements
         run: |

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17a391dc3882f136e567bf2687806ef6af46ad64
+          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
           path: iree-test-suites
           lfs: true
 
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17a391dc3882f136e567bf2687806ef6af46ad64
+          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
           path: iree-test-suites
           lfs: true
 

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 132f91e49d629c35f98492a9f619017b83782aba
+          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
           path: iree-test-suites
       - name: Install Torch ops test suite requirements
         run: |
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17a391dc3882f136e567bf2687806ef6af46ad64
+          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
           path: iree-test-suites
           # Don't need lfs for torch models yet.
           lfs: false

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
@@ -7,7 +7,20 @@
   ],
   "iree_run_module_flags": [],
   "skip_compile_tests": [],
-  "skip_run_tests": [],
+  "skip_run_tests": [
+    "AB/8192x8192xf32_bench",
+    "AB/4096x4096xf32_bench",
+    "AB/2048x2048xf32_bench"
+  ],
   "expected_compile_failures": [],
-  "expected_run_failures": []
+  "expected_run_failures": [],
+  "golden_times_ms": {
+    "AB/8192x8192xf32_bench": 5587.488262355328,
+    "AB/1024x1024xf32_bench": 1.1874544098876767,
+    "AB/256x256xf32_bench": 0.044473891122477315,
+    "AB/128x128xf32_bench": 0.03577919309132721,
+    "AB/2048x2048xf32_bench": 10.41092509722771,
+    "AB/4096x4096xf32_bench": 131.7884701769799,
+    "AB/512x512xf32_bench": 0.12528392536236224
+  }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
@@ -10,8 +10,15 @@
   ],
   "skip_compile_tests": [],
   "skip_run_tests": [
-    "generated/test_a_b_plus_c_float16",
-    "generated/test_a_t_b_float16"
+    "AB/8192x8192xf32_bench",
+    "AB/4096x4096xf32_bench",
+    "AB/2048x2048xf32_bench",
+    "AB/1024x1024xf32_bench",
+    "AB/256x256xf32_bench",
+    "AB/128x128xf32_bench",
+    "AB/512x512xf32_bench",
+    "ABPlusC/64x64xf16",
+    "ATB/64x64xf16"
   ],
   "expected_compile_failures": [],
   "expected_run_failures": []

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
@@ -10,16 +10,18 @@
   ],
   "skip_compile_tests": [],
   "skip_run_tests": [
-    "AB/8192x8192xf32_bench",
-    "AB/4096x4096xf32_bench",
-    "AB/2048x2048xf32_bench",
-    "AB/1024x1024xf32_bench",
-    "AB/256x256xf32_bench",
-    "AB/128x128xf32_bench",
-    "AB/512x512xf32_bench",
     "ABPlusC/64x64xf16",
     "ATB/64x64xf16"
   ],
   "expected_compile_failures": [],
-  "expected_run_failures": []
+  "expected_run_failures": [],
+  "golden_times_ms": {
+    "AB/8192x8192xf32_bench": 211.36675303181013,
+    "AB/1024x1024xf32_bench": 0.473261977629155,
+    "AB/256x256xf32_bench": 0.13523232175050667,
+    "AB/128x128xf32_bench": 0.10226182854380102,
+    "AB/2048x2048xf32_bench": 3.35047472617589,
+    "AB/4096x4096xf32_bench": 26.499415814344378,
+    "AB/512x512xf32_bench": 0.16945170770798412
+  }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
@@ -10,7 +10,14 @@
   ],
   "skip_compile_tests": [],
   "skip_run_tests": [
-    "generated/test_a_t_b_float16"
+    "AB/8192x8192xf32_bench",
+    "AB/4096x4096xf32_bench",
+    "AB/2048x2048xf32_bench",
+    "AB/1024x1024xf32_bench",
+    "AB/256x256xf32_bench",
+    "AB/128x128xf32_bench",
+    "AB/512x512xf32_bench",
+    "ATB/64x64xf16"
   ],
   "expected_compile_failures": [],
   "expected_run_failures": []

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
@@ -10,15 +10,17 @@
   ],
   "skip_compile_tests": [],
   "skip_run_tests": [
-    "AB/8192x8192xf32_bench",
-    "AB/4096x4096xf32_bench",
-    "AB/2048x2048xf32_bench",
-    "AB/1024x1024xf32_bench",
-    "AB/256x256xf32_bench",
-    "AB/128x128xf32_bench",
-    "AB/512x512xf32_bench",
     "ATB/64x64xf16"
   ],
   "expected_compile_failures": [],
-  "expected_run_failures": []
+  "expected_run_failures": [],
+  "golden_times_ms": {
+    "AB/8192x8192xf32_bench": 10.345919956763586,
+    "AB/1024x1024xf32_bench": 0.12306747736492638,
+    "AB/256x256xf32_bench": 0.06101156551354003,
+    "AB/128x128xf32_bench": 0.052202587451140196,
+    "AB/2048x2048xf32_bench": 0.2345012331137894,
+    "AB/4096x4096xf32_bench": 1.423236482683913,
+    "AB/512x512xf32_bench": 0.07336693902980182
+  }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
@@ -8,14 +8,21 @@
     "--device=vulkan"
   ],
   "skip_compile_tests": [
-    "generated/test_a_t_b_float16",
-    "generated/test_a_b_plus_c_float16",
-    "generated/test_a_b_t_float16",
-    "generated/test_relu_a_b_plus_c_float16",
-    "generated/test_gelu_a_b_plus_c_float16"
+    "ATB/64x64xf16",
+    "ABPlusC/64x64xf16",
+    "ABT/64x64xf16",
+    "ReluABPlusC/64x64xf16",
+    "GeluABPlusC/64x64xf16",
+    "AB/64x64xf16"
   ],
   "skip_run_tests": [
-    "generated/test_a_b_float16"
+    "AB/8192x8192xf32_bench",
+    "AB/4096x4096xf32_bench",
+    "AB/2048x2048xf32_bench",
+    "AB/1024x1024xf32_bench",
+    "AB/256x256xf32_bench",
+    "AB/128x128xf32_bench",
+    "AB/512x512xf32_bench"
   ],
   "expected_compile_failures": [],
   "expected_run_failures": []

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
@@ -13,17 +13,19 @@
     "ABT/64x64xf16",
     "ReluABPlusC/64x64xf16",
     "GeluABPlusC/64x64xf16",
-    "AB/64x64xf16"
+    "AB/64x64xf16",
+    "AB/Nx64xf16_64xNxf16"
   ],
-  "skip_run_tests": [
-    "AB/8192x8192xf32_bench",
-    "AB/4096x4096xf32_bench",
-    "AB/2048x2048xf32_bench",
-    "AB/1024x1024xf32_bench",
-    "AB/256x256xf32_bench",
-    "AB/128x128xf32_bench",
-    "AB/512x512xf32_bench"
-  ],
+  "skip_run_tests": [],
   "expected_compile_failures": [],
-  "expected_run_failures": []
+  "expected_run_failures": [],
+  "golden_times_ms": {
+    "AB/8192x8192xf32_bench": 107.60851647438749,
+    "AB/1024x1024xf32_bench": 0.4509026762196051,
+    "AB/256x256xf32_bench": 0.1743873563575457,
+    "AB/128x128xf32_bench": 0.148048073505022,
+    "AB/2048x2048xf32_bench": 1.5943956199949283,
+    "AB/4096x4096xf32_bench": 10.252960922347533,
+    "AB/512x512xf32_bench": 0.23526767679662958
+  }
 }


### PR DESCRIPTION
* update iree-test-suite ref across the repo
* add golden times for square gemm benchmarks

This update will allow downloading from hugging face and not from github lfs for onnx models.

ci-extra: test_torch