### PR TITLE
[ReductionVectorDistribute] Avoid adding lowering configs on failure

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2316,11 +2316,13 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
       return success();
     }
     if (clGPUEnableReductionVectorDistribution) {
+      LDBG() << "ReductionVectorDistribution: finding a suitable config...";
       if (succeeded(
               IREE::GPU::setReductionConfig(target, entryPointFn, linalgOp))) {
         LDBG() << "Vector Distribution Subgroup Reduction Config";
         return success();
       }
+      LDBG() << "ReductionVectorDistribution: failed to find a suitable config";
     }
     if (succeeded(setConvolutionConfig(target, entryPointFn, linalgOp, 16))) {
       LDBG() << "Convolution Config";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -179,6 +179,81 @@ func.func @test_multiple_reduction() {
 
 // -----
 
+// The same IR as 'test_multiple_reduction' but with an unsupported operation,
+// preventing this from going down vector distribute. Previously lowering configs
+// would be attached to the suppported operations even though the full dispatch
+// is unsupported.
+func.func @test_negative_multiple_reduction() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 1.638400e+05 : f32
+  %cst_1 = arith.constant 9.99999974E-6 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x10x16384xf16>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x10x16384x1x1xf16>>
+  %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x10x16384xf32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 32, 10, 16384], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x10x16384xf16>> -> tensor<2x32x10x16384xf16>
+  %unitdims_4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 32, 10, 16384, 1, 1], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x10x16384x1x1xf16>> -> tensor<2x32x10x16384x1x1xf16>
+
+  // Operation unsupported by reduction vector distribution.
+  %outs_4 = tensor.empty() : tensor<2x32x10x16384xf16>
+  %4 = linalg.reduce ins(%unitdims_4 : tensor<2x32x10x16384x1x1xf16>) outs(%outs_4 : tensor<2x32x10x16384xf16>) dimensions = [4, 5]
+    (%in: f16, %init: f16) {
+      %20 = arith.addf %in, %init : f16
+      linalg.yield %20 : f16
+    }
+
+  %5 = tensor.empty() : tensor<2x32x10x16384xf32>
+  %6 = tensor.empty() : tensor<2x32xf32>
+  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%3 : tensor<2x32x10x16384xf16>) outs(%5 : tensor<2x32x10x16384xf32>) {
+  ^bb0(%in: f16, %out: f32):
+    %13 = arith.extf %in : f16 to f32
+    linalg.yield %13 : f32
+  } -> tensor<2x32x10x16384xf32>
+  %8 = linalg.fill ins(%cst : f32) outs(%6 : tensor<2x32xf32>) -> tensor<2x32xf32>
+  %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%7 : tensor<2x32x10x16384xf32>) outs(%8 : tensor<2x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %13 = arith.addf %in, %out : f32
+    linalg.yield %13 : f32
+  } -> tensor<2x32xf32>
+  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%9 : tensor<2x32xf32>) outs(%6 : tensor<2x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %13 = arith.divf %in, %cst_0 : f32
+    linalg.yield %13 : f32
+  } -> tensor<2x32xf32>
+  %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%7, %10 : tensor<2x32x10x16384xf32>, tensor<2x32xf32>) outs(%8 : tensor<2x32xf32>) {
+  ^bb0(%in: f32, %in_2: f32, %out: f32):
+    %13 = arith.subf %in, %in_2 : f32
+    %14 = arith.mulf %13, %13 : f32
+    %15 = arith.addf %14, %out : f32
+    linalg.yield %15 : f32
+  } -> tensor<2x32xf32>
+  %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4, %10, %11 : tensor<2x32x10x16384xf16>, tensor<2x32xf32>, tensor<2x32xf32>) outs(%5 : tensor<2x32x10x16384xf32>) {
+  ^bb0(%in: f16, %in_2: f32, %in_3: f32, %out: f32):
+    %13 = arith.divf %in_3, %cst_0 : f32
+    %14 = arith.addf %13, %cst_1 : f32
+    %15 = math.rsqrt %14 : f32
+    %16 = arith.extf %in : f16 to f32
+    %17 = arith.subf %16, %in_2 : f32
+    %18 = arith.mulf %17, %15 : f32
+    linalg.yield %18 : f32
+  } -> tensor<2x32x10x16384xf32>
+  iree_tensor_ext.dispatch.tensor.store %12, %2, offsets = [0, 0, 0, 0], sizes = [2, 32, 10, 16384], strides = [1, 1, 1, 1] : tensor<2x32x10x16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x10x16384xf32>>
+  return
+}
+
+// Shouldn't go down vector distribute.
+// CHECK:       #iree_codegen.translation_info<pipeline =
+// CHECK-NOT:   LLVMGPUVectorDistribute
+
+// CHECK-LABEL: func.func @test_negative_multiple_reduction
+
+// Only one lowering config should be present.
+// CHECK:       #iree_gpu.lowering_config
+// CHECK-NOT:   #iree_gpu.lowering_config
+// CHECK:       return
+
+// -----
+
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>


### PR DESCRIPTION
The logic here was attaching lowering configs before validating that all ops were actually supported. This was causing issues where the reduction vector distribution pipeline would leave lowering configs in the IR even though it wasn't being used, resulting in compilation failures in later passes.