### PR TITLE
[Encoding] Propagate (Un)SetEncodingOp with dynamic encoding dims

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
@@ -79,6 +79,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgInterfaces",
         "@llvm-project//mlir:LinalgUtils",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     MLIRIR
     MLIRInferTypeOpInterface
     MLIRLinalgDialect
+    MLIRLinalgInterfacesIncGenLib
     MLIRLinalgUtils
     MLIRSupport
     MLIRTensorDialect

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -10,7 +10,10 @@
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -49,6 +52,23 @@ static Type getContractionInputTypeWithSignedness(OpBuilder &builder,
   return elemType;
 }
 
+/// Extract dynamic dimension values for a linalg operation in loop order.
+/// Returns values only for dimensions that are dynamic.
+static SmallVector<Value> getDynamicLoopDims(OpBuilder &builder,
+                                             linalg::LinalgOp linalgOp) {
+  SmallVector<Range> loopRanges =
+      linalgOp.createLoopRanges(builder, linalgOp.getLoc());
+
+  SmallVector<Value> dynamicDims;
+  for (Range &range : loopRanges) {
+    // OpFoldResult is either Value (dynamic) or Attribute (static).
+    if (auto value = dyn_cast<Value>(range.size)) {
+      dynamicDims.push_back(value);
+    }
+  }
+  return dynamicDims;
+}
+
 FailureOr<OpEncodingProperties>
 SerializableAttr::getEncodingProperties(Operation *op) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
@@ -57,7 +77,7 @@ SerializableAttr::getEncodingProperties(Operation *op) {
   }
 
   MLIRContext *ctx = op->getContext();
-  OpBuilder builder(ctx);
+  OpBuilder builder(op);
 
   OpEncodingProperties props;
   SmallVector<Type> elemTypes;
@@ -65,11 +85,14 @@ SerializableAttr::getEncodingProperties(Operation *op) {
   SmallVector<int64_t> iterationSizes = linalgOp.getStaticLoopRanges();
   EncodingOpType opType;
 
+  // Extract dynamic loop dimensions.
+  SmallVector<Value> dynamicDims = getDynamicLoopDims(builder, linalgOp);
+
   auto addEncoding = [&](int64_t operandIndex) {
     return EncodingProperties{EncodingAttr::get(ctx, operandIndex, opType,
                                                 elemTypes, maps,
                                                 iterationSizes),
-                              /*dynamicValues=*/{}};
+                              dynamicDims};
   };
 
   // Return encoding properties for contraction operations.

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/BUILD.bazel
@@ -27,10 +27,12 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgUtils",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/CMakeLists.txt
@@ -21,11 +21,13 @@ iree_cc_library(
     "Utils.cpp"
   DEPS
     LLVMSupport
+    MLIRAnalysis
     MLIRArithDialect
     MLIRIR
     MLIRInferTypeOpInterface
     MLIRLinalgDialect
     MLIRLinalgUtils
+    MLIRTensorDialect
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/DispatchCreation/PropagateEncodings.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/PropagateEncodings.cpp
@@ -46,6 +46,9 @@ bubbleUpSetEncodingOp(RewriterBase &rewriter, OpOperand *propagationSource,
                                        "not able to determine propagation "
                                        "attributes for operands and results");
   }
