### PR TITLE
[stablehlo] Drop noop sharding ops

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOCustomCalls.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOCustomCalls.cpp
@@ -7,6 +7,7 @@
 // Implements logic for lowering CHLO ops to StableHLO and Shape dialect ops,
 // taking care of CHLO's broadcasting semantics
 
+#include <llvm/Support/Casting.h>
 #include "compiler/plugins/input/StableHLO/Conversion/Passes.h"
 #include "compiler/plugins/input/StableHLO/Conversion/Preprocessing/Rewriters.h"
 #include "compiler/plugins/input/StableHLO/Conversion/Rewriters.h"
@@ -15,6 +16,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -238,6 +240,50 @@ struct ShapeAssertionDrop final
   }
 };
 
+struct NoOpShardingDrop final
+    : OpRewritePattern<mlir::stablehlo::CustomCallOp> {
+  using Base::Base;
+  using OpAdaptor = mlir::stablehlo::CustomCallOp::Adaptor;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::CustomCallOp op,
+                                PatternRewriter &rewriter) const final {
+    if (op.getCallTargetName() != "Sharding") {
+      return rewriter.notifyMatchFailure(op, "not ShardingCustomCall");
+    }
+    unsigned numOperands = op.getNumOperands();
+    if (numOperands != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "ShardingCustomCall with more than one operand");
+    }
+
+    // Get root of the operations
+    mlir::Operation *root = op.getOperation();
+    while (root->getParentOp() != nullptr) {
+      root = root->getParentOp();
+    }
+    auto rootAttrs =
+        llvm::dyn_cast<mlir::DictionaryAttr>(root->getAttrDictionary());
+    auto numPartitions = llvm::dyn_cast_if_present<mlir::IntegerAttr>(
+        rootAttrs.get("mhlo.num_partitions"));
+    auto numReplicas = llvm::dyn_cast_if_present<mlir::IntegerAttr>(
+        rootAttrs.get("mhlo.num_replicas"));
+    if (numPartitions == nullptr || numReplicas == nullptr) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "ShardingCustomCall: Number of partitions or replicas not specified");
+    }
+
+    if (numPartitions.getInt() == 1 && numReplicas.getInt() == 1) {
+      // Remove sharding as number of partitions and replicas is 1
+      rewriter.replaceOp(op, op.getOperands()[0]);
+      return success();
+    }
+    // There is more than one partition or replica
+    return rewriter.notifyMatchFailure(
+        op, "Sharding with multiple partitions or replicas is not supported");
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Pass Definition.
 //===----------------------------------------------------------------------===//
@@ -254,7 +300,8 @@ struct LegalizeStableHLOCustomCalls final
     MLIRContext *ctx = f.getContext();
 
     RewritePatternSet patterns(ctx);
-    patterns.add<HouseholderReflectorRewriter, ShapeAssertionDrop>(ctx);
+    patterns.add<HouseholderReflectorRewriter, ShapeAssertionDrop,
+                 NoOpShardingDrop>(ctx);
     if (failed(applyPatternsGreedily(f, std::move(patterns)))) {
       signalPassFailure();
     }

--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_custom_calls.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_custom_calls.mlir
@@ -10,3 +10,14 @@ func.func public @householder(%arg0: tensor<4x3xf32>, %arg1: tensor<2xf32>) -> (
   %0 = stablehlo.custom_call @ProductOfElementaryHouseholderReflectors(%arg0, %arg1) : (tensor<4x3xf32>, tensor<2xf32>) -> tensor<4x3xf32>
   return %0 : tensor<4x3xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @noop_sharding_custom_call
+func.func public @noop_sharding_custom_call(%arg0: tensor<2xui32>) {
+  %result = "stablehlo.custom_call"(%arg0) <{call_target_name = "Sharding"}> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding_per_value<[<@empty_mesh, [{}]>]>"}, mhlo.sharding = "{replicated}"} : (tensor<2xui32>) -> tensor<2xui32>
+  // CHECK-NOT: stablehlo.custom_call
+  // CHECK-NOT: sharding
+  return
+}
+

--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_custom_calls.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_custom_calls.mlir
@@ -20,4 +20,3 @@ func.func public @noop_sharding_custom_call(%arg0: tensor<2xui32>) {
   // CHECK-NOT: sharding
   return
 }
-


### PR DESCRIPTION
This PR drops noop sharding `stablehlo.custom_call`s (conversion pattern `NoOpShardingDrop`).

All sharding ops with number of partitions and number of replicas equal to `1` are replaced by their argument, the rest of them are marked as unsupported.