### PR TITLE
[LinalgExt] Extend arg_compare to support both value and index provided ( explicit-index mode)

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1247,12 +1247,18 @@ TopkOp::reifyResultShapes(OpBuilder &b,
 LogicalResult ArgCompareOp::verify() {
   Operation *op = getOperation();
 
-  unsigned numInputVals = llvm::size(getInputs());
-  if (numInputVals != 1) {
-    return op->emitOpError(
-               "expected exactly one tensor input operand, but got ")
-           << numInputVals;
+  // The operation supports two modes based on the number of inputs:
+  // - Implicit-index mode (1 input): Computes indices from iteration variables.
+  // - Explicit-index mode (2 inputs): Uses pre-existing (value, index) pairs.
+  unsigned numInputs = llvm::size(getInputs());
+  if (numInputs < 1 || numInputs > 2) {
+    return op->emitOpError("expected 1 or 2 input operands, but got ")
+           << numInputs;
   }
+
+  bool isExplicitIndexMode = numInputs == 2;
+  ShapedType inputValueType = getInputType();
+  Type inputElemType = inputValueType.getElementType();
 
   unsigned numOutputs = getNumDpsInits();
   if (numOutputs != 2) {
@@ -1261,21 +1267,48 @@ LogicalResult ArgCompareOp::verify() {
            << numOutputs;
   }
 
-  uint64_t dim = getDimension();
-  int64_t rank = getInputRank();
-  if (dim >= rank) {
-    return op->emitOpError("reduction dimension exceeds or equals input rank. ")
-           << "got dimension: " << dim << ", but input rank is: " << rank;
-  }
-
-  ShapedType inputType = getInputType();
   auto outputValueType = getOutputValueType();
   auto outputIndexType = getOutputIndexType();
 
-  if (inputType.getElementType() != outputValueType.getElementType()) {
+  if (isExplicitIndexMode) {
+    ShapedType inputIndexType = cast<ShapedType>(getInputIndex().getType());
+
+    if (failed(verifyCompatibleShape(inputValueType, inputIndexType))) {
+      return op->emitOpError(
+                 "explicit-index mode: value and index inputs must have same "
+                 "shape. ")
+             << "Value shape: "
+             << llvm::interleaved_array(inputValueType.getShape())
+             << ", index shape: "
+             << llvm::interleaved_array(inputIndexType.getShape());
+    }
+
+    if (!isa<IntegerType, IndexType>(inputIndexType.getElementType())) {
+      return op->emitOpError(
+                 "explicit-index mode: index input must have integer or index "
+                 "element type, but got ")
+             << inputIndexType.getElementType();
+    }
+
+    if (inputIndexType.getElementType() != outputIndexType.getElementType()) {
+      return op->emitOpError(
+                 "explicit-index mode: input and output index element types "
+                 "must match. ")
+             << "Input index type: " << inputIndexType.getElementType()
+             << ", output index type: " << outputIndexType.getElementType();
+    }
+  }
+
+  if (inputValueType.getElementType() != outputValueType.getElementType()) {
     return op->emitOpError("input and output value element types must match. ")
-           << "Input type: " << inputType.getElementType()
+           << "Input type: " << inputValueType.getElementType()
            << ", output value type: " << outputValueType.getElementType();
+  }
+
+  if (!isa<IntegerType, IndexType>(outputIndexType.getElementType())) {
+    return op->emitOpError(
+               "output index must have integer or index element type, but got ")
+           << outputIndexType.getElementType();
   }
 
   if (failed(verifyCompatibleShape(outputValueType, outputIndexType))) {
@@ -1286,10 +1319,17 @@ LogicalResult ArgCompareOp::verify() {
            << llvm::interleaved_array(outputIndexType.getShape());
   }
 
+  uint64_t dim = getDimension();
+  int64_t rank = getInputRank();
+  if (dim >= rank) {
+    return op->emitOpError("reduction dimension exceeds or equals input rank. ")
+           << "got dimension: " << dim << ", but input rank is: " << rank;
+  }
+
   SmallVector<int64_t> expectedShape;
   for (int64_t i = 0; i < rank; ++i) {
     if (i != dim) {
-      expectedShape.push_back(inputType.getDimSize(i));
+      expectedShape.push_back(inputValueType.getDimSize(i));
     }
   }
   if (!llvm::equal(expectedShape, outputValueType.getShape())) {
@@ -1307,13 +1347,13 @@ LogicalResult ArgCompareOp::verify() {
     return op->emitOpError("region block should have 2 arguments, but got ")
            << numArgs;
   }
-  Type inputElemType = inputType.getElementType();
+
   Type arg0Type = block.getArgument(0).getType();
   Type arg1Type = block.getArgument(1).getType();
 
   if (arg0Type != inputElemType || arg1Type != inputElemType) {
     return op->emitOpError(
-               "comparator region arguments must match input element type. ")
+               "comparator arguments must match input value element type. ")
            << "Expected: " << inputElemType << ", but got: " << arg0Type
            << " and " << arg1Type;
   }
@@ -1358,6 +1398,11 @@ SmallVector<AffineMap> IREE::LinalgExt::ArgCompareOp::getIndexingMapsArray() {
     proj.push_back(getAffineDimExpr(i, ctx));
   }
   AffineMap resultMap = AffineMap::get(rank, 0, proj, ctx);
+
+  if (hasExplicitIndexInput()) {
+    return {inputMap, inputMap, resultMap, resultMap};
+  }
+
   return {inputMap, resultMap, resultMap};
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -852,10 +852,11 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
       return getInputs().size() == 2;
     }
 
-    // Returns the index input operand. This method should only be called when
-    // the operation is in explicit-index mode.
+    // Returns the index input operand, or nullptr if not in explicit-index mode.
     Value getInputIndex() {
-      assert(hasExplicitIndexInput() && "Only valid in explicit-index mode");
+      if (!hasExplicitIndexInput()){
+        return nullptr;
+      }
       return getDpsInputOperand(1)->get();
     }
 
@@ -877,6 +878,28 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
 
     ShapedType getOutputIndexType() {
       return cast<ShapedType>(outputIndex().getType());
+    }
+
+    // Returns the ShapedType of the index input, or nullptr if not in
+    // explicit-index mode.
+    ShapedType getInputIndexType() {
+      if (Value idx = getInputIndex()) {
+        return cast<ShapedType>(idx.getType());
+      }
+      return nullptr;
+    }
+
+    // Returns the element type of the index input, or nullptr if not in
+    // explicit-index mode.
+    Type getInputIndexElementType() {
+      if (ShapedType idxType = getInputIndexType()) {
+        return idxType.getElementType();
+      }
+      return nullptr;
+    }
+
+    Type getOutputIndexElementType() {
+      return getOutputIndexType().getElementType();
     }
 
     int64_t getInputRank() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -752,14 +752,24 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     returning both the selected value and its corresponding index. The selection
     logic is defined by a user-specified comparator region.
 
-    The comparator region receives two candidate values and returns a single `i1`
-    result indicating whether the first argument should be preferred over the second.
+    The operation supports two modes:
 
-    This region defines the sorting rule, e.g., "greater than" for argmax or
-    "less than" for argmin. It allows for generalization beyond simple argmax-style
+    1. Implicit-index mode (single input): Computes (value, index) pairs from scratch.
+       Indices are implicitly computed from the reduction dimension's iteration index
+       (using linalg.index on the reduction dimension). The comparator
+       region receives two candidate values and returns a single `i1` result indicating
+       whether the first argument should be preferred.
+
+    2. Explicit-index mode (two inputs): Reduces existing (value, index) pairs.
+       Indices are explicitly provided as input. The comparator region receives
+       two candidate values and returns `i1` to select the preferred value.
+       This mode is used to combine results from split-reduction operations.
+
+    The comparator region defines the sorting rule, e.g., "greater than" for argmax or
+    "less than" for argmin, allowing for generalization beyond simple argmax-style
     behavior.
 
-    Example (argmax over dim 1):
+    Example (implicit-index mode - argmax over dim 1):
     ```mlir
     %input = memref<2x10xf32>
     %out_val = memref<2xf32>
@@ -774,7 +784,7 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     }
     ```
 
-    Example with index_base = 5 (i.e., indices start counting from 5):
+    Example (implicit-index mode with index_base = 5):
     ```mlir
     %input = memref<2x10xf32>
     %out_val = memref<2xf32>
@@ -785,6 +795,22 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
       ins(%input : memref<2x10xf32>)
       outs(%out_val, %out_idx : memref<2xf32>, memref<2xi32>)
       index_base(%base : index) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+    }
+    ```
+
+    Example (explicit-index mode - combining partial results):
+    ```mlir
+    %partial_vals = memref<2x4xf32>
+    %partial_idxs = memref<2x4xi32>
+    %out_val = memref<2xf32>
+    %out_idx = memref<2xi32>
+    iree_linalg_ext.arg_compare
+      dimension(1)
+      ins(%partial_vals, %partial_idxs : memref<2x4xf32>, memref<2x4xi32>)
+      outs(%out_val, %out_idx : memref<2xf32>, memref<2xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
       iree_linalg_ext.yield %cmp : i1
@@ -818,6 +844,19 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
     Value getInputValue() {
       return getDpsInputOperand(0)->get();
+    }
+
+    // Returns true when the operation is in explicit-index mode, which occurs
+    // when a second input operand provides pre-computed indices.
+    bool hasExplicitIndexInput() {
+      return getInputs().size() == 2;
+    }
+
+    // Returns the index input operand. This method should only be called when
+    // the operation is in explicit-index mode.
+    Value getInputIndex() {
+      assert(hasExplicitIndexInput() && "Only valid in explicit-index mode");
+      return getDpsInputOperand(1)->get();
     }
 
     Value outputValue() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -843,7 +843,7 @@ func.func @arg_compare_explicit_index_shape_mismatch(
     %out_val: tensor<2xf32>,
     %out_idx: tensor<2xi32>
 ) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{explicit-index mode: value and index inputs must have same shape. Value shape: [2, 10], index shape: [2, 8]}}
+  // expected-error@+1 {{explicit-index mode: value and index inputs must have the same shape. Value shape: [2, 10], index shape: [2, 8]}}
   %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val, %input_idx : tensor<2x10xf32>, tensor<2x8xi32>)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -600,14 +600,15 @@ func.func @map_scatter_0D(
 
 func.func @arg_compare_invalid_too_many_inputs(
     %input_val: tensor<2x10xf32>,
+    %input_idx: tensor<2x10xi32>,
     %input_extra: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<2xi32>
 ) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{expected exactly one tensor input operand, but got 2}}
+  // expected-error@+1 {{expected 1 or 2 input operands, but got 3}}
   %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
-    ins(%input_val, %input_extra : tensor<2x10xf32>, tensor<2x10xf32>)
+    ins(%input_val, %input_idx, %input_extra : tensor<2x10xf32>, tensor<2x10xi32>, tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
@@ -730,7 +731,7 @@ func.func @arg_compare_missing_region_yield(
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
-  // expected-error@+1 {{region block should have 2 arguments}}
+  // expected-error@+1 {{region block should have 2 arguments, but got 0}}
   %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
@@ -745,7 +746,7 @@ func.func @arg_compare_invalid_region_argument_type(
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
-  // expected-error@+1 {{ comparator region arguments must match input element type. Expected: 'f32', but got: 'f32' and 'i32'}}
+  // expected-error@+1 {{comparator arguments must match input value element type. Expected: 'f32', but got: 'f32' and 'i32'}}
   %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
@@ -832,6 +833,86 @@ func.func @arg_compare_invalid_index_base_type(
       iree_linalg_ext.yield %cmp : i1
   } -> tensor<2xf32>, tensor<2xindex>
   return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_shape_mismatch(
+    %input_val: tensor<2x10xf32>,
+    %input_idx: tensor<2x8xi32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi32>
+) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{explicit-index mode: value and index inputs must have same shape. Value shape: [2, 10], index shape: [2, 8]}}
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x10xf32>, tensor<2x8xi32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_non_integer(
+    %input_val: tensor<2x10xf32>,
+    %input_idx: tensor<2x10xf32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi32>
+) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{explicit-index mode: index input must have integer or index element type, but got 'f32'}}
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x10xf32>, tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_element_type_mismatch(
+    %input_val: tensor<2x10xf32>,
+    %input_idx: tensor<2x10xi32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi64>
+) -> (tensor<2xf32>, tensor<2xi64>) {
+  // expected-error@+1 {{explicit-index mode: input and output index element types must match. Input index type: 'i32', output index type: 'i64'}}
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x10xf32>, tensor<2x10xi32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi64>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi64>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi64>
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_wrong_comparator_args_count(
+    %input_val: tensor<2x10xf32>,
+    %input_idx: tensor<2x10xi32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi32>
+) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{region block should have 2 arguments, but got 3}}
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x10xf32>, tensor<2x10xi32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
+    ^bb0(%a: f32, %b: f32, %c: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1008,6 +1008,76 @@ func.func @arg_compare_with_base(
 
 // -----
 
+func.func @arg_compare_explicit_index(
+    %input_val : tensor<2x4xf32>,
+    %input_idx : tensor<2x4xi32>,
+    %outv : tensor<2xf32>,
+    %outi : tensor<2xi32>
+) -> (tensor<2xf32>, tensor<2xi32>) {
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x4xf32>, tensor<2x4xi32>)
+    outs(%outv, %outi : tensor<2xf32>, tensor<2xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// CHECK-LABEL: func.func @arg_compare_explicit_index(
+// CHECK-SAME:   %[[INPUT_VAL:[a-zA-Z0-9_]+]]: tensor<2x4xf32>
+// CHECK-SAME:   %[[INPUT_IDX:[a-zA-Z0-9_]+]]: tensor<2x4xi32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xi32>
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.arg_compare
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT_VAL]], %[[INPUT_IDX]] : tensor<2x4xf32>, tensor<2x4xi32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xi32>)
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1 : tensor<2xf32>, tensor<2xi32>
+
+// -----
+
+func.func @arg_compare_explicit_index_with_base(
+    %input_val : tensor<2x4xf32>,
+    %input_idx : tensor<2x4xi32>,
+    %outv : tensor<2xf32>,
+    %outi : tensor<2xi32>,
+    %base : index
+) -> (tensor<2xf32>, tensor<2xi32>) {
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x4xf32>, tensor<2x4xi32>)
+    outs(%outv, %outi : tensor<2xf32>, tensor<2xi32>)
+    index_base(%base : index) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// CHECK-LABEL: func.func @arg_compare_explicit_index_with_base(
+// CHECK-SAME:   %[[INPUT_VAL:[a-zA-Z0-9_]+]]: tensor<2x4xf32>
+// CHECK-SAME:   %[[INPUT_IDX:[a-zA-Z0-9_]+]]: tensor<2x4xi32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xi32>
+// CHECK-SAME:   %[[BASE:[a-zA-Z0-9_]+]]: index
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.arg_compare
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT_VAL]], %[[INPUT_IDX]] : tensor<2x4xf32>, tensor<2x4xi32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xi32>)
+// CHECK-SAME:     index_base(%[[BASE]] : index)
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1 : tensor<2xf32>, tensor<2xi32>
+
+// -----
+
 func.func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
     -> (tensor<1024xf32>, tensor<1024xf32>) {
   %cst1 = arith.constant 1 : index


### PR DESCRIPTION
 This PR extends the `arg_compare `operation to accept an optional second input for pre-computed indices, addressing a critical limitation discovered while implementing VectorDistribute pipeline support for argmax/argmin operations.
 
## Motivation
 While working on arg_compare support along the VectorDistribute pipeline, we encountered a fundamental issue with the merge reduction phase after partial reduction. Each tile produces a (max value, index) pair, and merging them creates this pattern:
 
 ```mlir
   %19:2 = linalg.generic {
    indexing_maps = [...], iterator_types = ["reduction"]
  } ins(%18#0, %18#1 : tensor<2048xf16>, tensor<2048xi32>)
    outs(%12, %13 : tensor<f16>, tensor<i32>) {
  ^bb0(%in: f16, %in_3: i32, %out: f16, %out_4: i32):
    %20 = arith.cmpf ogt, %in, %out : f16
    %21 = arith.select %20, %in, %out : f16
    %22 = arith.select %20, %in_3, %out_4 : i32
    linalg.yield %21, %22 : f16, i32
  }
 ```
 The upstream MLIR vectorizer cannot handle this pattern. The paired-select reduction (selecting both value and index based on the same condition) doesn't fit the single-combiner model that generic vectorization expects. 
 
This PR extends arg_compare to optionally accept index inputs, enabling it to handle both:
  1. Initial argmax: Compute (value, index) from scratch using iteration variables (linalg.index)
  2. Merge reduction: Merge partial (value, index) pairs from distributed tiles

This PR is mainly update the iree_linalg_ext.arg_compare op definition and verification logic, along with roundtrip and invalid IR tests.                                                          
                                                                                                                                                                                                                      
  After this PR, there will be a few PRs about                                                                                                                                                                        
  - Add tiling support                                                                                                                                                                                                
  - Add convert_to_loops lowering support                                                                                                                                                                             
  - Update partial reduction interface support.  
  - Update e2e test.   

Refer to discord discussion for more details: https://discordapp.com/channels/689900678990135345/1461079481803608158/1461079488770212096