+  // Carry through the encoding dims from the original set_encoding op.
+  propagationEncodings->encodingDims =
+      llvm::to_vector(encodingOp.getEncodingDims());
   Operation *targetOp = target.getOwner();
   if (!IREE::Flow::isNonNullAndOutsideDispatch(encodingOp) ||
       !IREE::Flow::isNonNullAndOutsideDispatch(targetOp)) {

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
@@ -537,3 +537,178 @@ util.func public @dont_propagate_non_projected_permutation(%arg0: tensor<?x4096x
 // CHECK:         iree_encoding.unset_encoding
 // CHECK:         tensor.empty
 // CHECK:         linalg.generic
+
+// -----
+
+// Test that bubble-up works with encoding_dims when they dominate the genericOp.
+// Here, the encoding_dims are function arguments, so they always dominate.
+
+#map_bubble = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map_bubble1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map_bubble2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_bubble3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_bubble4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#encoding_bubble = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_bubble2, #map_bubble3, #map_bubble4]>
+util.func public @bubble_through_dequant_with_encoding_dims(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>,
+    %m: index, %n: index, %k: index) -> tensor<2x11008x128xf32, #encoding_bubble> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_bubble>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map_bubble, #map_bubble1, #map_bubble1, #map_bubble],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    %13 = iree_encoding.set_encoding %11 encoding_dims{%m, %n, %k} : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding_bubble>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding_bubble>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding_bubble>
+}
+
+// CHECK-DAG:   #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[$ENCODING_IBMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP3]]], #[[MAP2]]]>
+// CHECK-DAG:   #[[$ENCODING_BMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP4]]], #[[MAP2]]]>
+// CHECK-LABEL: @bubble_through_dequant_with_encoding_dims
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>,
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<2x11008xf32>, %[[ARG2:.+]]: tensor<2x11008xf32>,
+// CHECK-SAME:    %[[M:.+]]: index, %[[N:.+]]: index, %[[K:.+]]: index
+// CHECK-DAG:   %[[SET_ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<2x11008x128xi8> -> tensor<2x11008x128xi8, #[[$ENCODING_IBMAP]]>
+// CHECK-DAG:   %[[SET_ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<2x11008xf32> -> tensor<2x11008xf32, #[[$ENCODING_BMAP]]>
+// CHECK-DAG:   %[[SET_ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<2x11008xf32> -> tensor<2x11008xf32, #[[$ENCODING_BMAP]]>
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32, #[[$ENCODING]]>
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING0]], %[[SET_ENCODING1]], %[[SET_ENCODING2]] : {{.*}} outs(%[[INIT]] :
+// CHECK:         flow.return %[[DEQUANT]]
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]]
+
+// -----
+
+// Test that bubble-up works with encoding_dims that need rematerialization.
+// The encoding_dims are computed from the generic output via tensor.dim, but
+// can be rematerialized as tensor.dim on the inputs (which fold to constants
+// for static dimensions).
+
+#map_remat = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map_remat1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map_remat2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_remat3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_remat4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#encoding_remat = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_remat2, #map_remat3, #map_remat4]>
+util.func public @bubble_with_rematerialized_encoding_dims(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>) -> tensor<2x11008x128xf32, #encoding_remat> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_remat>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map_remat, #map_remat1, #map_remat1, #map_remat],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    // encoding_dims are computed from the output, but can be rematerialized
+    // from the first input (which then fold to constants).
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %m = tensor.dim %11, %c0 : tensor<2x11008x128xf32>
+    %n = tensor.dim %11, %c1 : tensor<2x11008x128xf32>
+    %k = tensor.dim %11, %c2 : tensor<2x11008x128xf32>
+    %13 = iree_encoding.set_encoding %11 encoding_dims{%m, %n, %k} : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding_remat>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding_remat>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding_remat>
+}
+
+// The tensor.dim ops are rematerialized from the first input, folding to constants.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32]
+// CHECK-LABEL: @bubble_with_rematerialized_encoding_dims
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>,
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<2x11008xf32>, %[[ARG2:.+]]: tensor<2x11008xf32>
+// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:   %[[C11008:.+]] = arith.constant 11008 : index
+// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:   %[[SET_ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[C2]], %[[C11008]], %[[C128]]}
+// CHECK-DAG:   %[[SET_ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] encoding_dims{%[[C2]], %[[C11008]], %[[C128]]}
+// CHECK-DAG:   %[[SET_ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] encoding_dims{%[[C2]], %[[C11008]], %[[C128]]}
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32, #[[$ENCODING]]>
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING0]], %[[SET_ENCODING1]], %[[SET_ENCODING2]] : {{.*}} outs(%[[INIT]] :
+// CHECK:         flow.return %[[DEQUANT]]
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]]
+
+// -----
+
+// Test that bubble-up through generic works with recursive rematerialization
+// when encoding_dims use tensor.dim on a dominating tensor. Since the dominating
+// tensor is a function argument (outside the dispatch), both the tensor.dim and
+// set_encoding ops can be hoisted outside the dispatch.
+
+#map_dom = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map_dom1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map_dom2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map_dom3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map_dom4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#encoding_dom = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_dom2, #map_dom3, #map_dom4]>
+util.func public @bubble_with_recursive_rematerialization(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>,
+    %dominating: tensor<?x?xf32>) -> tensor<2x11008x128xf32, #encoding_dom> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_dom>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map_dom, #map_dom1, #map_dom1, #map_dom],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    // encoding_dim uses tensor.dim on a dominating tensor - can be rematerialized
+    %c0 = arith.constant 0 : index
+    %m = tensor.dim %dominating, %c0 : tensor<?x?xf32>
+    %c11008 = arith.constant 11008 : index
+    %c128 = arith.constant 128 : index
+    %13 = iree_encoding.set_encoding %11 encoding_dims{%m, %c11008, %c128} : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding_dom>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding_dom>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding_dom>
+}
+
+// The set_encoding is bubbled through the generic. Since encoding_dims use
+// tensor.dim on a dominating tensor (function argument), both the tensor.dim
+// and set_encoding ops can be hoisted outside the dispatch.
+// CHECK-LABEL: @bubble_with_recursive_rematerialization
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:   %[[C11008:.+]] = arith.constant 11008 : index
+// CHECK:       %[[DIM:.+]] = tensor.dim %{{.*}}, %[[C0]]
+// CHECK-DAG:   iree_encoding.set_encoding %{{.*}} encoding_dims{%[[DIM]], %[[C11008]], %[[C128]]}
+// CHECK-DAG:   iree_encoding.set_encoding %{{.*}} encoding_dims{%[[DIM]], %[[C11008]], %[[C128]]}
+// CHECK-DAG:   iree_encoding.set_encoding %{{.*}} encoding_dims{%[[DIM]], %[[C11008]], %[[C128]]}
+// CHECK:       flow.dispatch.region
+// CHECK:         tensor.empty() : tensor<2x11008x128xf32,
+// CHECK:         linalg.generic
+// CHECK:         flow.return
+// CHECK:       }

