### PR TITLE
[plugins][Torch] Add a flag to externalize transients during torch-to-IREE conversion

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
@@ -652,7 +652,7 @@ public:
     // Determine whether to build pure async or async + sync wrapper.
     bool generateSyncWrapper = true;
     // Determine whether to include a new transient buffer input to the
-    // generated async wrapper.
+    // generated async function and corresponding sync wrapper.
     bool externalizeTransientMemory = externalizeTransients;
     StringRef originalName = torchFunc.getName();
     std::string asyncFunctionName = originalName.str();

--- a/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
@@ -577,7 +577,7 @@ void createCoarseFencesSyncWrapper(StringRef syncFunctionName,
 
 } // namespace
 
-class FuncConversionPass
+class FuncConversionPass final
     : public impl::FuncConversionPassBase<FuncConversionPass> {
 public:
   using Base::Base;

--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -83,7 +83,7 @@ void createTorchToIREEPipeline(
   // differently and would not be subject to inlining.
   pm.addPass(mlir::createInlinerPass());
 
-  pm.addPass(createFuncConversionPass());
+  pm.addPass(createFuncConversionPass({options.externalizeTransients}));
   pm.addNestedPass<IREE::Util::FuncOp>(createCanonicalizerPass());
   pm.addPass(createSymbolDCEPass());
 

--- a/compiler/plugins/input/Torch/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.h
@@ -36,6 +36,13 @@ struct TorchToIREELoweringPipelineOptions
   Option<bool> decompose{*this, "decompose",
                          llvm::cl::desc("Decompose complex torch operations."),
                          llvm::cl::init(true)};
+  Option<bool> externalizeTransients{
+      *this, "externalize-transients",
+      llvm::cl::desc(
+          "If enabled, this option will append an external hal buffer to "
+          "program inputs. This buffer will be used for storing transient "
+          "memory and must be provided by the user."),
+      llvm::cl::init(false)};
 };
 
 // Creates a pipeline that lowers from the torch backend contract to IREE.

--- a/compiler/plugins/input/Torch/InputConversion/Passes.td
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.td
@@ -41,6 +41,13 @@ def FuncConversionPass :
     Conversion pass for finalizing functions and ABI. Replaces the generic
     torch-func-backend-type-conversion pass.
   }];
+  let options = [
+    Option<"externalizeTransients", "externalize-transients",
+           "bool",
+           /*default=*/"false",
+          "If enabled, this option will append an external hal buffer to "
+          "program inputs. This buffer will be used for storing transient "
+          "memory and must be provided by the user.">];
 }
 
 #endif // IREE_COMPILER_PLUGINS_INPUT_TORCH_INPUTCONVERSION_PASSES

