### PR TITLE
[CI] Update iree-test-suite

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
+          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
           path: iree-test-suites
       - name: Install ONNX ops test suite requirements
         run: |
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
+          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
           path: iree-test-suites
       - name: Install ONNX models test suite requirements
         run: |

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
+          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
           path: iree-test-suites
           lfs: true
 
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
+          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
           path: iree-test-suites
           lfs: true
 

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
+          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
           path: iree-test-suites
       - name: Install Torch ops test suite requirements
         run: |
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: dc50625f4ac9d561f52ced410b8470b8168ed8a1
+          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
           path: iree-test-suites
           # Don't need lfs for torch models yet.
           lfs: false

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
@@ -6,7 +6,9 @@
     "--iree-llvmcpu-target-cpu=host"
   ],
   "iree_run_module_flags": [],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "InterestingShapesBiasAdd/997x997xi8_NN_bias"
+  ],
   "skip_run_tests": [
     "AB/8192x8192xf32_bench",
     "AB/4096x4096xf32_bench",

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
@@ -8,7 +8,9 @@
   "iree_run_module_flags": [
     "--device=hip"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "InterestingShapesBiasAdd/997x997xi8_NN_bias"
+  ],
   "skip_run_tests": [
     "ABPlusC/64x64xf16",
     "ATB/64x64xf16"

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
@@ -8,7 +8,9 @@
   "iree_run_module_flags": [
     "--device=hip"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "InterestingShapesBiasAdd/997x997xi8_NN_bias"
+  ],
   "skip_run_tests": [
     "ATB/64x64xf16"
   ],

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
@@ -14,9 +14,14 @@
     "ReluABPlusC/64x64xf16",
     "GeluABPlusC/64x64xf16",
     "AB/64x64xf16",
-    "AB/Nx64xf16_64xNxf16"
+    "AB/Nx64xf16_64xNxf16",
+    "InterestingShapesBiasAdd/997x997xi8_NN_bias"
   ],
-  "skip_run_tests": [],
+  "skip_run_tests": [
+    "InterestingShapesBiasAdd/1152x997xf16_matmul_997x576xf16_NN",
+    "InterestingShapesBiasAdd/6144x419xbf16_matmul_419x384xbf16_NT",
+    "InterestingShapesBiasAdd/997x997xf16_NT_bias"
+  ],
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {


### PR DESCRIPTION
This update adds new quality tests to torch_ops which include:

* Tests for GEMM with interesting shapes https://github.com/iree-org/iree-test-suites/pull/146
* Skip's compiling i8 test due to https://github.com/iree-org/iree/issues/23136
* Skip's running some vulkan tests issue here https://github.com/iree-org/iree/issues/23141

ci-extra: test_torch