--- a/compiler/src/iree/compiler/DispatchCreation/test/propagate_encodings.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/propagate_encodings.mlir
@@ -29,3 +29,169 @@ util.func @dont_propagate_unserialized_layout(%src: tensor<1024x?xf16>) -> tenso
 // CHECK:         %[[CAST:.+]] = tensor.cast %[[SRC]] : tensor<1024x?xf16> to tensor<?x512xf16>
 // CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[CAST]] : tensor<?x512xf16> -> tensor<?x512xf16, #[[$ENCODING]]>
 // CHECK:         util.return %[[SET_ENCODING]]
+
+// -----
+
+// Test that propagation works with encoding_dims when they dominate the insertion point.
+// The encoding_dims are function arguments, so they always dominate.
+
+#encoding_with_dims = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_encoding_with_encoding_dims(%src: tensor<1024x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x512xf16, #encoding_with_dims> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%m, %n, %k} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_with_dims>
+  util.return %0 : tensor<?x512xf16, #encoding_with_dims>
+}
+
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_encoding_with_encoding_dims(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-SAME:    %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:    %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:    %[[K:[a-zA-Z0-9]+]]: index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works with encoding_dims that need rematerialization.
+// Here, the encoding_dims are computed from the cast result, but can be
+// rematerialized as tensor.dim on the cast source (which then folds to constants
+// for static dimensions).
+
+#encoding_remat = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_rematerialized_encoding_dims(%src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding_remat> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %c0 = arith.constant 0 : index
+  // This dim is computed from %cast, but can be rematerialized from %src
+  %m = tensor.dim %cast, %c0 : tensor<?x512xf16>
+  %c512 = arith.constant 512 : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%m, %c512} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_remat>
+  util.return %0 : tensor<?x512xf16, #encoding_remat>
+}
+
+// The tensor.dim is rematerialized as tensor.dim on %src, which folds to constant 1024.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_rematerialized_encoding_dims(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[C512:.+]] = arith.constant 512 : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[C1024]], %[[C512]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works when encoding_dims use tensor.dim on the
+// propagation source. The dim is rematerialized from the new source tensor.
+
+#encoding_dim_on_source = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_dim_on_propagation_source(
+    %src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding_dim_on_source> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %c0 = arith.constant 0 : index
+  // This dim depends on the cast result (propagation source).
+  // It gets rematerialized to use the new source (src).
+  %m = tensor.dim %cast, %c0 : tensor<?x512xf16>
+  %c512 = arith.constant 512 : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%m, %c512} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_dim_on_source>
+  util.return %0 : tensor<?x512xf16, #encoding_dim_on_source>
+}
+
+// Propagation succeeds because tensor.dim on propagation source (cast) is
+// rematerialized to use the new source (src). Since dim 0 is statically known
+// (1024), a constant is created instead of tensor.dim.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_dim_on_propagation_source(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-DAG:     %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[C512:.+]] = arith.constant 512 : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[C1024]], %[[C512]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]]
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works when encoding_dims are arithmetic ops with
+// dominating operands. The arith.addi can be cloned since its operands
+// (function arguments) dominate the new insertion point.
+
+#encoding_arith = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_arith_encoding_dims(
+    %src: tensor<1024x?xf16>, %m: index, %n: index) -> tensor<?x512xf16, #encoding_arith> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  // This arith.addi can be cloned since %m and %n dominate the cast
+  %sum = arith.addi %m, %n : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%sum} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_arith>
+  util.return %0 : tensor<?x512xf16, #encoding_arith>
+}
+
+// The arith.addi is cloned at the new insertion point.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_arith_encoding_dims(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-SAME:    %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:    %[[N:[a-zA-Z0-9]+]]: index
+// CHECK:         %[[SUM:.+]] = arith.addi %[[M]], %[[N]] : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[SUM]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that propagation works when encoding_dims use tensor.dim on a tensor
+// that already dominates (not the propagation source). The tensor.dim on %src
+// already dominates the cast, so no rematerialization is needed.
+
+#encoding_dim_dominates = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_dim_on_dominating_tensor(
+    %src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding_dim_dominates> {
+  %c1 = arith.constant 1 : index
+  // tensor.dim on %src - this dominates the cast already
+  %dynamic_dim = tensor.dim %src, %c1 : tensor<1024x?xf16>
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%dynamic_dim} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_dim_dominates>
+  util.return %0 : tensor<?x512xf16, #encoding_dim_dominates>
+}
+
+// The tensor.dim on %src already dominates, so it's used directly.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_dim_on_dominating_tensor(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         %[[DIM:.+]] = tensor.dim %[[SRC]], %[[C1]]
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[DIM]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]
+
+// -----
+
+// Test that recursive rematerialization works for arith ops with operands
+// that can be recursively rematerialized. The arith.muli uses %dim which is
+// computed from %cast. Since %dim is a tensor.dim on the propagation source,
+// it gets rematerialized from %src, and then arith.muli is cloned.
+
+#encoding_arith_recursive = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
+util.func @propagate_with_recursive_rematerialization(
+    %src: tensor<1024x?xf16>, %multiplier: index) -> tensor<?x512xf16, #encoding_arith_recursive> {
+  %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
+  %c0 = arith.constant 0 : index
+  // %dim depends on %cast
+  %dim = tensor.dim %cast, %c0 : tensor<?x512xf16>
+  // arith.muli can be cloned after recursively rematerializing %dim from %src.
+  %product = arith.muli %dim, %multiplier : index
+  %0 = iree_encoding.set_encoding %cast encoding_dims{%product} : tensor<?x512xf16> -> tensor<?x512xf16, #encoding_arith_recursive>
+  util.return %0 : tensor<?x512xf16, #encoding_arith_recursive>
+}
+
+// Propagation succeeds with recursive rematerialization of tensor.dim and arith.muli.
+// Since dim 0 of src (1024) is static, a constant is created instead of tensor.dim.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.layout{{.*}}
+// CHECK-LABEL: @propagate_with_recursive_rematerialization(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<1024x?xf16>
+// CHECK-SAME:    %[[MULT:[a-zA-Z0-9]+]]: index
+// CHECK:         %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK:         %[[PRODUCT:.+]] = arith.muli %[[MULT]], %[[C1024]] : index
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]] encoding_dims{%[[PRODUCT]]} : tensor<1024x?xf16> -> tensor<1024x?xf16, #[[$ENCODING]]>
+// CHECK:         %[[CAST:.+]] = tensor.cast %[[SET_ENCODING]] : tensor<1024x?xf16, #[[$ENCODING]]> to tensor<?x512xf16, #[[$ENCODING]]>
+// CHECK:         util.return %[[CAST]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding.mlir
@@ -49,20 +49,22 @@ util.func public @matmul_f32f32f32_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tens
 //  CHECK-DAG: #[[OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP1]], #[[MAP2]], #[[MAP3]]], iteration_sizes = [?, ?, ?]>
 //      CHECK: util.func public @matmul_f32f32f32_dynamic(
 // CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>, %[[ARG1:.+]]: tensor<?x?xf32>, %[[ARG2:.+]]: tensor<?x?xf32>
