### PR TITLE
[Transforms] fix const member initializes fo HoistIntoGlobalsPass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -390,7 +390,7 @@ public:
 
 private:
   const std::optional<ExprHoistingOptions::RegisterDialectsFn>
-      registerDependentDialectsFn;
+      registerDependentDialectsFn = std::nullopt;
 };
 
 } // namespace


### PR DESCRIPTION
constructor inherited by 'HoistIntoGlobalsPass' is implicitly deleted because field 'registerDependentDialectsFn' of const-qualified type 'const std::optional<ExprHoistingOptions::RegisterDialectsFn>' would not be initialized;
Provide explicit default constructor that initializes the const member to `std::nullopt`
Fixes : https://github.com/iree-org/iree/issues/23166