### PR TITLE
[Dispatch Creation] Add FoldReshapesIntoTensorBarriers to pass pipeline

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/InsertTensorBarriers.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/InsertTensorBarriers.cpp
@@ -61,26 +61,6 @@ static void collectInputsToComputeRegion(Value val,
   }
 }
 
-// Traverse backward along use-def chains starting from `val` to identify values
-// produced by compute operations. These values are candidates for inserting
-// compute_barrier.end operations.
-static void
-collectOutputsFromComputeRegion(Value val, llvm::SetVector<Value> &outputValues,
-                                llvm::DenseSet<Value> &visited) {
-  Operation *definingOp = val.getDefiningOp();
-  if (!definingOp || !visited.insert(val).second) {
-    return;
-  }
-
-  if (isComputeOp(definingOp)) {
-    outputValues.insert(val);
-  } else {
-    llvm::for_each(definingOp->getOperands(), [&](Value operand) {
-      collectOutputsFromComputeRegion(operand, outputValues, visited);
-    });
-  }
-}
-
 struct InsertTensorBarriersPass final
     : public impl::InsertTensorBarriersPassBase<InsertTensorBarriersPass> {
   using Base::Base;
@@ -112,22 +92,29 @@ struct InsertTensorBarriersPass final
     }
 
     // Insert compute_barrier.end operations for values that flow out of compute
-    // ops.
+    // ops. We find compute operation results that are used by non-compute
+    // operations. This approach works even when the function doesn't directly
+    // return tensor values (e.g., when they flow through HAL operations).
     llvm::SetVector<Value> needsEndBarrier;
-    visited.clear();
     funcOp.walk([&](Operation *op) {
-      if (!op->hasTrait<OpTrait::ReturnLike>()) {
+      if (!isComputeOp(op)) {
         return;
       }
-      for (Value operand : op->getOperands()) {
-        collectOutputsFromComputeRegion(operand, needsEndBarrier, visited);
+      for (Value result : op->getResults()) {
+        if (!isa<RankedTensorType>(result.getType())) {
+          continue;
+        }
+        const bool hasNonComputeUse =
+            llvm::any_of(result.getUsers(), [](Operation *user) {
+              return !isComputeOp(user) && !isa<tensor::DimOp>(user);
+            });
+        if (hasNonComputeUse) {
+          needsEndBarrier.insert(result);
+        }
       }
     });
 
     for (Value val : needsEndBarrier) {
-      if (!isa<RankedTensorType>(val.getType())) {
-        continue;
-      }
       Operation *definingOp = val.getDefiningOp();
       if (!definingOp) {
         continue;

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -121,6 +121,7 @@ static void addDispatchRegionCreationPreprocessingPasses(
       // 2. Bubble up expand_shape ops (or sink collapse_shape ops) to get
       //    elementwise operation into higher dimensions for more fusion
       //    opportunities.
+      .addPass(DispatchCreation::createFoldReshapesIntoTensorBarriersPass)
       .addPass([&]() {
         return DispatchCreation::createBubbleUpExpandShapesPass(
             DispatchCreation::BubbleUpExpandShapesPassOptions{

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -159,6 +159,7 @@ void buildGlobalOptimizationPassPipeline(
                          DispatchCreation::createInsertTensorBarriersPass);
   mainPassManager.addPass(DispatchCreation::createFoldUnitExtentDimsPass());
   FunctionLikeNest(mainPassManager)
+      .addPass(DispatchCreation::createFoldReshapesIntoTensorBarriersPass)
       .addPass([&]() {
         return createDemoteContractionInputsToBF16Pass(
             clDemoteContractionInputsToBF16Strategy);

--- a/compiler/src/iree/compiler/GlobalOptimization/test/transformation_pipeline.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/transformation_pipeline.mlir
@@ -50,13 +50,13 @@ util.func public @transpose_with_strided_conv(%arg0: tensor<40x1x1x32xbf16>, %ar
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<40x1x1x32xbf16>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x192x128x32xbf16>
 //       CHECK:   %[[START0:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG1]]
-//       CHECK:   %[[START1:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
-//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[START1]]
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//       CHECK:   %[[START1:.+]] = iree_tensor_ext.compute_barrier.start %[[COLLAPSED]]
 //       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[START0]][0, 0, 0, 0] [16, 96, 64, 32] [1, 2, 2, 1]
 //  CHECK-SAME:     tensor<16x192x128x32xbf16> to tensor<16x96x64x32xbf16>
 //       CHECK:   %[[CONTRACT:.+]] = linalg.generic
 //  CHECK-SAME:     iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-//  CHECK-SAME:     ins(%[[SLICE]], %[[COLLAPSED]] : tensor<16x96x64x32xbf16>, tensor<40x32xbf16>)
+//  CHECK-SAME:     ins(%[[SLICE]], %[[START1]] : tensor<16x96x64x32xbf16>, tensor<40x32xbf16>)
 //       CHECK:   %[[TRUNC:.+]] = linalg.generic
 //  CHECK-SAME:     ins(%[[CONTRACT]] : tensor<16x96x64x40xf32>)
 //       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[TRUNC]]


### PR DESCRIPTION
Folds reshapes into tensor barriers to prevent them from being propagated. This is especially important when it comes to preventing unit dims from getting propagated throughout the IR. This also fixes InsertTensorBarriers to handle cases where functions don't return a value and instead use `hal.tensor.alias`.

Closes: https://github.com/iree-org/iree/issues/23194



ci-extra: test_torch