### PR TITLE
[LinalgExt] MSVC Bug fix - useExp / useExp2 in AggregatedOpInterfaceImpl

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -281,9 +281,9 @@ static Value computeSubAndExp(OpBuilder &builder, Location loc,
         Value in = convertScalarToDtype(b, loc, args[0], args[1].getType(),
                                         /*isUnsignedCast=*/false);
         Value diff = arith::SubFOp::create(b, loc, args[1], in);
-        Operation *weight = useExp2 ? math::Exp2Op::create(b, loc, diff)
-                                    : math::ExpOp::create(b, loc, diff);
-        linalg::YieldOp::create(b, loc, weight->getResult(0));
+        Value weight = useExp2 ? math::Exp2Op::create(b, loc, diff).getResult()
+                               : math::ExpOp::create(b, loc, diff).getResult();
+        linalg::YieldOp::create(b, loc, weight);
       });
   return genericOp.getResult(0);
 }


### PR DESCRIPTION
The original code returns two types, and MSVC refuses to pick a common type. By switching the conditional to return a Value, the types are identical, so MSVC should accept it.

Solves the CI bug raised by https://github.com/iree-org/iree/pull/23211