### PR TITLE
[Dispatch Creation] Restrict broadcasting consumer fusion

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -617,13 +617,6 @@ static bool canFuseBroadcastingConsumer(
     return true;
   }
 
-  // Only block fusion if the root op is a reduction op (has reduction loops).
-  // Pure elementwise/parallel roots can always fuse with broadcasting
-  // consumers.
-  if (rootFusionOp.getNumLoops() == rootFusionOp.getNumParallelLoops()) {
-    return true;
-  }
-
   // FIXME: Implement getStaticLoopRanges for LinalgExt::CustomOp.
   if (isa<IREE::LinalgExt::CustomOp>(rootOp)) {
     return true;

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -622,30 +622,7 @@ static bool canFuseBroadcastingConsumer(
     return true;
   }
 
-  SmallVector<int64_t> rootIterationSpace = rootFusionOp.getStaticLoopRanges();
-  SmallVector<int64_t> consumerIterationSpace =
-      consumerFusionOp.getStaticLoopRanges();
-
-  // Only check when consumer might be broadcasting.
-  if (rootIterationSpace.size() > consumerIterationSpace.size()) {
-    return true;
-  }
-
-  auto computeIterationSpaceSize = [](ArrayRef<int64_t> shape) -> int64_t {
-    return ShapedType::isDynamicShape(shape)
-               ? ShapedType::kDynamic
-               : ShapedType::getNumElements(shape);
-  };
-  int64_t rootSize = computeIterationSpaceSize(rootIterationSpace);
-  int64_t consumerSize = computeIterationSpaceSize(consumerIterationSpace);
-
-  // Only block fusion if we can statically determine the iteration spaces
-  // don't match. For dynamic shapes, allow fusion.
-  if (ShapedType::isDynamic(rootSize) || ShapedType::isDynamic(consumerSize)) {
-    return true;
-  }
-
-  return consumerSize == rootSize;
+  return consumerFusionOp.getNumLoops() <= rootFusionOp.getNumLoops();
 }
 
 /// Returns true if this is a fusable use, while fusing a root with its

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -631,14 +631,12 @@ util.func public @broadcasting_dequant_op(%arg0 : tensor<?x?xi8>,
 // -----
 
 util.func @softmax_like_fusion(%arg0: tensor<2x4096x640xf16>,
-    %arg1: tensor<640xf16>, %arg2: tensor<640xf16>) -> tensor<2x4096x640x1xf16> {
-  %expanded = tensor.expand_shape %arg0 [[0], [1], [2, 3]]
-      output_shape [2, 4096, 640, 1] : tensor<2x4096x640xf16> into tensor<2x4096x640x1xf16>
+    %arg1: tensor<640xf16>, %arg2: tensor<640xf16>) -> tensor<2x4096x640xf16> {
   %cst = arith.constant 0.000000e+00 : f32
   %cst_0 = arith.constant 1.100000e+01 : f32
   %cst_1 = arith.constant 4.000000e+00 : f32
   %0 = tensor.empty() : tensor<2x4096x640xf32>
-  %1 = tensor.empty() : tensor<2x4096x640x1xf16>
+  %1 = tensor.empty() : tensor<2x4096x640xf16>
   %2 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
                        affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
@@ -682,22 +680,18 @@ util.func @softmax_like_fusion(%arg0: tensor<2x4096x640xf16>,
       %11 = arith.addf %10, %out : f32
       linalg.yield %11 : f32
   } -> tensor<2x4096xf32>
-  %expanded_2 = tensor.expand_shape %arg1 [[0, 1]] output_shape [640, 1]
-      : tensor<640xf16> into tensor<640x1xf16>
-  %expanded_3 = tensor.expand_shape %arg2 [[0, 1]] output_shape [640, 1]
-      : tensor<640xf16> into tensor<640x1xf16>
   %8 = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
-                       affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
-                       affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
-                       affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                       affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-      ins(%expanded, %6, %7, %expanded_2, %expanded_3
-          : tensor<2x4096x640x1xf16>, tensor<2x4096xf32>, tensor<2x4096xf32>,
-            tensor<640x1xf16>, tensor<640x1xf16>)
-      outs(%1 : tensor<2x4096x640x1xf16>) {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1)>,
+                       affine_map<(d0, d1, d2) -> (d2)>,
+                       affine_map<(d0, d1, d2) -> (d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%arg0, %6, %7, %arg1, %arg2
+          : tensor<2x4096x640xf16>, tensor<2x4096xf32>, tensor<2x4096xf32>,
+            tensor<640xf16>, tensor<640xf16>)
+      outs(%1 : tensor<2x4096x640xf16>) {
     ^bb0(%in: f16, %in_4: f32, %in_5: f32, %in_6: f16, %in_7: f16, %out: f16):
       %9 = arith.divf %in_5, %cst_0 : f32
       %10 = arith.addf %9, %cst_1 : f32
@@ -711,8 +705,8 @@ util.func @softmax_like_fusion(%arg0: tensor<2x4096x640xf16>,
       %18 = arith.addf %16, %17 : f32
       %19 = arith.truncf %18 : f32 to f16
       linalg.yield %19 : f16
-  } -> tensor<2x4096x640x1xf16>
-  util.return %8 : tensor<2x4096x640x1xf16>
+  } -> tensor<2x4096x640xf16>
+  util.return %8 : tensor<2x4096x640xf16>
 }
 // CHECK-LABEL: func public @softmax_like_fusion(
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4096x640xf16>
@@ -729,8 +723,8 @@ util.func @softmax_like_fusion(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         iterator_types = ["parallel", "parallel", "reduction"]
 //  CHECK-SAME:         ins(%[[BITEXTEND]], %[[GENERIC2]] :
 //       CHECK:     %[[GENERIC4:.+]] = linalg.generic
-//  CHECK-SAME:         iterator_types = ["parallel", "parallel", "parallel", "parallel"]
-//  CHECK-SAME:         ins(%{{.+}}, %[[GENERIC2]], %[[GENERIC3]]
+//  CHECK-SAME:         iterator_types = ["parallel", "parallel", "parallel"]
+//  CHECK-SAME:         ins(%[[ARG0]], %[[GENERIC2]], %[[GENERIC3]]
 //       CHECK:     flow.return %[[GENERIC4]]
 //       CHECK:   util.return %[[RESULT]]
 
@@ -2009,10 +2003,11 @@ util.func public @fuse_consumer_despite_nonfusable_sibling(%arg0: tensor<10x32x4
 
 // -----
 
-util.func public @reduction_broadcast_no_fusion(%arg0: tensor<128x512xf32>, %arg1: tensor<65536x512xf32>) -> tensor<65536x512xf32> {
+util.func public @reduction_broadcast_no_fusion(%arg0: tensor<128x512xf32>, %arg1: tensor<64x1024x512xf32>) -> tensor<64x1024x512xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %0 = tensor.empty() : tensor<512xf32>
   %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<512xf32>) -> tensor<512xf32>
+  // Reduction: 2 loops (parallel, reduction)
   %2 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>,
                        affine_map<(d0, d1) -> (d0)>],
@@ -2022,42 +2017,47 @@ util.func public @reduction_broadcast_no_fusion(%arg0: tensor<128x512xf32>, %arg
       %4 = arith.addf %in, %out : f32
       linalg.yield %4 : f32
   } -> tensor<512xf32>
-  %3 = tensor.empty() : tensor<65536x512xf32>
+  // Broadcast consumer: 3 loops (parallel, parallel, parallel)
+  %3 = tensor.empty() : tensor<64x1024x512xf32>
   %result = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1) -> (d1)>,
-                       affine_map<(d0, d1) -> (d0, d1)>,
-                       affine_map<(d0, d1) -> (d0, d1)>],
-      iterator_types = ["parallel", "parallel"]}
-      ins(%2, %arg1 : tensor<512xf32>, tensor<65536x512xf32>) outs(%3 : tensor<65536x512xf32>) {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%2, %arg1 : tensor<512xf32>, tensor<64x1024x512xf32>) outs(%3 : tensor<64x1024x512xf32>) {
     ^bb0(%in0: f32, %in1: f32, %out: f32):
       %4 = arith.mulf %in0, %in1 : f32
       linalg.yield %4 : f32
-  } -> tensor<65536x512xf32>
-  util.return %result : tensor<65536x512xf32>
+  } -> tensor<64x1024x512xf32>
+  util.return %result : tensor<64x1024x512xf32>
 }
 
 // CHECK-LABEL: util.func public @reduction_broadcast_no_fusion
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<128x512xf32>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<65536x512xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<64x1024x512xf32>
 //       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
 //       CHECK:     %[[REDUCTION:.+]] = linalg.generic
 //  CHECK-SAME:         iterator_types = ["parallel", "reduction"]
 //       CHECK:     flow.return %[[REDUCTION]]
 //       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.region
 //       CHECK:     %[[CONSUMER:.+]] = linalg.generic