-//      CHECK:   %[[LHS:.+]] = iree_encoding.set_encoding %[[ARG0]]
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//      CHECK:   %[[LHS:.+]] = iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:       tensor<?x?xf32, #[[LHS_ENCODING]]>
-//      CHECK:   %[[RHS:.+]] = iree_encoding.set_encoding %[[ARG1]]
+//      CHECK:   %[[RHS:.+]] = iree_encoding.set_encoding %[[ARG1]] encoding_dims{%[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:       tensor<?x?xf32, #[[RHS_ENCODING]]>
-//      CHECK:   %[[OUTS:.+]] = iree_encoding.set_encoding %[[ARG2]]
+//      CHECK:   %[[OUTS:.+]] = iree_encoding.set_encoding %[[ARG2]] encoding_dims{%[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:       tensor<?x?xf32, #[[OUT_ENCODING]]>
 //      CHECK:   %[[MATMUL:.+]] = linalg.matmul
 // CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
 // CHECK-SAME:       outs(%[[OUTS]] :
-//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
-//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[MATMUL]] : tensor<?x?xf32, #[[OUT_ENCODING]]> -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
+//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[MATMUL]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+// CHECK-SAME:       tensor<?x?xf32, #[[OUT_ENCODING]]> -> tensor<?x?xf32>
 //      CHECK:   util.return %[[RESULT]]
 
 // -----
