### PR TITLE
[Codegen][GPU] Enable swizzling for scaled matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -607,6 +607,11 @@ getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
         vmmaAttr.getIntrinsic(), operandIndex,
         operandIndex == kMMAOperandAcc && vmmaAttr.getColMajor());
   }
+  if (auto smmaAttr = dyn_cast<ScaledMMAAttr>(mmaKind)) {
+    return IREE::GPU::getSingleSubgroupLayout(
+        smmaAttr.getIntrinsic(), operandIndex,
+        operandIndex == kScaledMMAOperandAcc && smmaAttr.getColMajor());
+  }
   assert(false && "unhandled MMA Interface type.");
   return {};
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -284,6 +284,10 @@ getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
 MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
                                                 int64_t operandIndex);
 
+MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
+                                                int64_t operandIndex,
+                                                bool isAccColMajor);
+
 /// Returns the name of the tilling `level`, as used in the `lowering_config`
 /// attribute.
 StringRef getTilingLevelName(GPU::TilingLevel level);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -225,3 +225,12 @@ module {
 }
 // CHECK-LABEL: func @test_lane_increment_step_and_aligned
 //  CHECK-SAME:   lane_increment = #iree_gpu.lane_increment<64, step = 2, aligned>
+
+module {
+  func.func @test_swizzle_hint_promotion() attributes {
+      promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>]} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_swizzle_hint_promotion
+//  CHECK-SAME:   promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -941,10 +941,10 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
     // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
     FailureOr<Attribute> lhsSwizzleAttr =
-        getXORShuffleAttr(context, defaultConfigAttr, target, kind,
+        getXorShuffleAttr(context, defaultConfigAttr, target, kind,
                           schedule->kTileSizes, kMMAOperandLhs);
     FailureOr<Attribute> rhsSwizzleAttr =
-        getXORShuffleAttr(context, defaultConfigAttr, target, kind,
+        getXorShuffleAttr(context, defaultConfigAttr, target, kind,
                           schedule->kTileSizes, kMMAOperandRhs);
     if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
       promotionArray = {};

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -937,7 +937,6 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // TODO(#22119): We don't use global load DMA for scaled matmuls, because
     // compilation doesn't support it. Once this is fixed, we should use global
     // load DMA here when possible.
-
     promotionList.append({2, 3});
     auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
     FailureOr<Attribute> lhsSwizzleAttr =
@@ -947,10 +946,11 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
         getXORShuffleAttr(context, defaultConfigAttr, target, kind,
                           schedule->kTileSizes, kMMAOperandRhs);
     if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
-      return failure();
+      promotionArray = {};
+    } else {
+      promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
+                        defaultConfigAttr};
     }
