### PR TITLE
[runtime][bindings][python] Allow >= on sympy versions

### DIFF
--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -8,5 +8,5 @@ setuptools>=62.4.0
 numpy>=2.0.0b1
 requests>=2.28.0
 wheel>=0.36.2
-sympy==1.12.1
+sympy>=1.12.1
 ml_dtypes>=0.5.1


### PR DESCRIPTION
For some reason this requirement alone was == which causes conflicts with other packages that require newer versions (like pytorch). 1.14.0 seemed fine with local testing so changing this to >=.