### PR TITLE
Apply naming convention fixes. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -300,11 +300,11 @@ static Value generateEncodingTransferOps(RewriterBase &rewriter, Value src,
   if (srcType.getEncoding()) {
     value = IREE::Encoding::UnsetEncodingOp::create(
         rewriter, src.getLoc(), srcType.dropEncoding(), value, dynamicDims,
-        /*encodingDims=*/ValueRange{});
+        /*encoding_dims=*/ValueRange{});
   }
   if (destType.getEncoding()) {
     value = IREE::Encoding::SetEncodingOp::create(
-        rewriter, src.getLoc(), destType, value, /*encodingDims=*/ValueRange{});
+        rewriter, src.getLoc(), destType, value, /*encoding_dims=*/ValueRange{});
   }
   return value;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -304,7 +304,8 @@ static Value generateEncodingTransferOps(RewriterBase &rewriter, Value src,
   }
   if (destType.getEncoding()) {
     value = IREE::Encoding::SetEncodingOp::create(
-        rewriter, src.getLoc(), destType, value, /*encoding_dims=*/ValueRange{});
+        rewriter, src.getLoc(), destType, value,
+        /*encoding_dims=*/ValueRange{});
   }
   return value;
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2565,14 +2565,14 @@ void AsyncConstantOp::getAsyncAccessRanges(
 //===----------------------------------------------------------------------===//
 
 void AsyncSplatOp::build(OpBuilder &builder, OperationState &state,
-                         Type result_type, Value value, Value result_size,
-                         Attribute affinity, Value await_timepoint) {
-  state.addTypes(result_type);
-  if (await_timepoint) {
-    state.addOperands(await_timepoint);
+                         Type resultType, Value value, Value resultSize,
+                         Attribute affinity, Value awaitTimepoint) {
+  state.addTypes(resultType);
+  if (awaitTimepoint) {
+    state.addOperands(awaitTimepoint);
   }
   state.addOperands(value);
-  state.addOperands(result_size);
+  state.addOperands(resultSize);
   if (affinity) {
     state.addAttribute("affinity", affinity);
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
@@ -143,11 +143,11 @@ static func::FuncOp createWorkgroupFunc(IREE::Stream::TensorEncodeOp encodeOp,
     if (sourceType.getEncoding()) {
       value = IREE::Encoding::UnsetEncodingOp::create(
           builder, loc, sourceType.dropEncoding(), value, sourceDynamicDims,
-          /*encodingDims=*/ValueRange{});
+          /*encoding_dims=*/ValueRange{});
     }
     if (destinationType.getEncoding()) {
       value = IREE::Encoding::SetEncodingOp::create(
-          builder, loc, destinationType, value, /*encodingDims=*/ValueRange{});
+          builder, loc, destinationType, value, /*encoding_dims=*/ValueRange{});
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2430,7 +2430,7 @@ private:
                                 /*type=*/
                                 emitc::LValueType::get(emitc::OpaqueType::get(
                                     ctx, "iree_byte_span_t")),
-                                /*memberName=*/"arguments",
+                                /*member=*/"arguments",
                                 /*operand=*/call)
             .getResult();
 
@@ -2525,7 +2525,7 @@ private:
                                 /*type=*/
                                 emitc::LValueType::get(emitc::OpaqueType::get(
                                     ctx, "iree_byte_span_t")),
-                                /*memberName=*/"arguments",
+                                /*member=*/"arguments",
                                 /*operand=*/call)
             .getResult();
 

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -110,7 +110,7 @@ bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
     auto resType = RankedTensorType::get(
         operandType.getShape(), operandType.getElementType(), newEncoding);
     Value encodedInput = IREE::Encoding::SetEncodingOp::create(
-        rewriter, loc, resType, operand->get(), /*encodingDims=*/ValueRange{});
+        rewriter, loc, resType, operand->get(), /*encoding_dims=*/ValueRange{});
     encodedOperands.push_back(encodedInput);
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -250,7 +250,7 @@ static std::optional<PaddedValue> padProducerOfValue(RewriterBase &rewriter,
   Value newYieldedVal = map.lookup(operand);
   auto encodingOp = IREE::Encoding::SetEncodingOp::create(
       rewriter, returnOp->getLoc(), newResultType, newYieldedVal,
-      /*encodingDims=*/ValueRange{});
+      /*encoding_dims=*/ValueRange{});
   rewriter.modifyOpInPlace(
       returnOp, [&]() { returnOp.setOperand(resultNumber, encodingOp); });
 
@@ -284,7 +284,7 @@ static SmallVector<unsigned> padOperandsOfOp(RewriterBase &rewriter,
       Type operandType = operand.get().getType();
       auto unsetEncodignOp = IREE::Encoding::UnsetEncodingOp::create(
           rewriter, op->getLoc(), operandType, paddedVal->paddedValue,
-          paddedVal->dynamicDims, /*encodingDims=*/ValueRange{});
+          paddedVal->dynamicDims, /*encoding_dims=*/ValueRange{});
       op->setOperand(operandNum, unsetEncodignOp.getResult());
     });
   }

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -72,7 +72,7 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     // Otherwise, we need to create a new set_encoding op.
     auto setEncodingOp = IREE::Encoding::SetEncodingOp::create(
         builder, op->getLoc(), encodedOperandType, operand,
-        /*encodingDims=*/ValueRange{});
+        /*encoding_dims=*/ValueRange{});
     encodedOperands.push_back(setEncodingOp.getResult());
     result.generatedEncodingOps.push_back(setEncodingOp);
   }
