### PR TITLE
[LinalgExt] Support and use arg_compare with explicit-index mode in split reduction

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1749,6 +1749,14 @@ FailureOr<TilingResult> ArgCompareOp::tileToPartialReduction(
   tiledOperands.push_back(inputSlice->getResult(0));
   slices.push_back(inputSlice);
 
+  bool isExplicitIndexMode = hasExplicitIndexInput();
+  if (isExplicitIndexMode) {
+    Operation *inputIndexSlice =
+        getSlice(b, loc, getInputIndex(), offsets, sizes, strides);
+    tiledOperands.push_back(inputIndexSlice->getResult(0));
+    slices.push_back(inputIndexSlice);
+  }
+
   // Extract slices of the init operands (partial results). For split-reduction,
   // slice along the reduction dimension to get extra parallelism.
   SmallVector<OpFoldResult> initOffsets, initSizes, initStrides;
@@ -1770,10 +1778,9 @@ FailureOr<TilingResult> ArgCompareOp::tileToPartialReduction(
       continue;
     }
 
-    if (auto sizeAttr = dyn_cast<Attribute>(initSizes[i])) {
-      int64_t size = (cast<IntegerAttr>(sizeAttr)).getInt();
-      resultValShape.push_back(size);
-      resultIdxShape.push_back(size);
+    if (std::optional<int64_t> size = getConstantIntValue(initSizes[i])) {
+      resultValShape.push_back(*size);
+      resultIdxShape.push_back(*size);
       continue;
     }
 
@@ -1796,36 +1803,47 @@ FailureOr<TilingResult> ArgCompareOp::tileToPartialReduction(
   tiledOperands.push_back(initIdxSlice.getResult());
   slices.push_back(initIdxSlice);
 
-  // Create index_base for this chunk.
-  Value tileIndex =
-      getValueOrCreateConstantIndexOp(b, loc, splitReductionIvs[0]);
-  Value tileSize = getValueOrCreateConstantIndexOp(b, loc, sizes[reductionDim]);
-  Value tileStartIndex = arith::MulIOp::create(b, loc, tileIndex, tileSize);
-
-  Value newIndexBase;
-  if (Value globalIndexBase = getIndexBase()) {
-    // Add chunk start to existing index_base.
-    newIndexBase =
-        arith::AddIOp::create(b, loc, globalIndexBase, tileStartIndex);
-  } else {
-    // Use chunk start as index_base.
-    newIndexBase = tileStartIndex;
-  }
-
   SmallVector<Type, 2> resultTypes;
   if (hasPureTensorSemantics()) {
     resultTypes = {initValSlice->getResult(0).getType(),
                    initIdxSlice->getResult(0).getType()};
   }
 
-  // Create the tiled operation with adjusted index_base.
-  SmallVector<Value> operands = std::move(tiledOperands);
-  operands.push_back(newIndexBase);
-  Operation *tiledArgmaxOp = ArgCompareOp::create(
-      b, loc, resultTypes,
-      /*inputs=*/operands[0],
-      /*outputs=*/ValueRange{operands[1], operands[2]},
-      /*indexBase=*/operands[3], /*dimension=*/reductionDim);
+  ArgCompareOp tiledArgmaxOp;
+  if (isExplicitIndexMode) {
+    // Explicit-index mode: 2 inputs (value + index), no index_base.
+    // tiledOperands layout: [value_slice, index_slice, init_val, init_idx].
+    tiledArgmaxOp = ArgCompareOp::create(
+        b, loc, resultTypes,
+        /*inputs=*/ValueRange{tiledOperands[0], tiledOperands[1]},
+        /*outputs=*/ValueRange{tiledOperands[2], tiledOperands[3]},
+        /*indexBase=*/nullptr, /*dimension=*/reductionDim);
+  } else {
+    // Implicit-index mode: 1 input (value) + index_base.
+    // Create index_base for this chunk.
+    Value tileIndex =
+        getValueOrCreateConstantIndexOp(b, loc, splitReductionIvs[0]);
+    Value tileSize =
+        getValueOrCreateConstantIndexOp(b, loc, sizes[reductionDim]);
+    Value tileStartIndex = arith::MulIOp::create(b, loc, tileIndex, tileSize);
+
+    Value newIndexBase;
+    if (Value globalIndexBase = getIndexBase()) {
+      // Add chunk start to existing index_base.
+      newIndexBase =
+          arith::AddIOp::create(b, loc, globalIndexBase, tileStartIndex);
+    } else {
+      // Use chunk start as index_base.
+      newIndexBase = tileStartIndex;
+    }
+
+    // tiledOperands layout: [value_slice, init_val, init_idx].
+    tiledArgmaxOp = ArgCompareOp::create(
+        b, loc, resultTypes,
+        /*inputs=*/tiledOperands[0],
+        /*outputs=*/ValueRange{tiledOperands[1], tiledOperands[2]},
+        /*indexBase=*/newIndexBase, /*dimension=*/reductionDim);
+  }
 
   // Copy the region.
   Region &targetRegion = tiledArgmaxOp->getRegion(0);
@@ -1841,37 +1859,27 @@ FailureOr<MergeResult>
 ArgCompareOp::mergeReductions(OpBuilder &b, Location loc,
                               ValueRange partialReduce,
                               const llvm::SetVector<unsigned> &reductionDims) {
-  auto mergeReductionDims = llvm::to_vector_of<int64_t>(reductionDims);
-  // Create linalg.reduce to perform final merge of partial results.
-  auto reduction = linalg::ReduceOp::create(
-      b, loc, partialReduce, getDpsInits(), mergeReductionDims,
-      [this](OpBuilder &b, Location loc, ValueRange inputs) {
-        Block &originalBlock = getRegion().front();
-        IRMapping mapper;
+  int64_t reductionDim = *reductionDims.begin();
 
-        // Map the original block arguments to the new inputs.
-        mapper.map(originalBlock.getArgument(0), inputs[0]);
-        mapper.map(originalBlock.getArgument(1), inputs[2]);
-        for (Operation &op : originalBlock) {
-          if (op.hasTrait<OpTrait::IsTerminator>()) {
-            break;
-          }
-          b.clone(op, mapper);
-        }
+  // Create arg_compare in explicit-index mode to merge the partial results.
+  // Explicit-index mode: 2 inputs (value + index), no index_base.
+  ArgCompareOp mergeOp = ArgCompareOp::create(
+      b, loc,
+      hasPureTensorSemantics() ? TypeRange(getDpsInits().getTypes())
+                               : TypeRange{},
+      /*inputs=*/partialReduce,
+      /*outputs=*/getDpsInits(),
+      /*indexBase=*/nullptr,
+      /*dimension=*/reductionDim);
 
-        // The verifier from ArgCompareOp ensures the region block ends with
-        // iree_linalg_ext.yield i1, so we can safely extract the predicate.
-        Value predicate =
-            mapper.lookup(originalBlock.getTerminator()->getOperand(0));
-        Value selectedVal =
-            arith::SelectOp::create(b, loc, predicate, inputs[0], inputs[2]);
-        Value selectedIdx =
-            arith::SelectOp::create(b, loc, predicate, inputs[1], inputs[3]);
-        linalg::YieldOp::create(b, loc, ValueRange{selectedVal, selectedIdx});
-      });
+  // Clone the comparator region from the original operation.
+  Region &targetRegion = mergeOp.getRegion();
+  Region &sourceRegion = getRegion();
+  IRMapping mapper;
+  sourceRegion.cloneInto(&targetRegion, mapper);
 
-  return MergeResult{{reduction},
-                     {reduction->getResult(0), reduction->getResult(1)}};
+  return MergeResult{{mergeOp.getOperation()},
+                     {mergeOp.getResult(0), mergeOp.getResult(1)}};
 }
 
 LogicalResult ArgCompareOp::getPartialResultTilePosition(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1778,14 +1778,9 @@ FailureOr<TilingResult> ArgCompareOp::tileToPartialReduction(
       continue;
     }
 
-    if (std::optional<int64_t> size = getConstantIntValue(initSizes[i])) {
-      resultValShape.push_back(*size);
-      resultIdxShape.push_back(*size);
-      continue;
-    }
-
-    resultValShape.push_back(ShapedType::kDynamic);
-    resultIdxShape.push_back(ShapedType::kDynamic);
+    std::optional<int64_t> size = getConstantIntValue(initSizes[i]);
+    resultValShape.push_back(size.value_or(ShapedType::kDynamic));
+    resultIdxShape.push_back(size.value_or(ShapedType::kDynamic));
   }
 
   RankedTensorType sliceValResultType =
@@ -1859,7 +1854,7 @@ FailureOr<MergeResult>
 ArgCompareOp::mergeReductions(OpBuilder &b, Location loc,
                               ValueRange partialReduce,
                               const llvm::SetVector<unsigned> &reductionDims) {
-  int64_t reductionDim = *reductionDims.begin();
+  int64_t reductionDim = reductionDims.front();
 
   // Create arg_compare in explicit-index mode to merge the partial results.
   // Explicit-index mode: 2 inputs (value + index), no index_base.

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -218,10 +218,9 @@ util.func public @split_reduction_arg_compare(%arg0: tensor<4x1x128256xf16>) -> 
 //       CHECK:      } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
 //       CHECK:      flow.return %[[FORALL]]#0, %[[FORALL]]#1 : tensor<4x1x96xf16>, tensor<4x1x96xi32>
 //       CHECK:    }
-//       CHECK:    %[[REDUCE:.+]]:2 = linalg.reduce
-//  CHECK-SAME:        ins(%[[DISPATCH]]#0, %[[DISPATCH]]#1 :
-//  CHECK-SAME:        outs(%[[FILL_F16]], %[[FILL_I32]] :
-//  CHECK-SAME:        dimensions = [2]
+//       CHECK:    %[[REDUCE:.+]]:2 = iree_linalg_ext.arg_compare dimension(2)
+//  CHECK-SAME:        ins(%[[DISPATCH]]#0, %[[DISPATCH]]#1 : tensor<4x1x96xf16>, tensor<4x1x96xi32>)
+//  CHECK-SAME:        outs(%[[FILL_F16]], %[[FILL_I32]] : tensor<4x1xf16>, tensor<4x1xi32>)
 //       CHECK:    util.return %[[REDUCE]]#0, %[[REDUCE]]#1
 
 // -----

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
@@ -53,9 +53,9 @@ util.func public @basic_arg_compare(%arg0: tensor<4096xf32>)
   // CHECK:     iree_linalg_ext.arg_compare
   // CHECK-SAME: ins({{.*}} : tensor<1024xf32>)
 
-  // Second level: merge 4 partials via linalg.reduce.
+  // Second level: merge 4 partials via arg_compare with explicit-index mode.
   // CHECK: %[[RESULT:.+]]:2 = flow.dispatch.workgroups(%[[SPLIT]]#0, %[[SPLIT]]#1)
-  // CHECK:   linalg.reduce
+  // CHECK:   iree_linalg_ext.arg_compare
   // CHECK-SAME: ins({{.*}} : tensor<4xf32>, tensor<4xi32>)
   // CHECK-SAME: outs({{.*}} : tensor<f32>, tensor<i32>)
 


### PR DESCRIPTION
This PR revisits the split-reduction support for `arg_compare` (was introduced in #21903) and introduces two main changes:
- Updates the merge-reduction phase to use the arg_compare op (explicit index mode) to represent pairwise reduction on the (value, index) pair, which better facilitates the generic vectorization phase.
- Extends the existing split-reduction phase to support arg_compare with an explicit index input.