-//  CHECK-SAME:         iterator_types = ["parallel", "parallel"]
+//  CHECK-SAME:         iterator_types = ["parallel", "parallel", "parallel"]
 //  CHECK-SAME:         ins(%[[DISPATCH0]], %[[ARG1]] :
 //       CHECK:     flow.return %[[CONSUMER]]
 //       CHECK:   util.return %[[DISPATCH1]]
 
 // -----
 
+// Test case: reduction -> 1-to-1 elementwise -> broadcast
+// The reduction and 1-to-1 elementwise should fuse together,
+// but the broadcast should be in a separate dispatch.
 util.func public @reduction_elementwise_broadcast_fusion(
     %arg0: tensor<128x512xf32>,
-    %arg1: tensor<65536x512xf32>) -> tensor<65536x512xf32> {
+    %arg1: tensor<64x1024x512xf32>) -> tensor<64x1024x512xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %0 = tensor.empty() : tensor<512xf32>
   %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<512xf32>) -> tensor<512xf32>
+  // Reduction: 2 loops (parallel, reduction)
   %2 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>,
                        affine_map<(d0, d1) -> (d0)>],
@@ -2067,6 +2067,7 @@ util.func public @reduction_elementwise_broadcast_fusion(
       %5 = arith.addf %in, %out : f32
       linalg.yield %5 : f32
   } -> tensor<512xf32>
