### PR TITLE
Enforce braces around control flow statements in clang-format. 7/7.

### DIFF
--- a/compiler/.clang-format
+++ b/compiler/.clang-format
@@ -10,6 +10,7 @@
 # ordering.
 BasedOnStyle: LLVM
 AlwaysBreakTemplateDeclarations: Yes
+InsertBraces: Yes
 IncludeCategories:
   - Regex:           '^<.*\.h>'
     Priority:        1

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
@@ -31,8 +31,9 @@
     float newIn = idx >= reductionSize
                       ? -FLT_MAX
                       : (float)(inputBuffer[input_offset + idx]);
-    if (newIn == laneMax)
+    if (newIn == laneMax) {
       continue;
+    }
     laneMax = __builtin_fmaxf(newIn, laneMax);
     laneResult = newIn == laneMax ? idx : laneResult;
   }

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
@@ -31,8 +31,9 @@
     float newIn = idx >= reductionSize
                       ? -FLT_MAX
                       : (float)(inputBuffer[input_offset + idx]);
-    if (newIn == laneMax)
+    if (newIn == laneMax) {
       continue;
+    }
     laneMax = __builtin_fmaxf(newIn, laneMax);
     laneResult = newIn == laneMax ? idx : laneResult;
   }

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i32.c
@@ -25,8 +25,9 @@
     int32_t idx = warpSize * i + laneID;
     _Float16 newIn =
         idx >= reductionSize ? NEG_F16_MAX : inputBuffer[input_offset + idx];
-    if (newIn == laneMax)
+    if (newIn == laneMax) {
       continue;
+    }
     laneMax = __builtin_fmaxf16(newIn, laneMax);
     laneResult = newIn == laneMax ? idx : laneResult;
   }

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i64.c
@@ -25,8 +25,9 @@
     int32_t idx = warpSize * i + laneID;
     _Float16 newIn =
         idx >= reductionSize ? NEG_F16_MAX : inputBuffer[input_offset + idx];
-    if (newIn == laneMax)
+    if (newIn == laneMax) {
       continue;
+    }
     laneMax = __builtin_fmaxf16(newIn, laneMax);
     laneResult = newIn == laneMax ? idx : laneResult;
   }

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i32.c
@@ -24,8 +24,9 @@
     int32_t idx = warpSize * i + laneID;
     float newIn =
         idx >= reductionSize ? -FLT_MAX : inputBuffer[input_offset + idx];
-    if (newIn == laneMax)
+    if (newIn == laneMax) {
       continue;
+    }
     laneMax = __builtin_fmaxf(newIn, laneMax);
     laneResult = newIn == laneMax ? idx : laneResult;
   }

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i64.c
@@ -24,8 +24,9 @@
     int32_t idx = warpSize * i + laneID;
     float newIn =
         idx >= reductionSize ? -FLT_MAX : inputBuffer[input_offset + idx];
-    if (newIn == laneMax)
+    if (newIn == laneMax) {
       continue;
+    }
     laneMax = __builtin_fmaxf(newIn, laneMax);
     laneResult = newIn == laneMax ? idx : laneResult;
   }

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -52,9 +52,10 @@ struct BytecodeVersionParser : public llvm::cl::parser<std::optional<int64_t>> {
   bool parse(llvm::cl::Option &O, StringRef /*argName*/, StringRef arg,
              std::optional<int64_t> &v) {
     long long w;
-    if (llvm::getAsSignedInteger(arg, 10, w))
+    if (llvm::getAsSignedInteger(arg, 10, w)) {
       return O.error("Invalid argument '" + arg +
                      "', only integer is supported.");
+    }
     v = w;
     return false;
   }
@@ -264,8 +265,9 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
                                          remarksOutputFile.c_str());
     }
 
-    if (!ireeCompilerInvocationParseSource(r.inv, source))
+    if (!ireeCompilerInvocationParseSource(r.inv, source)) {
       return false;
+    }
 
     // Switch on compileMode to choose a pipeline to run.
     switch (compileMode) {
@@ -377,8 +379,9 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
       return 1;
     }
   } else {
-    if (!processBuffer(s.source))
+    if (!processBuffer(s.source)) {
       return 1;
+    }
   }
 
   ireeCompilerOutputKeep(s.output);


### PR DESCRIPTION
Braces has been mandatory for a long time and we call it out in our style guide: https://iree.dev/developers/general/contributing/#coding-style-guidelines.

Add them to clang-format so that I don't have to point it out in code reviews.

I cleaned up the codebase in the following PRs:
1. https://github.com/iree-org/iree/pull/23143
2. https://github.com/iree-org/iree/pull/23144
3. https://github.com/iree-org/iree/pull/23145
4. https://github.com/iree-org/iree/pull/23146
5. https://github.com/iree-org/iree/pull/23147
6. https://github.com/iree-org/iree/pull/23148
