### PR TITLE
Adding overflow-safe allocation helpers to iree/base.

### DIFF
--- a/runtime/src/iree/base/BUILD.bazel
+++ b/runtime/src/iree/base/BUILD.bazel
@@ -7,6 +7,7 @@
 # Common types and utilities used in the IREE codebase.
 
 load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_fuzz", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:cc_binary_benchmark.bzl", "cc_binary_benchmark")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -53,6 +54,16 @@ iree_runtime_cc_library(
         "//build_tools/third_party/libbacktrace",
         "//runtime/src/iree/base/internal:time",
         "//runtime/src/iree/base/tracing:provider",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "allocator_test",
+    srcs = ["allocator_test.cc"],
+    deps = [
+        ":base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )
 
@@ -173,5 +184,15 @@ iree_runtime_cc_test(
         ":loop_test_hdrs",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+cc_binary_benchmark(
+    name = "allocator_benchmark",
+    srcs = ["allocator_benchmark.cc"],
+    deps = [
+        ":base",
+        "//runtime/src/iree/testing:benchmark",
+        "//runtime/src/iree/testing:benchmark_main",
     ],
 )

--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -92,6 +92,17 @@ iree_cc_library(
 
 iree_cc_test(
   NAME
+    allocator_test
+  SRCS
+    "allocator_test.cc"
+  DEPS
+    ::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_test(
+  NAME
     bitfield_test
   SRCS
     "bitfield_test.cc"

--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -91,6 +91,13 @@ static inline bool iree_host_size_is_power_of_two(iree_host_size_t value) {
   return (value != 0) && ((value & (value - 1)) == 0);
 }
 
+// Returns true if |alignment| is valid for aligned allocation functions.
+// Valid alignments are either 0 (use default) or a power of two.
+static inline bool iree_host_size_is_valid_alignment(
+    iree_host_size_t alignment) {
+  return alignment == 0 || iree_host_size_is_power_of_two(alignment);
+}
+
 // Returns true if |value| matches the given minimum |alignment|.
 static inline bool iree_host_size_has_alignment(iree_host_size_t value,
                                                 iree_host_size_t alignment) {
@@ -107,6 +114,13 @@ static inline iree_device_size_t iree_device_align(
 // Returns true if |value| is a power-of-two.
 static inline bool iree_device_size_is_power_of_two(iree_device_size_t value) {
   return (value != 0) && ((value & (value - 1)) == 0);
+}
+
+// Returns true if |alignment| is valid for aligned allocation functions.
+// Valid alignments are either 0 (use default) or a power of two.
+static inline bool iree_device_size_is_valid_alignment(
+    iree_device_size_t alignment) {
+  return alignment == 0 || iree_device_size_is_power_of_two(alignment);
 }
 
 // Returns true if |value| matches the given minimum |alignment|.

--- a/runtime/src/iree/base/allocator.c
+++ b/runtime/src/iree/base/allocator.c
@@ -371,10 +371,11 @@ IREE_API_EXPORT iree_status_t iree_allocator_realloc_aligned(
   uint8_t* new_data = (uint8_t*)aligned_ptr;
   if (old_data != new_data) {
     // Alignment at offset changed; copy data to the new aligned offset.
-    // NOTE: this is copying up to the *new* byte length, as we don't store the
-    // old length and don't know how much to copy. Since we've already
-    // reallocated we know this will always be in-bounds, but it's inefficient.
-    // NOTE: memmove instead of memcpy as the regions may overlap.
+    // We copy up to the *new* byte_length since we don't track the old size.
+    // When growing, this may copy uninitialized bytes from the expanded region
+    // which is safe (memory is allocated) but inefficient. Callers should
+    // initialize any expanded region after reallocation.
+    // memmove instead of memcpy as the regions may overlap.
     memmove(new_data, old_data, byte_length);
   }
 

--- a/runtime/src/iree/base/allocator.h
+++ b/runtime/src/iree/base/allocator.h
@@ -295,10 +295,10 @@ iree_struct_layout_calculate(iree_host_size_t base_size,
   { (count_expr), sizeof(type), (align), (out_offset_ptr) }
 
 // Field descriptor for a flexible array member (FAM). FAMs are accessed via
-// the struct member (e.g., foo->bar[]) so no offset is needed, and they start
-// immediately after sizeof(struct) with no alignment padding.
+// the struct member (e.g., foo->bar[]) so no offset is needed. The alignment
+// ensures the FAM starts at an address suitable for its element type.
 #define IREE_STRUCT_FIELD_FAM(count_expr, type) \
-  { (count_expr), sizeof(type), 0, NULL }
+  { (count_expr), sizeof(type), iree_alignof(type), NULL }
 
 // Calculates struct layout using inline field descriptors.
 // C++ version uses a lambda to create a local array (compound literals are a

--- a/runtime/src/iree/base/allocator_benchmark.cc
+++ b/runtime/src/iree/base/allocator_benchmark.cc
@@ -1,0 +1,527 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Benchmarks for iree_allocator_t operations.
+// Build/run: iree-bazel-run //runtime/src/iree/base:allocator_benchmark
+//
+// These benchmarks measure the overhead of IREE's allocator abstraction layer
+// and various allocation patterns. Useful for comparing allocator
+// implementations and evaluating the cost of checked arithmetic helpers.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/testing/benchmark.h"
+
+//===----------------------------------------------------------------------===//
+// Benchmark configuration
+//===----------------------------------------------------------------------===//
+
+// Allocation sizes for benchmarks.
+#define ALLOC_SIZE_SMALL 64
+#define ALLOC_SIZE_MEDIUM 4096
+#define ALLOC_SIZE_LARGE (64 * 1024)
+
+// Array allocation parameters.
+#define ARRAY_COUNT 100
+#define ARRAY_ELEMENT_SIZE 32
+
+// Cache line alignment constant (matches IREE_HAL_HEAP_BUFFER_ALIGNMENT).
+#define CACHE_LINE_ALIGNMENT 64
+
+//===----------------------------------------------------------------------===//
+// Test structures for struct layout benchmarks
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  void* allocator;
+  uint16_t capacity;
+  uint16_t count;
+  void* user_handles;
+  void* native_handles;
+} test_wait_set_t;
+
+typedef struct {
+  uint64_t dummy[4];
+} test_wait_handle_t;
+
+typedef void* test_native_handle_t;
+
+typedef struct {
+  void* resource_vtable;
+  void* allocator;
+  uint64_t flags;
+  uint64_t size;
+} test_buffer_header_t;
+
+//===----------------------------------------------------------------------===//
+// Basic allocation benchmarks
+//===----------------------------------------------------------------------===//
+
+static iree_status_t BM_MallocFree_Small(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_MallocFree_Medium(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_MEDIUM, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_MallocFree_Large(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_LARGE, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_MallocUninitializedFree_Medium(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc_uninitialized(
+        allocator, ALLOC_SIZE_MEDIUM, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Realloc benchmarks
+//===----------------------------------------------------------------------===//
+
+static iree_status_t BM_ReallocGrow(const iree_benchmark_def_t* benchmark_def,
+                                    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr));
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_realloc(allocator, ALLOC_SIZE_MEDIUM, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_ReallocShrink(const iree_benchmark_def_t* benchmark_def,
+                                      iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_MEDIUM, &ptr));
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_realloc(allocator, ALLOC_SIZE_SMALL, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Clone benchmark
+//===----------------------------------------------------------------------===//
+
+static iree_status_t BM_Clone(const iree_benchmark_def_t* benchmark_def,
+                              iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  // Source data to clone.
+  uint8_t source_data[ALLOC_SIZE_MEDIUM];
+  memset(source_data, 0xAB, sizeof(source_data));
+  iree_const_byte_span_t source =
+      iree_make_const_byte_span(source_data, sizeof(source_data));
+
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_clone(allocator, source, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Array allocation benchmarks
+//===----------------------------------------------------------------------===//
+
+static iree_status_t BM_MallocArray(const iree_benchmark_def_t* benchmark_def,
+                                    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc_array(allocator, ARRAY_COUNT,
+                                                     ARRAY_ELEMENT_SIZE, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_MallocArrayUninitialized(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc_array_uninitialized(
+        allocator, ARRAY_COUNT, ARRAY_ELEMENT_SIZE, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_ReallocArray(const iree_benchmark_def_t* benchmark_def,
+                                     iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc_array(allocator, ARRAY_COUNT,
+                                                     ARRAY_ELEMENT_SIZE, &ptr));
+    IREE_RETURN_IF_ERROR(iree_allocator_realloc_array(
+        allocator, ARRAY_COUNT * 2, ARRAY_ELEMENT_SIZE, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Struct allocation benchmarks
+//===----------------------------------------------------------------------===//
+
+static iree_status_t BM_MallocWithTrailing(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc_with_trailing(
+        allocator, sizeof(test_wait_set_t), ALLOC_SIZE_MEDIUM, &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_MallocStructArray(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc_struct_array(
+        allocator, sizeof(test_wait_set_t), ARRAY_COUNT, ARRAY_ELEMENT_SIZE,
+        &ptr));
+    iree_allocator_free(allocator, ptr);
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Inline arena benchmarks
+//===----------------------------------------------------------------------===//
+
+static iree_status_t BM_InlineArenaMalloc(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    IREE_ALLOCATOR_INLINE_STORAGE(storage, 8192);
+    iree_allocator_t allocator = iree_allocator_inline_arena(&storage.header);
+    void* ptr1 = NULL;
+    void* ptr2 = NULL;
+    void* ptr3 = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr1));
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr2));
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr3));
+    // Arena frees are no-ops, storage cleaned up automatically.
+    iree_benchmark_use_ptr((char const volatile*)ptr1);
+    iree_benchmark_use_ptr((char const volatile*)ptr2);
+    iree_benchmark_use_ptr((char const volatile*)ptr3);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_SystemMallocMultiple(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t allocator = iree_allocator_system();
+  while (iree_benchmark_keep_running(benchmark_state, 1)) {
+    void* ptr1 = NULL;
+    void* ptr2 = NULL;
+    void* ptr3 = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr1));
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr2));
+    IREE_RETURN_IF_ERROR(
+        iree_allocator_malloc(allocator, ALLOC_SIZE_SMALL, &ptr3));
+    iree_allocator_free(allocator, ptr3);
+    iree_allocator_free(allocator, ptr2);
+    iree_allocator_free(allocator, ptr1);
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Struct layout calculation benchmarks
+//===----------------------------------------------------------------------===//
+// These measure the overhead of IREE_STRUCT_LAYOUT vs manual checked
+// arithmetic. With IREE_ATTRIBUTE_ALWAYS_INLINE, both should have identical
+// performance when counts are compile-time constants (complete constant
+// folding).
+
+static iree_status_t BM_StructLayoutManual(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1000)) {
+    for (int i = 0; i < 1000; ++i) {
+      iree_host_size_t capacity = 64;
+
+      iree_host_size_t user_handle_list_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+              capacity, sizeof(test_wait_handle_t), &user_handle_list_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+      iree_host_size_t native_handle_list_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+              capacity, sizeof(test_native_handle_t),
+              &native_handle_list_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+      iree_host_size_t total_size = 0;
+      if (IREE_UNLIKELY(
+              !iree_host_size_checked_add(sizeof(test_wait_set_t),
+                                          user_handle_list_size, &total_size) ||
+              !iree_host_size_checked_add(total_size, native_handle_list_size,
+                                          &total_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+
+      iree_benchmark_use_ptr((char const volatile*)&total_size);
+      iree_benchmark_use_ptr((char const volatile*)&user_handle_list_size);
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_StructLayoutMacro(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1000)) {
+    for (int i = 0; i < 1000; ++i) {
+      iree_host_size_t capacity = 64;
+      iree_host_size_t total = 0;
+      iree_host_size_t user_offset = 0;
+      iree_host_size_t native_offset = 0;
+
+      iree_status_t status = IREE_STRUCT_LAYOUT(
+          sizeof(test_wait_set_t), &total,
+          IREE_STRUCT_FIELD(capacity, test_wait_handle_t, &user_offset),
+          IREE_STRUCT_FIELD(capacity, test_native_handle_t, &native_offset));
+      if (!iree_status_is_ok(status)) {
+        return status;
+      }
+
+      iree_benchmark_use_ptr((char const volatile*)&total);
+      iree_benchmark_use_ptr((char const volatile*)&user_offset);
+    }
+  }
+  return iree_ok_status();
+}
+
+// Prevent constant propagation - volatile forces runtime evaluation.
+static iree_host_size_t get_dynamic_value(iree_host_size_t value) {
+  volatile iree_host_size_t v = value;
+  return v;
+}
+
+static iree_status_t BM_StructLayoutManual_Dynamic(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1000)) {
+    for (int i = 0; i < 1000; ++i) {
+      iree_host_size_t capacity = get_dynamic_value(64);
+
+      iree_host_size_t user_handle_list_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+              capacity, sizeof(test_wait_handle_t), &user_handle_list_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+      iree_host_size_t native_handle_list_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+              capacity, sizeof(test_native_handle_t),
+              &native_handle_list_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+      iree_host_size_t total_size = 0;
+      if (IREE_UNLIKELY(
+              !iree_host_size_checked_add(sizeof(test_wait_set_t),
+                                          user_handle_list_size, &total_size) ||
+              !iree_host_size_checked_add(total_size, native_handle_list_size,
+                                          &total_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+
+      iree_benchmark_use_ptr((char const volatile*)&total_size);
+      iree_benchmark_use_ptr((char const volatile*)&user_handle_list_size);
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_StructLayoutMacro_Dynamic(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1000)) {
+    for (int i = 0; i < 1000; ++i) {
+      iree_host_size_t capacity = get_dynamic_value(64);
+      iree_host_size_t total = 0;
+      iree_host_size_t user_offset = 0;
+      iree_host_size_t native_offset = 0;
+
+      iree_status_t status = IREE_STRUCT_LAYOUT(
+          sizeof(test_wait_set_t), &total,
+          IREE_STRUCT_FIELD(capacity, test_wait_handle_t, &user_offset),
+          IREE_STRUCT_FIELD(capacity, test_native_handle_t, &native_offset));
+      if (!iree_status_is_ok(status)) {
+        return status;
+      }
+
+      iree_benchmark_use_ptr((char const volatile*)&total);
+      iree_benchmark_use_ptr((char const volatile*)&user_offset);
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_StructLayoutManual_Aligned(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1000)) {
+    for (int i = 0; i < 1000; ++i) {
+      iree_host_size_t data_size = 4096;
+
+      // Header aligned to max_align_t.
+      iree_host_size_t header_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_align(
+              sizeof(test_buffer_header_t), iree_max_align_t, &header_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+
+      // Data offset aligned to cache line.
+      iree_host_size_t data_offset = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_align(
+              header_size, CACHE_LINE_ALIGNMENT, &data_offset))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+
+      // Total size.
+      iree_host_size_t total_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_add(data_offset, data_size,
+                                                    &total_size))) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "overflow");
+      }
+
+      iree_benchmark_use_ptr((char const volatile*)&total_size);
+      iree_benchmark_use_ptr((char const volatile*)&data_offset);
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t BM_StructLayoutMacro_Aligned(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  while (iree_benchmark_keep_running(benchmark_state, 1000)) {
+    for (int i = 0; i < 1000; ++i) {
+      iree_host_size_t data_size = 4096;
+      iree_host_size_t total = 0;
+      iree_host_size_t header_offset = 0;
+      iree_host_size_t data_offset = 0;
+
+      iree_status_t status = IREE_STRUCT_LAYOUT(
+          0, &total,
+          IREE_STRUCT_FIELD_ALIGNED(1, test_buffer_header_t, iree_max_align_t,
+                                    &header_offset),
+          IREE_STRUCT_FIELD_ALIGNED(data_size, uint8_t, CACHE_LINE_ALIGNMENT,
+                                    &data_offset));
+      if (!iree_status_is_ok(status)) {
+        return status;
+      }
+
+      iree_benchmark_use_ptr((char const volatile*)&total);
+      iree_benchmark_use_ptr((char const volatile*)&data_offset);
+    }
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Benchmark registration
+//===----------------------------------------------------------------------===//
+
+// Basic allocation.
+IREE_BENCHMARK_REGISTER(BM_MallocFree_Small);
+IREE_BENCHMARK_REGISTER(BM_MallocFree_Medium);
+IREE_BENCHMARK_REGISTER(BM_MallocFree_Large);
+IREE_BENCHMARK_REGISTER(BM_MallocUninitializedFree_Medium);
+
+// Realloc.
+IREE_BENCHMARK_REGISTER(BM_ReallocGrow);
+IREE_BENCHMARK_REGISTER(BM_ReallocShrink);
+
+// Clone.
+IREE_BENCHMARK_REGISTER(BM_Clone);
+
+// Array allocation.
+IREE_BENCHMARK_REGISTER(BM_MallocArray);
+IREE_BENCHMARK_REGISTER(BM_MallocArrayUninitialized);
+IREE_BENCHMARK_REGISTER(BM_ReallocArray);
+
+// Struct allocation.
+IREE_BENCHMARK_REGISTER(BM_MallocWithTrailing);
+IREE_BENCHMARK_REGISTER(BM_MallocStructArray);
+
+// Inline arena vs system allocator.
+IREE_BENCHMARK_REGISTER(BM_InlineArenaMalloc);
+IREE_BENCHMARK_REGISTER(BM_SystemMallocMultiple);
+
+// Struct layout calculation (constant counts - should constant-fold).
+IREE_BENCHMARK_REGISTER(BM_StructLayoutManual);
+IREE_BENCHMARK_REGISTER(BM_StructLayoutMacro);
+
+// Struct layout calculation (dynamic counts - runtime evaluation).
+IREE_BENCHMARK_REGISTER(BM_StructLayoutManual_Dynamic);
+IREE_BENCHMARK_REGISTER(BM_StructLayoutMacro_Dynamic);
+
+// Struct layout calculation with alignment.
+IREE_BENCHMARK_REGISTER(BM_StructLayoutManual_Aligned);
+IREE_BENCHMARK_REGISTER(BM_StructLayoutMacro_Aligned);

--- a/runtime/src/iree/base/allocator_test.cc
+++ b/runtime/src/iree/base/allocator_test.cc
@@ -1,0 +1,456 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using ::iree::Status;
+using ::iree::StatusCode;
+using ::iree::testing::status::IsOk;
+using ::iree::testing::status::StatusIs;
+
+//===----------------------------------------------------------------------===//
+// Checked arithmetic tests - iree_host_size_t
+//===----------------------------------------------------------------------===//
+
+TEST(CheckedArithmetic, AddNoOverflow) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_add(100, 200, &result));
+  EXPECT_EQ(result, 300);
+}
+
+TEST(CheckedArithmetic, AddOverflowMax) {
+  iree_host_size_t result;
+  EXPECT_FALSE(iree_host_size_checked_add(IREE_HOST_SIZE_MAX, 1, &result));
+}
+
+TEST(CheckedArithmetic, AddOverflowLarge) {
+  iree_host_size_t result;
+  EXPECT_FALSE(iree_host_size_checked_add(IREE_HOST_SIZE_MAX - 10,
+                                          IREE_HOST_SIZE_MAX - 10, &result));
+}
+
+TEST(CheckedArithmetic, AddZero) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_add(0, 0, &result));
+  EXPECT_EQ(result, 0);
+}
+
+TEST(CheckedArithmetic, AddMaxPlusZero) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_add(IREE_HOST_SIZE_MAX, 0, &result));
+  EXPECT_EQ(result, IREE_HOST_SIZE_MAX);
+}
+
+TEST(CheckedArithmetic, MulNoOverflow) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_mul(100, 200, &result));
+  EXPECT_EQ(result, 20000);
+}
+
+TEST(CheckedArithmetic, MulOverflowMaxTimesTwo) {
+  iree_host_size_t result;
+  EXPECT_FALSE(iree_host_size_checked_mul(IREE_HOST_SIZE_MAX, 2, &result));
+}
+
+TEST(CheckedArithmetic, MulOverflowLarge) {
+  iree_host_size_t result;
+  EXPECT_FALSE(iree_host_size_checked_mul(IREE_HOST_SIZE_MAX / 2 + 1,
+                                          IREE_HOST_SIZE_MAX / 2 + 1, &result));
+}
+
+TEST(CheckedArithmetic, MulZeroFirst) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_mul(0, IREE_HOST_SIZE_MAX, &result));
+  EXPECT_EQ(result, 0);
+}
+
+TEST(CheckedArithmetic, MulZeroSecond) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_mul(IREE_HOST_SIZE_MAX, 0, &result));
+  EXPECT_EQ(result, 0);
+}
+
+TEST(CheckedArithmetic, MulOneFirst) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_mul(1, IREE_HOST_SIZE_MAX, &result));
+  EXPECT_EQ(result, IREE_HOST_SIZE_MAX);
+}
+
+TEST(CheckedArithmetic, MulOneSecond) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_mul(IREE_HOST_SIZE_MAX, 1, &result));
+  EXPECT_EQ(result, IREE_HOST_SIZE_MAX);
+}
+
+TEST(CheckedArithmetic, MulAddNoOverflow) {
+  iree_host_size_t result;
+  // 100 + 10 * 20 = 300
+  EXPECT_TRUE(iree_host_size_checked_mul_add(100, 10, 20, &result));
+  EXPECT_EQ(result, 300);
+}
+
+TEST(CheckedArithmetic, MulAddMulOverflow) {
+  iree_host_size_t result;
+  // 0 + MAX * 2 overflows in multiplication
+  EXPECT_FALSE(
+      iree_host_size_checked_mul_add(0, IREE_HOST_SIZE_MAX, 2, &result));
+}
+
+TEST(CheckedArithmetic, MulAddAddOverflow) {
+  iree_host_size_t result;
+  // MAX + 1 * 1 overflows in addition
+  EXPECT_FALSE(
+      iree_host_size_checked_mul_add(IREE_HOST_SIZE_MAX, 1, 1, &result));
+}
+
+TEST(CheckedArithmetic, MulAddZeroCount) {
+  iree_host_size_t result;
+  // 100 + 0 * 1000 = 100
+  EXPECT_TRUE(iree_host_size_checked_mul_add(100, 0, 1000, &result));
+  EXPECT_EQ(result, 100);
+}
+
+TEST(CheckedArithmetic, AlignNoOverflow) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_align(100, 16, &result));
+  EXPECT_EQ(result, 112);
+}
+
+TEST(CheckedArithmetic, AlignAlreadyAligned) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_align(128, 16, &result));
+  EXPECT_EQ(result, 128);
+}
+
+TEST(CheckedArithmetic, AlignZero) {
+  iree_host_size_t result;
+  EXPECT_TRUE(iree_host_size_checked_align(0, 16, &result));
+  EXPECT_EQ(result, 0);
+}
+
+TEST(CheckedArithmetic, AlignOverflow) {
+  iree_host_size_t result;
+  // MAX - 5 + 15 (alignment-1) would overflow.
+  EXPECT_FALSE(
+      iree_host_size_checked_align(IREE_HOST_SIZE_MAX - 5, 16, &result));
+}
+
+TEST(CheckedArithmetic, AlignNearMaxNoOverflow) {
+  iree_host_size_t result;
+  // Value that is already aligned at MAX boundary should work.
+  iree_host_size_t max_aligned = IREE_HOST_SIZE_MAX & ~(iree_host_size_t)15;
+  EXPECT_TRUE(iree_host_size_checked_align(max_aligned, 16, &result));
+  EXPECT_EQ(result, max_aligned);
+}
+
+//===----------------------------------------------------------------------===//
+// Checked arithmetic tests - iree_device_size_t
+//===----------------------------------------------------------------------===//
+
+TEST(CheckedArithmeticDevice, AddNoOverflow) {
+  iree_device_size_t result;
+  EXPECT_TRUE(iree_device_size_checked_add(100, 200, &result));
+  EXPECT_EQ(result, 300);
+}
+
+TEST(CheckedArithmeticDevice, AddOverflow) {
+  iree_device_size_t result;
+  EXPECT_FALSE(iree_device_size_checked_add(IREE_DEVICE_SIZE_MAX, 1, &result));
+}
+
+TEST(CheckedArithmeticDevice, MulNoOverflow) {
+  iree_device_size_t result;
+  EXPECT_TRUE(iree_device_size_checked_mul(100, 200, &result));
+  EXPECT_EQ(result, 20000);
+}
+
+TEST(CheckedArithmeticDevice, MulOverflow) {
+  iree_device_size_t result;
+  EXPECT_FALSE(iree_device_size_checked_mul(IREE_DEVICE_SIZE_MAX, 2, &result));
+}
+
+TEST(CheckedArithmeticDevice, MulAddNoOverflow) {
+  iree_device_size_t result;
+  EXPECT_TRUE(iree_device_size_checked_mul_add(100, 10, 20, &result));
+  EXPECT_EQ(result, 300);
+}
+
+//===----------------------------------------------------------------------===//
+// Array allocation tests
+//===----------------------------------------------------------------------===//
+
+TEST(AllocatorArray, MallocArrayBasic) {
+  void* ptr = nullptr;
+  IREE_EXPECT_OK(
+      iree_allocator_malloc_array(iree_allocator_system(), 10, 8, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  // Verify memory is zeroed.
+  for (int i = 0; i < 80; ++i) {
+    EXPECT_EQ(static_cast<uint8_t*>(ptr)[i], 0);
+  }
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(AllocatorArray, MallocArrayOverflow) {
+  void* ptr = nullptr;
+  EXPECT_THAT(Status(iree_allocator_malloc_array(iree_allocator_system(),
+                                                 IREE_HOST_SIZE_MAX, 2, &ptr)),
+              StatusIs(StatusCode::kOutOfRange));
+}
+
+TEST(AllocatorArray, MallocArrayZeroCount) {
+  void* ptr = nullptr;
+  // Zero count results in zero bytes, which IREE's allocator rejects.
+  EXPECT_THAT(
+      Status(iree_allocator_malloc_array(iree_allocator_system(), 0, 8, &ptr)),
+      StatusIs(StatusCode::kInvalidArgument));
+}
+
+TEST(AllocatorArray, MallocArrayUninitializedBasic) {
+  void* ptr = nullptr;
+  IREE_EXPECT_OK(iree_allocator_malloc_array_uninitialized(
+      iree_allocator_system(), 10, 8, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(AllocatorArray, MallocArrayUninitializedOverflow) {
+  void* ptr = nullptr;
+  EXPECT_THAT(Status(iree_allocator_malloc_array_uninitialized(
+                  iree_allocator_system(), IREE_HOST_SIZE_MAX, 2, &ptr)),
+              StatusIs(StatusCode::kOutOfRange));
+}
+
+TEST(AllocatorArray, ReallocArrayBasic) {
+  void* ptr = nullptr;
+  IREE_EXPECT_OK(
+      iree_allocator_malloc_array(iree_allocator_system(), 10, 8, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  IREE_EXPECT_OK(
+      iree_allocator_realloc_array(iree_allocator_system(), 20, 8, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(AllocatorArray, ReallocArrayOverflow) {
+  void* ptr = nullptr;
+  IREE_EXPECT_OK(
+      iree_allocator_malloc_array(iree_allocator_system(), 10, 8, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  void* original_ptr = ptr;
+  EXPECT_THAT(Status(iree_allocator_realloc_array(iree_allocator_system(),
+                                                  IREE_HOST_SIZE_MAX, 2, &ptr)),
+              StatusIs(StatusCode::kOutOfRange));
+  // Original pointer should be unchanged on failure.
+  EXPECT_EQ(ptr, original_ptr);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Struct+trailing allocation tests
+//===----------------------------------------------------------------------===//
+
+TEST(AllocatorStruct, MallocWithTrailingBasic) {
+  void* ptr = nullptr;
+  IREE_EXPECT_OK(iree_allocator_malloc_with_trailing(iree_allocator_system(),
+                                                     64, 128, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(AllocatorStruct, MallocWithTrailingOverflow) {
+  void* ptr = nullptr;
+  // Use values that sum to overflow (each > MAX/2).
+  EXPECT_THAT(Status(iree_allocator_malloc_with_trailing(
+                  iree_allocator_system(), IREE_HOST_SIZE_MAX / 2 + 100,
+                  IREE_HOST_SIZE_MAX / 2 + 100, &ptr)),
+              StatusIs(StatusCode::kOutOfRange));
+}
+
+TEST(AllocatorStruct, MallocStructArrayBasic) {
+  void* ptr = nullptr;
+  IREE_EXPECT_OK(iree_allocator_malloc_struct_array(iree_allocator_system(), 64,
+                                                    10, 8, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(AllocatorStruct, MallocStructArrayOverflow) {
+  void* ptr = nullptr;
+  EXPECT_THAT(Status(iree_allocator_malloc_struct_array(
+                  iree_allocator_system(), 64, IREE_HOST_SIZE_MAX, 2, &ptr)),
+              StatusIs(StatusCode::kOutOfRange));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_allocator_grow_array tests
+//===----------------------------------------------------------------------===//
+
+TEST(GrowArray, BasicGrowth) {
+  uint64_t* ptr = nullptr;
+  iree_host_size_t capacity = 0;
+  // Initial allocation from 0 capacity with minimum of 8.
+  IREE_EXPECT_OK(iree_allocator_grow_array(
+      iree_allocator_system(), 8, sizeof(uint64_t), &capacity, (void**)&ptr));
+  EXPECT_EQ(capacity, 8u);
+  EXPECT_NE(ptr, nullptr);
+
+  // Write to verify allocation is valid.
+  for (iree_host_size_t i = 0; i < capacity; ++i) {
+    ptr[i] = i * 100;
+  }
+
+  // Grow from 8 to 16 (doubled).
+  IREE_EXPECT_OK(iree_allocator_grow_array(
+      iree_allocator_system(), 8, sizeof(uint64_t), &capacity, (void**)&ptr));
+  EXPECT_EQ(capacity, 16u);
+
+  // Verify old data preserved (realloc semantics).
+  for (iree_host_size_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(ptr[i], i * 100);
+  }
+
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(GrowArray, MinimumCapacityWins) {
+  uint64_t* ptr = nullptr;
+  iree_host_size_t capacity = 4;
+  // Pre-allocate with capacity 4.
+  IREE_EXPECT_OK(iree_allocator_malloc_array(iree_allocator_system(), capacity,
+                                             sizeof(uint64_t), (void**)&ptr));
+  // Grow: max(32, 4*2=8) = 32.
+  IREE_EXPECT_OK(iree_allocator_grow_array(
+      iree_allocator_system(), 32, sizeof(uint64_t), &capacity, (void**)&ptr));
+  EXPECT_EQ(capacity, 32u);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(GrowArray, DoubleWins) {
+  uint64_t* ptr = nullptr;
+  iree_host_size_t capacity = 100;
+  // Pre-allocate with capacity 100.
+  IREE_EXPECT_OK(iree_allocator_malloc_array(iree_allocator_system(), capacity,
+                                             sizeof(uint64_t), (void**)&ptr));
+  // Grow: max(8, 100*2=200) = 200.
+  IREE_EXPECT_OK(iree_allocator_grow_array(
+      iree_allocator_system(), 8, sizeof(uint64_t), &capacity, (void**)&ptr));
+  EXPECT_EQ(capacity, 200u);
+  iree_allocator_free(iree_allocator_system(), ptr);
+}
+
+TEST(GrowArray, OverflowOnDouble) {
+  void* ptr = nullptr;
+  iree_host_size_t capacity = IREE_HOST_SIZE_MAX;
+  EXPECT_THAT(
+      Status(iree_allocator_grow_array(iree_allocator_system(), 8,
+                                       sizeof(uint64_t), &capacity, &ptr)),
+      StatusIs(StatusCode::kOutOfRange));
+}
+
+//===----------------------------------------------------------------------===//
+// IREE_STRUCT_LAYOUT tests
+//===----------------------------------------------------------------------===//
+
+struct TestHeader {
+  void* vtable;
+  uint64_t flags;
+};
+
+struct TestElement {
+  uint64_t data[4];
+};
+
+TEST(StructLayout, BasicTwoFields) {
+  iree_host_size_t total = 0;
+  iree_host_size_t field1_offset = 0;
+  iree_host_size_t field2_offset = 0;
+  IREE_EXPECT_OK(
+      IREE_STRUCT_LAYOUT(sizeof(TestHeader), &total,
+                         IREE_STRUCT_FIELD(10, TestElement, &field1_offset),
+                         IREE_STRUCT_FIELD(5, uint64_t, &field2_offset)));
+
+  EXPECT_EQ(field1_offset, sizeof(TestHeader));
+  EXPECT_EQ(field2_offset, sizeof(TestHeader) + 10 * sizeof(TestElement));
+  EXPECT_EQ(total, sizeof(TestHeader) + 10 * sizeof(TestElement) +
+                       5 * sizeof(uint64_t));
+}
+
+TEST(StructLayout, AlignedFields) {
+  iree_host_size_t total = 0;
+  iree_host_size_t header_offset = 0;
+  iree_host_size_t data_offset = 0;
+  IREE_EXPECT_OK(IREE_STRUCT_LAYOUT(
+      0, &total, IREE_STRUCT_FIELD_ALIGNED(1, TestHeader, 16, &header_offset),
+      IREE_STRUCT_FIELD_ALIGNED(100, uint8_t, 64, &data_offset)));
+
+  EXPECT_EQ(header_offset, 0u);
+  // TestHeader is 16 bytes, data should be at offset 64 (aligned).
+  EXPECT_EQ(data_offset, 64u);
+  EXPECT_EQ(total, 64u + 100u);
+}
+
+TEST(StructLayout, NullOffsetPointer) {
+  iree_host_size_t total = 0;
+  IREE_EXPECT_OK(IREE_STRUCT_LAYOUT(sizeof(TestHeader), &total,
+                                    IREE_STRUCT_FIELD(10, TestElement, NULL),
+                                    IREE_STRUCT_FIELD(5, uint64_t, NULL)));
+  EXPECT_EQ(total, sizeof(TestHeader) + 10 * sizeof(TestElement) +
+                       5 * sizeof(uint64_t));
+}
+
+TEST(StructLayout, ZeroCountField) {
+  iree_host_size_t total = 0;
+  iree_host_size_t offset = 0;
+  IREE_EXPECT_OK(IREE_STRUCT_LAYOUT(
+      sizeof(TestHeader), &total, IREE_STRUCT_FIELD(0, TestElement, &offset)));
+  EXPECT_EQ(offset, sizeof(TestHeader));
+  EXPECT_EQ(total, sizeof(TestHeader));
+}
+
+TEST(StructLayout, OverflowOnMultiply) {
+  iree_host_size_t total = 0;
+  iree_status_t status = IREE_STRUCT_LAYOUT(
+      0, &total, IREE_STRUCT_FIELD(SIZE_MAX, TestElement, NULL));
+  EXPECT_TRUE(iree_status_is_out_of_range(status));
+  iree_status_free(status);
+}
+
+TEST(StructLayout, OverflowOnAdd) {
+  iree_host_size_t total = 0;
+  iree_status_t status = IREE_STRUCT_LAYOUT(
+      SIZE_MAX - 10, &total, IREE_STRUCT_FIELD(100, uint8_t, NULL));
+  EXPECT_TRUE(iree_status_is_out_of_range(status));
+  iree_status_free(status);
+}
+
+TEST(StructLayout, SingleField) {
+  iree_host_size_t total = 0;
+  iree_host_size_t offset = 0;
+  IREE_EXPECT_OK(IREE_STRUCT_LAYOUT(
+      sizeof(TestHeader), &total, IREE_STRUCT_FIELD(64, TestElement, &offset)));
+  EXPECT_EQ(offset, sizeof(TestHeader));
+  EXPECT_EQ(total, sizeof(TestHeader) + 64 * sizeof(TestElement));
+}
+
+TEST(StructLayout, ThreeFields) {
+  iree_host_size_t total = 0;
+  iree_host_size_t offset1 = 0, offset2 = 0, offset3 = 0;
+  IREE_EXPECT_OK(IREE_STRUCT_LAYOUT(sizeof(TestHeader), &total,
+                                    IREE_STRUCT_FIELD(10, uint8_t, &offset1),
+                                    IREE_STRUCT_FIELD(20, uint16_t, &offset2),
+                                    IREE_STRUCT_FIELD(30, uint32_t, &offset3)));
+  EXPECT_EQ(offset1, sizeof(TestHeader));
+  EXPECT_EQ(offset2, sizeof(TestHeader) + 10);
+  EXPECT_EQ(offset3, sizeof(TestHeader) + 10 + 40);
+  EXPECT_EQ(total, sizeof(TestHeader) + 10 + 40 + 120);
+}
+
+}  // namespace

--- a/runtime/src/iree/base/internal/event_pool.c
+++ b/runtime/src/iree/base/internal/event_pool.c
@@ -37,10 +37,14 @@ iree_status_t iree_event_pool_allocate(iree_host_size_t available_capacity,
   *out_event_pool = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // Calculate allocation size with overflow checking. available_list is a FAM
+  // accessed via event_pool->available_list[].
+  iree_host_size_t total_size = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, IREE_STRUCT_LAYOUT(
+              sizeof(iree_event_pool_t), &total_size,
+              IREE_STRUCT_FIELD_FAM(available_capacity, iree_event_t)));
   iree_event_pool_t* event_pool = NULL;
-  iree_host_size_t total_size =
-      sizeof(*event_pool) +
-      available_capacity * sizeof(event_pool->available_list[0]);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_allocator_malloc(host_allocator, total_size, (void**)&event_pool));

--- a/runtime/src/iree/base/internal/wait_handle_poll.c
+++ b/runtime/src/iree/base/internal/wait_handle_poll.c
@@ -146,11 +146,17 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
 
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_host_size_t user_handle_list_size =
-      capacity * iree_sizeof_struct(iree_wait_handle_t);
-  iree_host_size_t poll_fd_list_size = capacity * sizeof(struct pollfd);
-  iree_host_size_t total_size = iree_sizeof_struct(iree_wait_set_t) +
-                                user_handle_list_size + poll_fd_list_size;
+  iree_host_size_t total_size = 0;
+  iree_host_size_t user_handles_offset = 0;
+  iree_host_size_t poll_fds_offset = 0;
+  iree_status_t status = IREE_STRUCT_LAYOUT(
+      iree_sizeof_struct(iree_wait_set_t), &total_size,
+      IREE_STRUCT_FIELD(capacity, iree_wait_handle_t, &user_handles_offset),
+      IREE_STRUCT_FIELD(capacity, struct pollfd, &poll_fds_offset));
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
 
   iree_wait_set_t* set = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -160,10 +166,8 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
   iree_wait_set_clear(set);
 
   set->user_handles =
-      (iree_wait_handle_t*)((uint8_t*)set +
-                            iree_sizeof_struct(iree_wait_set_t));
-  set->poll_fds =
-      (struct pollfd*)((uint8_t*)set->user_handles + user_handle_list_size);
+      (iree_wait_handle_t*)((uint8_t*)set + user_handles_offset);
+  set->poll_fds = (struct pollfd*)((uint8_t*)set + poll_fds_offset);
 
   *out_set = set;
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/base/internal/wait_handle_poll.c
+++ b/runtime/src/iree/base/internal/wait_handle_poll.c
@@ -182,7 +182,7 @@ void iree_wait_set_free(iree_wait_set_t* set) {
 }
 
 bool iree_wait_set_is_empty(const iree_wait_set_t* set) {
-  return set->handle_count != 0;
+  return set->handle_count == 0;
 }
 
 iree_status_t iree_wait_set_insert(iree_wait_set_t* set,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
@@ -45,38 +45,36 @@ iree_status_t iree_hal_sync_driver_create(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_sync_driver_t* driver = NULL;
-  iree_host_size_t total_size = sizeof(*driver) +
-                                loader_count * sizeof(*driver->loaders) +
-                                identifier.size;
-  iree_status_t status =
-      iree_allocator_malloc(host_allocator, total_size, (void**)&driver);
-  if (iree_status_is_ok(status)) {
-    iree_hal_resource_initialize(&iree_hal_sync_driver_vtable,
-                                 &driver->resource);
-    driver->host_allocator = host_allocator;
-    driver->device_allocator = device_allocator;
-    iree_hal_allocator_retain(device_allocator);
+  iree_host_size_t total_size = 0;
+  iree_host_size_t identifier_offset = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, IREE_STRUCT_LAYOUT(
+              sizeof(*driver), &total_size,
+              IREE_STRUCT_FIELD_ALIGNED(loader_count,
+                                        iree_hal_executable_loader_t*, 1, NULL),
+              IREE_STRUCT_FIELD_ALIGNED(identifier.size, char, 1,
+                                        &identifier_offset)));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(host_allocator, total_size, (void**)&driver));
+  iree_hal_resource_initialize(&iree_hal_sync_driver_vtable, &driver->resource);
+  driver->host_allocator = host_allocator;
+  driver->device_allocator = device_allocator;
+  iree_hal_allocator_retain(device_allocator);
 
-    iree_string_view_append_to_buffer(
-        identifier, &driver->identifier,
-        (char*)driver + total_size - identifier.size);
-    memcpy(&driver->default_params, default_params,
-           sizeof(driver->default_params));
+  iree_string_view_append_to_buffer(identifier, &driver->identifier,
+                                    (char*)driver + identifier_offset);
+  memcpy(&driver->default_params, default_params,
+         sizeof(driver->default_params));
 
-    driver->loader_count = loader_count;
-    for (iree_host_size_t i = 0; i < driver->loader_count; ++i) {
-      driver->loaders[i] = loaders[i];
-      iree_hal_executable_loader_retain(driver->loaders[i]);
-    }
+  driver->loader_count = loader_count;
+  for (iree_host_size_t i = 0; i < driver->loader_count; ++i) {
+    driver->loaders[i] = loaders[i];
+    iree_hal_executable_loader_retain(driver->loaders[i]);
   }
 
-  if (iree_status_is_ok(status)) {
-    *out_driver = (iree_hal_driver_t*)driver;
-  } else {
-    iree_hal_driver_release((iree_hal_driver_t*)driver);
-  }
+  *out_driver = (iree_hal_driver_t*)driver;
   IREE_TRACE_ZONE_END(z0);
-  return status;
+  return iree_ok_status();
 }
 
 static void iree_hal_sync_driver_destroy(iree_hal_driver_t* base_driver) {

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -100,20 +100,23 @@ static iree_status_t iree_hal_elf_executable_create(
   // allocating so that we know the import count. Today since we allocate first
   // we need an additional allocation once we've seen the import table.
   iree_hal_elf_executable_t* executable = NULL;
-  iree_host_size_t total_size =
-      sizeof(*executable) +
-      executable_params->constant_count * sizeof(*executable_params->constants);
-  iree_status_t status =
-      iree_allocator_malloc(host_allocator, total_size, (void**)&executable);
-  if (iree_status_is_ok(status)) {
-    iree_hal_local_executable_initialize(&iree_hal_elf_executable_vtable,
-                                         host_allocator, &executable->base);
-  }
+  iree_host_size_t total_size = 0;
+  iree_host_size_t constants_offset = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, IREE_STRUCT_LAYOUT(sizeof(*executable), &total_size,
+                             IREE_STRUCT_FIELD_ALIGNED(
+                                 executable_params->constant_count, uint32_t,
+                                 iree_alignof(uint32_t), &constants_offset)));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_allocator_malloc(host_allocator, total_size, (void**)&executable));
+  iree_hal_local_executable_initialize(&iree_hal_elf_executable_vtable,
+                                       host_allocator, &executable->base);
 
   // Copy executable constants so we own them.
-  if (iree_status_is_ok(status) && executable_params->constant_count > 0) {
+  if (executable_params->constant_count > 0) {
     uint32_t* target_constants =
-        (uint32_t*)((uint8_t*)executable + sizeof(*executable));
+        (uint32_t*)((uint8_t*)executable + constants_offset);
     memcpy(target_constants, executable_params->constants,
            executable_params->constant_count *
                sizeof(*executable_params->constants));
@@ -121,11 +124,9 @@ static iree_status_t iree_hal_elf_executable_create(
   }
 
   // Attempt to load the ELF module.
-  if (iree_status_is_ok(status)) {
-    status = iree_elf_module_initialize_from_memory(
-        executable_params->executable_data, /*import_table=*/NULL,
-        host_allocator, &executable->module);
-  }
+  iree_status_t status = iree_elf_module_initialize_from_memory(
+      executable_params->executable_data, /*import_table=*/NULL, host_allocator,
+      &executable->module);
 
   // Query metadata and get the entry point function pointers.
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -230,32 +230,41 @@ static iree_status_t iree_hal_vmvx_executable_create(
   iree_host_size_t entry_count =
       iree_vm_module_signature(bytecode_module).export_function_count;
 
+  // Calculate allocation size with overflow checking. entry_fn_ordinals is a
+  // FAM accessed via executable->entry_fn_ordinals[]; dispatch_attrs alignment
+  // provides padding after entry_fn_ordinals.
+  iree_host_size_t total_size = 0;
+  iree_host_size_t dispatch_attrs_offset = 0;
+  iree_host_size_t worker_states_offset = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, IREE_STRUCT_LAYOUT(
+              sizeof(iree_hal_vmvx_executable_t), &total_size,
+              IREE_STRUCT_FIELD_FAM(entry_count, uint16_t),
+              IREE_STRUCT_FIELD_ALIGNED(entry_count,
+                                        iree_hal_executable_dispatch_attrs_v0_t,
+                                        8, &dispatch_attrs_offset),
+              IREE_STRUCT_FIELD_ALIGNED(worker_capacity,
+                                        iree_hal_vmvx_worker_state_t, 8,
+                                        &worker_states_offset)));
+
   iree_hal_vmvx_executable_t* executable = NULL;
-  const iree_host_size_t entry_fn_ordinals_size =
-      iree_host_align(entry_count * sizeof(*executable->entry_fn_ordinals), 8);
-  const iree_host_size_t dispatch_attrs_size = iree_host_align(
-      entry_count * sizeof(*executable->base.dispatch_attrs), 8);
-  const iree_host_size_t worker_states_size =
-      iree_host_align(worker_capacity * sizeof(*executable->worker_states), 8);
-  const iree_host_size_t total_size = sizeof(*executable) +
-                                      entry_fn_ordinals_size +
-                                      dispatch_attrs_size + worker_states_size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&executable);
   iree_hal_executable_dispatch_attrs_v0_t* dispatch_attrs = NULL;
   if (iree_status_is_ok(status)) {
-    uint8_t* ptr =
-        (uint8_t*)executable + sizeof(*executable) + entry_fn_ordinals_size;
-    dispatch_attrs = (iree_hal_executable_dispatch_attrs_v0_t*)ptr;
-    memset(dispatch_attrs, 0, dispatch_attrs_size);
-    ptr += dispatch_attrs_size;
+    dispatch_attrs =
+        (iree_hal_executable_dispatch_attrs_v0_t*)((uint8_t*)executable +
+                                                   dispatch_attrs_offset);
+    memset(dispatch_attrs, 0,
+           entry_count * sizeof(iree_hal_executable_dispatch_attrs_v0_t));
     iree_hal_local_executable_initialize(&iree_hal_vmvx_executable_vtable,
                                          host_allocator, &executable->base);
     executable->base.dispatch_attrs = dispatch_attrs;
 
     executable->worker_capacity = worker_capacity;
-    executable->worker_states = (iree_hal_vmvx_worker_state_t*)ptr;
-    ptr += worker_states_size;
+    executable->worker_states =
+        (iree_hal_vmvx_worker_state_t*)((uint8_t*)executable +
+                                        worker_states_offset);
 
     executable->bytecode_module = bytecode_module;
     executable->entry_fn_count = entry_count;

--- a/runtime/src/iree/io/parameter_index_provider.c
+++ b/runtime/src/iree/io/parameter_index_provider.c
@@ -46,9 +46,9 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_index_provider_create(
                            IREE_IO_PARAMETER_OP_BATCH_MAX_CONCURRENCY));
 
   iree_io_parameter_index_provider_t* provider = NULL;
-  iree_host_size_t total_size = sizeof(*provider) + scope.size;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(host_allocator, total_size, (void**)&provider));
+      z0, iree_allocator_malloc_with_trailing(host_allocator, sizeof(*provider),
+                                              scope.size, (void**)&provider));
   iree_atomic_ref_count_init(&provider->base.ref_count);
   provider->base.vtable = &iree_io_parameter_index_provider_vtable;
   provider->host_allocator = host_allocator;

--- a/runtime/src/iree/tokenizer/huggingface/literals_json.c
+++ b/runtime/src/iree/tokenizer/huggingface/literals_json.c
@@ -80,16 +80,14 @@ static iree_status_t iree_tokenizer_literals_parse_entry(
   }
 
   if (unescaped_length > ctx->unescape_capacity) {
-    iree_host_size_t new_capacity = ctx->unescape_capacity * 2;
-    if (new_capacity < unescaped_length) new_capacity = unescaped_length;
-    if (new_capacity < 64) new_capacity = 64;
-    status = iree_allocator_realloc(ctx->literals->allocator, new_capacity,
-                                    (void**)&ctx->unescape_buffer);
+    status = iree_allocator_grow_array(
+        ctx->literals->allocator, iree_max(64, unescaped_length),
+        /*element_size=*/1, &ctx->unescape_capacity,
+        (void**)&ctx->unescape_buffer);
     if (!iree_status_is_ok(status)) {
       ctx->status = status;
       return iree_status_from_code(IREE_STATUS_CANCELLED);
     }
-    ctx->unescape_capacity = new_capacity;
   }
 
   status = iree_json_unescape_string(content_value, ctx->unescape_capacity,

--- a/runtime/src/iree/tokenizer/huggingface/vocab_json.c
+++ b/runtime/src/iree/tokenizer/huggingface/vocab_json.c
@@ -116,16 +116,13 @@ static iree_status_t iree_tokenizer_parse_vocab_visitor(
   // Since unescaped_length <= escaped_length (escapes like \n shrink), we can
   // ensure the buffer fits the escaped size and unescape directly in one pass.
   if (key.size > context->unescape_capacity) {
-    iree_host_size_t new_capacity = context->unescape_capacity * 2;
-    if (new_capacity < key.size) new_capacity = key.size;
-    if (new_capacity < 256) new_capacity = 256;
-    status = iree_allocator_realloc(context->allocator, new_capacity,
-                                    (void**)&context->unescape_buffer);
+    status = iree_allocator_grow_array(
+        context->allocator, iree_max(256, key.size), /*element_size=*/1,
+        &context->unescape_capacity, (void**)&context->unescape_buffer);
     if (!iree_status_is_ok(status)) {
       context->status = status;
       return iree_status_from_code(IREE_STATUS_CANCELLED);
     }
-    context->unescape_capacity = new_capacity;
   }
 
   iree_host_size_t unescaped_length;

--- a/runtime/src/iree/tokenizer/literals.c
+++ b/runtime/src/iree/tokenizer/literals.c
@@ -47,24 +47,20 @@ iree_status_t iree_tokenizer_literals_add(
 
   // Grow entries array if needed.
   if (literals->count >= literals->capacity) {
-    iree_host_size_t new_capacity = literals->capacity * 2;
-    if (new_capacity < 16) new_capacity = 16;
-    IREE_RETURN_IF_ERROR(iree_allocator_realloc(
-        literals->allocator, new_capacity * sizeof(iree_tokenizer_literal_t),
+    IREE_RETURN_IF_ERROR(iree_allocator_grow_array(
+        literals->allocator, /*min_capacity=*/16,
+        sizeof(iree_tokenizer_literal_t), &literals->capacity,
         (void**)&literals->entries));
-    literals->capacity = new_capacity;
   }
 
   // Grow string storage if needed.
   iree_host_size_t new_string_size =
       literals->string_storage_size + content.size;
   if (new_string_size > literals->string_storage_capacity) {
-    iree_host_size_t new_capacity = literals->string_storage_capacity * 2;
-    if (new_capacity < 256) new_capacity = 256;
-    if (new_capacity < new_string_size) new_capacity = new_string_size;
-    IREE_RETURN_IF_ERROR(iree_allocator_realloc(
-        literals->allocator, new_capacity, (void**)&literals->string_storage));
-    literals->string_storage_capacity = new_capacity;
+    IREE_RETURN_IF_ERROR(iree_allocator_grow_array(
+        literals->allocator, iree_max(256, new_string_size),
+        /*element_size=*/1, &literals->string_storage_capacity,
+        (void**)&literals->string_storage));
 
     // Update all existing content pointers (they may have moved).
     char* base = literals->string_storage;

--- a/runtime/src/iree/tokenizer/vocab_builder.c
+++ b/runtime/src/iree/tokenizer/vocab_builder.c
@@ -110,19 +110,11 @@ static iree_status_t iree_tokenizer_vocab_builder_reserve_strings(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Grow by 2x or to min_capacity, whichever is larger.
-  // Guard against overflow when doubling.
-  iree_host_size_t new_capacity = builder->string_capacity;
-  if (new_capacity <= IREE_HOST_SIZE_MAX / 2) {
-    new_capacity *= 2;
-  }
-  if (new_capacity < min_capacity) new_capacity = min_capacity;
-  if (new_capacity < 256) new_capacity = 256;
-
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_realloc(builder->allocator, new_capacity,
-                                 (void**)&builder->string_data));
-
-  builder->string_capacity = new_capacity;
+      z0,
+      iree_allocator_grow_array(builder->allocator, iree_max(256, min_capacity),
+                                /*element_size=*/1, &builder->string_capacity,
+                                (void**)&builder->string_data));
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }

--- a/runtime/src/iree/tooling/function_io.c
+++ b/runtime/src/iree/tooling/function_io.c
@@ -134,18 +134,17 @@ static iree_status_t iree_io_stream_list_append_entry(
 
   // Grow if needed.
   if (list->count + 1 > list->capacity) {
-    iree_host_size_t new_capacity = iree_max(list->capacity * 2, 16);
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_allocator_realloc(list->host_allocator,
-                                   new_capacity * sizeof(*list->entries[0]),
-                                   (void**)&list->entries));
-    list->capacity = new_capacity;
+        z0,
+        iree_allocator_grow_array(list->host_allocator,
+                                  /*min_capacity=*/16, sizeof(list->entries[0]),
+                                  &list->capacity, (void**)&list->entries));
   }
 
   // Allocate the entry and its string storage.
   iree_io_stream_list_entry_t* entry = NULL;
-  iree_status_t status = iree_allocator_malloc(
-      list->host_allocator, sizeof(*entry) + path.size, (void**)&entry);
+  iree_status_t status = iree_allocator_malloc_with_trailing(
+      list->host_allocator, sizeof(*entry), path.size, (void**)&entry);
   if (iree_status_is_ok(status)) {
     entry->path.data = (const char*)entry + sizeof(*entry);
     entry->path.size = path.size;

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -624,9 +624,9 @@ static iree_status_t iree_vm_bytecode_module_resolve_source_location(
 // Lays out the nested tables within a |state| structure.
 // Returns the total size of the structure and all tables with padding applied.
 // |state| may be null if only the structure size is required for allocation.
-static iree_host_size_t iree_vm_bytecode_module_layout_state(
+static iree_status_t iree_vm_bytecode_module_layout_state(
     iree_vm_BytecodeModuleDef_table_t module_def,
-    iree_vm_bytecode_module_state_t* state) {
+    iree_vm_bytecode_module_state_t* state, iree_host_size_t* out_total_size) {
   iree_vm_ModuleStateDef_table_t module_state_def =
       iree_vm_BytecodeModuleDef_module_state(module_def);
   iree_host_size_t rwdata_storage_capacity = 0;
@@ -640,30 +640,35 @@ static iree_host_size_t iree_vm_bytecode_module_layout_state(
   iree_host_size_t import_function_count = iree_vm_ImportFunctionDef_vec_len(
       iree_vm_BytecodeModuleDef_imported_functions(module_def));
 
-  uint8_t* base_ptr = (uint8_t*)state;
-  iree_host_size_t offset =
-      iree_host_align(sizeof(iree_vm_bytecode_module_state_t), 16);
+  // Calculate layout with overflow checking. All counts come from flatbuffer
+  // data (untrusted input).
+  iree_host_size_t total_size = 0;
+  iree_host_size_t rwdata_offset = 0;
+  iree_host_size_t global_refs_offset = 0;
+  iree_host_size_t imports_offset = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      sizeof(iree_vm_bytecode_module_state_t), &total_size,
+      IREE_STRUCT_FIELD_ALIGNED(rwdata_storage_capacity, uint8_t, 16,
+                                &rwdata_offset),
+      IREE_STRUCT_FIELD_ALIGNED(global_ref_count, iree_vm_ref_t, 16,
+                                &global_refs_offset),
+      IREE_STRUCT_FIELD_ALIGNED(import_function_count,
+                                iree_vm_bytecode_import_t, 16,
+                                &imports_offset)));
 
   if (state) {
+    uint8_t* base_ptr = (uint8_t*)state;
     state->rwdata_storage =
-        iree_make_byte_span(base_ptr + offset, rwdata_storage_capacity);
-  }
-  offset += iree_host_align(rwdata_storage_capacity, 16);
-
-  if (state) {
+        iree_make_byte_span(base_ptr + rwdata_offset, rwdata_storage_capacity);
     state->global_ref_count = global_ref_count;
-    state->global_ref_table = (iree_vm_ref_t*)(base_ptr + offset);
-  }
-  offset += iree_host_align(global_ref_count * sizeof(iree_vm_ref_t), 16);
-
-  if (state) {
+    state->global_ref_table = (iree_vm_ref_t*)(base_ptr + global_refs_offset);
     state->import_count = import_function_count;
-    state->import_table = (iree_vm_bytecode_import_t*)(base_ptr + offset);
+    state->import_table =
+        (iree_vm_bytecode_import_t*)(base_ptr + imports_offset);
   }
-  offset +=
-      iree_host_align(import_function_count * sizeof(*state->import_table), 16);
 
-  return offset;
+  *out_total_size = total_size;
+  return iree_ok_status();
 }
 
 static iree_status_t iree_vm_bytecode_module_alloc_state(
@@ -677,8 +682,10 @@ static iree_status_t iree_vm_bytecode_module_alloc_state(
   iree_vm_BytecodeModuleDef_table_t module_def = module->def;
 
   // Compute the total size required (with padding) for the state structure.
-  iree_host_size_t total_state_struct_size =
-      iree_vm_bytecode_module_layout_state(module_def, NULL);
+  iree_host_size_t total_state_struct_size = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_vm_bytecode_module_layout_state(module_def, NULL,
+                                               &total_state_struct_size));
 
   // Allocate the storage for the structure and all its nested tables.
   iree_vm_bytecode_module_state_t* state = NULL;
@@ -688,7 +695,10 @@ static iree_status_t iree_vm_bytecode_module_alloc_state(
   state->allocator = allocator;
 
   // Perform layout to get the pointers into the storage for each nested table.
-  iree_vm_bytecode_module_layout_state(module_def, state);
+  // This cannot fail since we already computed the layout above.
+  iree_host_size_t unused_size = 0;
+  iree_status_ignore(
+      iree_vm_bytecode_module_layout_state(module_def, state, &unused_size));
 
   *out_module_state = (iree_vm_module_state_t*)state;
   IREE_TRACE_ZONE_END(z0);
@@ -730,8 +740,10 @@ static iree_status_t IREE_API_PTR iree_vm_bytecode_module_fork_state(
 
   // Compute the total size required (with padding) for the state structure.
   // This should exactly match the original parent_state size.
-  iree_host_size_t total_state_struct_size =
-      iree_vm_bytecode_module_layout_state(module_def, NULL);
+  iree_host_size_t total_state_struct_size = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_vm_bytecode_module_layout_state(module_def, NULL,
+                                               &total_state_struct_size));
 
   // Allocate the storage for the structure and all its nested tables.
   iree_vm_bytecode_module_state_t* child_state = NULL;
@@ -742,7 +754,10 @@ static iree_status_t IREE_API_PTR iree_vm_bytecode_module_fork_state(
 
   // Perform layout to get the pointers into the storage for each nested table.
   // They are initially unpopulated until we copy over the values.
-  iree_vm_bytecode_module_layout_state(module_def, child_state);
+  // This cannot fail since we already computed the layout above.
+  iree_host_size_t unused_size = 0;
+  iree_status_ignore(iree_vm_bytecode_module_layout_state(
+      module_def, child_state, &unused_size));
 
   // Copy rwdata directly. Any values that the module doesn't want to persist
   // across the fork will be reinitialized during the fork signal handler.
@@ -910,20 +925,25 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(
   }
 
   iree_vm_TypeDef_vec_t type_defs = iree_vm_BytecodeModuleDef_types(module_def);
-  size_t type_table_size = iree_host_align(
-      iree_vm_TypeDef_vec_len(type_defs) * sizeof(iree_vm_type_def_t), 16);
-
+  iree_host_size_t type_count = iree_vm_TypeDef_vec_len(type_defs);
   iree_host_size_t rodata_ref_count = iree_vm_RodataSegmentDef_vec_len(
       iree_vm_BytecodeModuleDef_rodata_segments(module_def));
-  size_t rodata_ref_table_size =
-      iree_host_align(rodata_ref_count * sizeof(iree_vm_buffer_t), 16);
+
+  // Calculate allocation size with overflow checking. All counts come from
+  // flatbuffer data (untrusted input). type_table is a FAM accessed via
+  // module->type_table; rodata_ref_table alignment pads type_table to 16.
+  iree_host_size_t total_size = 0;
+  iree_host_size_t rodata_ref_table_offset = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, IREE_STRUCT_LAYOUT(
+              sizeof(iree_vm_bytecode_module_t), &total_size,
+              IREE_STRUCT_FIELD_FAM(type_count, iree_vm_type_def_t),
+              IREE_STRUCT_FIELD_ALIGNED(rodata_ref_count, iree_vm_buffer_t, 16,
+                                        &rodata_ref_table_offset)));
 
   iree_vm_bytecode_module_t* module = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0,
-      iree_allocator_malloc(
-          allocator, sizeof(*module) + type_table_size + rodata_ref_table_size,
-          (void**)&module));
+      z0, iree_allocator_malloc(allocator, total_size, (void**)&module));
   module->allocator = allocator;
 
   iree_vm_FunctionDescriptor_vec_t function_descriptors =
@@ -941,7 +961,7 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(
   module->archive_allocator = archive_allocator;
   module->def = module_def;
 
-  module->type_count = iree_vm_TypeDef_vec_len(type_defs);
+  module->type_count = type_count;
   iree_status_t resolve_status = iree_vm_bytecode_module_resolve_types(
       instance, type_defs, flags, module->type_table);
   if (!iree_status_is_ok(resolve_status)) {
@@ -976,7 +996,7 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(
   // Setup rodata segments to point directly at the FlatBuffer memory.
   module->rodata_ref_count = rodata_ref_count;
   module->rodata_ref_table =
-      (iree_vm_buffer_t*)((uint8_t*)module + sizeof(*module) + type_table_size);
+      (iree_vm_buffer_t*)((uint8_t*)module + rodata_ref_table_offset);
   iree_vm_RodataSegmentDef_vec_t rodata_segments =
       iree_vm_BytecodeModuleDef_rodata_segments(module_def);
   for (int i = 0; i < module->rodata_ref_count; ++i) {

--- a/runtime/src/iree/vm/list.c
+++ b/runtime/src/iree/vm/list.c
@@ -399,8 +399,8 @@ static void iree_vm_list_copy_to_variant_list(iree_vm_list_t* src_list,
         if (iree_vm_type_def_is_ref(dst_storage[i].type)) {
           iree_vm_ref_release(&dst_storage[i].ref);
         }
-        dst_storage->type = iree_vm_make_ref_type_def(ref->type);
-        dst_storage->ref = *ref;
+        dst_storage[i].type = iree_vm_make_ref_type_def(ref->type);
+        dst_storage[i].ref = *ref;
       }
       break;
     }

--- a/runtime/src/iree/vm/list.c
+++ b/runtime/src/iree/vm/list.c
@@ -293,12 +293,16 @@ iree_vm_list_reserve(iree_vm_list_t* list, iree_host_size_t minimum_capacity) {
     return iree_ok_status();
   }
   iree_host_size_t old_capacity = list->capacity;
-  iree_host_size_t new_capacity = iree_host_align(minimum_capacity, 64);
-  IREE_RETURN_IF_ERROR(iree_allocator_realloc(
-      list->allocator, new_capacity * list->element_size, &list->storage));
+  iree_host_size_t aligned_capacity = 0;
+  if (!iree_host_size_checked_align(minimum_capacity, 64, &aligned_capacity)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "capacity overflow");
+  }
+  IREE_RETURN_IF_ERROR(iree_allocator_grow_array(
+      list->allocator, aligned_capacity, list->element_size, &list->capacity,
+      (void**)&list->storage));
+  // Zero-initialize newly allocated elements.
   memset((void*)((uintptr_t)list->storage + old_capacity * list->element_size),
-         0, (new_capacity - old_capacity) * list->element_size);
-  list->capacity = new_capacity;
+         0, (list->capacity - old_capacity) * list->element_size);
   return iree_ok_status();
 }
 
@@ -317,9 +321,8 @@ IREE_API_EXPORT iree_status_t iree_vm_list_resize(iree_vm_list_t* list,
     iree_vm_list_reset_range(list, new_size, list->count - new_size);
     list->count = new_size;
   } else if (new_size > list->capacity) {
-    // Extending beyond capacity.
-    IREE_RETURN_IF_ERROR(iree_vm_list_reserve(
-        list, iree_max(list->capacity * 2, iree_host_align(new_size, 64))));
+    // Extending beyond capacity. reserve() handles alignment and 2x growth.
+    IREE_RETURN_IF_ERROR(iree_vm_list_reserve(list, new_size));
   }
   list->count = new_size;
   return iree_ok_status();


### PR DESCRIPTION
Adds checked arithmetic primitives (iree_host_size_checked_add/mul/mul_add, iree_host/device_size_checked_align, etc), IREE_STRUCT_LAYOUT for computing struct-with-trailing-arrays sizes, and iree_allocator_malloc_array/grow_array for safe array allocations with overflow checking. Much of the runtime has been migrated to these new helpers though there are still places remaining for future improvements (tokenizer is being reworked to use this in other changes, some HAL drivers need upgrading still).

ci-extra: all