### PR TITLE
[CI][ROCm] Set AMD_LOG_LEVEL=1 in rocm/hip workflows

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -66,4 +66,6 @@ jobs:
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0
           IREE_NVIDIA_SM80_TESTS_DISABLE: 1
           IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}

--- a/.github/workflows/pkgci_test_amd_mi325.yml
+++ b/.github/workflows/pkgci_test_amd_mi325.yml
@@ -67,4 +67,6 @@ jobs:
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0
           IREE_NVIDIA_SM80_TESTS_DISABLE: 1
           IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}

--- a/.github/workflows/pkgci_test_amd_r9700.yml
+++ b/.github/workflows/pkgci_test_amd_r9700.yml
@@ -64,4 +64,6 @@ jobs:
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0
           IREE_NVIDIA_SM80_TESTS_DISABLE: 1
           IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -64,4 +64,6 @@ jobs:
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0
           IREE_NVIDIA_SM80_TESTS_DISABLE: 1
           IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -115,6 +115,9 @@ jobs:
           source ${VENV_DIR}/bin/activate
           python -m pip install -r iree-test-suites/onnx_ops/requirements.txt
       - name: Run ONNX ops test suite
+        env:
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree-test-suites/onnx_ops/ \
@@ -204,6 +207,9 @@ jobs:
           source ${VENV_DIR}/bin/activate
           python -m pip install -r iree-test-suites/onnx_models/requirements.txt
       - name: Run ONNX models test suite
+        env:
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree-test-suites/onnx_models/ \

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -84,6 +84,9 @@ jobs:
           source ${VENV_DIR}/bin/activate
           python -m pip install -r iree-test-suites/torch_ops/requirements.txt
       - name: Run Torch ops test suite
+        env:
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree-test-suites/torch_ops/ \
@@ -157,6 +160,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Torch Model tests
+        env:
+          # Enable hip logging on errors.
+          AMD_LOG_LEVEL: 1
         run: |
           source ${VENV_DIR}/bin/activate
           pytest \


### PR DESCRIPTION
This logs on error, so the performance impact should be nominal.