-    promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
-                      defaultConfigAttr};
   }
   if ((!mustBeAligned || couldNeedPadding) && cPromoteIfPadding) {
     // If needed then add C operand which would be operand 2 or 4 for unscaled

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -941,8 +941,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
     // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
     FailureOr<Attribute> lhsSwizzleAttr =
-    getXORShuffleAttr(context, defaultConfigAttr, target, kind,
-      schedule->kTileSizes, kMMAOperandLhs);
+        getXORShuffleAttr(context, defaultConfigAttr, target, kind,
+                          schedule->kTileSizes, kMMAOperandLhs);
     FailureOr<Attribute> rhsSwizzleAttr =
         getXORShuffleAttr(context, defaultConfigAttr, target, kind,
                           schedule->kTileSizes, kMMAOperandRhs);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -937,8 +937,20 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // TODO(#22119): We don't use global load DMA for scaled matmuls, because
     // compilation doesn't support it. Once this is fixed, we should use global
     // load DMA here when possible.
-    promotionArray = {};
+
     promotionList.append({2, 3});
+    auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
+    FailureOr<Attribute> lhsSwizzleAttr =
+        getXORShuffleAttr(context, defaultConfigAttr, target, kind,
+                          schedule->kTileSizes, kMMAOperandLhs);
+    FailureOr<Attribute> rhsSwizzleAttr =
+        getXORShuffleAttr(context, defaultConfigAttr, target, kind,
+                          schedule->kTileSizes, kMMAOperandRhs);
+    if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
+      return failure();
+    }
+    promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
+                      defaultConfigAttr};
   }
   if ((!mustBeAligned || couldNeedPadding) && cPromoteIfPadding) {
     // If needed then add C operand which would be operand 2 or 4 for unscaled

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -939,9 +939,10 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // load DMA here when possible.
     promotionList.append({2, 3});
     auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
+    // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
     FailureOr<Attribute> lhsSwizzleAttr =
-        getXORShuffleAttr(context, defaultConfigAttr, target, kind,
-                          schedule->kTileSizes, kMMAOperandLhs);
+    getXORShuffleAttr(context, defaultConfigAttr, target, kind,
+      schedule->kTileSizes, kMMAOperandLhs);
     FailureOr<Attribute> rhsSwizzleAttr =
         getXORShuffleAttr(context, defaultConfigAttr, target, kind,
                           schedule->kTileSizes, kMMAOperandRhs);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -603,11 +603,11 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
   funcPassManager.addPass(createUnrollAnnotatedLoopsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
-  // if (pipelineOptions.enableReduceSharedMemoryBankConflicts) {
-  //   GPUReduceBankConflictsPassOptions options = {};
-  //   options.paddingBits = 64;
-  //   funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
-  // }
+  if (pipelineOptions.enableReduceSharedMemoryBankConflicts) {
+    GPUReduceBankConflictsPassOptions options = {};
+    options.paddingBits = 64;
+    funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
+  }
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   if (forROCDL && pipelineOptions.prefetchNumStages >= 2) {
     funcPassManager.addPass(createFissionTransferOpsInControlFlowPass());
@@ -866,11 +866,11 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // if (options.enableReduceSharedMemoryBankConflicts) {
-  //   GPUReduceBankConflictsPassOptions options = {};
-  //   options.paddingBits = 64;
-  //   funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
-  // }
+  if (options.enableReduceSharedMemoryBankConflicts) {
+    GPUReduceBankConflictsPassOptions options = {};
+    options.paddingBits = 64;
+    funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
+  }
   if (forROCDL && options.prefetchNumStages >= 2) {
     ROCDLPrefetchSharedMemoryPassOptions prefetchOpts;
     prefetchOpts.numStages = options.prefetchNumStages;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -603,11 +603,11 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
   funcPassManager.addPass(createUnrollAnnotatedLoopsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
-  if (pipelineOptions.enableReduceSharedMemoryBankConflicts) {
-    GPUReduceBankConflictsPassOptions options = {};
-    options.paddingBits = 64;
-    funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
-  }
+  // if (pipelineOptions.enableReduceSharedMemoryBankConflicts) {
+  //   GPUReduceBankConflictsPassOptions options = {};
+  //   options.paddingBits = 64;
+  //   funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
+  // }
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   if (forROCDL && pipelineOptions.prefetchNumStages >= 2) {
     funcPassManager.addPass(createFissionTransferOpsInControlFlowPass());
@@ -866,11 +866,11 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  if (options.enableReduceSharedMemoryBankConflicts) {
-    GPUReduceBankConflictsPassOptions options = {};
-    options.paddingBits = 64;
-    funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
-  }
+  // if (options.enableReduceSharedMemoryBankConflicts) {
+  //   GPUReduceBankConflictsPassOptions options = {};
+  //   options.paddingBits = 64;
+  //   funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
+  // }
   if (forROCDL && options.prefetchNumStages >= 2) {
     ROCDLPrefetchSharedMemoryPassOptions prefetchOpts;
     prefetchOpts.numStages = options.prefetchNumStages;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -36,7 +36,7 @@ func.func @scaled_matmul(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
-//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 //  CHECK-SAME:     reduction = [0, 0, 1, 1]
 //  CHECK-SAME:     subgroup = [4, 8, 0, 0]
 //  CHECK-SAME:     workgroup = [256, 256, 0, 0]
@@ -71,11 +71,10 @@ func.func @scaled_matmul_with_batch(
 // CHECK-LABEL: func.func @scaled_matmul_with_batch
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
-//   CHECK-NOT:   promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
-//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 //  CHECK-SAME:     reduction = [0, 0, 0, 1, 1]
 //  CHECK-SAME:     subgroup = [0, 4, 8, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 256, 256, 0, 0]
@@ -141,7 +140,7 @@ func.func @scaled_matmul_with_dynamic_batch(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
-//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 //  CHECK-SAME:     reduction = [0, 0, 0, 1, 1]
 //  CHECK-SAME:     subgroup = [0, 4, 4, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 128, 256, 0, 0]
@@ -179,7 +178,7 @@ func.func @small_scaled_matmul(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
-//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 //  CHECK-SAME:     reduction = [0, 0, 1, 1]
 //  CHECK-SAME:     subgroup = [1, 1, 0, 0]
 //  CHECK-SAME:     workgroup = [16, 16, 0, 0]
@@ -292,6 +291,7 @@ func.func @scaled_matmul_accumulate(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 //  CHECK-SAME:     reduction = [0, 0, 1, 1]
 //  CHECK-SAME:     subgroup = [2, 8, 0, 0]
 //       CHECK:     workgroup = [128, 256, 0, 0]

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TargetParser",
         "@llvm-project//mlir:AMDGPUDialect",
+        "@llvm-project//mlir:AMDGPUUtils",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     LLVMSupport
     LLVMTargetParser
     MLIRAMDGPUDialect
+    MLIRAMDGPUUtils
     MLIRAffineDialect
     MLIRAnalysis
     MLIRArithDialect

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -828,24 +828,38 @@ bool isXORShuffleValid(int64_t numRowElems, int64_t numAccessElems,
   // The number of total tile elements we want to swizzle must be greater than
   // or equal to the number of elements in a row.
   if (totalTileElems < numRowElems) {
+    LDBG() << "The number of row elements exceed the total elements in the tile"
+           << "\n";
     return false;
   }
   // We need at least one column of access elements to swizzle within a row.
-  if (numAccessElems < numRowElems) {
+  if (numRowElems < numAccessElems) {
+    LDBG()
+        << "The number of access elements exceed the total elements in the row"
+        << "\n";
     return false;
   }
   // The size of a row must evenly divide the total number of tile elements.
   if (totalTileElems % numRowElems != 0) {
+    LDBG() << "The number of row elements does not evenly divide the total "
+              "elements in the tile"
+           << "\n";
     return false;
   }
   // The number of access elements must evenly divide the number of row
   // elements.
   if (numRowElems % numAccessElems != 0) {
+    LDBG() << "The number of access elements does not evenly divide the number "
+              "of row elements"
+           << "\n";
     return false;
   }
   // The number of columns in a row must evenly divide the total number of tile
   // elements. This is to avoid incomplete rows at the end of the tile.
-  if (((numRowElems / numAccessElems) % totalTileElems) != 0) {
+  if (totalTileElems % (numRowElems / numAccessElems) != 0) {
+    LDBG() << "The number of columns in a row does not evenly divide the total "
+              "elements in the tile"
+           << "\n";
     return false;
   }
   return true;

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -839,7 +839,7 @@ validateXorShuffle(FailureOr<std::pair<int64_t, int64_t>> swizzle,
 
 // Disabling clang-tidy for the following functions, as it will be externally
 // linked to the CAPI in a future PR.
-// NOLINTBEGIN
+// NOLINTBEGIN(misc-use-internal-linkage)
 FailureOr<std::pair<int64_t, int64_t>>
 getXorShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     int operandIndex) {
@@ -960,7 +960,7 @@ getXorShuffleParams(IREE::GPU::TargetAttr target,
   }
   return xorShuffleAttr;
 }
-// NOLINTEND
+// NOLINTEND(misc-use-internal-linkage)
 
 FailureOr<Attribute>
 getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -898,9 +898,8 @@ FailureOr<std::pair<int64_t, int64_t>> getXorShuffleParamsForTunedChipset(
     return failure();
   }
   if (*maybeChipset == amdgpu::Chipset(9, 5, 0)) {
-    return validateXorShuffle(
-        getXorShuffleParamsForGfx950(target, intrinsic, operandIndex),
-        intrinsic, operandIndex);
+    return validateXorShuffle(getXorShuffleParamsForGfx950(target, intrinsic),
+                              intrinsic, operandIndex);
   }
   return failure();
 }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -801,6 +801,9 @@ getTotalTileElems(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
          llvm::product_of(layout.element);
 }
 
+// Disabling clang-tidy for the following function, as it will be externally
+// linked to the CAPI in a future PR. 
+// NOLINTBEGIN
 FailureOr<std::pair<int64_t, int64_t>>
 getXorShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     int operandIndex) {
@@ -813,6 +816,7 @@ getXorShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
   }
   return std::pair(*maybeMinimumAccessElems, *maybeTotalTileElems);
 }
+// NOLINTEND
 
 bool isXORShuffleValid(int64_t numRowElems, int64_t numAccessElems,
                        int64_t totalTileElems) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -767,7 +767,7 @@ getKSize(IREE::Codegen::InnerTileDescAttrInterface intrinsic) {
   intrinsic.getUndistributedTileTypes(undistributedTypes);
   auto shape = undistributedTypes[lhsOperandIndex].getShape();
   auto lhsIteratorTypes = intrinsic.getOperandIteratorTypes()[lhsOperandIndex];
-  for (auto [dim, iteratorType] : llvm::zip_equals(shape, lhsIteratorTypes)) {
+  for (auto [dim, iteratorType] : llvm::zip_equal(shape, lhsIteratorTypes)) {
     if (iteratorType == utils::IteratorType::reduction) {
       kSize *= dim;
     }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -767,11 +767,9 @@ getKSize(IREE::Codegen::InnerTileDescAttrInterface intrinsic) {
   intrinsic.getUndistributedTileTypes(undistributedTypes);
   auto shape = undistributedTypes[lhsOperandIndex].getShape();
   auto lhsIteratorTypes = intrinsic.getOperandIteratorTypes()[lhsOperandIndex];
-  assert(lhsIteratorTypes.size() == shape.size() &&
-         "Iterator types and shape must have the same size");
-  for (auto [i, iteratorType] : llvm::enumerate(lhsIteratorTypes)) {
+  for (auto [dim, iteratorType] : llvm::zip_equals(shape, lhsIteratorTypes)) {
     if (iteratorType == utils::IteratorType::reduction) {
-      kSize *= shape[i];
+      kSize *= dim;
     }
   }
   return kSize;

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -769,8 +769,8 @@ getKSize(IREE::Codegen::InnerTileDescAttrInterface intrinsic) {
   auto lhsIteratorTypes = intrinsic.getOperandIteratorTypes()[lhsOperandIndex];
   assert(lhsIteratorTypes.size() == shape.size() &&
          "Iterator types and shape must have the same size");
-  for (int i = 0; i < lhsIteratorTypes.size(); i++) {
-    if (lhsIteratorTypes[i] == utils::IteratorType::reduction) {
+  for (auto [i, iteratorType] : llvm::enumerate(lhsIteratorTypes)) {
+    if (iteratorType == utils::IteratorType::reduction) {
       kSize *= shape[i];
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -751,7 +751,7 @@ getOperandBitwidth(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                    int operandIndex) {
   SmallVector<Type> elementTypes;
   intrinsic.getElementTypes(elementTypes);
-  assert(elementTypes.size() > operandIndex && "Operand index out of bounds");
+  assert(operandIndex > 0 && "operand index must be positive");
   return elementTypes[operandIndex].getIntOrFloatBitWidth();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -579,9 +579,7 @@ Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
 gpu::AllReduceOperation combiningKindToAllReduce(vector::CombiningKind kind) {
   switch (kind) {
 #define MAP_CASE(X)                                                            \
-  \ 
   case vector::CombiningKind::X:                                               \
-  \ 
     return gpu::AllReduceOperation::X
 
     MAP_CASE(ADD);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -178,10 +178,8 @@ mlir::gpu::AllReduceOperation
 combiningKindToAllReduce(vector::CombiningKind kind);
 
 struct XorShuffleParams {
-  int64_t row_width;
-  int64_t access_width;
-  XorShuffleParams(int64_t row_width, int64_t access_width)
-      : row_width(row_width), access_width(access_width) {}
+  int64_t rowElems;
+  int64_t accessElems;
 };
 
 /// For a given MMA intrinsic and operand, returns the lower bound and upper

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -188,7 +188,7 @@ combiningKindToAllReduce(vector::CombiningKind kind);
 /// - sweep row elements over all multiple of the access elements, respecting
 /// the upper bound.
 FailureOr<std::pair<int64_t, int64_t>>
-getXORShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
+getXorShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     int operandIndex);
 
 /// Returns true if the XOR shuffle is valid for the given number of row
@@ -208,13 +208,13 @@ bool isXORShuffleValid(int64_t numRowElems, int64_t numAccessElems,
 
 /// Returns XOR shuffle parameters known to be optimal for the given target and
 /// intrinsic based on profiling results.
-FailureOr<std::pair<int64_t, int64_t>> getXORShuffleParamsForTunedChipset(
+FailureOr<std::pair<int64_t, int64_t>> getXorShuffleParamsForTunedChipset(
     IREE::GPU::TargetAttr target,
     IREE::Codegen::InnerTileDescAttrInterface intrinsic, int operandIndex);
 
 /// Note this generic heuristic for untuned cases is not guaranteed to be
 /// optimal for all targets and intrinsics.
-FailureOr<std::pair<int64_t, int64_t>> getXORShuffleParamsForUntunedChipset(
+FailureOr<std::pair<int64_t, int64_t>> getXorShuffleParamsForUntunedChipset(
     IREE::GPU::TargetAttr target,
     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
     ArrayRef<int64_t> reductionTileSizes, int operandIndex);
@@ -228,14 +228,14 @@ FailureOr<std::pair<int64_t, int64_t>> getXORShuffleParamsForUntunedChipset(
 /// generic heuristic for untuned cases is not guaranteed to be optimal for all
 /// targets and intrinsics.
 FailureOr<std::pair<int64_t, int64_t>>
-getXORShuffleParams(IREE::GPU::TargetAttr target,
+getXorShuffleParams(IREE::GPU::TargetAttr target,
                     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     ArrayRef<int64_t> reductionTileSizes, int operandIndex);
 
 /// Returns the XOR shuffle attribute for the given target, intrinsic, and
 /// operand index.
 FailureOr<Attribute>
-getXORShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
+getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                   IREE::GPU::TargetAttr target,
                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                   ArrayRef<int64_t> reductionTileSizes, int operandIndex);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -177,6 +177,13 @@ Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
 mlir::gpu::AllReduceOperation
 combiningKindToAllReduce(vector::CombiningKind kind);
 
+struct XorShuffleParams {
+  int64_t row_width;
+  int64_t access_width;
+  XorShuffleParams(int64_t row_width, int64_t access_width)
+      : row_width(row_width), access_width(access_width) {}
+};
+
 /// For a given MMA intrinsic and operand, returns the lower bound and upper
 /// bound for valid values of XOR shuffle attribute parameters, access width and
 /// row width. For both parameters, the elements ingested per thread at a time
@@ -187,7 +194,7 @@ combiningKindToAllReduce(vector::CombiningKind kind);
 /// the upper bound.
 /// - sweep row elements over all multiple of the access elements, respecting
 /// the upper bound.
-FailureOr<std::pair<int64_t, int64_t>>
+FailureOr<XorShuffleParams>
 getXorShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     int operandIndex);
 
@@ -208,13 +215,13 @@ bool isXORShuffleValid(int64_t numRowElems, int64_t numAccessElems,
 
 /// Returns XOR shuffle parameters known to be optimal for the given target and
 /// intrinsic based on profiling results.
-FailureOr<std::pair<int64_t, int64_t>> getXorShuffleParamsForTunedChipset(
+FailureOr<XorShuffleParams> getXorShuffleParamsForTunedChipset(
     IREE::GPU::TargetAttr target,
     IREE::Codegen::InnerTileDescAttrInterface intrinsic, int operandIndex);
 
 /// Note this generic heuristic for untuned cases is not guaranteed to be
 /// optimal for all targets and intrinsics.
-FailureOr<std::pair<int64_t, int64_t>> getXorShuffleParamsForUntunedChipset(
+FailureOr<XorShuffleParams> getXorShuffleParamsForUntunedChipset(
     IREE::GPU::TargetAttr target,
     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
     ArrayRef<int64_t> reductionTileSizes, int operandIndex);
@@ -227,7 +234,7 @@ FailureOr<std::pair<int64_t, int64_t>> getXorShuffleParamsForUntunedChipset(
 /// computed by calculating the K tile size and LDS bank width. Note this
 /// generic heuristic for untuned cases is not guaranteed to be optimal for all
 /// targets and intrinsics.
-FailureOr<std::pair<int64_t, int64_t>>
+FailureOr<XorShuffleParams>
 getXorShuffleParams(IREE::GPU::TargetAttr target,
                     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     ArrayRef<int64_t> reductionTileSizes, int operandIndex);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -177,6 +177,35 @@ Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
 mlir::gpu::AllReduceOperation
 combiningKindToAllReduce(vector::CombiningKind kind);
 
+/// This struct matches the parameters of the `iree_codegen.xor_shuffle`
+/// attribute. Notably only the first two parameters are used in this struct
+/// because the other parameters are not used in the current implementation of
+/// the XOR shuffle.
+/// The parameters are:
+/// - rowElems: number of elements across which we apply a swizzle.
+/// - accessElems: number of elements in one swizzle group.
+/// So for example:
+/// For data of length 8: [0][1][2][3][4][5][6][7]
+/// and an XOR shuffle with rowElems = 4, accessElems = 2,
+/// we can apply a swizzle to each logical row of 4 elements in groups of 2
+/// elements.
+///
+/// Original data:
+/// |               | swizzle group 0   | swizzle group 1   |
+/// |---------------|-------------------|-------------------|
+/// Logical row 0:  | [0][1]            | [2][3]            |
+/// Logical row 1:  | [4][5]            | [6][7]            |
+///
+/// Swizzled data:
+/// |               | swizzle group 0   | swizzle group 1   |
+/// |---------------|-------------------|-------------------|
+/// Logical row 0:  | [0][1]            | [2][3]            |
+/// Logical row 1:  | [6][7]            | [4][5]            |
+///
+/// Final result: [0][1][2][3][6][7][4][5]
+/// Note that when the swizzle was applied, the swaps were performed on
+/// groups of 2 elements at a time (accessElems), across the 4 elements in the
+/// row (rowElems).
 struct XorShuffleParams {
   int64_t rowElems;
   int64_t accessElems;

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -193,6 +193,16 @@ getXORShuffleBounds(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
 
 /// Returns true if the XOR shuffle is valid for the given number of row
 /// elements, number of access elements, and total tile elements.
+/// Else returns false.
+/// An XOR Shuffle can be invalid for many reasons:
+/// - The number of row elements exceeds the total elements in the tile.
+/// - The number of access elements exceeds the total elements in the row.
+/// - The number of row elements does not evenly divide the total elements in
+/// the tile.
+/// - The number of access elements does not evenly divide the number of row
+/// elements.
+/// - The number of columns in a row does not evenly divide the total number of
+/// tile elements.
 bool isXORShuffleValid(int64_t numRowElems, int64_t numAccessElems,
                        int64_t totalTileElems);
 


### PR DESCRIPTION
This is the fourth of a series of PRs that together implement support in
IREE for XOR swizzling through the SwizzleHintOp.

There are four PRs that need to be merged:
1) Allow rank > 1 swizzle hint op operands and add a pass to flatten
swizzle hint allocs.
2) Add patterns which can fold reshapes and `extract_slice` ops into
empty ops through swizzle hint ops.
3) Add swizzle hint attribute to be set in `lowering_config` and
consumed in `GPUPromoteMatmulOperandsPass`.
4) Update `LLVMGPUSelectLoweringStrategy` Pass to set xor swizzles for
MXFP4 GEMMs.

This is PR 4, which does three things:
- Expresses the row width as a function of CacheLineSizeInBits and the element type of the chosen intrinsic's operands.
- Adds swizzle attribute to promotion type.
- Adds a test for the swizzle attribute which should have been added in PR 3.

We see an average 4.8% geomean improvement over top of main in the mxfp4 gemms tested. See [full data here](https://gist.github.com/Muzammiluddin-Syed-ECE/71c517206d89018f8706d661c94294b6/).

|shape|Feature_Throughput (TFLOps)|Top_of_main_Throughput(TFLOps)|improvement_ratio|improvement_percent|
|-----|---------------------------|------------------------------|-----------------|-------------------|
|1000_1024_8192_512|96.044057|86.408117|1.111517|11.151661|
|16300_1024_8192_512|1282.544470|1219.842766|1.051401|5.140146|
|500_16384_26624_1664|713.748860|723.841063|0.986057|-1.394257|
|53200_53248_8192_512|1194.983741|1107.453688|1.079037|7.903721|
|8100_16384_8192_512|1388.739043|1301.227179|1.067253|6.725333|
|8192_512_256_16|305.040291|301.612872|1.011364|1.136364|
|8192_53248_8192_512|1734.982869|1728.772840|1.003592|0.359216|
|...|...|...|...|...|
|OVERALL_GEOMEAN|||1.049751|4.975053|