### PR TITLE
Simplify quantifiers all_of, any_of, none_of. NFC.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -921,9 +921,9 @@ struct ScatterMaterializeInsertedDim final
       }
     }
 
-    llvm::ArrayRef<bool> toInsertDims =
+    auto toInsertDims =
         llvm::ArrayRef<bool>(isInsertDims).drop_front(frontInsertedDims);
-    if (!llvm::any_of(toInsertDims, [](auto d) { return d; })) {
+    if (llvm::none_of(toInsertDims, [](bool d) { return d; })) {
       return rewriter.notifyMatchFailure(op, "no dimensions to insert");
     }
 
@@ -931,7 +931,7 @@ struct ScatterMaterializeInsertedDim final
     SmallVector<ReassociationExprs> reassociationMap;
     reassociationMap.push_back({rewriter.getAffineDimExpr(0)});
 
-    for (auto it : llvm::enumerate(llvm::ArrayRef<bool>(toInsertDims))) {
+    for (auto it : llvm::enumerate(toInsertDims)) {
       if (!it.value()) {
         reassociationMap.push_back({});
       }

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -413,7 +413,7 @@ static void formatIOAttr(DictionaryAttr attrs, llvm::raw_ostream &os) {
   auto shouldIncludeAttr = [](const NamedAttribute &attr) {
     return attr.getName().getValue() != "iree.abi.name";
   };
-  if (!llvm::any_of(attrs, shouldIncludeAttr)) {
+  if (llvm::none_of(attrs, shouldIncludeAttr)) {
     return;
   }
   os << " {";

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -344,9 +344,8 @@ static LogicalResult isUnpaddedAndAtBoundary(Operation *op) {
   // If all consumers are dispatch tensor stores, then the `op` is decomposable
   // if it is an UnPackOp.
   if (isa<linalg::UnPackOp>(op) &&
-      llvm::all_of(op->getUsers(), [&](Operation *user) {
-        return isa<IREE::TensorExt::DispatchTensorStoreOp>(user);
-      })) {
+      llvm::all_of(op->getUsers(),
+                   llvm::IsaPred<IREE::TensorExt::DispatchTensorStoreOp>)) {
     return success();
   }
   return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -734,7 +734,7 @@ void populateMaterializeEncodingPatterns(
         return resultType == typeConverter.convertType(resultType);
       });
   target.addDynamicallyLegalOp<func::ReturnOp>([](func::ReturnOp returnOp) {
-    return !llvm::any_of(returnOp.getOperandTypes(),
+    return llvm::none_of(returnOp.getOperandTypes(),
                          isRankedTensorTypeWithEncoding);
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -423,9 +423,7 @@ static LogicalResult rewriteForallToWorkgroup(RewriterBase &rewriter,
   }
   SmallVector<Attribute> blockMapping =
       llvm::to_vector(forallOp.getMapping()->getValue());
-  if (llvm::any_of(blockMapping, [](Attribute map) {
-        return !isa<gpu::GPUBlockMappingAttr>(map);
-      })) {
+  if (!llvm::all_of(blockMapping, llvm::IsaPred<gpu::GPUBlockMappingAttr>)) {
     return forallOp->emitError("mapping must be #gpu.block<x/y/z/>");
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -485,9 +485,8 @@ fuseNestedLaneAndWarpForalls(RewriterBase &rewriter, scf::ForallOp warpForallOp,
                              scf::ForallOp laneForallOp) {
   // Verify mappings.
   if (!warpForallOp.getMapping() ||
-      !llvm::all_of(*warpForallOp.getMapping(), [](Attribute mappingAttr) {
-        return isa<gpu::GPUWarpMappingAttr>(mappingAttr);
-      })) {
+      !llvm::all_of(*warpForallOp.getMapping(),
+                    llvm::IsaPred<gpu::GPUWarpMappingAttr>)) {
     return rewriter.notifyMatchFailure(warpForallOp, "not a warp forall op");
   }
   if (!laneForallOp.getMapping() || laneForallOp.getMapping()->size() != 1 ||

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -303,9 +303,7 @@ NestedLayoutAttr::getRecombinedLayout(ArrayRef<VectorLayoutInterface> layouts,
                                       ArrayRef<AffineMap> maps,
                                       AffineMap resultMap) {
   constexpr int64_t kInvalid = -1;
-  if (llvm::any_of(layouts, [](VectorLayoutInterface layout) {
-        return !isa<NestedLayoutAttr>(layout);
-      })) {
+  if (!llvm::all_of(layouts, llvm::IsaPred<NestedLayoutAttr>)) {
     return NestedLayoutAttr();
   }
   MLIRContext *context = resultMap.getContext();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -798,7 +798,7 @@ MemRefDescriptor HALDispatchABI::loadBinding(Operation *forOp, int64_t ordinal,
   // requested range is valid.
   auto [strides, offset] = memRefType.getStridesAndOffset();
   if (memRefType.hasStaticShape() &&
-      !llvm::any_of(strides, ShapedType::isDynamic) &&
+      llvm::none_of(strides, ShapedType::isDynamic) &&
       ShapedType::isStatic(offset)) {
     return MemRefDescriptor::fromStaticShape(builder, loc, *typeConverter,
                                              memRefType, basePtrValue);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -408,7 +408,7 @@ struct ConvertIREEBindingSubspanOp final
 
     auto [strides, offset] = memrefType.getStridesAndOffset();
     if (memrefType.hasStaticShape() &&
-        !llvm::any_of(strides, ShapedType::isDynamic) &&
+        llvm::none_of(strides, ShapedType::isDynamic) &&
         ShapedType::isStatic(offset)) {
       auto desc = MemRefDescriptor::fromStaticShape(
           rewriter, loc, *getTypeConverter(), memrefType, llvmBufferBasePtr);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -403,9 +403,8 @@ LogicalResult isAtBoundary(Operation *op) {
       return success();
     }
   } else if (isa<linalg::UnPackOp>(op)) {
-    if (llvm::all_of(op->getUsers(), [](Operation *user) {
-          return isa<IREE::TensorExt::DispatchTensorStoreOp>(user);
-        })) {
+    if (llvm::all_of(op->getUsers(),
+                     llvm::IsaPred<IREE::TensorExt::DispatchTensorStoreOp>)) {
       return success();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -661,9 +661,8 @@ struct FoldSplitReductionForallWithWorkgroupForall
     }
     std::optional<ArrayAttr> workgroupMapping = workgroupLoop.getMapping();
     if (!workgroupMapping ||
-        llvm::any_of(workgroupMapping->getValue(), [](Attribute attr) {
-          return !isa<IREE::Codegen::WorkgroupMappingAttr>(attr);
-        })) {
+        !llvm::all_of(workgroupMapping->getValue(),
+                      llvm::IsaPred<IREE::Codegen::WorkgroupMappingAttr>)) {
       return rewriter.notifyMatchFailure(
           workgroupLoop, "nested loop is not a workgroup mapping loop");
     }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -229,9 +229,7 @@ static FailureOr<AffineMap> getComposedAffineMap(Attribute attr) {
       return AffineMap();
     }
     // All entries should have type `AffineMapAttr`.
-    if (!llvm::all_of(mapsAttr, [](Attribute attr) {
-          return isa<AffineMapAttr>(attr);
-        })) {
+    if (!llvm::all_of(mapsAttr, llvm::IsaPred<AffineMapAttr>)) {
       return failure();
     }
     AffineMap map =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -101,9 +101,10 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   llvm::SetVector<Value> argumentsSet;
   mlir::getUsedValuesDefinedAbove(region, argumentsSet);
   // Unranked tensors are not supported.
-  assert(!llvm::any_of(argumentsSet, [](Value v) {
-    return isa<UnrankedTensorType>(v.getType());
-  }) && "unranked tensors are not supported");
+  assert(llvm::none_of(
+             argumentsSet,
+             [](Value v) { return isa<UnrankedTensorType>(v.getType()); }) &&
+         "unranked tensors are not supported");
 
   // Compute dimensions of tensor args.
   SmallVector<Value> argumentDims;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -643,9 +643,8 @@ FailureOr<Operation *> hoistOutOfDispatch(RewriterBase &rewriter,
         return producer && producer->getParentOfType<DispatchRegionOp>();
       })) {
     rewriter.setInsertionPoint(dispatchRegionOp);
-  } else if (llvm::all_of(op->getUsers(), [&](Operation *user) {
-               return isa<IREE::Flow::ReturnOp>(user);
-             })) {
+  } else if (llvm::all_of(op->getUsers(),
+                          llvm::IsaPred<IREE::Flow::ReturnOp>)) {
     rewriter.setInsertionPointAfter(dispatchRegionOp);
   } else {
     return rewriter.notifyMatchFailure(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -254,7 +254,7 @@ static void expandRegion(Region &region, bool canModifyEntryBlock,
   // Update all block arguments.
   auto timepointType = IREE::Stream::TimepointType::get(region.getContext());
   for (auto &block : region.getBlocks()) {
-    if (!llvm::any_of(block.getArgumentTypes(), isResourceType)) {
+    if (llvm::none_of(block.getArgumentTypes(), isResourceType)) {
       continue;
     }
     if (block.isEntryBlock() && !canModifyEntryBlock) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -230,7 +230,7 @@ static void expandRegion(Region &region, bool canModifyEntryBlock,
   // Update all block arguments.
   auto indexType = IndexType::get(region.getContext());
   for (auto &block : region.getBlocks()) {
-    if (!llvm::any_of(block.getArgumentTypes(), isResourceType)) {
+    if (llvm::none_of(block.getArgumentTypes(), isResourceType)) {
       continue;
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -737,7 +737,7 @@ isFusableWithConsumer(OpOperand &fusedOperand, const FusionTracker &tracker,
       continue;
     }
     if (isa<linalg::ConvolutionOpInterface>(producer) &&
-        !llvm::any_of(
+        llvm::none_of(
             consumerDstOp.getDpsInitsMutable(), [&](OpOperand &initOperand) {
               return canUseInOperandAsInitOperand(inputOperand, &initOperand);
             })) {
@@ -979,9 +979,8 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
       // by the `isClonableIntoDispatchOp` call above, but for now this is done
       // as a point fix.
       if (IREE::LinalgExt::isGatherlikeOp(&op) &&
-          llvm::all_of(op.getUsers(), [](Operation *op) {
-            return isa<IREE::LinalgExt::AttentionOp>(op);
-          })) {
+          llvm::all_of(op.getUsers(),
+                       llvm::IsaPred<IREE::LinalgExt::AttentionOp>)) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -253,7 +253,7 @@ static bool isHorizontalToGroup(Operation *op,
   llvm::SetVector<Operation *> slice;
   [[maybe_unused]] LogicalResult result = getBackwardSlice(op, &slice, options);
   assert(result.succeeded());
-  return !llvm::any_of(currGroup, [&](Operation *groupedOp) {
+  return llvm::none_of(currGroup, [&](Operation *groupedOp) {
     return slice.contains(groupedOp);
   });
 }

--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
@@ -213,7 +213,7 @@ static void expandRegion(Region &region, SymbolTable &symbolTable,
   // Update all block arguments.
   auto indexType = IndexType::get(region.getContext());
   for (auto &block : region.getBlocks()) {
-    if (!llvm::any_of(block.getArgumentTypes(), isDynamicTensor)) {
+    if (llvm::none_of(block.getArgumentTypes(), isDynamicTensor)) {
       continue;
     }
 


### PR DESCRIPTION
* Use `llvm::IsaPred<T>` instead of lambdas where possible
* `!any_of` --> `none_of`