### PR TITLE
Avoid unnecessary copies in for loops. NFC.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -807,7 +807,7 @@ struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
         auto updateTy = cast<ShapedType>(update.getType());
         llvm::SmallVector<int64_t> newShape;
         newShape.reserve(updateTy.getRank());
-        for (long i : updatePerm) {
+        for (int64_t i : updatePerm) {
           newShape.push_back(updateTy.getDimSize(i));
         }
         update = mlir::stablehlo::TransposeOp::create(

--- a/compiler/plugins/target/LLVMCPU/LibraryBuilder.cpp
+++ b/compiler/plugins/target/LLVMCPU/LibraryBuilder.cpp
@@ -553,7 +553,7 @@ LibraryBuilder::buildLibraryV0ExportTable(std::string libraryName) {
 
   // iree_hal_executable_export_table_v0_t::ptrs
   SmallVector<llvm::Constant *> exportPtrValues;
-  for (auto dispatch : exports) {
+  for (const Dispatch &dispatch : exports) {
     exportPtrValues.push_back(dispatch.func);
   }
   llvm::Constant *exportPtrs = createArrayConstant(
@@ -562,7 +562,7 @@ LibraryBuilder::buildLibraryV0ExportTable(std::string libraryName) {
   // iree_hal_executable_export_table_v0_t::attrs
   // Always populate the attrs table as it contains required dispatch metadata.
   SmallVector<llvm::Constant *> exportAttrValues;
-  for (auto dispatch : exports) {
+  for (const Dispatch &dispatch : exports) {
     exportAttrValues.push_back(llvm::ConstantStruct::get(
         dispatchAttrsType,
         {
@@ -605,7 +605,7 @@ LibraryBuilder::buildLibraryV0ExportTable(std::string libraryName) {
   llvm::Constant *exportNames = llvm::Constant::getNullValue(ptrType);
   if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
     SmallVector<llvm::Constant *> exportNameValues;
-    for (auto dispatch : exports) {
+    for (const Dispatch &dispatch : exports) {
       exportNameValues.push_back(createStringConstant(dispatch.name, module));
     }
     exportNames = createArrayConstant(libraryName + "_names", ptrType,
@@ -618,7 +618,7 @@ LibraryBuilder::buildLibraryV0ExportTable(std::string libraryName) {
       exports, [](auto &dispatch) { return !dispatch.tag.empty(); });
   if (mode == Mode::INCLUDE_REFLECTION_ATTRS && hasAnyTags) {
     SmallVector<llvm::Constant *> exportTagValues;
-    for (auto dispatch : exports) {
+    for (const Dispatch &dispatch : exports) {
       exportTagValues.push_back(
           createStringConstantOrNull(dispatch.tag, module));
     }
@@ -731,10 +731,10 @@ LibraryBuilder::buildLibraryV0ExportTable(std::string libraryName) {
   llvm::Constant *exportStageLocations = llvm::Constant::getNullValue(ptrType);
   if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
     SmallVector<llvm::Constant *> exportStageTableValues;
-    for (auto dispatch : exports) {
+    for (const Dispatch &dispatch : exports) {
       SmallVector<llvm::Constant *> exportStageNameValues;
       SmallVector<llvm::Constant *> exportSourceLocationValues;
-      for (auto &stageLocation : dispatch.stageLocations) {
+      for (const SourceLocation &stageLocation : dispatch.stageLocations) {
         exportStageNameValues.push_back(
             createStringConstant(stageLocation.stage, module));
         exportSourceLocationValues.push_back(llvm::ConstantStruct::get(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/PreprocessExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/PreprocessExecutables.cpp
@@ -144,7 +144,7 @@ static LogicalResult preprocessWithCommand(IREE::HAL::ExecutableOp executableOp,
 #endif // _WIN32
   Tokenize(command, stringSaver, rawArgs, /*MarkEOLs=*/false);
   SmallVector<StringRef> args;
-  for (auto rawArg : rawArgs) {
+  for (const char *rawArg : rawArgs) {
     args.push_back(StringRef(rawArg));
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
@@ -66,7 +66,7 @@ bool recognizeDispatchEntryPoints(ModuleOp moduleOp, SymbolTable &symbolTable,
       if (!isa<BindingType>(arg.getType())) {
         continue;
       }
-      for (auto *user : arg.getUsers()) {
+      for (Operation *user : arg.getUsers()) {
         auto subspanOp = dyn_cast<BindingSubspanOp>(user);
         if (!subspanOp) {
           result = false;
@@ -108,7 +108,7 @@ updateBindingEncodings(FunctionOpInterface funcOp,
                                  "does not have a valid encoding.\n");
       continue;
     }
-    for (auto *user : arg.getUsers()) {
+    for (Operation *user : arg.getUsers()) {
       auto subspanOp = cast<BindingSubspanOp>(user);
       auto encodingTypeInterface =
           cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.cpp
@@ -66,7 +66,7 @@ bool recognizeDispatchEntryPoints(ModuleOp moduleOp, SymbolTable &symbolTable,
       if (!isa<BindingType>(arg.getType())) {
         continue;
       }
-      for (auto user : arg.getUsers()) {
+      for (auto *user : arg.getUsers()) {
         auto subspanOp = dyn_cast<BindingSubspanOp>(user);
         if (!subspanOp) {
           result = false;
@@ -108,7 +108,7 @@ updateBindingEncodings(FunctionOpInterface funcOp,
                                  "does not have a valid encoding.\n");
       continue;
     }
-    for (auto user : arg.getUsers()) {
+    for (auto *user : arg.getUsers()) {
       auto subspanOp = cast<BindingSubspanOp>(user);
       auto encodingTypeInterface =
           cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
@@ -23,7 +23,7 @@ namespace mlir::iree_compiler::IREE::Stream {
 template <typename T>
 SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
   SmallPtrSet<const T *, 4> resultSet;
-  for (auto *dialect : moduleOp.getContext()->getLoadedDialects()) {
+  for (Dialect *dialect : moduleOp.getContext()->getLoadedDialects()) {
     auto *dialectInterface = dialect->getRegisteredInterface<T>();
     if (!dialectInterface) {
       continue;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Utils.h
@@ -23,7 +23,7 @@ namespace mlir::iree_compiler::IREE::Stream {
 template <typename T>
 SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
   SmallPtrSet<const T *, 4> resultSet;
-  for (auto dialect : moduleOp.getContext()->getLoadedDialects()) {
+  for (auto *dialect : moduleOp.getContext()->getLoadedDialects()) {
     auto *dialectInterface = dialect->getRegisteredInterface<T>();
     if (!dialectInterface) {
       continue;

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2518,7 +2518,7 @@ private:
       return success();
     }
 
-    auto ctx = builder.getContext();
+    auto *ctx = builder.getContext();
 
     auto arguments =
         emitc::MemberOp::create(builder, loc,
@@ -3018,7 +3018,7 @@ class CallYieldableOpConversion
       return op.emitError() << "callee must be an import for yieldable call";
     }
 
-    auto ctx = op->getContext();
+    auto *ctx = op->getContext();
     auto loc = op.getLoc();
 
     auto moduleOp =
@@ -3174,7 +3174,7 @@ class CallVariadicYieldableOpConversion
       return op.emitError() << "callee must be an import for yieldable call";
     }
 
-    auto ctx = op->getContext();
+    auto *ctx = op->getContext();
     auto loc = op.getLoc();
 
     auto moduleOp =

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2518,7 +2518,7 @@ private:
       return success();
     }
 
-    auto *ctx = builder.getContext();
+    MLIRContext *ctx = builder.getContext();
 
     auto arguments =
         emitc::MemberOp::create(builder, loc,
@@ -3018,8 +3018,8 @@ class CallYieldableOpConversion
       return op.emitError() << "callee must be an import for yieldable call";
     }
 
-    auto *ctx = op->getContext();
-    auto loc = op.getLoc();
+    MLIRContext *ctx = op->getContext();
+    Location loc = op.getLoc();
 
     auto moduleOp =
         importOp.getOperation()->getParentOfType<IREE::VM::ModuleOp>();
@@ -3174,8 +3174,8 @@ class CallVariadicYieldableOpConversion
       return op.emitError() << "callee must be an import for yieldable call";
     }
 
-    auto *ctx = op->getContext();
-    auto loc = op.getLoc();
+    MLIRContext *ctx = op->getContext();
+    Location loc = op.getLoc();
 
     auto moduleOp =
         importOp.getOperation()->getParentOfType<IREE::VM::ModuleOp>();

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -107,7 +107,7 @@ struct InlineConstGlobalInitializer : public OpRewritePattern<InitializerOp> {
     if (deadOps.empty()) {
       return failure();
     }
-    for (auto *deadOp : deadOps) {
+    for (Operation *deadOp : deadOps) {
       rewriter.eraseOp(deadOp);
     }
     return success();

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -107,7 +107,7 @@ struct InlineConstGlobalInitializer : public OpRewritePattern<InitializerOp> {
     if (deadOps.empty()) {
       return failure();
     }
-    for (auto deadOp : deadOps) {
+    for (auto *deadOp : deadOps) {
       rewriter.eraseOp(deadOp);
     }
     return success();

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -175,7 +175,7 @@ public:
                              int successorIndex) override {
     // Reserve space for the block offset. It will get fixed up when we are all
     // done and know all of the block offsets.
-    blockOffsetFixups_.push_back({targetBlock, bytecode_.size()});
+    blockOffsetFixups_.emplace_back(targetBlock, bytecode_.size());
     bytecode_.resize(bytecode_.size() + sizeof(int32_t));
 
     // Compute required remappings - we only need to emit them when the source
@@ -214,7 +214,7 @@ public:
   LogicalResult encodeBranchTarget(Block *targetBlock) override {
     // Reserve space for the block offset. It will get fixed up when we are all
     // done and know all of the block offsets.
-    blockOffsetFixups_.push_back({targetBlock, bytecode_.size()});
+    blockOffsetFixups_.emplace_back(targetBlock, bytecode_.size());
     bytecode_.resize(bytecode_.size() + sizeof(int32_t));
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/AnnotateFunctions.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/AnnotateFunctions.cpp
@@ -50,11 +50,11 @@ static FuncInfo analyzeFunction(IREE::VM::FuncOp funcOp,
   funcOp.walk([&](Operation *op) {
     // Collect callees.
     if (auto callOp = dyn_cast<IREE::VM::CallOp>(op)) {
-      if (auto callee = symbolTable.lookup(callOp.getCallee())) {
+      if (auto *callee = symbolTable.lookup(callOp.getCallee())) {
         info.callees.push_back(callee);
       }
     } else if (auto callOp = dyn_cast<IREE::VM::CallVariadicOp>(op)) {
-      if (auto callee = symbolTable.lookup(callOp.getCallee())) {
+      if (auto *callee = symbolTable.lookup(callOp.getCallee())) {
         info.callees.push_back(callee);
       }
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/AnnotateFunctions.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/AnnotateFunctions.cpp
@@ -50,11 +50,11 @@ static FuncInfo analyzeFunction(IREE::VM::FuncOp funcOp,
   funcOp.walk([&](Operation *op) {
     // Collect callees.
     if (auto callOp = dyn_cast<IREE::VM::CallOp>(op)) {
-      if (auto *callee = symbolTable.lookup(callOp.getCallee())) {
+      if (Operation *callee = symbolTable.lookup(callOp.getCallee())) {
         info.callees.push_back(callee);
       }
     } else if (auto callOp = dyn_cast<IREE::VM::CallVariadicOp>(op)) {
-      if (auto *callee = symbolTable.lookup(callOp.getCallee())) {
+      if (Operation *callee = symbolTable.lookup(callOp.getCallee())) {
         info.callees.push_back(callee);
       }
     }


### PR DESCRIPTION
- Use const & or explicit types for range-based for loops
- Convert index-based loops to range-based where possible
- Use `T *` where applicable
- Clean up surrounding code by hand

Assisted-by: clang-tidy