### PR TITLE
[GPU] Add quantization inefficiency debug print for MMA heuristics.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/Support/DebugLog.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -61,6 +62,57 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const GemmSize &gemmSize) {
     assert(false && "Unhandled gemm size");
     return os << "NotSet";
   }
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const QuantizationInefficiency &inefficiency) {
+  os << "QuantizationInefficiency: ";
+  os << llvm::format("%.2f%%", inefficiency.inefficiency * 100);
+  os << " (WG=" << inefficiency.batch << "*" << inefficiency.numWGsM << "*"
+     << inefficiency.numWGsN << "=" << inefficiency.numWorkgroups;
+  os << ", WGP=" << inefficiency.numWGPs;
+  os << ", waves=" << inefficiency.numWaves << ")";
+  return os;
+}
+
+QuantizationInefficiency
+computeQuantizationInefficiency(const GPUMatmulShapeType &problem,
+                                const GPUMMASchedule &schedule,
+                                int64_t wgpCount) {
+  QuantizationInefficiency result;
+  result.numWGPs = wgpCount;
+
+  // Compute actual problem sizes
+  int64_t actualM = ShapedType::getNumElements(problem.mSizes);
+  int64_t actualN = ShapedType::getNumElements(problem.nSizes);
+  int64_t actualBatch = problem.batchSizes.empty()
+                            ? 1
+                            : ShapedType::getNumElements(problem.batchSizes);
+
+  // Compute workgroup tile sizes
+  int64_t tileSizeM = schedule.getTotalMSize() * schedule.getTotalMTileSize() *
+                      schedule.getTotalMSubgroupCount();
+  int64_t tileSizeN = schedule.getTotalNSize() * schedule.getTotalNTileSize() *
+                      schedule.getTotalNSubgroupCount();
+
+  // Number of workgroups = batch * ceil(M/tileM) * ceil(N/tileN)
+  result.batch = actualBatch;
+  result.numWGsM = llvm::divideCeil(actualM, tileSizeM);
+  result.numWGsN = llvm::divideCeil(actualN, tileSizeN);
+  result.numWorkgroups = result.batch * result.numWGsM * result.numWGsN;
+
+  // Number of waves = ceil(WG / WGP)
+  result.numWaves = llvm::divideCeil(result.numWorkgroups, wgpCount);
+
+  // Quantization inefficiency = (ceil(WG/WGP) - WG/WGP) / ceil(WG/WGP)
+  // Simplifies to: 1 - WG / (ceil(WG/WGP) * WGP)
+  int64_t totalWGPSlots = result.numWaves * wgpCount;
+  result.inefficiency =
+      (totalWGPSlots > 0)
+          ? 1.0f - static_cast<float>(result.numWorkgroups) / totalWGPSlots
+          : 0.0f;
+
+  return result;
 }
 
 static int64_t calculateOperandsSharedMemoryUsedInBytes(
@@ -671,6 +723,10 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
         getOptimalMMASchedule(problem, intrinsic, localSeeds);
 
     LDBG() << "Chosen MMA schedule:\n" << schedule;
+    if (wgpCount.has_value()) {
+      LDBG() << computeQuantizationInefficiency(problem, schedule,
+                                                wgpCount.value());
+    }
 
     auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
       int64_t lhsBitwidth = intrinsic.aType.getIntOrFloatBitWidth();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -139,6 +139,31 @@ struct GPUMMASchedule {
   }
 };
 
+/// Struct containing quantization inefficiency metrics for a schedule.
+/// Quantization inefficiency measures WGP underutilization in the last wave:
+///   inefficiency = (ceil(WG/WGP) - WG/WGP) / ceil(WG/WGP)
+/// where WG = number of workgroups, WGP = number of workgroup processors.
+struct QuantizationInefficiency {
+  float inefficiency = 0.0f;
+  int64_t numWorkgroups = 0;
+  int64_t numWGPs = 0;
+  int64_t numWaves = 0;
+  // Formula components: WG = batch * numWGsM * numWGsN
+  int64_t batch = 1;
+  int64_t numWGsM = 0;
+  int64_t numWGsN = 0;
+};
+
+/// Computes quantization inefficiency for a given problem, schedule, and
+/// WGP count. This measures the fraction of idle WGPs in the last wave.
+QuantizationInefficiency
+computeQuantizationInefficiency(const GPUMatmulShapeType &problem,
+                                const GPUMMASchedule &schedule,
+                                int64_t wgpCount);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const QuantizationInefficiency &inefficiency);
+
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
 FailureOr<GPUMMASchedule> deduceMMASchedule(


### PR DESCRIPTION
Add just the debug output to measure WGP underutilization in MMA schedule selection:
```
QuantificationInefficiency = (ceil(WG/WGP) - WG/WGP) / ceil(WG/WGP)
```
where:
`WG = batch × ceil(M/tileM) × ceil(N/tileN)`
and
`WGP is Workgroup Processors`


Enabled in debug print:
```
--debug-only=iree-codegen-gpu-heuristics
```

Example print:
```
QuantizationInefficiency: 15.79% (WG=1*32*16=512, WGP=304, waves=2)
```