### PR TITLE
[CPU] Add fp8 emulation support for CPU backend

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -60,6 +60,7 @@ class TargetConverter:
                 "@llvm-project//mlir:AllPassesAndDialects": ["MLIRAllDialects"],
                 "@llvm-project//mlir:ArithOpsIncGen": ["MLIRArithDialect"],
                 "@llvm-project//mlir:BufferizationInterfaces": [""],
+                "@llvm-project//mlir:BuiltinTypesIncGen": [""],
                 "@llvm-project//mlir:CommonFolders": [""],
                 "@llvm-project//mlir:ConversionPasses": [""],
                 "@llvm-project//mlir:DialectUtils": [""],

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -240,6 +240,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationInterfaces",
         "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:BuiltinTypesIncGen",
         "@llvm-project//mlir:BytecodeWriter",
         "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:DialectUtils",

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -214,8 +214,9 @@ public:
 
   /// Returns the Inf encoding for the small float type (0 if no Inf support).
   Value getInfEncodingConst() {
-    if (!smallHasInf)
+    if (!smallHasInf) {
       return createI32Const(0);
+    }
     return getSmallExpMaskConst();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -75,7 +75,6 @@ static void appendTypesIf(MLIRContext *ctx, SmallVectorImpl<Type> &types) {
 //   - NaN: exp=max, mantissa!=0 (IEEE), or special encoding (FNUZ: 0x80)
 
 // F32 format constants (IEEE 754 binary32).
-constexpr int kF32ExpBits = 8;
 constexpr int kF32MantBits = 23;
 constexpr int kF32Bias = 127;
 
@@ -358,9 +357,8 @@ struct TruncFToFP8 final : public OpRewritePattern<arith::TruncFOp> {
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const override {
     Type resultType = op.getResult().getType();
-    Type inputType = op.getIn().getType();
     Type resultElemType = getElementTypeOrSelf(resultType);
-    Type inputElemType = getElementTypeOrSelf(inputType);
+    Type inputElemType = getElementTypeOrSelf(op.getIn().getType());
 
     // TODO(#23105): handle other fp types, e.g., fp4.
     if (!isa<Float32Type>(inputElemType) ||

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -13,13 +13,19 @@
 //
 //===---------------------------------------------------------------------===//
 
+#include <type_traits>
+
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-convert-unsupported-float-arith"
 
@@ -30,6 +36,522 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+/// SFINAE (i.e., substitution failure is not an error) helper to detect if
+/// T::get(MLIRContext*) is valid.
+template <typename T, typename = void>
+struct HasContextGet : std::false_type {};
+template <typename T>
+struct HasContextGet<
+    T, std::void_t<decltype(T::get(std::declval<MLIRContext *>()))>>
+    : std::true_type {};
+
+/// Helpers to append types to a vector if they are f8 types.
+template <typename T>
+void maybeAppendType(MLIRContext *ctx, SmallVectorImpl<Type> &types) {
+  if constexpr (HasContextGet<T>::value) {
+    Type t = T::get(ctx);
+    if (isa<FloatType>(t) && t.getIntOrFloatBitWidth() == 8) {
+      types.push_back(t);
+    }
+  }
+}
+template <typename... Ts>
+void appendTypesIf(MLIRContext *ctx, SmallVectorImpl<Type> &types) {
+  (maybeAppendType<Ts>(ctx, types), ...);
+}
+
+//===----------------------------------------------------------------------===//
+// Float type format parameters
+//===----------------------------------------------------------------------===//
+
+/// Parameters describing a floating-point format for conversion.
+struct FloatTypeInfo {
+  unsigned expBits;     // Number of exponent bits.
+  unsigned mantBits;    // Number of mantissa bits (excluding implicit bit).
+  int bias;             // Exponent bias.
+  bool hasInf;          // Whether the format supports infinity.
+  bool hasNegZero;      // Whether the format supports negative zero.
+  unsigned nanEncoding; // Bit pattern for canonical NaN.
+  unsigned infEncoding; // Bit pattern for +Inf (0 if no Inf support).
+};
+
+/// Returns format info for a float type by querying APFloat semantics. It
+/// assumes that the type can always be casted to FloatType.
+static FloatTypeInfo getFloatTypeInfo(Type type) {
+  auto floatType = cast<FloatType>(type);
+  const llvm::fltSemantics &sem = floatType.getFloatSemantics();
+  FloatTypeInfo info;
+
+  // Derive format parameters from APFloat semantics.
+  // Precision includes the implicit bit, so mantissa bits = precision - 1.
+  info.mantBits = llvm::APFloat::semanticsPrecision(sem) - 1;
+  unsigned totalBits = llvm::APFloat::semanticsSizeInBits(sem);
+  // Total bits = 1 (sign) + expBits + mantBits.
+  info.expBits = totalBits - 1 - info.mantBits;
+
+  // Bias = 1 - minExponent. This works for both IEEE and FNUZ formats.
+  // For f32: minExp = -126, so bias = 1 - (-126) = 127.
+  // For f8E5M2FNUZ: minExp = -15, so bias = 1 - (-15) = 16.
+  int minExp = llvm::APFloat::semanticsMinExponent(sem);
+  info.bias = 1 - minExp;
+
+  info.hasInf = llvm::APFloat::semanticsHasInf(sem);
+  // Check for negative zero support by seeing if getZero with negative=true
+  // produces a negative zero (vs NaN in FNUZ types where 0x80 encodes NaN).
+  llvm::APFloat negZero = llvm::APFloat::getZero(sem, /*Negative=*/true);
+  info.hasNegZero = negZero.isZero() && negZero.isNegative();
+
+  // Compute NaN and Inf encodings based on format type.
+  unsigned maxExpCode = (1u << info.expBits) - 1;
+  unsigned mantMask = (1u << info.mantBits) - 1;
+
+  if (!info.hasNegZero && !info.hasInf) {
+    // FNUZ types: NaN = 0x80 (sign bit set, all else zero), no Inf.
+    info.nanEncoding = 1u << (totalBits - 1);
+    info.infEncoding = 0;
+  } else if (info.hasInf) {
+    // IEEE types: NaN = all exp bits + some mant bits, Inf = all exp bits.
+    info.infEncoding = maxExpCode << info.mantBits;
+    info.nanEncoding = info.infEncoding | mantMask;
+  } else {
+    // FN types (like f8E4M3FN): No Inf, but has NaN at max exp with mant != 0.
+    info.infEncoding = 0;
+    info.nanEncoding = (maxExpCode << info.mantBits) | mantMask;
+  }
+
+  return info;
+}
+
+//===----------------------------------------------------------------------===//
+// Helper for float emulation patterns
+//===----------------------------------------------------------------------===//
+
+/// Helper class for emulating float conversions using integer bit manipulation.
+/// Handles both scalar and vector types uniformly.
+class FloatEmulationHelper {
+public:
+  FloatEmulationHelper(RewriterBase &rewriter, Location loc, Type type)
+      : rewriter(rewriter), loc(loc), vecType(dyn_cast<VectorType>(type)) {
+    Type i32ScalarType = rewriter.getI32Type();
+    Type i8ScalarType = rewriter.getI8Type();
+    i32Type = vecType ? VectorType::get(vecType.getShape(), i32ScalarType)
+                      : i32ScalarType;
+    i8Type = vecType ? VectorType::get(vecType.getShape(), i8ScalarType)
+                     : i8ScalarType;
+  }
+
+  /// Creates an i32 constant, splatted if working with vectors.
+  Value createI32Const(int64_t value) {
+    auto attr = rewriter.getIntegerAttr(rewriter.getI32Type(), value);
+    if (vecType) {
+      auto splatAttr = SplatElementsAttr::get(cast<ShapedType>(i32Type), attr);
+      return rewriter.createOrFold<arith::ConstantOp>(loc, i32Type, splatAttr);
+    }
+    return rewriter.createOrFold<arith::ConstantOp>(loc, i32Type, attr);
+  }
+
+  /// Extracts sign, exponent, and mantissa from an i32 value.
+  /// Returns {sign, biasedExp, mantissa}.
+  std::tuple<Value, Value, Value> extractFields(Value i32Val,
+                                                const FloatTypeInfo &info) {
+    Value cExpShift = createI32Const(info.mantBits);
+    Value cSignShift = createI32Const(info.expBits + info.mantBits);
+    Value cExpMask = createI32Const((1 << info.expBits) - 1);
+    Value cMantMask = createI32Const((1 << info.mantBits) - 1);
+
+    Value sign = arith::ShRUIOp::create(rewriter, loc, i32Val, cSignShift);
+    Value biasedExp = arith::ShRUIOp::create(rewriter, loc, i32Val, cExpShift);
+    biasedExp = arith::AndIOp::create(rewriter, loc, biasedExp, cExpMask);
+    Value mant = arith::AndIOp::create(rewriter, loc, i32Val, cMantMask);
+
+    return {sign, biasedExp, mant};
+  }
+
+  /// Packs sign, exponent, and mantissa into an i32 value.
+  Value packFields(Value sign, Value biasedExp, Value mant,
+                   const FloatTypeInfo &info) {
+    Value cExpShift = createI32Const(info.mantBits);
+    Value cSignShift = createI32Const(info.expBits + info.mantBits);
+
+    Value signShifted = arith::ShLIOp::create(rewriter, loc, sign, cSignShift);
+    Value expShifted =
+        arith::ShLIOp::create(rewriter, loc, biasedExp, cExpShift);
+    Value result = arith::OrIOp::create(rewriter, loc, signShifted, expShifted);
+    return arith::OrIOp::create(rewriter, loc, result, mant);
+  }
+
+  /// Checks if the value represents zero (exp == 0 && mant == 0).
+  Value isZero(Value biasedExp, Value mant) {
+    Value c0 = createI32Const(0);
+    Value expIsZero = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, biasedExp, c0);
+    Value mantIsZero = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, mant, c0);
+    return arith::AndIOp::create(rewriter, loc, expIsZero, mantIsZero);
+  }
+
+  Type getI32Type() const { return i32Type; }
+  Type getI8Type() const { return i8Type; }
+
+private:
+  RewriterBase &rewriter;
+  Location loc;
+  VectorType vecType;
+  Type i32Type;
+  Type i8Type;
+};
+
+//===----------------------------------------------------------------------===//
+// TruncF to small float emulation pattern
+//===----------------------------------------------------------------------===//
+
+/// Emulates arith.truncf from f32 to fp8 using integer bit manipulation.
+/// This is needed because LLVM doesn't support fptrunc to fp8 types.
+///
+/// The conversion handles three categories of fp8 formats:
+///
+/// 1. FNUZ types (f8E5M2FNUZ, f8E4M3FNUZ): No Inf, no negative zero.
+///    - NaN is encoded as 0x80 (sign=1, exp=0, mant=0).
+///    - Overflow (finite values too large) produces NaN.
+///    - Zero is always positive (0x00).
+///
+/// 2. IEEE types (f8E5M2): Has Inf and negative zero.
+///    - NaN is encoded as exp=max with non-zero mantissa.
+///    - Inf is encoded as exp=max with zero mantissa.
+///    - Overflow produces signed Inf (preserves sign).
+///    - Zero preserves sign (+0.0 or -0.0).
+///
+/// 3. FN types (f8E4M3FN): No Inf, but has negative zero.
+///    - NaN is encoded at a specific bit pattern (e.g., 0x7F).
+///    - Overflow produces NaN.
+///    - Zero preserves sign (+0.0 or -0.0).
+///
+/// Special value handling priority (highest to lowest):
+///   1. Source NaN -> destination NaN (must propagate).
+///   2. Source Inf -> destination Inf (IEEE) or NaN (FNUZ/FN).
+///   3. Source zero -> destination zero (preserve sign if supported).
+///   4. Overflow -> Inf (IEEE) or NaN (FNUZ/FN).
+///   5. Underflow -> zero.
+///
+/// Denormal handling:
+///   This implementation uses flush-to-zero (FTZ) semantics for denormals.
+///   When the adjusted exponent is <= 0 (underflow), the result is flushed to
+///   zero rather than producing a denormal fp8 value. This is a known
+///   limitation that simplifies the implementation. Proper denormal support
+///   would require additional logic to compute the subnormal mantissa shift.
+///
+/// Rounding:
+///   Uses round-half-away-from-zero (adding the round bit), not IEEE 754
+///   round-half-to-even (banker's rounding). This is a simplification that
+///   may cause minor differences compared to strict IEEE 754 implementations.
+struct TruncFToFP8 final : public OpRewritePattern<arith::TruncFOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(arith::TruncFOp op,
+                                PatternRewriter &rewriter) const override {
+    Type resultType = op.getResult().getType();
+    Type inputType = op.getIn().getType();
+    Type resultElemType = getElementTypeOrSelf(resultType);
+    Type inputElemType = getElementTypeOrSelf(inputType);
+
+    // TODO(#23105): handle other fp types, e.g., fp4.
+    if (!isa<Float32Type>(inputElemType) ||
+        resultElemType.getIntOrFloatBitWidth() != 8) {
+      return failure();
+    }
+
+    FloatTypeInfo srcInfo = getFloatTypeInfo(inputElemType);
+    FloatTypeInfo dstInfo = getFloatTypeInfo(resultElemType);
+    Location loc = op.getLoc();
+    FloatEmulationHelper helper(rewriter, loc, resultType);
+
+    // Calculate format-specific constants.
+    int biasDiff = srcInfo.bias - dstInfo.bias;
+    int mantShift = srcInfo.mantBits - dstInfo.mantBits;
+    int dstMantMask = (1 << dstInfo.mantBits) - 1;
+    int roundBit = 1 << (mantShift - 1);
+
+    // For IEEE types, max normal exponent is (2^expBits - 2) because
+    // (2^expBits - 1) encodes Inf/NaN. For FNUZ types, all exponent codes
+    // except 0 (with sign=1 for NaN) are valid normal values.
+    int dstMaxNormalExp = dstInfo.hasInf ? (1 << dstInfo.expBits) - 2
+                                         : (1 << dstInfo.expBits) - 1;
+
+    Value c0 = helper.createI32Const(0);
+    Value c1 = helper.createI32Const(1);
+    Value cBiasDiff = helper.createI32Const(biasDiff);
+    Value cMantShift = helper.createI32Const(mantShift);
+    Value cDstMaxNormalExp = helper.createI32Const(dstMaxNormalExp);
+    Value cDstMantMask = helper.createI32Const(dstMantMask);
+    Value cRoundBit = helper.createI32Const(roundBit);
+    Value cMantOverflowBit = helper.createI32Const(1 << srcInfo.mantBits);
+    Value cSrcExpMask = helper.createI32Const((1 << srcInfo.expBits) - 1);
+    Value cNaN = helper.createI32Const(dstInfo.nanEncoding);
+    // Overflow produces Inf for IEEE types, NaN for FNUZ/FN types.
+    Value cOverflow = helper.createI32Const(
+        dstInfo.hasInf ? dstInfo.infEncoding : dstInfo.nanEncoding);
+
+    // Bitcast f32 to i32 and extract fields.
+    Value i32Val = arith::BitcastOp::create(rewriter, loc, helper.getI32Type(),
+                                            op.getIn());
+    auto [sign, biasedExpSrc, mantSrc] = helper.extractFields(i32Val, srcInfo);
+
+    // Check for NaN/Inf in source (exponent == max).
+    Value srcIsNanOrInf = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, biasedExpSrc, cSrcExpMask);
+    // Distinguish NaN vs Inf in source: NaN has non-zero mantissa.
+    Value srcIsNan = arith::AndIOp::create(
+        rewriter, loc, srcIsNanOrInf,
+        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ne, mantSrc,
+                              c0));
+    Value srcIsInf = arith::AndIOp::create(
+        rewriter, loc, srcIsNanOrInf,
+        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq, mantSrc,
+                              c0));
+
+    // Check for zero.
+    Value isZeroVal = helper.isZero(biasedExpSrc, mantSrc);
+
+    // Adjust exponent bias.
+    Value biasedExpDst =
+        arith::SubIOp::create(rewriter, loc, biasedExpSrc, cBiasDiff);
+
+    // Check for overflow (exp > dstMaxNormalExp) and underflow (exp <= 0).
+    Value isOverflow =
+        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sgt,
+                              biasedExpDst, cDstMaxNormalExp);
+    Value isUnderflow = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::sle, biasedExpDst, c0);
+
+    // Round mantissa and handle mantissa overflow (carry into exponent).
+    Value mantRounded =
+        arith::AddIOp::create(rewriter, loc, mantSrc, cRoundBit);
+    Value mantOverflow =
+        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::uge,
+                              mantRounded, cMantOverflowBit);
+
+    Value expIncr = arith::AddIOp::create(rewriter, loc, biasedExpDst, c1);
+    biasedExpDst = arith::SelectOp::create(rewriter, loc, mantOverflow, expIncr,
+                                           biasedExpDst);
+    mantRounded =
+        arith::SelectOp::create(rewriter, loc, mantOverflow, c0, mantRounded);
+
+    // Re-check overflow after potential exponent increment from rounding.
+    isOverflow = arith::OrIOp::create(
+        rewriter, loc, isOverflow,
+        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sgt,
+                              biasedExpDst, cDstMaxNormalExp));
+
+    // Shift mantissa to destination width.
+    Value mantDst =
+        arith::ShRUIOp::create(rewriter, loc, mantRounded, cMantShift);
+    mantDst = arith::AndIOp::create(rewriter, loc, mantDst, cDstMantMask);
+
+    // Pack result and handle special cases.
+    Value result = helper.packFields(sign, biasedExpDst, mantDst, dstInfo);
+
+    // Compute sign bit position for destination format.
+    int dstSignBitPos = dstInfo.expBits + dstInfo.mantBits;
+    Value cSignShift = helper.createI32Const(dstSignBitPos);
+    Value signBit = arith::ShLIOp::create(rewriter, loc, sign, cSignShift);
+
+    // For IEEE types with Inf, compute signed Inf (preserve sign on overflow).
+    // For FNUZ/FN types, overflow/Inf always produces NaN (unsigned).
+    Value signedOverflow = cOverflow;
+    if (dstInfo.hasInf) {
+      signedOverflow = arith::OrIOp::create(rewriter, loc, cOverflow, signBit);
+    }
+
+    // For types with negative zero support, compute signed zero.
+    // FNUZ types don't have negative zero, so zero is always positive.
+    Value zeroResult = c0;
+    if (dstInfo.hasNegZero) {
+      zeroResult = signBit;
+    }
+
+    // Select order matters: later selects take precedence over earlier ones.
+    // This is critical because multiple conditions can be true simultaneously.
+    // For example, f32 NaN has exp=255, so after bias adjustment (255-112=143),
+    // it exceeds dstMaxNormalExp (30), making both srcIsNan AND overflow true.
+    // If overflow were checked after srcIsNan, NaN would incorrectly become
+    // Inf.
+    //
+    // Order from lowest to highest priority:
+    // 1. Overflow/underflow for normal values.
+    // 2. Zero input (preserve sign for IEEE types).
+    // 3. Source Inf (takes precedence over overflow, since Inf also overflows).
+    // 4. Source NaN (highest priority, must always propagate).
+    result = arith::SelectOp::create(rewriter, loc, isOverflow, signedOverflow,
+                                     result);
+    result = arith::SelectOp::create(rewriter, loc, isUnderflow, c0, result);
+    result =
+        arith::SelectOp::create(rewriter, loc, isZeroVal, zeroResult, result);
+    result = arith::SelectOp::create(rewriter, loc, srcIsInf, signedOverflow,
+                                     result);
+    result = arith::SelectOp::create(rewriter, loc, srcIsNan, cNaN, result);
+
+    // Truncate to i8 and bitcast to fp8.
+    result = arith::TruncIOp::create(rewriter, loc, helper.getI8Type(), result);
+    result = arith::BitcastOp::create(rewriter, loc, resultType, result);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ExtF from small float emulation pattern
+//===----------------------------------------------------------------------===//
+
+/// Emulates arith.extf from fp8 to f32 using integer bit manipulation.
+/// This is needed because LLVM doesn't support fpext from fp8 types.
+///
+/// The conversion handles three categories of fp8 formats:
+///
+/// 1. FNUZ types (f8E5M2FNUZ, f8E4M3FNUZ): No Inf, no negative zero.
+///    - NaN is detected by exact bit pattern match (0x80).
+///    - Zero (exp=0, mant=0) is always positive in f32.
+///    - Note: FNUZ NaN (0x80) has exp=0, mant=0, so NaN check must take
+///      precedence over zero check.
+///
+/// 2. IEEE types (f8E5M2): Has Inf and negative zero.
+///    - NaN is detected as exp=max && mant!=0 -> f32 NaN (0x7FC00000).
+///    - Inf is detected as exp=max && mant==0 -> f32 signed Inf.
+///    - Zero preserves sign (+0.0 or -0.0).
+///
+/// 3. FN types (f8E4M3FN): No Inf, but has negative zero.
+///    - NaN is detected by exact bit pattern match (e.g., 0x7F).
+///    - Other exp=max values are valid normal numbers (no Inf).
+///    - Zero preserves sign (+0.0 or -0.0).
+///
+/// Special value handling priority (highest to lowest):
+///   1. Source NaN -> f32 NaN (0x7FC00000).
+///   2. Source Inf -> f32 signed Inf (IEEE types only).
+///   3. Source zero -> f32 zero (preserve sign if supported).
+///
+/// Denormal handling:
+///   This implementation does NOT correctly handle denormal fp8 inputs
+///   (exp=0, mant!=0). Denormal values are treated as if they were normal
+///   values with biased exponent 0, which produces incorrect (larger) results.
+///   This is a known limitation. When round-tripping through this emulation,
+///   TruncFToFP8 uses FTZ so denormals won't be produced. However, fp8 data
+///   from external sources (e.g., model weights) containing denormals will not
+///   be converted correctly. Proper denormal support would require detecting
+///   exp=0 && mant!=0 and computing the appropriate f32 exponent/mantissa.
+struct ExtFFromFP8 final : public OpRewritePattern<arith::ExtFOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(arith::ExtFOp op,
+                                PatternRewriter &rewriter) const override {
+    Type resultType = op.getResult().getType();
+    Type inputType = op.getIn().getType();
+    Type resultElemType = getElementTypeOrSelf(resultType);
+    Type inputElemType = getElementTypeOrSelf(inputType);
+
+    // TODO(#23105): handle other fp types, e.g., fp4.
+    if (inputElemType.getIntOrFloatBitWidth() != 8 ||
+        !isa<Float32Type>(resultElemType)) {
+      return failure();
+    }
+
+    FloatTypeInfo srcInfo = getFloatTypeInfo(inputElemType);
+    FloatTypeInfo dstInfo = getFloatTypeInfo(resultElemType);
+    Location loc = op.getLoc();
+    FloatEmulationHelper helper(rewriter, loc, resultType);
+
+    // Calculate format-specific constants.
+    int biasDiff = dstInfo.bias - srcInfo.bias;
+    int mantShift = dstInfo.mantBits - srcInfo.mantBits;
+    int srcMaxExp = (1 << srcInfo.expBits) - 1;
+
+    Value c0 = helper.createI32Const(0);
+    Value cBiasDiff = helper.createI32Const(biasDiff);
+    Value cMantShift = helper.createI32Const(mantShift);
+    Value cSrcMaxExp = helper.createI32Const(srcMaxExp);
+    Value cF32NaN = helper.createI32Const(0x7FC00000);
+    Value cF32Inf = helper.createI32Const(0x7F800000);
+    Value cSignBit = helper.createI32Const(0x80000000);
+
+    // Bitcast fp8 to i8, extend to i32, and extract fields.
+    Value i8Val =
+        arith::BitcastOp::create(rewriter, loc, helper.getI8Type(), op.getIn());
+    Value i32Val =
+        arith::ExtUIOp::create(rewriter, loc, helper.getI32Type(), i8Val);
+    auto [sign, biasedExpSrc, mantSrc] = helper.extractFields(i32Val, srcInfo);
+
+    // Detect special values based on format type.
+    Value isNaN;
+    Value isInf;
+    if (!srcInfo.hasNegZero && !srcInfo.hasInf) {
+      // FNUZ: NaN = 0x80 (sign=1, exp=0, mant=0), no Inf.
+      Value cFNUZNaN = helper.createI32Const(srcInfo.nanEncoding);
+      isNaN = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
+                                    i32Val, cFNUZNaN);
+    } else if (srcInfo.hasInf) {
+      // IEEE types: NaN = exp==max && mant!=0, Inf = exp==max && mant==0.
+      Value expIsMax = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::eq, biasedExpSrc, cSrcMaxExp);
+      Value mantIsZero = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::eq, mantSrc, c0);
+      Value mantIsNonZero = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::ne, mantSrc, c0);
+      isNaN = arith::AndIOp::create(rewriter, loc, expIsMax, mantIsNonZero);
+      isInf = arith::AndIOp::create(rewriter, loc, expIsMax, mantIsZero);
+    } else {
+      // FN types (like f8E4M3FN): No Inf, NaN only at specific encoding.
+      // NaN = exp==max && mant==maxMant (e.g., 0x7F for f8E4M3FN).
+      // Other exp==max values with mant!=maxMant are valid normal numbers.
+      Value cNaNEncoding = helper.createI32Const(srcInfo.nanEncoding);
+      isNaN = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
+                                    i32Val, cNaNEncoding);
+    }
+
+    // Check for zero.
+    Value isZeroVal = helper.isZero(biasedExpSrc, mantSrc);
+
+    // Adjust exponent bias and shift mantissa.
+    Value biasedExpDst =
+        arith::AddIOp::create(rewriter, loc, biasedExpSrc, cBiasDiff);
+    Value mantDst = arith::ShLIOp::create(rewriter, loc, mantSrc, cMantShift);
+
+    // Pack result and handle special cases.
+    Value result = helper.packFields(sign, biasedExpDst, mantDst, dstInfo);
+
+    // For types with negative zero support, compute signed zero in f32.
+    // f32 -0.0 = 0x80000000 (sign bit at position 31).
+    Value zeroResult = c0;
+    if (srcInfo.hasNegZero) {
+      Value cF32SignShift = helper.createI32Const(31);
+      Value f32SignBit =
+          arith::ShLIOp::create(rewriter, loc, sign, cF32SignShift);
+      zeroResult = f32SignBit;
+    }
+
+    // Handle zero first (before NaN check for non-FNUZ types).
+    // For FNUZ, zero check must come after NaN check since NaN (0x80) has
+    // exp=0, mant=0 which looks like zero except for sign bit.
+    result =
+        arith::SelectOp::create(rewriter, loc, isZeroVal, zeroResult, result);
+
+    // Handle Inf (IEEE types only): preserve sign.
+    if (srcInfo.hasInf) {
+      Value signedInf = arith::SelectOp::create(
+          rewriter, loc,
+          arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ne, sign,
+                                c0),
+          arith::OrIOp::create(rewriter, loc, cF32Inf, cSignBit), cF32Inf);
+      result = arith::SelectOp::create(rewriter, loc, isInf, signedInf, result);
+    }
+
+    // Handle NaN last so it takes precedence over zero for FNUZ types. Then
+    // bitcast it back to f32.
+    result = arith::SelectOp::create(rewriter, loc, isNaN, cF32NaN, result);
+    result = arith::BitcastOp::create(rewriter, loc, resultType, result);
+    rewriter.replaceOp(op, result);
+
+    return success();
+  }
+};
+
 struct ConvertUnsupportedFloatArithPass final
     : public impl::ConvertUnsupportedFloatArithPassBase<
           ConvertUnsupportedFloatArithPass> {
@@ -39,12 +561,23 @@ struct ConvertUnsupportedFloatArithPass final
 
 } // namespace
 
