### PR TITLE
[Codegen] Extend small float emulation to support f4E2M1FN types.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -108,9 +108,8 @@ public:
     Type f32Scalar = rewriter.getF32Type();
     i32Type =
         vecType ? VectorType::get(vecType.getShape(), i32Scalar) : i32Scalar;
-    smallIntType = vecType
-                       ? VectorType::get(vecType.getShape(), smallIntScalar)
-                       : smallIntScalar;
+    smallIntType = vecType ? VectorType::get(vecType.getShape(), smallIntScalar)
+                           : smallIntScalar;
     f32Type =
         vecType ? VectorType::get(vecType.getShape(), f32Scalar) : f32Scalar;
 


### PR DESCRIPTION
Generalizes the existing fp8 emulation patterns to handle 4-bit float types:

- Renamed TruncFToFP8 → TruncFToSmallFloat and ExtFFromFP8 → ExtFFromSmallFloat
- FloatEmulationHelper now takes smallFloatBitWidth parameter for i4/i8 type
- Added special handling for types without NaN (f4E2M1FN has no NaN/Inf)
- Updated comments to use generic examples (e.g., "0x80 for fp8, 0x8 for fp4")

`f4E2M1FN` format: `1 sign + 2 exp + 1 mantissa, bias = 1` Key differences from fp8:
- Overflow saturates to max (±6.0) instead of producing NaN/Inf
- Different denormal range (0.5 instead of ~1e-5)

Tests cover positive/negative arithmetic, overflow saturation, denormal handling, and underflow to zero.