### PR TITLE
New distribution tile heuristic for CPU data-tiled matmuls.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2055,9 +2055,9 @@ getMmt4dLoweringConfig(linalg::LinalgOp op, DictionaryAttr targetConfig) {
   auto staticSizeOr = [](int64_t value, int64_t valueIfDynamic) {
     return ShapedType::isDynamic(value) ? valueIfDynamic : value;
   };
-  const int64_t M1 = staticSizeOr(lhsShape[mmt4dDimBase + 0], 1024);
-  const int64_t N1 = staticSizeOr(rhsShape[mmt4dDimBase + 0], 1024);
-  const int64_t K1 = staticSizeOr(lhsShape[mmt4dDimBase + 1], 1024);
+  const int64_t M1 = staticSizeOr(lhsShape[mmt4dDimBase + 0], 64);
+  const int64_t N1 = staticSizeOr(rhsShape[mmt4dDimBase + 0], 64);
+  const int64_t K1 = staticSizeOr(lhsShape[mmt4dDimBase + 1], 64);
 
   // M0, N0, K0 should almost always be static, but there could be an exception
   // on targets like Arm SVE, so just to be safe, also normalize.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2071,7 +2071,7 @@ getMmt4dLoweringConfig(linalg::LinalgOp op, DictionaryAttr targetConfig) {
     // that will need to be loaded over the entire matmul. Note that each matrix
     // (LHS, RHS) is traversed a number of times equal to the number of tiles
     // of the opposite (RHS, LHS) matrix.
-    return numTilesN * M + numTilesM * N;
+    return numTilesN * M * lhsTypeBits + numTilesM * N * rhsTypeBits;
   };
 
   int64_t selectedTileM = 1;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -281,7 +281,8 @@ func.func @ukernel_dispatch() attributes {hal.executable.target = #executable_ta
 //       CHECK:       scf.for
 //       CHECK:         scf.for
 //       CHECK:           scf.for
-//   CHECK-NOT:             scf.for
+//       CHECK:             scf.for
+//   CHECK-NOT:               scf.for
 //       CHECK:   iree_codegen.ukernel.generic "iree_uk_mmt4d"
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
@@ -177,7 +177,7 @@ func.func @mmt4d_384x384x512_4x1x4_dispatch_0(%3: tensor<96x384x4x1xf32>, %4: te
   %6 = linalg.mmt4d ins(%3, %4 : tensor<96x384x4x1xf32>, tensor<128x384x4x1xf32>) outs(%5 : tensor<96x128x4x4xf32>) -> tensor<96x128x4x4xf32>
   return %6 : tensor<96x128x4x4xf32>
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [16, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 4, 4, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [48, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 4, 4, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 //       CHECK: func.func @mmt4d_384x384x512_4x1x4_dispatch_0(
 //       CHECK:   linalg.mmt4d
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -115,7 +115,7 @@ func.func @mmt4d_tensors(%arg0: tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x?x1
   %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%init : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
   return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 4, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 128, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
 // CHECK:      func.func @mmt4d_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -137,8 +137,8 @@ func.func @mmtd4_with_fill(%arg0 : tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x
   %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%fill : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
   return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 4, 16]>
-// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [32, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 4, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, [8]]>
+// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [32, 128, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
 // CHECK:      func.func @mmtd4_with_fill
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -115,7 +115,7 @@ func.func @mmt4d_tensors(%arg0: tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x?x1
   %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%init : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
   return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 4, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
 // CHECK:      func.func @mmt4d_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -137,8 +137,8 @@ func.func @mmtd4_with_fill(%arg0 : tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x
   %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%fill : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
   return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, [8]]>
-// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 4, 16]>
+// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [32, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 4, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
 // CHECK:      func.func @mmtd4_with_fill
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -433,7 +433,7 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
   return %pack : tensor<5x10240x16x1xf16>
 }
 // CHECK-DAG:   #[[$CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16, [16]]>
-// CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, [16], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [5, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, [16], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK-DAG:   #[[$CONFIG2:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
 // CHECK-LABEL: func.func @mmt4d_generic_unpack_pack(
 // CHECK:         linalg.fill

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -115,7 +115,7 @@ func.func @mmt4d_tensors(%arg0: tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x?x1
   %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%init : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
   return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [4, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
 // CHECK:      func.func @mmt4d_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -138,7 +138,7 @@ func.func @mmtd4_with_fill(%arg0 : tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x
   return %mmt4d : tensor<32x?x8x?xf32>
 }
 // CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, [8]]>
-// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [4, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
 // CHECK:      func.func @mmtd4_with_fill
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1451,7 +1451,7 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
   return %pack : tensor<5x10240x16x1xf16>
 }
 // CHECK-DAG:   #[[$CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16, 16]>
-// CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [5, 20, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK-DAG:   #[[$CONFIG2:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
 // CHECK-LABEL: func.func @mmt4d_generic_unpack_pack(
 // CHECK:         linalg.fill


### PR DESCRIPTION
Looked at our performance on a hundred matmul shapes; hadn't done so in a long time. The new heuristic provides substantial [speedups](https://docs.google.com/spreadsheets/d/1TiLAsmQuEqbze0BvjS6g_KskiCPMUsSNiHBrq9KPxks/edit?usp=sharing) across many shapes (> 1.2x on larger shapes, sometimes > 1.5x, never a regression). It also makes more sense heuristically.

A key finding was that the tile sizes that we were getting out of `getDefaultDistributedLevelTileSizes` were not at all the `maxTileSizes` that we gave it as its input. The effective tile sizes were chosen to be divisors of the tensors' dimensions. As a result, the only way to have precise control over tile sizes is to directly choose them as divisors. Then we don't need to call `getDefaultDistributedLevelTileSizes` anymore. This PR does that, which is why the new heuristic explicitly iterates over divisors.

The previous heuristic was meant to be based on two cache-size-ish parameters but that never really worked. The new heuristic has a single cache-size-ish parameter, `iree-llvmcpu-matmul-tile-bytes`, and tuning shows that it really works as intended. The docstring on the command-line flag has details.

There is a second command-line parameter, `iree-llvmcpu-matmul-tile-undercount-whole-matrix`, to allow growing tiles past the limit for the sake of fitting entire matrices in one tile.

Data collected on EPYC 9575F, single-threaded, bf16 matmuls: https://docs.google.com/spreadsheets/d/1TiLAsmQuEqbze0BvjS6g_KskiCPMUsSNiHBrq9KPxks/edit?usp=sharing

The focus on single-threaded is intentional: that is the primary server use case. However, as far as this heuristic is concerned, to a reasonable first approximation, tuning for N threads is a simple matter of dividing the `iree-llvmcpu-matmul-tile-bytes` parameter by N. There is some wiggle room though; the default 4M tile size is smaller than many CPUs' L3 cache and thus will still work unchanged up to several threads. Just be aware that if you ever want to tune for multi-thread matmuls on CPU, you may need to reduce `iree-llvmcpu-matmul-tile-bytes`.

A vaguely reasonable default "cache size" is estimated based on the target architecture, which is very little information but is all we have. Users are expected to override `iree-llvmcpu-matmul-tile-bytes` anyway, but do feel free to improve the defaults.