### PR TITLE
Prefer `.contains()` and `.empty()`. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -366,7 +366,7 @@ unrollSharedMemoryLoops(mlir::FunctionOpInterface funcOp,
                         const llvm::SmallDenseSet<scf::ForOp> &loopsToIgnore) {
   SmallVector<scf::ForOp> forOpsToUnroll;
   funcOp.walk([&](scf::ForOp forOp) {
-    if (!loopsToIgnore.count(forOp)) {
+    if (!loopsToIgnore.contains(forOp)) {
       forOpsToUnroll.push_back(forOp);
     }
   });

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -106,7 +106,7 @@ getTileAndDistributeConfig(ArrayRef<Operation *> computeOps,
   partitionableLoopsSet.insert(partitionableLoops.begin(),
                                partitionableLoops.end());
   for (auto loopId : llvm::seq<unsigned>(0, tileSizes.size())) {
-    if (partitionableLoopsSet.count(loopId)) {
+    if (partitionableLoopsSet.contains(loopId)) {
       continue;
     }
     tileSizes[loopId] = 0;

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -73,7 +73,7 @@ void collectTiledAndFusedOps(Operation *rootOp,
     for (OpOperand &operand : current->getOpOperands()) {
       Operation *producer = operand.get().getDefiningOp();
       if (!producer || !isa<TilingInterface>(producer) ||
-          result.count(producer)) {
+          result.contains(producer)) {
         continue;
       }
       worklist.push_back(producer);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -41,7 +41,7 @@ void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
       addressOfOps.push_back(addressOfOp);
     }
   });
-  if (addressOfOps.size() == 0) {
+  if (addressOfOps.empty()) {
     return;
   }
   OpBuilder builder(moduleOp);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -122,7 +122,7 @@ bool canPerformVectorAccessUsingAllThreads(ArrayRef<int64_t> shape,
   // Verify that each dimension of the shape can be distributed on the
   // threads
   // For zero dim tensor, consider it's too small to access using all threads.
-  if (shape.size() == 0) {
+  if (shape.empty()) {
     return false;
   }
   int64_t threadsAvailable = threadCount;

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
@@ -28,7 +28,7 @@ getDefaultDistributionTileSizes(TilingInterface op) {
   llvm::DenseSet<unsigned> partitionedLoopsSet(partitionedLoops.begin(),
                                                partitionedLoops.end());
   for (auto dim : llvm::seq<int64_t>(0, distTileSizes.size())) {
-    if (!partitionedLoopsSet.count(dim)) {
+    if (!partitionedLoopsSet.contains(dim)) {
       distTileSizes[dim] = 0;
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -974,7 +974,7 @@ SmallVector<Operation *> getCloneableOps(IREE::Flow::DispatchRegionOp regionOp,
   while (!worklist.empty()) {
     Value outsideValue = worklist.pop_back_val();
     // Skip values that were already visited.
-    if (visited.count(outsideValue)) {
+    if (visited.contains(outsideValue)) {
       continue;
     }
     visited.insert(outsideValue);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -318,7 +318,7 @@ CollapsingInfo::initialize(unsigned origNumLoops,
       if (dim >= origNumLoops) {
         return failure();
       }
-      if (processedDims.count(dim)) {
+      if (processedDims.contains(dim)) {
         return failure();
       }
       processedDims.insert(dim);
@@ -333,7 +333,7 @@ CollapsingInfo::initialize(unsigned origNumLoops,
   // Add all the preserved dims of the original op as single
   // elements to `collapsedOpToOrigOpIterationDim`.
   for (auto dim : llvm::seq<int64_t>(0, origNumLoops)) {
-    if (processedDims.count(dim)) {
+    if (processedDims.contains(dim)) {
       continue;
     }
     collapsedOpToOrigOpIterationDim.emplace_back(ReassociationIndices{dim});

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -406,7 +406,7 @@ struct AllocationScope {
   // All aliases of |resource| will also be mapped.
   void mapResourceRange(Value resource, ResourceRange resourceRange,
                         AsmState *asmState) {
-    if (resourceRangeMap.count(resource)) {
+    if (resourceRangeMap.contains(resource)) {
       return;
     }
 
@@ -472,7 +472,7 @@ struct AllocationScope {
 
   // Returns true if the given |resource| has a storage range mapped to it.
   bool hasResourceRange(Value resource) const {
-    return resourceRangeMap.count(resource) != 0;
+    return resourceRangeMap.contains(resource) != 0;
   }
 
   // Calls |callback| for |resource| and each value aliasing it.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -234,7 +234,7 @@ static SmallVector<Block *, 8> sortBlocksInDominanceOrder(Region &region) {
   }
   llvm::SmallSetVector<Block *, 8> markedBlocks;
   std::function<void(Block *)> visit = [&](Block *block) {
-    if (markedBlocks.count(block) > 0) {
+    if (markedBlocks.contains(block)) {
       return;
     }
     for (auto *childBlock : dominanceInfo.getNode(block)->children()) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
@@ -177,7 +177,7 @@ struct FoldBlockArgumentsPattern
         continue;
       }
       auto blockSources = llvm::ArrayRef(blockSourceMap[&block]);
-      if (blockSources.size() == 0) {
+      if (blockSources.empty()) {
         continue;
       }
 
@@ -308,7 +308,7 @@ struct ElideBranchOperandsPattern
         continue;
       }
       auto blockSources = llvm::ArrayRef(blockSourceMap[&block]);
-      if (blockSources.size() == 0) {
+      if (blockSources.empty()) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -314,7 +314,7 @@ static void updateSubrangeOp(IREE::Util::SubrangeOpInterface op,
   if (!resultResource) {
     return;
   }
-  if (subrangeMap.count(resultResource)) {
+  if (subrangeMap.contains(resultResource)) {
     return;
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/LinearScan/LiveIntervals.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/LinearScan/LiveIntervals.cpp
@@ -171,7 +171,7 @@ void LiveIntervals::sortBlocksInDominanceOrder(IREE::VM::FuncOp funcOp) {
   }
   llvm::SmallSetVector<Block *, 8> markedBlocks;
   std::function<void(Block *)> visit = [&](Block *block) {
-    if (markedBlocks.count(block) > 0) {
+    if (markedBlocks.contains(block)) {
       return;
     }
     for (auto *childBlock : dominanceInfo.getNode(block)->children()) {
@@ -205,7 +205,7 @@ void LiveIntervals::buildIntervals(ValueLiveness &liveness) {
   for (auto *block : blockOrder_) {
     // Process block arguments.
     for (auto blockArg : block->getArguments()) {
-      if (valueToInterval_.count(blockArg)) {
+      if (valueToInterval_.contains(blockArg)) {
         continue;
       }
 
@@ -233,7 +233,7 @@ void LiveIntervals::buildIntervals(ValueLiveness &liveness) {
       uint32_t opIndex = opToIndex_[&op];
 
       for (auto result : op.getResults()) {
-        if (valueToInterval_.count(result)) {
+        if (valueToInterval_.contains(result)) {
           continue;
         }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -169,7 +169,7 @@ sortBlocksInDominanceOrder(IREE::VM::FuncOp funcOp) {
   }
   llvm::SmallSetVector<Block *, 8> markedBlocks;
   std::function<void(Block *)> visit = [&](Block *block) {
-    if (markedBlocks.count(block) > 0) {
+    if (markedBlocks.contains(block)) {
       return;
     }
     for (auto *childBlock : dominanceInfo.getNode(block)->children()) {
@@ -732,7 +732,7 @@ struct FeedbackArcSet {
     llvm::SmallSetVector<NodeID, 8> unmarkedNodes = acyclicNodes;
     llvm::SmallSetVector<NodeID, 8> markedNodes;
     std::function<void(NodeID)> visit = [&](NodeID node) {
-      if (markedNodes.count(node) > 0) {
+      if (markedNodes.contains(node)) {
         return;
       }
       for (auto &edge : acyclicEdges) {

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -260,7 +260,7 @@ LogicalResult ValueLiveness::computeLiveIntervals(IREE::VM::FuncOp funcOp) {
 
     // Handle values entering the block and dying within.
     for (auto value : blockSets.liveIn) {
-      if (blockSets.liveOut.count(value)) {
+      if (blockSets.liveOut.contains(value)) {
         continue;
       }
       Operation *lastUse = &block.front();
@@ -280,7 +280,7 @@ LogicalResult ValueLiveness::computeLiveIntervals(IREE::VM::FuncOp funcOp) {
 
     // Handle values defined within the block and not escaping.
     for (auto value : blockSets.defined) {
-      if (blockSets.liveOut.count(value)) {
+      if (blockSets.liveOut.contains(value)) {
         continue;
       }
       Operation *firstUse =
@@ -313,7 +313,7 @@ ArrayRef<Value> ValueLiveness::getBlockLiveOuts(Block *block) {
 
 bool ValueLiveness::isLastValueUse(Value value, Operation *useOp) {
   auto &blockSets = blockLiveness_[useOp->getBlock()];
-  if (blockSets.liveOut.count(value)) {
+  if (blockSets.liveOut.contains(value)) {
     // Value is escapes the block the useOp is in so it is definitely not the
     // last use.
     return false;
@@ -370,7 +370,7 @@ bool ValueLiveness::isLastRealValueUse(Value value, Operation *useOp,
 
   // Check if value escapes block.
   auto &blockSets = blockLiveness_[useOp->getBlock()];
-  if (blockSets.liveOut.count(value)) {
+  if (blockSets.liveOut.contains(value)) {
     // Value is in liveOut. For non-terminators, this means the value has uses
     // after this block, so it's not at last use.
     if (!useOp->hasTrait<OpTrait::IsTerminator>()) {

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
@@ -282,7 +282,7 @@ class MaterializeRefDiscardsPass
 
         SmallVector<Value> dyingRefs;
         for (Value ref : allRefs) {
-          if (escapingRefs.count(ref)) {
+          if (escapingRefs.contains(ref)) {
             continue;
           }
 
@@ -357,7 +357,7 @@ class MaterializeRefDiscardsPass
           }
 
           // Skip escaping refs.
-          if (escapingRefs.count(value)) {
+          if (escapingRefs.contains(value)) {
             continue;
           }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Utils/TypeTable.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Utils/TypeTable.cpp
@@ -17,7 +17,7 @@ std::vector<TypeDef> buildTypeTable(IREE::VM::ModuleOp moduleOp) {
     if (auto refPtrType = dyn_cast<IREE::VM::RefType>(type)) {
       type = refPtrType.getObjectType();
     }
-    if (typeMap.count(type)) {
+    if (typeMap.contains(type)) {
       return;
     }
     std::string str;


### PR DESCRIPTION
- Use .contains() instead of .count() for membership checks
- Use .empty() instead of .size() == 0 for emptiness checks

Assisted-by: clang-tidy