### PR TITLE
Adding iree-bazel-* wrapper tools for improved Bazel workflows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Testing/
 # Bazel artifacts
 **/bazel-*
 MODULE.bazel.lock
+.iree-bazel-try/
 
 # Executables
 *.exe

--- a/build_tools/bazel/build_test_all.sh
+++ b/build_tools/bazel/build_test_all.sh
@@ -169,7 +169,7 @@ BAZEL_TEST_CMD+=(
   --test_tag_filters="${TEST_TAG_FILTERS?}"
   --keep_going
   --test_output=errors
-  --config=generic_clang
+  --config=generic_clang_ci
 )
 
 "${BAZEL_STARTUP_CMD[@]}" query //... | \

--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -52,6 +52,23 @@ build --flag_alias=iree_link_compiler_shared=//compiler/src/iree/compiler/API:li
 build --flag_alias=iree_enable_runtime_tracing=//runtime/src/iree/base/tracing:tracing_provider
 
 ###############################################################################
+# Local development configuration.
+# Use with: bazel build --config=localdev //...
+#
+# Combines several optimizations for faster local iteration:
+# - Skymeld (merged analysis/execution for faster multi-target builds)
+# - Ramdisk sandbox on Linux (reduces I/O bottleneck with many cores)
+#
+# Note: Disk cache is configured in user.bazelrc (created by iree-bazel-configure).
+###############################################################################
+
+build:localdev --experimental_merged_skyframe_analysis_execution
+
+# Linux: use ramdisk for sandbox to reduce I/O with many cores.
+# This is a no-op on other platforms.
+build:localdev --sandbox_base=/dev/shm
+
+###############################################################################
 # Options for "generic_gcc" builds
 ###############################################################################
 
@@ -139,9 +156,24 @@ build:generic_clang --copt=-Wthread-safety-beta
 build:generic_clang --copt=-Wunused-comparison
 build:generic_clang --copt=-Wvla
 
-# Treat backrefs during linking as errors.
-build:generic_clang --linkopt=-Wl,--warn-backrefs
+###############################################################################
+# Linker options.
+###############################################################################
+
+# Treat linker warnings as errors (supported by all linkers).
 build:generic_clang --linkopt=-Wl,--fatal-warnings
+
+# Mold linker (faster linking for local development).
+build:mold --linkopt=-fuse-ld=mold
+
+###############################################################################
+# CI configuration.
+# Use --config=generic_clang_ci to replicate CI builds locally.
+###############################################################################
+
+build:generic_clang_ci --config=generic_clang
+# Warn on link order issues (not supported by all linkers, so CI-only).
+build:generic_clang_ci --linkopt=-Wl,--warn-backrefs
 
 ###############################################################################
 # Additional options for MacOS based clang builds.

--- a/build_tools/bin/README.md
+++ b/build_tools/bin/README.md
@@ -1,0 +1,140 @@
+# IREE Developer Tools
+
+This directory contains command-line tools that developers add to their PATH for
+convenient access across all IREE worktrees. Tools here provide streamlined
+workflows for building, testing, and experimenting with IREE.
+
+**Naming convention**: All tools must be prefixed with `iree-` to avoid PATH
+conflicts. Do not use names that conflict with existing IREE tools (e.g., don't
+name something `iree-run-module` or `iree-compile`).
+
+## Setup
+
+Add this directory to your PATH:
+
+```bash
+export PATH="$PATH:$PWD/build_tools/bin"
+```
+
+Or add to your shell configuration for persistence.
+
+---
+
+## Bazel Tools
+
+Wrapper tools for building IREE with Bazel. These handle configuration, provide
+better defaults, and work from any subdirectory within a worktree.
+
+For complete Bazel build documentation, see:
+[Building with Bazel](../../docs/website/docs/developers/building/bazel.md)
+
+### Quick Start
+
+```bash
+# Configure once per worktree
+iree-bazel-configure
+
+# Build
+iree-bazel-build //tools:iree-compile
+
+# Test
+iree-bazel-test //runtime/src/iree/base:status_test
+
+# Run
+iree-bazel-run //tools:iree-compile -- --help
+```
+
+> **Tip: Working with Claude Code?**
+>
+> All `iree-bazel-*` tools provide machine-readable documentation via `--agent_md`:
+>
+> ```shell
+> # Generate documentation for Claude
+> iree-bazel-configure --agent_md >> CLAUDE.local.md
+> ```
+>
+> This appends concise tool documentation to your local Claude instructions,
+> teaching Claude how to use the `iree-bazel-*` tools in your project.
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `iree-bazel-configure` | Configure IREE for Bazel builds (run once per worktree) |
+| `iree-bazel-build` | Build targets |
+| `iree-bazel-test` | Run tests |
+| `iree-bazel-run` | Build and run executables from current directory |
+| `iree-bazel-query` | Query the build graph |
+| `iree-bazel-try` | Compile and run C/C++ snippets without BUILD files |
+| `iree-bazel-fuzz` | Run libFuzzer targets with persistent corpus |
+| `iree-bazel-lib` | Shared library (sourced by other tools) |
+
+### Common Options
+
+All tools support:
+- `-h, --help` - Show help
+- `-n, --dry_run` - Show command without executing
+- `-v, --verbose` - Verbose output
+
+Short flags can be combined: `-nv` is equivalent to `-n -v`.
+
+### Configuration
+
+Driver configuration happens during `iree-bazel-configure`:
+
+```bash
+# Enable CUDA driver
+IREE_HAL_DRIVER_CUDA=ON iree-bazel-configure
+
+# Enable multiple drivers
+IREE_HAL_DRIVER_CUDA=ON IREE_HAL_DRIVER_VULKAN=ON iree-bazel-configure
+```
+
+### Output Directories
+
+Built artifacts are placed in standard Bazel output directories at the repo root:
+- `bazel-bin/` - Built executables and libraries
+- `bazel-testlogs/` - Test outputs and logs
+- `bazel-out/` - Full build tree
+
+### Watch Mode
+
+Several tools support watch mode (`-w`) which rebuilds/reruns on file changes:
+
+```bash
+iree-bazel-build -w //tools:iree-opt     # Rebuild on changes
+iree-bazel-test -w //runtime/...:test    # Rerun tests on changes
+iree-bazel-run -w //tools:iree-opt -- input.mlir  # Restart on changes
+```
+
+Watch mode requires [ibazel](https://github.com/bazelbuild/bazel-watcher).
+
+### Quick Experiments with iree-bazel-try
+
+Compile and run C/C++ snippets against IREE without writing BUILD files:
+
+```bash
+# Quick API exploration
+iree-bazel-try -e '
+#include "iree/base/api.h"
+#include <stdio.h>
+int main() {
+  printf("ok: %d\n", iree_status_is_ok(iree_ok_status()));
+  return 0;
+}'
+
+# Run tests
+iree-bazel-try -e '
+#include "iree/testing/gtest_harness.h"
+TEST(Status, Ok) { IREE_EXPECT_OK(iree_ok_status()); }
+'
+
+# MLIR transforms
+echo 'func.func @f() { return }' | iree-bazel-try -e '
+#include "iree/compiler/Tools/MlirTransformHarness.h"
+void xform(ModuleOp m) { m.walk([](Operation *op) { llvm::outs() << op->getName() << "\n"; }); }
+MLIR_TRANSFORM_MAIN_NO_PRINT(xform)
+'
+```
+
+Run `iree-bazel-try --help` for full documentation.

--- a/build_tools/bin/iree-bazel-build
+++ b/build_tools/bin/iree-bazel-build
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Build IREE targets with Bazel.
+#
+# Usage: iree-bazel-build [options] [target] [bazel-args...]
+#
+# Examples:
+#   iree-bazel-build                      # Build all tools
+#   iree-bazel-build //compiler/...       # Build compiler
+#   iree-bazel-build --config=debug       # Debug build
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-build"
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+eval "set -- $(iree_expand_combined_flags "$@")"
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-build - Build IREE with Bazel
+
+USAGE
+    iree-bazel-build [options] [target] [bazel-args...]
+
+OPTIONS
+    -n, --dry_run    Show the bazel command without executing
+    -v, --verbose    Show the bazel command before executing
+    -k, --keep_going Continue building after errors
+    -w, --watch      Watch mode: rebuild on file changes
+    -h, --help       Show this help
+
+    NOTE: Short flags can be combined: -nv is equivalent to -n -v
+
+ARGUMENTS
+    target       Bazel target (required)
+    bazel-args   Additional arguments passed to bazel build
+
+EXAMPLES
+    # Build the compiler tool
+    iree-bazel-build //tools:iree-compile
+
+    # Build multiple tools at once
+    iree-bazel-build //tools:iree-compile //tools:iree-opt
+
+    # Build the runtime module executor
+    iree-bazel-build //tools:iree-run-module
+
+    # Build all compiler components
+    iree-bazel-build //compiler/...
+
+    # Debug build
+    iree-bazel-build //tools:iree-compile --config=debug
+
+    # Continue building after errors
+    iree-bazel-build -k //compiler/...
+
+    # Watch and rebuild on changes
+    iree-bazel-build -w //tools:iree-opt
+
+    # Show command without executing (verbose dry-run)
+    iree-bazel-build -nv //tools:iree-compile
+
+COMMON TARGETS
+    //tools/...              All tools
+    //compiler/...           Compiler components
+    //runtime/...            Runtime components
+    //tools:iree-compile     Main compiler tool
+    //tools:iree-run-module  Module runner
+
+CONFIGURATIONS
+    --config=localdev        Local dev optimizations (disk cache, skymeld)
+    --config=debug           No optimizations, assertions enabled
+    --config=asserts         Optimized with assertions
+    --config=asan            Address Sanitizer
+    --config=msan            Memory Sanitizer
+    --config=tsan            Thread Sanitizer
+
+SEE ALSO
+    iree-bazel-configure, iree-bazel-test
+EOF
+}
+
+# Parse arguments.
+KEEP_GOING=0
+WATCH_MODE=0
+TARGET=""
+BAZEL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --agent-md|--agent_md)
+            iree_show_agent_md
+            exit 0
+            ;;
+        -n|--dry_run|--dry-run)
+            IREE_BAZEL_DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            IREE_BAZEL_VERBOSE=1
+            shift
+            ;;
+        -k|--keep_going|--keep-going)
+            KEEP_GOING=1
+            shift
+            ;;
+        -w|--watch)
+            WATCH_MODE=1
+            shift
+            ;;
+        -*)
+            BAZEL_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            if [[ -z "$TARGET" ]]; then
+                TARGET="$1"
+            else
+                BAZEL_ARGS+=("$1")
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Set up worktree (after arg parsing so --help works anywhere).
+iree_setup_worktree
+
+# Target is required.
+if [[ -z "$TARGET" ]]; then
+    iree_error "Target is required for bazel build"
+    echo ""
+    echo "Examples:"
+    echo "  iree-bazel-build //tools:iree-compile"
+    echo "  iree-bazel-build //tools:iree-compile //tools:iree-opt"
+    echo "  iree-bazel-build //tools:iree-run-module"
+    echo "  iree-bazel-build //compiler/..."
+    exit 1
+fi
+
+# Build the command with default configs before user args.
+iree_bazel_build_default_configs
+BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
+CMD=("$BAZEL_BIN" build "${IREE_BAZEL_DEFAULT_CONFIGS[@]}")
+if [[ "$KEEP_GOING" == "1" ]]; then
+    CMD+=(--keep_going)
+fi
+CMD+=("$TARGET" "${BAZEL_ARGS[@]}")
+
+# Execute or show.
+if iree_is_verbose || iree_is_dry_run; then
+    iree_info "Command: ${CMD[*]}"
+fi
+
+if iree_is_dry_run; then
+    exit 0
+fi
+
+iree_info "Building $TARGET"
+exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-build
+++ b/build_tools/bin/iree-bazel-build
@@ -12,7 +12,7 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-build"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
@@ -90,7 +90,7 @@ TARGET=""
 BAZEL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
+    case "${1}" in
         -h|--help)
             show_help
             exit 0
@@ -116,14 +116,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            BAZEL_ARGS+=("$1")
+            BAZEL_ARGS+=("${1}")
             shift
             ;;
         *)
-            if [[ -z "$TARGET" ]]; then
-                TARGET="$1"
+            if [[ -z "${TARGET}" ]]; then
+                TARGET="${1}"
             else
-                BAZEL_ARGS+=("$1")
+                BAZEL_ARGS+=("${1}")
             fi
             shift
             ;;
@@ -134,7 +134,7 @@ done
 iree_setup_worktree
 
 # Target is required.
-if [[ -z "$TARGET" ]]; then
+if [[ -z "${TARGET}" ]]; then
     iree_error "Target is required for bazel build"
     echo ""
     echo "Examples:"
@@ -147,12 +147,12 @@ fi
 
 # Build the command with default configs before user args.
 iree_bazel_build_default_configs
-BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
-CMD=("$BAZEL_BIN" build "${IREE_BAZEL_DEFAULT_CONFIGS[@]}")
-if [[ "$KEEP_GOING" == "1" ]]; then
+BAZEL_BIN=$(iree_get_bazel_command "${WATCH_MODE}")
+CMD=("${BAZEL_BIN}" build "${IREE_BAZEL_DEFAULT_CONFIGS[@]}")
+if [[ "${KEEP_GOING}" == "1" ]]; then
     CMD+=(--keep_going)
 fi
-CMD+=("$TARGET" "${BAZEL_ARGS[@]}")
+CMD+=("${TARGET}" "${BAZEL_ARGS[@]}")
 
 # Execute or show.
 if iree_is_verbose || iree_is_dry_run; then
@@ -163,5 +163,5 @@ if iree_is_dry_run; then
     exit 0
 fi
 
-iree_info "Building $TARGET"
+iree_info "Building ${TARGET}"
 exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-configure
+++ b/build_tools/bin/iree-bazel-configure
@@ -10,7 +10,7 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-configure"
 
 show_help() {
@@ -77,16 +77,16 @@ esac
 
 # Set up worktree (configure doesn't call iree_ensure_configured - it IS the configure).
 iree_require_worktree
-cd "$IREE_BAZEL_WORKTREE_DIR"
+cd "${IREE_BAZEL_WORKTREE_DIR}"
 
-iree_info "Configuring IREE for Bazel in $IREE_BAZEL_WORKTREE_DIR..."
+iree_info "Configuring IREE for Bazel in ${IREE_BAZEL_WORKTREE_DIR}..."
 
 # Run platform detection.
 if [[ -f "configure_bazel.py" ]]; then
     iree_info "Running configure_bazel.py..."
     python3 configure_bazel.py
 else
-    iree_error "configure_bazel.py not found in $IREE_BAZEL_WORKTREE_DIR"
+    iree_error "configure_bazel.py not found in ${IREE_BAZEL_WORKTREE_DIR}"
     exit 1
 fi
 
@@ -96,13 +96,13 @@ if [[ ! -f "user.bazelrc" ]]; then
 
     # Platform-specific cache directory defaults.
     if [[ -n "${IREE_BAZEL_CACHE_DIR:-}" ]]; then
-        CACHE_DIR="$IREE_BAZEL_CACHE_DIR"
-    elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+        CACHE_DIR="${IREE_BAZEL_CACHE_DIR}"
+    elif [[ "${OSTYPE}" == "msys" || "${OSTYPE}" == "cygwin" || "${OSTYPE}" == "win32" ]]; then
         # Windows: Use shorter path to avoid 260 character limit.
         CACHE_DIR="c:/bazelcache"
     else
         # Unix: Use XDG cache directory.
-        CACHE_DIR="$HOME/.cache/bazel-iree"
+        CACHE_DIR="${HOME}/.cache/bazel-iree"
     fi
 
     cat > user.bazelrc << EOF
@@ -110,7 +110,12 @@ if [[ ! -f "user.bazelrc" ]]; then
 # This file is not version-controlled.
 
 # Disk cache for faster rebuilds (override with IREE_BAZEL_CACHE_DIR).
-build --disk_cache=$CACHE_DIR
+build --disk_cache=${CACHE_DIR}
+
+# Garbage collect disk cache to prevent unbounded growth.
+# Max size 50GB, GC runs when Bazel is idle for 5s.
+build --experimental_disk_cache_gc_max_size=50G
+build --experimental_disk_cache_gc_idle_delay=5s
 
 # Debug config: no optimizations, with assertions.
 build:debug --config=asserts --compilation_mode=opt '--per_file_copt=iree|llvm@-O0' --strip=never

--- a/build_tools/bin/iree-bazel-configure
+++ b/build_tools/bin/iree-bazel-configure
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Configure IREE for Bazel builds.
+#
+# Usage: iree-bazel-configure
+#
+# This script runs configure_bazel.py to detect platform/compiler and
+# creates a user.bazelrc with recommended settings.
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-configure"
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-configure - Configure IREE for Bazel builds
+
+USAGE
+    iree-bazel-configure
+    IREE_HAL_DRIVER_CUDA=ON iree-bazel-configure
+
+WHAT IT DOES
+    1. Runs configure_bazel.py to detect platform/compiler
+    2. Writes HAL driver configuration from environment variables
+    3. Creates user.bazelrc with recommended settings (if not exists)
+
+GENERATED FILES
+    configured.bazelrc    Platform detection + driver configuration
+    user.bazelrc         Local settings (disk cache, debug config)
+
+ENVIRONMENT VARIABLES
+    IREE_BAZEL_CACHE_DIR - Bazel disk cache location
+        Unix default: ~/.cache/bazel-iree
+        Windows default: c:/bazelcache (avoids path length issues)
+
+    HAL Drivers (runtime, matches CMake conventions):
+      IREE_HAL_DRIVER_CUDA=ON        - Enable CUDA driver
+      IREE_HAL_DRIVER_VULKAN=ON      - Enable Vulkan driver
+      IREE_HAL_DRIVER_HIP=ON         - Enable HIP driver
+      IREE_HAL_DRIVER_METAL=ON       - Enable Metal driver
+      IREE_HAL_DRIVER_AMDGPU=ON      - Enable AMDGPU driver
+      IREE_HAL_DRIVER_LOCAL_SYNC=ON  - Enable local-sync (default)
+      IREE_HAL_DRIVER_LOCAL_TASK=ON  - Enable local-task (default)
+      IREE_HAL_DRIVER_NULL=ON        - Enable null driver
+
+    Values: ON/YES/TRUE/Y/1 (enabled), OFF/NO/FALSE/N/0 (disabled)
+    Defaults: local-sync, local-task, vulkan enabled (matches CMake)
+
+    Note: Compiler backends are always built in Bazel (plugin architecture).
+
+EXAMPLES
+    # Configure with defaults
+    iree-bazel-configure
+
+    # Enable CUDA
+    IREE_HAL_DRIVER_CUDA=ON iree-bazel-configure
+
+    # Enable multiple drivers
+    IREE_HAL_DRIVER_CUDA=ON IREE_HAL_DRIVER_VULKAN=ON iree-bazel-configure
+
+AFTER CONFIGURATION
+    iree-bazel-build      Build IREE targets
+    iree-bazel-test       Run tests with configured drivers
+
+SEE ALSO
+    iree-bazel-build, iree-bazel-test
+EOF
+}
+
+# Handle help and agent-md before worktree check.
+case "${1:-}" in
+    -h|--help) show_help; exit 0 ;;
+    --agent-md|--agent_md) iree_show_agent_md; exit 0 ;;
+esac
+
+# Set up worktree (configure doesn't call iree_ensure_configured - it IS the configure).
+iree_require_worktree
+cd "$IREE_BAZEL_WORKTREE_DIR"
+
+iree_info "Configuring IREE for Bazel in $IREE_BAZEL_WORKTREE_DIR..."
+
+# Run platform detection.
+if [[ -f "configure_bazel.py" ]]; then
+    iree_info "Running configure_bazel.py..."
+    python3 configure_bazel.py
+else
+    iree_error "configure_bazel.py not found in $IREE_BAZEL_WORKTREE_DIR"
+    exit 1
+fi
+
+# Create user.bazelrc if it doesn't exist.
+if [[ ! -f "user.bazelrc" ]]; then
+    iree_info "Creating user.bazelrc..."
+
+    # Platform-specific cache directory defaults.
+    if [[ -n "${IREE_BAZEL_CACHE_DIR:-}" ]]; then
+        CACHE_DIR="$IREE_BAZEL_CACHE_DIR"
+    elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+        # Windows: Use shorter path to avoid 260 character limit.
+        CACHE_DIR="c:/bazelcache"
+    else
+        # Unix: Use XDG cache directory.
+        CACHE_DIR="$HOME/.cache/bazel-iree"
+    fi
+
+    cat > user.bazelrc << EOF
+# Local Bazel configuration.
+# This file is not version-controlled.
+
+# Disk cache for faster rebuilds (override with IREE_BAZEL_CACHE_DIR).
+build --disk_cache=$CACHE_DIR
+
+# Debug config: no optimizations, with assertions.
+build:debug --config=asserts --compilation_mode=opt '--per_file_copt=iree|llvm@-O0' --strip=never
+
+# Enable assertions (optimized but with runtime checks).
+build:asserts --compilation_mode=opt '--copt=-UNDEBUG'
+EOF
+    iree_info "Created user.bazelrc with recommended settings"
+else
+    iree_info "user.bazelrc already exists, skipping"
+fi
+
+iree_info "Configuration complete!"
+echo ""
+echo "Build with:  iree-bazel-build [target]"
+echo "Test with:   iree-bazel-test [target]"

--- a/build_tools/bin/iree-bazel-fuzz
+++ b/build_tools/bin/iree-bazel-fuzz
@@ -12,15 +12,15 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-fuzz"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
 eval "set -- $(iree_expand_combined_flags "$@")"
 
 # Fuzz-specific globals.
-FUZZ_CACHE_DIR="${IREE_FUZZ_CACHE:-$HOME/.cache/iree-fuzz-cache}"
-FUZZ_CORPUS_DIR="${IREE_FUZZ_CORPUS:-$HOME/.cache/iree-fuzz-corpus}"
+FUZZ_CACHE_DIR="${IREE_FUZZ_CACHE:-${HOME}/.cache/iree-fuzz-cache}"
+FUZZ_CORPUS_DIR="${IREE_FUZZ_CORPUS:-${HOME}/.cache/iree-fuzz-corpus}"
 FUZZ_MINIMIZE=0
 FUZZ_DICT_ONLY=0
 FUZZ_MIN_USES=10       # Minimum usage count for dict entries
@@ -81,45 +81,46 @@ EOF
 
 # Extract target name from bazel label (e.g., "//foo/bar:baz" -> "baz")
 get_target_name() {
-    local target="$1"
+    local target="${1}"
     echo "${target##*:}"
 }
 
 # Get the repo-relative directory for a target (e.g., "runtime/src/iree/base").
 # Uses bazel query to find source file location.
 get_target_relative_dir() {
-    local target="$1"
-    local BAZEL_BIN=$(iree_get_bazel_command)
+    local target="${1}"
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
 
     # Query for source files of this target.
     local src_location
-    src_location=$("$BAZEL_BIN" query "labels(srcs, $target)" --output=location 2>/dev/null | head -1)
+    src_location=$("${BAZEL_BIN}" query "labels(srcs, ${target})" --output=location 2>/dev/null | head -1)
 
-    if [[ -n "$src_location" ]]; then
+    if [[ -n "${src_location}" ]]; then
         # Extract directory from "path/to/file.cc:1:1" and make it relative.
         local src_file="${src_location%%:*}"
         local src_dir
-        src_dir=$(dirname "$src_file")
+        src_dir=$(dirname "${src_file}")
 
         # Make path relative to worktree root.
-        echo "${src_dir#$IREE_BAZEL_WORKTREE_DIR/}"
+        echo "${src_dir#${IREE_BAZEL_WORKTREE_DIR}/}"
     fi
 }
 
 # Get the dict file path for a target in the fuzz-corpus directory.
 # Returns path even if file doesn't exist yet (for creation).
 find_dict_file() {
-    local target="$1"
+    local target="${1}"
     local target_name
-    target_name=$(get_target_name "$target")
+    target_name=$(get_target_name "${target}")
 
     local relative_dir
-    relative_dir=$(get_target_relative_dir "$target")
+    relative_dir=$(get_target_relative_dir "${target}")
 
-    if [[ -n "$relative_dir" ]]; then
-        local dict_dir="$FUZZ_CORPUS_DIR/$relative_dir"
-        mkdir -p "$dict_dir"
-        echo "$dict_dir/${target_name}.dict"
+    if [[ -n "${relative_dir}" ]]; then
+        local dict_dir="${FUZZ_CORPUS_DIR}/${relative_dir}"
+        mkdir -p "${dict_dir}"
+        echo "${dict_dir}/${target_name}.dict"
     fi
 }
 
