### PR TITLE
Integrate torch-mlir@ac33bab4

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.h
@@ -21,10 +21,10 @@ namespace mlir::iree_compiler::TorchInput {
 // collapse instead of a generic reshape.
 struct BackendLegalOps {
   static const llvm::SmallVector<std::string> get() {
-    return {"aten.flatten.using_ints",  "aten.unflatten.int",
-            "aten.adaptive_avg_pool1d", "aten.adaptive_avg_pool2d",
-            "aten.adaptive_max_pool1d", "aten.fft_rfft",
-            "aten.convolution_backward"};
+    return {"aten.flatten.using_ints",   "aten.unflatten.int",
+            "aten.adaptive_avg_pool1d",  "aten.adaptive_avg_pool2d",
+            "aten.adaptive_max_pool1d",  "aten.fft_rfft",
+            "aten.convolution_backward", "aten.scaled_dot_product_attention"};
   };
 };
 


### PR DESCRIPTION
Spit from an already-complex LLVM integrate.