### PR TITLE
[Util] Fix `util.func` printer with untied result

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -404,7 +404,7 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
     return std::nullopt;
   }
   auto valueAttrs = storageAttr.getValue();
-  if (valueAttrs.empty()) {
+  if (valueAttrs.empty() || resultIndex >= valueAttrs.size()) {
     return std::nullopt;
   }
   if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op)) {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_ops.mlir
@@ -189,3 +189,17 @@ util.func @scf_unreachable_no_message(%cond: i1) {
   }
   util.return
 }
+
+// -----
+
+// Tests roundtrip with an explicit untied result. This test uses generic
+// syntax, as this scenario can't be written with custom syntax.
+
+// CHECK-LABEL: util.func public @explicit_untied_result
+"builtin.module"() ({
+  "util.func"() <{function_type = (!hal.device) -> (i1, i64), sym_name = "explicit_untied_result", sym_visibility = "public", tied_operands = [-1 : index]}> ({
+  ^bb0(%arg0: !hal.device):
+    %0:2 = "hal.device.query"(%arg0) <{category = "sys", key = "foo"}> : (!hal.device) -> (i1, i64)
+    "util.return"(%0#0, %0#1) : (i1, i64) -> ()
+  }) : () -> ()
+}) : () -> ()


### PR DESCRIPTION
Fix `util.func` printer to avoid out-of-bounds access if the `util.func` explicitly specifies an untied result (`-1`).

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22967.