### PR TITLE
[Samples] Fix hal.executable.export syntax in custom dispatch samples.

### DIFF
--- a/samples/custom_dispatch/cuda/kernels/README.md
+++ b/samples/custom_dispatch/cuda/kernels/README.md
@@ -75,11 +75,11 @@ nvcc ... (TODO, see CMakeLists.txt) -o kernels_sm_80.ptx
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) attributes {workgroup_size = [64 : index, 1 : index, 1 : index]} count(%device: !hal.device, %workload: index) -> (index, index, index) {
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index
-    }
+    } attributes {workgroup_size = [64 : index, 1 : index, 1 : index]}
   }
 ```
 

--- a/samples/custom_dispatch/cuda/kernels/example.mlir
+++ b/samples/custom_dispatch/cuda/kernels/example.mlir
@@ -79,11 +79,7 @@ module @example attributes {hal.device.targets = [#cuda_target]} {
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) attributes {
-      // Certain backends (like CUDA) require a workgroup size (aka block
-      // size) to be defined ahead of time.
-      workgroup_size = [64 : index, 1 : index, 1 : index]
-    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       // This host function is used to compute the XYZ workgroup count
       // dispatched at runtime. It can query the %device for capabilities
       // and limits (shared memory size, etc). The other arguments are the
@@ -92,6 +88,10 @@ module @example attributes {hal.device.targets = [#cuda_target]} {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index
+    } attributes {
+      // Certain backends (like CUDA) require a workgroup size (aka block
+      // size) to be defined ahead of time.
+      workgroup_size = [64 : index, 1 : index, 1 : index]
     }
 
     // Similar to the above but in-place by using a read/write binding.
@@ -99,12 +99,12 @@ module @example attributes {hal.device.targets = [#cuda_target]} {
         layout(#hal.pipeline.layout<constants = 1, bindings = [
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) attributes {
-      workgroup_size = [64 : index, 1 : index, 1 : index]
-    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index
+    } attributes {
+      workgroup_size = [64 : index, 1 : index, 1 : index]
     }
 
   }  // hal.executable.source

--- a/samples/custom_dispatch/hip/kernels/example.mlir
+++ b/samples/custom_dispatch/hip/kernels/example.mlir
@@ -70,11 +70,7 @@ module @example attributes {hal.device.targets = [#rocm_target]} {
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) attributes {
-      // Certain backends (like ROCM) require a workgroup size (aka block
-      // size) to be defined ahead of time.
-      workgroup_size = [64 : index, 1 : index, 1 : index]
-    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       // This host function is used to compute the XYZ workgroup count
       // dispatched at runtime. It can query the %device for capabilities
       // and limits (shared memory size, etc). The other arguments are the
@@ -83,6 +79,10 @@ module @example attributes {hal.device.targets = [#rocm_target]} {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index
+    } attributes {
+      // Certain backends (like ROCM) require a workgroup size (aka block
+      // size) to be defined ahead of time.
+      workgroup_size = [64 : index, 1 : index, 1 : index]
     }
 
     // Similar to the above but in-place by using a read/write binding.
@@ -90,12 +90,12 @@ module @example attributes {hal.device.targets = [#rocm_target]} {
         layout(#hal.pipeline.layout<constants = 1, bindings = [
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) attributes {
-      workgroup_size = [64 : index, 1 : index, 1 : index]
-    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index
+    } attributes {
+      workgroup_size = [64 : index, 1 : index, 1 : index]
     }
 
   }  // hal.executable.source


### PR DESCRIPTION
The `hal.executable.export` assembly format requires `count` to come before `attributes`, but the HIP and CUDA custom dispatch samples had them in the wrong order.

This was a regression from commit 6dcf0864ef which restructured the workgroup count region but incorrectly updated the sample files.

Fixes #22877.