### PR TITLE
[CI] Re-enable select onnx_ops tests

### DIFF
--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O0.json
@@ -17,10 +17,6 @@
     "onnx/node/generated/test_nonmaxsuppression_two_batches"
   ],
   "skip_run_tests": [
-    "onnx/node/generated/test_gru_seq_length",
-    "onnx/node/generated/test_rnn_seq_length",
-    "onnx/node/generated/test_scan9_sum",
-    "onnx/node/generated/test_stft_with_window",
     "onnx/node/generated/test_tfidfvectorizer_tf_batch_onlybigrams_skip0",
     "onnx/node/generated/test_tfidfvectorizer_tf_batch_onlybigrams_skip5",
     "onnx/node/generated/test_tfidfvectorizer_tf_batch_uniandbigrams_skip5",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O3.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O3.json
@@ -18,10 +18,6 @@
     "onnx/node/generated/test_constantofshape_int_shape_zero"
   ],
   "skip_run_tests": [
-    "onnx/node/generated/test_gru_seq_length",
-    "onnx/node/generated/test_rnn_seq_length",
-    "onnx/node/generated/test_scan9_sum",
-    "onnx/node/generated/test_stft_with_window",
     "onnx/node/generated/test_tfidfvectorizer_tf_batch_onlybigrams_skip0",
     "onnx/node/generated/test_tfidfvectorizer_tf_batch_onlybigrams_skip5",
     "onnx/node/generated/test_tfidfvectorizer_tf_batch_uniandbigrams_skip5",


### PR DESCRIPTION
These unskipped tests will fail on CI. The issue is explained here: https://github.com/iree-org/iree/issues/23189 Only:

* test_gru_seq_length
* test_rnn_seq_length
* test_scan9_sum
* test_stft_with_window

are selected for execution since they do generate dispatches and are considered bugs.

Tests:

* test_tfidfvectorizer_tf_batch_onlybigrams_skip0
* test_tfidfvectorizer_tf_batch_onlybigrams_skip5
* test_tfidfvectorizer_tf_batch_uniandbigrams_skip5

Are not selected for execution since they are lower priority. They do not generate dispatches. These tests all started failing with https://github.com/iree-org/iree/pull/22813
