### PR TITLE
[docs] Add policy for AI tool use

### DIFF
--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -332,6 +332,28 @@ Dependency updates | `integrates/*` | `integrates/llvm-20240501`
 Branches that do not meet these guidelines may be deleted, especially if
 they [appear to be stale](https://github.com/iree-org/iree/branches/stale).
 
+### :octicons-hubot-16: AI tool use
+
+We adopt the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)
+and require all AI-assisted contributions (Pull Requests, issues, design
+proposals) to be reviewed and understood by the author(s).
+
+The key points include:
+1. "Contributors must read and review all LLM-generated code or text before they
+   ask other project members to review it."
+2. "Contributors are expected to be transparent and label contributions that
+   contain substantial amounts of tool-generated content." This can be done with
+   the `Assisted-by: tool-name` trailer in PR descriptions.
+3. "To ensure sufficient self review and understanding of the work, it is
+   strongly recommended that contributors write PR descriptions themselves (if
+   needed, using tools for translation or copy-editing)." This also extends to
+   code documentation, issue descriptions, and design proposals.
+
+We extend the LLVM policy with an exception for bot-authored contributions
+(e.g., updating dependencies, fixing build script, etc.); bot account may create
+Pull Requests as long as the bot maintainers ensure they are first inline and
+primarily responsible for reviewing those contributions.
+
 ## Tips for contributors
 
 ### Tool recommendations

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -350,8 +350,13 @@ The key points include:
    strongly recommended that contributors write PR descriptions themselves (if
    needed, using tools for translation or copy-editing)." This also extends to
    code documentation, issue descriptions, and design proposals.
+ 4. "Contributors are responsible for ensuring that they have the right to
+   contribute code under the terms of our license, [...]. Using AI tools to
+   regenerate copyrighted material does not remove the copyright, and
+   contributors are responsible for ensuring that such material does not appear
+   in their contributions."
 
-We extend the LLVM policy with an exception for bot-authored contributions
+We extend the LLVM policy with an exception for AI bot-authored contributions
 (e.g., updating dependencies, fixing build script, etc.); bot account may create
 Pull Requests as long as the bot maintainers ensure they are first in line and
 primarily responsible for reviewing those contributions.

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -339,6 +339,7 @@ and require all AI-assisted contributions (Pull Requests, issues, design
 proposals) to be reviewed and understood by the author(s).
 
 The key points include:
+
 1. "Contributors must read and review all LLM-generated code or text before they
    ask other project members to review it."
 2. "Contributors are expected to be transparent and label contributions that

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -350,7 +350,7 @@ The key points include:
    strongly recommended that contributors write PR descriptions themselves (if
    needed, using tools for translation or copy-editing)." This also extends to
    code documentation, issue descriptions, and design proposals.
- 4. "Contributors are responsible for ensuring that they have the right to
+4. "Contributors are responsible for ensuring that they have the right to
    contribute code under the terms of our license, [...]. Using AI tools to
    regenerate copyrighted material does not remove the copyright, and
    contributors are responsible for ensuring that such material does not appear

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -344,7 +344,8 @@ The key points include:
    ask other project members to review it."
 2. "Contributors are expected to be transparent and label contributions that
    contain substantial amounts of tool-generated content." This can be done with
-   the `Assisted-by: tool-name` trailer in PR descriptions.
+   the `Assisted-by: tool-name` or the `Co-authored-by: tool-name tool@email`
+   trailer in PR descriptions.
 3. "To ensure sufficient self review and understanding of the work, it is
    strongly recommended that contributors write PR descriptions themselves (if
    needed, using tools for translation or copy-editing)." This also extends to

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -353,7 +353,7 @@ The key points include:
 
 We extend the LLVM policy with an exception for bot-authored contributions
 (e.g., updating dependencies, fixing build script, etc.); bot account may create
-Pull Requests as long as the bot maintainers ensure they are first inline and
+Pull Requests as long as the bot maintainers ensure they are first in line and
 primarily responsible for reviewing those contributions.
 
 ## Tips for contributors


### PR DESCRIPTION
Adopt the LLVM policy and highlight the key points applicable to day-to-day development. Carve out an exception for potential bot-authored contributions.