### PR TITLE
[Codegen] Fix compiler errors in LinkTuningSpecsPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -409,12 +409,8 @@ static FailureOr<NamedSequenceOp> emitLinkedDefaultTuningSpec(ModuleOp module) {
   SmallVector<Attribute> mergedActions;
 
   for (ForeachMatchOp foreachMatchOp : foreachMatchOps) {
-    ArrayAttr matchers = foreachMatchOp.getMatchers();
-    ArrayAttr actions = foreachMatchOp.getActions();
-    for (auto [matcher, action] : llvm::zip_equal(matchers, actions)) {
-      mergedMatchers.push_back(cast<SymbolRefAttr>(matcher));
-      mergedActions.push_back(cast<SymbolRefAttr>(action));
-    }
+    llvm::append_range(mergedMatchers, foreachMatchOp.getMatchers());
+    llvm::append_range(mergedActions, foreachMatchOp.getActions());
   }
 
   Region &region = newEntryPoint.getRegion();
@@ -423,8 +419,8 @@ static FailureOr<NamedSequenceOp> emitLinkedDefaultTuningSpec(ModuleOp module) {
   builder.setInsertionPointToStart(body);
   auto mergedForeachMatch = ForeachMatchOp::create(
       builder, loc, resultTypes, newEntryPoint.getArgument(0),
-      /* forwarded_inputs = */ ValueRange(),
-      /* restrictRoot = */ nullptr, /* flattenResults = */ nullptr,
+      /*forwarded_inputs=*/ValueRange(),
+      /*restrict_root=*/false, /*flatten_results=*/false,
       builder.getArrayAttr(mergedMatchers),
       builder.getArrayAttr(mergedActions));
   transform::YieldOp::create(builder, loc, mergedForeachMatch->getResult(0));


### PR DESCRIPTION
Pass booleans instead of `nullptr`; the former confuses some compilers because both `bool` and `Value` are constructible with `nullptr`.

Also clean up comments and needlessly complicated code just above.

Fixes: https://github.com/iree-org/iree/issues/23164