@@ -101,7 +101,7 @@ static IREE::Encoding::PropagationResult propagateThroughEncodingCastableOp(
     std::tie(std::ignore, resultDynamicDims) = decomposeMixedValues(mixedSizes);
     auto unsetEncodingOp = IREE::Encoding::UnsetEncodingOp::create(
         builder, op->getLoc(), originalResult.getType(), encodedResult,
-        resultDynamicDims, /*encodingDims=*/ValueRange{});
+        resultDynamicDims, /*encoding_dims=*/ValueRange{});
     result.generatedEncodingOps.push_back(unsetEncodingOp);
     result.replacements.push_back(unsetEncodingOp.getResult());
   }

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -226,14 +226,14 @@ void ParameterOptions::bindOptions(OptionsBinder &binder) {
   // Deprecated flags aliasing the new ones above.
   binder.opt<std::string>(
       "iree-opt-export-parameters", exportPath,
-      deprecated("use --iree-parameter-export=<path> instead"),
+      Deprecated("use --iree-parameter-export=<path> instead"),
       llvm::cl::Hidden,
       llvm::cl::desc("File path to an archive to export parameters to with an "
                      "optional `scope=` prefix."),
       llvm::cl::cat(category));
   binder.opt<std::string>(
       "iree-opt-splat-parameters", splatPath,
-      deprecated("use --iree-parameter-splat=<path> instead"), llvm::cl::Hidden,
+      Deprecated("use --iree-parameter-splat=<path> instead"), llvm::cl::Hidden,
       llvm::cl::desc(
           "File path to create a parameter archive of splat values out of all "
           "parameter backed globals."),

--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -75,9 +75,9 @@ struct opt_scope {
 // The apply method is a no-op since OptionsBinder handles the deprecation
 // warning through the callback mechanism, but it's required because LLVM's
 // applicator will try to call it when the modifier is forwarded.
-struct deprecated {
+struct Deprecated {
   llvm::StringRef message;
-  explicit deprecated(llvm::StringRef msg) : message(msg) {}
+  explicit Deprecated(llvm::StringRef msg) : message(msg) {}
   template <class Opt>
   void apply(Opt &) const {}
 };
@@ -111,7 +111,7 @@ public:
 
   template <typename T, typename V, typename... Mods>
   void opt(llvm::StringRef name, V &value, Mods... Ms) {
-    const deprecated *dep = filterDeprecated(Ms...);
+    const Deprecated *dep = filterDeprecated(Ms...);
     auto [changedCallback, clCallback] = makeChangedCallback<V>(name, dep);
     OptionInfo &info = getOptionsStorage()[name];
     if (!scope) {
@@ -422,7 +422,7 @@ private:
   template <typename V>
   static std::pair<OptionInfo::ChangedCallback, llvm::cl::cb<void, V>>
   makeChangedCallback(llvm::StringRef name = "",
-                      const deprecated *dep = nullptr) {
+                      const Deprecated *dep = nullptr) {
     std::shared_ptr<bool> changed = std::make_shared<bool>(false);
     // Capture name and message by value for lambda lifetime.
     std::string optName = name.str();
@@ -493,11 +493,11 @@ private:
 
   // Extracts deprecated modifier from args (returns nullptr if not found).
   template <typename... Args>
-  static const deprecated *filterDeprecated(const Args &...args) {
-    const deprecated *result = nullptr;
+  static const Deprecated *filterDeprecated(const Args &...args) {
+    const Deprecated *result = nullptr;
     (
         [&] {
-          if constexpr (std::is_same_v<std::decay_t<Args>, deprecated>) {
+          if constexpr (std::is_same_v<std::decay_t<Args>, Deprecated>) {
             result = &args;
           }
         }(),


### PR DESCRIPTION
- Rename deprecated struct to Deprecated (CamelCase for types)
- Fix named argument comments to match actual parameter names

Assisted-by: clang-tidy