--- a/compiler/plugins/input/Torch/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/test/CMakeLists.txt
@@ -5,6 +5,7 @@ iree_lit_test_suite(
     "apply_pdl_patterns_torch.mlir"
     "assume_strict_symbols.mlir"
     "auto_input_conversion.mlir"
+    "auto_input_conversion_with_transients.mlir"
     "attention.mlir"
     "bind_symbolic_shapes.mlir"
     "bitcast_tensor.mlir"

--- a/compiler/plugins/input/Torch/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/test/CMakeLists.txt
@@ -10,6 +10,7 @@ iree_lit_test_suite(
     "bitcast_tensor.mlir"
     "func_conversion.mlir"
     "func_conversion_invalid.mlir"
+    "func_conversion_transients.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"

--- a/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion_with_transients.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion_with_transients.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-externalize-transients --compile-to=input --split-input-file %s | FileCheck %s
+// RUN: iree-compile --iree-torch-externalize-transients --compile-to=input --split-input-file %s | FileCheck %s
 
 // Check that the auto input conversion respects the driver option to externalize transients.
 

--- a/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion_with_transients.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion_with_transients.mlir
@@ -6,8 +6,8 @@
 //       CHECK: util.func public @main$async(
 //  CHECK-SAME:     %[[INPUT:.+]]: !hal.buffer_view, %[[EXTERNAL_BUFFER:.+]]: !hal.buffer,
 //  CHECK-SAME:     %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) -> !hal.buffer_view
-//       CHECK: %[[TRANSIENTS_CALL:.+]] = hal.tensor.transients %[[COMPUTATION:.+]] : tensor<5x4xf32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
-//       CHECK: %[[BARRIER:.+]] = hal.tensor.barrier join(%[[TRANSIENTS_CALL]] : tensor<5x4xf32>)
+//       CHECK: %[[TRANSIENTS:.+]] = hal.tensor.transients %[[COMPUTATION:.+]] : tensor<5x4xf32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//       CHECK: %[[BARRIER:.+]] = hal.tensor.barrier join(%[[TRANSIENTS]] : tensor<5x4xf32>)
 
 //       CHECK: util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer) -> !hal.buffer_view
 builtin.module @check_transients_generation{

--- a/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion_with_transients.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/auto_input_conversion_with_transients.mlir
@@ -1,0 +1,33 @@
+// RUN: iree-compile --iree-externalize-transients --compile-to=input --split-input-file %s | FileCheck %s
+
+// Check that the auto input conversion respects the driver option to externalize transients.
+
+// CHECK-LABEL: @check_transients_generation
+//       CHECK: util.func public @main$async(
+//  CHECK-SAME: %arg0: !hal.buffer_view, %arg1: !hal.buffer,
+//  CHECK-SAME: %arg2: !hal.fence, %arg3: !hal.fence) -> !hal.buffer_view
+//       CHECK: %[[TRANSIENTS_CALL:.+]] = hal.tensor.transients %[[COMP:.+]] : tensor<5x4xf32> from %arg1 : !hal.buffer
+//       CHECK: %[[BARRIER:.+]] = hal.tensor.barrier join(%[[TRANSIENTS_CALL]] : tensor<5x4xf32>)
+
+//       CHECK: util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer) -> !hal.buffer_view
+builtin.module @check_transients_generation{
+func.func @main(%arg0: !torch.vtensor<[5,4],f32>) -> (!torch.vtensor<[5,4],f32>) {
+  %int1 = torch.constant.int 1
+  %0 = torch.aten.add.Tensor %arg0, %arg0, %int1 : !torch.vtensor<[5,4],f32>, !torch.vtensor<[5,4],f32>, !torch.int -> !torch.vtensor<[5,4],f32>
+  return %0 : !torch.vtensor<[5,4],f32>
+}
+}
+
+
+// -----
+// CHECK-LABEL: @return_immutable_arg
+// CHECK: util.func public @main$async
+// CHECK-SAME: !hal.buffer
+// CHECK: hal.fence.signal<%arg3 : !hal.fence>
+// CHECK: util.return %arg0
+// CHECK-NOT: hal.tensor.transients
+builtin.module @return_immutable_arg {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}

--- a/compiler/plugins/input/Torch/InputConversion/test/func_conversion_transients.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/func_conversion_transients.mlir
@@ -5,7 +5,7 @@
 // CHECK-LABEL: @immutable_import_export
 //       CHECK: util.func public @main$async(
 //  CHECK-SAME:     %[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view,
-//  CHECK-SAME:     %[[TRANSIENT_STORAGE:.+]]: !hal.buffer,
+//  CHECK-SAME:     %[[EXTERNAL_BUFFER:.+]]: !hal.buffer,
 //  CHECK-SAME:     %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) ->
 //  CHECK-SAME:     (!hal.buffer_view, !hal.buffer_view)
 //  CHECK-SAME:     iree.abi.model = "coarse-fences"
@@ -18,9 +18,9 @@
 //   CHECK-DAG:   %[[TORCH_RESULT1:.+]] = torch.operator "foobar1"(%[[TORCH_ARG1]])
 //   CHECK-DAG:   %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
 //   CHECK-DAG:   %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
-//   CHECK-DAG:   %[[TRANSIENT_CALL0:.+]] = hal.tensor.transients %[[TENSOR_RESULT0]] : tensor<4x5xi32> from %[[TRANSIENT_STORAGE]] : !hal.buffer
-//   CHECK-DAG:   %[[TRANSIENT_CALL1:.+]] = hal.tensor.transients %[[TENSOR_RESULT1]] : tensor<5x4xf32> from %[[TRANSIENT_STORAGE]] : !hal.buffer
-//       CHECK:   %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENT_CALL0]], %[[TRANSIENT_CALL1]] : tensor<4x5xi32>, tensor<5x4xf32>) => %[[SIGNAL]]
+//   CHECK-DAG:   %[[TRANSIENTS0:.+]] = hal.tensor.transients %[[TENSOR_RESULT0]] : tensor<4x5xi32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//   CHECK-DAG:   %[[TRANSIENTS1:.+]] = hal.tensor.transients %[[TENSOR_RESULT1]] : tensor<5x4xf32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//       CHECK:   %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENTS0]], %[[TRANSIENTS1]] : tensor<4x5xi32>, tensor<5x4xf32>) => %[[SIGNAL]]
 //   CHECK-DAG:   %[[FUNC_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
 //   CHECK-DAG:   %[[FUNC_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
 //       CHECK:   util.return %[[FUNC_RESULT0]], %[[FUNC_RESULT1]]

--- a/compiler/plugins/input/Torch/InputConversion/test/func_conversion_transients.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/func_conversion_transients.mlir
@@ -1,0 +1,136 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(torch-iree-func-conversion{externalize-transients=true})" --allow-unregistered-dialect --split-input-file %s | FileCheck %s
+
+// This file contains some tests from the parallel file `func_conversion.mlir`, but is run with `externalize-transients=True`.
+
+// CHECK-LABEL: @immutable_import_export
+//       CHECK: util.func public @main$async(
+//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
+//  CHECK-SAME:     %[[TRANSIENT_STORAGE:.+]]: !hal.buffer,
+//  CHECK-SAME:     %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) ->
+//  CHECK-SAME:     (!hal.buffer_view, !hal.buffer_view)
+//  CHECK-SAME:     iree.abi.model = "coarse-fences"
+//  CHECK-SAME:     iree.abi.stub
+//   CHECK-DAG:   %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%[[WAIT]]) => %arg0 : !hal.buffer_view -> tensor<4x5xi32>
+//   CHECK-DAG:   %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%[[WAIT]]) => %arg1 : !hal.buffer_view -> tensor<5x4xf32>
+//   CHECK-DAG:   %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]] : tensor<4x5xi32> -> !torch.vtensor<[4,5],si32>
+//   CHECK-DAG:   %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]] : tensor<5x4xf32> -> !torch.vtensor<[5,4],f32>
+//   CHECK-DAG:   %[[TORCH_RESULT0:.+]] = torch.operator "foobar0"(%[[TORCH_ARG0]])
+//   CHECK-DAG:   %[[TORCH_RESULT1:.+]] = torch.operator "foobar1"(%[[TORCH_ARG1]])
+//   CHECK-DAG:   %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG:   %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//   CHECK-DAG:   %[[TRANSIENT_CALL0:.+]] = hal.tensor.transients %[[TENSOR_RESULT0]] : tensor<4x5xi32> from %[[TRANSIENT_STORAGE]] : !hal.buffer
+//   CHECK-DAG:   %[[TRANSIENT_CALL1:.+]] = hal.tensor.transients %[[TENSOR_RESULT1]] : tensor<5x4xf32> from %[[TRANSIENT_STORAGE]] : !hal.buffer
+//       CHECK:   %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENT_CALL0]], %[[TRANSIENT_CALL1]] : tensor<4x5xi32>, tensor<5x4xf32>) => %[[SIGNAL]]
+//   CHECK-DAG:   %[[FUNC_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
+//   CHECK-DAG:   %[[FUNC_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
+//       CHECK:   util.return %[[FUNC_RESULT0]], %[[FUNC_RESULT1]]
+//
+//       CHECK: util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer)
+//  CHECK-SAME:     -> (!hal.buffer_view, !hal.buffer_view)
+//  CHECK-SAME:     iree.abi.stub
+//   CHECK-DAG:   %[[CONSTANT0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[CONSTANT1:.+]] = arith.constant -1 : i32
+//   CHECK-DAG:   %[[DEVICE0:.+]] = hal.devices.get %[[CONSTANT0]] : !hal.device
+//   CHECK-DAG:   %[[NULL_FENCE:.+]] = util.null : !hal.fence
+//       CHECK:   %[[NEW_FENCE:.+]] = hal.fence.create device(%[[DEVICE0]] : !hal.device) flags("None")
+//       CHECK:   %[[CALL_RESULTS:.+]]:2 = util.call @main$async(%arg0, %arg1, %arg2, %[[NULL_FENCE]], %[[NEW_FENCE]])
+//       CHECK:   %[[AWAIT_STATUS:.+]] = hal.fence.await until([%[[NEW_FENCE]]]) timeout_millis(%[[CONSTANT1]])
+//       CHECK:   util.return %[[CALL_RESULTS]]#0, %[[CALL_RESULTS]]#1 : !hal.buffer_view, !hal.buffer_view
+builtin.module @immutable_import_export {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f32>)
+    -> (!torch.vtensor<[4,5],si32>, !torch.vtensor<[5,4],f32>) {
+  %0 = torch.operator "foobar0"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
+  %1 = torch.operator "foobar1"(%arg1) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  return %0, %1 : !torch.vtensor<[4,5],si32>, !torch.vtensor<[5,4],f32>
+}
+}
+
+// -----
+// CHECK-LABEL: @return_immutable_arg
+// CHECK: util.func public @main$async
+// CHECK: hal.fence.signal<%arg3 : !hal.fence>
+// CHECK: util.return %arg0
+// CHECK-NOT: hal.tensor.transients
+builtin.module @return_immutable_arg {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {
+  return %arg0 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// CHECK-LABEL: @mutable_input_overwrite_no_return
+//       CHECK: util.func public @main$async(
+//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
+//  CHECK-SAME:     %arg2: !hal.buffer,
+//  CHECK-SAME:     %arg3: !hal.fence, %arg4: !hal.fence) -> !hal.buffer_view
+//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%arg3) => %arg0
+//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
+//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%arg3) => %arg1
+//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
+//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
+//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
+//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//       CHECK: %[[EXPORT_ALIAS1:.+]] = hal.tensor.alias wait(%arg3) => %[[TENSOR_ARG1]] : tensor<5x4xf32> to %arg1 : !hal.buffer_view
+//   CHECK-DAG: %[[TRANSIENT_CALL1:.+]] = hal.tensor.transients %[[EXPORT_ALIAS1]] : tensor<5x4xf32> from %arg2 : !hal.buffer
+//   CHECK-DAG: %[[TRANSIENT_CALL0:.+]] = hal.tensor.transients %[[TENSOR_ARG0]] : tensor<4x5xi32> from %arg2 : !hal.buffer
+//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENT_CALL1]], %[[TRANSIENT_CALL0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg4 : !hal.fence
+//   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
+//   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
+//       CHECK: util.return %[[EXPORT_RESULT1]]
+builtin.module @mutable_input_overwrite_no_return {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.tensor<[5,4],f32>)
+    -> (!torch.vtensor<[4,5],si32>) {
+  %0 = torch.copy.to_vtensor %arg1 : !torch.vtensor<[5,4],f32>
+  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  %2 = torch.operator "other_calc"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
+  torch.overwrite.tensor.contents %1 overwrites %arg1 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
+  return %2 : !torch.vtensor<[4,5],si32>
+}
+}
+
+// -----
+// CHECK-LABEL: @immutable_import_export
+// CHECK: hal.buffer_view.dim<%arg0
+// CHECK: hal.buffer_view.dim<%arg1
+builtin.module @immutable_import_export {
+func.func @main(%arg0: !torch.vtensor<[4,?],si32>, %arg1: !torch.vtensor<[?,4],f32>)
+    -> (!torch.vtensor<[4,?],si32>, !torch.vtensor<[?,4],f32>) {
+  %0 = torch.operator "foobar0"(%arg0) : (!torch.vtensor<[4,?],si32>) -> !torch.vtensor<[4,?],si32>
+  %1 = torch.operator "foobar1"(%arg1) : (!torch.vtensor<[?,4],f32>) -> !torch.vtensor<[?,4],f32>
+  return %0, %1 : !torch.vtensor<[4,?],si32>, !torch.vtensor<[?,4],f32>
+}
+}
+
+// -----
+// CHECK-LABEL: @mutable_input_overwrite_no_return
+//       CHECK: util.func public @main$async(
+//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
+//  CHECK-SAME:     %arg2: !hal.buffer,
+//  CHECK-SAME:     %arg3: !hal.fence, %arg4: !hal.fence) -> !hal.buffer_view
+//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import on(#hal.device.promise<@dev_a>) wait(%arg3) => %arg0
+//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
+//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import on(#hal.device.promise<@dev_b>) wait(%arg3) => %arg1
+//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
+//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
+//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
+//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//       CHECK: %[[EXPORT_ALIAS1:.+]] = hal.tensor.alias on(#hal.device.promise<@dev_b>) wait(%arg3) => %[[TENSOR_ARG1]] : tensor<5x4xf32> to %arg1 : !hal.buffer_view
+//   CHECK-DAG: %[[TRANSIENTS_CALL1:.+]] = hal.tensor.transients %[[EXPORT_ALIAS1]] : tensor<5x4xf32> from %arg2 : !hal.buffer
+//   CHECK-DAG: %[[TRANSIENTS_CALL0:.+]] = hal.tensor.transients %[[TENSOR_ARG0]] : tensor<4x5xi32> from %arg2 : !hal.buffer
+//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENTS_CALL1]], %[[TRANSIENTS_CALL0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg4 : !hal.fence
+//   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export on(#hal.device.promise<@dev_b>) %[[BARRIER_RESULTS]]#0
+//   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export on(#hal.device.promise<@dev_a>) %[[BARRIER_RESULTS]]#1
+//       CHECK: util.return %[[EXPORT_RESULT1]]
+builtin.module @mutable_input_overwrite_no_return_affinities {
+func.func @main(%arg0: !torch.vtensor<[4,5],si32> {iree.abi.affinity = #hal.device.promise<@dev_a>},
+                %arg1: !torch.tensor<[5,4],f32> {iree.abi.affinity = #hal.device.promise<@dev_b>})
+    -> (!torch.vtensor<[4,5],si32> {iree.abi.affinity = #hal.device.promise<@dev_a>}) {
+  %0 = torch.copy.to_vtensor %arg1 : !torch.vtensor<[5,4],f32>
+  %1 = torch.operator "mutate_inplace"(%0) : (!torch.vtensor<[5,4],f32>) -> !torch.vtensor<[5,4],f32>
+  %2 = torch.operator "other_calc"(%arg0) : (!torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
+  torch.overwrite.tensor.contents %1 overwrites %arg1 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
+  return %2 : !torch.vtensor<[4,5],si32>
+}
+}

--- a/compiler/plugins/input/Torch/InputConversion/test/func_conversion_transients.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/func_conversion_transients.mlir
@@ -4,14 +4,14 @@
 
 // CHECK-LABEL: @immutable_import_export
 //       CHECK: util.func public @main$async(
-//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
+//  CHECK-SAME:     %[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view,
 //  CHECK-SAME:     %[[TRANSIENT_STORAGE:.+]]: !hal.buffer,
 //  CHECK-SAME:     %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) ->
 //  CHECK-SAME:     (!hal.buffer_view, !hal.buffer_view)
 //  CHECK-SAME:     iree.abi.model = "coarse-fences"
 //  CHECK-SAME:     iree.abi.stub
-//   CHECK-DAG:   %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%[[WAIT]]) => %arg0 : !hal.buffer_view -> tensor<4x5xi32>
-//   CHECK-DAG:   %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%[[WAIT]]) => %arg1 : !hal.buffer_view -> tensor<5x4xf32>
+//   CHECK-DAG:   %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] : !hal.buffer_view -> tensor<4x5xi32>
+//   CHECK-DAG:   %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG1]] : !hal.buffer_view -> tensor<5x4xf32>
 //   CHECK-DAG:   %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]] : tensor<4x5xi32> -> !torch.vtensor<[4,5],si32>
 //   CHECK-DAG:   %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]] : tensor<5x4xf32> -> !torch.vtensor<[5,4],f32>
 //   CHECK-DAG:   %[[TORCH_RESULT0:.+]] = torch.operator "foobar0"(%[[TORCH_ARG0]])
@@ -25,7 +25,7 @@
 //   CHECK-DAG:   %[[FUNC_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
 //       CHECK:   util.return %[[FUNC_RESULT0]], %[[FUNC_RESULT1]]
 //
-//       CHECK: util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer)
+//       CHECK: util.func public @main(%[[SYNC_ARG0:.+]]: !hal.buffer_view, %[[SYNC_ARG1:.+]]: !hal.buffer_view, %[[SYNC_STORAGE:.+]]: !hal.buffer)
 //  CHECK-SAME:     -> (!hal.buffer_view, !hal.buffer_view)
 //  CHECK-SAME:     iree.abi.stub
 //   CHECK-DAG:   %[[CONSTANT0:.+]] = arith.constant 0 : index
@@ -33,7 +33,7 @@
 //   CHECK-DAG:   %[[DEVICE0:.+]] = hal.devices.get %[[CONSTANT0]] : !hal.device
 //   CHECK-DAG:   %[[NULL_FENCE:.+]] = util.null : !hal.fence
 //       CHECK:   %[[NEW_FENCE:.+]] = hal.fence.create device(%[[DEVICE0]] : !hal.device) flags("None")
-//       CHECK:   %[[CALL_RESULTS:.+]]:2 = util.call @main$async(%arg0, %arg1, %arg2, %[[NULL_FENCE]], %[[NEW_FENCE]])
+//       CHECK:   %[[CALL_RESULTS:.+]]:2 = util.call @main$async(%[[SYNC_ARG0]], %[[SYNC_ARG1]], %[[SYNC_STORAGE]], %[[NULL_FENCE]], %[[NEW_FENCE]])
 //       CHECK:   %[[AWAIT_STATUS:.+]] = hal.fence.await until([%[[NEW_FENCE]]]) timeout_millis(%[[CONSTANT1]])
 //       CHECK:   util.return %[[CALL_RESULTS]]#0, %[[CALL_RESULTS]]#1 : !hal.buffer_view, !hal.buffer_view
 builtin.module @immutable_import_export {
@@ -46,11 +46,16 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.vtensor<[5,4],f
 }
 
 // -----
-// CHECK-LABEL: @return_immutable_arg
-// CHECK: util.func public @main$async
-// CHECK: hal.fence.signal<%arg3 : !hal.fence>
-// CHECK: util.return %arg0
-// CHECK-NOT: hal.tensor.transients
+// Converting this trivial return func should still generate the external buffer arg.
+// However, there should not be any `!hal.tensor.transients` op created.
+// CHECK-LABEL:   @return_immutable_arg
+//       CHECK:   util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view,
+//  CHECK-SAME:       %[[EXTERNAL_BUFFER:.+]]: !hal.buffer,
+//  CHECK-SAME:       %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) ->
+//       CHECK:   hal.fence.signal<%[[SIGNAL]] : !hal.fence>
+//       CHECK:   util.return %[[ARG0]]
+//       CHECK:   util.func public @main(%[[SYNC_ARG0:.+]]: !hal.buffer_view, %[[SYNC_EXTERNAL_BUFFER:.+]]: !hal.buffer)
+//   CHECK-NOT:   hal.tensor.transients
 builtin.module @return_immutable_arg {
 func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>  {
   return %arg0 : !torch.vtensor<[4,5],si32>
@@ -60,21 +65,21 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>) -> !torch.vtensor<[4,5],si32>
 // -----
 // CHECK-LABEL: @mutable_input_overwrite_no_return
 //       CHECK: util.func public @main$async(
-//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
-//  CHECK-SAME:     %arg2: !hal.buffer,
-//  CHECK-SAME:     %arg3: !hal.fence, %arg4: !hal.fence) -> !hal.buffer_view
-//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import wait(%arg3) => %arg0
-//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
-//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import wait(%arg3) => %arg1
-//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
-//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
-//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
-//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
-//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
-//       CHECK: %[[EXPORT_ALIAS1:.+]] = hal.tensor.alias wait(%arg3) => %[[TENSOR_ARG1]] : tensor<5x4xf32> to %arg1 : !hal.buffer_view
-//   CHECK-DAG: %[[TRANSIENT_CALL1:.+]] = hal.tensor.transients %[[EXPORT_ALIAS1]] : tensor<5x4xf32> from %arg2 : !hal.buffer
-//   CHECK-DAG: %[[TRANSIENT_CALL0:.+]] = hal.tensor.transients %[[TENSOR_ARG0]] : tensor<4x5xi32> from %arg2 : !hal.buffer
-//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENT_CALL1]], %[[TRANSIENT_CALL0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg4 : !hal.fence
+//  CHECK-SAME:     %[[INPUT:.+]]: !hal.buffer_view, %[[MUTABLE_INPUT:.+]]: !hal.buffer_view,
+//  CHECK-SAME:     %[[EXTERNAL_BUFFER:.+]]: !hal.buffer,
+//  CHECK-SAME:     %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) -> !hal.buffer_view
+//   CHECK-DAG: %[[WAIT_INPUT:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[INPUT]]
+//   CHECK-DAG: %[[TORCH_INPUT:.+]] = torch_c.from_builtin_tensor %[[WAIT_INPUT]]
+//   CHECK-DAG: %[[WAIT_MUTABLE_INPUT:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[MUTABLE_INPUT]]
+//   CHECK-DAG: %[[TORCH_MUTABLE_INPUT:.+]] = torch_c.from_builtin_tensor %[[WAIT_MUTABLE_INPUT]]
+//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_INPUT]])
+//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_MUTABLE_INPUT]])
+//   CHECK-DAG: %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG: %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//       CHECK: %[[ALIAS:.+]] = hal.tensor.alias wait(%[[WAIT]]) => %[[TENSOR_RESULT1]] : tensor<5x4xf32> to %[[MUTABLE_INPUT]] : !hal.buffer_view
+//   CHECK-DAG: %[[TRANSIENTS1:.+]] = hal.tensor.transients %[[ALIAS]] : tensor<5x4xf32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//   CHECK-DAG: %[[TRANSIENTS0:.+]] = hal.tensor.transients %[[TENSOR_RESULT0]] : tensor<4x5xi32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENTS1]], %[[TRANSIENTS0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %[[SIGNAL]] : !hal.fence
 //   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#0
 //   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export %[[BARRIER_RESULTS]]#1
 //       CHECK: util.return %[[EXPORT_RESULT1]]
@@ -90,9 +95,32 @@ func.func @main(%arg0: !torch.vtensor<[4,5],si32>, %arg1: !torch.tensor<[5,4],f3
 }
 
 // -----
-// CHECK-LABEL: @immutable_import_export
-// CHECK: hal.buffer_view.dim<%arg0
-// CHECK: hal.buffer_view.dim<%arg1
+// This should be generating `hal.tensor.transients` with dynamic dims.
+// CHECK-LABEL:  @immutable_import_export {
+//       CHECK:  util.func public @main$async(
+//  CHECK-SAME:     %[[INPUT0:.+]]: !hal.buffer_view, %[[INPUT1:.+]]: !hal.buffer_view,
+//  CHECK-SAME:     %[[EXTERNAL_BUFFER:.+]]: !hal.buffer, %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence)
+//  CHECK-SAME:     -> (!hal.buffer_view, !hal.buffer_view)
+//       CHECK:  %[[INPUT0_DIM1:.+]] = hal.buffer_view.dim<%[[INPUT0]] : !hal.buffer_view>[1] : index
+//       CHECK:  %[[WAIT_INPUT0:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[INPUT0]] : !hal.buffer_view -> tensor<4x?xi32>{%[[INPUT0_DIM1]]}
+//       CHECK:  %[[TORCH_INPUT0:.+]] = torch_c.from_builtin_tensor %[[WAIT_INPUT0]] : tensor<4x?xi32> -> !torch.vtensor<[4,?],si32>
+//       CHECK:  %[[INPUT1_DIM0:.+]] = hal.buffer_view.dim<%[[INPUT1]] : !hal.buffer_view>[0] : index
+//       CHECK:  %[[WAIT_INPUT1:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[INPUT1]] : !hal.buffer_view -> tensor<?x4xf32>{%[[INPUT1_DIM0]]}
+//       CHECK:  %[[TORCH_INPUT1:.+]] = torch_c.from_builtin_tensor %[[WAIT_INPUT1]] : tensor<?x4xf32> -> !torch.vtensor<[?,4],f32>
+//       CHECK:  %[[TORCH_RESULT0:.+]] = torch.operator "foobar0"(%[[TORCH_INPUT0]]) : (!torch.vtensor<[4,?],si32>) -> !torch.vtensor<[4,?],si32>
+//       CHECK:  %[[TORCH_RESULT1:.+]] = torch.operator "foobar1"(%[[TORCH_INPUT1]]) : (!torch.vtensor<[?,4],f32>) -> !torch.vtensor<[?,4],f32>
+//       CHECK:  %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]] : !torch.vtensor<[4,?],si32> -> tensor<4x?xi32>
+//       CHECK:  %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]] : !torch.vtensor<[?,4],f32> -> tensor<?x4xf32>
+//       CHECK:  %[[CST1:.+]] = arith.constant 1 : index
+//       CHECK:  %[[RESULT0_DIM1:.+]] = tensor.dim %[[TENSOR_RESULT0]], %[[CST1]] : tensor<4x?xi32>
+//       CHECK:  %[[TRANSIENTS0:.+]] = hal.tensor.transients %[[TENSOR_RESULT0]] : tensor<4x?xi32>{%[[RESULT0_DIM1]]} from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//       CHECK:  %[[CST0:.+]] = arith.constant 0 : index
+//       CHECK:  %[[RESULT1_DIM0:.+]] = tensor.dim %[[TENSOR_RESULT1]], %[[CST0]] : tensor<?x4xf32>
+//       CHECK:  %[[TRANSIENTS1:.+]] = hal.tensor.transients %[[TENSOR_RESULT1]] : tensor<?x4xf32>{%[[RESULT1_DIM0]]} from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//       CHECK:  %[[BARRIER:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENTS0]], %[[TRANSIENTS1]] : tensor<4x?xi32>, tensor<?x4xf32>) => %[[SIGNAL]] : !hal.fence
+//       CHECK:  %[[EXPORT0:.+]] = hal.tensor.export %[[BARRIER]]#0 : tensor<4x?xi32>{%[[RESULT0_DIM1]]} -> !hal.buffer_view
+//       CHECK:  %[[EXPORT1:.+]] = hal.tensor.export %[[BARRIER]]#1 : tensor<?x4xf32>{%[[RESULT1_DIM0]]} -> !hal.buffer_view
+//       CHECK:  util.return %[[EXPORT0]], %[[EXPORT1]] : !hal.buffer_view, !hal.buffer_view
 builtin.module @immutable_import_export {
 func.func @main(%arg0: !torch.vtensor<[4,?],si32>, %arg1: !torch.vtensor<[?,4],f32>)
     -> (!torch.vtensor<[4,?],si32>, !torch.vtensor<[?,4],f32>) {
@@ -105,21 +133,21 @@ func.func @main(%arg0: !torch.vtensor<[4,?],si32>, %arg1: !torch.vtensor<[?,4],f
 // -----
 // CHECK-LABEL: @mutable_input_overwrite_no_return
 //       CHECK: util.func public @main$async(
-//  CHECK-SAME:     %arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
-//  CHECK-SAME:     %arg2: !hal.buffer,
-//  CHECK-SAME:     %arg3: !hal.fence, %arg4: !hal.fence) -> !hal.buffer_view
-//   CHECK-DAG: %[[WAIT_ARG0:.+]] = hal.tensor.import on(#hal.device.promise<@dev_a>) wait(%arg3) => %arg0
-//   CHECK-DAG: %[[TORCH_ARG0:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG0]]
-//   CHECK-DAG: %[[WAIT_ARG1:.+]] = hal.tensor.import on(#hal.device.promise<@dev_b>) wait(%arg3) => %arg1
-//   CHECK-DAG: %[[TORCH_ARG1:.+]] = torch_c.from_builtin_tensor %[[WAIT_ARG1]]
-//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_ARG0]])
-//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_ARG1]])
-//   CHECK-DAG: %[[TENSOR_ARG0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
-//   CHECK-DAG: %[[TENSOR_ARG1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
-//       CHECK: %[[EXPORT_ALIAS1:.+]] = hal.tensor.alias on(#hal.device.promise<@dev_b>) wait(%arg3) => %[[TENSOR_ARG1]] : tensor<5x4xf32> to %arg1 : !hal.buffer_view
-//   CHECK-DAG: %[[TRANSIENTS_CALL1:.+]] = hal.tensor.transients %[[EXPORT_ALIAS1]] : tensor<5x4xf32> from %arg2 : !hal.buffer
-//   CHECK-DAG: %[[TRANSIENTS_CALL0:.+]] = hal.tensor.transients %[[TENSOR_ARG0]] : tensor<4x5xi32> from %arg2 : !hal.buffer
-//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENTS_CALL1]], %[[TRANSIENTS_CALL0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %arg4 : !hal.fence
+//  CHECK-SAME:     %[[INPUT:.+]]: !hal.buffer_view, %[[MUTABLE_INPUT:.+]]: !hal.buffer_view,
+//  CHECK-SAME:     %[[EXTERNAL_BUFFER:.+]]: !hal.buffer,
+//  CHECK-SAME:     %[[WAIT:.+]]: !hal.fence, %[[SIGNAL:.+]]: !hal.fence) -> !hal.buffer_view
+//   CHECK-DAG: %[[WAIT_INPUT:.+]] = hal.tensor.import on(#hal.device.promise<@dev_a>) wait(%[[WAIT]]) => %[[INPUT]]
+//   CHECK-DAG: %[[TORCH_INPUT:.+]] = torch_c.from_builtin_tensor %[[WAIT_INPUT]]
+//   CHECK-DAG: %[[WAIT_MUTABLE_INPUT:.+]] = hal.tensor.import on(#hal.device.promise<@dev_b>) wait(%[[WAIT]]) => %[[MUTABLE_INPUT]]
+//   CHECK-DAG: %[[TORCH_MUTABLE_INPUT:.+]] = torch_c.from_builtin_tensor %[[WAIT_MUTABLE_INPUT]]
+//   CHECK-DAG: %[[TORCH_RESULT0:.+]] = torch.operator "other_calc"(%[[TORCH_INPUT]])
+//   CHECK-DAG: %[[TORCH_RESULT1:.+]] = torch.operator "mutate_inplace"(%[[TORCH_MUTABLE_INPUT]])
+//   CHECK-DAG: %[[TENSOR_RESULT0:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT0]]
+//   CHECK-DAG: %[[TENSOR_RESULT1:.+]] = torch_c.to_builtin_tensor %[[TORCH_RESULT1]]
+//       CHECK: %[[ALIAS:.+]] = hal.tensor.alias on(#hal.device.promise<@dev_b>) wait(%[[WAIT]]) => %[[TENSOR_RESULT1]] : tensor<5x4xf32> to %[[MUTABLE_INPUT]] : !hal.buffer_view
+//   CHECK-DAG: %[[TRANSIENTS_ALIAS:.+]] = hal.tensor.transients %[[ALIAS]] : tensor<5x4xf32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//   CHECK-DAG: %[[TRANSIENTS_RESULT0:.+]] = hal.tensor.transients %[[TENSOR_RESULT0]] : tensor<4x5xi32> from %[[EXTERNAL_BUFFER]] : !hal.buffer
+//       CHECK: %[[BARRIER_RESULTS:.+]]:2 = hal.tensor.barrier join(%[[TRANSIENTS_ALIAS]], %[[TRANSIENTS_RESULT0]] : tensor<5x4xf32>, tensor<4x5xi32>) => %[[SIGNAL]] : !hal.fence
 //   CHECK-DAG: %[[EXPORT_RESULT0:.+]] = hal.tensor.export on(#hal.device.promise<@dev_b>) %[[BARRIER_RESULTS]]#0
 //   CHECK-DAG: %[[EXPORT_RESULT1:.+]] = hal.tensor.export on(#hal.device.promise<@dev_a>) %[[BARRIER_RESULTS]]#1
 //       CHECK: util.return %[[EXPORT_RESULT1]]

--- a/compiler/plugins/input/Torch/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/PluginRegistration.cpp
@@ -29,6 +29,7 @@ namespace {
 struct TorchOptions {
   bool strictSymbolicShapes = true;
   bool decompose = true;
+  bool externalizeTransients = false;
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("Torch Input");
     binder.opt<bool>(
@@ -38,6 +39,13 @@ struct TorchOptions {
     binder.opt<bool>("iree-torch-decompose-complex-ops", decompose,
                      llvm::cl::cat(category),
                      llvm::cl::desc("Decompose complex torch operations."));
+    binder.opt<bool>(
+        "iree-externalize-transients", externalizeTransients,
+        llvm::cl::cat(category),
+        llvm::cl::desc(
+            "If enabled, this option will append an external hal buffer to "
+            "program inputs. This buffer will be used for storing transient "
+            "memory and must be provided by the user."));
   }
 };
 
@@ -87,6 +95,7 @@ struct TorchSession
       TorchInput::TorchToIREELoweringPipelineOptions torchOptions;
       torchOptions.strictSymbolicShapes = options.strictSymbolicShapes;
       torchOptions.decompose = options.decompose;
+      torchOptions.externalizeTransients = options.externalizeTransients;
       TorchInput::createTorchToIREEPipeline(passManager, torchOptions);
       return true;
     }

--- a/compiler/plugins/input/Torch/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/PluginRegistration.cpp
@@ -40,7 +40,7 @@ struct TorchOptions {
                      llvm::cl::cat(category),
                      llvm::cl::desc("Decompose complex torch operations."));
     binder.opt<bool>(
-        "iree-externalize-transients", externalizeTransients,
+        "iree-torch-externalize-transients", externalizeTransients,
         llvm::cl::cat(category),
         llvm::cl::desc("If enabled, an external hal buffer will be appended to "
                        "program inputs when converting torch functions to IREE "

--- a/compiler/plugins/input/Torch/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/PluginRegistration.cpp
@@ -42,10 +42,10 @@ struct TorchOptions {
     binder.opt<bool>(
         "iree-externalize-transients", externalizeTransients,
         llvm::cl::cat(category),
-        llvm::cl::desc(
-            "If enabled, this option will append an external hal buffer to "
-            "program inputs. This buffer will be used for storing transient "
-            "memory and must be provided by the user."));
+        llvm::cl::desc("If enabled, an external hal buffer will be appended to "
+                       "program inputs when converting torch functions to IREE "
+                       "input. This buffer will be used for storing transient "
+                       "memory and must be provided by the user at runtime."));
   }
 };
 


### PR DESCRIPTION
This is currently set up to add a `!hal.buffer` program argument to both the async func and the sync wrapper during `FuncConversionPass`, and treat it as a transient memory user allocation for all outputs (inplace or exported).

The intended use:

`iree-compile <usual-args> --iree-externalize-transients`

When invoking the main compiled program, the user will be expected to query the required transient buffer size and provide an additional `!hal.buffer` input.

-------

Edit: some notes about why we are using a flag.

We are choosing to append a buffer input through this pass using flag, rather than starting with a torch program with an extra mutable dynamic tensor arg and indicating the purpose of the extra tensor with an op like `torch.overwrite.tensor.contents`.

The reason a torch op doesn't make sense is that there isn't a clear import path for this. There isn't a torch op that says "use this tensor as scratch memory", and we'd need to put together something rather contrived in order to trace a function with the correct signature to match the desired IREE-input IR, when we have no intention of doing anything within torch-mlir proper to handle this special op.
