### PR TITLE
[Codegen] Add pass to remove iree_codegen.index_hint ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -147,6 +147,7 @@ iree_compiler_cc_library(
         "PropagateReshapesByExpansion.cpp",
         "ReconcileTranslationInfo.cpp",
         "RematerializeParallelOps.cpp",
+        "RemoveIndexHints.cpp",
         "RemoveSingleIterationLoop.cpp",
         "ReplaceSlowMinMaxOps.cpp",
         "ReshapePatterns.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -140,6 +140,7 @@ iree_cc_library(
     "PropagateReshapesByExpansion.cpp"
     "ReconcileTranslationInfo.cpp"
     "RematerializeParallelOps.cpp"
+    "RemoveIndexHints.cpp"
     "RemoveSingleIterationLoop.cpp"
     "ReplaceSlowMinMaxOps.cpp"
     "ReshapePatterns.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -881,6 +881,21 @@ def RematerializeParallelOpsPass :
   let summary = "Pass to rematerialize and merge parallel ops into consumers.";
 }
 
+def RemoveIndexHintsPass :
+    InterfacePass<"iree-codegen-remove-index-hints", "mlir::FunctionOpInterface"> {
+  let summary = "Remove iree_codegen.index_hint operations";
+  let description = [{
+    This pass removes all iree_codegen.index_hint operations by replacing
+    them with their input values (pass-through semantics).
+
+    Index hints are used to convey optimization information to downstream
+    passes and should be cleaned up once that information has been consumed.
+  }];
+  let dependentDialects = [
+    "IREE::Codegen::IREECodegenDialect"
+  ];
+}
+
 def RemoveSingleIterationLoopPass :
     InterfacePass<"iree-codegen-remove-single-iteration-loop", "mlir::FunctionOpInterface"> {
   let summary = "Remove distributed loop with single iteration.";

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveIndexHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveIndexHints.cpp
@@ -24,14 +24,12 @@ struct RemoveIndexHintsPass final
     FunctionOpInterface funcOp = getOperation();
     IRRewriter rewriter(funcOp.getContext());
 
-    // Collect all index_hint operations
     SmallVector<IREE::Codegen::IndexHintOp> indexHintOps;
     funcOp.walk([&](IREE::Codegen::IndexHintOp hintOp) {
       indexHintOps.push_back(hintOp);
     });
 
     for (auto hintOp : indexHintOps) {
-      // Replace hint result with the original input (pass-through)
       hintOp.getResult().replaceAllUsesWith(hintOp.getInput());
       rewriter.eraseOp(hintOp);
     }

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveIndexHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveIndexHints.cpp
@@ -1,0 +1,43 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_REMOVEINDEXHINTSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+/// Pass to remove all iree_codegen.index_hint operations by replacing them
+/// with their input values.
+struct RemoveIndexHintsPass final
+    : impl::RemoveIndexHintsPassBase<RemoveIndexHintsPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+    IRRewriter rewriter(funcOp.getContext());
+
+    // Collect all index_hint operations
+    SmallVector<IREE::Codegen::IndexHintOp> indexHintOps;
+    funcOp.walk([&](IREE::Codegen::IndexHintOp hintOp) {
+      indexHintOps.push_back(hintOp);
+    });
+
+    for (auto hintOp : indexHintOps) {
+      // Replace hint result with the original input (pass-through)
+      hintOp.getResult().replaceAllUsesWith(hintOp.getInput());
+      rewriter.eraseOp(hintOp);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -108,6 +108,7 @@ iree_lit_test_suite(
             "reductions.mlir",
             "rematerialize_parallel_ops.mlir",
             "remove_dead_allocs.mlir",
+            "remove_index_hints.mlir",
             "remove_single_iteration_loop.mlir",
             "resolve_swizzle_hints.mlir",
             "resolve_workgroup_count_hints.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -104,6 +104,7 @@ iree_lit_test_suite(
     "reductions.mlir"
     "rematerialize_parallel_ops.mlir"
     "remove_dead_allocs.mlir"
+    "remove_index_hints.mlir"
     "remove_single_iteration_loop.mlir"
     "repeated_matcher_use.mlir"
     "replace_slow_min_max_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_index_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_index_hints.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-codegen-remove-index-hints))' %s | FileCheck %s
 
-// Test: index_hint with lane_constant is removed
+// Test: index_hint with lane_constant is removed.
 // CHECK-LABEL: func.func @remove_lane_constant_hint
 // CHECK-NOT: iree_codegen.index_hint
 // CHECK: return %arg0
@@ -11,7 +11,7 @@ func.func @remove_lane_constant_hint(%arg0: index) -> index {
 
 // -----
 
-// Test: index_hint with lane_increment is removed
+// Test: index_hint with lane_increment is removed.
 // CHECK-LABEL: func.func @remove_lane_increment_hint
 // CHECK-NOT: iree_codegen.index_hint
 // CHECK: return %arg0
@@ -22,7 +22,7 @@ func.func @remove_lane_increment_hint(%arg0: index) -> index {
 
 // -----
 
-// Test: Multiple hints in sequence are all removed
+// Test: Multiple hints in sequence are all removed.
 // CHECK-LABEL: func.func @remove_multiple_hints
 // CHECK-NOT: iree_codegen.index_hint
 // CHECK: arith.addi %arg0, %arg1

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_index_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_index_hints.mlir
@@ -1,0 +1,34 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-codegen-remove-index-hints))' %s | FileCheck %s
+
+// Test: index_hint with lane_constant is removed
+// CHECK-LABEL: func.func @remove_lane_constant_hint
+// CHECK-NOT: iree_codegen.index_hint
+// CHECK: return %arg0
+func.func @remove_lane_constant_hint(%arg0: index) -> index {
+  %hint = iree_codegen.index_hint %arg0(#iree_gpu.lane_constant<16>) : index
+  return %hint : index
+}
+
+// -----
+
+// Test: index_hint with lane_increment is removed
+// CHECK-LABEL: func.func @remove_lane_increment_hint
+// CHECK-NOT: iree_codegen.index_hint
+// CHECK: return %arg0
+func.func @remove_lane_increment_hint(%arg0: index) -> index {
+  %hint = iree_codegen.index_hint %arg0(#iree_gpu.lane_increment<16>) : index
+  return %hint : index
+}
+
+// -----
+
+// Test: Multiple hints in sequence are all removed
+// CHECK-LABEL: func.func @remove_multiple_hints
+// CHECK-NOT: iree_codegen.index_hint
+// CHECK: arith.addi %arg0, %arg1
+func.func @remove_multiple_hints(%arg0: index, %arg1: index) -> index {
+  %hint0 = iree_codegen.index_hint %arg0(#iree_gpu.lane_constant<16>) : index
+  %hint1 = iree_codegen.index_hint %arg1(#iree_gpu.lane_increment<16>) : index
+  %sum = arith.addi %hint0, %hint1 : index
+  return %sum : index
+}


### PR DESCRIPTION
Adds a pass to remove iree_codegen.index_hint operations. The pass unconditionally drops all index_hint ops, and should be used once the compiler is done using them for optimizations. The ops can get in the way of later optimizations, so this pass should be used to drop them once they are no longer needed.

The pass is not added to any pipelines, because we are not generating index_hint ops anywhere yet, but this pass will be added later once index_hints start to be used.