### PR TITLE
[TensorExt] Improves `BitCastOfTensorCastStaticInfo` to handle constant dynamic dims

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -72,14 +72,14 @@ struct BitCastOfTensorCastStaticInfo final : OpRewritePattern<BitCastOp> {
     SmallVector<OpFoldResult> newResultMixed;
     int64_t rank = resTensorType.getRank();
     for (int64_t i = 0; i < rank - 1; ++i) {
-      int64_t castSize = tensorCastSrcType.getShape()[i];
-      OpFoldResult resOfr = resultMixed[i];
       // Try cast source static info first.
+      int64_t castSize = tensorCastSrcType.getShape()[i];
       if (!ShapedType::isDynamic(castSize)) {
         newResultMixed.push_back(rewriter.getIndexAttr(castSize));
         continue;
       }
       // Try result constant.
+      OpFoldResult resOfr = resultMixed[i];
       if (std::optional<int64_t> resConst = getConstantIntValue(resOfr)) {
         newResultMixed.push_back(rewriter.getIndexAttr(*resConst));
         continue;

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
@@ -24,6 +24,23 @@ util.func public @tensorBitCastCastProducer(%arg0: tensor<10x3x6xi8>, %arg1: ind
 
 // -----
 
+// CHECK-LABEL: @bitcastOfCastWithConstAndDynDims
+util.func public @bitcastOfCastWithConstAndDynDims(%arg0: tensor<4x?x4096xi8>, %d0: index) -> tensor<?x?x?xf4E2M1FN> {
+  // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<4x?x4096xi8>
+  // CHECK-SAME: %[[D0:[A-Za-z0-9]+]]: index
+  %c4 = arith.constant 4 : index
+  %c4096 = arith.constant 4096 : index
+  %c8192 = arith.constant 8192 : index
+  %0 = tensor.cast %arg0 : tensor<4x?x4096xi8> to tensor<?x?x?xi8>
+  // CHECK: %[[BITCAST:.+]] = iree_tensor_ext.bitcast %[[ARG0]] : tensor<4x?x4096xi8>{%[[D0]]} -> tensor<4x?x8192xf4E2M1FN>{%[[D0]]}
+  %1 = iree_tensor_ext.bitcast %0 : tensor<?x?x?xi8>{%c4, %d0, %c4096} -> tensor<?x?x?xf4E2M1FN>{%c4, %d0, %c8192}
+  // CHECK: %[[CAST:.+]] = tensor.cast %[[BITCAST]] : tensor<4x?x8192xf4E2M1FN> to tensor<?x?x?xf4E2M1FN>
+  util.return %1 : tensor<?x?x?xf4E2M1FN>
+  // CHECK: util.return %[[CAST]]
+}
+
+// -----
+
 // CHECK-LABEL: @barrierStartFoldDuplicate
 util.func public @barrierStartFoldDuplicate(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
   // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
@@ -41,6 +41,35 @@ util.func public @bitcastOfCastWithConstAndDynDims(%arg0: tensor<4x?x4096xi8>, %
 
 // -----
 
+// CHECK-LABEL: @bitcastOfCastAllDynWithConstants
+util.func public @bitcastOfCastAllDynWithConstants(%arg0: tensor<4x128x4096xi8>) -> tensor<?x?x?xi4> {
+  // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<4x128x4096xi8>
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  %c8192 = arith.constant 8192 : index
+  %0 = tensor.cast %arg0 : tensor<4x128x4096xi8> to tensor<4x?x4096xi8>
+  // CHECK: %[[BITCAST:.+]] = iree_tensor_ext.bitcast %[[ARG0]] : tensor<4x128x4096xi8> -> tensor<4x128x8192xi4>
+  %1 = iree_tensor_ext.bitcast %0 : tensor<4x?x4096xi8>{%c128} -> tensor<?x?x?xi4>{%c4, %c128, %c8192}
+  // CHECK: %[[CAST:.+]] = tensor.cast %[[BITCAST]] : tensor<4x128x8192xi4> to tensor<?x?x?xi4>
+  util.return %1 : tensor<?x?x?xi4>
+  // CHECK: util.return %[[CAST]]
+}
+
+// -----
+
+// CHECK-LABEL: @bitcastOfCastRankMismatch
+util.func public @bitcastOfCastRankMismatch(%arg0: tensor<128x?xf32>, %d0: index, %d1: index) -> tensor<?xi32> {
+  %c128 = arith.constant 128 : index
+  %0 = tensor.cast %arg0 : tensor<128x?xf32> to tensor<?x?xf32>
+  // CHECK: tensor.cast
+  // CHECK: iree_tensor_ext.bitcast
+  %1 = iree_tensor_ext.bitcast %0 : tensor<?x?xf32>{%c128, %d0} -> tensor<?xi32>{%d1}
+  util.return %1 : tensor<?xi32>
+  // CHECK: util.return
+}
+
+// -----
+
 // CHECK-LABEL: @barrierStartFoldDuplicate
 util.func public @barrierStartFoldDuplicate(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
   // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]

--- a/compiler/src/iree/compiler/Utils/ShapeUtils.h
+++ b/compiler/src/iree/compiler/Utils/ShapeUtils.h
@@ -13,14 +13,27 @@
 
 namespace mlir::iree_compiler {
 
-/// Helper to compare shapes of two shaped types by SSA equivalence.
-/// Requires that all sizes are statically equal with no extra analysis.
-/// Dynamic dimensions with soft or provable equality will still return false.
+/// Helper to compare shapes of two shaped types for equality.
 ///
-/// This is in contrast with cast compatible comparison which allows static and
-/// dynamic sizes to compare positively.
+/// For dimensions that are both dynamic, SSA value equality is required.
+/// For dimensions that are both static, the sizes must match.
+///
+/// If `allowCasting` is false (default), a static dim will not match a dynamic
+/// dim even if the dynamic value is a constant. This strict mode is suitable
+/// for fold patterns where type equality matters.
+///
+/// If `allowCasting` is true, a static dim can match a dynamic dim if the
+/// dynamic value is a constant with the same size.
 bool compareShapesEqual(ShapedType lhsType, ValueRange lhsDynamicDims,
-                        ShapedType rhsType, ValueRange rhsDynamicDims);
+                        ShapedType rhsType, ValueRange rhsDynamicDims,
+                        bool allowCasting = false);
+
+/// Same as compareShapesEqual, but ignores the last dimension.
+bool compareShapesEqualExceptLastDim(ShapedType lhsType,
+                                     ValueRange lhsDynamicDims,
+                                     ShapedType rhsType,
+                                     ValueRange rhsDynamicDims,
+                                     bool allowCasting);
 
 /// Helper to check whether 'from' is castable to the target ranked tensor type.
 bool isCastableToTensorType(Type from, RankedTensorType to);

--- a/compiler/src/iree/compiler/Utils/ShapeUtils.h
+++ b/compiler/src/iree/compiler/Utils/ShapeUtils.h
@@ -13,27 +13,25 @@
 
 namespace mlir::iree_compiler {
 
-/// Helper to compare shapes of two shaped types for equality.
+/// Helper to compare shapes of two shaped types by SSA equivalence.
+/// Requires that all sizes are statically equal with no extra analysis.
+/// Dynamic dimensions with soft or provable equality will still return false.
 ///
-/// For dimensions that are both dynamic, SSA value equality is required.
-/// For dimensions that are both static, the sizes must match.
-///
-/// If `allowCasting` is false (default), a static dim will not match a dynamic
-/// dim even if the dynamic value is a constant. This strict mode is suitable
-/// for fold patterns where type equality matters.
-///
-/// If `allowCasting` is true, a static dim can match a dynamic dim if the
-/// dynamic value is a constant with the same size.
+/// This is in contrast with cast compatible comparison which allows static and
+/// dynamic sizes to compare positively.
 bool compareShapesEqual(ShapedType lhsType, ValueRange lhsDynamicDims,
-                        ShapedType rhsType, ValueRange rhsDynamicDims,
-                        bool allowCasting = false);
+                        ShapedType rhsType, ValueRange rhsDynamicDims);
 
-/// Same as compareShapesEqual, but ignores the last dimension.
-bool compareShapesEqualExceptLastDim(ShapedType lhsType,
-                                     ValueRange lhsDynamicDims,
-                                     ShapedType rhsType,
-                                     ValueRange rhsDynamicDims,
-                                     bool allowCasting);
+/// Similar to compareShapesEqual, but allows a static dim to match a dynamic
+/// dim if the dynamic value is a constant with the same size.
+bool compareMixedShapesEqual(ShapedType lhsType, ValueRange lhsDynamicDims,
+                             ShapedType rhsType, ValueRange rhsDynamicDims);
+
+/// Same as compareMixedShapesEqual, but ignores the last dimension.
+bool compareMixedShapesEqualExceptLast(ShapedType lhsType,
+                                       ValueRange lhsDynamicDims,
+                                       ShapedType rhsType,
+                                       ValueRange rhsDynamicDims);
 
 /// Helper to check whether 'from' is castable to the target ranked tensor type.
 bool isCastableToTensorType(Type from, RankedTensorType to);


### PR DESCRIPTION
Handles cases like `tensor<?x?x?xi8>{%c4, %d0, %c4096}` where dynamic dims are actually constants.

These patterns originated from https://github.com/nod-ai/amd-shark-ai/blob/fca16186c53e663435934a9ab2aab6bfb6f93e0a/amdsharktank/amdsharktank/kernels/gemm_fp4.py#L55.