### PR TITLE
Enable passing e2e tests for ROCM, VMVX, and Vulkan backends

### DIFF
--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -73,8 +73,10 @@ iree_check_single_backend_test_suite(
 VMVX_SRCS = enforce_glob(
     # keep sorted
     [
+        "argmax.mlir",
         "conv2d.mlir",
         "gather_like_ops.mlir",
+        "index.mlir",
         "narrow_n_matmuls.mlir",
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
@@ -84,10 +86,8 @@ VMVX_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
-        "argmax.mlir",
         "fp_to_subbyte.mlir",
         "fp4_f32_conversion.mlir",
-        "index.mlir",
         "large_linalg_matmul.mlir",
         "subbyte_to_fp.mlir",
     ],
@@ -124,18 +124,18 @@ iree_check_single_backend_test_suite(
 VULKAN_SRCS = enforce_glob(
     # keep sorted
     [
+        "argmax.mlir",
         "conv2d.mlir",
         "gather_like_ops.mlir",
+        "index.mlir",
         "narrow_n_matmuls.mlir",
         "softmax.mlir",
         "subbyte_to_fp.mlir",
     ],
     include = ["*.mlir"],
     exclude = [
-        "argmax.mlir",
         "fp_to_subbyte.mlir",
         "fp4_f32_conversion.mlir",
-        "index.mlir",
         "large_linalg_matmul.mlir",
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
@@ -221,20 +221,20 @@ ROCM_SRCS = enforce_glob(
     # keep sorted
     [
         "argmax.mlir",
+        "conv2d.mlir",
+        "fp4_f32_conversion.mlir",
+        "fp_to_subbyte.mlir",
         "gather_like_ops.mlir",
+        "index.mlir",
+        "narrow_n_matmuls.mlir",
         "pack_i8.mlir",
         "softmax.mlir",
+        "subbyte_to_fp.mlir",
         "unpack.mlir",
     ],
     include = ["*.mlir"],
     exclude = [
-        "conv2d.mlir",
-        "fp_to_subbyte.mlir",
-        "fp4_f32_conversion.mlir",
-        "index.mlir",
         "large_linalg_matmul.mlir",
-        "narrow_n_matmuls.mlir",
-        "subbyte_to_fp.mlir",
         # https://github.com/llvm/llvm-project/issues/131386 causes
         # See bug #20294
         "pack.mlir",

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -55,8 +55,10 @@ iree_check_single_backend_test_suite(
   NAME
     check_vmvx_local-task
   SRCS
+    "argmax.mlir"
     "conv2d.mlir"
     "gather_like_ops.mlir"
+    "index.mlir"
     "narrow_n_matmuls.mlir"
     "pack.mlir"
     "pack_dynamic_inner_tiles.mlir"
@@ -89,8 +91,10 @@ iree_check_single_backend_test_suite(
   NAME
     check_vulkan-spirv_vulkan
   SRCS
+    "argmax.mlir"
     "conv2d.mlir"
     "gather_like_ops.mlir"
+    "index.mlir"
     "narrow_n_matmuls.mlir"
     "softmax.mlir"
     "subbyte_to_fp.mlir"
@@ -156,9 +160,15 @@ iree_check_single_backend_test_suite(
     check_rocm_hip
   SRCS
     "argmax.mlir"
+    "conv2d.mlir"
+    "fp4_f32_conversion.mlir"
+    "fp_to_subbyte.mlir"
     "gather_like_ops.mlir"
+    "index.mlir"
+    "narrow_n_matmuls.mlir"
     "pack_i8.mlir"
     "softmax.mlir"
+    "subbyte_to_fp.mlir"
     "unpack.mlir"
   TARGET_BACKEND
     "rocm"

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -69,6 +69,7 @@ VMVX_SRCS = enforce_glob(
     # keep sorted
     [
         "arg_compare.mlir",
+        "attention.mlir",
         "gather.mlir",
         "map_gather.mlir",
         "map_scatter.mlir",
@@ -81,7 +82,6 @@ VMVX_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
-        "attention.mlir",
         "attention_i1_mask.mlir",
         "attention_i1_mask_encoding.mlir",
     ],
@@ -195,9 +195,12 @@ iree_check_single_backend_test_suite(
         [
             "arg_compare.mlir",
             "gather.mlir",
+            "map_gather.mlir",
+            "map_scatter.mlir",
             "scan.mlir",
             "scatter.mlir",
             "sort.mlir",
+            "top-k.mlir",
             "winograd_input.mlir",
             "winograd_output.mlir",
         ],
@@ -206,9 +209,6 @@ iree_check_single_backend_test_suite(
             "attention.mlir",
             "attention_i1_mask.mlir",
             "attention_i1_mask_encoding.mlir",
-            "map_gather.mlir",
-            "map_scatter.mlir",
-            "top-k.mlir",
         ],
     ),
     driver = "vulkan",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_check_single_backend_test_suite(
     check_vmvx_local-task
   SRCS
     "arg_compare.mlir"
+    "attention.mlir"
     "gather.mlir"
     "map_gather.mlir"
     "map_scatter.mlir"
@@ -138,9 +139,12 @@ iree_check_single_backend_test_suite(
   SRCS
     "arg_compare.mlir"
     "gather.mlir"
+    "map_gather.mlir"
+    "map_scatter.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"
+    "top-k.mlir"
     "winograd_input.mlir"
     "winograd_output.mlir"
   TARGET_BACKEND

--- a/tests/e2e/stablehlo_ops/BUILD.bazel
+++ b/tests/e2e/stablehlo_ops/BUILD.bazel
@@ -241,6 +241,7 @@ iree_check_single_backend_test_suite(
             "reduce_window.mlir",
             "remainder.mlir",
             "reshape.mlir",
+            "reverse.mlir",
             "rng_normal.mlir",
             "rng_uniform.mlir",
             "round.mlir",
@@ -264,7 +265,6 @@ iree_check_single_backend_test_suite(
         exclude = [
             "exponential_fp16.mlir",
             "fft.mlir",  # TODO(#9583)
-            "reverse.mlir",  # TODO(#12415): disabled due to miscompilation on Pixel 6.
         ],
     ),
     compiler_flags = [

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -287,6 +287,7 @@ iree_check_single_backend_test_suite(
     "reduce_window.mlir"
     "remainder.mlir"
     "reshape.mlir"
+    "reverse.mlir"
     "rng_normal.mlir"
     "rng_uniform.mlir"
     "round.mlir"


### PR DESCRIPTION
Enable tests that were previously excluded but now pass:

ROCM/HIP (tests/e2e/linalg):
- conv2d, narrow_n_matmuls, subbyte_to_fp, fp_to_subbyte, fp4_f32_conversion, index

VMVX (tests/e2e/linalg):
- argmax, index

VMVX (tests/e2e/linalg_ext_ops):
- attention

Vulkan (tests/e2e/linalg):
- argmax, index

Vulkan (tests/e2e/linalg_ext_ops):
- map_gather, map_scatter, top-k

Vulkan (tests/e2e/stablehlo_ops):
- reverse

Below is the additional testing time on my machine (using gfx1100):

```
● Test execution times for newly enabled tests:
  ┌──────────┬───────┬────────────┐
  │ Backend  │ Tests │ Total Time │
  ├──────────┼───────┼────────────┤
  │ ROCM/HIP │ 6     │ 3.06 sec   │
  ├──────────┼───────┼────────────┤
  │ VMVX     │ 3     │ 0.28 sec   │
  ├──────────┼───────┼────────────┤
  │ Vulkan   │ 6     │ 0.58 sec   │
  ├──────────┼───────┼────────────┤
  │ Total    │ 15    │ ~3.9 sec   │
  └──────────┴───────┴────────────┘
  Individual test breakdown:

  ROCM/HIP:
  - conv2d: 0.28s
  - fp4_f32_conversion: 0.39s
  - fp_to_subbyte: 0.43s
  - index: 0.27s
  - narrow_n_matmuls: 0.97s
  - subbyte_to_fp: 0.72s

  VMVX:
  - argmax: 0.04s
  - index: 0.04s
  - attention: 0.20s

  Vulkan:
  - argmax: 0.05s
  - index: 0.05s
  - map_gather: 0.13s
  - map_scatter: 0.12s
  - top-k: 0.19s
  - reverse: 0.05s

  All tests are fast (under 1 second each). The slowest is narrow_n_matmuls on ROCM at ~1 second.
```