### PR TITLE
[StableHLO] Rework zero-extent canonicalizer

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -1123,7 +1123,7 @@ struct ZeroExtentTensorCanon final : RewritePattern {
       updatedResults.set(index);
     }
 
-    if (updatedResults.all()) {
+    if (didUpdate && updatedResults.all()) {
       // If we have replaced all results with a tensor.empty, there is no need
       // to update the operation in the next step.
       return success();

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
@@ -710,10 +710,12 @@ func.func @scatter_zero_ext(%arg0 : tensor<f32>, %arg1 : tensor<1x0xi32>, %arg2 
 // -----
 
 // CHECK-LABEL: @while_zero_extent
-// CHECK: %[[R0:.+]] = tensor.empty() : tensor<75x0xf32>
-// CHECK: %[[R1:.+]] = tensor.empty() : tensor<75x0xf32>
-// CHECK: %[[R2:.+]]:2 = stablehlo.while
-// CHECK: return %[[R2]]#0, %[[R0]]
+// CHECK: %[[EMPTY0:.+]] = tensor.empty() : tensor<75x0xf32>
+// CHECK: %[[WHILE:.+]]:2 = stablehlo.while
+// CHECK: %[[EMPTY1:.+]] = tensor.empty() : tensor<75x0xf32>
+// CHECK: stablehlo.return {{.*}} %[[EMPTY1]]
+// CHECK: %[[EMPTY2:.+]] = tensor.empty() : tensor<75x0xf32>
+// CHECK: return %[[WHILE]]#0, %[[EMPTY2]]
 
 
 func.func public @while_zero_extent(%arg0: tensor<i32>, %arg1: tensor<3xf32>, %arg2: tensor<75x0xf32>) -> (tensor<i32>, tensor<75x0xf32>) {

--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_iree_input_dialects.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_iree_input_dialects.mlir
@@ -101,6 +101,16 @@ func.func public @empty_zero_extent(%arg0: tensor<ui8>, %arg1: tensor<0x4xui32>)
 
 // -----
 
+// CHECK-LABEL: func.func @add_zero_ext
+func.func @add_zero_ext(%arg0 : tensor<5x0xi32>, %arg1 : tensor<5x0xi32>) -> tensor<5x0xi32> {
+  %0 = stablehlo.add %arg0, %arg1 : tensor<5x0xi32>
+  func.return %0 : tensor<5x0xi32>
+}
+// CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<5x0xi32>
+// CHECK:   return %[[EMPTY]]
+
+// -----
+
 // CHECK-LABEL: @convert_return
 func.func @convert_return() -> tensor<i32> {
   // CHECK: %[[CST:.+]] = arith.constant dense<1>


### PR DESCRIPTION
Rework the canonicalization pattern for zero-extent tensors. The combination of `replaceAllUsesWith` and modification of the operation in-place can lead to issues if both results and operands need to updated. The new implementation avoids this combination.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22969.