@@ -127,76 +128,76 @@ find_dict_file() {
 # Filters to entries with usage count >= threshold.
 # Converts octal escapes (\NNN) to hex escapes (\xNN) for libFuzzer compatibility.
 parse_dict_entries() {
-    local output_file="$1"
-    local min_uses="$2"
+    local output_file="${1}"
+    local min_uses="${2}"
 
     # Extract lines between "Recommended dictionary" and "End of recommended"
     # Format: "\NNN\NNN" # Uses: NNN (libFuzzer outputs octal, but only parses hex)
-    sed -n '/^###### Recommended dictionary/,/^###### End of recommended/p' "$output_file" \
+    sed -n '/^###### Recommended dictionary/,/^###### End of recommended/p' "${output_file}" \
         | grep -E '^"' \
         | while IFS= read -r line; do
             # Extract usage count
             local uses
-            uses=$(echo "$line" | grep -oE 'Uses: [0-9]+' | grep -oE '[0-9]+')
-            if [[ -n "$uses" ]] && [[ "$uses" -ge "$min_uses" ]]; then
+            uses=$(echo "${line}" | grep -oE 'Uses: [0-9]+' | grep -oE '[0-9]+')
+            if [[ -n "${uses}" ]] && [[ "${uses}" -ge "${min_uses}" ]]; then
                 # Output just the string part (before #), converting octal to hex.
                 # \NNN (octal) -> \xNN (hex)
-                echo "$line" | sed 's/ *#.*//' | perl -pe 's/\\([0-7]{3})/sprintf("\\x%02x", oct($1))/ge'
+                echo "${line}" | sed 's/ *#.*//' | perl -pe 's/\\([0-7]{3})/sprintf("\\x%02x", oct($1))/ge'
             fi
         done
 }
 
 # Merge new dict entries into dict file (creates file if needed).
 merge_dict_entries() {
-    local dict_file="$1"
-    local new_entries="$2"
+    local dict_file="${1}"
+    local new_entries="${2}"
     local temp_file
     local valid_entries
 
-    if [[ -z "$new_entries" ]]; then
+    if [[ -z "${new_entries}" ]]; then
         iree_debug "No new dictionary entries to add"
         return 0
     fi
 
     temp_file=$(mktemp)
     valid_entries=$(mktemp)
-    trap "rm -f '$temp_file' '$valid_entries'" RETURN
+    trap "rm -f '${temp_file}' '${valid_entries}'" RETURN
 
     # Filter new entries to only valid ones (start with " and end with ").
     # Use printf to avoid bash escape interpretation.
-    printf '%s\n' "$new_entries" | while IFS= read -r entry; do
+    printf '%s\n' "${new_entries}" | while IFS= read -r entry; do
         # Validate: must start with " and end with "
-        if [[ "$entry" =~ ^\".*\"$ ]]; then
-            printf '%s\n' "$entry"
+        if [[ "${entry}" =~ ^\".*\"$ ]]; then
+            printf '%s\n' "${entry}"
         else
-            iree_debug "Skipping malformed dict entry: $entry"
+            iree_debug "Skipping malformed dict entry: ${entry}"
         fi
-    done > "$valid_entries"
+    done > "${valid_entries}"
 
-    if [[ ! -s "$valid_entries" ]]; then
+    if [[ ! -s "${valid_entries}" ]]; then
         iree_debug "No valid dictionary entries to add"
         return 0
     fi
 
     # Combine existing entries (if any) with new entries, sort, dedupe.
     {
-        grep -E '^"' "$dict_file" 2>/dev/null || true
-        cat "$valid_entries"
-    } | sort -u > "$temp_file"
+        grep -E '^"' "${dict_file}" 2>/dev/null || true
+        cat "${valid_entries}"
+    } | sort -u > "${temp_file}"
 
     local old_count new_count added_count
-    old_count=$(grep -cE '^"' "$dict_file" 2>/dev/null || echo 0)
-    new_count=$(wc -l < "$temp_file")
+    old_count=$(grep -cE '^"' "${dict_file}" 2>/dev/null || echo 0)
+    new_count=$(wc -l < "${temp_file}")
     added_count=$((new_count - old_count))
 
-    if [[ "$added_count" -gt 0 ]]; then
+    if [[ "${added_count}" -gt 0 ]]; then
         # Preserve comments from original file (if exists), then add sorted entries.
         {
-            grep -E '^#|^$' "$dict_file" 2>/dev/null || true
-            cat "$temp_file"
+            grep -E '^#|^$' "${dict_file}" 2>/dev/null || true
+            cat "${temp_file}"
         } > "${dict_file}.new"
-        mv "${dict_file}.new" "$dict_file"
-        iree_info "Added $added_count new dictionary entries to $dict_file"
+        mv "${dict_file}.new" "${dict_file}"
+        iree_info "Added ${added_count} new dictionary entries to ${dict_file}"
     else
         iree_debug "No new unique dictionary entries"
     fi
@@ -204,29 +205,29 @@ merge_dict_entries() {
 
 # Run corpus minimization using set_cover_merge.
 minimize_corpus() {
-    local binary="$1"
-    local corpus_dir="$2"
+    local binary="${1}"
+    local corpus_dir="${2}"
 
     local corpus_count
-    corpus_count=$(ls -1 "$corpus_dir" 2>/dev/null | wc -l)
+    corpus_count=$(ls -1 "${corpus_dir}" 2>/dev/null | wc -l)
 
-    if [[ "$corpus_count" -eq 0 ]]; then
+    if [[ "${corpus_count}" -eq 0 ]]; then
         iree_debug "Corpus is empty, nothing to minimize"
         return 0
     fi
 
-    iree_info "Minimizing corpus ($corpus_count files)..."
+    iree_info "Minimizing corpus (${corpus_count} files)..."
 
     local temp_corpus
     temp_corpus=$(mktemp -d)
-    trap "rm -rf '$temp_corpus'" RETURN
+    trap "rm -rf '${temp_corpus}'" RETURN
 
-    if "$binary" -set_cover_merge=1 "$temp_corpus" "$corpus_dir" 2>/dev/null; then
+    if "${binary}" -set_cover_merge=1 "${temp_corpus}" "${corpus_dir}" 2>/dev/null; then
         local new_count
-        new_count=$(ls -1 "$temp_corpus" | wc -l)
-        rm -rf "$corpus_dir"/*
-        mv "$temp_corpus"/* "$corpus_dir"/ 2>/dev/null || true
-        iree_info "Corpus minimized: $corpus_count -> $new_count files"
+        new_count=$(ls -1 "${temp_corpus}" | wc -l)
+        rm -rf "${corpus_dir}"/*
+        mv "${temp_corpus}"/* "${corpus_dir}"/ 2>/dev/null || true
+        iree_info "Corpus minimized: ${corpus_count} -> ${new_count} files"
     else
         iree_warn "Corpus minimization failed"
     fi
@@ -239,13 +240,13 @@ FUZZER_ARGS=()
 PARSING_FUZZER_ARGS=0
 
 while [[ $# -gt 0 ]]; do
-    if [[ "$PARSING_FUZZER_ARGS" == "1" ]]; then
-        FUZZER_ARGS+=("$1")
+    if [[ "${PARSING_FUZZER_ARGS}" == "1" ]]; then
+        FUZZER_ARGS+=("${1}")
         shift
         continue
     fi
 
-    case "$1" in
+    case "${1}" in
         -h|--help)
             show_help
             exit 0
@@ -275,14 +276,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            BAZEL_ARGS+=("$1")
+            BAZEL_ARGS+=("${1}")
             shift
             ;;
         *)
-            if [[ -z "$TARGET" ]]; then
-                TARGET="$1"
+            if [[ -z "${TARGET}" ]]; then
+                TARGET="${1}"
             else
-                BAZEL_ARGS+=("$1")
+                BAZEL_ARGS+=("${1}")
             fi
             shift
             ;;
@@ -290,7 +291,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Target is required.
-if [[ -z "$TARGET" ]]; then
+if [[ -z "${TARGET}" ]]; then
     iree_error "Target is required"
     echo ""
     show_help
@@ -301,38 +302,38 @@ fi
 iree_setup_worktree
 
 # Extract target info for directory structure.
-TARGET_NAME=$(get_target_name "$TARGET")
-TARGET_RELATIVE_DIR=$(get_target_relative_dir "$TARGET")
+TARGET_NAME=$(get_target_name "${TARGET}")
+TARGET_RELATIVE_DIR=$(get_target_relative_dir "${TARGET}")
 
 # Set up corpus and artifact directories with repo-relative paths.
 # Structure: ~/.cache/iree-fuzz-cache/<relative-path>/<target>/corpus/
 #            ~/.cache/iree-fuzz-cache/<relative-path>/<target>/artifacts/
-if [[ -n "$TARGET_RELATIVE_DIR" ]]; then
-    FUZZ_TARGET_DIR="$FUZZ_CACHE_DIR/$TARGET_RELATIVE_DIR/$TARGET_NAME"
+if [[ -n "${TARGET_RELATIVE_DIR}" ]]; then
+    FUZZ_TARGET_DIR="${FUZZ_CACHE_DIR}/${TARGET_RELATIVE_DIR}/${TARGET_NAME}"
 else
     # Fallback if we can't determine relative path.
-    FUZZ_TARGET_DIR="$FUZZ_CACHE_DIR/$TARGET_NAME"
+    FUZZ_TARGET_DIR="${FUZZ_CACHE_DIR}/${TARGET_NAME}"
 fi
-CORPUS_DIR="$FUZZ_TARGET_DIR/corpus"
-ARTIFACT_DIR="$FUZZ_TARGET_DIR/artifacts"
+CORPUS_DIR="${FUZZ_TARGET_DIR}/corpus"
+ARTIFACT_DIR="${FUZZ_TARGET_DIR}/artifacts"
 
 # Find dictionary file.
-DICT_FILE=$(find_dict_file "$TARGET")
+DICT_FILE=$(find_dict_file "${TARGET}")
 
 # Set up bazel args with fuzzer config.
 iree_bazel_build_default_configs
 BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "--config=fuzzer" "${BAZEL_ARGS[@]}")
 
 # Create corpus and artifact directories.
-mkdir -p "$CORPUS_DIR" "$ARTIFACT_DIR"
+mkdir -p "${CORPUS_DIR}" "${ARTIFACT_DIR}"
 
 # Verbose/dry-run output.
 if iree_is_verbose || iree_is_dry_run; then
-    iree_info "Target: $TARGET"
-    iree_info "Corpus: $CORPUS_DIR"
-    iree_info "Artifacts: $ARTIFACT_DIR"
-    if [[ -n "$DICT_FILE" ]]; then
-        iree_info "Dict: $DICT_FILE"
+    iree_info "Target: ${TARGET}"
+    iree_info "Corpus: ${CORPUS_DIR}"
+    iree_info "Artifacts: ${ARTIFACT_DIR}"
+    if [[ -n "${DICT_FILE}" ]]; then
+        iree_info "Dict: ${DICT_FILE}"
     fi
     iree_info "Bazel args: ${BAZEL_ARGS[*]}"
     iree_info "Fuzzer args: ${FUZZER_ARGS[*]:-<none>}"
@@ -343,65 +344,65 @@ if iree_is_dry_run; then
 fi
 
 # Build the target.
-iree_debug "Building $TARGET..."
-if ! iree_bazel_build_quiet "$TARGET" "${BAZEL_ARGS[@]}"; then
+iree_debug "Building ${TARGET}..."
+if ! iree_bazel_build_quiet "${TARGET}" "${BAZEL_ARGS[@]}"; then
     exit $?
 fi
 
 # Get the binary path.
-BINARY_PATH=$(iree_bazel_get_binary_path "$TARGET" "${BAZEL_ARGS[@]}")
-if [[ -z "$BINARY_PATH" ]] || [[ ! -x "$BINARY_PATH" ]]; then
-    iree_error "Could not find built binary for $TARGET"
+BINARY_PATH=$(iree_bazel_get_binary_path "${TARGET}" "${BAZEL_ARGS[@]}")
+if [[ -z "${BINARY_PATH}" ]] || [[ ! -x "${BINARY_PATH}" ]]; then
+    iree_error "Could not find built binary for ${TARGET}"
     exit 1
 fi
 
-iree_debug "Binary: $BINARY_PATH"
+iree_debug "Binary: ${BINARY_PATH}"
 
 # Minimize corpus if requested or if corpus is too large.
-CORPUS_COUNT=$(ls -1 "$CORPUS_DIR" 2>/dev/null | wc -l)
-if [[ "$FUZZ_MINIMIZE" == "1" ]]; then
-    minimize_corpus "$BINARY_PATH" "$CORPUS_DIR"
-elif [[ "$CORPUS_COUNT" -gt "$FUZZ_AUTO_MINIMIZE" ]]; then
-    iree_info "Corpus has $CORPUS_COUNT files (threshold: $FUZZ_AUTO_MINIMIZE), auto-minimizing..."
-    minimize_corpus "$BINARY_PATH" "$CORPUS_DIR"
+CORPUS_COUNT=$(ls -1 "${CORPUS_DIR}" 2>/dev/null | wc -l)
+if [[ "${FUZZ_MINIMIZE}" == "1" ]]; then
+    minimize_corpus "${BINARY_PATH}" "${CORPUS_DIR}"
+elif [[ "${CORPUS_COUNT}" -gt "${FUZZ_AUTO_MINIMIZE}" ]]; then
+    iree_info "Corpus has ${CORPUS_COUNT} files (threshold: ${FUZZ_AUTO_MINIMIZE}), auto-minimizing..."
+    minimize_corpus "${BINARY_PATH}" "${CORPUS_DIR}"
 fi
 
 # Dict-only mode: just run briefly to generate dictionary recommendations.
-if [[ "$FUZZ_DICT_ONLY" == "1" ]]; then
-    if [[ -z "$DICT_FILE" ]]; then
-        iree_error "No .dict file found for $TARGET"
+if [[ "${FUZZ_DICT_ONLY}" == "1" ]]; then
+    if [[ -z "${DICT_FILE}" ]]; then
+        iree_error "No .dict file found for ${TARGET}"
         exit 1
     fi
 
     iree_info "Running corpus to extract dictionary entries..."
     OUTPUT_FILE=$(mktemp)
-    trap "rm -f '$OUTPUT_FILE'" EXIT
+    trap "rm -f '${OUTPUT_FILE}'" EXIT
 
     # Run with existing corpus, short time limit.
-    "$BINARY_PATH" "$CORPUS_DIR" -max_total_time=5 2>&1 | tee "$OUTPUT_FILE"
+    "${BINARY_PATH}" "${CORPUS_DIR}" -max_total_time=5 2>&1 | tee "${OUTPUT_FILE}"
 
     # Extract and merge dictionary entries.
-    NEW_ENTRIES=$(parse_dict_entries "$OUTPUT_FILE" "$FUZZ_MIN_USES")
-    merge_dict_entries "$DICT_FILE" "$NEW_ENTRIES"
+    NEW_ENTRIES=$(parse_dict_entries "${OUTPUT_FILE}" "${FUZZ_MIN_USES}")
+    merge_dict_entries "${DICT_FILE}" "${NEW_ENTRIES}"
     exit 0
 fi
 
 # Set up log directory for this instance (temp, cleaned on success).
-FUZZ_LOG_DIR="/tmp/iree-bazel-fuzz/$TARGET_NAME/$$"
-mkdir -p "$FUZZ_LOG_DIR"
+FUZZ_LOG_DIR="/tmp/iree-bazel-fuzz/${TARGET_NAME}/$$"
+mkdir -p "${FUZZ_LOG_DIR}"
 
 # Build fuzzer command.
-FUZZ_CMD=("$BINARY_PATH" "$CORPUS_DIR")
+FUZZ_CMD=("${BINARY_PATH}" "${CORPUS_DIR}")
 
 # Redirect artifacts to persistent location, logs to temp.
-FUZZ_CMD+=("-artifact_prefix=$ARTIFACT_DIR/")
+FUZZ_CMD+=("-artifact_prefix=${ARTIFACT_DIR}/")
 
 # Add dictionary if it exists.
-if [[ -n "$DICT_FILE" ]] && [[ -f "$DICT_FILE" ]]; then
-    FUZZ_CMD+=("-dict=$DICT_FILE")
-    iree_info "Using dictionary: $DICT_FILE"
-elif [[ -n "$DICT_FILE" ]]; then
-    iree_debug "Dictionary will be created at: $DICT_FILE"
+if [[ -n "${DICT_FILE}" ]] && [[ -f "${DICT_FILE}" ]]; then
+    FUZZ_CMD+=("-dict=${DICT_FILE}")
+    iree_info "Using dictionary: ${DICT_FILE}"
+elif [[ -n "${DICT_FILE}" ]]; then
+    iree_debug "Dictionary will be created at: ${DICT_FILE}"
 fi
 
 # Add per-input timeout if not specified but max_total_time is.
@@ -409,19 +410,19 @@ fi
 HAS_TIMEOUT=0
 MAX_TOTAL_TIME=0
 for arg in "${FUZZER_ARGS[@]}"; do
-    if [[ "$arg" =~ ^-timeout= ]]; then
+    if [[ "${arg}" =~ ^-timeout= ]]; then
         HAS_TIMEOUT=1
-    elif [[ "$arg" =~ ^-max_total_time=([0-9]+) ]]; then
+    elif [[ "${arg}" =~ ^-max_total_time=([0-9]+) ]]; then
         MAX_TOTAL_TIME="${BASH_REMATCH[1]}"
     fi
 done
-if [[ "$HAS_TIMEOUT" -eq 0 ]] && [[ "$MAX_TOTAL_TIME" -gt 0 ]]; then
+if [[ "${HAS_TIMEOUT}" -eq 0 ]] && [[ "${MAX_TOTAL_TIME}" -gt 0 ]]; then
     # Default timeout to 2x max_total_time (minimum 5 seconds).
     DEFAULT_TIMEOUT=$((MAX_TOTAL_TIME * 2))
-    if [[ "$DEFAULT_TIMEOUT" -lt 5 ]]; then
+    if [[ "${DEFAULT_TIMEOUT}" -lt 5 ]]; then
         DEFAULT_TIMEOUT=5
     fi
-    FUZZ_CMD+=("-timeout=$DEFAULT_TIMEOUT")
+    FUZZ_CMD+=("-timeout=${DEFAULT_TIMEOUT}")
     iree_debug "Auto-setting timeout=${DEFAULT_TIMEOUT}s (2x max_total_time)"
 fi
 
@@ -434,74 +435,74 @@ cleanup() {
     local exit_code=$?
 
     # Prevent running twice (INT then EXIT).
-    if [[ "$CLEANUP_DONE" -eq 1 ]]; then
-        exit $exit_code
+    if [[ "${CLEANUP_DONE}" -eq 1 ]]; then
+        exit ${exit_code}
     fi
     CLEANUP_DONE=1
     trap - EXIT INT TERM
 
     # Extract dictionary from log files using grep to find exact section.
-    if [[ -n "$DICT_FILE" ]] && [[ -d "$FUZZ_LOG_DIR" ]]; then
+    if [[ -n "${DICT_FILE}" ]] && [[ -d "${FUZZ_LOG_DIR}" ]]; then
         # Use grep -A to get lines after the dictionary marker.
         # The dictionary section ends with "End of recommended", so we stop there.
         local dict_output
-        dict_output=$(grep -h -A 1000 '^###### Recommended dictionary' "$FUZZ_LOG_DIR"/*.log 2>/dev/null \
+        dict_output=$(grep -h -A 1000 '^###### Recommended dictionary' "${FUZZ_LOG_DIR}"/*.log 2>/dev/null \
             | sed '/^###### End of recommended/q' \
             | grep -E '^"' || true)
-        if [[ -n "$dict_output" ]]; then
-            NEW_ENTRIES=$(echo "$dict_output" \
+        if [[ -n "${dict_output}" ]]; then
+            NEW_ENTRIES=$(echo "${dict_output}" \
                 | while IFS= read -r line; do
                     local uses
-                    uses=$(echo "$line" | grep -oE 'Uses: [0-9]+' | grep -oE '[0-9]+')
-                    if [[ -n "$uses" ]] && [[ "$uses" -ge "$FUZZ_MIN_USES" ]]; then
-                        echo "$line" | sed 's/ *#.*//' | perl -pe 's/\\([0-7]{3})/sprintf("\\x%02x", oct($1))/ge'
+                    uses=$(echo "${line}" | grep -oE 'Uses: [0-9]+' | grep -oE '[0-9]+')
+                    if [[ -n "${uses}" ]] && [[ "${uses}" -ge "${FUZZ_MIN_USES}" ]]; then
+                        echo "${line}" | sed 's/ *#.*//' | perl -pe 's/\\([0-7]{3})/sprintf("\\x%02x", oct($1))/ge'
                     fi
                 done)
-            merge_dict_entries "$DICT_FILE" "$NEW_ENTRIES"
+            merge_dict_entries "${DICT_FILE}" "${NEW_ENTRIES}"
         fi
     fi
 
     # Report corpus size.
     local corpus_count
-    corpus_count=$(ls -1 "$CORPUS_DIR" 2>/dev/null | wc -l)
-    iree_info "Corpus: $corpus_count files in $CORPUS_DIR"
+    corpus_count=$(ls -1 "${CORPUS_DIR}" 2>/dev/null | wc -l)
+    iree_info "Corpus: ${corpus_count} files in ${CORPUS_DIR}"
 
     # Check for crash/leak/timeout artifacts in persistent location.
     local artifact_count
-    artifact_count=$(ls -1 "$ARTIFACT_DIR" 2>/dev/null | wc -l)
-    if [[ "$artifact_count" -gt 0 ]]; then
-        iree_warn "Artifacts ($artifact_count files): $ARTIFACT_DIR"
-        ls -1 "$ARTIFACT_DIR" | head -5 | while read -r artifact; do
-            echo "  $artifact"
+    artifact_count=$(ls -1 "${ARTIFACT_DIR}" 2>/dev/null | wc -l)
+    if [[ "${artifact_count}" -gt 0 ]]; then
+        iree_warn "Artifacts (${artifact_count} files): ${ARTIFACT_DIR}"
+        ls -1 "${ARTIFACT_DIR}" | head -5 | while read -r artifact; do
+            echo "  ${artifact}"
         done
-        if [[ "$artifact_count" -gt 5 ]]; then
+        if [[ "${artifact_count}" -gt 5 ]]; then
             echo "  ... and $((artifact_count - 5)) more"
         fi
     fi
 
     # Clean up log directory on success, keep on failure for debugging.
-    if [[ "$exit_code" -eq 0 ]]; then
-        rm -rf "$FUZZ_LOG_DIR"
+    if [[ "${exit_code}" -eq 0 ]]; then
+        rm -rf "${FUZZ_LOG_DIR}"
     else
         # Show error messages from logs on failure.
-        if [[ "$exit_code" -ne 0 ]]; then
+        if [[ "${exit_code}" -ne 0 ]]; then
             local errors
-            errors=$(grep -h -E '(ERROR|FATAL|ASAN|SUMMARY:|ParseDictionaryFile:)' "$FUZZ_LOG_DIR"/*.log 2>/dev/null | head -20 || true)
-            if [[ -n "$errors" ]]; then
+            errors=$(grep -h -E '(ERROR|FATAL|ASAN|SUMMARY:|ParseDictionaryFile:)' "${FUZZ_LOG_DIR}"/*.log 2>/dev/null | head -20 || true)
+            if [[ -n "${errors}" ]]; then
                 iree_error "Fuzzer failed:"
-                echo "$errors" >&2
+                echo "${errors}" >&2
             fi
         fi
-        iree_info "Logs and artifacts: $FUZZ_LOG_DIR"
+        iree_info "Logs and artifacts: ${FUZZ_LOG_DIR}"
     fi
 
-    exit $exit_code
+    exit ${exit_code}
 }
 trap cleanup EXIT INT TERM
 
 # Run the fuzzer from log directory so fuzz-N.log files go there.
 # Output goes to log files only - we just show status.
 iree_info "Starting fuzzer (Ctrl+C to stop)..."
-iree_info "Logs: $FUZZ_LOG_DIR"
-cd "$FUZZ_LOG_DIR"
+iree_info "Logs: ${FUZZ_LOG_DIR}"
+cd "${FUZZ_LOG_DIR}"
 "${FUZZ_CMD[@]}" > main.log 2>&1

--- a/build_tools/bin/iree-bazel-fuzz
+++ b/build_tools/bin/iree-bazel-fuzz
@@ -1,0 +1,507 @@
+#!/bin/bash
+# Run libFuzzer targets with persistent corpus and dictionary management.
+#
+# Usage: iree-bazel-fuzz [options] <target> [-- fuzzer-args...]
+#
+# Examples:
+#   iree-bazel-fuzz //runtime/src/iree/base/internal:unicode_fuzz
+#   iree-bazel-fuzz //path/to:target -- -max_total_time=60 -jobs=8
+#   iree-bazel-fuzz -m //path/to:target   # minimize corpus first
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-fuzz"
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+eval "set -- $(iree_expand_combined_flags "$@")"
+
+# Fuzz-specific globals.
+FUZZ_CACHE_DIR="${IREE_FUZZ_CACHE:-$HOME/.cache/iree-fuzz-cache}"
+FUZZ_CORPUS_DIR="${IREE_FUZZ_CORPUS:-$HOME/.cache/iree-fuzz-corpus}"
+FUZZ_MINIMIZE=0
+FUZZ_DICT_ONLY=0
+FUZZ_MIN_USES=10       # Minimum usage count for dict entries
+FUZZ_AUTO_MINIMIZE=1000  # Auto-minimize when corpus exceeds this count
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-fuzz - Run libFuzzer targets with persistent corpus/dict
+
+USAGE
+    iree-bazel-fuzz [options] <target> [-- fuzzer-args...]
+
+OPTIONS
+    -n, --dry_run       Show command without executing
+    -v, --verbose       Show command before executing
+    -m, --minimize      Minimize corpus with set_cover_merge before fuzzing
+    -d, --dict_only     Update dict from corpus without new fuzzing
+    -h, --help          Show this help
+
+    NOTE: Short flags can be combined: -nv is equivalent to -n -v
+
+ARGUMENTS
+    target              Bazel fuzz target (required)
+    fuzzer-args         Arguments passed to libFuzzer (after --)
+
+EXAMPLES
+    # Basic fuzzing (Ctrl+C to stop)
+    iree-bazel-fuzz //runtime/src/iree/base/internal:unicode_fuzz
+
+    # Time-limited with parallel workers
+    iree-bazel-fuzz //path/to:target -- -max_total_time=60 -jobs=8
+
+    # Minimize corpus before fuzzing
+    iree-bazel-fuzz -m //path/to:target
+
+    # Just update dictionary from existing corpus
+    iree-bazel-fuzz -d //path/to:target
+
+CORPUS & DICTIONARY
+    Corpus:    ~/.cache/iree-fuzz-cache/<relative-path>/<target>/corpus/
+    Artifacts: ~/.cache/iree-fuzz-cache/<relative-path>/<target>/artifacts/
+    Dictionary: ~/.cache/iree-fuzz-corpus/<relative-path>/<target>.dict
+
+    Paths mirror the source tree structure. Artifacts (crash-*, slow-unit-*)
+    persist across runs. Dictionary entries (Uses > 10) are auto-appended.
+    Corpus is auto-minimized when it exceeds 1000 files.
+
+COMMON FUZZER FLAGS
+    -max_total_time=N   Stop after N seconds
+    -jobs=N             Run N parallel fuzzing jobs
+    -workers=M          Use M worker processes (default: min(jobs, cores/2))
+    -dict=file          Load additional dictionary
+
+SEE ALSO
+    iree-bazel-build, iree-bazel-run, iree-bazel-test
+EOF
+}
+
+# Extract target name from bazel label (e.g., "//foo/bar:baz" -> "baz")
+get_target_name() {
+    local target="$1"
+    echo "${target##*:}"
+}
+
+# Get the repo-relative directory for a target (e.g., "runtime/src/iree/base").
+# Uses bazel query to find source file location.
+get_target_relative_dir() {
+    local target="$1"
+    local BAZEL_BIN=$(iree_get_bazel_command)
+
+    # Query for source files of this target.
+    local src_location
+    src_location=$("$BAZEL_BIN" query "labels(srcs, $target)" --output=location 2>/dev/null | head -1)
+
+    if [[ -n "$src_location" ]]; then
+        # Extract directory from "path/to/file.cc:1:1" and make it relative.
+        local src_file="${src_location%%:*}"
+        local src_dir
+        src_dir=$(dirname "$src_file")
+
+        # Make path relative to worktree root.
+        echo "${src_dir#$IREE_BAZEL_WORKTREE_DIR/}"
+    fi
+}
+
+# Get the dict file path for a target in the fuzz-corpus directory.
+# Returns path even if file doesn't exist yet (for creation).
+find_dict_file() {
+    local target="$1"
+    local target_name
+    target_name=$(get_target_name "$target")
+
+    local relative_dir
+    relative_dir=$(get_target_relative_dir "$target")
+
+    if [[ -n "$relative_dir" ]]; then
+        local dict_dir="$FUZZ_CORPUS_DIR/$relative_dir"
+        mkdir -p "$dict_dir"
+        echo "$dict_dir/${target_name}.dict"
+    fi
+}
+
+# Parse recommended dictionary from fuzzer output.
+# Filters to entries with usage count >= threshold.
+# Converts octal escapes (\NNN) to hex escapes (\xNN) for libFuzzer compatibility.
+parse_dict_entries() {
+    local output_file="$1"
+    local min_uses="$2"
+
+    # Extract lines between "Recommended dictionary" and "End of recommended"
+    # Format: "\NNN\NNN" # Uses: NNN (libFuzzer outputs octal, but only parses hex)
+    sed -n '/^###### Recommended dictionary/,/^###### End of recommended/p' "$output_file" \
+        | grep -E '^"' \
+        | while IFS= read -r line; do
+            # Extract usage count
+            local uses
+            uses=$(echo "$line" | grep -oE 'Uses: [0-9]+' | grep -oE '[0-9]+')
+            if [[ -n "$uses" ]] && [[ "$uses" -ge "$min_uses" ]]; then
+                # Output just the string part (before #), converting octal to hex.
+                # \NNN (octal) -> \xNN (hex)
+                echo "$line" | sed 's/ *#.*//' | perl -pe 's/\\([0-7]{3})/sprintf("\\x%02x", oct($1))/ge'
+            fi
+        done
+}
+
+# Merge new dict entries into dict file (creates file if needed).
+merge_dict_entries() {
+    local dict_file="$1"
+    local new_entries="$2"
+    local temp_file
+    local valid_entries
+
+    if [[ -z "$new_entries" ]]; then
+        iree_debug "No new dictionary entries to add"
+        return 0
+    fi
+
+    temp_file=$(mktemp)
+    valid_entries=$(mktemp)
+    trap "rm -f '$temp_file' '$valid_entries'" RETURN
+
+    # Filter new entries to only valid ones (start with " and end with ").
+    # Use printf to avoid bash escape interpretation.
+    printf '%s\n' "$new_entries" | while IFS= read -r entry; do
+        # Validate: must start with " and end with "
+        if [[ "$entry" =~ ^\".*\"$ ]]; then
+            printf '%s\n' "$entry"
+        else
+            iree_debug "Skipping malformed dict entry: $entry"
+        fi
+    done > "$valid_entries"
+
+    if [[ ! -s "$valid_entries" ]]; then
+        iree_debug "No valid dictionary entries to add"
+        return 0
+    fi
+
+    # Combine existing entries (if any) with new entries, sort, dedupe.
+    {
+        grep -E '^"' "$dict_file" 2>/dev/null || true
+        cat "$valid_entries"
+    } | sort -u > "$temp_file"
+
+    local old_count new_count added_count
+    old_count=$(grep -cE '^"' "$dict_file" 2>/dev/null || echo 0)
+    new_count=$(wc -l < "$temp_file")
+    added_count=$((new_count - old_count))
+
+    if [[ "$added_count" -gt 0 ]]; then
+        # Preserve comments from original file (if exists), then add sorted entries.
+        {
+            grep -E '^#|^$' "$dict_file" 2>/dev/null || true
+            cat "$temp_file"
+        } > "${dict_file}.new"
+        mv "${dict_file}.new" "$dict_file"
+        iree_info "Added $added_count new dictionary entries to $dict_file"
+    else
+        iree_debug "No new unique dictionary entries"
+    fi
+}
+
+# Run corpus minimization using set_cover_merge.
+minimize_corpus() {
+    local binary="$1"
+    local corpus_dir="$2"
+
+    local corpus_count
+    corpus_count=$(ls -1 "$corpus_dir" 2>/dev/null | wc -l)
+
+    if [[ "$corpus_count" -eq 0 ]]; then
+        iree_debug "Corpus is empty, nothing to minimize"
+        return 0
+    fi
+
+    iree_info "Minimizing corpus ($corpus_count files)..."
+
+    local temp_corpus
+    temp_corpus=$(mktemp -d)
+    trap "rm -rf '$temp_corpus'" RETURN
+
+    if "$binary" -set_cover_merge=1 "$temp_corpus" "$corpus_dir" 2>/dev/null; then
+        local new_count
+        new_count=$(ls -1 "$temp_corpus" | wc -l)
+        rm -rf "$corpus_dir"/*
+        mv "$temp_corpus"/* "$corpus_dir"/ 2>/dev/null || true
+        iree_info "Corpus minimized: $corpus_count -> $new_count files"
+    else
+        iree_warn "Corpus minimization failed"
+    fi
+}
+
+# Parse arguments.
+TARGET=""
+BAZEL_ARGS=()
+FUZZER_ARGS=()
+PARSING_FUZZER_ARGS=0
+
+while [[ $# -gt 0 ]]; do
+    if [[ "$PARSING_FUZZER_ARGS" == "1" ]]; then
+        FUZZER_ARGS+=("$1")
+        shift
+        continue
+    fi
+
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --agent-md|--agent_md)
+            iree_show_agent_md
+            exit 0
+            ;;
+        -n|--dry_run|--dry-run)
+            IREE_BAZEL_DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            IREE_BAZEL_VERBOSE=1
+            shift
+            ;;
+        -m|--minimize)
+            FUZZ_MINIMIZE=1
+            shift
+            ;;
+        -d|--dict_only|--dict-only)
+            FUZZ_DICT_ONLY=1
+            shift
+            ;;
+        --)
+            PARSING_FUZZER_ARGS=1
+            shift
+            ;;
+        -*)
+            BAZEL_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            if [[ -z "$TARGET" ]]; then
+                TARGET="$1"
+            else
+                BAZEL_ARGS+=("$1")
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Target is required.
+if [[ -z "$TARGET" ]]; then
+    iree_error "Target is required"
+    echo ""
+    show_help
+    exit 1
+fi
+
+# Set up worktree.
+iree_setup_worktree
+
+# Extract target info for directory structure.
+TARGET_NAME=$(get_target_name "$TARGET")
+TARGET_RELATIVE_DIR=$(get_target_relative_dir "$TARGET")
+
+# Set up corpus and artifact directories with repo-relative paths.
+# Structure: ~/.cache/iree-fuzz-cache/<relative-path>/<target>/corpus/
+#            ~/.cache/iree-fuzz-cache/<relative-path>/<target>/artifacts/
+if [[ -n "$TARGET_RELATIVE_DIR" ]]; then
+    FUZZ_TARGET_DIR="$FUZZ_CACHE_DIR/$TARGET_RELATIVE_DIR/$TARGET_NAME"
+else
+    # Fallback if we can't determine relative path.
+    FUZZ_TARGET_DIR="$FUZZ_CACHE_DIR/$TARGET_NAME"
+fi
+CORPUS_DIR="$FUZZ_TARGET_DIR/corpus"
+ARTIFACT_DIR="$FUZZ_TARGET_DIR/artifacts"
+
+# Find dictionary file.
+DICT_FILE=$(find_dict_file "$TARGET")
+
+# Set up bazel args with fuzzer config.
+iree_bazel_build_default_configs
+BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "--config=fuzzer" "${BAZEL_ARGS[@]}")
+
+# Create corpus and artifact directories.
+mkdir -p "$CORPUS_DIR" "$ARTIFACT_DIR"
+
+# Verbose/dry-run output.
+if iree_is_verbose || iree_is_dry_run; then
+    iree_info "Target: $TARGET"
+    iree_info "Corpus: $CORPUS_DIR"
+    iree_info "Artifacts: $ARTIFACT_DIR"
+    if [[ -n "$DICT_FILE" ]]; then
+        iree_info "Dict: $DICT_FILE"
+    fi
+    iree_info "Bazel args: ${BAZEL_ARGS[*]}"
+    iree_info "Fuzzer args: ${FUZZER_ARGS[*]:-<none>}"
+fi
+
+if iree_is_dry_run; then
+    exit 0
+fi
+
+# Build the target.
+iree_debug "Building $TARGET..."
+if ! iree_bazel_build_quiet "$TARGET" "${BAZEL_ARGS[@]}"; then
+    exit $?
+fi
+
+# Get the binary path.
+BINARY_PATH=$(iree_bazel_get_binary_path "$TARGET" "${BAZEL_ARGS[@]}")
+if [[ -z "$BINARY_PATH" ]] || [[ ! -x "$BINARY_PATH" ]]; then
+    iree_error "Could not find built binary for $TARGET"
+    exit 1
+fi
+
+iree_debug "Binary: $BINARY_PATH"
+
+# Minimize corpus if requested or if corpus is too large.
+CORPUS_COUNT=$(ls -1 "$CORPUS_DIR" 2>/dev/null | wc -l)
+if [[ "$FUZZ_MINIMIZE" == "1" ]]; then
+    minimize_corpus "$BINARY_PATH" "$CORPUS_DIR"
+elif [[ "$CORPUS_COUNT" -gt "$FUZZ_AUTO_MINIMIZE" ]]; then
+    iree_info "Corpus has $CORPUS_COUNT files (threshold: $FUZZ_AUTO_MINIMIZE), auto-minimizing..."
+    minimize_corpus "$BINARY_PATH" "$CORPUS_DIR"
+fi
+
+# Dict-only mode: just run briefly to generate dictionary recommendations.
+if [[ "$FUZZ_DICT_ONLY" == "1" ]]; then
+    if [[ -z "$DICT_FILE" ]]; then
+        iree_error "No .dict file found for $TARGET"
+        exit 1
+    fi
+
+    iree_info "Running corpus to extract dictionary entries..."
+    OUTPUT_FILE=$(mktemp)
+    trap "rm -f '$OUTPUT_FILE'" EXIT
+
+    # Run with existing corpus, short time limit.
+    "$BINARY_PATH" "$CORPUS_DIR" -max_total_time=5 2>&1 | tee "$OUTPUT_FILE"
+
+    # Extract and merge dictionary entries.
+    NEW_ENTRIES=$(parse_dict_entries "$OUTPUT_FILE" "$FUZZ_MIN_USES")
+    merge_dict_entries "$DICT_FILE" "$NEW_ENTRIES"
+    exit 0
+fi
+
+# Set up log directory for this instance (temp, cleaned on success).
+FUZZ_LOG_DIR="/tmp/iree-bazel-fuzz/$TARGET_NAME/$$"
+mkdir -p "$FUZZ_LOG_DIR"
+
+# Build fuzzer command.
+FUZZ_CMD=("$BINARY_PATH" "$CORPUS_DIR")
+
+# Redirect artifacts to persistent location, logs to temp.
+FUZZ_CMD+=("-artifact_prefix=$ARTIFACT_DIR/")
+
+# Add dictionary if it exists.
+if [[ -n "$DICT_FILE" ]] && [[ -f "$DICT_FILE" ]]; then
+    FUZZ_CMD+=("-dict=$DICT_FILE")
+    iree_info "Using dictionary: $DICT_FILE"
+elif [[ -n "$DICT_FILE" ]]; then
+    iree_debug "Dictionary will be created at: $DICT_FILE"
+fi
+
+# Add per-input timeout if not specified but max_total_time is.
+# This prevents pathological inputs from hanging the fuzzer.
+HAS_TIMEOUT=0
+MAX_TOTAL_TIME=0
+for arg in "${FUZZER_ARGS[@]}"; do
+    if [[ "$arg" =~ ^-timeout= ]]; then
+        HAS_TIMEOUT=1
+    elif [[ "$arg" =~ ^-max_total_time=([0-9]+) ]]; then
+        MAX_TOTAL_TIME="${BASH_REMATCH[1]}"
+    fi
+done
+if [[ "$HAS_TIMEOUT" -eq 0 ]] && [[ "$MAX_TOTAL_TIME" -gt 0 ]]; then
+    # Default timeout to 2x max_total_time (minimum 5 seconds).
+    DEFAULT_TIMEOUT=$((MAX_TOTAL_TIME * 2))
+    if [[ "$DEFAULT_TIMEOUT" -lt 5 ]]; then
+        DEFAULT_TIMEOUT=5
+    fi
+    FUZZ_CMD+=("-timeout=$DEFAULT_TIMEOUT")
+    iree_debug "Auto-setting timeout=${DEFAULT_TIMEOUT}s (2x max_total_time)"
+fi
+
+# Add user fuzzer args.
+FUZZ_CMD+=("${FUZZER_ARGS[@]}")
+
+# Cleanup and dict update on exit.
+CLEANUP_DONE=0
+cleanup() {
+    local exit_code=$?
+
+    # Prevent running twice (INT then EXIT).
+    if [[ "$CLEANUP_DONE" -eq 1 ]]; then
+        exit $exit_code
+    fi
+    CLEANUP_DONE=1
+    trap - EXIT INT TERM
+
+    # Extract dictionary from log files using grep to find exact section.
+    if [[ -n "$DICT_FILE" ]] && [[ -d "$FUZZ_LOG_DIR" ]]; then
+        # Use grep -A to get lines after the dictionary marker.
+        # The dictionary section ends with "End of recommended", so we stop there.
+        local dict_output
+        dict_output=$(grep -h -A 1000 '^###### Recommended dictionary' "$FUZZ_LOG_DIR"/*.log 2>/dev/null \
+            | sed '/^###### End of recommended/q' \
+            | grep -E '^"' || true)
+        if [[ -n "$dict_output" ]]; then
+            NEW_ENTRIES=$(echo "$dict_output" \
+                | while IFS= read -r line; do
+                    local uses
+                    uses=$(echo "$line" | grep -oE 'Uses: [0-9]+' | grep -oE '[0-9]+')
+                    if [[ -n "$uses" ]] && [[ "$uses" -ge "$FUZZ_MIN_USES" ]]; then
+                        echo "$line" | sed 's/ *#.*//' | perl -pe 's/\\([0-7]{3})/sprintf("\\x%02x", oct($1))/ge'
+                    fi
+                done)
+            merge_dict_entries "$DICT_FILE" "$NEW_ENTRIES"
+        fi
+    fi
+
+    # Report corpus size.
+    local corpus_count
+    corpus_count=$(ls -1 "$CORPUS_DIR" 2>/dev/null | wc -l)
+    iree_info "Corpus: $corpus_count files in $CORPUS_DIR"
+
+    # Check for crash/leak/timeout artifacts in persistent location.
+    local artifact_count
+    artifact_count=$(ls -1 "$ARTIFACT_DIR" 2>/dev/null | wc -l)
+    if [[ "$artifact_count" -gt 0 ]]; then
+        iree_warn "Artifacts ($artifact_count files): $ARTIFACT_DIR"
+        ls -1 "$ARTIFACT_DIR" | head -5 | while read -r artifact; do
+            echo "  $artifact"
+        done
+        if [[ "$artifact_count" -gt 5 ]]; then
+            echo "  ... and $((artifact_count - 5)) more"
+        fi
+    fi
+
+    # Clean up log directory on success, keep on failure for debugging.
+    if [[ "$exit_code" -eq 0 ]]; then
+        rm -rf "$FUZZ_LOG_DIR"
+    else
+        # Show error messages from logs on failure.
+        if [[ "$exit_code" -ne 0 ]]; then
+            local errors
+            errors=$(grep -h -E '(ERROR|FATAL|ASAN|SUMMARY:|ParseDictionaryFile:)' "$FUZZ_LOG_DIR"/*.log 2>/dev/null | head -20 || true)
+            if [[ -n "$errors" ]]; then
+                iree_error "Fuzzer failed:"
+                echo "$errors" >&2
+            fi
+        fi
+        iree_info "Logs and artifacts: $FUZZ_LOG_DIR"
+    fi
+
+    exit $exit_code
+}
+trap cleanup EXIT INT TERM
+
+# Run the fuzzer from log directory so fuzz-N.log files go there.
+# Output goes to log files only - we just show status.
+iree_info "Starting fuzzer (Ctrl+C to stop)..."
+iree_info "Logs: $FUZZ_LOG_DIR"
+cd "$FUZZ_LOG_DIR"
+"${FUZZ_CMD[@]}" > main.log 2>&1

--- a/build_tools/bin/iree-bazel-lib
+++ b/build_tools/bin/iree-bazel-lib
@@ -28,23 +28,23 @@ _IREE_BAZEL_TOOL_NAME=""
 
 # Print info message with tool name prefix (to stderr, never pollutes stdout).
 iree_info() {
-    printf "${_IREE_BAZEL_COLOR_GREEN}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+    printf "${_IREE_BAZEL_COLOR_GREEN}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "${1}" >&2
 }
 
 # Print warning message with tool name prefix (to stderr).
 iree_warn() {
-    printf "${_IREE_BAZEL_COLOR_YELLOW}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+    printf "${_IREE_BAZEL_COLOR_YELLOW}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "${1}" >&2
 }
 
 # Print error message with tool name prefix to stderr.
 iree_error() {
-    printf "${_IREE_BAZEL_COLOR_RED}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+    printf "${_IREE_BAZEL_COLOR_RED}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "${1}" >&2
 }
 
 # Print debug message (only if IREE_BAZEL_VERBOSE is set).
 iree_debug() {
     [[ "${IREE_BAZEL_VERBOSE:-0}" == "1" ]] && \
-        printf "${_IREE_BAZEL_COLOR_CYAN}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+        printf "${_IREE_BAZEL_COLOR_CYAN}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "${1}" >&2
     return 0
 }
 
@@ -99,13 +99,13 @@ EOF
 # Find the IREE worktree root (directory with .git and .bazelversion).
 # Outputs the path to stdout, returns 1 if not found.
 iree_find_worktree_root() {
-    local directory="${1:-$PWD}"
-    while [[ "$directory" != "/" ]]; do
-        if [[ -e "$directory/.git" ]] && [[ -f "$directory/.bazelversion" ]]; then
-            echo "$directory"
+    local directory="${1:-${PWD}}"
+    while [[ "${directory}" != "/" ]]; do
+        if [[ -e "${directory}/.git" ]] && [[ -f "${directory}/.bazelversion" ]]; then
+            echo "${directory}"
             return 0
         fi
-        directory=$(dirname "$directory")
+        directory=$(dirname "${directory}")
     done
     return 1
 }
@@ -114,7 +114,7 @@ iree_find_worktree_root() {
 # Sets IREE_BAZEL_WORKTREE_DIR on success.
 iree_require_worktree() {
     IREE_BAZEL_WORKTREE_DIR=$(iree_find_worktree_root)
-    if [[ -z "$IREE_BAZEL_WORKTREE_DIR" ]]; then
+    if [[ -z "${IREE_BAZEL_WORKTREE_DIR}" ]]; then
         iree_error "Not in an IREE worktree (no .bazelversion found)"
         iree_error "Must be in a directory with .git and .bazelversion files"
         exit 1
@@ -154,8 +154,8 @@ iree_ensure_configured() {
 #   - IREE_BAZEL_DRY_RUN (default 0)
 #   - IREE_BAZEL_VERBOSE (default 0)
 iree_bazel_init() {
-    _IREE_BAZEL_TOOL_NAME="$1"
-    IREE_BAZEL_ORIG_CWD="$PWD"
+    _IREE_BAZEL_TOOL_NAME="${1}"
+    IREE_BAZEL_ORIG_CWD="${PWD}"
     IREE_BAZEL_DRY_RUN="${IREE_BAZEL_DRY_RUN:-0}"
     IREE_BAZEL_VERBOSE="${IREE_BAZEL_VERBOSE:-0}"
 }
@@ -165,18 +165,18 @@ iree_bazel_init() {
 # Must be called after parsing args (so --help can work outside worktree).
 iree_setup_worktree() {
     iree_require_worktree
-    cd "$IREE_BAZEL_WORKTREE_DIR"
+    cd "${IREE_BAZEL_WORKTREE_DIR}"
     iree_ensure_configured
 }
 
 # Check if dry-run mode is enabled.
 iree_is_dry_run() {
-    [[ "$IREE_BAZEL_DRY_RUN" == "1" ]]
+    [[ "${IREE_BAZEL_DRY_RUN}" == "1" ]]
 }
 
 # Check if verbose mode is enabled.
 iree_is_verbose() {
-    [[ "$IREE_BAZEL_VERBOSE" == "1" ]]
+    [[ "${IREE_BAZEL_VERBOSE}" == "1" ]]
 }
 
 # Get the bazel command to use (bazel or ibazel for watch mode).
@@ -184,7 +184,7 @@ iree_is_verbose() {
 iree_get_bazel_command() {
     local watch_mode="${1:-0}"
 
-    if [[ "$watch_mode" == "1" ]]; then
+    if [[ "${watch_mode}" == "1" ]]; then
         if ! command -v ibazel >/dev/null 2>&1; then
             iree_error "ibazel not found. Install with: go install github.com/bazelbuild/bazel-watcher/cmd/ibazel@latest"
             exit 1
@@ -213,16 +213,16 @@ iree_get_bazel_command() {
 iree_expand_combined_flags() {
     local result=()
     while [[ $# -gt 0 ]]; do
-        local arg="$1"
+        local arg="${1}"
         shift
         # Match single dash followed by 2+ lowercase letters (no '=' or other chars).
-        if [[ "$arg" =~ ^-([a-z]{2,})$ ]]; then
+        if [[ "${arg}" =~ ^-([a-z]{2,})$ ]]; then
             local flags="${BASH_REMATCH[1]}"
             for (( i=0; i<${#flags}; i++ )); do
-                result+=("-${flags:$i:1}")
+                result+=("-${flags:${i}:1}")
             done
         else
-            result+=("$arg")
+            result+=("${arg}")
         fi
     done
     # Print quoted args suitable for eval.
@@ -284,15 +284,16 @@ iree_bazel_build_default_configs() {
 #   $2... - Bazel args (configs, etc.) - MUST match the build args
 # Outputs: Absolute path to built binary
 iree_bazel_get_binary_path() {
-    local target="$1"
+    local target="${1}"
     shift
-    local BAZEL_BIN=$(iree_get_bazel_command)
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
     local relative_path
     # Pass all bazel args to cquery so it uses the same configuration as build.
-    relative_path=$("$BAZEL_BIN" cquery --output=files "$target" "$@" 2>/dev/null)
+    relative_path=$("${BAZEL_BIN}" cquery --output=files "${target}" "$@" 2>/dev/null)
     # Convert to absolute path (bazel returns paths relative to workspace).
-    if [[ -n "$relative_path" ]]; then
-        echo "$PWD/$relative_path"
+    if [[ -n "${relative_path}" ]]; then
+        echo "${PWD}/${relative_path}"
     fi
 }
 
@@ -306,11 +307,11 @@ iree_bazel_get_binary_path() {
 #   After finding "--" in args, remaining args go to the program
 #
 # Example:
-#   iree_bazel_build_and_exec "//tools:iree-compile" "$IREE_BAZEL_ORIG_CWD" \
+#   iree_bazel_build_and_exec "//tools:iree-compile" "${IREE_BAZEL_ORIG_CWD}" \
 #       --config=debug -- input.mlir -o output.vmfb
 iree_bazel_build_and_exec() {
-    local target="$1"
-    local run_cwd="$2"
+    local target="${1}"
+    local run_cwd="${2}"
     shift 2
 
     local -a bazel_args=()
@@ -319,12 +320,12 @@ iree_bazel_build_and_exec() {
 
     # Split args into bazel args and program args.
     while [[ $# -gt 0 ]]; do
-        if [[ "$parsing_program_args" == "1" ]]; then
-            program_args+=("$1")
-        elif [[ "$1" == "--" ]]; then
+        if [[ "${parsing_program_args}" == "1" ]]; then
+            program_args+=("${1}")
+        elif [[ "${1}" == "--" ]]; then
             parsing_program_args=1
         else
-            bazel_args+=("$1")
+            bazel_args+=("${1}")
         fi
         shift
     done
@@ -333,24 +334,24 @@ iree_bazel_build_and_exec() {
     iree_debug "Program args: ${program_args[*]:-<none>}"
 
     # Build the target quietly (no output on success).
-    if ! iree_bazel_build_quiet "$target" "${bazel_args[@]}"; then
+    if ! iree_bazel_build_quiet "${target}" "${bazel_args[@]}"; then
         return $?
     fi
 
     # Get the binary path (pass same args so cquery uses same configuration).
     local binary_path
-    binary_path=$(iree_bazel_get_binary_path "$target" "${bazel_args[@]}")
-    if [[ -z "$binary_path" ]] || [[ ! -x "$binary_path" ]]; then
-        iree_error "Could not find built binary for $target"
+    binary_path=$(iree_bazel_get_binary_path "${target}" "${bazel_args[@]}")
+    if [[ -z "${binary_path}" ]] || [[ ! -x "${binary_path}" ]]; then
+        iree_error "Could not find built binary for ${target}"
         return 1
     fi
 
-    iree_debug "Binary: $binary_path"
-    iree_debug "Running from: $run_cwd"
+    iree_debug "Binary: ${binary_path}"
+    iree_debug "Running from: ${run_cwd}"
 
     # Run from original directory.
-    cd "$run_cwd"
-    exec "$binary_path" "${program_args[@]}"
+    cd "${run_cwd}"
+    exec "${binary_path}" "${program_args[@]}"
 }
 
 # Build a bazel target only (no execution).
@@ -363,19 +364,20 @@ iree_bazel_build_and_exec() {
 # Example:
 #   binary_path=$(iree_bazel_build_only "//tools:iree-compile" --config=debug)
 iree_bazel_build_only() {
-    local target="$1"
+    local target="${1}"
     shift
-    local BAZEL_BIN=$(iree_get_bazel_command)
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
     local -a bazel_args=("$@")
 
-    iree_debug "Building $target..."
+    iree_debug "Building ${target}..."
 
-    if ! "$BAZEL_BIN" build "$target" "${bazel_args[@]}"; then
+    if ! "${BAZEL_BIN}" build "${target}" "${bazel_args[@]}"; then
         return $?
     fi
 
     # Pass same args so cquery uses same configuration.
-    iree_bazel_get_binary_path "$target" "${bazel_args[@]}"
+    iree_bazel_get_binary_path "${target}" "${bazel_args[@]}"
 }
 
 # Build a bazel target quietly - no output on success, full output on failure.
@@ -387,15 +389,16 @@ iree_bazel_build_only() {
 #
 # Returns: exit code from bazel build
 iree_bazel_build_quiet() {
-    local target="$1"
+    local target="${1}"
     shift
-    local BAZEL_BIN=$(iree_get_bazel_command)
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
 
-    iree_debug "Building $target..."
+    iree_debug "Building ${target}..."
 
     if iree_is_verbose; then
         # Verbose mode: show everything.
-        "$BAZEL_BIN" build "$target" "$@"
+        "${BAZEL_BIN}" build "${target}" "$@"
         return $?
     fi
 
@@ -403,14 +406,14 @@ iree_bazel_build_quiet() {
     # Force colors since we'll display to terminal on failure.
     local log_file
     log_file=$(mktemp)
-    trap "rm -f '$log_file'" RETURN
+    trap "rm -f '${log_file}'" RETURN
 
-    if "$BAZEL_BIN" build --color=yes "$target" "$@" >"$log_file" 2>&1; then
+    if "${BAZEL_BIN}" build --color=yes "${target}" "$@" >"${log_file}" 2>&1; then
         return 0
     else
         local exit_code=$?
         # Build failed - show the captured output.
-        cat "$log_file" >&2
-        return $exit_code
+        cat "${log_file}" >&2
+        return ${exit_code}
     fi
 }

--- a/build_tools/bin/iree-bazel-lib
+++ b/build_tools/bin/iree-bazel-lib
@@ -1,0 +1,416 @@
+# iree-bazel-lib - Shared functions for iree-bazel-* tools
+#
+# This file is meant to be sourced, not executed directly.
+# Usage in scripts:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/iree-bazel-lib"
+#   iree_bazel_init "iree-bazel-build"
+
+# Prevent double-sourcing.
+[[ -n "${_IREE_BAZEL_LIB_LOADED:-}" ]] && return 0
+_IREE_BAZEL_LIB_LOADED=1
+
+# -----------------------------------------------------------------------------
+# Colors
+# -----------------------------------------------------------------------------
+_IREE_BAZEL_COLOR_GREEN='\033[0;32m'
+_IREE_BAZEL_COLOR_YELLOW='\033[0;33m'
+_IREE_BAZEL_COLOR_RED='\033[0;31m'
+_IREE_BAZEL_COLOR_CYAN='\033[0;36m'
+_IREE_BAZEL_COLOR_NC='\033[0m'
+
+# Tool name for logging (set via iree_bazel_init).
+_IREE_BAZEL_TOOL_NAME=""
+
+# -----------------------------------------------------------------------------
+# Logging functions
+# -----------------------------------------------------------------------------
+
+# Print info message with tool name prefix (to stderr, never pollutes stdout).
+iree_info() {
+    printf "${_IREE_BAZEL_COLOR_GREEN}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+}
+
+# Print warning message with tool name prefix (to stderr).
+iree_warn() {
+    printf "${_IREE_BAZEL_COLOR_YELLOW}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+}
+
+# Print error message with tool name prefix to stderr.
+iree_error() {
+    printf "${_IREE_BAZEL_COLOR_RED}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+}
+
+# Print debug message (only if IREE_BAZEL_VERBOSE is set).
+iree_debug() {
+    [[ "${IREE_BAZEL_VERBOSE:-0}" == "1" ]] && \
+        printf "${_IREE_BAZEL_COLOR_CYAN}[${_IREE_BAZEL_TOOL_NAME}]${_IREE_BAZEL_COLOR_NC} %s\n" "$1" >&2
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# Agent documentation
+# -----------------------------------------------------------------------------
+
+# Print a concise snippet for CLAUDE.md/AGENT.md files describing the bazel suite.
+# Called by all iree-bazel-* tools via --agent-md flag.
+iree_show_agent_md() {
+    cat << 'EOF'
+## iree-bazel-* Tools
+
+Use `iree-bazel-*` wrappers instead of raw `bazel` commands. They handle
+configuration, provide better defaults, and work from any subdirectory.
+
+**Setup (ask user before first use):**
+- Run `iree-bazel-configure` once per worktree to set up Bazel configuration
+- Tools will error with helpful message if not configured yet
+
+**Main tools:**
+- `iree-bazel-build <target> [bazel-args]` - Build targets
+- `iree-bazel-test <target> [bazel-args]` - Run tests
+- `iree-bazel-run <target> [bazel-args] [-- program-args]` - Build and run binary
+- `iree-bazel-try [options] -e 'code' [-- program-args]` - Quick C/C++ experiments
+
+**Additional tools:** `iree-bazel-query`, `iree-bazel-fuzz` (see `--help`)
+
+**Examples:**
+```shell
+iree-bazel-build //tools:iree-compile
+iree-bazel-test //runtime/src/iree/base:status_test
+iree-bazel-run //tools:iree-compile -- --help
+iree-bazel-try -e 'int main() { return 0; }'
+```
+
+**Output directories** (at repo root):
+- `bazel-bin/` - built executables and libraries
+- `bazel-testlogs/` - test outputs and logs
+
+**Important:** Use absolute labels (`//tools:target` not `:target`). Try to stay
+in the worktree directory when running commands.
+
+Run `<tool> --help` for full documentation.
+EOF
+}
+
+# -----------------------------------------------------------------------------
+# Worktree detection
+# -----------------------------------------------------------------------------
+
+# Find the IREE worktree root (directory with .git and .bazelversion).
+# Outputs the path to stdout, returns 1 if not found.
+iree_find_worktree_root() {
+    local directory="${1:-$PWD}"
+    while [[ "$directory" != "/" ]]; do
+        if [[ -e "$directory/.git" ]] && [[ -f "$directory/.bazelversion" ]]; then
+            echo "$directory"
+            return 0
+        fi
+        directory=$(dirname "$directory")
+    done
+    return 1
+}
+
+# Require being in a worktree, exit with error if not.
+# Sets IREE_BAZEL_WORKTREE_DIR on success.
+iree_require_worktree() {
+    IREE_BAZEL_WORKTREE_DIR=$(iree_find_worktree_root)
+    if [[ -z "$IREE_BAZEL_WORKTREE_DIR" ]]; then
+        iree_error "Not in an IREE worktree (no .bazelversion found)"
+        iree_error "Must be in a directory with .git and .bazelversion files"
+        exit 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+# Check that bazel is configured, error if not.
+# Must be called after cd to worktree root.
+iree_ensure_configured() {
+    if [[ ! -f "configured.bazelrc" ]]; then
+        iree_error "Bazel is not configured for this worktree"
+        echo ""
+        echo "Run this command to configure:"
+        echo "  iree-bazel-configure"
+        echo ""
+        echo "For configuration options, run:"
+        echo "  iree-bazel-configure --help"
+        exit 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Initialization
+# -----------------------------------------------------------------------------
+
+# Initialize the library for a specific tool.
+# Args:
+#   $1 - Tool name (e.g., "iree-bazel-build")
+#
+# This sets up:
+#   - Tool name for logging
+#   - IREE_BAZEL_ORIG_CWD (original working directory before any cd)
+#   - IREE_BAZEL_DRY_RUN (default 0)
+#   - IREE_BAZEL_VERBOSE (default 0)
+iree_bazel_init() {
+    _IREE_BAZEL_TOOL_NAME="$1"
+    IREE_BAZEL_ORIG_CWD="$PWD"
+    IREE_BAZEL_DRY_RUN="${IREE_BAZEL_DRY_RUN:-0}"
+    IREE_BAZEL_VERBOSE="${IREE_BAZEL_VERBOSE:-0}"
+}
+
+# Set up the worktree environment.
+# Combines: require worktree + cd to it + ensure configured.
+# Must be called after parsing args (so --help can work outside worktree).
+iree_setup_worktree() {
+    iree_require_worktree
+    cd "$IREE_BAZEL_WORKTREE_DIR"
+    iree_ensure_configured
+}
+
+# Check if dry-run mode is enabled.
+iree_is_dry_run() {
+    [[ "$IREE_BAZEL_DRY_RUN" == "1" ]]
+}
+
+# Check if verbose mode is enabled.
+iree_is_verbose() {
+    [[ "$IREE_BAZEL_VERBOSE" == "1" ]]
+}
+
+# Get the bazel command to use (bazel or ibazel for watch mode).
+# Assumes bazelisk is installed as 'bazel' (standard installation pattern).
+iree_get_bazel_command() {
+    local watch_mode="${1:-0}"
+
+    if [[ "$watch_mode" == "1" ]]; then
+        if ! command -v ibazel >/dev/null 2>&1; then
+            iree_error "ibazel not found. Install with: go install github.com/bazelbuild/bazel-watcher/cmd/ibazel@latest"
+            exit 1
+        fi
+        echo "ibazel"
+    else
+        echo "bazel"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Argument preprocessing
+# -----------------------------------------------------------------------------
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+# This allows Unix-style combined flags as documented in help text.
+#
+# Usage: Call before argument parsing loop to expand combined flags.
+#   eval "set -- $(iree_expand_combined_flags "$@")"
+#
+# Examples:
+#   -nv   -> -n -v
+#   -nvk  -> -n -v -k
+#   --foo -> --foo (unchanged)
+#   -n    -> -n (unchanged)
+iree_expand_combined_flags() {
+    local result=()
+    while [[ $# -gt 0 ]]; do
+        local arg="$1"
+        shift
+        # Match single dash followed by 2+ lowercase letters (no '=' or other chars).
+        if [[ "$arg" =~ ^-([a-z]{2,})$ ]]; then
+            local flags="${BASH_REMATCH[1]}"
+            for (( i=0; i<${#flags}; i++ )); do
+                result+=("-${flags:$i:1}")
+            done
+        else
+            result+=("$arg")
+        fi
+    done
+    # Print quoted args suitable for eval.
+    printf '%q ' "${result[@]}"
+}
+
+# -----------------------------------------------------------------------------
+# Default configuration flags
+# -----------------------------------------------------------------------------
+
+# Build the list of default bazel config flags.
+# These are inserted before user-provided flags so users can override.
+# Populates IREE_BAZEL_DEFAULT_CONFIGS array.
+#
+# Current defaults:
+#   --config=localdev    Local dev optimizations (disk cache, skymeld)
+#   --verbose_failures   (only in verbose mode) Show full command on failure
+#
+# Future: auto-detect hardware and enable drivers:
+#   - HIP_PATH -> --config=hip
+#   - VULKAN_SDK -> --config=vulkan
+#   - CUDA_PATH -> --config=cuda
+iree_bazel_build_default_configs() {
+    IREE_BAZEL_DEFAULT_CONFIGS=()
+
+    # Always use localdev for interactive development.
+    IREE_BAZEL_DEFAULT_CONFIGS+=(--config=localdev)
+
+    # Verbose mode: show full commands on failure.
+    if iree_is_verbose; then
+        IREE_BAZEL_DEFAULT_CONFIGS+=(--verbose_failures)
+    fi
+
+    # Use mold linker if available (significantly faster than ld/gold).
+    if command -v mold &>/dev/null; then
+        IREE_BAZEL_DEFAULT_CONFIGS+=(--config=mold)
+        iree_debug "Using mold linker"
+    fi
+
+    # TODO: Auto-detect available hardware/SDKs.
+    # if [[ -n "${HIP_PATH:-}" ]]; then
+    #     IREE_BAZEL_DEFAULT_CONFIGS+=(--config=hip)
+    # fi
+    # if [[ -n "${VULKAN_SDK:-}" ]]; then
+    #     IREE_BAZEL_DEFAULT_CONFIGS+=(--config=vulkan)
+    # fi
+
+    iree_debug "Default configs: ${IREE_BAZEL_DEFAULT_CONFIGS[*]}"
+}
+
+# -----------------------------------------------------------------------------
+# Build and execution
+# -----------------------------------------------------------------------------
+
+# Get the output file path for a bazel target.
+# Must be called from the worktree root directory.
+# Args:
+#   $1 - Bazel target label
+#   $2... - Bazel args (configs, etc.) - MUST match the build args
+# Outputs: Absolute path to built binary
+iree_bazel_get_binary_path() {
+    local target="$1"
+    shift
+    local BAZEL_BIN=$(iree_get_bazel_command)
+    local relative_path
+    # Pass all bazel args to cquery so it uses the same configuration as build.
+    relative_path=$("$BAZEL_BIN" cquery --output=files "$target" "$@" 2>/dev/null)
+    # Convert to absolute path (bazel returns paths relative to workspace).
+    if [[ -n "$relative_path" ]]; then
+        echo "$PWD/$relative_path"
+    fi
+}
+
+# Build a bazel target and execute it from the original working directory.
+# This solves the problem where bazel run changes cwd to the execroot.
+#
+# Args:
+#   $1 - Bazel target label
+#   $2 - Original working directory to run from
+#   $3... - Bazel args (everything before --)
+#   After finding "--" in args, remaining args go to the program
+#
+# Example:
+#   iree_bazel_build_and_exec "//tools:iree-compile" "$IREE_BAZEL_ORIG_CWD" \
+#       --config=debug -- input.mlir -o output.vmfb
+iree_bazel_build_and_exec() {
+    local target="$1"
+    local run_cwd="$2"
+    shift 2
+
+    local -a bazel_args=()
+    local -a program_args=()
+    local parsing_program_args=0
+
+    # Split args into bazel args and program args.
+    while [[ $# -gt 0 ]]; do
+        if [[ "$parsing_program_args" == "1" ]]; then
+            program_args+=("$1")
+        elif [[ "$1" == "--" ]]; then
+            parsing_program_args=1
+        else
+            bazel_args+=("$1")
+        fi
+        shift
+    done
+
+    iree_debug "Bazel args: ${bazel_args[*]:-<none>}"
+    iree_debug "Program args: ${program_args[*]:-<none>}"
+
+    # Build the target quietly (no output on success).
+    if ! iree_bazel_build_quiet "$target" "${bazel_args[@]}"; then
+        return $?
+    fi
+
+    # Get the binary path (pass same args so cquery uses same configuration).
+    local binary_path
+    binary_path=$(iree_bazel_get_binary_path "$target" "${bazel_args[@]}")
+    if [[ -z "$binary_path" ]] || [[ ! -x "$binary_path" ]]; then
+        iree_error "Could not find built binary for $target"
+        return 1
+    fi
+
+    iree_debug "Binary: $binary_path"
+    iree_debug "Running from: $run_cwd"
+
+    # Run from original directory.
+    cd "$run_cwd"
+    exec "$binary_path" "${program_args[@]}"
+}
+
+# Build a bazel target only (no execution).
+# Returns the binary path via stdout.
+#
+# Args:
+#   $1 - Bazel target label
+#   $2... - Bazel args
+#
+# Example:
+#   binary_path=$(iree_bazel_build_only "//tools:iree-compile" --config=debug)
+iree_bazel_build_only() {
+    local target="$1"
+    shift
+    local BAZEL_BIN=$(iree_get_bazel_command)
+    local -a bazel_args=("$@")
+
+    iree_debug "Building $target..."
+
+    if ! "$BAZEL_BIN" build "$target" "${bazel_args[@]}"; then
+        return $?
+    fi
+
+    # Pass same args so cquery uses same configuration.
+    iree_bazel_get_binary_path "$target" "${bazel_args[@]}"
+}
+
+# Build a bazel target quietly - no output on success, full output on failure.
+# Use this for run/try tools where we want clean output by default.
+#
+# Args:
+#   $1 - Bazel target label
+#   $2... - Bazel args
+#
+# Returns: exit code from bazel build
+iree_bazel_build_quiet() {
+    local target="$1"
+    shift
+    local BAZEL_BIN=$(iree_get_bazel_command)
+
+    iree_debug "Building $target..."
+
+    if iree_is_verbose; then
+        # Verbose mode: show everything.
+        "$BAZEL_BIN" build "$target" "$@"
+        return $?
+    fi
+
+    # Quiet mode: capture output, only show on failure.
+    # Force colors since we'll display to terminal on failure.
+    local log_file
+    log_file=$(mktemp)
+    trap "rm -f '$log_file'" RETURN
+
+    if "$BAZEL_BIN" build --color=yes "$target" "$@" >"$log_file" 2>&1; then
+        return 0
+    else
+        local exit_code=$?
+        # Build failed - show the captured output.
+        cat "$log_file" >&2
+        return $exit_code
+    fi
+}

--- a/build_tools/bin/iree-bazel-query
+++ b/build_tools/bin/iree-bazel-query
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Query IREE build graph with Bazel.
+#
+# Usage: iree-bazel-query [options] <query> [bazel-args...]
+#
+# Examples:
+#   iree-bazel-query 'deps(//tools:iree-compile)'
+#   iree-bazel-query 'rdeps(//..., //runtime/src/iree/base:base)'
+#   iree-bazel-query 'kind(cc_library, //runtime/...)'
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-query"
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+eval "set -- $(iree_expand_combined_flags "$@")"
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-query - Query IREE build graph with Bazel
+
+USAGE
+    iree-bazel-query [options] <query> [bazel-args...]
+
+OPTIONS
+    -n, --dry_run    Show the bazel command without executing
+    -v, --verbose    Show the bazel command before executing
+    -h, --help       Show this help
+
+    NOTE: Short flags can be combined: -nv is equivalent to -n -v
+
+ARGUMENTS
+    query          Bazel query expression (required)
+    bazel-args     Additional arguments passed to bazel query
+
+EXAMPLES
+    iree-bazel-query //tools:iree-compile           # Show target
+    iree-bazel-query '//tools/...'                  # List all tools
+    iree-bazel-query 'deps(//tools:iree-compile)'   # Show dependencies
+    iree-bazel-query 'rdeps(//..., //runtime/src/iree/base:base)'
+    iree-bazel-query 'kind(cc_library, //runtime/...)'
+    iree-bazel-query 'somepath(//tools:iree-compile, //runtime/src/iree/vm:vm)'
+    iree-bazel-query -n 'deps(//tools:iree-compile)'  # Show command only
+
+COMMON QUERY FUNCTIONS
+    deps(target)           All dependencies of target
+    rdeps(universe, target) Reverse dependencies within universe
+    kind(rule, pattern)    Targets of specific rule type
+    somepath(from, to)     Path between two targets
+    allpaths(from, to)     All paths between targets
+    attr(name, pattern, targets)  Targets with matching attribute
+
+OUTPUT OPTIONS
+    --output=label         Target labels only (default)
+    --output=package       Package names only
+    --output=build         BUILD file contents
+    --output=graph         Graphviz DOT format
+    --noimplicit_deps      Exclude implicit dependencies
+
+SEE ALSO
+    iree-bazel-build, iree-bazel-test, iree-bazel-run
+    https://bazel.build/query/guide
+EOF
+}
+
+# Parse arguments.
+QUERY=""
+BAZEL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --agent-md|--agent_md)
+            iree_show_agent_md
+            exit 0
+            ;;
+        -n|--dry_run|--dry-run)
+            IREE_BAZEL_DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            IREE_BAZEL_VERBOSE=1
+            shift
+            ;;
+        -*)
+            BAZEL_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            if [[ -z "$QUERY" ]]; then
+                QUERY="$1"
+            else
+                BAZEL_ARGS+=("$1")
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Query is required.
+if [[ -z "$QUERY" ]]; then
+    iree_error "Query expression is required"
+    echo ""
+    show_help
+    exit 1
+fi
+
+# Set up worktree (after arg parsing so --help works anywhere).
+iree_setup_worktree
+
+# Build the command with default configs (affects select() in build graph).
+iree_bazel_build_default_configs
+BAZEL_BIN=$(iree_get_bazel_command)
+CMD=("$BAZEL_BIN" query "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "$QUERY" "${BAZEL_ARGS[@]}")
+
+# Execute or show.
+if iree_is_verbose || iree_is_dry_run; then
+    iree_info "Command: ${CMD[*]}"
+fi
+
+if iree_is_dry_run; then
+    exit 0
+fi
+
+iree_info "Querying: $QUERY"
+exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-query
+++ b/build_tools/bin/iree-bazel-query
@@ -12,7 +12,7 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-query"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
@@ -71,7 +71,7 @@ QUERY=""
 BAZEL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
+    case "${1}" in
         -h|--help)
             show_help
             exit 0
@@ -89,14 +89,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            BAZEL_ARGS+=("$1")
+            BAZEL_ARGS+=("${1}")
             shift
             ;;
         *)
-            if [[ -z "$QUERY" ]]; then
-                QUERY="$1"
+            if [[ -z "${QUERY}" ]]; then
+                QUERY="${1}"
             else
-                BAZEL_ARGS+=("$1")
+                BAZEL_ARGS+=("${1}")
             fi
             shift
             ;;
@@ -104,7 +104,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Query is required.
-if [[ -z "$QUERY" ]]; then
+if [[ -z "${QUERY}" ]]; then
     iree_error "Query expression is required"
     echo ""
     show_help
@@ -117,7 +117,7 @@ iree_setup_worktree
 # Build the command with default configs (affects select() in build graph).
 iree_bazel_build_default_configs
 BAZEL_BIN=$(iree_get_bazel_command)
-CMD=("$BAZEL_BIN" query "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "$QUERY" "${BAZEL_ARGS[@]}")
+CMD=("${BAZEL_BIN}" query "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${QUERY}" "${BAZEL_ARGS[@]}")
 
 # Execute or show.
 if iree_is_verbose || iree_is_dry_run; then
@@ -128,5 +128,5 @@ if iree_is_dry_run; then
     exit 0
 fi
 
-iree_info "Querying: $QUERY"
+iree_info "Querying: ${QUERY}"
 exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-run
+++ b/build_tools/bin/iree-bazel-run
@@ -12,7 +12,7 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-run"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
@@ -82,13 +82,13 @@ PROGRAM_ARGS=()
 PARSING_PROGRAM_ARGS=0
 
 while [[ $# -gt 0 ]]; do
-    if [[ "$PARSING_PROGRAM_ARGS" == "1" ]]; then
-        PROGRAM_ARGS+=("$1")
+    if [[ "${PARSING_PROGRAM_ARGS}" == "1" ]]; then
+        PROGRAM_ARGS+=("${1}")
         shift
         continue
     fi
 
-    case "$1" in
+    case "${1}" in
         -h|--help)
             show_help
             exit 0
@@ -114,14 +114,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            BAZEL_ARGS+=("$1")
+            BAZEL_ARGS+=("${1}")
             shift
             ;;
         *)
-            if [[ -z "$TARGET" ]]; then
-                TARGET="$1"
+            if [[ -z "${TARGET}" ]]; then
+                TARGET="${1}"
             else
-                BAZEL_ARGS+=("$1")
+                BAZEL_ARGS+=("${1}")
             fi
             shift
             ;;
@@ -129,7 +129,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Target is required for run.
-if [[ -z "$TARGET" ]]; then
+if [[ -z "${TARGET}" ]]; then
     iree_error "Target is required for bazel run"
     echo ""
     show_help
@@ -145,43 +145,43 @@ BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${BAZEL_ARGS[@]}")
 
 # Dry run: show what would be run and exit.
 if iree_is_verbose || iree_is_dry_run; then
-    if [[ "$WATCH_MODE" == "1" ]]; then
-        BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
+    if [[ "${WATCH_MODE}" == "1" ]]; then
+        BAZEL_BIN=$(iree_get_bazel_command "${WATCH_MODE}")
         if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
-            iree_info "Command: $BAZEL_BIN run --run_under=\"cd $IREE_BAZEL_ORIG_CWD && \" ${BAZEL_ARGS[*]} $TARGET -- ${PROGRAM_ARGS[*]}"
+            iree_info "Command: ${BAZEL_BIN} run --run_under=\"cd ${IREE_BAZEL_ORIG_CWD} && \" ${BAZEL_ARGS[*]} ${TARGET} -- ${PROGRAM_ARGS[*]}"
         else
-            iree_info "Command: $BAZEL_BIN run --run_under=\"cd $IREE_BAZEL_ORIG_CWD && \" ${BAZEL_ARGS[*]} $TARGET"
+            iree_info "Command: ${BAZEL_BIN} run --run_under=\"cd ${IREE_BAZEL_ORIG_CWD} && \" ${BAZEL_ARGS[*]} ${TARGET}"
         fi
     else
         if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
-            iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary> ${PROGRAM_ARGS[*]}"
+            iree_info "Command: bazel build ${TARGET} ${BAZEL_ARGS[*]} && <binary> ${PROGRAM_ARGS[*]}"
         else
-            iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary>"
+            iree_info "Command: bazel build ${TARGET} ${BAZEL_ARGS[*]} && <binary>"
         fi
     fi
-    iree_info "Run directory: $IREE_BAZEL_ORIG_CWD"
+    iree_info "Run directory: ${IREE_BAZEL_ORIG_CWD}"
 fi
 
 if iree_is_dry_run; then
     exit 0
 fi
 
-iree_debug "Running $TARGET"
+iree_debug "Running ${TARGET}"
 
-if [[ "$WATCH_MODE" == "1" ]]; then
+if [[ "${WATCH_MODE}" == "1" ]]; then
     # Watch mode: use ibazel run with --run_under to match our cwd behavior.
     # NOTE: This holds the Bazel server lock while the binary runs, but that's
     # acceptable for a dedicated watch shell. ibazel needs to control the process
     # lifecycle to restart it on changes.
-    BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
-    CMD=("$BAZEL_BIN" run --run_under="cd $IREE_BAZEL_ORIG_CWD && " "${BAZEL_ARGS[@]}" "$TARGET")
+    BAZEL_BIN=$(iree_get_bazel_command "${WATCH_MODE}")
+    CMD=("${BAZEL_BIN}" run --run_under="cd ${IREE_BAZEL_ORIG_CWD} && " "${BAZEL_ARGS[@]}" "${TARGET}")
     if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
         CMD+=(-- "${PROGRAM_ARGS[@]}")
     fi
-    iree_info "Watch mode: running from $IREE_BAZEL_ORIG_CWD"
+    iree_info "Watch mode: running from ${IREE_BAZEL_ORIG_CWD}"
     exec "${CMD[@]}"
 else
     # Normal mode: build and execute from original working directory.
     # This releases the Bazel server lock before execution, allowing parallel builds.
-    iree_bazel_build_and_exec "$TARGET" "$IREE_BAZEL_ORIG_CWD" "${BAZEL_ARGS[@]}" -- "${PROGRAM_ARGS[@]}"
+    iree_bazel_build_and_exec "${TARGET}" "${IREE_BAZEL_ORIG_CWD}" "${BAZEL_ARGS[@]}" -- "${PROGRAM_ARGS[@]}"
 fi

--- a/build_tools/bin/iree-bazel-run
+++ b/build_tools/bin/iree-bazel-run
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Run IREE executables with Bazel.
+#
+# Usage: iree-bazel-run [options] <target> [bazel-args...] [-- program-args...]
+#
+# Examples:
+#   iree-bazel-run //tools:iree-compile -- --help
+#   iree-bazel-run //runtime/src/iree/tokenizer:tokenizer_test
+#   iree-bazel-run --config=debug //tools:iree-opt -- input.mlir
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-run"
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+eval "set -- $(iree_expand_combined_flags "$@")"
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-run - Run IREE executables with Bazel
+
+USAGE
+    iree-bazel-run [options] <target> [bazel-args...] [-- program-args...]
+
+OPTIONS
+    -n, --dry_run    Show the bazel command without executing
+    -v, --verbose    Show the bazel command before executing
+    -w, --watch      Watch mode: rebuild and restart on file changes
+    -h, --help       Show this help
+
+    NOTE: Short flags can be combined: -nv is equivalent to -n -v
+
+ARGUMENTS
+    target         Bazel executable target (required)
+    bazel-args     Arguments passed to bazel build (before --)
+    program-args   Arguments passed to the executable (after --)
+
+EXAMPLES
+    iree-bazel-run //tools:iree-compile -- --help
+    iree-bazel-run //tools:iree-opt -- input.mlir -o output.mlir
+    iree-bazel-run //runtime/src/iree/tokenizer:tokenizer_test
+    iree-bazel-run --config=debug //tools:iree-compile -- model.mlir
+    iree-bazel-run -w //tools:iree-opt -- input.mlir  # Watch and restart on changes
+    iree-bazel-run -nv //tools:iree-compile -- --help   # Show command only
+
+WORKING DIRECTORY
+    Unlike raw "bazel run", this tool runs the binary from your current
+    working directory, so relative paths in arguments work as expected.
+
+WATCH MODE
+    Watch mode (-w) uses ibazel and holds the Bazel server lock while the
+    binary runs. This is necessary for ibazel to control the process lifecycle
+    and restart on changes. Normal mode releases the lock after building.
+
+COMMON TARGETS
+    //tools:iree-compile         Main compiler
+    //tools:iree-opt             MLIR optimization tool
+    //tools:iree-run-module      Execute compiled modules
+    //tools:iree-benchmark-module  Performance benchmarking
+
+CONFIGURATIONS
+    --config=localdev        Local dev optimizations (disk cache, skymeld)
+    --config=debug           No optimizations, assertions enabled
+    --config=asserts         Optimized with assertions
+    --config=asan            Address Sanitizer
+    --config=msan            Memory Sanitizer
+    --config=tsan            Thread Sanitizer
+
+SEE ALSO
+    iree-bazel-build, iree-bazel-test, iree-bazel-query
+EOF
+}
+
+# Parse arguments.
+WATCH_MODE=0
+TARGET=""
+BAZEL_ARGS=()
+PROGRAM_ARGS=()
+PARSING_PROGRAM_ARGS=0
+
+while [[ $# -gt 0 ]]; do
+    if [[ "$PARSING_PROGRAM_ARGS" == "1" ]]; then
+        PROGRAM_ARGS+=("$1")
+        shift
+        continue
+    fi
+
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --agent-md|--agent_md)
+            iree_show_agent_md
+            exit 0
+            ;;
+        -n|--dry_run|--dry-run)
+            IREE_BAZEL_DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            IREE_BAZEL_VERBOSE=1
+            shift
+            ;;
+        -w|--watch)
+            WATCH_MODE=1
+            shift
+            ;;
+        --)
+            PARSING_PROGRAM_ARGS=1
+            shift
+            ;;
+        -*)
+            BAZEL_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            if [[ -z "$TARGET" ]]; then
+                TARGET="$1"
+            else
+                BAZEL_ARGS+=("$1")
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Target is required for run.
+if [[ -z "$TARGET" ]]; then
+    iree_error "Target is required for bazel run"
+    echo ""
+    show_help
+    exit 1
+fi
+
+# Set up worktree (after arg parsing so --help works anywhere).
+iree_setup_worktree
+
+# Prepend default configs to bazel args.
+iree_bazel_build_default_configs
+BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${BAZEL_ARGS[@]}")
+
+# Dry run: show what would be run and exit.
+if iree_is_verbose || iree_is_dry_run; then
+    if [[ "$WATCH_MODE" == "1" ]]; then
+        BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
+        if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
+            iree_info "Command: $BAZEL_BIN run --run_under=\"cd $IREE_BAZEL_ORIG_CWD && \" ${BAZEL_ARGS[*]} $TARGET -- ${PROGRAM_ARGS[*]}"
+        else
+            iree_info "Command: $BAZEL_BIN run --run_under=\"cd $IREE_BAZEL_ORIG_CWD && \" ${BAZEL_ARGS[*]} $TARGET"
+        fi
+    else
+        if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
+            iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary> ${PROGRAM_ARGS[*]}"
+        else
+            iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary>"
+        fi
+    fi
+    iree_info "Run directory: $IREE_BAZEL_ORIG_CWD"
+fi
+
+if iree_is_dry_run; then
+    exit 0
+fi
+
+iree_debug "Running $TARGET"
+
+if [[ "$WATCH_MODE" == "1" ]]; then
+    # Watch mode: use ibazel run with --run_under to match our cwd behavior.
+    # NOTE: This holds the Bazel server lock while the binary runs, but that's
+    # acceptable for a dedicated watch shell. ibazel needs to control the process
+    # lifecycle to restart it on changes.
+    BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
+    CMD=("$BAZEL_BIN" run --run_under="cd $IREE_BAZEL_ORIG_CWD && " "${BAZEL_ARGS[@]}" "$TARGET")
+    if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
+        CMD+=(-- "${PROGRAM_ARGS[@]}")
+    fi
+    iree_info "Watch mode: running from $IREE_BAZEL_ORIG_CWD"
+    exec "${CMD[@]}"
+else
+    # Normal mode: build and execute from original working directory.
+    # This releases the Bazel server lock before execution, allowing parallel builds.
+    iree_bazel_build_and_exec "$TARGET" "$IREE_BAZEL_ORIG_CWD" "${BAZEL_ARGS[@]}" -- "${PROGRAM_ARGS[@]}"
+fi

--- a/build_tools/bin/iree-bazel-test
+++ b/build_tools/bin/iree-bazel-test
@@ -12,7 +12,7 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-test"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
@@ -90,7 +90,7 @@ TARGET=""
 BAZEL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
+    case "${1}" in
         -h|--help)
             show_help
             exit 0
@@ -112,14 +112,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            BAZEL_ARGS+=("$1")
+            BAZEL_ARGS+=("${1}")
             shift
             ;;
         *)
-            if [[ -z "$TARGET" ]]; then
-                TARGET="$1"
+            if [[ -z "${TARGET}" ]]; then
+                TARGET="${1}"
             else
-                BAZEL_ARGS+=("$1")
+                BAZEL_ARGS+=("${1}")
             fi
             shift
             ;;
@@ -130,7 +130,7 @@ done
 iree_setup_worktree
 
 # Target is required.
-if [[ -z "$TARGET" ]]; then
+if [[ -z "${TARGET}" ]]; then
     iree_error "Target is required for bazel test"
     echo ""
     echo "Examples:"
@@ -149,10 +149,10 @@ BUILD_FILTERS=""
 
 # Build the command with default configs before user args.
 iree_bazel_build_default_configs
-BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
-CMD=("$BAZEL_BIN" test "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" --keep_going "$TARGET"
-    --test_tag_filters="$TAG_FILTERS"
-    --build_tag_filters="$BUILD_FILTERS"
+BAZEL_BIN=$(iree_get_bazel_command "${WATCH_MODE}")
+CMD=("${BAZEL_BIN}" test "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" --keep_going "${TARGET}"
+    --test_tag_filters="${TAG_FILTERS}"
+    --build_tag_filters="${BUILD_FILTERS}"
     "${BAZEL_ARGS[@]}")
 
 # Execute or show.
@@ -164,6 +164,6 @@ if iree_is_dry_run; then
     exit 0
 fi
 
-iree_info "Testing $TARGET"
-iree_info "Tag filters: $TAG_FILTERS"
+iree_info "Testing ${TARGET}"
+iree_info "Tag filters: ${TAG_FILTERS}"
 exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-test
+++ b/build_tools/bin/iree-bazel-test
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Run IREE tests with Bazel.
+#
+# Usage: iree-bazel-test [options] [target] [bazel-args...]
+#
+# Examples:
+#   iree-bazel-test                       # Run all tests (CPU only)
+#   iree-bazel-test //compiler/...        # Test compiler only
+#   iree-bazel-test --config=asan         # Test with AddressSanitizer
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-test"
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+eval "set -- $(iree_expand_combined_flags "$@")"
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-test - Run IREE tests with Bazel
+
+USAGE
+    iree-bazel-test [options] [target] [bazel-args...]
+
+OPTIONS
+    -n, --dry_run    Show the bazel command without executing
+    -v, --verbose    Show the bazel command before executing
+    -w, --watch      Watch mode: rerun tests on file changes
+    -h, --help       Show this help
+
+    NOTE: Short flags can be combined: -nv is equivalent to -n -v
+    NOTE: --keep_going is always enabled for test runs.
+
+ARGUMENTS
+    target       Bazel target (required)
+    bazel-args   Additional arguments passed to bazel test
+
+EXAMPLES
+    # Test all compiler components
+    iree-bazel-test //compiler/...
+
+    # Test a specific test target
+    iree-bazel-test //runtime/src/iree/base:status_test
+
+    # Test all tools
+    iree-bazel-test //tools/...
+
+    # Test with AddressSanitizer
+    iree-bazel-test //compiler/... --config=asan
+
+    # Watch and rerun on changes (great for TDD)
+    iree-bazel-test -w //runtime/src/iree/base:status_test
+
+    # Show command without executing (verbose dry-run)
+    iree-bazel-test -nv //compiler/...
+
+DEFAULT BEHAVIOR
+    - Runs tests using drivers configured in 'iree-bazel-configure'
+    - Continues on test failures (--keep_going)
+
+CONFIGURING DRIVERS
+    Configure drivers ONCE, then test repeatedly:
+
+    IREE_HAL_DRIVER_CUDA=ON iree-bazel-configure   # Enable CUDA
+    iree-bazel-test //runtime/...                   # Tests include CUDA
+
+    IREE_HAL_DRIVER_CUDA=OFF iree-bazel-configure  # Disable CUDA
+    iree-bazel-test //runtime/...                   # CUDA tests skipped
+
+    All configuration happens during 'iree-bazel-configure'.
+
+CONFIGURATIONS
+    --config=localdev        Local dev optimizations (disk cache, skymeld)
+    --config=debug           Debug build tests
+    --config=asan            Address Sanitizer
+    --config=msan            Memory Sanitizer
+    --config=tsan            Thread Sanitizer
+
+SEE ALSO
+    iree-bazel-configure, iree-bazel-build
+EOF
+}
+
+# Parse arguments.
+WATCH_MODE=0
+TARGET=""
+BAZEL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --agent-md|--agent_md)
+            iree_show_agent_md
+            exit 0
+            ;;
+        -n|--dry_run|--dry-run)
+            IREE_BAZEL_DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            IREE_BAZEL_VERBOSE=1
+            shift
+            ;;
+        -w|--watch)
+            WATCH_MODE=1
+            shift
+            ;;
+        -*)
+            BAZEL_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            if [[ -z "$TARGET" ]]; then
+                TARGET="$1"
+            else
+                BAZEL_ARGS+=("$1")
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Set up worktree (after arg parsing so --help works anywhere).
+iree_setup_worktree
+
+# Target is required.
+if [[ -z "$TARGET" ]]; then
+    iree_error "Target is required for bazel test"
+    echo ""
+    echo "Examples:"
+    echo "  iree-bazel-test //compiler/..."
+    echo "  iree-bazel-test //runtime/src/iree/base:status_test"
+    echo "  iree-bazel-test //tools/..."
+    exit 1
+fi
+
+# Build tag filters based on environment.
+TAG_FILTERS="-nodocker"
+BUILD_FILTERS=""
+
+# Driver filtering is controlled by configured.bazelrc (written by iree-bazel-configure).
+# No runtime env var checks - configuration happens once during configure.
+
+# Build the command with default configs before user args.
+iree_bazel_build_default_configs
+BAZEL_BIN=$(iree_get_bazel_command "$WATCH_MODE")
+CMD=("$BAZEL_BIN" test "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" --keep_going "$TARGET"
+    --test_tag_filters="$TAG_FILTERS"
+    --build_tag_filters="$BUILD_FILTERS"
+    "${BAZEL_ARGS[@]}")
+
+# Execute or show.
+if iree_is_verbose || iree_is_dry_run; then
+    iree_info "Command: ${CMD[*]}"
+fi
+
+if iree_is_dry_run; then
+    exit 0
+fi
+
+iree_info "Testing $TARGET"
+iree_info "Tag filters: $TAG_FILTERS"
+exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-try
+++ b/build_tools/bin/iree-bazel-try
@@ -13,7 +13,7 @@ set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/iree-bazel-lib"
+source "${SCRIPT_DIR}/iree-bazel-lib"
 iree_bazel_init "iree-bazel-try"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
@@ -261,18 +261,18 @@ MAX_CACHE_SLOTS=8
 # This allows multiple runs with same deps config to share the cached BUILD.bazel.
 # Args: source_files array (via nameref), extra_deps array, copts array, linkopts array, language
 compute_cache_hash() {
-    local -n _source_files=$1
-    local -n _extra_deps=$2
-    local -n _copts=$3
-    local -n _linkopts=$4
+    local -n _source_files=${1}
+    local -n _extra_deps=${2}
+    local -n _copts=${3}
+    local -n _linkopts=${4}
     local _language=${5:-c}
     {
         # Hash language (determines file extension and compilation mode).
-        printf 'language:%s\n' "$_language"
+        printf 'language:%s\n' "${_language}"
         # Hash #include directives (determines inferred deps).
         printf 'includes:\n'
         for src in "${_source_files[@]}"; do
-            grep -h '#include\s*"[^"]*"' "$src" 2>/dev/null | \
+            grep -h '#include\s*"[^"]*"' "${src}" 2>/dev/null | \
                 sed 's/.*#include\s*"\([^"]*\)".*/\1/' | \
                 grep -E '^(iree/|llvm/|mlir/)'
         done | sort -u
@@ -290,52 +290,22 @@ compute_cache_hash() {
 # Ensure cache doesn't exceed MAX_CACHE_SLOTS by evicting oldest slots.
 # Uses mtime for LRU ordering (we touch slots on use).
 enforce_cache_limit() {
-    local cache_dir="$1"
-    if [[ ! -d "$cache_dir" ]]; then
+    local cache_dir="${1}"
+    if [[ ! -d "${cache_dir}" ]]; then
         return
     fi
     local slot_count
-    slot_count=$(find "$cache_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
-    if [[ "$slot_count" -gt "$MAX_CACHE_SLOTS" ]]; then
+    slot_count=$(find "${cache_dir}" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+    if [[ "${slot_count}" -gt "${MAX_CACHE_SLOTS}" ]]; then
         local excess=$((slot_count - MAX_CACHE_SLOTS))
-        iree_debug "Cache has $slot_count slots, evicting $excess oldest"
+        iree_debug "Cache has ${slot_count} slots, evicting ${excess} oldest"
         # Find oldest directories by mtime and remove them.
-        find "$cache_dir" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' 2>/dev/null | \
-            sort -n | head -n "$excess" | cut -d' ' -f2- | \
+        find "${cache_dir}" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' 2>/dev/null | \
+            sort -n | head -n "${excess}" | cut -d' ' -f2- | \
             while read -r old_slot; do
-                rm -rf "$old_slot"
-                iree_debug "Evicted cache slot: $old_slot"
+                rm -rf "${old_slot}"
+                iree_debug "Evicted cache slot: ${old_slot}"
             done
-    fi
-}
-
-# Ensure .iree-bazel-try is in .git/info/exclude (local exclude, not .gitignore).
-ensure_ignores() {
-    local worktree="$1"
-
-    # Find the git directory (handles worktrees where .git is a file pointing elsewhere).
-    local git_dir
-    if [[ -f "$worktree/.git" ]]; then
-        # Worktree: .git is a file containing "gitdir: /path/to/git/dir"
-        git_dir=$(sed 's/^gitdir: //' "$worktree/.git")
-    else
-        git_dir="$worktree/.git"
-    fi
-
-    local exclude_file="$git_dir/info/exclude"
-
-    # Create info directory if needed.
-    mkdir -p "$(dirname "$exclude_file")"
-
-    # Add to exclude if not present.
-    if [[ -f "$exclude_file" ]]; then
-        if ! grep -q '^\.iree-bazel-try/$' "$exclude_file" 2>/dev/null; then
-            echo '.iree-bazel-try/' >> "$exclude_file"
-            iree_debug "Added .iree-bazel-try/ to $exclude_file"
-        fi
-    else
-        echo '.iree-bazel-try/' > "$exclude_file"
-        iree_debug "Created $exclude_file with .iree-bazel-try/"
     fi
 }
 
@@ -344,7 +314,8 @@ ensure_ignores() {
 # Outputs one dep per line.
 infer_deps_from_sources() {
     local -a sources=("$@")
-    local BAZEL_BIN=$(iree_get_bazel_command)
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
     local -a runtime_patterns=()
     local -a compiler_patterns=()
     local -a llvm_files=()
@@ -352,7 +323,7 @@ infer_deps_from_sources() {
 
     # Collect all headers from all source files.
     for src in "${sources[@]}"; do
-        if [[ ! -f "$src" ]]; then
+        if [[ ! -f "${src}" ]]; then
             continue
         fi
 
@@ -361,7 +332,7 @@ infer_deps_from_sources() {
             local dir_path="${header%/*}"
             local filename="${header##*/}"
 
-            case "$header" in
+            case "${header}" in
                 iree/compiler/*)
                     # Pattern: iree/compiler/Foo/Bar:file.h (use path for specificity).
                     compiler_patterns+=("${dir_path}:${filename}")
@@ -372,14 +343,14 @@ infer_deps_from_sources() {
                     ;;
                 llvm/*)
                     # LLVM uses different structure, just use filename.
-                    llvm_files+=("$filename")
+                    llvm_files+=("${filename}")
                     ;;
                 mlir/*)
                     # MLIR uses different structure, just use filename.
-                    mlir_files+=("$filename")
+                    mlir_files+=("${filename}")
                     ;;
             esac
-        done < <(grep -h '#include\s*"[^"]*"' "$src" 2>/dev/null | \
+        done < <(grep -h '#include\s*"[^"]*"' "${src}" 2>/dev/null | \
                  sed 's/.*#include\s*"\([^"]*\)".*/\1/' | \
                  grep -E '^(iree/|llvm/|mlir/)')
     done
@@ -392,8 +363,8 @@ infer_deps_from_sources() {
         local pattern
         pattern=$(printf '%s\n' "${runtime_patterns[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
-            [[ -n "$dep" ]] && all_deps+=("$dep")
-        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', //runtime/src/iree/...)" 2>/dev/null)
+            [[ -n "${dep}" ]] && all_deps+=("${dep}")
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', //runtime/src/iree/...)" 2>/dev/null)
     fi
 
     if [[ ${#compiler_patterns[@]} -gt 0 ]]; then
@@ -401,8 +372,8 @@ infer_deps_from_sources() {
         local pattern
         pattern=$(printf '%s\n' "${compiler_patterns[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
-            [[ -n "$dep" ]] && all_deps+=("$dep")
-        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', //compiler/src/iree/compiler/...)" 2>/dev/null)
+            [[ -n "${dep}" ]] && all_deps+=("${dep}")
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', //compiler/src/iree/compiler/...)" 2>/dev/null)
     fi
 
     if [[ ${#llvm_files[@]} -gt 0 ]]; then
@@ -410,8 +381,8 @@ infer_deps_from_sources() {
         local pattern
         pattern=$(printf '%s\n' "${llvm_files[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
-            [[ -n "$dep" ]] && all_deps+=("$dep")
-        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', @llvm-project//llvm/...)" 2>/dev/null)
+            [[ -n "${dep}" ]] && all_deps+=("${dep}")
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', @llvm-project//llvm/...)" 2>/dev/null)
     fi
 
     if [[ ${#mlir_files[@]} -gt 0 ]]; then
@@ -419,8 +390,8 @@ infer_deps_from_sources() {
         local pattern
         pattern=$(printf '%s\n' "${mlir_files[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
-            [[ -n "$dep" ]] && all_deps+=("$dep")
-        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', @llvm-project//mlir/...)" 2>/dev/null)
+            [[ -n "${dep}" ]] && all_deps+=("${dep}")
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', @llvm-project//mlir/...)" 2>/dev/null)
     fi
 
     # Output unique deps.
@@ -430,16 +401,16 @@ infer_deps_from_sources() {
 # Try to find a dep for a missing symbol using bazel query.
 # This is called when build fails.
 find_dep_for_symbol() {
-    local symbol="$1"
-    local worktree="$2"
+    local symbol="${1}"
+    local worktree="${2}"
 
     # Search for the symbol in IREE runtime sources.
     local matches
-    matches=$(grep -rl "^[^/]*\b${symbol}\b" "$worktree/runtime/src/iree/" 2>/dev/null | head -5)
+    matches=$(grep -rl "^[^/]*\b${symbol}\b" "${worktree}/runtime/src/iree/" 2>/dev/null | head -5)
 
-    for match in $matches; do
+    for match in ${matches}; do
         # Convert file path to bazel package.
-        local rel_path="${match#$worktree/}"
+        local rel_path="${match#${worktree}/}"
         local dir_path="${rel_path%/*}"
         echo "//${dir_path}"
         return 0
@@ -451,38 +422,38 @@ find_dep_for_symbol() {
 # Parse build errors and suggest missing deps.
 # Returns deps to add, one per line.
 parse_build_errors() {
-    local log_file="$1"
-    local worktree="$2"
+    local log_file="${1}"
+    local worktree="${2}"
     local -A suggested_deps
 
     # Look for undefined reference errors.
     while IFS= read -r symbol; do
-        if [[ -n "$symbol" ]]; then
+        if [[ -n "${symbol}" ]]; then
             local dep
-            if dep=$(find_dep_for_symbol "$symbol" "$worktree" 2>/dev/null); then
-                if [[ -z "${suggested_deps[$dep]:-}" ]]; then
-                    suggested_deps[$dep]=1
-                    echo "$dep"
+            if dep=$(find_dep_for_symbol "${symbol}" "${worktree}" 2>/dev/null); then
+                if [[ -z "${suggested_deps[${dep}]:-}" ]]; then
+                    suggested_deps[${dep}]=1
+                    echo "${dep}"
                 fi
             fi
         fi
-    done < <(grep -o "undefined reference to \`[^']*'" "$log_file" 2>/dev/null | \
+    done < <(grep -o "undefined reference to \`[^']*'" "${log_file}" 2>/dev/null | \
              sed "s/undefined reference to \`\\([^']*\\)'/\\1/")
 
     # Look for missing header errors.
     while IFS= read -r header; do
-        if [[ "$header" == iree/* ]]; then
+        if [[ "${header}" == iree/* ]]; then
             local package="${header%/*}"
             # Simplify to top-level package.
             local component="${package#iree/}"
             component="${component%%/*}"
-            local dep="//runtime/src/iree/$component"
-            if [[ -z "${suggested_deps[$dep]:-}" ]]; then
-                suggested_deps[$dep]=1
-                echo "$dep"
+            local dep="//runtime/src/iree/${component}"
+            if [[ -z "${suggested_deps[${dep}]:-}" ]]; then
+                suggested_deps[${dep}]=1
+                echo "${dep}"
             fi
         fi
-    done < <(grep -o "fatal error: '[^']*' file not found" "$log_file" 2>/dev/null | \
+    done < <(grep -o "fatal error: '[^']*' file not found" "${log_file}" 2>/dev/null | \
              sed "s/fatal error: '\\([^']*\\)' file not found/\\1/")
 }
 
@@ -505,13 +476,13 @@ declare -a PROGRAM_ARGS=()
 # Parse arguments.
 PARSING_PROGRAM_ARGS=0
 while [[ $# -gt 0 ]]; do
-    if [[ "$PARSING_PROGRAM_ARGS" == "1" ]]; then
-        PROGRAM_ARGS+=("$1")
+    if [[ "${PARSING_PROGRAM_ARGS}" == "1" ]]; then
+        PROGRAM_ARGS+=("${1}")
         shift
         continue
     fi
 
-    case "$1" in
+    case "${1}" in
         -h|--help)
             show_help
             exit 0
@@ -541,7 +512,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --retry)
-            MAX_RETRIES="$2"
+            MAX_RETRIES="${2}"
             shift 2
             ;;
         --retry=*)
@@ -549,7 +520,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -o|--output)
-            OUTPUT_PATH="$2"
+            OUTPUT_PATH="${2}"
             shift 2
             ;;
         --output=*)
@@ -557,7 +528,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -x)
-            LANGUAGE="$2"
+            LANGUAGE="${2}"
             shift 2
             ;;
         -e|--execute)
@@ -569,7 +540,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --dep)
-            EXTRA_DEPS+=("$2")
+            EXTRA_DEPS+=("${2}")
             shift 2
             ;;
         --dep=*)
@@ -577,7 +548,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --copt)
-            COPTS+=("$2")
+            COPTS+=("${2}")
             shift 2
             ;;
         --copt=*)
@@ -585,7 +556,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --linkopt)
-            LINKOPTS+=("$2")
+            LINKOPTS+=("${2}")
             shift 2
             ;;
         --linkopt=*)
@@ -593,7 +564,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --config=*)
-            BAZEL_ARGS+=("$1")
+            BAZEL_ARGS+=("${1}")
             shift
             ;;
         --)
@@ -601,12 +572,12 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -*)
-            iree_error "Unknown option: $1"
+            iree_error "Unknown option: ${1}"
             echo "Use --help for usage information."
             exit 1
             ;;
         *)
-            SOURCE_FILES+=("$1")
+            SOURCE_FILES+=("${1}")
             shift
             ;;
     esac
@@ -614,7 +585,7 @@ done
 
 # Find worktree root.
 iree_require_worktree
-cd "$IREE_BAZEL_WORKTREE_DIR"
+cd "${IREE_BAZEL_WORKTREE_DIR}"
 iree_ensure_configured
 
 # Prepend default configs to bazel args.
@@ -623,7 +594,7 @@ BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${BAZEL_ARGS[@]}")
 
 # Determine input source.
 HAS_STDIN=0
-if [[ -z "$INLINE_CODE" ]] && [[ ${#SOURCE_FILES[@]} -eq 0 ]]; then
+if [[ -z "${INLINE_CODE}" ]] && [[ ${#SOURCE_FILES[@]} -eq 0 ]]; then
     # Check if stdin has data.
     if [[ -t 0 ]]; then
         iree_error "No input provided. Specify files, use -e, or pipe to stdin."
@@ -633,19 +604,18 @@ if [[ -z "$INLINE_CODE" ]] && [[ ${#SOURCE_FILES[@]} -eq 0 ]]; then
     HAS_STDIN=1
 fi
 
-# Set up base directory and ensure it's git-ignored.
-TRY_BASE="$IREE_BAZEL_WORKTREE_DIR/.iree-bazel-try"
-CACHE_DIR="$TRY_BASE/cache"
-STAGING_DIR="$TRY_BASE/staging_$$"
-ensure_ignores "$IREE_BAZEL_WORKTREE_DIR"
+# Set up base directory (ignored via .gitignore).
+TRY_BASE="${IREE_BAZEL_WORKTREE_DIR}/.iree-bazel-try"
+CACHE_DIR="${TRY_BASE}/cache"
+STAGING_DIR="${TRY_BASE}/staging_$$"
 
 # Create staging directory for source files (needed for deps inference).
-mkdir -p "$STAGING_DIR"
+mkdir -p "${STAGING_DIR}"
 
 # Cleanup staging on exit (cache slots are kept).
 cleanup_staging() {
-    if [[ -n "$STAGING_DIR" ]] && [[ -d "$STAGING_DIR" ]]; then
-        rm -rf "$STAGING_DIR"
+    if [[ -n "${STAGING_DIR}" ]] && [[ -d "${STAGING_DIR}" ]]; then
+        rm -rf "${STAGING_DIR}"
     fi
 }
 trap cleanup_staging EXIT
@@ -656,15 +626,15 @@ declare -a STAGED_SOURCE_PATHS=()
 
 # Read stdin into variable if needed (so we can scan it for auto-detection).
 STDIN_CONTENT=""
-if [[ "$HAS_STDIN" == "1" ]]; then
+if [[ "${HAS_STDIN}" == "1" ]]; then
     STDIN_CONTENT=$(cat)
 fi
 
 # Auto-detect C++ from includes if language not explicitly set.
 # C++-only headers: llvm/, mlir/, iree/compiler/, iree/testing/, gtest/, gmock/, benchmark/
 ALL_CODE="${INLINE_CODE}${STDIN_CONTENT}"
-if [[ -z "$LANGUAGE" ]]; then
-    if echo "$ALL_CODE" | grep -qE '#include\s*[<"](llvm/|mlir/|iree/compiler/|iree/testing/|gtest/|gmock/|benchmark/)'; then
+if [[ -z "${LANGUAGE}" ]]; then
+    if echo "${ALL_CODE}" | grep -qE '#include\s*[<"](llvm/|mlir/|iree/compiler/|iree/testing/|gtest/|gmock/|benchmark/)'; then
         LANGUAGE="c++"
         iree_debug "Auto-detected C++ from includes"
     else
@@ -674,51 +644,51 @@ fi
 
 
 # Handle inline code.
-if [[ -n "$INLINE_CODE" ]]; then
-    if [[ "$LANGUAGE" == "c++" ]]; then
-        INLINE_FILE="$STAGING_DIR/inline.cc"
+if [[ -n "${INLINE_CODE}" ]]; then
+    if [[ "${LANGUAGE}" == "c++" ]]; then
+        INLINE_FILE="${STAGING_DIR}/inline.cc"
     else
-        INLINE_FILE="$STAGING_DIR/inline.c"
+        INLINE_FILE="${STAGING_DIR}/inline.c"
     fi
-    printf '%s' "$INLINE_CODE" > "$INLINE_FILE"
-    BUILD_SRCS+=("$(basename "$INLINE_FILE")")
-    STAGED_SOURCE_PATHS+=("$INLINE_FILE")
-    iree_debug "Wrote inline code to $INLINE_FILE"
+    printf '%s' "${INLINE_CODE}" > "${INLINE_FILE}"
+    BUILD_SRCS+=("$(basename "${INLINE_FILE}")")
+    STAGED_SOURCE_PATHS+=("${INLINE_FILE}")
+    iree_debug "Wrote inline code to ${INLINE_FILE}"
 fi
 
 # Handle stdin.
-if [[ -n "$STDIN_CONTENT" ]]; then
-    if [[ "$LANGUAGE" == "c++" ]]; then
-        STDIN_FILE="$STAGING_DIR/stdin.cc"
+if [[ -n "${STDIN_CONTENT}" ]]; then
+    if [[ "${LANGUAGE}" == "c++" ]]; then
+        STDIN_FILE="${STAGING_DIR}/stdin.cc"
     else
-        STDIN_FILE="$STAGING_DIR/stdin.c"
+        STDIN_FILE="${STAGING_DIR}/stdin.c"
     fi
-    printf '%s' "$STDIN_CONTENT" > "$STDIN_FILE"
-    BUILD_SRCS+=("$(basename "$STDIN_FILE")")
-    STAGED_SOURCE_PATHS+=("$STDIN_FILE")
-    iree_debug "Wrote stdin to $STDIN_FILE"
+    printf '%s' "${STDIN_CONTENT}" > "${STDIN_FILE}"
+    BUILD_SRCS+=("$(basename "${STDIN_FILE}")")
+    STAGED_SOURCE_PATHS+=("${STDIN_FILE}")
+    iree_debug "Wrote stdin to ${STDIN_FILE}"
 fi
 
 # Handle source files.
 for src in "${SOURCE_FILES[@]}"; do
-    if [[ ! -f "$src" ]]; then
-        iree_error "Source file not found: $src"
+    if [[ ! -f "${src}" ]]; then
+        iree_error "Source file not found: ${src}"
         exit 1
     fi
     # Copy to staging dir.
-    cp "$src" "$STAGING_DIR/"
-    BUILD_SRCS+=("$(basename "$src")")
-    STAGED_SOURCE_PATHS+=("$STAGING_DIR/$(basename "$src")")
-    iree_debug "Staged $src"
+    cp "${src}" "${STAGING_DIR}/"
+    BUILD_SRCS+=("$(basename "${src}")")
+    STAGED_SOURCE_PATHS+=("${STAGING_DIR}/$(basename "${src}")")
+    iree_debug "Staged ${src}"
 done
 
 # Determine if this is C++.
 IS_CPP=0
-if [[ "$LANGUAGE" == "c++" ]]; then
+if [[ "${LANGUAGE}" == "c++" ]]; then
     IS_CPP=1
 else
     for src in "${BUILD_SRCS[@]}"; do
-        case "$src" in
+        case "${src}" in
             *.cc|*.cpp|*.cxx|*.C)
                 IS_CPP=1
                 break
@@ -730,40 +700,40 @@ fi
 # Compute cache hash BEFORE deps inference.
 # Hash is based on #includes + explicit deps + build options + language (NOT source content).
 # This allows runs with same deps config to share BUILD.bazel analysis cache.
-CACHE_HASH=$(compute_cache_hash STAGED_SOURCE_PATHS EXTRA_DEPS COPTS LINKOPTS "$LANGUAGE")
-SLOT_DIR="$CACHE_DIR/$CACHE_HASH"
-LOCK_FILE="$CACHE_DIR/$CACHE_HASH.lock"
+CACHE_HASH=$(compute_cache_hash STAGED_SOURCE_PATHS EXTRA_DEPS COPTS LINKOPTS "${LANGUAGE}")
+SLOT_DIR="${CACHE_DIR}/${CACHE_HASH}"
+LOCK_FILE="${CACHE_DIR}/${CACHE_HASH}.lock"
 
 # Ensure cache directory exists.
-mkdir -p "$CACHE_DIR"
+mkdir -p "${CACHE_DIR}"
 
 # Acquire exclusive lock on this slot to prevent parallel runs from clobbering.
 # Lock is released automatically when the script exits.
-exec 9>"$LOCK_FILE"
+exec 9>"${LOCK_FILE}"
 if ! flock -w 60 9; then
-    iree_error "Timeout waiting for lock on cache slot $CACHE_HASH"
+    iree_error "Timeout waiting for lock on cache slot ${CACHE_HASH}"
     exit 1
 fi
-iree_debug "Acquired lock on slot $CACHE_HASH"
+iree_debug "Acquired lock on slot ${CACHE_HASH}"
 
 # Check cache AFTER acquiring lock (another process may have created it while we waited).
 CACHE_HIT=0
-if [[ -d "$SLOT_DIR" ]] && [[ -f "$SLOT_DIR/BUILD.bazel" ]]; then
+if [[ -d "${SLOT_DIR}" ]] && [[ -f "${SLOT_DIR}/BUILD.bazel" ]]; then
     CACHE_HIT=1
-    iree_debug "Cache hit: reusing slot $CACHE_HASH (skipping deps inference)"
+    iree_debug "Cache hit: reusing slot ${CACHE_HASH} (skipping deps inference)"
 fi
 
 # Only infer deps on cache miss.
 declare -A DEPS_MAP=()
 declare -a DEPS=()
 
-if [[ "$CACHE_HIT" == "0" ]]; then
+if [[ "${CACHE_HIT}" == "0" ]]; then
     # Infer deps from source files (expensive bazel query).
     declare -a INFERRED_DEPS=()
-    if [[ "$INFER_DEPS" == "1" ]]; then
+    if [[ "${INFER_DEPS}" == "1" ]]; then
         while IFS= read -r dep; do
-            if [[ -n "$dep" ]]; then
-                INFERRED_DEPS+=("$dep")
+            if [[ -n "${dep}" ]]; then
+                INFERRED_DEPS+=("${dep}")
             fi
         done < <(infer_deps_from_sources "${STAGED_SOURCE_PATHS[@]}")
 
@@ -774,16 +744,16 @@ if [[ "$CACHE_HIT" == "0" ]]; then
 
     # Build deps list (inferred + explicit, deduplicated).
     for dep in "${INFERRED_DEPS[@]}"; do
-        if [[ -z "${DEPS_MAP[$dep]:-}" ]]; then
-            DEPS_MAP[$dep]=1
-            DEPS+=("$dep")
+        if [[ -z "${DEPS_MAP[${dep}]:-}" ]]; then
+            DEPS_MAP[${dep}]=1
+            DEPS+=("${dep}")
         fi
     done
 
     for dep in "${EXTRA_DEPS[@]}"; do
-        if [[ -z "${DEPS_MAP[$dep]:-}" ]]; then
-            DEPS_MAP[$dep]=1
-            DEPS+=("$dep")
+        if [[ -z "${DEPS_MAP[${dep}]:-}" ]]; then
+            DEPS_MAP[${dep}]=1
+            DEPS+=("${dep}")
         fi
     done
 
@@ -795,7 +765,7 @@ fi
 
 # Function to generate BUILD.bazel file.
 generate_build_file() {
-    local build_file="$1"
+    local build_file="${1}"
     shift
     local -a deps=("$@")
 
@@ -808,29 +778,29 @@ generate_build_file() {
         printf '    srcs = ['
         local first=1
         for src in "${BUILD_SRCS[@]}"; do
-            if [[ "$first" == "1" ]]; then
+            if [[ "${first}" == "1" ]]; then
                 first=0
             else
                 printf ', '
             fi
-            printf '"%s"' "$src"
+            printf '"%s"' "${src}"
         done
         printf '],\n'
         printf '    deps = [\n'
         for dep in "${deps[@]}"; do
-            printf '        "%s",\n' "$dep"
+            printf '        "%s",\n' "${dep}"
         done
         printf '    ],\n'
         if [[ ${#COPTS[@]} -gt 0 ]]; then
             printf '    copts = ['
             first=1
             for opt in "${COPTS[@]}"; do
-                if [[ "$first" == "1" ]]; then
+                if [[ "${first}" == "1" ]]; then
                     first=0
                 else
                     printf ', '
                 fi
-                printf '"%s"' "$opt"
+                printf '"%s"' "${opt}"
             done
             printf '],\n'
         fi
@@ -838,68 +808,69 @@ generate_build_file() {
             printf '    linkopts = ['
             first=1
             for opt in "${LINKOPTS[@]}"; do
-                if [[ "$first" == "1" ]]; then
+                if [[ "${first}" == "1" ]]; then
                     first=0
                 else
                     printf ', '
                 fi
-                printf '"%s"' "$opt"
+                printf '"%s"' "${opt}"
             done
             printf '],\n'
         fi
         echo ')'
-    } > "$build_file"
+    } > "${build_file}"
 }
 
 # Set up cache slot.
-if [[ "$CACHE_HIT" == "0" ]]; then
-    iree_debug "Cache miss: creating slot $CACHE_HASH"
-    mkdir -p "$SLOT_DIR"
+if [[ "${CACHE_HIT}" == "0" ]]; then
+    iree_debug "Cache miss: creating slot ${CACHE_HASH}"
+    mkdir -p "${SLOT_DIR}"
 
     # Generate BUILD.bazel for new slot.
-    BUILD_FILE="$SLOT_DIR/BUILD.bazel"
-    generate_build_file "$BUILD_FILE" "${DEPS[@]}"
+    BUILD_FILE="${SLOT_DIR}/BUILD.bazel"
+    generate_build_file "${BUILD_FILE}" "${DEPS[@]}"
 
     iree_debug "Generated BUILD.bazel:"
-    if [[ "$IREE_BAZEL_VERBOSE" == "1" ]]; then
-        cat "$BUILD_FILE" | sed 's/^/    /' >&2
+    if [[ "${IREE_BAZEL_VERBOSE}" == "1" ]]; then
+        cat "${BUILD_FILE}" | sed 's/^/    /' >&2
     fi
 fi
 
 # Copy source files from staging to cache slot.
 for staged_file in "${STAGED_SOURCE_PATHS[@]}"; do
-    cp "$staged_file" "$SLOT_DIR/"
+    cp "${staged_file}" "${SLOT_DIR}/"
 done
 
 # Touch the slot directory to update mtime for LRU tracking.
-touch "$SLOT_DIR"
+touch "${SLOT_DIR}"
 
 # Enforce cache size limit (evict old slots if needed).
-enforce_cache_limit "$CACHE_DIR"
+enforce_cache_limit "${CACHE_DIR}"
 
-if [[ "$KEEP_TEMP" == "1" ]]; then
-    iree_info "Cache slot: $SLOT_DIR"
+if [[ "${KEEP_TEMP}" == "1" ]]; then
+    iree_info "Cache slot: ${SLOT_DIR}"
 fi
 
 # Build the target with retry logic.
-TARGET="//.iree-bazel-try/cache/$CACHE_HASH:snippet"
-BUILD_LOG="$SLOT_DIR/build.log"
+TARGET="//.iree-bazel-try/cache/${CACHE_HASH}:snippet"
+BUILD_LOG="${SLOT_DIR}/build.log"
 
 do_build() {
-    local BAZEL_BIN=$(iree_get_bazel_command)
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
     if iree_is_verbose; then
         # Verbose mode: show everything, also save to log for retry logic.
-        "$BAZEL_BIN" build "$TARGET" "${BAZEL_ARGS[@]}" 2>&1 | tee "$BUILD_LOG"
+        "${BAZEL_BIN}" build "${TARGET}" "${BAZEL_ARGS[@]}" 2>&1 | tee "${BUILD_LOG}"
         return "${PIPESTATUS[0]}"
     else
         # Quiet mode: capture output, only show on failure.
         # Force colors since we'll display to terminal on failure.
-        if "$BAZEL_BIN" build --color=yes "$TARGET" "${BAZEL_ARGS[@]}" >"$BUILD_LOG" 2>&1; then
+        if "${BAZEL_BIN}" build --color=yes "${TARGET}" "${BAZEL_ARGS[@]}" >"${BUILD_LOG}" 2>&1; then
             return 0
         else
             local exit_code=$?
-            cat "$BUILD_LOG" >&2
-            return $exit_code
+            cat "${BUILD_LOG}" >&2
+            return ${exit_code}
         fi
     fi
 }
@@ -908,74 +879,74 @@ build_with_retry() {
     local attempt=1
     local current_deps=("${DEPS[@]}")
 
-    while [[ $attempt -le $MAX_RETRIES ]]; do
-        iree_debug "Build attempt $attempt/$MAX_RETRIES"
+    while [[ ${attempt} -le ${MAX_RETRIES} ]]; do
+        iree_debug "Build attempt ${attempt}/${MAX_RETRIES}"
 
         if do_build; then
             return 0
         fi
 
         # Build failed - try to find missing deps.
-        if [[ "$INFER_DEPS" == "0" ]]; then
+        if [[ "${INFER_DEPS}" == "0" ]]; then
             # User disabled inference, don't retry.
             return 1
         fi
 
         local new_deps_found=0
         while IFS= read -r new_dep; do
-            if [[ -n "$new_dep" ]] && [[ -z "${DEPS_MAP[$new_dep]:-}" ]]; then
-                iree_warn "Adding inferred dep: $new_dep"
-                DEPS_MAP[$new_dep]=1
-                current_deps+=("$new_dep")
+            if [[ -n "${new_dep}" ]] && [[ -z "${DEPS_MAP[${new_dep}]:-}" ]]; then
+                iree_warn "Adding inferred dep: ${new_dep}"
+                DEPS_MAP[${new_dep}]=1
+                current_deps+=("${new_dep}")
                 new_deps_found=1
             fi
-        done < <(parse_build_errors "$BUILD_LOG" "$IREE_BAZEL_WORKTREE_DIR")
+        done < <(parse_build_errors "${BUILD_LOG}" "${IREE_BAZEL_WORKTREE_DIR}")
 
-        if [[ "$new_deps_found" == "0" ]]; then
+        if [[ "${new_deps_found}" == "0" ]]; then
             # No new deps to try, give up.
             iree_error "Build failed and no additional deps could be inferred"
             return 1
         fi
 
         # Regenerate BUILD file with new deps.
-        generate_build_file "$BUILD_FILE" "${current_deps[@]}"
+        generate_build_file "${BUILD_FILE}" "${current_deps[@]}"
         iree_debug "Regenerated BUILD.bazel with new deps"
 
         attempt=$((attempt + 1))
     done
 
-    iree_error "Build failed after $MAX_RETRIES attempts"
+    iree_error "Build failed after ${MAX_RETRIES} attempts"
     return 1
 }
 
-if [[ "$COMPILE_ONLY" == "1" ]] || [[ -n "$OUTPUT_PATH" ]]; then
+if [[ "${COMPILE_ONLY}" == "1" ]] || [[ -n "${OUTPUT_PATH}" ]]; then
     # Dry run: show what would be built and exit.
-    if [[ "$DRY_RUN" == "1" ]]; then
-        iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]}"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        iree_info "Command: bazel build ${TARGET} ${BAZEL_ARGS[*]}"
         iree_info "Deps: ${DEPS[*]}"
         exit 0
     fi
 
-    iree_debug "Building $TARGET..."
+    iree_debug "Building ${TARGET}..."
 
     if ! build_with_retry; then
         exit 1
     fi
 
     # Copy output if requested.
-    if [[ -n "$OUTPUT_PATH" ]]; then
-        BINARY_PATH="$IREE_BAZEL_WORKTREE_DIR/bazel-bin/.iree-bazel-try/cache/$CACHE_HASH/snippet"
-        if [[ -f "$BINARY_PATH" ]]; then
-            cp "$BINARY_PATH" "$OUTPUT_PATH"
-            chmod +x "$OUTPUT_PATH"
-            iree_info "Binary saved to: $OUTPUT_PATH"
+    if [[ -n "${OUTPUT_PATH}" ]]; then
+        BINARY_PATH="${IREE_BAZEL_WORKTREE_DIR}/bazel-bin/.iree-bazel-try/cache/${CACHE_HASH}/snippet"
+        if [[ -f "${BINARY_PATH}" ]]; then
+            cp "${BINARY_PATH}" "${OUTPUT_PATH}"
+            chmod +x "${OUTPUT_PATH}"
+            iree_info "Binary saved to: ${OUTPUT_PATH}"
         else
-            iree_error "Could not find built binary at $BINARY_PATH"
+            iree_error "Could not find built binary at ${BINARY_PATH}"
             exit 1
         fi
     fi
 
-    if [[ "$COMPILE_ONLY" == "1" ]]; then
+    if [[ "${COMPILE_ONLY}" == "1" ]]; then
         iree_debug "Build successful"
         exit 0
     fi
@@ -983,18 +954,18 @@ fi
 
 # Run the target.
 # Dry run: show what would be run and exit.
-if [[ "$DRY_RUN" == "1" ]]; then
+if [[ "${DRY_RUN}" == "1" ]]; then
     if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
-        iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary> ${PROGRAM_ARGS[*]}"
+        iree_info "Command: bazel build ${TARGET} ${BAZEL_ARGS[*]} && <binary> ${PROGRAM_ARGS[*]}"
     else
-        iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary>"
+        iree_info "Command: bazel build ${TARGET} ${BAZEL_ARGS[*]} && <binary>"
     fi
     iree_info "Deps: ${DEPS[*]}"
-    iree_info "Run directory: $IREE_BAZEL_ORIG_CWD"
+    iree_info "Run directory: ${IREE_BAZEL_ORIG_CWD}"
     exit 0
 fi
 
-iree_debug "Running $TARGET..."
+iree_debug "Running ${TARGET}..."
 
 # Build first (using retry logic).
 if ! build_with_retry; then
@@ -1004,14 +975,14 @@ fi
 # Get the binary path and run from original directory.
 # We know the exact structure since we generate the BUILD file, so we can
 # compute the path directly instead of calling bazel cquery (saves ~500ms).
-BINARY_PATH="$IREE_BAZEL_WORKTREE_DIR/bazel-bin/.iree-bazel-try/cache/$CACHE_HASH/snippet"
-if [[ ! -x "$BINARY_PATH" ]]; then
-    iree_error "Could not find built binary at $BINARY_PATH"
+BINARY_PATH="${IREE_BAZEL_WORKTREE_DIR}/bazel-bin/.iree-bazel-try/cache/${CACHE_HASH}/snippet"
+if [[ ! -x "${BINARY_PATH}" ]]; then
+    iree_error "Could not find built binary at ${BINARY_PATH}"
     exit 1
 fi
 
-iree_debug "Binary: $BINARY_PATH"
-iree_debug "Running from: $IREE_BAZEL_ORIG_CWD"
+iree_debug "Binary: ${BINARY_PATH}"
+iree_debug "Running from: ${IREE_BAZEL_ORIG_CWD}"
 
-cd "$IREE_BAZEL_ORIG_CWD"
-exec "$BINARY_PATH" "${PROGRAM_ARGS[@]}"
+cd "${IREE_BAZEL_ORIG_CWD}"
+exec "${BINARY_PATH}" "${PROGRAM_ARGS[@]}"

--- a/build_tools/bin/iree-bazel-try
+++ b/build_tools/bin/iree-bazel-try
@@ -1,0 +1,1017 @@
+#!/bin/bash
+# Quickly compile and run C/C++ snippets against IREE runtime.
+#
+# Usage: iree-bazel-try [options] [files...] [-- program-args...]
+#
+# Examples:
+#   iree-bazel-try snippet.c
+#   echo 'int main() { return 0; }' | iree-bazel-try
+#   iree-bazel-try -e 'int main() { return 42; }' -c
+#   iree-bazel-try --dep //runtime/src/iree/vm test.c -- --help
+
+set -e
+
+# Source shared library.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/iree-bazel-lib"
+iree_bazel_init "iree-bazel-try"
+
+# Expand combined short flags (e.g., -nv -> -n -v).
+eval "set -- $(iree_expand_combined_flags "$@")"
+
+show_help() {
+    cat << 'EOF'
+iree-bazel-try - Compile and run C/C++ snippets against IREE runtime
+
+Automatically infers dependencies from #include directives. Just write code
+with IREE headers and it figures out what deps are needed.
+
+USAGE
+    iree-bazel-try [options] [files...] [-- program-args...]
+
+OPTIONS
+    -n, --dry_run       Show the bazel command without executing
+    -v, --verbose       Show bazel commands, inferred deps, and temp paths
+    -h, --help          Show this help
+
+    NOTE: Short flags can be combined: -nv is equivalent to -n -v
+
+INPUT (at least one required)
+    files...              C/C++ source files (multiple allowed)
+    -e, --execute=CODE    Inline code (repeatable, concatenated)
+    (stdin)               Reads from stdin if no files and no -e
+
+LANGUAGE
+    -x c                  Force C language (default for stdin)
+    -x c++                Force C++ language
+
+COMPILATION
+    --config=NAME         Bazel config (debug, asan, msan, tsan)
+    --copt=FLAG           Add compiler flag (repeatable)
+    --linkopt=FLAG        Add linker flag (repeatable)
+    --dep=LABEL           Add explicit Bazel dependency (repeatable)
+    --no_infer            Disable automatic dependency inference
+    --retry=N             Max build retries for dep fixing (default: 3)
+
+OUTPUT
+    -c, --compile_only  Compile but don't run (exit 0 on success)
+    -o, --output PATH   Copy binary to PATH after build
+
+DEBUG
+    --keep              Keep temp directory for inspection
+
+EXIT CODES
+    0                   Success (build/run completed)
+    1                   Build failed (compiler errors, missing deps)
+    N                   Program exit code (when running)
+
+===============================================================================
+QUICK EXPLORATION - Use C like you'd use Python
+===============================================================================
+
+The primary use case: quickly answer "what does this function do?" without
+writing BUILD files or hunting for dependencies.
+
+EXAMPLE: "What does iree_unicode_utf8_decode return for an emoji?"
+    $ iree-bazel-try -e '
+    #include "iree/base/internal/unicode.h"
+    #include <stdio.h>
+    int main() {
+      const char* emoji = "\xF0\x9F\x98\x80";  // U+1F600 grinning face
+      iree_string_view_t text = iree_make_cstring_view(emoji);
+      iree_host_size_t pos = 0;
+      uint32_t cp = iree_unicode_utf8_decode(text, &pos);
+      printf("Codepoint: U+%04X, bytes consumed: %zu\n", cp, pos);
+      return 0;
+    }'
+    Codepoint: U+1F600, bytes consumed: 4
+
+===============================================================================
+MORE EXAMPLES
+===============================================================================
+
+EXAMPLE: Minimal test (stdin)
+    $ echo 'int main() { return 0; }' | iree-bazel-try
+    (no output, exit code 0)
+
+EXAMPLE: Using IREE APIs (auto-infers deps)
+    $ iree-bazel-try -e '#include "iree/base/api.h"
+    #include <stdio.h>
+    int main() {
+      iree_status_t s = iree_ok_status();
+      printf("ok: %d\n", iree_status_is_ok(s));
+      return 0;
+    }'
+    ok: 1
+
+EXAMPLE: Compile-only mode
+    $ iree-bazel-try -c -e 'int main() { return 0; }'
+    (exit code 0)
+
+EXAMPLE: Pass arguments to program
+    $ iree-bazel-try -e '#include <stdio.h>
+    int main(int argc, char** argv) {
+      for (int i = 0; i < argc; i++) printf("%d: %s\n", i, argv[i]);
+      return 0;
+    }' -- --flag value
+    0: bazel-bin/.iree-bazel-try/.../snippet
+    1: --flag
+    2: value
+
+EXAMPLE: Multiple source files
+    $ echo 'int helper() { return 42; }' > helper.c
+    $ echo 'extern int helper(); int main() { return helper() - 42; }' > main.c
+    $ iree-bazel-try main.c helper.c
+    (exit code 0)
+
+EXAMPLE: C++ with custom flags (auto-detected from includes or use -x c++)
+    $ iree-bazel-try --copt=-std=c++17 -e '
+    #include <optional>
+    #include <stdio.h>
+    int main() {
+      std::optional<int> x = 42;
+      printf("%d\n", *x);
+      return 0;
+    }'
+    42
+
+EXAMPLE: Build with AddressSanitizer
+    $ iree-bazel-try --config=asan -e '
+    #include <stdlib.h>
+    int main() {
+      int* p = malloc(4);
+      free(p);
+      return *p;  // use-after-free
+    }'
+    ==ERROR: AddressSanitizer: heap-use-after-free...
+
+EXAMPLE: Verbose mode (shows deps and commands)
+    $ iree-bazel-try -v -c -e '#include "iree/hal/api.h"
+    int main() { return 0; }'
+    [iree-bazel-try] Inferred deps: //runtime/src/iree/hal
+    [iree-bazel-try] Building //.iree-bazel-try/...:snippet...
+
+===============================================================================
+MLIR TRANSFORM HARNESS - Quick compiler experiments
+===============================================================================
+
+For one-shot MLIR transforms without modifying the compiler. C++ auto-detected.
+
+EXAMPLE: Walk operations (analysis)
+    $ echo 'func.func @f() { return }' | iree-bazel-try -e '
+    #include "iree/compiler/Tools/MlirTransformHarness.h"
+    void xform(ModuleOp m) {
+      m.walk([](Operation *op) { llvm::outs() << op->getName() << "\n"; });
+    }
+    MLIR_TRANSFORM_MAIN_NO_PRINT(xform)
+    '
+    func.return
+    func.func
+    builtin.module
+
+EXAMPLE: Pattern rewrite (transform)
+    $ echo 'func.func @f(%a: i32) -> i32 {
+      %c0 = arith.constant 0 : i32
+      %r = arith.addi %a, %c0 : i32
+      return %r : i32
+    }' | iree-bazel-try -e '
+    #include "iree/compiler/Tools/MlirTransformHarness.h"
+    #include "mlir/Dialect/Arith/IR/Arith.h"
+    struct AddZero : OpRewritePattern<arith::AddIOp> {
+      using OpRewritePattern::OpRewritePattern;
+      LogicalResult matchAndRewrite(arith::AddIOp op, PatternRewriter &rw) const override {
+        if (auto c = op.getRhs().getDefiningOp<arith::ConstantIntOp>())
+          if (c.value() == 0) { rw.replaceOp(op, op.getLhs()); return success(); }
+        return failure();
+      }
+    };
+    MLIR_PATTERN_MAIN(AddZero)
+    '
+    (outputs transformed IR with addi removed)
+
+===============================================================================
+GTEST HARNESS - Quick runtime tests
+===============================================================================
+
+Run gtests without BUILD files. Includes status matchers. C++ auto-detected.
+
+EXAMPLE: Test with status matchers
+    $ iree-bazel-try -e '
+    #include "iree/testing/gtest_harness.h"
+    TEST(StatusTest, OkStatus) {
+      IREE_EXPECT_OK(iree_ok_status());
+      EXPECT_THAT(iree_ok_status(), IsOk());
+    }
+    TEST(StatusTest, ErrorStatus) {
+      EXPECT_THAT(iree_make_status(IREE_STATUS_INVALID_ARGUMENT),
+                  StatusIs(StatusCode::kInvalidArgument));
+    }
+    '
+
+===============================================================================
+GBENCHMARK HARNESS - Quick benchmarks
+===============================================================================
+
+Run Google Benchmark microbenchmarks. C++ auto-detected.
+
+EXAMPLE: Benchmark memory allocation
+    $ iree-bazel-try -e '
+    #include "iree/testing/gbenchmark_harness.h"
+    void BM_Alloc(benchmark::State& state) {
+      for (auto _ : state) {
+        void* p = NULL;
+        iree_allocator_malloc(iree_allocator_system(), 1024, &p);
+        DoNotOptimize(p);
+        iree_allocator_free(iree_allocator_system(), p);
+      }
+    }
+    BENCHMARK(BM_Alloc);
+    '
+
+===============================================================================
+AUTOMATIC DEPENDENCY INFERENCE
+===============================================================================
+
+The tool automatically scans source files for #include "iree/..." directives
+and infers the corresponding Bazel dependencies:
+
+    #include "iree/base/api.h"      -> //runtime/src/iree/base
+    #include "iree/hal/buffer.h"    -> //runtime/src/iree/hal
+    #include "iree/vm/module.h"     -> //runtime/src/iree/vm
+    #include "iree/io/file_handle.h" -> //runtime/src/iree/io
+
+If the build fails with missing symbols, the tool will attempt to find the
+correct dependency using bazel query and retry the build (up to --retry times).
+
+Use --no_infer to disable this and rely only on explicit --dep flags.
+
+AI AGENT INTEGRATION
+    --agent-md          Print a concise snippet for CLAUDE.md/AGENT.md files
+
+SEE ALSO
+    iree-bazel-build, iree-bazel-test, iree-bazel-run
+EOF
+}
+
+# Maximum number of cache slots to keep (LRU eviction beyond this).
+MAX_CACHE_SLOTS=8
+
+# Compute a hash for cache slot naming based on deps-affecting inputs.
+# Hash is based on #includes + explicit deps + build options + language (NOT source content).
+# This allows multiple runs with same deps config to share the cached BUILD.bazel.
+# Args: source_files array (via nameref), extra_deps array, copts array, linkopts array, language
+compute_cache_hash() {
+    local -n _source_files=$1
+    local -n _extra_deps=$2
+    local -n _copts=$3
+    local -n _linkopts=$4
+    local _language=${5:-c}
+    {
+        # Hash language (determines file extension and compilation mode).
+        printf 'language:%s\n' "$_language"
+        # Hash #include directives (determines inferred deps).
+        printf 'includes:\n'
+        for src in "${_source_files[@]}"; do
+            grep -h '#include\s*"[^"]*"' "$src" 2>/dev/null | \
+                sed 's/.*#include\s*"\([^"]*\)".*/\1/' | \
+                grep -E '^(iree/|llvm/|mlir/)'
+        done | sort -u
+        # Hash explicit deps (user-provided --dep flags).
+        printf 'extra_deps:\n'
+        printf '%s\n' "${_extra_deps[@]}" | sort -u
+        # Hash build options that affect BUILD.bazel.
+        printf 'copts:\n'
+        printf '%s\n' "${_copts[@]}" | sort -u
+        printf 'linkopts:\n'
+        printf '%s\n' "${_linkopts[@]}" | sort -u
+    } | md5sum | cut -c1-12
+}
+
+# Ensure cache doesn't exceed MAX_CACHE_SLOTS by evicting oldest slots.
+# Uses mtime for LRU ordering (we touch slots on use).
+enforce_cache_limit() {
+    local cache_dir="$1"
+    if [[ ! -d "$cache_dir" ]]; then
+        return
+    fi
+    local slot_count
+    slot_count=$(find "$cache_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+    if [[ "$slot_count" -gt "$MAX_CACHE_SLOTS" ]]; then
+        local excess=$((slot_count - MAX_CACHE_SLOTS))
+        iree_debug "Cache has $slot_count slots, evicting $excess oldest"
+        # Find oldest directories by mtime and remove them.
+        find "$cache_dir" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' 2>/dev/null | \
+            sort -n | head -n "$excess" | cut -d' ' -f2- | \
+            while read -r old_slot; do
+                rm -rf "$old_slot"
+                iree_debug "Evicted cache slot: $old_slot"
+            done
+    fi
+}
+
+# Ensure .iree-bazel-try is in .git/info/exclude (local exclude, not .gitignore).
+ensure_ignores() {
+    local worktree="$1"
+
+    # Find the git directory (handles worktrees where .git is a file pointing elsewhere).
+    local git_dir
+    if [[ -f "$worktree/.git" ]]; then
+        # Worktree: .git is a file containing "gitdir: /path/to/git/dir"
+        git_dir=$(sed 's/^gitdir: //' "$worktree/.git")
+    else
+        git_dir="$worktree/.git"
+    fi
+
+    local exclude_file="$git_dir/info/exclude"
+
+    # Create info directory if needed.
+    mkdir -p "$(dirname "$exclude_file")"
+
+    # Add to exclude if not present.
+    if [[ -f "$exclude_file" ]]; then
+        if ! grep -q '^\.iree-bazel-try/$' "$exclude_file" 2>/dev/null; then
+            echo '.iree-bazel-try/' >> "$exclude_file"
+            iree_debug "Added .iree-bazel-try/ to $exclude_file"
+        fi
+    else
+        echo '.iree-bazel-try/' > "$exclude_file"
+        iree_debug "Created $exclude_file with .iree-bazel-try/"
+    fi
+}
+
+# Infer Bazel deps from #include directives in source files.
+# Uses bazel query attr(hdrs, pattern) to find targets that export each header.
+# Outputs one dep per line.
+infer_deps_from_sources() {
+    local -a sources=("$@")
+    local BAZEL_BIN=$(iree_get_bazel_command)
+    local -a runtime_patterns=()
+    local -a compiler_patterns=()
+    local -a llvm_files=()
+    local -a mlir_files=()
+
+    # Collect all headers from all source files.
+    for src in "${sources[@]}"; do
+        if [[ ! -f "$src" ]]; then
+            continue
+        fi
+
+        # Extract all #include "..." directives.
+        while IFS= read -r header; do
+            local dir_path="${header%/*}"
+            local filename="${header##*/}"
+
+            case "$header" in
+                iree/compiler/*)
+                    # Pattern: iree/compiler/Foo/Bar:file.h (use path for specificity).
+                    compiler_patterns+=("${dir_path}:${filename}")
+                    ;;
+                iree/*)
+                    # Pattern: iree/base:api.h or iree/base/internal:unicode.h.
+                    runtime_patterns+=("${dir_path}:${filename}")
+                    ;;
+                llvm/*)
+                    # LLVM uses different structure, just use filename.
+                    llvm_files+=("$filename")
+                    ;;
+                mlir/*)
+                    # MLIR uses different structure, just use filename.
+                    mlir_files+=("$filename")
+                    ;;
+            esac
+        done < <(grep -h '#include\s*"[^"]*"' "$src" 2>/dev/null | \
+                 sed 's/.*#include\s*"\([^"]*\)".*/\1/' | \
+                 grep -E '^(iree/|llvm/|mlir/)')
+    done
+
+    # Query each category using attr(hdrs, pattern) - handles all package structures.
+    local -a all_deps=()
+
+    if [[ ${#runtime_patterns[@]} -gt 0 ]]; then
+        iree_debug "Querying deps for ${#runtime_patterns[@]} runtime headers..."
+        local pattern
+        pattern=$(printf '%s\n' "${runtime_patterns[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
+        while IFS= read -r dep; do
+            [[ -n "$dep" ]] && all_deps+=("$dep")
+        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', //runtime/src/iree/...)" 2>/dev/null)
+    fi
+
+    if [[ ${#compiler_patterns[@]} -gt 0 ]]; then
+        iree_debug "Querying deps for ${#compiler_patterns[@]} compiler headers..."
+        local pattern
+        pattern=$(printf '%s\n' "${compiler_patterns[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
+        while IFS= read -r dep; do
+            [[ -n "$dep" ]] && all_deps+=("$dep")
+        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', //compiler/src/iree/compiler/...)" 2>/dev/null)
+    fi
+
+    if [[ ${#llvm_files[@]} -gt 0 ]]; then
+        iree_debug "Querying deps for ${#llvm_files[@]} LLVM headers..."
+        local pattern
+        pattern=$(printf '%s\n' "${llvm_files[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
+        while IFS= read -r dep; do
+            [[ -n "$dep" ]] && all_deps+=("$dep")
+        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', @llvm-project//llvm/...)" 2>/dev/null)
+    fi
+
+    if [[ ${#mlir_files[@]} -gt 0 ]]; then
+        iree_debug "Querying deps for ${#mlir_files[@]} MLIR headers..."
+        local pattern
+        pattern=$(printf '%s\n' "${mlir_files[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
+        while IFS= read -r dep; do
+            [[ -n "$dep" ]] && all_deps+=("$dep")
+        done < <("$BAZEL_BIN" query "attr(hdrs, '(${pattern})', @llvm-project//mlir/...)" 2>/dev/null)
+    fi
+
+    # Output unique deps.
+    printf '%s\n' "${all_deps[@]}" | sort -u
+}
+
+# Try to find a dep for a missing symbol using bazel query.
+# This is called when build fails.
+find_dep_for_symbol() {
+    local symbol="$1"
+    local worktree="$2"
+
+    # Search for the symbol in IREE runtime sources.
+    local matches
+    matches=$(grep -rl "^[^/]*\b${symbol}\b" "$worktree/runtime/src/iree/" 2>/dev/null | head -5)
+
+    for match in $matches; do
+        # Convert file path to bazel package.
+        local rel_path="${match#$worktree/}"
+        local dir_path="${rel_path%/*}"
+        echo "//${dir_path}"
+        return 0
+    done
+
+    return 1
+}
+
+# Parse build errors and suggest missing deps.
+# Returns deps to add, one per line.
+parse_build_errors() {
+    local log_file="$1"
+    local worktree="$2"
+    local -A suggested_deps
+
+    # Look for undefined reference errors.
+    while IFS= read -r symbol; do
+        if [[ -n "$symbol" ]]; then
+            local dep
+            if dep=$(find_dep_for_symbol "$symbol" "$worktree" 2>/dev/null); then
+                if [[ -z "${suggested_deps[$dep]:-}" ]]; then
+                    suggested_deps[$dep]=1
+                    echo "$dep"
+                fi
+            fi
+        fi
+    done < <(grep -o "undefined reference to \`[^']*'" "$log_file" 2>/dev/null | \
+             sed "s/undefined reference to \`\\([^']*\\)'/\\1/")
+
+    # Look for missing header errors.
+    while IFS= read -r header; do
+        if [[ "$header" == iree/* ]]; then
+            local package="${header%/*}"
+            # Simplify to top-level package.
+            local component="${package#iree/}"
+            component="${component%%/*}"
+            local dep="//runtime/src/iree/$component"
+            if [[ -z "${suggested_deps[$dep]:-}" ]]; then
+                suggested_deps[$dep]=1
+                echo "$dep"
+            fi
+        fi
+    done < <(grep -o "fatal error: '[^']*' file not found" "$log_file" 2>/dev/null | \
+             sed "s/fatal error: '\\([^']*\\)' file not found/\\1/")
+}
+
+# Main script.
+DRY_RUN=0
+COMPILE_ONLY=0
+KEEP_TEMP=0
+INFER_DEPS=1
+MAX_RETRIES=3
+OUTPUT_PATH=""
+LANGUAGE=""
+INLINE_CODE=""
+declare -a SOURCE_FILES=()
+declare -a EXTRA_DEPS=()
+declare -a COPTS=()
+declare -a LINKOPTS=()
+declare -a BAZEL_ARGS=()
+declare -a PROGRAM_ARGS=()
+
+# Parse arguments.
+PARSING_PROGRAM_ARGS=0
+while [[ $# -gt 0 ]]; do
+    if [[ "$PARSING_PROGRAM_ARGS" == "1" ]]; then
+        PROGRAM_ARGS+=("$1")
+        shift
+        continue
+    fi
+
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --agent-md|--agent_md)
+            iree_show_agent_md
+            exit 0
+            ;;
+        -n|--dry_run|--dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            IREE_BAZEL_VERBOSE=1
+            shift
+            ;;
+        -c|--compile_only|--compile_only)
+            COMPILE_ONLY=1
+            shift
+            ;;
+        --keep)
+            KEEP_TEMP=1
+            shift
+            ;;
+        --no_infer|--no_infer)
+            INFER_DEPS=0
+            shift
+            ;;
+        --retry)
+            MAX_RETRIES="$2"
+            shift 2
+            ;;
+        --retry=*)
+            MAX_RETRIES="${1#--retry=}"
+            shift
+            ;;
+        -o|--output)
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        --output=*)
+            OUTPUT_PATH="${1#--output=}"
+            shift
+            ;;
+        -x)
+            LANGUAGE="$2"
+            shift 2
+            ;;
+        -e|--execute)
+            INLINE_CODE="${INLINE_CODE}${2}"$'\n'
+            shift 2
+            ;;
+        --execute=*)
+            INLINE_CODE="${INLINE_CODE}${1#--execute=}"$'\n'
+            shift
+            ;;
+        --dep)
+            EXTRA_DEPS+=("$2")
+            shift 2
+            ;;
+        --dep=*)
+            EXTRA_DEPS+=("${1#--dep=}")
+            shift
+            ;;
+        --copt)
+            COPTS+=("$2")
+            shift 2
+            ;;
+        --copt=*)
+            COPTS+=("${1#--copt=}")
+            shift
+            ;;
+        --linkopt)
+            LINKOPTS+=("$2")
+            shift 2
+            ;;
+        --linkopt=*)
+            LINKOPTS+=("${1#--linkopt=}")
+            shift
+            ;;
+        --config=*)
+            BAZEL_ARGS+=("$1")
+            shift
+            ;;
+        --)
+            PARSING_PROGRAM_ARGS=1
+            shift
+            ;;
+        -*)
+            iree_error "Unknown option: $1"
+            echo "Use --help for usage information."
+            exit 1
+            ;;
+        *)
+            SOURCE_FILES+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Find worktree root.
+iree_require_worktree
+cd "$IREE_BAZEL_WORKTREE_DIR"
+iree_ensure_configured
+
+# Prepend default configs to bazel args.
+iree_bazel_build_default_configs
+BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${BAZEL_ARGS[@]}")
+
+# Determine input source.
+HAS_STDIN=0
+if [[ -z "$INLINE_CODE" ]] && [[ ${#SOURCE_FILES[@]} -eq 0 ]]; then
+    # Check if stdin has data.
+    if [[ -t 0 ]]; then
+        iree_error "No input provided. Specify files, use -e, or pipe to stdin."
+        echo "Use --help for usage information."
+        exit 1
+    fi
+    HAS_STDIN=1
+fi
+
+# Set up base directory and ensure it's git-ignored.
+TRY_BASE="$IREE_BAZEL_WORKTREE_DIR/.iree-bazel-try"
+CACHE_DIR="$TRY_BASE/cache"
+STAGING_DIR="$TRY_BASE/staging_$$"
+ensure_ignores "$IREE_BAZEL_WORKTREE_DIR"
+
+# Create staging directory for source files (needed for deps inference).
+mkdir -p "$STAGING_DIR"
+
+# Cleanup staging on exit (cache slots are kept).
+cleanup_staging() {
+    if [[ -n "$STAGING_DIR" ]] && [[ -d "$STAGING_DIR" ]]; then
+        rm -rf "$STAGING_DIR"
+    fi
+}
+trap cleanup_staging EXIT
+
+# Collect source files in staging directory.
+declare -a BUILD_SRCS=()
+declare -a STAGED_SOURCE_PATHS=()
+
+# Read stdin into variable if needed (so we can scan it for auto-detection).
+STDIN_CONTENT=""
+if [[ "$HAS_STDIN" == "1" ]]; then
+    STDIN_CONTENT=$(cat)
+fi
+
+# Auto-detect C++ from includes if language not explicitly set.
+# C++-only headers: llvm/, mlir/, iree/compiler/, iree/testing/, gtest/, gmock/, benchmark/
+ALL_CODE="${INLINE_CODE}${STDIN_CONTENT}"
+if [[ -z "$LANGUAGE" ]]; then
+    if echo "$ALL_CODE" | grep -qE '#include\s*[<"](llvm/|mlir/|iree/compiler/|iree/testing/|gtest/|gmock/|benchmark/)'; then
+        LANGUAGE="c++"
+        iree_debug "Auto-detected C++ from includes"
+    else
+        LANGUAGE="c"
+    fi
+fi
+
+
+# Handle inline code.
+if [[ -n "$INLINE_CODE" ]]; then
+    if [[ "$LANGUAGE" == "c++" ]]; then
+        INLINE_FILE="$STAGING_DIR/inline.cc"
+    else
+        INLINE_FILE="$STAGING_DIR/inline.c"
+    fi
+    printf '%s' "$INLINE_CODE" > "$INLINE_FILE"
+    BUILD_SRCS+=("$(basename "$INLINE_FILE")")
+    STAGED_SOURCE_PATHS+=("$INLINE_FILE")
+    iree_debug "Wrote inline code to $INLINE_FILE"
+fi
+
+# Handle stdin.
+if [[ -n "$STDIN_CONTENT" ]]; then
+    if [[ "$LANGUAGE" == "c++" ]]; then
+        STDIN_FILE="$STAGING_DIR/stdin.cc"
+    else
+        STDIN_FILE="$STAGING_DIR/stdin.c"
+    fi
+    printf '%s' "$STDIN_CONTENT" > "$STDIN_FILE"
+    BUILD_SRCS+=("$(basename "$STDIN_FILE")")
+    STAGED_SOURCE_PATHS+=("$STDIN_FILE")
+    iree_debug "Wrote stdin to $STDIN_FILE"
+fi
+
+# Handle source files.
+for src in "${SOURCE_FILES[@]}"; do
+    if [[ ! -f "$src" ]]; then
+        iree_error "Source file not found: $src"
+        exit 1
+    fi
+    # Copy to staging dir.
+    cp "$src" "$STAGING_DIR/"
+    BUILD_SRCS+=("$(basename "$src")")
+    STAGED_SOURCE_PATHS+=("$STAGING_DIR/$(basename "$src")")
+    iree_debug "Staged $src"
+done
+
+# Determine if this is C++.
+IS_CPP=0
+if [[ "$LANGUAGE" == "c++" ]]; then
+    IS_CPP=1
+else
+    for src in "${BUILD_SRCS[@]}"; do
+        case "$src" in
+            *.cc|*.cpp|*.cxx|*.C)
+                IS_CPP=1
+                break
+                ;;
+        esac
+    done
+fi
+
+# Compute cache hash BEFORE deps inference.
+# Hash is based on #includes + explicit deps + build options + language (NOT source content).
+# This allows runs with same deps config to share BUILD.bazel analysis cache.
+CACHE_HASH=$(compute_cache_hash STAGED_SOURCE_PATHS EXTRA_DEPS COPTS LINKOPTS "$LANGUAGE")
+SLOT_DIR="$CACHE_DIR/$CACHE_HASH"
+LOCK_FILE="$CACHE_DIR/$CACHE_HASH.lock"
+
+# Ensure cache directory exists.
+mkdir -p "$CACHE_DIR"
+
+# Acquire exclusive lock on this slot to prevent parallel runs from clobbering.
+# Lock is released automatically when the script exits.
+exec 9>"$LOCK_FILE"
+if ! flock -w 60 9; then
+    iree_error "Timeout waiting for lock on cache slot $CACHE_HASH"
+    exit 1
+fi
+iree_debug "Acquired lock on slot $CACHE_HASH"
+
+# Check cache AFTER acquiring lock (another process may have created it while we waited).
+CACHE_HIT=0
+if [[ -d "$SLOT_DIR" ]] && [[ -f "$SLOT_DIR/BUILD.bazel" ]]; then
+    CACHE_HIT=1
+    iree_debug "Cache hit: reusing slot $CACHE_HASH (skipping deps inference)"
+fi
+
+# Only infer deps on cache miss.
+declare -A DEPS_MAP=()
+declare -a DEPS=()
+
+if [[ "$CACHE_HIT" == "0" ]]; then
+    # Infer deps from source files (expensive bazel query).
+    declare -a INFERRED_DEPS=()
+    if [[ "$INFER_DEPS" == "1" ]]; then
+        while IFS= read -r dep; do
+            if [[ -n "$dep" ]]; then
+                INFERRED_DEPS+=("$dep")
+            fi
+        done < <(infer_deps_from_sources "${STAGED_SOURCE_PATHS[@]}")
+
+        if [[ ${#INFERRED_DEPS[@]} -gt 0 ]]; then
+            iree_debug "Inferred deps: ${INFERRED_DEPS[*]}"
+        fi
+    fi
+
+    # Build deps list (inferred + explicit, deduplicated).
+    for dep in "${INFERRED_DEPS[@]}"; do
+        if [[ -z "${DEPS_MAP[$dep]:-}" ]]; then
+            DEPS_MAP[$dep]=1
+            DEPS+=("$dep")
+        fi
+    done
+
+    for dep in "${EXTRA_DEPS[@]}"; do
+        if [[ -z "${DEPS_MAP[$dep]:-}" ]]; then
+            DEPS_MAP[$dep]=1
+            DEPS+=("$dep")
+        fi
+    done
+
+    # If no deps at all, add base as minimum.
+    if [[ ${#DEPS[@]} -eq 0 ]]; then
+        DEPS+=("//runtime/src/iree/base")
+    fi
+fi
+
+# Function to generate BUILD.bazel file.
+generate_build_file() {
+    local build_file="$1"
+    shift
+    local -a deps=("$@")
+
+    {
+        echo '# Auto-generated by iree-bazel-try'
+        echo ''
+        echo 'cc_binary('
+        echo '    name = "snippet",'
+        echo '    testonly = True,'
+        printf '    srcs = ['
+        local first=1
+        for src in "${BUILD_SRCS[@]}"; do
+            if [[ "$first" == "1" ]]; then
+                first=0
+            else
+                printf ', '
+            fi
+            printf '"%s"' "$src"
+        done
+        printf '],\n'
+        printf '    deps = [\n'
+        for dep in "${deps[@]}"; do
+            printf '        "%s",\n' "$dep"
+        done
+        printf '    ],\n'
+        if [[ ${#COPTS[@]} -gt 0 ]]; then
+            printf '    copts = ['
+            first=1
+            for opt in "${COPTS[@]}"; do
+                if [[ "$first" == "1" ]]; then
+                    first=0
+                else
+                    printf ', '
+                fi
+                printf '"%s"' "$opt"
+            done
+            printf '],\n'
+        fi
+        if [[ ${#LINKOPTS[@]} -gt 0 ]]; then
+            printf '    linkopts = ['
+            first=1
+            for opt in "${LINKOPTS[@]}"; do
+                if [[ "$first" == "1" ]]; then
+                    first=0
+                else
+                    printf ', '
+                fi
+                printf '"%s"' "$opt"
+            done
+            printf '],\n'
+        fi
+        echo ')'
+    } > "$build_file"
+}
+
+# Set up cache slot.
+if [[ "$CACHE_HIT" == "0" ]]; then
+    iree_debug "Cache miss: creating slot $CACHE_HASH"
+    mkdir -p "$SLOT_DIR"
+
+    # Generate BUILD.bazel for new slot.
+    BUILD_FILE="$SLOT_DIR/BUILD.bazel"
+    generate_build_file "$BUILD_FILE" "${DEPS[@]}"
+
+    iree_debug "Generated BUILD.bazel:"
+    if [[ "$IREE_BAZEL_VERBOSE" == "1" ]]; then
+        cat "$BUILD_FILE" | sed 's/^/    /' >&2
+    fi
+fi
+
+# Copy source files from staging to cache slot.
+for staged_file in "${STAGED_SOURCE_PATHS[@]}"; do
+    cp "$staged_file" "$SLOT_DIR/"
+done
+
+# Touch the slot directory to update mtime for LRU tracking.
+touch "$SLOT_DIR"
+
+# Enforce cache size limit (evict old slots if needed).
+enforce_cache_limit "$CACHE_DIR"
+
+if [[ "$KEEP_TEMP" == "1" ]]; then
+    iree_info "Cache slot: $SLOT_DIR"
+fi
+
+# Build the target with retry logic.
+TARGET="//.iree-bazel-try/cache/$CACHE_HASH:snippet"
+BUILD_LOG="$SLOT_DIR/build.log"
+
+do_build() {
+    local BAZEL_BIN=$(iree_get_bazel_command)
+    if iree_is_verbose; then
+        # Verbose mode: show everything, also save to log for retry logic.
+        "$BAZEL_BIN" build "$TARGET" "${BAZEL_ARGS[@]}" 2>&1 | tee "$BUILD_LOG"
+        return "${PIPESTATUS[0]}"
+    else
+        # Quiet mode: capture output, only show on failure.
+        # Force colors since we'll display to terminal on failure.
+        if "$BAZEL_BIN" build --color=yes "$TARGET" "${BAZEL_ARGS[@]}" >"$BUILD_LOG" 2>&1; then
+            return 0
+        else
+            local exit_code=$?
+            cat "$BUILD_LOG" >&2
+            return $exit_code
+        fi
+    fi
+}
+
+build_with_retry() {
+    local attempt=1
+    local current_deps=("${DEPS[@]}")
+
+    while [[ $attempt -le $MAX_RETRIES ]]; do
+        iree_debug "Build attempt $attempt/$MAX_RETRIES"
+
+        if do_build; then
+            return 0
+        fi
+
+        # Build failed - try to find missing deps.
+        if [[ "$INFER_DEPS" == "0" ]]; then
+            # User disabled inference, don't retry.
+            return 1
+        fi
+
+        local new_deps_found=0
+        while IFS= read -r new_dep; do
+            if [[ -n "$new_dep" ]] && [[ -z "${DEPS_MAP[$new_dep]:-}" ]]; then
+                iree_warn "Adding inferred dep: $new_dep"
+                DEPS_MAP[$new_dep]=1
+                current_deps+=("$new_dep")
+                new_deps_found=1
+            fi
+        done < <(parse_build_errors "$BUILD_LOG" "$IREE_BAZEL_WORKTREE_DIR")
+
+        if [[ "$new_deps_found" == "0" ]]; then
+            # No new deps to try, give up.
+            iree_error "Build failed and no additional deps could be inferred"
+            return 1
+        fi
+
+        # Regenerate BUILD file with new deps.
+        generate_build_file "$BUILD_FILE" "${current_deps[@]}"
+        iree_debug "Regenerated BUILD.bazel with new deps"
+
+        attempt=$((attempt + 1))
+    done
+
+    iree_error "Build failed after $MAX_RETRIES attempts"
+    return 1
+}
+
+if [[ "$COMPILE_ONLY" == "1" ]] || [[ -n "$OUTPUT_PATH" ]]; then
+    # Dry run: show what would be built and exit.
+    if [[ "$DRY_RUN" == "1" ]]; then
+        iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]}"
+        iree_info "Deps: ${DEPS[*]}"
+        exit 0
+    fi
+
+    iree_debug "Building $TARGET..."
+
+    if ! build_with_retry; then
+        exit 1
+    fi
+
+    # Copy output if requested.
+    if [[ -n "$OUTPUT_PATH" ]]; then
+        BINARY_PATH="$IREE_BAZEL_WORKTREE_DIR/bazel-bin/.iree-bazel-try/cache/$CACHE_HASH/snippet"
+        if [[ -f "$BINARY_PATH" ]]; then
+            cp "$BINARY_PATH" "$OUTPUT_PATH"
+            chmod +x "$OUTPUT_PATH"
+            iree_info "Binary saved to: $OUTPUT_PATH"
+        else
+            iree_error "Could not find built binary at $BINARY_PATH"
+            exit 1
+        fi
+    fi
+
+    if [[ "$COMPILE_ONLY" == "1" ]]; then
+        iree_debug "Build successful"
+        exit 0
+    fi
+fi
+
+# Run the target.
+# Dry run: show what would be run and exit.
+if [[ "$DRY_RUN" == "1" ]]; then
+    if [[ ${#PROGRAM_ARGS[@]} -gt 0 ]]; then
+        iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary> ${PROGRAM_ARGS[*]}"
+    else
+        iree_info "Command: bazel build $TARGET ${BAZEL_ARGS[*]} && <binary>"
+    fi
+    iree_info "Deps: ${DEPS[*]}"
+    iree_info "Run directory: $IREE_BAZEL_ORIG_CWD"
+    exit 0
+fi
+
+iree_debug "Running $TARGET..."
+
+# Build first (using retry logic).
+if ! build_with_retry; then
+    exit 1
+fi
+
+# Get the binary path and run from original directory.
+# We know the exact structure since we generate the BUILD file, so we can
+# compute the path directly instead of calling bazel cquery (saves ~500ms).
+BINARY_PATH="$IREE_BAZEL_WORKTREE_DIR/bazel-bin/.iree-bazel-try/cache/$CACHE_HASH/snippet"
+if [[ ! -x "$BINARY_PATH" ]]; then
+    iree_error "Could not find built binary at $BINARY_PATH"
+    exit 1
+fi
+
+iree_debug "Binary: $BINARY_PATH"
+iree_debug "Running from: $IREE_BAZEL_ORIG_CWD"
+
+cd "$IREE_BAZEL_ORIG_CWD"
+exec "$BINARY_PATH" "${PROGRAM_ARGS[@]}"

--- a/compiler/src/iree/compiler/Tools/BUILD.bazel
+++ b/compiler/src/iree/compiler/Tools/BUILD.bazel
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_compiler_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -208,4 +208,29 @@ iree_compiler_cc_library(
         ],
         "//conditions:default": [],
     }),
+)
+
+iree_compiler_cc_library(
+    name = "MlirTransformHarness",
+    hdrs = ["MlirTransformHarness.h"],
+    deps = [
+        ":init_passes_and_dialects",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:BytecodeWriter",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Rewrite",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+iree_compiler_cc_test(
+    name = "MlirTransformHarnessDemo",
+    srcs = ["MlirTransformHarnessDemo.cpp"],
+    data = ["MlirTransformHarnessDemo.mlir"],
+    deps = [
+        ":MlirTransformHarness",
+    ],
 )

--- a/compiler/src/iree/compiler/Tools/MlirTransformHarness.h
+++ b/compiler/src/iree/compiler/Tools/MlirTransformHarness.h
@@ -1,0 +1,350 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Harness for one-shot MLIR transformations via iree-bazel-try.
+// Uses standard MLIR tool patterns for I/O, flag parsing, and pass pipelines.
+//
+// Basic transform (stdin -> transform -> stdout):
+//   echo 'func.func @test() { return }' | iree-bazel-try -e '
+//   #include "iree/compiler/Tools/MlirTransformHarness.h"
+//   void myTransform(ModuleOp module) {
+//     module.walk([](mlir::Operation *op) {
+//       llvm::outs() << "Found: " << op->getName() << "\n";
+//     });
+//   }
+//   MLIR_TRANSFORM_MAIN(myTransform)
+//   '
+//
+// File input and output:
+//   iree-bazel-try -e '...' -- input.mlir -o output.mlir
+//
+// Bytecode format support (auto-detected on input, explicit on output):
+//   iree-bazel-try -e '...' -- input.mlirbc -o output.mlirbc --emit-bytecode
+//
+// Pass pipeline preprocessing:
+//   echo 'func.func @f(%a: i32) { ... }' | iree-bazel-try -e '
+//   #include "iree/compiler/Tools/MlirTransformHarness.h"
+//   void analyze(ModuleOp m) {
+//     // Analyze IR after canonicalization.
+//     int ops = 0;
+//     m.walk([&](Operation *op) { ops++; });
+//     llvm::outs() << "Operations: " << ops << "\n";
+//   }
+//   MLIR_TRANSFORM_MAIN_NO_PRINT(analyze)
+//   ' -- --pass-pipeline='builtin.module(func.func(canonicalize,cse))'
+//
+// Pattern application:
+//   echo 'module { ... }' | iree-bazel-try -e '
+//   #include "iree/compiler/Tools/MlirTransformHarness.h"
+//   struct MyPattern : public mlir::OpRewritePattern<SomeOp> {
+//     using OpRewritePattern::OpRewritePattern;
+//     LogicalResult matchAndRewrite(SomeOp op, PatternRewriter &rw) const
+//     override {
+//       // ... pattern implementation
+//       return success();
+//     }
+//   };
+//   MLIR_PATTERN_MAIN(MyPattern)
+//   '
+//
+// The harness handles:
+// - Standard MLIR file I/O (supports stdin, .mlir, .mlirbc formats)
+// - Flag parsing (--pass-pipeline, --emit-bytecode, -o, etc.)
+// - Full IREE compiler dialect/pass registration (same as iree-opt)
+// - Pass pipeline execution before user transform
+// - Calling your transform function or applying patterns
+// - Printing the result to stdout (unless NO_PRINT variant used)
+
+#ifndef IREE_COMPILER_TOOLS_MLIRTRANSFORMHARNESS_H_
+#define IREE_COMPILER_TOOLS_MLIRTRANSFORMHARNESS_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "iree/compiler/Tools/init_dialects.h"
+#include "iree/compiler/Tools/init_passes.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+// Options for controlling transform harness behavior.
+struct TransformHarnessOptions {
+  // Print module to output after transform completes.
+  bool printOutput = true;
+
+  // Emit bytecode format instead of textual MLIR.
+  bool emitBytecode = false;
+
+  // Verify IR after passes (when pass pipeline is used).
+  bool verifyEachPass = true;
+
+  // Allow unregistered dialects in parsed IR.
+  bool allowUnregisteredDialects = true;
+};
+
+// Main entry point for transform harness.
+// Handles argument parsing, file I/O, pass pipeline execution, and user
+// transform.
+//
+// Args:
+//   argc, argv: Command line arguments (uses llvm::cl for parsing)
+//   transformFn: User's transform function to apply to the module
+//   options: Harness configuration options
+//
+// Returns: 0 on success, non-zero on failure
+//
+// Supported flags:
+//   <input-file>                  Input MLIR file (- for stdin, auto-detects
+//                                 .mlir/.mlirbc)
+//   -o <file>                     Output file (- for stdout)
+//   --pass-pipeline-before=<str>  Pass pipeline to run BEFORE transform
+//   --pass-pipeline-after=<str>   Pass pipeline to run AFTER transform
+//   --emit-bytecode               Emit bytecode instead of text
+//   --verify-each                 Verify IR after each pass (default: true)
+//   --allow-unregistered-dialect  Allow unregistered dialects (default: true)
+inline int
+runMlirTransformHarness(int argc, char **argv,
+                        std::function<void(mlir::ModuleOp)> transformFn,
+                        TransformHarnessOptions options = {}) {
+  // Initialize LLVM (handles signal handlers, etc.).
+  llvm::InitLLVM y(argc, argv);
+
+  // Register command-line options (static ensures single initialization).
+  static llvm::cl::opt<std::string> inputFilename(
+      llvm::cl::Positional, llvm::cl::desc("<input file or '-' for stdin>"),
+      llvm::cl::init("-"));
+
+  static llvm::cl::opt<std::string> outputFilename(
+      "o", llvm::cl::desc("Output filename"), llvm::cl::value_desc("filename"),
+      llvm::cl::init("-"));
+
+  static llvm::cl::opt<std::string> passPipelineBefore(
+      "pass-pipeline-before",
+      llvm::cl::desc("Pass pipeline to run before transform"),
+      llvm::cl::value_desc("pipeline"), llvm::cl::init(""));
+
+  static llvm::cl::opt<std::string> passPipelineAfter(
+      "pass-pipeline-after",
+      llvm::cl::desc("Pass pipeline to run after transform"),
+      llvm::cl::value_desc("pipeline"), llvm::cl::init(""));
+
+  static llvm::cl::opt<bool> emitBytecode(
+      "emit-bytecode", llvm::cl::desc("Emit bytecode instead of textual IR"),
+      llvm::cl::init(false));
+
+  static llvm::cl::opt<bool> verifyEach(
+      "verify-each", llvm::cl::desc("Verify IR after each pass"),
+      llvm::cl::init(true));
+
+  static llvm::cl::opt<bool> allowUnregisteredDialect(
+      "allow-unregistered-dialect",
+      llvm::cl::desc("Allow unregistered dialects"), llvm::cl::init(true));
+
+  // Parse command line options.
+  llvm::cl::ParseCommandLineOptions(
+      argc, argv,
+      "IREE Transform Harness - MLIR transformation experimentation tool\n");
+
+  // Register all IREE dialects and passes (same as iree-opt).
+  mlir::DialectRegistry registry;
+  mlir::iree_compiler::registerAllDialects(registry);
+  mlir::iree_compiler::registerAllPasses();
+
+  // Create context with all registered dialects.
+  mlir::MLIRContext context(registry);
+  if (allowUnregisteredDialect || options.allowUnregisteredDialects) {
+    context.allowUnregisteredDialects();
+  }
+  context.loadAllAvailableDialects();
+
+  // Open input file (handles stdin via "-", auto-detects .mlir vs .mlirbc).
+  std::string errorMessage;
+  auto inputFile = mlir::openInputFile(inputFilename, &errorMessage);
+  if (!inputFile) {
+    llvm::errs() << "Error opening input file: " << errorMessage << "\n";
+    return 1;
+  }
+
+  // Create source manager with shared ownership (allows zero-copy buffer
+  // references).
+  auto sourceMgr = std::make_shared<llvm::SourceMgr>();
+  sourceMgr->AddNewSourceBuffer(std::move(inputFile), llvm::SMLoc());
+
+  // Parse input (auto-detects text vs bytecode format).
+  mlir::ParserConfig parserConfig(&context);
+  mlir::OwningOpRef<mlir::ModuleOp> moduleRef =
+      mlir::parseSourceFile<mlir::ModuleOp>(*sourceMgr, parserConfig);
+
+  if (!moduleRef) {
+    llvm::errs() << "Failed to parse input file\n";
+    return 1;
+  }
+
+  // Run pass pipeline before user transform if specified.
+  if (!passPipelineBefore.getValue().empty()) {
+    mlir::PassManager pm(&context);
+
+    // Enable verification if requested.
+    if (verifyEach || options.verifyEachPass) {
+      pm.enableVerifier();
+    }
+
+    // Parse pipeline string (e.g., "builtin.module(canonicalize,cse)").
+    if (failed(mlir::parsePassPipeline(passPipelineBefore, pm))) {
+      llvm::errs() << "Failed to parse pass pipeline: " << passPipelineBefore
+                   << "\n";
+      return 1;
+    }
+
+    // Run the pipeline.
+    if (failed(pm.run(*moduleRef))) {
+      llvm::errs() << "Pass pipeline execution failed\n";
+      return 1;
+    }
+  }
+
+  // Run the user's transform function.
+  try {
+    transformFn(*moduleRef);
+  } catch (const std::exception &e) {
+    llvm::errs() << "Transform function threw exception: " << e.what() << "\n";
+    return 1;
+  }
+
+  // Run pass pipeline after user transform if specified.
+  if (!passPipelineAfter.getValue().empty()) {
+    mlir::PassManager pm(&context);
+
+    // Enable verification if requested.
+    if (verifyEach || options.verifyEachPass) {
+      pm.enableVerifier();
+    }
+
+    // Parse pipeline string (e.g., "builtin.module(canonicalize,cse)").
+    if (failed(mlir::parsePassPipeline(passPipelineAfter, pm))) {
+      llvm::errs() << "Failed to parse pass pipeline: " << passPipelineAfter
+                   << "\n";
+      return 1;
+    }
+
+    // Run the pipeline.
+    if (failed(pm.run(*moduleRef))) {
+      llvm::errs() << "Pass pipeline execution failed\n";
+      return 1;
+    }
+  }
+
+  // Write output if requested.
+  if (options.printOutput) {
+    auto outputFile = mlir::openOutputFile(outputFilename, &errorMessage);
+    if (!outputFile) {
+      llvm::errs() << "Error opening output file: " << errorMessage << "\n";
+      return 1;
+    }
+
+    // Choose output format (bytecode or text).
+    if (emitBytecode || options.emitBytecode) {
+      mlir::BytecodeWriterConfig bytecodeConfig;
+      if (failed(mlir::writeBytecodeToFile(*moduleRef, outputFile->os(),
+                                           bytecodeConfig))) {
+        llvm::errs() << "Failed to write bytecode output\n";
+        return 1;
+      }
+    } else {
+      // Text output with default formatting.
+      moduleRef->print(outputFile->os());
+    }
+
+    // Keep output file only if write succeeded.
+    outputFile->keep();
+  }
+
+  return 0;
+}
+
+// Pattern-based transform helper.
+// Applies patterns using greedy rewrite driver.
+//
+// Args:
+//   argc, argv: Command line arguments (uses llvm::cl for parsing)
+//   populatePatterns: Function that adds patterns to the set
+//   options: Harness configuration options
+//
+// Returns: 0 on success, non-zero on failure
+inline int runMlirPatternHarness(
+    int argc, char **argv,
+    std::function<void(mlir::RewritePatternSet &)> populatePatterns,
+    TransformHarnessOptions options = {}) {
+  // Wrap pattern application in a transform function.
+  return runMlirTransformHarness(
+      argc, argv,
+      [&](mlir::ModuleOp module) {
+        mlir::RewritePatternSet patterns(module.getContext());
+        populatePatterns(patterns);
+
+        // Apply patterns greedily until fixpoint.
+        (void)mlir::applyPatternsGreedily(module, std::move(patterns));
+      },
+      options);
+}
+
+} // namespace mlir::iree_compiler
+
+// Convenience macro to define main() with output printing.
+#define MLIR_TRANSFORM_MAIN(transformFn)                                       \
+  int main(int argc, char **argv) {                                            \
+    return mlir::iree_compiler::runMlirTransformHarness(argc, argv,            \
+                                                        transformFn, {});      \
+  }
+
+// Convenience macro to define main() without output printing.
+#define MLIR_TRANSFORM_MAIN_NO_PRINT(transformFn)                              \
+  int main(int argc, char **argv) {                                            \
+    return mlir::iree_compiler::runMlirTransformHarness(                       \
+        argc, argv, transformFn, {.printOutput = false});                      \
+  }
+
+// Convenience macro for pattern-based transforms.
+// Usage: MLIR_PATTERN_MAIN(MyPattern) or MLIR_PATTERN_MAIN(Pat1, Pat2, Pat3)
+#define MLIR_PATTERN_MAIN(...)                                                 \
+  int main(int argc, char **argv) {                                            \
+    return mlir::iree_compiler::runMlirPatternHarness(                         \
+        argc, argv,                                                            \
+        [](mlir::RewritePatternSet &patterns) {                                \
+          patterns.add<__VA_ARGS__>(patterns.getContext());                    \
+        },                                                                     \
+        {});                                                                   \
+  }
+
+// Convenience macro for pattern-based transforms without output printing.
+#define MLIR_PATTERN_MAIN_NO_PRINT(...)                                        \
+  int main(int argc, char **argv) {                                            \
+    return mlir::iree_compiler::runMlirPatternHarness(                         \
+        argc, argv,                                                            \
+        [](mlir::RewritePatternSet &patterns) {                                \
+          patterns.add<__VA_ARGS__>(patterns.getContext());                    \
+        },                                                                     \
+        {.printOutput = false});                                               \
+  }
+
+// Bring common namespaces into scope so user code looks like normal IREE code.
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+#endif // IREE_COMPILER_TOOLS_MLIRTRANSFORMHARNESS_H_

--- a/compiler/src/iree/compiler/Tools/MlirTransformHarnessDemo.cpp
+++ b/compiler/src/iree/compiler/Tools/MlirTransformHarnessDemo.cpp
@@ -1,0 +1,30 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Demo of iree/compiler/Tools/MlirTransformHarness.h usage.
+// Can be used with iree-bazel-try for one-shot MLIR transforms.
+
+#include "iree/compiler/Tools/MlirTransformHarness.h"
+
+// Demo 1: Count operations
+void countOperations(ModuleOp module) {
+  int count = 0;
+  module.walk([&](Operation *op) { count++; });
+  llvm::outs() << "Total operations: " << count << "\n";
+}
+
+// Demo 2: Print operation names
+void printOperationNames(ModuleOp module) {
+  module.walk([](Operation *op) { llvm::outs() << op->getName() << "\n"; });
+}
+
+// Demo 3: Add module attribute
+void addModuleAttribute(ModuleOp module) {
+  module->setAttr("demo.processed", mlir::UnitAttr::get(module.getContext()));
+}
+
+// Use the first demo by default
+MLIR_TRANSFORM_MAIN(countOperations)

--- a/compiler/src/iree/compiler/Tools/MlirTransformHarnessDemo.mlir
+++ b/compiler/src/iree/compiler/Tools/MlirTransformHarnessDemo.mlir
@@ -1,0 +1,6 @@
+// Test input for MlirTransformHarnessDemo
+func.func @demo_function(%arg0: i32, %arg1: i32) -> i32 {
+  %0 = arith.addi %arg0, %arg1 : i32
+  %1 = arith.muli %0, %arg0 : i32
+  return %1 : i32
+}

--- a/configure_bazel.py
+++ b/configure_bazel.py
@@ -70,8 +70,8 @@ def cmake_bool_is_true(value):
 
 
 def get_hal_driver_defaults():
-    """Get HAL driver defaults matching CMake logic (CMakeLists.txt:275-318)."""
-    defaults_enabled = True  # IREE_HAL_DRIVER_DEFAULTS
+    """Get HAL driver defaults matching CMake option(IREE_HAL_DRIVER_*) definitions."""
+    defaults_enabled = True  # Matches IREE_HAL_DRIVER_DEFAULTS in CMakeLists.txt
 
     return {
         "AMDGPU": False,

--- a/docs/website/docs/developers/building/bazel.md
+++ b/docs/website/docs/developers/building/bazel.md
@@ -20,9 +20,18 @@ This page walks through building IREE from source using the
 
 === ":fontawesome-brands-linux: Linux"
 
-    1. Install Bazel, matching IREE's
-        [`.bazelversion`](https://github.com/iree-org/iree/blob/main/.bazelversion)
-        by following the
+    1. **Recommended:** Install [bazelisk](https://github.com/bazelbuild/bazelisk)
+        to automatically use the correct Bazel version from
+        [`.bazelversion`](https://github.com/iree-org/iree/blob/main/.bazelversion):
+
+        ```shell
+        # Via Go (if installed)
+        go install github.com/bazelbuild/bazelisk@latest
+
+        # Or download binary from GitHub releases
+        ```
+
+        **Alternative:** Install Bazel 7.3.1 manually by following the
         [official docs](https://bazel.build/install).
 
     2. Install a compiler such as Clang (GCC is not fully supported).
@@ -52,10 +61,16 @@ This page walks through building IREE from source using the
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
         ```
 
-    2. Install Bazel, matching IREE's
-        [`.bazelversion`](https://github.com/iree-org/iree/blob/main/.bazelversion)
-        by following the [official docs](https://bazel.build/install/os-x) or
-        via Homebrew:
+    2. **Recommended:** Install [bazelisk](https://github.com/bazelbuild/bazelisk)
+        to automatically use the correct Bazel version from
+        [`.bazelversion`](https://github.com/iree-org/iree/blob/main/.bazelversion):
+
+        ```shell
+        brew install bazelisk
+        ```
+
+        **Alternative:** Install Bazel 7.3.1 manually by following the
+        [official docs](https://bazel.build/install/os-x) or via Homebrew:
 
         ```shell
         brew install bazel
@@ -74,9 +89,22 @@ This page walks through building IREE from source using the
         You can simplify installation by using a package manager like
         [Scoop](https://scoop.sh/) or [Chocolatey](https://chocolatey.org/).
 
-    1. Install Bazel, matching IREE's
-        [`.bazelversion`](https://github.com/iree-org/iree/blob/main/.bazelversion)
-        by following the [official docs](https://bazel.build/install/windows).
+    1. **Recommended:** Install [bazelisk](https://github.com/bazelbuild/bazelisk)
+        to automatically use the correct Bazel version from
+        [`.bazelversion`](https://github.com/iree-org/iree/blob/main/.bazelversion):
+
+        ```powershell
+        # Via Scoop
+        scoop install bazelisk
+
+        # Via Chocolatey
+        choco install bazelisk
+
+        # Or download binary from GitHub releases
+        ```
+
+        **Alternative:** Install Bazel 7.3.1 manually by following the
+        [official docs](https://bazel.build/install/windows).
 
         Also install [MSYS2](https://www.msys2.org/) by following Bazel's documentation.
 
@@ -97,82 +125,106 @@ This page walks through building IREE from source using the
 
 ## :octicons-rocket-16: Quickstart: clone and build
 
-### Clone
-
-Use [Git](https://git-scm.com/) to clone the IREE repository and initialize its
-submodules:
+**TL;DR** - Copy and paste this to get started:
 
 ```shell
+# Clone and setup
 git clone https://github.com/iree-org/iree.git
 cd iree
 git submodule update --init
+python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+
+# Add tools to PATH (from repo root)
+export PATH="$PWD/build_tools/bin:$PATH"
+
+# Configure once
+iree-bazel-configure
+
+# Build and test
+iree-bazel-build //tools:iree-compile
+iree-bazel-test //...
 ```
 
-Configure Bazel:
+!!! tip "Building with CUDA?"
 
-```shell
-# This generates a `configured.bazelrc` file by analyzing your environment.
-# Skipping this step will make it difficult to select your platform/compiler.
-python3 configure_bazel.py
-```
+    Enable GPU drivers before configure:
 
-=== ":fontawesome-brands-linux: Linux"
+    ```shell
+    IREE_HAL_DRIVER_CUDA=ON iree-bazel-configure
+    ```
 
-    (No Linux-specific tips for configuring)
+    Requires CUDA toolkit installed separately.
 
-=== ":fontawesome-brands-apple: macOS"
+!!! note "Driver configuration is sticky"
 
-    (No macOS-specific tips for configuring)
+    Re-run `iree-bazel-configure` whenever you change `IREE_HAL_DRIVER_*` settings.
 
-=== ":fontawesome-brands-windows: Windows"
+!!! tip "Working with Claude Code?"
 
-    !!! tip
+    All `iree-bazel-*` tools provide machine-readable documentation via `--agent_md`:
+
+    ```shell
+    # Generate documentation for Claude
+    iree-bazel-configure --agent_md >> CLAUDE.local.md
+    ```
+
+    This appends concise tool documentation to your local Claude instructions,
+    teaching Claude how to use the `iree-bazel-*` tools in your project.
+
+### Detailed steps
+
+1. **Clone the repository:**
+
+    ```shell
+    git clone https://github.com/iree-org/iree.git
+    cd iree
+    git submodule update --init
+    ```
+
+    !!! tip "Windows: Short paths"
 
         Clone to a short path like `C:\projects\` to avoid issues with Windows
         maximum path lengths (260 characters).
 
-    !!! tip
+2. **Install Python dependencies:**
 
-        `configure_bazel.py` only detects that you have Windows and will output
-        the default `--config=windows` to `configured.bazelrc`, which assumes
-        the latest version of MSVC. To avoid some warnings, you may want to
-        replace it with (for example) `--config=msvc2022`.
+    ```shell
+    python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+    ```
 
-### Build
+3. **Add wrapper tools to PATH:**
 
-Run all tests:
+    ```shell
+    export PATH="$PWD/build_tools/bin:$PATH"
+    ```
 
-```shell
-bazel test -k //...
-```
+    The `iree-bazel-*` wrapper tools simplify common workflows and provide sensible
+    defaults for local development. Run from the IREE repository root.
 
-Run all tests _except_ those that require CUDA:
+4. **Configure once per worktree:**
 
-```shell
-bazel test -k //... \
-    --iree_drivers=local-sync,local-task,vulkan \
-    --test_tag_filters="-driver=cuda,-target=cuda" \
-    --build_tag_filters="-driver=cuda,-target=cuda"
-```
+    ```shell
+    iree-bazel-configure
+    ```
 
-Run all tests _except_ those that require a GPU (any API):
+    This detects your platform/compiler and creates configuration files
+    (`configured.bazelrc` and `user.bazelrc`). Re-run this command to change
+    driver settings or after major environment changes.
 
-```shell
-bazel test -k //... \
-    --iree_drivers=local-sync,local-task,vulkan \
-    --test_tag_filters="-driver=vulkan,-driver=metal,-driver=cuda,-target=cuda" \
-    --build_tag_filters="-driver=cuda,-target=cuda"
-```
+5. **Build and test:**
 
-!!! tip
+    ```shell
+    # Build specific targets
+    iree-bazel-build //tools:iree-compile
 
-    See the
-    [`build_tools/bazel/build_test_all.sh`](https://github.com/iree-org/iree/blob/main/build_tools/bazel/build_test_all.sh)
-    script for examples of other flags and environment variables that can be
-    used to configure what Bazel runs.
+    # Run all tests
+    iree-bazel-test //...
 
-In general, build artifacts will be under the `bazel-bin` directory at the top
-level.
+    # Run tests in a specific directory
+    iree-bazel-test //runtime/...
+    ```
+
+Build artifacts are under the `bazel-bin/` directory, test logs under `bazel-testlogs/`.
 
 ## :octicons-gear-16: Local development configuration
 
@@ -183,10 +235,13 @@ bazel build --config=localdev //tools/...
 bazel test --config=localdev //runtime/...
 ```
 
+!!! note
+
+    The `iree-bazel-*` wrapper tools use `--config=localdev` by default, so you
+    don't need to specify it manually.
+
 This enables several optimizations:
 
-- **Persistent disk cache** at `~/.cache/bazel-iree/` (survives reboots, shared
-  across worktrees)
 - **Skymeld** (merged analysis/execution phases for faster multi-target builds)
 - **Ramdisk sandbox** on Linux (reduces I/O bottleneck with many CPU cores)
 
@@ -196,8 +251,13 @@ and works on all platforms.
 
 ## :octicons-pencil-16: Optional `user.bazelrc`
 
+!!! note
+
+    `iree-bazel-configure` creates `user.bazelrc` automatically with platform-specific
+    defaults (including disk cache location). You can customize it further as shown below.
+
 You can put a `user.bazelrc` at the root of the repository for personal
-customizations (ignored by git). For example, to always use localdev settings:
+customizations (ignored by git). For example:
 
 === ":fontawesome-brands-linux: Linux"
 
@@ -235,12 +295,138 @@ customizations (ignored by git). For example, to always use localdev settings:
     # Always use localdev optimizations
     build --config=localdev
 
-    # Override disk cache path to avoid Windows path length issues.
-    # The default ~/.cache/bazel-iree can exceed the 260 character limit.
-    build:localdev --disk_cache=c:/bazelcache
-
+    # Debug config for Windows
     build:debug --compilation_mode=dbg --copt=/O2 --per_file_copt=iree@/Od --strip=never
     ```
+
+## :octicons-tools-16: Bazel Wrapper Tools
+
+IREE provides wrapper scripts in `build_tools/bin/` that simplify common Bazel workflows:
+
+**Setup:**
+
+```shell
+# Add to your PATH (in ~/.bashrc or similar)
+export PATH="$PATH:/path/to/iree/build_tools/bin"
+```
+
+**Available tools:**
+
+- `iree-bazel-configure` - Initial Bazel setup (run once per worktree)
+- `iree-bazel-build [target]` - Build with optimized defaults
+    (supports `-w` watch mode)
+- `iree-bazel-test [target]` - Run tests with configured drivers
+    (supports `-w` watch mode)
+- `iree-bazel-run <target> [-- args]` - Build and execute from current directory
+    (supports `-w` watch mode)
+- `iree-bazel-query <expr>` - Query the build graph
+- `iree-bazel-try <file>` - Compile/run C++ snippets without BUILD files
+- `iree-bazel-fuzz <target>` - Run fuzzer with corpus management
+
+**Examples:**
+
+```shell
+# Configure with CUDA support
+IREE_HAL_DRIVER_CUDA=ON iree-bazel-configure
+
+# Build compiler tools
+iree-bazel-build //tools:iree-compile
+
+# Run all tests (using configured drivers)
+iree-bazel-test //...
+
+# Reconfigure to enable multiple drivers
+IREE_HAL_DRIVER_CUDA=ON IREE_HAL_DRIVER_VULKAN=ON iree-bazel-configure
+
+# Run tool from current directory
+iree-bazel-run //tools:iree-compile -- input.mlir -o output.vmfb
+
+# Quick C++ experiment
+iree-bazel-try -e '#include "iree/base/api.h"
+int main() { return iree_status_is_ok(iree_ok_status()) ? 0 : 1; }'
+```
+
+**Watch mode:**
+
+Add `-w` or `--watch` to automatically rebuild/retest on file changes:
+
+```shell
+# Rebuild on changes
+iree-bazel-build -w //tools:iree-compile
+
+# Rerun tests on changes (great for TDD)
+iree-bazel-test -w //runtime/src/iree/base:status_test
+
+# Rebuild and restart binary on changes
+iree-bazel-run -w //tools:iree-opt -- input.mlir
+```
+
+Watch mode uses [ibazel](https://github.com/bazelbuild/bazel-watcher) which must
+be installed separately:
+
+```shell
+go install github.com/bazelbuild/bazel-watcher/cmd/ibazel@latest
+```
+
+!!! note "Bazel server lock behavior"
+
+    Watch mode holds the Bazel server lock while the binary runs (necessary for
+    ibazel to control process lifecycle). Normal mode releases the lock after
+    building, allowing parallel builds in other shells.
+
+**Environment variables:**
+
+- `IREE_BAZEL_CACHE_DIR`: Bazel disk cache location
+    (default: `~/.cache/bazel-iree`)
+- `IREE_HAL_DRIVER_*`: Enable/disable HAL drivers
+    (configure-time, matches CMake)
+    - `IREE_HAL_DRIVER_CUDA=ON`: Enable CUDA driver
+    - `IREE_HAL_DRIVER_VULKAN=ON`: Enable Vulkan driver
+    - Values: ON/YES/TRUE/Y/1 or OFF/NO/FALSE/N/0
+- `IREE_FUZZ_CACHE`: Fuzzer corpus cache
+    (default: `~/.cache/iree-fuzz-cache`)
+- `IREE_FUZZ_CORPUS`: Fuzzer dictionaries
+    (default: `~/.cache/iree-fuzz-corpus`)
+
+**Tips:**
+
+- Add `-v` flag to see the exact Bazel command being executed
+- Wrappers use `--config=localdev` by default for faster local iteration
+- Run `<tool> --help` for detailed usage information
+
+## :octicons-book-16: Advanced: Under the Hood
+
+### Wrapper → Raw Bazel mapping
+
+The wrapper tools are thin shells around standard Bazel commands. Here's what
+they do:
+
+| Wrapper | Equivalent Raw Command |
+|---------|------------------------|
+| `iree-bazel-build //foo` | `bazel build --config=localdev //foo` |
+| `iree-bazel-build -w //foo` | `ibazel build --config=localdev //foo` |
+| `iree-bazel-test //...` | `bazel test --config=localdev //...` |
+| `iree-bazel-test -w //...` | `ibazel test --config=localdev //...` |
+| `iree-bazel-run //foo` | Build + exec (releases lock) |
+| `iree-bazel-run -w //foo` | `ibazel run --run_under="cd $PWD && " //foo` |
+| `iree-bazel-configure` | `python3 configure_bazel.py` + create `user.bazelrc` |
+
+**Debugging wrappers:** Use `-v` or `--verbose` flag to print the exact Bazel
+command being executed.
+
+**For CI/scripts:** Raw `bazel` commands work fine. Wrappers are optional
+helpers for local development.
+
+### Configuration files
+
+- `configured.bazelrc` - Written by `configure_bazel.py` (platform detection,
+  driver settings)
+- `user.bazelrc` - Created by `iree-bazel-configure` (disk cache location,
+  custom configs)
+- `build_tools/bazel/iree.bazelrc` - Main IREE configuration (localdev, GPU,
+  etc.)
+
+All three files are loaded automatically by Bazel in this order.
 
 ## What's next?
 
@@ -249,7 +435,7 @@ customizations (ignored by git). For example, to always use localdev settings:
 Build all of IREE's 'tools' directory:
 
 ```shell
-bazel build tools/...
+bazel build //tools/...
 ```
 
 Check out what was built:

--- a/docs/website/docs/developers/building/bazel.md
+++ b/docs/website/docs/developers/building/bazel.md
@@ -174,15 +174,36 @@ bazel test -k //... \
 In general, build artifacts will be under the `bazel-bin` directory at the top
 level.
 
-## :octicons-gear-16: Recommended `user.bazelrc`
+## :octicons-gear-16: Local development configuration
 
-You can put a user.bazelrc at the root of the repository and it will be ignored
-by git.
+For faster local development iteration, use the `--config=localdev` flag:
+
+```shell
+bazel build --config=localdev //tools/...
+bazel test --config=localdev //runtime/...
+```
+
+This enables several optimizations:
+
+- **Persistent disk cache** at `~/.cache/bazel-iree/` (survives reboots, shared
+  across worktrees)
+- **Skymeld** (merged analysis/execution phases for faster multi-target builds)
+- **Ramdisk sandbox** on Linux (reduces I/O bottleneck with many CPU cores)
+
+The `localdev` config is defined in
+[`build_tools/bazel/iree.bazelrc`](https://github.com/iree-org/iree/blob/main/build_tools/bazel/iree.bazelrc)
+and works on all platforms.
+
+## :octicons-pencil-16: Optional `user.bazelrc`
+
+You can put a `user.bazelrc` at the root of the repository for personal
+customizations (ignored by git). For example, to always use localdev settings:
 
 === ":fontawesome-brands-linux: Linux"
 
     ```shell
-    build --disk_cache=/tmp/bazel-cache
+    # Always use localdev optimizations
+    build --config=localdev
 
     # Use --config=debug to compile IREE and LLVM without optimizations
     # and with assertions enabled.
@@ -196,7 +217,8 @@ by git.
 === ":fontawesome-brands-apple: macOS"
 
     ```shell
-    build --disk_cache=/tmp/bazel-cache
+    # Always use localdev optimizations
+    build --config=localdev
 
     # Use --config=debug to compile IREE and LLVM without optimizations
     # and with assertions enabled.
@@ -210,7 +232,13 @@ by git.
 === ":fontawesome-brands-windows: Windows"
 
     ```shell
-    build --disk_cache=c:/bazelcache
+    # Always use localdev optimizations
+    build --config=localdev
+
+    # Override disk cache path to avoid Windows path length issues.
+    # The default ~/.cache/bazel-iree can exceed the 260 character limit.
+    build:localdev --disk_cache=c:/bazelcache
+
     build:debug --compilation_mode=dbg --copt=/O2 --per_file_copt=iree@/Od --strip=never
     ```
 

--- a/runtime/src/iree/testing/BUILD.bazel
+++ b/runtime/src/iree/testing/BUILD.bazel
@@ -6,7 +6,7 @@
 
 # Testing utilities for IREE.
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -62,5 +62,43 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:flags",
         "@com_google_googletest//:gtest",
+    ],
+)
+
+iree_runtime_cc_library(
+    name = "gtest_harness",
+    testonly = True,
+    hdrs = ["gtest_harness.h"],
+    deps = [
+        ":gtest",
+        ":gtest_main",
+        "//runtime/src/iree/base",
+    ],
+)
+
+iree_runtime_cc_library(
+    name = "gbenchmark_harness",
+    testonly = True,
+    hdrs = ["gbenchmark_harness.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "@com_google_benchmark//:benchmark",
+        "@com_google_benchmark//:benchmark_main",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "gtest_harness_demo",
+    srcs = ["gtest_harness_demo.cc"],
+    deps = [
+        ":gtest_harness",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "gbenchmark_harness_demo",
+    srcs = ["gbenchmark_harness_demo.cc"],
+    deps = [
+        ":gbenchmark_harness",
     ],
 )

--- a/runtime/src/iree/testing/gbenchmark_harness.h
+++ b/runtime/src/iree/testing/gbenchmark_harness.h
@@ -1,0 +1,49 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Minimal harness for one-shot Google Benchmark experiments via iree-bazel-try.
+// Uses the standard Google Benchmark C++ API with IREE types available.
+//
+// Basic benchmark:
+//   iree-bazel-try -e '
+//   #include "iree/testing/gbenchmark_harness.h"
+//   void BM_Noop(benchmark::State& state) {
+//     for (auto _ : state) {}
+//   }
+//   BENCHMARK(BM_Noop);
+//   '
+//
+// With IREE allocator:
+//   iree-bazel-try -e '
+//   #include "iree/testing/gbenchmark_harness.h"
+//   void BM_Alloc(benchmark::State& state) {
+//     for (auto _ : state) {
+//       void* p = NULL;
+//       iree_allocator_malloc(iree_allocator_system(), 1024, &p);
+//       DoNotOptimize(p);
+//       iree_allocator_free(iree_allocator_system(), p);
+//     }
+//   }
+//   BENCHMARK(BM_Alloc);
+//   '
+//
+// The harness handles:
+// - Google Benchmark inclusion and main() via benchmark_main
+// - IREE base types (iree_allocator_t, iree_status_t, etc.)
+// - Common benchmark utilities (DoNotOptimize, ClobberMemory)
+
+#ifndef IREE_TESTING_GBENCHMARK_HARNESS_H_
+#define IREE_TESTING_GBENCHMARK_HARNESS_H_
+
+#include "benchmark/benchmark.h"
+#include "iree/base/api.h"
+
+// Bring common benchmark utilities into scope for convenience.
+using ::benchmark::ClobberMemory;
+using ::benchmark::DoNotOptimize;
+using ::benchmark::State;
+
+#endif  // IREE_TESTING_GBENCHMARK_HARNESS_H_

--- a/runtime/src/iree/testing/gbenchmark_harness_demo.cc
+++ b/runtime/src/iree/testing/gbenchmark_harness_demo.cc
@@ -1,0 +1,36 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Demo of iree/testing/gbenchmark_harness.h usage.
+// Can be used with iree-bazel-try for one-shot benchmarking.
+
+#include "iree/testing/gbenchmark_harness.h"
+
+static void BM_Noop(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(state.iterations());
+  }
+}
+BENCHMARK(BM_Noop);
+
+static void BM_SystemAllocator(benchmark::State& state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  for (auto _ : state) {
+    void* ptr = NULL;
+    iree_allocator_malloc(allocator, 1024, &ptr);
+    benchmark::DoNotOptimize(ptr);
+    iree_allocator_free(allocator, ptr);
+  }
+}
+BENCHMARK(BM_SystemAllocator);
+
+static void BM_StatusCreation(benchmark::State& state) {
+  for (auto _ : state) {
+    iree_status_t status = iree_make_status(IREE_STATUS_OK);
+    benchmark::DoNotOptimize(status);
+  }
+}
+BENCHMARK(BM_StatusCreation);

--- a/runtime/src/iree/testing/gtest_harness.h
+++ b/runtime/src/iree/testing/gtest_harness.h
@@ -1,0 +1,53 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Minimal harness for one-shot gtest experiments via iree-bazel-try.
+// Includes gtest, status matchers, and common usings for convenient tests.
+//
+// Basic test:
+//   iree-bazel-try -e '
+//   #include "iree/testing/gtest_harness.h"
+//   TEST(Quick, StatusOk) {
+//     IREE_EXPECT_OK(iree_ok_status());
+//   }
+//   '
+//
+// With status matchers:
+//   iree-bazel-try -e '
+//   #include "iree/testing/gtest_harness.h"
+//   TEST(StatusTest, Matchers) {
+//     EXPECT_THAT(iree_ok_status(), IsOk());
+//     EXPECT_THAT(iree_make_status(IREE_STATUS_INVALID_ARGUMENT),
+//                 StatusIs(StatusCode::kInvalidArgument));
+//   }
+//   '
+//
+// The harness handles:
+// - gtest/gmock inclusion and main() via gtest_main
+// - IREE status matchers (IsOk, StatusIs, IsOkAndHolds)
+// - Common test assertion macros (IREE_EXPECT_OK, IREE_ASSERT_OK)
+
+#ifndef IREE_TESTING_GTEST_HARNESS_H_
+#define IREE_TESTING_GTEST_HARNESS_H_
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+// Bring common test utilities into scope for convenience.
+using iree::Status;
+using iree::StatusCode;
+using iree::StatusOr;
+using iree::testing::status::IsOk;
+using iree::testing::status::IsOkAndHolds;
+using iree::testing::status::StatusIs;
+using ::testing::_;
+using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::Ne;
+using ::testing::Not;
+
+#endif  // IREE_TESTING_GTEST_HARNESS_H_

--- a/runtime/src/iree/testing/gtest_harness_demo.cc
+++ b/runtime/src/iree/testing/gtest_harness_demo.cc
@@ -1,0 +1,27 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Demo of iree/testing/gtest_harness.h usage.
+// Can be used with iree-bazel-try for one-shot testing.
+
+#include "iree/testing/gtest_harness.h"
+
+TEST(GTestHarnessDemo, StatusOk) { IREE_EXPECT_OK(iree_ok_status()); }
+
+TEST(GTestHarnessDemo, StatusMatchers) {
+  EXPECT_THAT(iree_ok_status(), IsOk());
+  EXPECT_THAT(iree_make_status(IREE_STATUS_INVALID_ARGUMENT),
+              StatusIs(StatusCode::kInvalidArgument));
+}
+
+TEST(GTestHarnessDemo, AllocatorSystem) {
+  iree_allocator_t allocator = iree_allocator_system();
+  void* ptr = NULL;
+  iree_status_t status = iree_allocator_malloc(allocator, 1024, &ptr);
+  IREE_EXPECT_OK(status);
+  EXPECT_NE(ptr, nullptr);
+  iree_allocator_free(allocator, ptr);
+}


### PR DESCRIPTION
Introduces a suite of wrapper tools in build_tools/bin/ that provide a
unified interface for IREE's Bazel builds:

- iree-bazel-configure: Platform detection and HAL driver configuration
  with environment variable support matching CMake conventions
- iree-bazel-build|test|run: Build, test, and run wrappers with watch
  mode support (-w flag) for rapid iteration
- iree-bazel-try: Quick compilation and execution of C/C++ snippets
  against IREE runtime with automatic dependency inference
- iree-bazel-query|fuzz: Query and fuzzing tool wrappers
- iree-bazel-lib: Shared library infrastructure for all tools

Key improvements:
- Driver configuration via environment variables (IREE_HAL_DRIVER_CUDA=ON)
- Watch mode for continuous rebuilds during development
- Simplified workflow: configure once, then build/test/run
- Automatic dependency resolution for experimentation with iree-bazel-try
- Consistent command-line interface across all tools
- --agent_md flag for easily adding to CLAUDE.local.md/etc

To support iree-bazel-try this commit adds three new harnesses for rapid
development:
1. gtest_harness.h - Google Test with IREE status matchers
2. gbenchmark_harness.h - Google Benchmark with IREE base types
3. MlirTransformHarness.h - MLIR transformation experiments w/ I/O

The MLIR harness uses standard MLIR patterns (mlir::openInputFile,
parseSourceFile) for transparent .mlir/.mlirbc support, llvm::cl for flag
parsing, and supports pass pipelines before/after transforms via
--pass-pipeline-before/--pass-pipeline-after flags.

Required some updates to configure_bazel.py to read HAL driver settings
from environment variables and write --iree_drivers flag to
configured.bazelrc, matching CMake's driver selection logic. In the
future I'll be cleaning up the --iree_drivers flag and adding some more
flags so that we have a greater equivalence between CMake and Bazel for
selecting feature subsets.  A 'localdev' bazel config for faster local iteration
was added to be used by the tools (or --config=localdev) that consistently
handles:
- Persistent disk cache to speed up clean builds
- Skymeld for better parallelism
- Ramdisk sandbox to reduce I/O bottleneck Support for 'mold' config
  required routing a CI flag around it.

Website documentation is updated to recommend bazelisk for version
management (as our CI uses) and documents the new tool-based workflow with
quickstart examples. Raw bazel instructions are left in as an advanced
section.
