### PR TITLE
[AArch64] Disable breaking up transfer+extract into multiple scalar loads for AArch64

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -88,7 +88,8 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     // scalar fashion into scalar loads. This will let scalar loads to be folded
     // into broadcast/arithmetic operations and reduce register pressure.
     vector::populateScalarVectorTransferLoweringPatterns(
-        patterns, /*benefit=*/1, /*allowMultipleUses=*/true);
+        patterns, /*benefit=*/1,
+        /*allowMultipleUses=*/!(targetConfig && isAArch64(targetConfig)));
     vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
     vector::populateVectorMultiReductionReorderPatterns(
         patterns, vectorMultiReductionLowering);


### PR DESCRIPTION
Disable the transformation that breaks up vector loads followed by an extract into multiple scalar loads for the AArch64 target.

With this transformation disabled we keep the efficient vector loads while opening opportunities for using indexed forms of instructions, for example
https://developer.arm.com/documentation/ddi0602/2025-12/SIMD-FP-Instructions/FMLA--by-element---Floating-point-fused-multiply-add-to-accumulator--by-element--?lang=en

We have observed 8-12% performance improvements on various matrix multiplication workloads and GPT2 with Neon.

Signed-off-by: Momchil Velikov <momchil.velikov@arm.com>