### PR TITLE
[GPU] Remove slice guard when doing pad producer fusion in FuseAndHoist

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -266,7 +266,9 @@ struct FuseTilableSliceProducers final
       return failure();
     }
     auto tilableProducer = sliceOp.getSource().getDefiningOp<TilingInterface>();
-    if (!tilableProducer) {
+    // Pad fusion is handled separately as we dont want zero slice guards that
+    // happen by default.
+    if (!tilableProducer || isa<tensor::PadOp>(tilableProducer)) {
       return failure();
     }
 
@@ -394,6 +396,12 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     patterns.add<FuseTilableSliceProducers>(context);
     tensor::populateFoldTensorEmptyPatterns(patterns);
     scf::ForallOp::getCanonicalizationPatterns(patterns, context);
+    auto zeroSliceGuard = [](tensor::ExtractSliceOp) -> std::optional<bool> {
+      // Do not use zero slice gaurd.
+      return false;
+    };
+    patterns.add<linalg::ExtractSliceOfPadTensorSwapPattern>(context,
+                                                             zeroSliceGuard);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp->emitOpError("failed to apply fusion + hoisting patterns (set 3)");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -875,3 +875,37 @@ func.func @fuse_warp_and_lane_foralls_with_coalesced_dma(%src: tensor<2x2x64xf32
 //       CHECK:     }
 //       CHECK:   } {mapping = [#gpu.thread<linear_dim_2>, #gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
 //       CHECK:   return %[[THREAD_FORALL]]
+
+
+// -----
+// Check that we dont make a zeroslice guard when fusing pad.
+#map = affine_map<(d0) -> (d0 * 64)>
+func.func @fuse_pad(%arg0: tensor<?xf16>, %arg1: index) -> tensor<128xf16> {
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = tensor.empty() : tensor<128xf16>
+  %padded = tensor.pad %arg0 low[0] high[%arg1] {
+    ^bb0(%arg10: index):
+      tensor.yield %cst : f16
+  } : tensor<?xf16> to tensor<128xf16>
+  %1 = scf.forall (%arg2) in (2) shared_outs(%arg3 = %0) -> (tensor<128xf16>) {
+    %2 = affine.apply #map(%arg2)
+    %extracted_slice = tensor.extract_slice %padded[%2] [64] [1] : tensor<128xf16> to tensor<64xf16>
+    %extracted_slice_0 = tensor.extract_slice %arg3[%2] [64] [1] : tensor<128xf16> to tensor<64xf16>
+    %3 = linalg.copy ins(%extracted_slice : tensor<64xf16>) outs(%extracted_slice_0 : tensor<64xf16>) -> tensor<64xf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %3 into %arg3[%2] [64] [1] : tensor<64xf16> into tensor<128xf16>
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return %1 : tensor<128xf16>
+}
+
+// CHECK-LABEL: func @fuse_pad
+//       CHECK:   scf.forall
+//   CHECK-NOT:     scf.if
+//       CHECK:     tensor.pad
+//       CHECK:     linalg.copy
+//       CHECK:   scf.forall.in_parallel
+//       CHECK:   return


### PR DESCRIPTION
Since we are doing structured code generation we are able to handle zero slices appropriately and don't need slice guards.
Fixes : https://github.com/iree-org/iree/issues/23028