### PR TITLE
[CI] Update torch_ops config file and run tests when config files are modified

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -195,14 +195,6 @@ PRESUBMIT_TOUCH_ONLY_JOBS = [
         "test_torch",
         ["tests/external/iree-test-suites/torch*"],
     ),
-    (
-        "test_onnx",
-        ["tests/external/iree-test-suites/onnx*"],
-    ),
-    (
-        "test_sharktank",
-        ["tests/external/iree-test-suites/sharktank*"],
-    ),
 ]
 
 PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -191,6 +191,18 @@ PRESUBMIT_TOUCH_ONLY_JOBS = [
             ".github/worklflows/ci_windows_x64_msvc.yml",
         ],
     ),
+    (
+        "test_torch",
+        ["tests/external/iree-test-suites/torch*"],
+    ),
+    (
+        "test_onnx",
+        ["tests/external/iree-test-suites/onnx*"],
+    ),
+    (
+        "test_sharktank",
+        ["tests/external/iree-test-suites/sharktank*"],
+    ),
 ]
 
 PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
@@ -8,12 +8,29 @@
   "iree_run_module_flags": [
     "--device=hip"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "InterestingShapesBiasAdd/997x997xi8_NN_bias"
+  ],
   "skip_run_tests": [
     "ABPlusC/64x64xf16",
-    "ATB/64x64xf16"
+    "ATB/64x64xf16",
+    "AB/1024x1024xf32_bench",
+    "AB/128x128xf32_bench",
+    "AB/2048x2048xf32_bench",
+    "AB/256x256xf32_bench",
+    "AB/4096x4096xf32_bench",
+    "AB/512x512xf32_bench",
+    "AB/8192x8192xf32_bench"
   ],
   "expected_compile_failures": [],
   "expected_run_failures": [],
-  "golden_times_ms": {}
+  "golden_times_ms": {
+    "AB/1024x1024xf32_bench" : 0.0,
+    "AB/128x128xf32_bench" : 0.0,
+    "AB/2048x2048xf32_bench" : 0.0,
+    "AB/256x256xf32_bench" : 0.0,
+    "AB/4096x4096xf32_bench" : 0.0,
+    "AB/512x512xf32_bench" : 0.0,
+    "AB/8192x8192xf32_bench" : 0.0
+  }
 }


### PR DESCRIPTION
* Updates torch_ops configuration file to skip running some tests (new tests added without golden_value and a new failing that was not skipped).
* Adds a new rule to configure_ci.py to run torch tests whenever configuration files are modified. This is because otherwise one needs to remember to add ci-extra to test relevant tests. (onnx and sharktank are not included here since they are always run on pre-submit)