### PR TITLE
[Codegen] Add gpu.subgroup_size to dispatch bounds handling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
@@ -97,6 +97,9 @@ hal.executable private @manual_subgroup_size {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
         %lane_id = gpu.lane_id
 
+// CHECK-NEXT: arith.constant 64 : index
+        %subgroup_size = gpu.subgroup_size : index
+
         return
       }
     }


### PR DESCRIPTION
A PCF PR began creating loops that use gpu.subgroup_size. This led me to notice that PropagateDispatchSizeBounds wasn't rewriting subgroup_size to the known subgroup size. This commit adds support for that rewrite.

Assisted-By: Claude (did all the actual editing here)