### PR TITLE
[CPU] Enable E2E MX (scaled matmul) tests for CPU backends.

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -329,6 +329,32 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ]
 )]
 
+# LLVMCPU, MX (MXFP4) matmul with data-tiling. Optimized MX support is not
+# implemented for CPU, so encodings are dropped and it effectively runs through
+# the non-data-tiling path. This ensures the compiler path works and provides a
+# reference for other backends.
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cpu_dt_mxfp4_f32",
+    compiler_flags = [
+        "--iree-opt-data-tiling",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f4E2M1FN",
+        "--acc_type=f32",
+        "--mx_scale_type=f8E8M0FNU",
+        "--mx_block_size=32",
+        "--shapes=easy_large_static",
+        "--transpose_rhs",
+    ],
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = ["generic"],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
 ###########################################################################
 ##
 ## VMVX backend

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -950,6 +950,32 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cpu_dt_mxfp4_f32
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=easy_large_static"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+  TARGET_CPU_FEATURES_VARIANTS
+    "generic"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_vmvx_dt_uk_i8_small
   TEST_TYPE
     matmul


### PR DESCRIPTION
Optimized MX support is not implemented for CPU, so scaled contraction ops have their encodings dropped and run through the non-data-tiling path. This ensures the compiler path works correctly and provides a reference implementation for other backends.

- Add scaled contraction handling in CPUEncodingExternalModels.cpp that drops encodings and clones the op as-is for CPU backends.
- Add lit test in materialize_encoding_x86_64.mlir to verify encoding materialization for scaled matmul.
- Add E2E test rule for MXFP4 matmul targeting llvm-cpu backend.

Fixes https://github.com/iree-org/iree/issues/23105