+static void populateCPUSourceAndTargetType(MLIRContext *ctx, Operation *op,
+                                           SmallVectorImpl<Type> &sourceTypes,
+                                           Type &targetType) {
+  // For CPU backend, we emulate all the fp8 types to fp32.
+  appendTypesIf<
+#define GET_TYPEDEF_LIST
+#include "mlir/IR/BuiltinTypes.cpp.inc"
+      >(ctx, sourceTypes);
+  targetType = Float32Type::get(ctx);
+}
+
 // Populates source and target conversion types based on the target
 // architecture.
 // TODO(pashu123): Refine the patterns based on the target arch.
-static void populateSourceAndTargetType(MLIRContext *ctx, Operation *op,
-                                        SmallVectorImpl<Type> &sourceTypes,
-                                        Type &targetType) {
+static void populateGPUSourceAndTargetType(MLIRContext *ctx, Operation *op,
+                                           SmallVectorImpl<Type> &sourceTypes,
+                                           Type &targetType) {
   auto gpuAttr = getGPUTargetAttr(op);
   if (!gpuAttr) {
     return;
@@ -52,7 +585,7 @@ static void populateSourceAndTargetType(MLIRContext *ctx, Operation *op,
   StringRef chipset = gpuAttr.getArch();
   FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(chipset);
   if (failed(maybeChipset)) {
-    LLVM_DEBUG(llvm::dbgs() << "Invalid chip name");
+    LDBG() << "Invalid chip name";
     return;
   }
   constexpr amdgpu::Chipset kGfx942{9, 4, 2};
@@ -84,11 +617,20 @@ void ConvertUnsupportedFloatArithPass::runOnOperation() {
   SmallVector<Type> sourceTypes;
   Type targetType = nullptr;
 
-  populateSourceAndTargetType(context, funcOp, sourceTypes, targetType);
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+  bool isCPU = isLLVMCPUBackend(targetAttr);
+  if (isCPU) {
+    populateCPUSourceAndTargetType(context, funcOp, sourceTypes, targetType);
+  } else if (isROCMBackend(targetAttr)) {
+    populateGPUSourceAndTargetType(context, funcOp, sourceTypes, targetType);
+  } else {
+    LDBG() << "backend does not require float emulation";
+    return;
+  }
 
   if (sourceTypes.empty() || !targetType) {
-    LLVM_DEBUG(llvm::dbgs() << "no source or target type specified, float "
-                               "emulation will do nothing\n");
+    LDBG() << "no source or target type specified, float emulation will do "
+              "nothing";
     return;
   }
 
@@ -97,16 +639,31 @@ void ConvertUnsupportedFloatArithPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  TypeConverter converter;
-  arith::populateEmulateUnsupportedFloatsConversions(converter, sourceTypes,
-                                                     targetType);
-  RewritePatternSet patterns(context);
-  arith::populateEmulateUnsupportedFloatsPatterns(patterns, converter);
-  ConversionTarget target(*context);
-  arith::populateEmulateUnsupportedFloatsLegality(target, converter);
+  // Apply the standard float emulation patterns. This inserts extf/truncf pairs
+  // around unsupported float operations.
+  {
+    TypeConverter converter;
+    arith::populateEmulateUnsupportedFloatsConversions(converter, sourceTypes,
+                                                       targetType);
+    RewritePatternSet patterns(context);
+    arith::populateEmulateUnsupportedFloatsPatterns(patterns, converter);
+    ConversionTarget target(*context);
+    arith::populateEmulateUnsupportedFloatsLegality(target, converter);
 
-  if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
-    signalPassFailure();
+    if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+
+  // For CPU, emulate extf/truncf to/from small float types using integer ops.
+  // This is needed because LLVM doesn't support fpext/fptrunc for fp8 types;
+  // the fp8 types eventually get lowered to i8 in LLVM IR.
+  if (isCPU) {
+    RewritePatternSet emulationPatterns(context);
+    emulationPatterns.add<TruncFToFP8, ExtFFromFP8>(context);
+    if (failed(applyPatternsGreedily(funcOp, std::move(emulationPatterns)))) {
+      return signalPassFailure();
+    }
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -99,9 +99,21 @@ def ConvertBf16ToUInt16BuffersPass :
 def ConvertUnsupportedFloatArithPass
     : InterfacePass<"iree-convert-unsupported-float-arith",
                     "mlir::FunctionOpInterface"> {
-  let summary = "Convert arith operations on unsupported(source types) float "
-                "types to the target type. Populates the source and target "
-                "based on the target architecture.";
+  let summary = "Emulate arith operations on unsupported float types (e.g., fp8).";
+  let description = [{
+    Emulates floating-point operations on types not natively supported by the
+    target backend. The pass:
+
+    1. Wraps unsupported float operations with extf/truncf pairs to perform
+       arithmetic in a supported type (e.g., f32).
+
+    2. For CPU targets, emulates extf/truncf operations themselves using integer
+       bit manipulation, since LLVM doesn't support fpext/fptrunc for fp8 types.
+
+    The emulation follows IREE's runtime/src/iree/base/internal/math.h, including
+    IEEE 754 round-to-nearest-even semantics and proper handling of denormals,
+    NaN, Inf, and special encodings (FNUZ types).
+  }];
 }
 
 def ConvertToDestinationPassingStylePass :

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-convert-unsupported-float-arith))" %s | FileCheck %s
 
 // CHECK-LABEL: func.func @negf_f8_unsupported
-// CHECK-SAME: (%[[ARG0:.*]]: f8E4M3FNUZ) -> f8E4M3FNUZ
-// CHECK: %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FNUZ to f32
-// CHECK: %[[NEG:.*]] = arith.negf %[[EXT]] : f32
-// CHECK: %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FNUZ
-// CHECK: return %[[TRUNC]] : f8E4M3FNUZ
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f8E4M3FNUZ
+// CHECK:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FNUZ to f32
+// CHECK:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
+// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FNUZ
+// CHECK:         return %[[TRUNC]] : f8E4M3FNUZ
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 func.func @negf_f8_unsupported(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes
 { hal.executable.target = #executable_target_rocm_hsaco_fb }{
@@ -16,13 +16,13 @@ func.func @negf_f8_unsupported(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes
 // -----
 
 // CHECK-LABEL: func.func @expand_f8(
-// CHECK-SAME: %[[ARG0:.*]]: f8E5M2FNUZ
-// CHECK: %[[EXT0:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E5M2FNUZ to f32
-// CHECK: %[[CST:.*]] = arith.constant 1.000000e+00 : f8E5M2FNUZ
-// CHECK: %[[EXT1:.*]] = arith.extf %[[CST]] {{.*}} : f8E5M2FNUZ to f32
-// CHECK: %[[SUM:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
-// CHECK: %[[TRUNC:.*]] = arith.truncf %[[SUM]] {{.*}} : f32 to f8E5M2FNUZ
-// CHECK: return %[[TRUNC]] : f8E5M2FNUZ
+// CHECK-SAME:    %[[ARG0:.*]]: f8E5M2FNUZ
+// CHECK:         %[[EXT0:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E5M2FNUZ to f32
+// CHECK:         %[[CST:.*]] = arith.constant 1.000000e+00 : f8E5M2FNUZ
+// CHECK:         %[[EXT1:.*]] = arith.extf %[[CST]] {{.*}} : f8E5M2FNUZ to f32
+// CHECK:         %[[SUM:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
+// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[SUM]] {{.*}} : f32 to f8E5M2FNUZ
+// CHECK:         return %[[TRUNC]] : f8E5M2FNUZ
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 func.func @expand_f8(%x: f8E5M2FNUZ) -> f8E5M2FNUZ attributes
 { hal.executable.target = #executable_target_rocm_hsaco_fb }{
@@ -34,11 +34,11 @@ func.func @expand_f8(%x: f8E5M2FNUZ) -> f8E5M2FNUZ attributes
 // -----
 
 // CHECK-LABEL: func.func @negf_f8_unsupported_ocp
-// CHECK-SAME: (%[[ARG0:.*]]: f8E4M3FN) -> f8E4M3FN
-// CHECK: %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FN to f32
-// CHECK: %[[NEG:.*]] = arith.negf %[[EXT]] : f32
-// CHECK: %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FN
-// CHECK: return %[[TRUNC]] : f8E4M3FN
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FN) -> f8E4M3FN
+// CHECK:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FN to f32
+// CHECK:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
+// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FN
+// CHECK:         return %[[TRUNC]] : f8E4M3FN
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 func.func @negf_f8_unsupported_ocp(%arg0 : f8E4M3FN) -> f8E4M3FN attributes
 { hal.executable.target = #executable_target_rocm_hsaco_fb }{
@@ -49,13 +49,13 @@ func.func @negf_f8_unsupported_ocp(%arg0 : f8E4M3FN) -> f8E4M3FN attributes
 // -----
 
 // CHECK-LABEL: func.func @expand_f8_ocp(
-// CHECK-SAME: %[[ARG0:.*]]: f8E5M2
-// CHECK: %[[EXT0:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E5M2 to f32
-// CHECK: %[[CST:.*]] = arith.constant 1.000000e+00 : f8E5M2
-// CHECK: %[[EXT1:.*]] = arith.extf %[[CST]] {{.*}} : f8E5M2 to f32
-// CHECK: %[[SUM:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
-// CHECK: %[[TRUNC:.*]] = arith.truncf %[[SUM]] {{.*}} : f32 to f8E5M2
-// CHECK: return %[[TRUNC]] : f8E5M2
+// CHECK-SAME:    %[[ARG0:.*]]: f8E5M2
+// CHECK:         %[[EXT0:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E5M2 to f32
+// CHECK:         %[[CST:.*]] = arith.constant 1.000000e+00 : f8E5M2
+// CHECK:         %[[EXT1:.*]] = arith.extf %[[CST]] {{.*}} : f8E5M2 to f32
+// CHECK:         %[[SUM:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
+// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[SUM]] {{.*}} : f32 to f8E5M2
+// CHECK:         return %[[TRUNC]] : f8E5M2
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 func.func @expand_f8_ocp(%x: f8E5M2) -> f8E5M2 attributes
 { hal.executable.target = #executable_target_rocm_hsaco_fb }{
@@ -66,10 +66,154 @@ func.func @expand_f8_ocp(%x: f8E5M2) -> f8E5M2 attributes
 
 // -----
 
-// CHECK-LABEL: func.func @dont_expand_cpu_target
-// CHECK: {{.+}} = arith.negf {{.*}} : f8E4M3FNUZ
-func.func @dont_expand_cpu_target(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes
+// Test CPU target with f8E4M3FNUZ - both extf and truncf should be emulated.
+// CHECK-LABEL: func.func @expand_cpu_target_f8e4m3fnuz
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f8E4M3FNUZ
+//
+// ExtF emulation: fp8 -> i8 -> i32 -> extract fields -> pack f32 -> bitcast
+// CHECK:         %[[BITCAST_IN:.*]] = arith.bitcast %[[ARG0]] : f8E4M3FNUZ to i8
+// CHECK:         %[[EXT_I32:.*]] = arith.extui %[[BITCAST_IN]] : i8 to i32
+// CHECK:         arith.shrui
+// CHECK:         arith.andi
+// CHECK:         arith.bitcast %{{.*}} : i32 to f32
+//
+// Negf on f32
+// CHECK:         %[[NEG:.*]] = arith.negf %{{.*}} : f32
+//
+// TruncF emulation: f32 -> bitcast i32 -> extract fields -> pack i8 -> bitcast fp8
+// CHECK:         arith.bitcast %[[NEG]] : f32 to i32
+// CHECK:         arith.shrui
+// CHECK:         arith.andi
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E4M3FNUZ
+// CHECK:         return %[[RESULT]] : f8E4M3FNUZ
+func.func @expand_cpu_target_f8e4m3fnuz(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes
 { hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
     %0 = arith.negf %arg0 : f8E4M3FNUZ
     return %0 : f8E4M3FNUZ
+}
+
+// -----
+
+// Test CPU target with f8E5M2FNUZ.
+// CHECK-LABEL: func.func @expand_cpu_target_f8e5m2fnuz
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E5M2FNUZ) -> f8E5M2FNUZ
+// CHECK:         %[[BITCAST_IN:.*]] = arith.bitcast %[[ARG0]] : f8E5M2FNUZ to i8
+// CHECK:         %[[EXT_I32:.*]] = arith.extui %[[BITCAST_IN]] : i8 to i32
+// CHECK:         arith.bitcast %{{.*}} : i32 to f32
+// CHECK:         %[[ADD:.*]] = arith.addf %{{.*}}, %{{.*}} : f32
+// CHECK:         arith.bitcast %[[ADD]] : f32 to i32
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E5M2FNUZ
+// CHECK:         return %[[RESULT]] : f8E5M2FNUZ
+func.func @expand_cpu_target_f8e5m2fnuz(%arg0 : f8E5M2FNUZ) -> f8E5M2FNUZ attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %c = arith.constant 1.0 : f8E5M2FNUZ
+    %0 = arith.addf %arg0, %c : f8E5M2FNUZ
+    return %0 : f8E5M2FNUZ
+}
+
+// -----
+
+// Test explicit truncf emulation for CPU target.
+// CHECK-LABEL: func.func @truncf_cpu_f32_to_f8e5m2fnuz
+// CHECK-SAME:    (%[[ARG0:.*]]: f32) -> f8E5M2FNUZ
+// CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f32 to i32
+// CHECK:         arith.shrui %[[BITCAST]]
+// CHECK:         arith.andi
+// CHECK:         arith.subi
+// CHECK:         arith.cmpi
+// CHECK:         arith.select
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E5M2FNUZ
+// CHECK:         return %[[RESULT]] : f8E5M2FNUZ
+func.func @truncf_cpu_f32_to_f8e5m2fnuz(%arg0 : f32) -> f8E5M2FNUZ attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %0 = arith.truncf %arg0 : f32 to f8E5M2FNUZ
+    return %0 : f8E5M2FNUZ
+}
+
+// -----
+
+// Test explicit extf emulation for CPU target.
+// CHECK-LABEL: func.func @extf_cpu_f8e5m2fnuz_to_f32
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E5M2FNUZ) -> f32
+// CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f8E5M2FNUZ to i8
+// CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
+// CHECK:         arith.shrui %[[EXT]]
+// CHECK:         arith.andi
+// CHECK:         arith.addi
+// CHECK:         arith.shli
+// CHECK:         arith.ori
+// CHECK:         arith.select
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i32 to f32
+// CHECK:         return %[[RESULT]] : f32
+func.func @extf_cpu_f8e5m2fnuz_to_f32(%arg0 : f8E5M2FNUZ) -> f32 attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %0 = arith.extf %arg0 : f8E5M2FNUZ to f32
+    return %0 : f32
+}
+
+// -----
+
+// Test vector truncf emulation for CPU target.
+// CHECK-LABEL: func.func @truncf_cpu_vector_f32_to_f8e5m2fnuz
+// CHECK-SAME:    (%[[ARG0:.*]]: vector<4xf32>) -> vector<4xf8E5M2FNUZ>
+// CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : vector<4xf32> to vector<4xi32>
+// CHECK:         arith.shrui
+// CHECK:         arith.andi
+// CHECK:         arith.trunci %{{.*}} : vector<4xi32> to vector<4xi8>
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : vector<4xi8> to vector<4xf8E5M2FNUZ>
+// CHECK:         return %[[RESULT]] : vector<4xf8E5M2FNUZ>
+func.func @truncf_cpu_vector_f32_to_f8e5m2fnuz(%arg0 : vector<4xf32>) -> vector<4xf8E5M2FNUZ> attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %0 = arith.truncf %arg0 : vector<4xf32> to vector<4xf8E5M2FNUZ>
+    return %0 : vector<4xf8E5M2FNUZ>
+}
+
+// -----
+
+// Test vector extf emulation for CPU target.
+// CHECK-LABEL: func.func @extf_cpu_vector_f8e5m2fnuz_to_f32
+// CHECK-SAME:    (%[[ARG0:.*]]: vector<4xf8E5M2FNUZ>) -> vector<4xf32>
+// CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : vector<4xf8E5M2FNUZ> to vector<4xi8>
+// CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : vector<4xi8> to vector<4xi32>
+// CHECK:         arith.shrui
+// CHECK:         arith.andi
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : vector<4xi32> to vector<4xf32>
+// CHECK:         return %[[RESULT]] : vector<4xf32>
+func.func @extf_cpu_vector_f8e5m2fnuz_to_f32(%arg0 : vector<4xf8E5M2FNUZ>) -> vector<4xf32> attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %0 = arith.extf %arg0 : vector<4xf8E5M2FNUZ> to vector<4xf32>
+    return %0 : vector<4xf32>
+}
+
+// -----
+
+// Test f8E4M3FNUZ truncf emulation for CPU target.
+// CHECK-LABEL: func.func @truncf_cpu_f32_to_f8e4m3fnuz
+// CHECK-SAME:    (%[[ARG0:.*]]: f32) -> f8E4M3FNUZ
+// CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f32 to i32
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E4M3FNUZ
+// CHECK:         return %[[RESULT]] : f8E4M3FNUZ
+func.func @truncf_cpu_f32_to_f8e4m3fnuz(%arg0 : f32) -> f8E4M3FNUZ attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %0 = arith.truncf %arg0 : f32 to f8E4M3FNUZ
+    return %0 : f8E4M3FNUZ
+}
+
+// -----
+
+// Test f8E4M3FNUZ extf emulation for CPU target.
+// CHECK-LABEL: func.func @extf_cpu_f8e4m3fnuz_to_f32
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f32
+// CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f8E4M3FNUZ to i8
+// CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i32 to f32
+// CHECK:         return %[[RESULT]] : f32
+func.func @extf_cpu_f8e4m3fnuz_to_f32(%arg0 : f8E4M3FNUZ) -> f32 attributes
+{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+    %0 = arith.extf %arg0 : f8E4M3FNUZ to f32
+    return %0 : f32
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
@@ -146,9 +146,9 @@ func.func @truncf_cpu_f32_to_f8e5m2fnuz(%arg0 : f32) -> f8E5M2FNUZ attributes
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
 // CHECK:         arith.shrui %[[EXT]]
 // CHECK:         arith.andi
-// CHECK:         arith.addi
-// CHECK:         arith.shli
-// CHECK:         arith.ori
+// Denormal handling uses uitofp + mulf instead of enumeration.
+// CHECK:         arith.uitofp {{.*}} : i32 to f32
+// CHECK:         arith.mulf {{.*}} : f32
 // CHECK:         arith.select
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i32 to f32
 // CHECK:         return %[[RESULT]] : f32
@@ -185,6 +185,9 @@ func.func @truncf_cpu_vector_f32_to_f8e5m2fnuz(%arg0 : vector<4xf32>) -> vector<
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : vector<4xi8> to vector<4xi32>
 // CHECK:         arith.shrui
 // CHECK:         arith.andi
+// Denormal handling uses uitofp + mulf.
+// CHECK:         arith.uitofp {{.*}} : vector<4xi32> to vector<4xf32>
+// CHECK:         arith.mulf {{.*}} : vector<4xf32>
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : vector<4xi32> to vector<4xf32>
 // CHECK:         return %[[RESULT]] : vector<4xf32>
 func.func @extf_cpu_vector_f8e5m2fnuz_to_f32(%arg0 : vector<4xf8E5M2FNUZ>) -> vector<4xf32> attributes
@@ -217,6 +220,9 @@ func.func @truncf_cpu_f32_to_f8e4m3fnuz(%arg0 : f32) -> f8E4M3FNUZ attributes
 // CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f32
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f8E4M3FNUZ to i8
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
+// Denormal handling uses uitofp + mulf.
+// CHECK:         arith.uitofp {{.*}} : i32 to f32
+// CHECK:         arith.mulf {{.*}} : f32
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i32 to f32
 // CHECK:         return %[[RESULT]] : f32
 func.func @extf_cpu_f8e4m3fnuz_to_f32(%arg0 : f8E4M3FNUZ) -> f32 attributes

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
@@ -304,13 +304,16 @@ func.func @truncf_fnuz_nan_handling_e4m3(%arg0 : f32) -> f8E4M3FNUZ attributes
 // CHECK-LABEL: func.func @extf_fnuz_nan_handling
 // CHECK-SAME:    (%[[ARG0:.*]]: f8E5M2FNUZ) -> f32
 //
-// 0x80 (128) = FNUZ NaN encoding.
 // 0x7FC00000 (2143289344) = canonical f32 quiet NaN.
-// CHECK-DAG:     %[[C128:.*]] = arith.constant 128 : i32
 // CHECK-DAG:     %[[F32_NAN:.*]] = arith.constant 2143289344 : i32
+//
+// ExtF emulation: bitcast fp8 -> i8, extend to i32.
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f8E5M2FNUZ to i8
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
+//
+// 0x80 (128) = FNUZ NaN encoding.
 // isNan = (inputBits == 0x80)
+// CHECK-DAG:     %[[C128:.*]] = arith.constant 128 : i32
 // CHECK:         %[[IS_NAN:.*]] = arith.cmpi eq, %[[EXT]], %[[C128]] : i32
 //
 // If input is FNUZ NaN (0x80), output canonical f32 NaN (0x7FC00000).

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -630,7 +630,8 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
       .addPredicatedPass(clInstrumentMemoryAccesses,
-                         createInstrumentMemoryAccessesPass);
+                         createInstrumentMemoryAccessesPass)
+      .addPass(createConvertUnsupportedFloatArithPass);
 
   if (enableAArch64SME) {
     FunctionLikeNest(modulePassManager).addPass([&] {

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -244,7 +244,6 @@ ROCM_SRCS = enforce_glob(
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
         "small_float_arith.mlir",
-        "subbyte_to_fp.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -29,6 +29,7 @@ LLVM_SRCS = enforce_glob(
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
         "pack_i8.mlir",
+        "small_float_arith.mlir",
         "softmax.mlir",
         "subbyte_to_fp.mlir",
         "unpack.mlir",
@@ -89,6 +90,7 @@ VMVX_SRCS = enforce_glob(
         "fp_to_subbyte.mlir",
         "fp4_f32_conversion.mlir",
         "large_linalg_matmul.mlir",
+        "small_float_arith.mlir",
         "subbyte_to_fp.mlir",
     ],
 )
@@ -140,6 +142,7 @@ VULKAN_SRCS = enforce_glob(
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
         "pack_i8.mlir",
+        "small_float_arith.mlir",
         "unpack.mlir",
     ],
 )
@@ -199,6 +202,7 @@ CUDA_SRCS = enforce_glob(
         # See bug #20294
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
+        "small_float_arith.mlir",
     ],
 )
 
@@ -239,6 +243,8 @@ ROCM_SRCS = enforce_glob(
         # See bug #20294
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
+        "small_float_arith.mlir",
+        "subbyte_to_fp.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_check_single_backend_test_suite(
     "pack.mlir"
     "pack_dynamic_inner_tiles.mlir"
     "pack_i8.mlir"
+    "small_float_arith.mlir"
     "softmax.mlir"
     "subbyte_to_fp.mlir"
     "unpack.mlir"

--- a/tests/e2e/linalg/small_float_arith.mlir
+++ b/tests/e2e/linalg/small_float_arith.mlir
@@ -1,0 +1,230 @@
+func.func @add_f8E5M2FNUZ() {
+  %input = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf8E5M2FNUZ>
+  %init = tensor.empty() : tensor<4xf8E5M2FNUZ>
+  %add = linalg.add
+    ins(%input, %input : tensor<4xf8E5M2FNUZ>, tensor<4xf8E5M2FNUZ>)
+    outs(%init : tensor<4xf8E5M2FNUZ>) -> tensor<4xf8E5M2FNUZ>
+  check.expect_almost_eq_const(%add, dense<[0.0, 2.0, 4.0, 8.0]> : tensor<4xf8E5M2FNUZ>) : tensor<4xf8E5M2FNUZ>
+  return
+}
+
+func.func @sub_f8E5M2FNUZ() {
+  %lhs = util.unfoldable_constant dense<[4.0, 8.0, 16.0, 32.0]> : tensor<4xf8E5M2FNUZ>
+  %rhs = util.unfoldable_constant dense<[1.0, 2.0, 4.0, 8.0]> : tensor<4xf8E5M2FNUZ>
+  %init = tensor.empty() : tensor<4xf8E5M2FNUZ>
+  %sub = linalg.sub
+    ins(%lhs, %rhs : tensor<4xf8E5M2FNUZ>, tensor<4xf8E5M2FNUZ>)
+    outs(%init : tensor<4xf8E5M2FNUZ>) -> tensor<4xf8E5M2FNUZ>
+  check.expect_almost_eq_const(%sub, dense<[3.0, 6.0, 12.0, 24.0]> : tensor<4xf8E5M2FNUZ>) : tensor<4xf8E5M2FNUZ>
+  return
+}
+
+func.func @mul_f8E5M2FNUZ() {
+  %lhs = util.unfoldable_constant dense<[1.0, 2.0, 4.0, 8.0]> : tensor<4xf8E5M2FNUZ>
+  %rhs = util.unfoldable_constant dense<[2.0, 2.0, 2.0, 2.0]> : tensor<4xf8E5M2FNUZ>
+  %init = tensor.empty() : tensor<4xf8E5M2FNUZ>
+  %mul = linalg.mul
+    ins(%lhs, %rhs : tensor<4xf8E5M2FNUZ>, tensor<4xf8E5M2FNUZ>)
+    outs(%init : tensor<4xf8E5M2FNUZ>) -> tensor<4xf8E5M2FNUZ>
+  check.expect_almost_eq_const(%mul, dense<[2.0, 4.0, 8.0, 16.0]> : tensor<4xf8E5M2FNUZ>) : tensor<4xf8E5M2FNUZ>
+  return
+}
+
+func.func @negf_f8E5M2FNUZ() {
+  %input = util.unfoldable_constant dense<[1.0, -2.0, 4.0, -8.0]> : tensor<4xf8E5M2FNUZ>
+  %init = tensor.empty() : tensor<4xf8E5M2FNUZ>
+  %neg = linalg.negf
+    ins(%input : tensor<4xf8E5M2FNUZ>)
+    outs(%init : tensor<4xf8E5M2FNUZ>) -> tensor<4xf8E5M2FNUZ>
+  check.expect_almost_eq_const(%neg, dense<[-1.0, 2.0, -4.0, 8.0]> : tensor<4xf8E5M2FNUZ>) : tensor<4xf8E5M2FNUZ>
+  return
+}
+
+func.func @add_f8E4M3FNUZ() {
+  %input = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf8E4M3FNUZ>
+  %init = tensor.empty() : tensor<4xf8E4M3FNUZ>
+  %add = linalg.add
+    ins(%input, %input : tensor<4xf8E4M3FNUZ>, tensor<4xf8E4M3FNUZ>)
+    outs(%init : tensor<4xf8E4M3FNUZ>) -> tensor<4xf8E4M3FNUZ>
+  check.expect_almost_eq_const(%add, dense<[0.0, 2.0, 4.0, 8.0]> : tensor<4xf8E4M3FNUZ>) : tensor<4xf8E4M3FNUZ>
+  return
+}
+
+func.func @mul_f8E4M3FNUZ() {
+  %lhs = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf8E4M3FNUZ>
+  %rhs = util.unfoldable_constant dense<[2.0, 2.0, 2.0, 2.0]> : tensor<4xf8E4M3FNUZ>
+  %init = tensor.empty() : tensor<4xf8E4M3FNUZ>
+  %mul = linalg.mul
+    ins(%lhs, %rhs : tensor<4xf8E4M3FNUZ>, tensor<4xf8E4M3FNUZ>)
+    outs(%init : tensor<4xf8E4M3FNUZ>) -> tensor<4xf8E4M3FNUZ>
+  check.expect_almost_eq_const(%mul, dense<[2.0, 4.0, 6.0, 8.0]> : tensor<4xf8E4M3FNUZ>) : tensor<4xf8E4M3FNUZ>
+  return
+}
+
+func.func @add_f8E5M2() {
+  %input = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf8E5M2>
+  %init = tensor.empty() : tensor<4xf8E5M2>
+  %add = linalg.add
+    ins(%input, %input : tensor<4xf8E5M2>, tensor<4xf8E5M2>)
+    outs(%init : tensor<4xf8E5M2>) -> tensor<4xf8E5M2>
+  check.expect_almost_eq_const(%add, dense<[0.0, 2.0, 4.0, 8.0]> : tensor<4xf8E5M2>) : tensor<4xf8E5M2>
+  return
+}
+
+func.func @add_f8E4M3FN() {
+  %input = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf8E4M3FN>
+  %init = tensor.empty() : tensor<4xf8E4M3FN>
+  %add = linalg.add
+    ins(%input, %input : tensor<4xf8E4M3FN>, tensor<4xf8E4M3FN>)
+    outs(%init : tensor<4xf8E4M3FN>) -> tensor<4xf8E4M3FN>
+  check.expect_almost_eq_const(%add, dense<[0.0, 2.0, 4.0, 8.0]> : tensor<4xf8E4M3FN>) : tensor<4xf8E4M3FN>
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Special value tests for each fp8 type.
+//===----------------------------------------------------------------------===//
+
+// f8E5M2FNUZ: No Inf, No -0, NaN = 0x80. Max finite = 57344.0.
+// Test vector:
+//   [0]: Zero + Zero = Zero.
+//   [1]: Normal + Normal = Normal.
+//   [2]: Positive overflow → NaN.
+//   [3]: Near-max (no overflow).
+//   [4]: NaN + x = NaN (NaN propagation).
+//   [5]: Negative overflow → NaN.
+//   [6]: Small + Small = Small.
+//   [7]: Negative normal.
+func.func @special_f8E5M2FNUZ() {
+  %lhs = util.unfoldable_constant dense<[0.0, 4.0, 32768.0, 49152.0, 0x80, -32768.0, 0.125, -4.0]> : tensor<8xf8E5M2FNUZ>
+  %rhs = util.unfoldable_constant dense<[0.0, 4.0, 32768.0, 1.0, 1.0, -32768.0, 0.125, -4.0]> : tensor<8xf8E5M2FNUZ>
+  %init = tensor.empty() : tensor<8xf8E5M2FNUZ>
+  %add = linalg.add
+    ins(%lhs, %rhs : tensor<8xf8E5M2FNUZ>, tensor<8xf8E5M2FNUZ>)
+    outs(%init : tensor<8xf8E5M2FNUZ>) -> tensor<8xf8E5M2FNUZ>
+  check.expect_almost_eq_const(%add, dense<[0.0, 8.0, 0x80, 49152.0, 0x80, 0x80, 0.25, -8.0]> : tensor<8xf8E5M2FNUZ>) : tensor<8xf8E5M2FNUZ>
+  return
+}
+
+// f8E4M3FNUZ: No Inf, No -0, NaN = 0x80. Max finite = 240.0.
+// Test vector:
+//   [0]: Zero + Zero = Zero.
+//   [1]: Normal + Normal = Normal.
+//   [2]: Positive overflow → NaN.
+//   [3]: Near-max (no overflow).
+//   [4]: NaN + x = NaN (NaN propagation).
+//   [5]: Negative overflow → NaN.
+//   [6]: Small + Small = Small.
+//   [7]: Negative normal.
+func.func @special_f8E4M3FNUZ() {
+  %lhs = util.unfoldable_constant dense<[0.0, 4.0, 192.0, 224.0, 0x80, -192.0, 0.125, -4.0]> : tensor<8xf8E4M3FNUZ>
+  %rhs = util.unfoldable_constant dense<[0.0, 4.0, 192.0, 1.0, 1.0, -192.0, 0.125, -4.0]> : tensor<8xf8E4M3FNUZ>
+  %init = tensor.empty() : tensor<8xf8E4M3FNUZ>
+  %add = linalg.add
+    ins(%lhs, %rhs : tensor<8xf8E4M3FNUZ>, tensor<8xf8E4M3FNUZ>)
+    outs(%init : tensor<8xf8E4M3FNUZ>) -> tensor<8xf8E4M3FNUZ>
+  check.expect_almost_eq_const(%add, dense<[0.0, 8.0, 0x80, 224.0, 0x80, 0x80, 0.25, -8.0]> : tensor<8xf8E4M3FNUZ>) : tensor<8xf8E4M3FNUZ>
+  return
+}
+
+// f8E5M2: Has Inf, Has -0, IEEE-like. Max finite = 57344.0, +Inf = 0x7C, -Inf = 0xFC.
+// Test vector:
+//   [0]: Zero + Zero = Zero.
+//   [1]: -0 + 0 = +0.
+//   [2]: Positive overflow → +Inf.
+//   [3]: +Inf + x = +Inf.
+//   [4]: NaN + x = NaN (NaN propagation).
+//   [5]: Negative overflow → -Inf.
+//   [6]: -Inf + x = -Inf.
+//   [7]: +Inf + -Inf = NaN.
+func.func @special_f8E5M2() {
+  %lhs = util.unfoldable_constant dense<[0.0, -0.0, 32768.0, 0x7C, 0x7F, -32768.0, 0xFC, 0x7C]> : tensor<8xf8E5M2>
+  %rhs = util.unfoldable_constant dense<[0.0, 0.0, 32768.0, 1.0, 1.0, -32768.0, -1.0, 0xFC]> : tensor<8xf8E5M2>
+  %init = tensor.empty() : tensor<8xf8E5M2>
+  %add = linalg.add
+    ins(%lhs, %rhs : tensor<8xf8E5M2>, tensor<8xf8E5M2>)
+    outs(%init : tensor<8xf8E5M2>) -> tensor<8xf8E5M2>
+  check.expect_almost_eq_const(%add, dense<[0.0, 0.0, 0x7C, 0x7C, 0x7F, 0xFC, 0xFC, 0x7F]> : tensor<8xf8E5M2>) : tensor<8xf8E5M2>
+  return
+}
+
+// f8E4M3FN: No Inf, Has -0, NaN = 0x7F. Max finite = 448.0.
+// Test vector:
+//   [0]: Zero + Zero = Zero.
+//   [1]: -0 + 0 = +0.
+//   [2]: Positive overflow → NaN.
+//   [3]: Near-max (no overflow).
+//   [4]: NaN + x = NaN (NaN propagation).
+//   [5]: Negative overflow → NaN.
+//   [6]: Small + Small = Small.
+//   [7]: Negative normal.
+func.func @special_f8E4M3FN() {
+  %lhs = util.unfoldable_constant dense<[0.0, -0.0, 384.0, 416.0, 0x7F, -384.0, 0.125, -4.0]> : tensor<8xf8E4M3FN>
+  %rhs = util.unfoldable_constant dense<[0.0, 0.0, 384.0, 1.0, 1.0, -384.0, 0.125, -4.0]> : tensor<8xf8E4M3FN>
+  %init = tensor.empty() : tensor<8xf8E4M3FN>
+  %add = linalg.add
+    ins(%lhs, %rhs : tensor<8xf8E4M3FN>, tensor<8xf8E4M3FN>)
+    outs(%init : tensor<8xf8E4M3FN>) -> tensor<8xf8E4M3FN>
+  check.expect_almost_eq_const(%add, dense<[0.0, 0.0, 0x7F, 416.0, 0x7F, 0x7F, 0.25, -8.0]> : tensor<8xf8E4M3FN>) : tensor<8xf8E4M3FN>
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Negative zero preservation tests for IEEE fp8 types.
+// IEEE types (f8E5M2, f8E4M3FN) support negative zero and should preserve it.
+// We use bitcast to i8 and check.expect_eq_const to verify bit patterns,
+// since check.expect_almost_eq_const treats -0.0 == +0.0.
+//
+// Bit patterns:
+//   f8E5M2:   +0.0 = 0x00, -0.0 = 0x80
+//   f8E4M3FN: +0.0 = 0x00, -0.0 = 0x80
+//===----------------------------------------------------------------------===//
+
+// Test: negf(+0.0) should produce -0.0 for f8E5M2.
+// Expected bit pattern: 0x80 (-128 as signed i8).
+func.func @negzero_negf_f8E5M2() {
+  %input = util.unfoldable_constant dense<[0.0, 0.0, 0.0, 0.0]> : tensor<4xf8E5M2>
+  %init = tensor.empty() : tensor<4xf8E5M2>
+  %neg = linalg.negf ins(%input : tensor<4xf8E5M2>) outs(%init : tensor<4xf8E5M2>) -> tensor<4xf8E5M2>
+  %result_i8 = arith.bitcast %neg : tensor<4xf8E5M2> to tensor<4xi8>
+  // -128 = 0x80 = -0.0 in f8E5M2
+  check.expect_eq_const(%result_i8, dense<[-128, -128, -128, -128]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+// Test: negf(+0.0) should produce -0.0 for f8E4M3FN.
+// Expected bit pattern: 0x80 (-128 as signed i8).
+func.func @negzero_negf_f8E4M3FN() {
+  %input = util.unfoldable_constant dense<[0.0, 0.0, 0.0, 0.0]> : tensor<4xf8E4M3FN>
+  %init = tensor.empty() : tensor<4xf8E4M3FN>
+  %neg = linalg.negf ins(%input : tensor<4xf8E4M3FN>) outs(%init : tensor<4xf8E4M3FN>) -> tensor<4xf8E4M3FN>
+  %result_i8 = arith.bitcast %neg : tensor<4xf8E4M3FN> to tensor<4xi8>
+  // -128 = 0x80 = -0.0 in f8E4M3FN
+  check.expect_eq_const(%result_i8, dense<[-128, -128, -128, -128]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+// Test: -0.0 * 1.0 should preserve -0.0 for f8E5M2.
+// IEEE semantics: -0.0 * positive = -0.0
+func.func @negzero_mul_f8E5M2() {
+  %input = util.unfoldable_constant dense<[-0.0, -0.0, -0.0, -0.0]> : tensor<4xf8E5M2>
+  %one = util.unfoldable_constant dense<[1.0, 1.0, 1.0, 1.0]> : tensor<4xf8E5M2>
+  %init = tensor.empty() : tensor<4xf8E5M2>
+  %mul = linalg.mul ins(%input, %one : tensor<4xf8E5M2>, tensor<4xf8E5M2>) outs(%init : tensor<4xf8E5M2>) -> tensor<4xf8E5M2>
+  %result_i8 = arith.bitcast %mul : tensor<4xf8E5M2> to tensor<4xi8>
+  // -128 = 0x80 = -0.0 in f8E5M2
+  check.expect_eq_const(%result_i8, dense<[-128, -128, -128, -128]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+// Test: -0.0 * 1.0 should preserve -0.0 for f8E4M3FN.
+func.func @negzero_mul_f8E4M3FN() {
+  %input = util.unfoldable_constant dense<[-0.0, -0.0, -0.0, -0.0]> : tensor<4xf8E4M3FN>
+  %one = util.unfoldable_constant dense<[1.0, 1.0, 1.0, 1.0]> : tensor<4xf8E4M3FN>
+  %init = tensor.empty() : tensor<4xf8E4M3FN>
+  %mul = linalg.mul ins(%input, %one : tensor<4xf8E4M3FN>, tensor<4xf8E4M3FN>) outs(%init : tensor<4xf8E4M3FN>) -> tensor<4xf8E4M3FN>
+  %result_i8 = arith.bitcast %mul : tensor<4xf8E4M3FN> to tensor<4xi8>
+  // -128 = 0x80 = -0.0 in f8E4M3FN
+  check.expect_eq_const(%result_i8, dense<[-128, -128, -128, -128]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}


### PR DESCRIPTION
Extend ConvertUnsupportedFloatArithPass to handle the CPU backend by emulating fp8 arithmetic operations through f32. This is needed because LLVM doesn't natively support fptrunc/fpext for fp8 types.

- Add TruncFToFP8 pattern: emulates f32 -> fp8 using integer bit manipulation (extract sign/exp/mant, adjust bias, round, pack to i8).
- Add ExtFFromFP8 pattern: emulates fp8 -> f32 using integer bit manipulation (unpack from i8, adjust bias, pack to i32).
- Supported fp8 formats:
  * FNUZ (f8E5M2FNUZ, f8E4M3FNUZ): NaN=0x80, no Inf, no negative zero 
  * IEEE (f8E5M2): Has Inf and negative zero
  * FN (f8E4M3FN): No Inf, has negative zero
- Handle both scalar and vector types.
- Add lit tests for CPU target emulation.
- Add e2e tests (small_float_arith.mlir) for CPU backend.
- E2E tests: Round-to-nearest-even, denormal conversions, and special value handling

It is a step towards https://github.com/iree-org/iree/issues/23105

Signed-off-by: hanhanW <hanhan0912@gmail.com>