### PR TITLE
[CPU] Fix nondeterminism in host cpu features

### DIFF
--- a/compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.cpp
+++ b/compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.cpp
@@ -6,9 +6,9 @@
 
 #include "compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/TargetParser/AArch64TargetParser.h"
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/RISCVTargetParser.h"


### PR DESCRIPTION
This is hard to test for because only the (dynamic) host feature list is unordered, unlike features for a specific target, and we can't assume a specific host in tests.