### PR TITLE
[LinalgExt] Add verifier check to disallow index_base in explicit-index mode

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1298,6 +1298,11 @@ LogicalResult ArgCompareOp::verify() {
              << "Input index type: " << inputIndexElemType
              << ", output index type: " << outputIndexElemType;
     }
+
+    if (getIndexBase()) {
+      return op->emitOpError(
+          "index_base must not be used with explicit indices");
+    }
   }
 
   Type outputValueElemType = outputValueType.getElementType();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -917,6 +917,28 @@ func.func @arg_compare_explicit_index_wrong_comparator_args_count(
 
 // -----
 
+func.func @arg_compare_invalid_explicit_index_with_base(
+    %input_val: tensor<2x4xf32>,
+    %input_idx: tensor<2x4xi32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi32>,
+    %base: index
+) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{index_base must not be used with explicit indices}}
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : tensor<2x4xf32>, tensor<2x4xi32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>)
+    index_base(%base : index) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// -----
+
 func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
   // expected-error@+1 {{expected one or two input operands}}
   %0:2 = iree_linalg_ext.topk

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1041,43 +1041,6 @@ func.func @arg_compare_explicit_index(
 
 // -----
 
-func.func @arg_compare_explicit_index_with_base(
-    %input_val : tensor<2x4xf32>,
-    %input_idx : tensor<2x4xi32>,
-    %outv : tensor<2xf32>,
-    %outi : tensor<2xi32>,
-    %base : index
-) -> (tensor<2xf32>, tensor<2xi32>) {
-  %0:2 = iree_linalg_ext.arg_compare
-    dimension(1)
-    ins(%input_val, %input_idx : tensor<2x4xf32>, tensor<2x4xi32>)
-    outs(%outv, %outi : tensor<2xf32>, tensor<2xi32>)
-    index_base(%base : index) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
-  } -> tensor<2xf32>, tensor<2xi32>
-  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
-}
-
-// CHECK-LABEL: func.func @arg_compare_explicit_index_with_base(
-// CHECK-SAME:   %[[INPUT_VAL:[a-zA-Z0-9_]+]]: tensor<2x4xf32>
-// CHECK-SAME:   %[[INPUT_IDX:[a-zA-Z0-9_]+]]: tensor<2x4xi32>
-// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
-// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xi32>
-// CHECK-SAME:   %[[BASE:[a-zA-Z0-9_]+]]: index
-// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.arg_compare
-// CHECK-SAME:     dimension(1)
-// CHECK-SAME:     ins(%[[INPUT_VAL]], %[[INPUT_IDX]] : tensor<2x4xf32>, tensor<2x4xi32>)
-// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xi32>)
-// CHECK-SAME:     index_base(%[[BASE]] : index)
-// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
-// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
-// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
-// CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1 : tensor<2xf32>, tensor<2xi32>
-
-// -----
-
 func.func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
     -> (tensor<1024xf32>, tensor<1024xf32>) {
   %cst1 = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -981,51 +981,6 @@ func.func @arg_compare_explicit_index_memref_dynamic(
 
 // -----
 
-func.func @arg_compare_explicit_index_with_base_memref(
-    %input_values: memref<2x10xf32>,
-    %input_indices: memref<2x10xi32>,
-    %out_values: memref<2xf32>,
-    %out_indices: memref<2xi32>,
-    %base: index
-) {
-  iree_linalg_ext.arg_compare
-    dimension(1)
-    ins(%input_values, %input_indices : memref<2x10xf32>, memref<2x10xi32>)
-    outs(%out_values, %out_indices : memref<2xf32>, memref<2xi32>)
-    index_base(%base : index) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
-  }
-  return
-}
-
-// CHECK-LABEL: func.func @arg_compare_explicit_index_with_base_memref
-// CHECK-SAME: %[[INPUT_VAL:.+]]: memref<2x10xf32>
-// CHECK-SAME: %[[INPUT_IDX:.+]]: memref<2x10xi32>
-// CHECK-SAME: %[[OUTVAL:.+]]: memref<2xf32>
-// CHECK-SAME: %[[OUTIDX:.+]]: memref<2xi32>
-// CHECK-SAME: %[[BASE:.+]]: index
-
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
-
-// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
-// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<2xf32>
-// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<2xi32>
-// CHECK:     %[[V1:.+]] = memref.load %[[INPUT_VAL]][%[[I]], %[[J]]] : memref<2x10xf32>
-// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
-// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
-// CHECK:     %[[I1:.+]] = memref.load %[[INPUT_IDX]][%[[I]], %[[J]]] : memref<2x10xi32>
-// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[I1]], %[[I0]] : i32
-// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
-// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
-
-// -----
-
 func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) {
   iree_linalg_ext.pack %arg0 inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
   return


### PR DESCRIPTION
 The `index_base` parameter was designed for implicit-index mode to offset computed indices during tiling. In explicit-index mode, indices should be already pre-computed and global, so `index_base` has no semantic meaning.
   
 This PR adds a verifier check to make `index_base` illegal in explicit-index mode for `ArgCompareOp`, clarifying the operation's semantics and preventing user confusion.