### PR TITLE
[CI][Torch] Enable split reduction and O3 for llama_8b_fp16 quality tests with gfx942 config

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/modules/scheduler_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/modules/scheduler_gfx942.json
@@ -3,9 +3,10 @@
   "compiler_flags": [
       "--iree-hal-target-device=hip",
       "--iree-hip-target=gfx942",
-      "--iree-opt-level=O1",
+      "--iree-opt-level=O3",
       "--iree-stream-resource-memory-model=discrete",
       "--iree-hal-indirect-command-buffers=true",
-      "--iree-hal-memoization=true"
+      "--iree-hal-memoization=true",
+      "--iree-dispatch-creation-enable-split-reduction"
   ]
 }


### PR DESCRIPTION
This PR enables `-opt-level=O3` for the llama 8b fp16 quality test. 

"--iree-dispatch-creation-enable-split-reduction" will be removed when it is set to true by default. 

ci-extra: test_torch