### PR TITLE
[Stream] Restrict import of dynamically shaped tensors

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -56,7 +56,7 @@ static bool doesOperationNeedWrapping(Operation *op) {
              return false;
            }
            return !llvm::all_of(result.getUsers(),
-                                llvm::IsaPred<TensorImportOp>);
+                                llvm::IsaPred<TensorImportOp, tensor::DimOp>);
          });
 }
 
@@ -111,8 +111,6 @@ struct GenericResourcePattern : public ConversionPattern {
 
       auto importAffinityAttr =
           affinityAnalysis->lookupResourceAffinity(result);
-      auto dynamicDims =
-          IREE::Util::buildDynamicDimsForValue(op->getLoc(), result, rewriter);
       SmallPtrSet<Operation *, 4> consumingOps;
       auto importedValue = buildTensorImportOp(
           op->getLoc(), result, rewriter.getType<IREE::Stream::ResourceType>(),
@@ -166,6 +164,10 @@ struct GenericResourcePattern : public ConversionPattern {
     // Gather dynamic dimensions from the input value.
     auto dynamicDims =
         IREE::Util::buildDynamicDimsForValue(loc, sourceTensor, builder);
+    // Operations determining the dynamic dimensions must operate on the
+    // original value to avoid a dominance issue.
+    llvm::for_each(dynamicDims,
+                   [&](Value v) { consumingOps.insert(v.getDefiningOp()); });
 
     // Compute the size of the tensor once in the stream resource.
     // This may differ from the external encoding of the tensor as imports are
@@ -291,6 +293,13 @@ struct ConvertToStreamPass final
         context, conversionTarget, typeConverter, &affinityAnalysis, patterns);
     populateHALToStreamConversionPatterns(
         context, conversionTarget, typeConverter, &affinityAnalysis, patterns);
+
+    // We need to allow tensor.dim here, because the import of dynamically
+    // shaped tensors from unknown operations needs to determine the dynamic
+    // dimensions. It is also important that this is marked legal here, or more
+    // specifically after `populateStandardToStreamConversionPatterns`, because
+    // that function would otherwise mark it illegal.
+    conversionTarget.addLegalOp<tensor::DimOp>();
 
     conversionTarget.markUnknownOpDynamicallyLegal(
         [&](Operation *op) -> bool { return !doesOperationNeedWrapping(op); });

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
@@ -6,11 +6,7 @@
 
 #include <utility>
 
-#include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
-#include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
-#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTraits.h"
@@ -18,7 +14,6 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -260,41 +255,6 @@ struct VerifyInputPass
     verifier.addIllegalOp<IREE::Util::GlobalAddressOp>();
     verifier.addIllegalOp<IREE::Util::GlobalLoadIndirectOp>();
     verifier.addIllegalOp<IREE::Util::GlobalStoreIndirectOp>();
-
-    // Verify that we don't try to import dynamically shaped tensors from
-    // non-size, non-shape aware unknown operations, as we won't be able to
-    // determine their size during lowering to Stream resources.
-    verifier.addOpVerifier([](Operation *op)
-                               -> std::optional<Verifier::Legality> {
-      if (llvm::IsaPred<mlir::linalg::LinalgDialect, IREE::Util::UtilDialect,
-                        IREE::Encoding::IREEEncodingDialect,
-                        IREE::LinalgExt::IREELinalgExtDialect,
-                        IREE::HAL::HALDialect>(op->getDialect())) {
-        return std::nullopt;
-      }
-      if (llvm::IsaPred<mlir::tensor::EmptyOp, IREE::Codegen::UKernelGenericOp>(
-              op)) {
-        return std::nullopt;
-      }
-
-      auto anyDynamicTensorTy = [](TypeRange types) {
-        return llvm::any_of(types, [](Type t) {
-          if (auto tensorTy = dyn_cast<TensorType>(t)) {
-            return !tensorTy.hasStaticShape();
-          }
-          return false;
-        });
-      };
-      if (!llvm::IsaPred<IREE::Util::ShapeAwareOpInterface,
-                         IREE::Util::SizeAwareOpInterface>(op) &&
-          anyDynamicTensorTy(op->getResultTypes())) {
-        op->emitOpError()
-            << "cannot import dynamically shaped tensor from unknown "
-               "operation that is not size- or shape-aware";
-        return Verifier::Legality::ILLEGAL;
-      }
-      return std::nullopt;
-    });
 
     if (failed(verifier.run(getOperation()))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --allow-unregistered-dialect --iree-stream-conversion %s | FileCheck %s
+// RUN: iree-opt --split-input-file --allow-unregistered-dialect --iree-stream-conversion --verify-diagnostics %s | FileCheck %s
 
 // CHECK: stream.executable private @executable
 flow.executable private @executable {
@@ -179,4 +179,15 @@ util.func public @unrealizedCastCleanup(%cond: i1, %lhs: tensor<1024xf32>, %rhs:
   %0 = arith.select %cond, %lhs, %rhs : tensor<1024xf32>
   // CHECK: util.return %[[RET]], %[[RET_SIZE]]
   util.return %0 : tensor<1024xf32>
+}
+
+// -----
+
+// Tests that import of dynamically shaped tensors from an operation that is
+// not shape/size-aware fails.
+
+util.func public @failed_dynamic_import() -> tensor<8x?xf32> {
+  // expected-error @+1 {{failed to legalize operation 'some.op' that was explicitly marked illegal}}
+  %0 = "some.op"() : () -> tensor<8x?xf32>
+  util.return %0 : tensor<8x?xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -68,24 +68,6 @@ util.func public @custom_ops(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
 
 // -----
 
-// Tests that ops producing dynamically shaped tensors in other dialects pass through ok.
-// CHECK-LABEL:   util.func public @custom_dynamic_ops
-// CHECK-SAME:      -> (!stream.resource<*>, index)
-
-util.func public @custom_dynamic_ops() -> tensor<8x?xf32> {
-  // CHECK:           %[[RET_TENSOR:.*]] = "some.op"() : () -> tensor<8x?xf32>
-  %0 = "some.op"() : () -> tensor<8x?xf32>
-  // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1
-  // CHECK:           %[[DIM_1:.*]] = tensor.dim %[[RET_TENSOR]], %[[CONSTANT_1]]
-  // CHECK:           %[[RET_SIZE:.*]] = stream.tensor.sizeof tensor<8x?xf32>{%[[DIM_1]]}
-  // CHECK:           %[[RET_EXTERNAL:.*]] = stream.tensor.import consume %[[RET_TENSOR]]
-  // CHECK:           %[[RET:.*]] = stream.async.transfer %[[RET_EXTERNAL]]
-  // CHECK:           util.return %[[RET]], %[[RET_SIZE]] : !stream.resource<*>, index
-  util.return %0 : tensor<8x?xf32>
-}
-
-// -----
-
 // This is the while test, which exercises flow control and readbacks but is
 // still simple enough to reason about: tests/e2e/tosa_ops/while.mlir
 // This test is also nice because it contains a check test op, which requires

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -68,6 +68,24 @@ util.func public @custom_ops(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
 
 // -----
 
+// Tests that ops producing dynamically shaped tensors in other dialects pass through ok.
+// CHECK-LABEL:   util.func public @custom_dynamic_ops
+// CHECK-SAME:      -> (!stream.resource<*>, index)
+
+util.func public @custom_dynamic_ops() -> tensor<8x?xf32> {
+  // CHECK:           %[[RET_TENSOR:.*]] = "some.op"() : () -> tensor<8x?xf32>
+  %0 = "some.op"() : () -> tensor<8x?xf32>
+  // CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1
+  // CHECK:           %[[DIM_1:.*]] = tensor.dim %[[RET_TENSOR]], %[[CONSTANT_1]]
+  // CHECK:           %[[RET_SIZE:.*]] = stream.tensor.sizeof tensor<8x?xf32>{%[[DIM_1]]}
+  // CHECK:           %[[RET_EXTERNAL:.*]] = stream.tensor.import consume %[[RET_TENSOR]]
+  // CHECK:           %[[RET:.*]] = stream.async.transfer %[[RET_EXTERNAL]]
+  // CHECK:           util.return %[[RET]], %[[RET_SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<8x?xf32>
+}
+
+// -----
+
 // This is the while test, which exercises flow control and readbacks but is
 // still simple enough to reason about: tests/e2e/tosa_ops/while.mlir
 // This test is also nice because it contains a check test op, which requires


### PR DESCRIPTION
Return failure from the `GenericResourcePattern` to not import tensors from unknown operations that are not shape- or size-aware. Importing a dynamically shaped tensor requires to determine the size and for operations that are not shape/size-aware, this would require inserting `tensor.dim` operations, which are illegal after this pass.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22968.