@@ -295,22 +297,24 @@ util.func public @batch_matmul_f32f32f32_dynamic(%arg0 : tensor<?x?x?xf32>, %arg
 //  CHECK-DAG: #[[OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP1]], #[[MAP2]], #[[MAP3]]], iteration_sizes = [?, ?, ?, ?]>
 //      CHECK: util.func public @batch_matmul_f32f32f32_dynamic(
 // CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?x?xf32>, %[[ARG1:.+]]: tensor<?x?x?xf32>, %[[ARG2:.+]]: tensor<?x?x?xf32>
-//      CHECK:   %[[LHS:.+]] = iree_encoding.set_encoding %[[ARG0]]
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//  CHECK-DAG:   %[[BATCH:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[ARG0]], %[[C2]]
+//  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C2]]
+//      CHECK:   %[[LHS:.+]] = iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[BATCH]], %[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:       tensor<?x?x?xf32, #[[LHS_ENCODING]]>
-//      CHECK:   %[[RHS:.+]] = iree_encoding.set_encoding %[[ARG1]]
+//      CHECK:   %[[RHS:.+]] = iree_encoding.set_encoding %[[ARG1]] encoding_dims{%[[BATCH]], %[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:       tensor<?x?x?xf32, #[[RHS_ENCODING]]>
-//      CHECK:   %[[OUTS:.+]] = iree_encoding.set_encoding %[[ARG2]]
+//      CHECK:   %[[OUTS:.+]] = iree_encoding.set_encoding %[[ARG2]] encoding_dims{%[[BATCH]], %[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:       tensor<?x?x?xf32, #[[OUT_ENCODING]]>
 //      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
 // CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
 // CHECK-SAME:       outs(%[[OUTS]] :
-//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
-//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
-//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C2]]
-//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[BATCH_MATMUL]] : tensor<?x?x?xf32, #[[OUT_ENCODING]]> -> tensor<?x?x?xf32>{%[[D0]], %[[D1]], %[[D2]]}
+//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[BATCH_MATMUL]] encoding_dims{%[[BATCH]], %[[M]], %[[N]], %[[K]]}
+// CHECK-SAME:       tensor<?x?x?xf32, #[[OUT_ENCODING]]> -> tensor<?x?x?xf32>
 //      CHECK:   util.return %[[RESULT]]
 
 // -----
@@ -1144,9 +1148,14 @@ util.func public @broadcasting_dequant_op(%arg0: !hal.buffer_view, %arg1: !hal.b
 // CHECK-DAG:  %[[ARG1_D2:.+]] = hal.buffer_view.dim<%[[ARG1]] : !hal.buffer_view>[2] : index
 // CHECK:      %{{.+}} = flow.dispatch.region
 // CHECK:        %[[BCAST:.+]] = linalg.generic
-// CHECK:        %[[LHS:.+]] = iree_encoding.set_encoding %[[BCAST]] : tensor<?x?x?xi32>
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:    %[[M:.+]] = tensor.dim %{{.+}}, %[[C0]]
+// CHECK-DAG:    %[[K:.+]] = tensor.dim %{{.+}}, %[[C1]]
+// CHECK-DAG:    %[[N:.+]] = tensor.dim %{{.+}}, %[[C1]]
+// CHECK:        %[[LHS:.+]] = iree_encoding.set_encoding %[[BCAST]] encoding_dims{%[[ARG1_D0]], %[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:     -> tensor<?x?x?xi32, #[[LHS_ENCODING]]>
-// CHECK:        %[[RHS:.+]] = iree_encoding.set_encoding %{{.+}} : tensor<?x?x?xi32>
+// CHECK:        %[[RHS:.+]] = iree_encoding.set_encoding %{{.+}} encoding_dims{%[[ARG1_D0]], %[[M]], %[[N]], %[[K]]}
 // CHECK-SAME:     -> tensor<?x?x?xi32, #[[RHS_ENCODING]]>
 // CHECK:        %[[INIT:.+]] = tensor.empty({{.+}}) :  tensor<?x?x?xi32, #[[OUT_ENCODING]]>
 // CHECK:        %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[INIT]]
@@ -1154,7 +1163,8 @@ util.func public @broadcasting_dequant_op(%arg0: !hal.buffer_view, %arg1: !hal.b
 // CHECK-SAME:     indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP4]]]
 // CHECK-SAME:     ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME:    outs(%[[FILL]]
-// CHECK:        %[[UNSET:.+]] = iree_encoding.unset_encoding %[[GEMM]]{{.+}} -> tensor<?x?x?xi32>{%[[ARG1_D0]], %[[ARG0_D0]], %[[ARG1_D1]]}
+// CHECK:        %[[UNSET:.+]] = iree_encoding.unset_encoding %[[GEMM]] encoding_dims{%[[ARG1_D0]], %[[M]], %[[N]], %[[K]]}
+// CHECK-SAME:     -> tensor<?x?x?xi32>{%[[ARG1_D0]], %[[ARG0_D0]], %[[ARG1_D1]]}
 // CHECK:        flow.return %[[UNSET]]
 
 // -----
@@ -1258,6 +1268,46 @@ util.func public @scaled_contraction_f4_f4_f8_f8_f32(
 // CHECK-ALL-SAME:      outs(%[[C_ENC]]
 // CHECK:             %[[RESULT:.*]] = iree_encoding.unset_encoding %[[GENERIC]] : tensor<256x512xf32, #[[$ENC4]]> -> tensor<256x512xf32>
 // CHECK-ALL:         util.return %[[RESULT]] : tensor<256x512xf32>
+
+// -----
+
+// Test dynamic scaled_matmul to verify encoding_dims are populated
+util.func public @scaled_contraction_dynamic(
+    %a : tensor<?x?x32xf4E2M1FN>, %b : tensor<?x?x32xf4E2M1FN>,
+    %a_scales : tensor<?x?xf8E8M0FNU>, %b_scales : tensor<?x?xf8E8M0FNU>,
+    %c : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+                       affine_map<(d0, d1, d2, d3) -> (d1, d2)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%a, %b, %a_scales, %b_scales : tensor<?x?x32xf4E2M1FN>, tensor<?x?x32xf4E2M1FN>, tensor<?x?xf8E8M0FNU>, tensor<?x?xf8E8M0FNU>)
+      outs(%c : tensor<?x?xf32>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f4E2M1FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %12 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %13 = arith.scaling_extf %in_0, %in_2 : f4E2M1FN, f8E8M0FNU to f32
+    %14 = arith.mulf %12, %13 : f32
+    %15 = arith.addf %out, %14 : f32
+    linalg.yield %15 : f32
+  } -> tensor<?x?xf32>
+  util.return %0 : tensor<?x?xf32>
+}
+//      CHECK: util.func public @scaled_contraction_dynamic
+// CHECK-SAME:   %[[A:[a-zA-Z0-9]+]]: tensor<?x?x32xf4E2M1FN>, %[[B:[a-zA-Z0-9]+]]: tensor<?x?x32xf4E2M1FN>
+// CHECK-SAME:   %[[AS:[a-zA-Z0-9]+]]: tensor<?x?xf8E8M0FNU>, %[[BS:[a-zA-Z0-9]+]]: tensor<?x?xf8E8M0FNU>
+// CHECK-SAME:   %[[C:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[A]], %{{.*}}
+//  CHECK-DAG:   %[[K:.+]] = tensor.dim %[[A]], %{{.*}}
+//  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[B]], %{{.*}}
+//      CHECK:   %[[A_ENC:.+]] = iree_encoding.set_encoding %[[A]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+//      CHECK:   %[[B_ENC:.+]] = iree_encoding.set_encoding %[[B]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+//      CHECK:   %[[AS_ENC:.+]] = iree_encoding.set_encoding %[[AS]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+//      CHECK:   %[[BS_ENC:.+]] = iree_encoding.set_encoding %[[BS]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+//      CHECK:   %[[C_ENC:.+]] = iree_encoding.set_encoding %[[C]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+//      CHECK:   %[[GENERIC:.+]] = linalg.generic {{.*}} ins(%[[A_ENC]], %[[B_ENC]], %[[AS_ENC]], %[[BS_ENC]] {{.*}} outs(%[[C_ENC]]
+//      CHECK:   iree_encoding.unset_encoding %[[GENERIC]] encoding_dims{%[[M]], %[[N]], %[[K]]}
 
 // -----
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
+        "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Encoding::IR
+    iree::compiler::Dialect::Encoding::Utils
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -33,7 +34,8 @@ namespace {
 /// 1. Are encoded by casting their types to the encoded types.
 /// 2. Are able to directly use the source of any producer unset_encoding ops
 ///    for propagation, and do not need to re-set the encoding.
-static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
+static FailureOr<IREE::Encoding::PropagationResult>
+propagateThroughEncodingCastableOp(
     RewriterBase &builder, Operation *op,
     IREE::Encoding::PropagationEncoding encodings,
     OpOperand *propagationSource) {
@@ -43,6 +45,22 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
       propagationSource->get().getDefiningOp<IREE::Encoding::UnsetEncodingOp>();
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPoint(op);
+
+  // Try to rematerialize encoding dims at the new insertion point.
+  // For bubble-up propagation through encoding castable ops (tensor.cast,
+  // tensor.collapse_shape, etc.), tensor.dim ops on the result can be
+  // recreated from the source operand. These ops have a single tensor
+  // input as their first operand.
+  Value sourceOperand = op->getOperand(0);
+  FailureOr<SmallVector<Value>> rematerializedDims =
+      IREE::Encoding::rematerializeEncodingDims(
+          builder, op, encodings.encodingDims, propagationSource->get(),
+          sourceOperand);
+  if (failed(rematerializedDims)) {
+    return failure();
+  }
+  encodings.encodingDims = *rematerializedDims;
+
   for (auto [operand, encoding] :
        llvm::zip_equal(op->getOperands(), encodings.operandEncodings)) {
     // Scalar operands do not need encodings.
@@ -72,7 +90,7 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     // Otherwise, we need to create a new set_encoding op.
     auto setEncodingOp = IREE::Encoding::SetEncodingOp::create(
         builder, op->getLoc(), encodedOperandType, operand,
-        /*encoding_dims=*/ValueRange{});
+        encodings.encodingDims);
     encodedOperands.push_back(setEncodingOp.getResult());
     result.generatedEncodingOps.push_back(setEncodingOp);
   }
@@ -101,7 +119,7 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     std::tie(std::ignore, resultDynamicDims) = decomposeMixedValues(mixedSizes);
     auto unsetEncodingOp = IREE::Encoding::UnsetEncodingOp::create(
         builder, op->getLoc(), originalResult.getType(), encodedResult,
-        resultDynamicDims, /*encoding_dims=*/ValueRange{});
+        resultDynamicDims, encodings.encodingDims);
     result.generatedEncodingOps.push_back(unsetEncodingOp);
     result.replacements.push_back(unsetEncodingOp.getResult());
   }


### PR DESCRIPTION

This PR adds support for propagating dynamic encoding_dims through encoding operations during dispatch creation:
- **`EncodingTypes.cpp`**: Extract dynamic dimension values (Batch, M, N, K) from contractions, only for dimensions that are dynamic in iteration_sizes
-  **`Utils.cpp`**: Add rematerializeEncodingDims helper to recreate encoding dims at new insertion points during propagation (handles dominance, tensor.dim remapping, pure op cloning)
-  **`HoistEncodingOps.cpp`**: Rematerialize encoding dims when bubbling up set_encoding through generic ops
-  **`EncodingExternalModels.cpp`**: Rematerialize encoding dims when propagating through tensor.cast and similar ops

**Note:** The previous version was closed automatically as I hadn't stacked it correctly: https://github.com/iree-org/iree/pull/23075