### PR TITLE
[LinalgExt] Add map_gather e2e tests for CPU/VMVX/ROCM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -300,6 +300,8 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
         *ctx);
     IREE::LinalgExt::MapScatterOp::attachInterface<
         AllParallelAsPartitionableLoops<IREE::LinalgExt::MapScatterOp>>(*ctx);
+    IREE::LinalgExt::MapGatherOp::attachInterface<
+        AllParallelAsPartitionableLoops<IREE::LinalgExt::MapGatherOp>>(*ctx);
   });
   registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
     tensor::PadOp::attachInterface<

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -19,6 +19,7 @@ ALL_SRCS = enforce_glob(
         "attention.mlir",
         "attention_i1_mask_encoding.mlir",
         "gather.mlir",
+        "map_gather.mlir",
         "map_scatter.mlir",
         "scan.mlir",
         "scatter.mlir",
@@ -69,6 +70,7 @@ VMVX_SRCS = enforce_glob(
     [
         "arg_compare.mlir",
         "gather.mlir",
+        "map_gather.mlir",
         "map_scatter.mlir",
         "scan.mlir",
         "scatter.mlir",
@@ -109,6 +111,7 @@ LLVM_GPU_SRCS = enforce_glob(
         "attention.mlir",
         "attention_i1_mask.mlir",
         "attention_i1_mask_encoding.mlir",
+        "map_gather.mlir",
         "map_scatter.mlir",
     ],
 )
@@ -134,6 +137,7 @@ ROCM_HIP_SRCS = enforce_glob(
     [
         "arg_compare.mlir",
         "gather.mlir",
+        "map_gather.mlir",
         "map_scatter.mlir",
         "scan.mlir",
         "scatter.mlir",
@@ -175,6 +179,7 @@ iree_check_single_backend_test_suite(
             "attention.mlir",
             "attention_i1_mask.mlir",
             "attention_i1_mask_encoding.mlir",
+            "map_gather.mlir",
             "map_scatter.mlir",
             "top-k.mlir",
         ],
@@ -201,6 +206,7 @@ iree_check_single_backend_test_suite(
             "attention.mlir",
             "attention_i1_mask.mlir",
             "attention_i1_mask_encoding.mlir",
+            "map_gather.mlir",
             "map_scatter.mlir",
             "top-k.mlir",
         ],

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_check_single_backend_test_suite(
     "attention.mlir"
     "attention_i1_mask_encoding.mlir"
     "gather.mlir"
+    "map_gather.mlir"
     "map_scatter.mlir"
     "scan.mlir"
     "scatter.mlir"
@@ -57,6 +58,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "arg_compare.mlir"
     "gather.mlir"
+    "map_gather.mlir"
     "map_scatter.mlir"
     "scan.mlir"
     "scatter.mlir"
@@ -100,6 +102,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "arg_compare.mlir"
     "gather.mlir"
+    "map_gather.mlir"
     "map_scatter.mlir"
     "scan.mlir"
     "scatter.mlir"

--- a/tests/e2e/linalg_ext_ops/map_gather.mlir
+++ b/tests/e2e/linalg_ext_ops/map_gather.mlir
@@ -1,0 +1,54 @@
+func.func @copy_like() {
+  %source = util.unfoldable_constant dense<123.0> : tensor<4x16x64xf32>
+  %output = tensor.empty() : tensor<4x16x64xf32>
+  %padding = arith.constant 0.0 : f32
+  %0 = iree_linalg_ext.map_gather %source into %output {
+    ^bb0(%idx0: index, %idx1: index, %idx2: index):
+      iree_linalg_ext.yield %idx0, %idx1, %idx2, %padding : index, index, index, f32
+  } : tensor<4x16x64xf32> into tensor<4x16x64xf32> -> tensor<4x16x64xf32>
+  check.expect_almost_eq(%0, %source) : tensor<4x16x64xf32>
+  return
+}
+
+func.func @expand_shape_like() {
+  %source = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]> : tensor<16xf32>
+  %padding = arith.constant 0.0 : f32
+  %output = tensor.empty() : tensor<4x4xf32>
+  %result = iree_linalg_ext.map_gather %source into %output {
+  ^bb0(%idx0: index, %idx1: index):
+    %linear = affine.linearize_index disjoint [%idx0, %idx1] by (4, 4) : index
+    iree_linalg_ext.yield %linear, %padding : index, f32
+  } : tensor<16xf32> into tensor<4x4xf32> -> tensor<4x4xf32>
+  %expected = tensor.expand_shape %source [[0, 1]] output_shape [4, 4] : tensor<16xf32> into tensor<4x4xf32>
+  check.expect_almost_eq(%result, %expected) : tensor<4x4xf32>
+  return
+}
+
+func.func @collapse_shape_like() {
+  %source = util.unfoldable_constant dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]> : tensor<4x4xi32>
+  %padding = arith.constant 0 : i32
+  %output = tensor.empty() : tensor<16xi32>
+  %result = iree_linalg_ext.map_gather %source into %output {
+  ^bb0(%idx0: index):
+    %2:2 = affine.delinearize_index %idx0 into (4, 4) : index, index
+    iree_linalg_ext.yield %2#0, %2#1, %padding : index, index, i32
+  } : tensor<4x4xi32> into tensor<16xi32> -> tensor<16xi32>
+  %expected = tensor.collapse_shape %source [[0, 1]] : tensor<4x4xi32> into tensor<16xi32>
+  check.expect_eq(%result, %expected) : tensor<16xi32>
+  return
+}
+
+func.func @pad_slice_like() {
+  // Source is 4 elements, output is 8 elements (with padding for out-of-bounds)
+  %source = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>
+  %padding = arith.constant 0.0 : f32
+  %output = tensor.empty() : tensor<8xf32>
+  %result = iree_linalg_ext.map_gather %source into %output {
+  ^bb0(%idx0: index):
+    // Identity mapping - indices 0-3 are in-bounds, 4-7 get padding
+    iree_linalg_ext.yield %idx0, %padding : index, f32
+  } : tensor<4xf32> into tensor<8xf32> -> tensor<8xf32>
+  %expected = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0]> : tensor<8xf32>
+  check.expect_almost_eq(%result, %expected) : tensor<8xf32>
+  return
+}


### PR DESCRIPTION
It attaches PartitionableLoops interfaces to the op and adds e2e tests for map_gather op on CPU/VMVX/ROCM.
No additional lit tests are added because they are templated and identical to other LinalgExt ops. Adding lit tests do not provide additional value because all the code paths are covered via other LinalgExt op tests.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>