### PR TITLE
Add initial clang-tidy configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 option(IREE_BUILD_TRACY "Enables building the 'iree-tracy-capture' CLI tool and includes it in runtime Python bindings." OFF)
 option(IREE_BUILD_BUNDLED_LLVM "Builds the bundled llvm-project (vs using installed)" ON)
+option(IREE_BUILD_CLANG_TOOLS_EXTRA "Enables building the 'clang-tools-extra' LLVM targets." OFF)
 option(IREE_USE_SYSTEM_DEPS "Uses certain system libraries instead of building downloaded dependencies" OFF)
 
 if(IREE_USE_SYSTEM_DEPS)
@@ -569,10 +570,6 @@ set_property(GLOBAL PROPERTY IREE_RUNTIME_COVERAGE_TARGETS "")
 # and instrumented execution don't line up enough).
 if(IREE_ENABLE_RUNTIME_COVERAGE AND NOT _UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
   message(FATAL_ERROR "IREE_ENABLE_*_COVERAGE requires building in Debug")
-endif()
-
-if(IREE_REVERSE_ITERATION)
-  set(LLVM_ENABLE_REVERSE_ITERATION ON CACHE BOOL "" FORCE)
 endif()
 
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -180,6 +180,11 @@ macro(iree_llvm_set_bundled_cmake_options)
   # that in IREE as a super-project.
   set(MLIR_DISABLE_CONFIGURE_PYTHON_DEV_PACKAGES ON CACHE BOOL "" FORCE)
 
+  # Enable reverse iteration over LLVM unordered maps/sets.
+  if(IREE_REVERSE_ITERATION)
+    set(LLVM_ENABLE_REVERSE_ITERATION ON CACHE BOOL "" FORCE)
+  endif()
+
   # If we are building clang/lld/etc, these will be the targets.
   # Otherwise, empty so scripts can detect unavailability.
   set(IREE_CLANG_TARGET)
@@ -252,6 +257,10 @@ macro(iree_llvm_set_bundled_cmake_options)
   endif()
   if(IREE_LLD_TARGET)
     list(APPEND LLVM_ENABLE_PROJECTS lld)
+  endif()
+
+  if(IREE_BUILD_CLANG_TOOLS_EXTRA)
+    list(APPEND LLVM_ENABLE_PROJECTS clang-tools-extra)
   endif()
 
   list(REMOVE_DUPLICATES LLVM_ENABLE_PROJECTS)

--- a/compiler/.clang-tidy
+++ b/compiler/.clang-tidy
@@ -1,0 +1,71 @@
+HeaderFilterRegex: '(.*/llvm/include/llvm/.*)|(.*/mlir/include/mlir/.*)'
+Checks: >
+  -*,
+  clang-diagnostic-*,
+  llvm-*,
+  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-include-order,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-override-with-different-visibility,
+  bugprone-*,
+  -bugprone-assignment-in-if-condition,
+  -bugprone-unchecked-optional-access,
+  modernize-use-bool-literals,
+  modernize-loop-convert,
+  modernize-make-unique,
+  modernize-raw-string-literal,
+  modernize-use-equals-default,
+  modernize-use-default-member-init,
+  modernize-use-emplace,
+  modernize-min-max-use-initializer-list,
+  modernize-use-nodiscard,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-*,
+  readability-avoid-const-params-in-decls,
+  readability-const-return-type,
+  readability-container-contains,
+  readability-container-size-empty,
+  readability-identifier-naming,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-redundant-casting,
+  readability-redundant-control-flow,
+  readability-redundant-inline-specifier,
+  readability-redundant-smartptr-get,
+  readability-redundant-typename,
+  readability-redundant-void-arg,
+  readability-simplify-boolean-expr,
+  readability-simplify-subscript-expr,
+  readability-use-anyofallof
+
+CheckOptions:
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           1
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           1
+  - key:             readability-identifier-naming.VariableIgnoredRegexp
+    value:           'DebugType'
+  - key:             readability-identifier-naming.ParameterIgnoredRegexp
+    value:           'LevelOrType'

--- a/compiler/.clang-tidy
+++ b/compiler/.clang-tidy
@@ -22,9 +22,7 @@ Checks: >
   modernize-raw-string-literal,
   modernize-use-equals-default,
   modernize-use-default-member-init,
-  modernize-use-emplace,
   modernize-min-max-use-initializer-list,
-  modernize-use-nodiscard,
   modernize-use-nullptr,
   modernize-use-override,
   modernize-use-using,
@@ -47,25 +45,27 @@ Checks: >
   readability-use-anyofallof
 
 CheckOptions:
-  - key:             readability-identifier-naming.MemberCase
-    value:           camelBack
-  - key:             readability-identifier-naming.ParameterCase
-    value:           camelBack
-  - key:             readability-identifier-naming.VariableCase
-    value:           camelBack
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
   - key:             readability-identifier-naming.FunctionCase
     value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberIgnoredRegexp
+    value:           '.*_|^ID$'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterIgnoredRegexp
+    value:           'LevelOrType'
+  - key:             readability-identifier-naming.VariableIgnoredRegexp
+    value:           'DebugType'
   - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
     value:           1
   - key:             modernize-use-default-member-init.UseAssignment
     value:           1
-  - key:             readability-identifier-naming.VariableIgnoredRegexp
-    value:           'DebugType'
-  - key:             readability-identifier-naming.ParameterIgnoredRegexp
-    value:           'LevelOrType'

--- a/compiler/.clang-tidy
+++ b/compiler/.clang-tidy
@@ -1,10 +1,12 @@
-HeaderFilterRegex: '(.*/llvm/include/llvm/.*)|(.*/mlir/include/mlir/.*)'
+HeaderFilterRegex: '.*'
+ExcludeHeaderFilterRegex: '.*/llvm/include/.*|.*/mlir/include/.*|.*/llvm-project/include/.*|.*\.inc$'
 Checks: >
   -*,
   clang-diagnostic-*,
   llvm-*,
-  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-header-guard,
   -llvm-include-order,
+  -llvm-prefer-static-over-anonymous-namespace,
   misc-*,
   -misc-const-correctness,
   -misc-include-cleaner,
@@ -15,6 +17,11 @@ Checks: >
   -misc-override-with-different-visibility,
   bugprone-*,
   -bugprone-assignment-in-if-condition,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-crtp-constructor-accessibility,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-narrowing-conversions,
   -bugprone-unchecked-optional-access,
   modernize-use-bool-literals,
   modernize-loop-convert,
@@ -27,6 +34,7 @@ Checks: >
   modernize-use-override,
   modernize-use-using,
   performance-*,
+  -performance-enum-size,
   readability-avoid-const-params-in-decls,
   readability-const-return-type,
   readability-container-contains,
@@ -54,7 +62,7 @@ CheckOptions:
   - key:             readability-identifier-naming.MemberCase
     value:           camelBack
   - key:             readability-identifier-naming.MemberIgnoredRegexp
-    value:           '.*_|^ID$'
+    value:           '.*_|^[A-Z]+$'
   - key:             readability-identifier-naming.ParameterCase
     value:           camelBack
   - key:             readability-identifier-naming.UnionCase
@@ -62,9 +70,9 @@ CheckOptions:
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack
   - key:             readability-identifier-naming.ParameterIgnoredRegexp
-    value:           'LevelOrType'
+    value:           'LevelOrType|^[A-Z]+$'
   - key:             readability-identifier-naming.VariableIgnoredRegexp
-    value:           'DebugType'
+    value:           'DebugType|^[A-Z][A-Z0-9_]*$'
   - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
     value:           1
   - key:             modernize-use-default-member-init.UseAssignment

--- a/llvm-external-projects/iree-dialects/.clang-tidy
+++ b/llvm-external-projects/iree-dialects/.clang-tidy
@@ -1,0 +1,71 @@
+HeaderFilterRegex: '(.*/llvm/include/llvm/.*)|(.*/mlir/include/mlir/.*)'
+Checks: >
+  -*,
+  clang-diagnostic-*,
+  llvm-*,
+  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-include-order,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-override-with-different-visibility,
+  bugprone-*,
+  -bugprone-assignment-in-if-condition,
+  -bugprone-unchecked-optional-access,
+  modernize-use-bool-literals,
+  modernize-loop-convert,
+  modernize-make-unique,
+  modernize-raw-string-literal,
+  modernize-use-equals-default,
+  modernize-use-default-member-init,
+  modernize-use-emplace,
+  modernize-min-max-use-initializer-list,
+  modernize-use-nodiscard,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-*,
+  readability-avoid-const-params-in-decls,
+  readability-const-return-type,
+  readability-container-contains,
+  readability-container-size-empty,
+  readability-identifier-naming,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-redundant-casting,
+  readability-redundant-control-flow,
+  readability-redundant-inline-specifier,
+  readability-redundant-smartptr-get,
+  readability-redundant-typename,
+  readability-redundant-void-arg,
+  readability-simplify-boolean-expr,
+  readability-simplify-subscript-expr,
+  readability-use-anyofallof
+
+CheckOptions:
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           1
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           1
+  - key:             readability-identifier-naming.VariableIgnoredRegexp
+    value:           'DebugType'
+  - key:             readability-identifier-naming.ParameterIgnoredRegexp
+    value:           'LevelOrType'

--- a/llvm-external-projects/iree-dialects/.clang-tidy
+++ b/llvm-external-projects/iree-dialects/.clang-tidy
@@ -22,9 +22,7 @@ Checks: >
   modernize-raw-string-literal,
   modernize-use-equals-default,
   modernize-use-default-member-init,
-  modernize-use-emplace,
   modernize-min-max-use-initializer-list,
-  modernize-use-nodiscard,
   modernize-use-nullptr,
   modernize-use-override,
   modernize-use-using,
@@ -47,25 +45,27 @@ Checks: >
   readability-use-anyofallof
 
 CheckOptions:
-  - key:             readability-identifier-naming.MemberCase
-    value:           camelBack
-  - key:             readability-identifier-naming.ParameterCase
-    value:           camelBack
-  - key:             readability-identifier-naming.VariableCase
-    value:           camelBack
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
   - key:             readability-identifier-naming.FunctionCase
     value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberIgnoredRegexp
+    value:           '.*_|^ID$'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterIgnoredRegexp
+    value:           'LevelOrType'
+  - key:             readability-identifier-naming.VariableIgnoredRegexp
+    value:           'DebugType'
   - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
     value:           1
   - key:             modernize-use-default-member-init.UseAssignment
     value:           1
-  - key:             readability-identifier-naming.VariableIgnoredRegexp
-    value:           'DebugType'
-  - key:             readability-identifier-naming.ParameterIgnoredRegexp
-    value:           'LevelOrType'

--- a/llvm-external-projects/iree-dialects/.clang-tidy
+++ b/llvm-external-projects/iree-dialects/.clang-tidy
@@ -1,10 +1,12 @@
-HeaderFilterRegex: '(.*/llvm/include/llvm/.*)|(.*/mlir/include/mlir/.*)'
+HeaderFilterRegex: '.*'
+ExcludeHeaderFilterRegex: '.*/llvm/include/.*|.*/mlir/include/.*|.*/llvm-project/include/.*|.*\.inc$'
 Checks: >
   -*,
   clang-diagnostic-*,
   llvm-*,
-  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-header-guard,
   -llvm-include-order,
+  -llvm-prefer-static-over-anonymous-namespace,
   misc-*,
   -misc-const-correctness,
   -misc-include-cleaner,
@@ -15,6 +17,11 @@ Checks: >
   -misc-override-with-different-visibility,
   bugprone-*,
   -bugprone-assignment-in-if-condition,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-crtp-constructor-accessibility,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-narrowing-conversions,
   -bugprone-unchecked-optional-access,
   modernize-use-bool-literals,
   modernize-loop-convert,
@@ -27,6 +34,7 @@ Checks: >
   modernize-use-override,
   modernize-use-using,
   performance-*,
+  -performance-enum-size,
   readability-avoid-const-params-in-decls,
   readability-const-return-type,
   readability-container-contains,
@@ -54,7 +62,7 @@ CheckOptions:
   - key:             readability-identifier-naming.MemberCase
     value:           camelBack
   - key:             readability-identifier-naming.MemberIgnoredRegexp
-    value:           '.*_|^ID$'
+    value:           '.*_|^[A-Z]+$'
   - key:             readability-identifier-naming.ParameterCase
     value:           camelBack
   - key:             readability-identifier-naming.UnionCase
@@ -62,9 +70,9 @@ CheckOptions:
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack
   - key:             readability-identifier-naming.ParameterIgnoredRegexp
-    value:           'LevelOrType'
+    value:           'LevelOrType|^[A-Z]+$'
   - key:             readability-identifier-naming.VariableIgnoredRegexp
-    value:           'DebugType'
+    value:           'DebugType|^[A-Z][A-Z0-9_]*$'
   - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
     value:           1
   - key:             modernize-use-default-member-init.UseAssignment


### PR DESCRIPTION
Add `.clang-tidy` files for compiler directories. These are based on the MLIR configuration with iree-specific tweaks. I ran these on the past 100 commits to confirm these settings produce reasonable warnings.

Sample command:
```shell
git diff HEAD~100 -U0 --relative -- . \
  | ../third_party/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py \
     -clang-tidy-binary=~/iree/main/build/llvm-project/bin/clang-tidy \
     -config-file=.clang-tidy  -p1 -j64 -quiet
```

Also add support for building clang tidy from source (`-DIREE_BUILD_CLANG_TOOLS_EXTRA=ON`). We may benefit from this instead of random system installations because the `llvm-*` constains mlir-specific checks.

The end goal is to have these run in CI (pre-commit only) and produce warnings (without blocking merging), so that I don't have to leave so many code review nits.