+  // 1-to-1 elementwise: 1 loop (same iteration space as reduction output)
   %3 = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> (d0)>],
@@ -2076,23 +2077,24 @@ util.func public @reduction_elementwise_broadcast_fusion(
       %5 = arith.mulf %in, %in : f32
       linalg.yield %5 : f32
   } -> tensor<512xf32>
-  %4 = tensor.empty() : tensor<65536x512xf32>
+  // Broadcast: 3 loops (much larger iteration space)
+  %4 = tensor.empty() : tensor<64x1024x512xf32>
   %result = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1) -> (d1)>,
-                       affine_map<(d0, d1) -> (d0, d1)>,
-                       affine_map<(d0, d1) -> (d0, d1)>],
-      iterator_types = ["parallel", "parallel"]}
-      ins(%3, %arg1 : tensor<512xf32>, tensor<65536x512xf32>) outs(%4 : tensor<65536x512xf32>) {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%3, %arg1 : tensor<512xf32>, tensor<64x1024x512xf32>) outs(%4 : tensor<64x1024x512xf32>) {
     ^bb0(%in0: f32, %in1: f32, %out: f32):
       %5 = arith.mulf %in0, %in1 : f32
       linalg.yield %5 : f32
-  } -> tensor<65536x512xf32>
-  util.return %result : tensor<65536x512xf32>
+  } -> tensor<64x1024x512xf32>
+  util.return %result : tensor<64x1024x512xf32>
 }
 
 // CHECK-LABEL: util.func public @reduction_elementwise_broadcast_fusion
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<128x512xf32>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<65536x512xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<64x1024x512xf32>
 //       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
 //       CHECK:     %[[REDUCTION:.+]] = linalg.generic
 //  CHECK-SAME:         iterator_types = ["parallel", "reduction"]
@@ -2101,7 +2103,7 @@ util.func public @reduction_elementwise_broadcast_fusion(
 //       CHECK:     flow.return %[[ELEMENTWISE]]
 //       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.region
 //       CHECK:     %[[BROADCAST:.+]] = linalg.generic
-//  CHECK-SAME:         iterator_types = ["parallel", "parallel"]
+//  CHECK-SAME:         iterator_types = ["parallel", "parallel", "parallel"]
 //  CHECK-SAME:         ins(%[[DISPATCH0]], %[[ARG1]] :
 //       CHECK:     flow.return %[[BROADCAST]]
 //       CHECK:   util.return %[[DISPATCH1]]


### PR DESCRIPTION
Restricts fusion of reduction ops with parallel broadcast consumers to only allow fusion when the consumer's iteration space is the same rank as the producer's iteration space.


Closes https://github.com/iree-org/iree/issues/23157