### PR TITLE
[Codegen] Add an option to enable fp8/fp4 software emulation for all GPU targets.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -369,8 +369,7 @@ private:
 ///    - f4E2M1FN has no NaN and no negative zero.
 struct TruncFToSmallFloat final : OpRewritePattern<arith::TruncFOp> {
   TruncFToSmallFloat(MLIRContext *ctx, ArrayRef<Type> sourceTypes)
-      : OpRewritePattern(ctx),
-        sourceTypes(sourceTypes.begin(), sourceTypes.end()) {}
+      : OpRewritePattern(ctx), sourceTypes(sourceTypes) {}
 
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const override {
@@ -603,8 +602,7 @@ private:
 /// which is simpler and more general than enumerating all possible values.
 struct ExtFFromSmallFloat final : OpRewritePattern<arith::ExtFOp> {
   ExtFFromSmallFloat(MLIRContext *ctx, ArrayRef<Type> sourceTypes)
-      : OpRewritePattern(ctx),
-        sourceTypes(sourceTypes.begin(), sourceTypes.end()) {}
+      : OpRewritePattern(ctx), sourceTypes(sourceTypes) {}
 
   LogicalResult matchAndRewrite(arith::ExtFOp op,
                                 PatternRewriter &rewriter) const override {
@@ -845,7 +843,7 @@ void ConvertUnsupportedFloatArithPass::runOnOperation() {
   // the small float types need the emulation. For GPU targets, some types may
   // have hardware conversion support and can be skipped.
   SmallVector<Type> typesNeedingConversionEmulation = allSmallFloatTypes;
-  if (auto gpuAttr = getGPUTargetAttr(funcOp)) {
+  if (IREE::GPU::TargetAttr gpuAttr = getGPUTargetAttr(funcOp)) {
     typesNeedingConversionEmulation =
         getTypesNeedingConversionEmulationForGPU(context, gpuAttr);
   }

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -41,7 +41,8 @@ using hasContextGet = decltype(T::get(std::declval<MLIRContext *>()));
 
 /// Helpers to append types to a vector if they are small float types (fp4/fp8).
 template <typename T>
-static void maybeAppendType(MLIRContext *ctx, SmallVectorImpl<Type> &types) {
+static void maybeAppendSmallFloatType(MLIRContext *ctx,
+                                      SmallVectorImpl<Type> &types) {
   if constexpr (llvm::is_detected<hasContextGet, T>::value) {
     Type t = T::get(ctx);
     if (isa<FloatType>(t)) {
@@ -52,9 +53,11 @@ static void maybeAppendType(MLIRContext *ctx, SmallVectorImpl<Type> &types) {
     }
   }
 }
+
 template <typename... Ts>
-static void appendTypesIf(MLIRContext *ctx, SmallVectorImpl<Type> &types) {
-  (maybeAppendType<Ts>(ctx, types), ...);
+static void appendSmallFloatTypes(MLIRContext *ctx,
+                                  SmallVectorImpl<Type> &types) {
+  (maybeAppendSmallFloatType<Ts>(ctx, types), ...);
 }
 
 //===----------------------------------------------------------------------===//
@@ -126,8 +129,12 @@ public:
     // Check for FNUZ types where NaN is encoded as sign bit only
     // (e.g., 0x80 for fp8, 0x8 for fp4). These types have no negative zero
     // and no infinity.
-    llvm::APFloat negZero = llvm::APFloat::getZero(sem, /*Negative=*/true);
-    smallHasNegZero = negZero.isZero() && negZero.isNegative();
+    if (llvm::APFloat::semanticsHasZero(sem)) {
+      llvm::APFloat negZero = llvm::APFloat::getZero(sem, /*Negative=*/true);
+      smallHasNegZero = negZero.isZero() && negZero.isNegative();
+    } else {
+      smallHasNegZero = false;
+    }
     smallNanIsNegZero = !smallHasNegZero && !smallHasInf && smallHasNan;
   }
 
@@ -361,7 +368,9 @@ private:
 ///    - Max exponent values are valid finite numbers (except NaN encoding).
 ///    - f4E2M1FN has no NaN and no negative zero.
 struct TruncFToSmallFloat final : OpRewritePattern<arith::TruncFOp> {
-  using Base::Base;
+  TruncFToSmallFloat(MLIRContext *ctx, ArrayRef<Type> sourceTypes)
+      : OpRewritePattern(ctx),
+        sourceTypes(sourceTypes.begin(), sourceTypes.end()) {}
 
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const override {
@@ -372,6 +381,11 @@ struct TruncFToSmallFloat final : OpRewritePattern<arith::TruncFOp> {
     unsigned resultBitWidth = resultElemType.getIntOrFloatBitWidth();
     if (!isa<Float32Type>(inputElemType) ||
         (resultBitWidth != 4 && resultBitWidth != 8)) {
+      return failure();
+    }
+
+    // Only match types that are in our source types list.
+    if (!llvm::is_contained(sourceTypes, resultElemType)) {
       return failure();
     }
 
@@ -567,6 +581,9 @@ struct TruncFToSmallFloat final : OpRewritePattern<arith::TruncFOp> {
     rewriter.replaceOp(op, result);
     return success();
   }
+
+private:
+  SmallVector<Type> sourceTypes;
 };
 
 //===----------------------------------------------------------------------===//
@@ -585,7 +602,9 @@ struct TruncFToSmallFloat final : OpRewritePattern<arith::TruncFOp> {
 /// We implement this using uitofp + mulf with a precomputed scale factor,
 /// which is simpler and more general than enumerating all possible values.
 struct ExtFFromSmallFloat final : OpRewritePattern<arith::ExtFOp> {
-  using Base::Base;
+  ExtFFromSmallFloat(MLIRContext *ctx, ArrayRef<Type> sourceTypes)
+      : OpRewritePattern(ctx),
+        sourceTypes(sourceTypes.begin(), sourceTypes.end()) {}
 
   LogicalResult matchAndRewrite(arith::ExtFOp op,
                                 PatternRewriter &rewriter) const override {
@@ -597,6 +616,11 @@ struct ExtFFromSmallFloat final : OpRewritePattern<arith::ExtFOp> {
     unsigned inputBitWidth = inputElemType.getIntOrFloatBitWidth();
     if ((inputBitWidth != 4 && inputBitWidth != 8) ||
         !isa<Float32Type>(resultElemType)) {
+      return failure();
+    }
+
+    // Only match types that are in our source types list.
+    if (!llvm::is_contained(sourceTypes, inputElemType)) {
       return failure();
     }
 
@@ -728,6 +752,9 @@ struct ExtFFromSmallFloat final : OpRewritePattern<arith::ExtFOp> {
 
     return success();
   }
+
+private:
+  SmallVector<Type> sourceTypes;
 };
 
 struct ConvertUnsupportedFloatArithPass final
@@ -737,109 +764,98 @@ struct ConvertUnsupportedFloatArithPass final
   using Base::Base;
 };
 
-} // namespace
-
-static void populateCPUSourceAndTargetType(MLIRContext *ctx, Operation *op,
-                                           SmallVectorImpl<Type> &sourceTypes,
-                                           Type &targetType) {
-  // For CPU backend, we emulate all small float types (fp4, fp8) to fp32. This
-  // supports any future new small float types automatically.
-  appendTypesIf<
+/// Returns the types that need extf/truncf emulation (bit manipulation) for
+/// the given GPU target. Types with hardware conversion instructions are
+/// excluded since ArithToAMDGPU patterns in ConvertToROCDL handle those.
+///
+/// Note: ALL small float types need arithmetic emulation (wrapping addf/mulf
+/// with extf/truncf) because no GPU has native fp4/fp8 arithmetic instructions.
+/// This function only determines which types need SOFTWARE conversion.
+static SmallVector<Type>
+getTypesNeedingConversionEmulationForGPU(MLIRContext *context,
+                                         IREE::GPU::TargetAttr gpuAttr) {
+  SmallVector<Type> types;
+  appendSmallFloatTypes<
 #define GET_TYPEDEF_LIST
 #include "mlir/IR/BuiltinTypes.cpp.inc"
-      >(ctx, sourceTypes);
-  targetType = Float32Type::get(ctx);
-}
+      >(context, types);
 
-// Populates source and target conversion types based on the target
-// architecture.
-// TODO(pashu123): Refine the patterns based on the target arch.
-static void populateGPUSourceAndTargetType(MLIRContext *ctx, Operation *op,
-                                           SmallVectorImpl<Type> &sourceTypes,
-                                           Type &targetType) {
-  auto gpuAttr = getGPUTargetAttr(op);
-  if (!gpuAttr) {
-    return;
-  }
+  // Remove types that have hardware conversion support on this chip.
   StringRef chipset = gpuAttr.getArch();
   FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(chipset);
   if (failed(maybeChipset)) {
     LDBG() << "Invalid chip name";
-    return;
+    return types;
   }
   constexpr amdgpu::Chipset kGfx942{9, 4, 2};
   constexpr amdgpu::Chipset kGfx950{9, 5, 0};
-  constexpr amdgpu::Chipset kGfx10{10, 0, 0};
-  constexpr amdgpu::Chipset kGfx12{12, 0, 0};
-  // Add source and target conversion types for gfx94{*} series.
-  if (*maybeChipset >= kGfx942 && *maybeChipset <= kGfx950) {
-    sourceTypes.insert(sourceTypes.end(), {Float8E4M3FNUZType::get(ctx),
-                                           Float8E5M2FNUZType::get(ctx)});
-    targetType = Float32Type::get(ctx);
+  if (*maybeChipset >= kGfx942 && *maybeChipset < kGfx950) {
+    // gfx942 has hardware conversion for FNUZ types.
+    llvm::erase(types, Float8E4M3FNUZType::get(context));
+    llvm::erase(types, Float8E5M2FNUZType::get(context));
   }
-  // gfx950 and gfx12+ support OCP FP8 conversions
-  if (*maybeChipset >= kGfx12 ||
-      (*maybeChipset <= kGfx10 && *maybeChipset >= kGfx950)) {
-    // TODO(kdrewnia): On gfx950, add fp4 or fp6 here maybe.
-    // TODO(kdrewnia): After checking for instruction avaiability, turn
-    // the target type down to f16.
-    sourceTypes.push_back(Float8E4M3FNType::get(ctx));
-    sourceTypes.push_back(Float8E5M2Type::get(ctx));
-    targetType = Float32Type::get(ctx);
+  if (amdgpu::hasOcpFp8(*maybeChipset)) {
+    // gfx950+ and gfx12+ have hardware conversion for OCP types.
+    llvm::erase(types, Float8E4M3FNType::get(context));
+    llvm::erase(types, Float8E5M2Type::get(context));
+    llvm::erase(types, Float4E2M1FNType::get(context));
   }
-  return;
+  return types;
 }
+
+} // namespace
 
 void ConvertUnsupportedFloatArithPass::runOnOperation() {
   MLIRContext *context = &getContext();
   FunctionOpInterface funcOp = getOperation();
-  SmallVector<Type> sourceTypes;
-  Type targetType = nullptr;
+  Type targetType = Float32Type::get(context);
 
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
-  bool isCPU = isLLVMCPUBackend(targetAttr);
-  if (isCPU) {
-    populateCPUSourceAndTargetType(context, funcOp, sourceTypes, targetType);
-  } else if (isROCMBackend(targetAttr)) {
-    populateGPUSourceAndTargetType(context, funcOp, sourceTypes, targetType);
-  } else {
-    LDBG() << "backend does not require float emulation";
-    return;
-  }
-
-  if (sourceTypes.empty() || !targetType) {
-    LDBG() << "no source or target type specified, float emulation will do "
-              "nothing";
-    return;
-  }
-
-  if (llvm::is_contained(sourceTypes, targetType)) {
-    funcOp->emitError() << " target type cannot be an unsupported source type";
-    return signalPassFailure();
-  }
+  // All small float types (fp4, fp8) need arithmetic emulation unless the
+  // hardware has native arithmetic instructions for these types. Operations
+  // like addf/mulf usually have to be wrapped with extf/truncf to compute in
+  // f32.
+  SmallVector<Type> allSmallFloatTypes;
+  appendSmallFloatTypes<
+#define GET_TYPEDEF_LIST
+#include "mlir/IR/BuiltinTypes.cpp.inc"
+      >(context, allSmallFloatTypes);
 
   // Apply the standard float emulation patterns. This inserts extf/truncf pairs
   // around unsupported float operations.
   {
     TypeConverter converter;
-    arith::populateEmulateUnsupportedFloatsConversions(converter, sourceTypes,
-                                                       targetType);
+    arith::populateEmulateUnsupportedFloatsConversions(
+        converter, allSmallFloatTypes, targetType);
     RewritePatternSet patterns(context);
     arith::populateEmulateUnsupportedFloatsPatterns(patterns, converter);
     ConversionTarget target(*context);
     arith::populateEmulateUnsupportedFloatsLegality(target, converter);
+
+    // Mark scaling ops as legal - they have their own expansion patterns in
+    // arith::populateExpandScalingExtTruncPatterns that run in later passes.
+    // We don't want to insert extf/truncf pairs around them.
+    target.addLegalOp<arith::ScalingExtFOp, arith::ScalingTruncFOp>();
 
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
 
-  // For CPU, emulate extf/truncf to/from small float types using integer ops.
-  // This is needed because LLVM doesn't support fpext/fptrunc for fp4/fp8
-  // types; these types eventually get lowered to small integers in LLVM IR.
-  if (isCPU) {
+  // Determine which types need software conversion emulation. By default, all
+  // the small float types need the emulation. For GPU targets, some types may
+  // have hardware conversion support and can be skipped.
+  SmallVector<Type> typesNeedingConversionEmulation = allSmallFloatTypes;
+  if (auto gpuAttr = getGPUTargetAttr(funcOp)) {
+    typesNeedingConversionEmulation =
+        getTypesNeedingConversionEmulationForGPU(context, gpuAttr);
+  }
+
+  // Emulate extf/truncf to/from small float types using integer bit
+  // manipulation. Only for types without hardware conversion support.
+  if (!typesNeedingConversionEmulation.empty()) {
     RewritePatternSet emulationPatterns(context);
-    emulationPatterns.add<TruncFToSmallFloat, ExtFFromSmallFloat>(context);
+    emulationPatterns.add<TruncFToSmallFloat, ExtFFromSmallFloat>(
+        context, typesNeedingConversionEmulation);
     walkAndApplyPatterns(funcOp, std::move(emulationPatterns));
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertUnsupportedFloatArithPass.cpp
@@ -852,7 +852,8 @@ void ConvertUnsupportedFloatArithPass::runOnOperation() {
 
   // Emulate extf/truncf to/from small float types using integer bit
   // manipulation. Only for types without hardware conversion support.
-  if (!typesNeedingConversionEmulation.empty()) {
+  // This is gated by the enableExtTruncEmulation flag.
+  if (enableExtTruncEmulation && !typesNeedingConversionEmulation.empty()) {
     RewritePatternSet emulationPatterns(context);
     emulationPatterns.add<TruncFToSmallFloat, ExtFFromSmallFloat>(
         context, typesNeedingConversionEmulation);

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -107,12 +107,15 @@ def ConvertUnsupportedFloatArithPass
     1. Wraps unsupported float operations with extf/truncf pairs to perform
        arithmetic in a supported type (e.g., f32).
 
-    2. For CPU targets, emulates extf/truncf operations themselves using integer
-       bit manipulation, since LLVM doesn't support fpext/fptrunc for fp8 types.
+    2. Emulates extf/truncf operations using integer bit manipulation, if the
+       backend doesn't natively support fpext/fptrunc for fp4/fp8 types.
 
     The emulation follows IREE's runtime/src/iree/base/internal/math.h, including
     IEEE 754 round-to-nearest-even semantics and proper handling of denormals,
     NaN, Inf, and special encodings (FNUZ types).
+
+    Note: arith.scaling_extf/truncf operations (used for MX/microscaling) are
+    preserved and handled by separate expansion patterns in later passes.
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -117,6 +117,13 @@ def ConvertUnsupportedFloatArithPass
     Note: arith.scaling_extf/truncf operations (used for MX/microscaling) are
     preserved and handled by separate expansion patterns in later passes.
   }];
+  let options = [
+    Option<"enableExtTruncEmulation", "enable-ext-trunc-emulation",
+           "bool", /*default=*/"true",
+           "Enable software emulation for extf/truncf of fp4/fp8 types "
+           "without hardware support. When disabled, types requiring emulation "
+           "will be left unconverted and may cause errors in later passes.">
+  ];
 }
 
 def ConvertToDestinationPassingStylePass :

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
@@ -1,64 +1,21 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-convert-unsupported-float-arith))" %s | FileCheck %s
 
-// CHECK-LABEL: func.func @negf_f8_unsupported
-// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f8E4M3FNUZ
-// CHECK:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FNUZ to f32
-// CHECK:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
-// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FNUZ
-// CHECK:         return %[[TRUNC]] : f8E4M3FNUZ
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
-func.func @negf_f8_unsupported(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes
-{ hal.executable.target = #executable_target_rocm_hsaco_fb }{
-    %0 = arith.negf %arg0 : f8E4M3FNUZ
-    return %0 : f8E4M3FNUZ
-}
-
-// -----
-
-// CHECK-LABEL: func.func @expand_f8(
-// CHECK-SAME:    %[[ARG0:.*]]: f8E5M2FNUZ
-// CHECK:         %[[EXT0:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E5M2FNUZ to f32
-// CHECK:         %[[CST:.*]] = arith.constant 1.000000e+00 : f8E5M2FNUZ
-// CHECK:         %[[EXT1:.*]] = arith.extf %[[CST]] {{.*}} : f8E5M2FNUZ to f32
-// CHECK:         %[[SUM:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
-// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[SUM]] {{.*}} : f32 to f8E5M2FNUZ
-// CHECK:         return %[[TRUNC]] : f8E5M2FNUZ
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
-func.func @expand_f8(%x: f8E5M2FNUZ) -> f8E5M2FNUZ attributes
-{ hal.executable.target = #executable_target_rocm_hsaco_fb }{
-  %c = arith.constant 1.0 : f8E5M2FNUZ
-  %y = arith.addf %x, %c : f8E5M2FNUZ
-  func.return %y : f8E5M2FNUZ
-}
-
-// -----
-
-// CHECK-LABEL: func.func @negf_f8_unsupported_ocp
-// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FN) -> f8E4M3FN
-// CHECK:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FN to f32
-// CHECK:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
-// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FN
-// CHECK:         return %[[TRUNC]] : f8E4M3FN
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
-func.func @negf_f8_unsupported_ocp(%arg0 : f8E4M3FN) -> f8E4M3FN attributes
-{ hal.executable.target = #executable_target_rocm_hsaco_fb }{
-    %0 = arith.negf %arg0 : f8E4M3FN
-    return %0 : f8E4M3FN
-}
-
-// -----
-
 // CHECK-LABEL: func.func @expand_f8_ocp(
 // CHECK-SAME:    %[[ARG0:.*]]: f8E5M2
-// CHECK:         %[[EXT0:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E5M2 to f32
-// CHECK:         %[[CST:.*]] = arith.constant 1.000000e+00 : f8E5M2
-// CHECK:         %[[EXT1:.*]] = arith.extf %[[CST]] {{.*}} : f8E5M2 to f32
-// CHECK:         %[[SUM:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
-// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[SUM]] {{.*}} : f32 to f8E5M2
-// CHECK:         return %[[TRUNC]] : f8E5M2
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
-func.func @expand_f8_ocp(%x: f8E5M2) -> f8E5M2 attributes
-{ hal.executable.target = #executable_target_rocm_hsaco_fb }{
+// ExtF emulation for operand: fp8 -> i8 -> i32 -> bitcast f32
+// CHECK:         arith.bitcast %[[ARG0]] : f8E5M2 to i8
+// CHECK:         arith.extui
+// CHECK:         arith.bitcast %{{.*}} : i32 to f32
+// ExtF emulation for constant
+// CHECK:         arith.bitcast %{{.*}} : i32 to f32
+// Addf on f32
+// CHECK:         %[[SUM:.*]] = arith.addf %{{.*}}, %{{.*}} : f32
+// TruncF emulation: f32 -> i32 -> i8 -> fp8
+// CHECK:         arith.bitcast %[[SUM]] : f32 to i32
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E5M2
+// CHECK:         return %[[RESULT]] : f8E5M2
+func.func @expand_f8_ocp(%x: f8E5M2) -> f8E5M2 {
   %c = arith.constant 1.0 : f8E5M2
   %y = arith.addf %x, %c : f8E5M2
   func.return %y : f8E5M2
@@ -66,9 +23,7 @@ func.func @expand_f8_ocp(%x: f8E5M2) -> f8E5M2 attributes
 
 // -----
 
-// Test CPU target with f8E4M3FNUZ - both extf and truncf should be emulated.
-//
-// CHECK-LABEL: func.func @expand_cpu_target_f8e4m3fnuz
+// CHECK-LABEL: func.func @expand_f8e4m3fnuz
 // CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f8E4M3FNUZ
 //
 // ExtF emulation: fp8 -> i8 -> i32 -> extract fields -> pack f32 -> bitcast
@@ -88,17 +43,14 @@ func.func @expand_f8_ocp(%x: f8E5M2) -> f8E5M2 attributes
 // CHECK:         arith.trunci %{{.*}} : i32 to i8
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E4M3FNUZ
 // CHECK:         return %[[RESULT]] : f8E4M3FNUZ
-func.func @expand_cpu_target_f8e4m3fnuz(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @expand_f8e4m3fnuz(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ {
     %0 = arith.negf %arg0 : f8E4M3FNUZ
     return %0 : f8E4M3FNUZ
 }
 
 // -----
 
-// Test CPU target with f8E5M2FNUZ.
-//
-// CHECK-LABEL: func.func @expand_cpu_target_f8e5m2fnuz
+// CHECK-LABEL: func.func @expand_f8e5m2fnuz
 // CHECK-SAME:    (%[[ARG0:.*]]: f8E5M2FNUZ) -> f8E5M2FNUZ
 // CHECK:         %[[BITCAST_IN:.*]] = arith.bitcast %[[ARG0]] : f8E5M2FNUZ to i8
 // CHECK:         %[[EXT_I32:.*]] = arith.extui %[[BITCAST_IN]] : i8 to i32
@@ -108,8 +60,7 @@ func.func @expand_cpu_target_f8e4m3fnuz(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attrib
 // CHECK:         arith.trunci %{{.*}} : i32 to i8
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E5M2FNUZ
 // CHECK:         return %[[RESULT]] : f8E5M2FNUZ
-func.func @expand_cpu_target_f8e5m2fnuz(%arg0 : f8E5M2FNUZ) -> f8E5M2FNUZ attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @expand_f8e5m2fnuz(%arg0 : f8E5M2FNUZ) -> f8E5M2FNUZ {
     %c = arith.constant 1.0 : f8E5M2FNUZ
     %0 = arith.addf %arg0, %c : f8E5M2FNUZ
     return %0 : f8E5M2FNUZ
@@ -117,9 +68,7 @@ func.func @expand_cpu_target_f8e5m2fnuz(%arg0 : f8E5M2FNUZ) -> f8E5M2FNUZ attrib
 
 // -----
 
-// Test explicit truncf emulation for CPU target.
-//
-// CHECK-LABEL: func.func @truncf_cpu_f32_to_f8e5m2fnuz
+// CHECK-LABEL: func.func @truncf_f32_to_f8e5m2fnuz
 // CHECK-SAME:    (%[[ARG0:.*]]: f32) -> f8E5M2FNUZ
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f32 to i32
 // CHECK:         arith.shrui %[[BITCAST]]
@@ -130,17 +79,14 @@ func.func @expand_cpu_target_f8e5m2fnuz(%arg0 : f8E5M2FNUZ) -> f8E5M2FNUZ attrib
 // CHECK:         arith.trunci %{{.*}} : i32 to i8
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E5M2FNUZ
 // CHECK:         return %[[RESULT]] : f8E5M2FNUZ
-func.func @truncf_cpu_f32_to_f8e5m2fnuz(%arg0 : f32) -> f8E5M2FNUZ attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @truncf_f32_to_f8e5m2fnuz(%arg0 : f32) -> f8E5M2FNUZ {
     %0 = arith.truncf %arg0 : f32 to f8E5M2FNUZ
     return %0 : f8E5M2FNUZ
 }
 
 // -----
 
-// Test explicit extf emulation for CPU target.
-//
-// CHECK-LABEL: func.func @extf_cpu_f8e5m2fnuz_to_f32
+// CHECK-LABEL: func.func @extf_f8e5m2fnuz_to_f32
 // CHECK-SAME:    (%[[ARG0:.*]]: f8E5M2FNUZ) -> f32
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f8E5M2FNUZ to i8
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
@@ -152,17 +98,14 @@ func.func @truncf_cpu_f32_to_f8e5m2fnuz(%arg0 : f32) -> f8E5M2FNUZ attributes
 // CHECK:         arith.select
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i32 to f32
 // CHECK:         return %[[RESULT]] : f32
-func.func @extf_cpu_f8e5m2fnuz_to_f32(%arg0 : f8E5M2FNUZ) -> f32 attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @extf_f8e5m2fnuz_to_f32(%arg0 : f8E5M2FNUZ) -> f32 {
     %0 = arith.extf %arg0 : f8E5M2FNUZ to f32
     return %0 : f32
 }
 
 // -----
 
-// Test vector truncf emulation for CPU target.
-//
-// CHECK-LABEL: func.func @truncf_cpu_vector_f32_to_f8e5m2fnuz
+// CHECK-LABEL: func.func @truncf_vector_f32_to_f8e5m2fnuz
 // CHECK-SAME:    (%[[ARG0:.*]]: vector<4xf32>) -> vector<4xf8E5M2FNUZ>
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : vector<4xf32> to vector<4xi32>
 // CHECK:         arith.shrui
@@ -170,16 +113,14 @@ func.func @extf_cpu_f8e5m2fnuz_to_f32(%arg0 : f8E5M2FNUZ) -> f32 attributes
 // CHECK:         arith.trunci %{{.*}} : vector<4xi32> to vector<4xi8>
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : vector<4xi8> to vector<4xf8E5M2FNUZ>
 // CHECK:         return %[[RESULT]] : vector<4xf8E5M2FNUZ>
-func.func @truncf_cpu_vector_f32_to_f8e5m2fnuz(%arg0 : vector<4xf32>) -> vector<4xf8E5M2FNUZ> attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @truncf_vector_f32_to_f8e5m2fnuz(%arg0 : vector<4xf32>) -> vector<4xf8E5M2FNUZ> {
     %0 = arith.truncf %arg0 : vector<4xf32> to vector<4xf8E5M2FNUZ>
     return %0 : vector<4xf8E5M2FNUZ>
 }
 
 // -----
 
-// Test vector extf emulation for CPU target.
-// CHECK-LABEL: func.func @extf_cpu_vector_f8e5m2fnuz_to_f32
+// CHECK-LABEL: func.func @extf_vector_f8e5m2fnuz_to_f32
 // CHECK-SAME:    (%[[ARG0:.*]]: vector<4xf8E5M2FNUZ>) -> vector<4xf32>
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : vector<4xf8E5M2FNUZ> to vector<4xi8>
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : vector<4xi8> to vector<4xi32>
@@ -190,33 +131,27 @@ func.func @truncf_cpu_vector_f32_to_f8e5m2fnuz(%arg0 : vector<4xf32>) -> vector<
 // CHECK:         arith.mulf {{.*}} : vector<4xf32>
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : vector<4xi32> to vector<4xf32>
 // CHECK:         return %[[RESULT]] : vector<4xf32>
-func.func @extf_cpu_vector_f8e5m2fnuz_to_f32(%arg0 : vector<4xf8E5M2FNUZ>) -> vector<4xf32> attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @extf_vector_f8e5m2fnuz_to_f32(%arg0 : vector<4xf8E5M2FNUZ>) -> vector<4xf32> {
     %0 = arith.extf %arg0 : vector<4xf8E5M2FNUZ> to vector<4xf32>
     return %0 : vector<4xf32>
 }
 
 // -----
 
-// Test f8E4M3FNUZ truncf emulation for CPU target.
-//
-// CHECK-LABEL: func.func @truncf_cpu_f32_to_f8e4m3fnuz
+// CHECK-LABEL: func.func @truncf_f32_to_f8e4m3fnuz
 // CHECK-SAME:    (%[[ARG0:.*]]: f32) -> f8E4M3FNUZ
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f32 to i32
 // CHECK:         arith.trunci %{{.*}} : i32 to i8
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i8 to f8E4M3FNUZ
 // CHECK:         return %[[RESULT]] : f8E4M3FNUZ
-func.func @truncf_cpu_f32_to_f8e4m3fnuz(%arg0 : f32) -> f8E4M3FNUZ attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @truncf_f32_to_f8e4m3fnuz(%arg0 : f32) -> f8E4M3FNUZ {
     %0 = arith.truncf %arg0 : f32 to f8E4M3FNUZ
     return %0 : f8E4M3FNUZ
 }
 
 // -----
 
-// Test f8E4M3FNUZ extf emulation for CPU target.
-//
-// CHECK-LABEL: func.func @extf_cpu_f8e4m3fnuz_to_f32
+// CHECK-LABEL: func.func @extf_f8e4m3fnuz_to_f32
 // CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ) -> f32
 // CHECK:         %[[BITCAST:.*]] = arith.bitcast %[[ARG0]] : f8E4M3FNUZ to i8
 // CHECK:         %[[EXT:.*]] = arith.extui %[[BITCAST]] : i8 to i32
@@ -225,8 +160,7 @@ func.func @truncf_cpu_f32_to_f8e4m3fnuz(%arg0 : f32) -> f8E4M3FNUZ attributes
 // CHECK:         arith.mulf {{.*}} : f32
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i32 to f32
 // CHECK:         return %[[RESULT]] : f32
-func.func @extf_cpu_f8e4m3fnuz_to_f32(%arg0 : f8E4M3FNUZ) -> f32 attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @extf_f8e4m3fnuz_to_f32(%arg0 : f8E4M3FNUZ) -> f32 {
     %0 = arith.extf %arg0 : f8E4M3FNUZ to f32
     return %0 : f32
 }
@@ -265,8 +199,7 @@ func.func @extf_cpu_f8e4m3fnuz_to_f32(%arg0 : f8E4M3FNUZ) -> f32 attributes
 // This ensures it's the outermost select, overriding negative zero correction.
 // CHECK:         %[[FINAL:.*]] = arith.select %[[SRC_IS_NAN]], %[[C128]], %{{.*}} : i32
 // CHECK-NEXT:    arith.trunci %[[FINAL]] : i32 to i8
-func.func @truncf_fnuz_nan_handling(%arg0 : f32) -> f8E5M2FNUZ attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @truncf_fnuz_nan_handling(%arg0 : f32) -> f8E5M2FNUZ {
     %0 = arith.truncf %arg0 : f32 to f8E5M2FNUZ
     return %0 : f8E5M2FNUZ
 }
@@ -287,8 +220,7 @@ func.func @truncf_fnuz_nan_handling(%arg0 : f32) -> f8E5M2FNUZ attributes
 // srcIsNan select must be immediately before trunci (outermost in cascade).
 // CHECK:         %[[FINAL:.*]] = arith.select %[[SRC_IS_NAN]], %[[C128]], %{{.*}} : i32
 // CHECK-NEXT:    arith.trunci %[[FINAL]] : i32 to i8
-func.func @truncf_fnuz_nan_handling_e4m3(%arg0 : f32) -> f8E4M3FNUZ attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @truncf_fnuz_nan_handling_e4m3(%arg0 : f32) -> f8E4M3FNUZ {
     %0 = arith.truncf %arg0 : f32 to f8E4M3FNUZ
     return %0 : f8E4M3FNUZ
 }
@@ -318,19 +250,18 @@ func.func @truncf_fnuz_nan_handling_e4m3(%arg0 : f32) -> f8E4M3FNUZ attributes
 //
 // If input is FNUZ NaN (0x80), output canonical f32 NaN (0x7FC00000).
 // CHECK:         arith.select %[[IS_NAN]], %[[F32_NAN]], %{{.*}} : i32
-func.func @extf_fnuz_nan_handling(%arg0 : f8E5M2FNUZ) -> f32 attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @extf_fnuz_nan_handling(%arg0 : f8E5M2FNUZ) -> f32 {
     %0 = arith.extf %arg0 : f8E5M2FNUZ to f32
     return %0 : f32
 }
 
 // -----
 
-// Test CPU target with f4E2M1FN - both extf and truncf should be emulated.
+// Test f4E2M1FN - both extf and truncf should be emulated.
 // This fp4 type has no NaN and no infinity. The key difference from fp8 is
 // using i4 instead of i8 for the packed integer type.
 //
-// CHECK-LABEL: func.func @expand_cpu_target_f4e2m1fn
+// CHECK-LABEL: func.func @expand_f4e2m1fn
 // CHECK-SAME:    (%[[ARG0:.*]]: f4E2M1FN) -> f4E2M1FN
 //
 // ExtF emulation: fp4 -> i4 -> i32 -> extract fields -> pack f32 -> bitcast
@@ -350,8 +281,125 @@ func.func @extf_fnuz_nan_handling(%arg0 : f8E5M2FNUZ) -> f32 attributes
 // CHECK:         arith.trunci %{{.*}} : i32 to i4
 // CHECK:         %[[RESULT:.*]] = arith.bitcast %{{.*}} : i4 to f4E2M1FN
 // CHECK:         return %[[RESULT]] : f4E2M1FN
-func.func @expand_cpu_target_f4e2m1fn(%arg0 : f4E2M1FN) -> f4E2M1FN attributes
-{ hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz"}>}{
+func.func @expand_f4e2m1fn(%arg0 : f4E2M1FN) -> f4E2M1FN {
     %0 = arith.negf %arg0 : f4E2M1FN
     return %0 : f4E2M1FN
+}
+
+// -----
+
+// Test that scaling_extf is preserved (not emulated).
+// These ops have their own expansion patterns in upstream MLIR
+// (arith::populateExpandScalingExtTruncPatterns) that run later.
+//
+// CHECK-LABEL: func.func @scaling_extf_preserved
+// CHECK-SAME:    (%[[ARG0:.*]]: tensor<16xf8E4M3FN>, %[[SCALE:.*]]: tensor<16xf8E8M0FNU>)
+// CHECK:         %[[RESULT:.*]] = arith.scaling_extf %[[ARG0]], %[[SCALE]] : tensor<16xf8E4M3FN>, tensor<16xf8E8M0FNU> to tensor<16xf32>
+// CHECK:         return %[[RESULT]] : tensor<16xf32>
+func.func @scaling_extf_preserved(%arg0 : tensor<16xf8E4M3FN>, %scale : tensor<16xf8E8M0FNU>) -> tensor<16xf32> {
+  %0 = arith.scaling_extf %arg0, %scale : tensor<16xf8E4M3FN>, tensor<16xf8E8M0FNU> to tensor<16xf32>
+  return %0 : tensor<16xf32>
+}
+
+// -----
+
+// Test that scaling_truncf is preserved (not emulated).
+//
+// CHECK-LABEL: func.func @scaling_truncf_preserved
+// CHECK-SAME:    (%[[ARG0:.*]]: tensor<16xf32>, %[[SCALE:.*]]: tensor<16xf8E8M0FNU>)
+// CHECK:         %[[RESULT:.*]] = arith.scaling_truncf %[[ARG0]], %[[SCALE]] : tensor<16xf32>, tensor<16xf8E8M0FNU> to tensor<16xf8E4M3FN>
+// CHECK:         return %[[RESULT]] : tensor<16xf8E4M3FN>
+func.func @scaling_truncf_preserved(%arg0 : tensor<16xf32>, %scale : tensor<16xf8E8M0FNU>) -> tensor<16xf8E4M3FN> {
+  %0 = arith.scaling_truncf %arg0, %scale : tensor<16xf32>, tensor<16xf8E8M0FNU> to tensor<16xf8E4M3FN>
+  return %0 : tensor<16xf8E4M3FN>
+}
+
+// -----
+
+// Test GPU target-specific type filtering for FNUZ types.
+// gfx942 has FNUZ hardware conversion support. Arithmetic is still wrapped
+// with extf/truncf (no native fp8 arithmetic), but the conversions are NOT
+// emulated via bit manipulation - they stay as arith.extf/truncf and get
+// lowered to hardware intrinsics by ArithToAMDGPU in ConvertToROCDL.
+//
+// CHECK-LABEL: func.func @gpu_fnuz_gfx942_hw_conversion
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ)
+// Arithmetic emulation: wrap with extf/truncf
+// CHECK:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FNUZ to f32
+// CHECK:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
+// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FNUZ
+// No bit manipulation (no arith.bitcast) - conversions use hardware
+// CHECK-NOT:     arith.bitcast
+// CHECK:         return %[[TRUNC]]
+#executable_target_gfx942 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+func.func @gpu_fnuz_gfx942_hw_conversion(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes {
+  hal.executable.target = #executable_target_gfx942}
+{
+  %0 = arith.negf %arg0 : f8E4M3FNUZ
+  return %0 : f8E4M3FNUZ
+}
+
+// -----
+
+// Test GPU target-specific type filtering for OCP types.
+// gfx942 lacks OCP hardware - should be emulated via i32 bit manipulation.
+//
+// CHECK-LABEL: func.func @gpu_ocp_gfx942_emulated
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FN)
+// CHECK:         arith.bitcast %[[ARG0]] : f8E4M3FN to i8
+// CHECK:         arith.extui
+// CHECK:         arith.negf %{{.*}} : f32
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         arith.bitcast %{{.*}} : i8 to f8E4M3FN
+#executable_target_gfx942_ocp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+func.func @gpu_ocp_gfx942_emulated(%arg0 : f8E4M3FN) -> f8E4M3FN attributes {
+  hal.executable.target = #executable_target_gfx942_ocp
+} {
+  %0 = arith.negf %arg0 : f8E4M3FN
+  return %0 : f8E4M3FN
+}
+
+// -----
+
+// Test GPU target-specific type filtering for OCP types.
+// gfx950 has OCP hardware conversion support. Arithmetic is still wrapped
+// with extf/truncf (no native fp8 arithmetic), but the conversions are NOT
+// emulated via bit manipulation - they stay as arith.extf/truncf and get
+// lowered to hardware intrinsics by ArithToAMDGPU in ConvertToROCDL.
+//
+// CHECK-LABEL: func.func @gpu_ocp_gfx950_hw_conversion
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FN)
+// Arithmetic emulation: wrap with extf/truncf
+// CHECK:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FN to f32
+// CHECK:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
+// CHECK:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FN
+// No bit manipulation (no arith.bitcast) - conversions use hardware
+// CHECK-NOT:     arith.bitcast
+// CHECK:         return %[[TRUNC]]
+#executable_target_gfx950 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+func.func @gpu_ocp_gfx950_hw_conversion(%arg0 : f8E4M3FN) -> f8E4M3FN attributes {
+  hal.executable.target = #executable_target_gfx950
+} {
+  %0 = arith.negf %arg0 : f8E4M3FN
+  return %0 : f8E4M3FN
+}
+
+// -----
+
+// Test GPU target-specific type filtering for FNUZ types.
+// gfx950 lacks FNUZ hardware - should be emulated via i32 bit manipulation.
+//
+// CHECK-LABEL: func.func @gpu_fnuz_gfx950_emulated
+// CHECK-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ)
+// CHECK:         arith.bitcast %[[ARG0]] : f8E4M3FNUZ to i8
+// CHECK:         arith.extui
+// CHECK:         arith.negf %{{.*}} : f32
+// CHECK:         arith.trunci %{{.*}} : i32 to i8
+// CHECK:         arith.bitcast %{{.*}} : i8 to f8E4M3FNUZ
+#executable_target_gfx950_fnuz = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+func.func @gpu_fnuz_gfx950_emulated(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes {
+  hal.executable.target = #executable_target_gfx950_fnuz
+} {
+  %0 = arith.negf %arg0 : f8E4M3FNUZ
+  return %0 : f8E4M3FNUZ
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-convert-unsupported-float-arith))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-convert-unsupported-float-arith{enable-ext-trunc-emulation=false}))" %s | FileCheck %s --check-prefix=NOEMU
 
 // CHECK-LABEL: func.func @expand_f8_ocp(
 // CHECK-SAME:    %[[ARG0:.*]]: f8E5M2
@@ -351,6 +352,15 @@ func.func @gpu_fnuz_gfx942_hw_conversion(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attri
 // CHECK:         arith.negf %{{.*}} : f32
 // CHECK:         arith.trunci %{{.*}} : i32 to i8
 // CHECK:         arith.bitcast %{{.*}} : i8 to f8E4M3FN
+//
+// With emulation disabled, extf/truncf remain unconverted (no bitcast).
+// NOEMU-LABEL: func.func @gpu_ocp_gfx942_emulated
+// NOEMU-SAME:    (%[[ARG0:.*]]: f8E4M3FN)
+// NOEMU:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FN to f32
+// NOEMU:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
+// NOEMU:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FN
+// NOEMU-NOT:     arith.bitcast
+// NOEMU:         return %[[TRUNC]]
 #executable_target_gfx942_ocp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 func.func @gpu_ocp_gfx942_emulated(%arg0 : f8E4M3FN) -> f8E4M3FN attributes {
   hal.executable.target = #executable_target_gfx942_ocp
@@ -396,6 +406,15 @@ func.func @gpu_ocp_gfx950_hw_conversion(%arg0 : f8E4M3FN) -> f8E4M3FN attributes
 // CHECK:         arith.negf %{{.*}} : f32
 // CHECK:         arith.trunci %{{.*}} : i32 to i8
 // CHECK:         arith.bitcast %{{.*}} : i8 to f8E4M3FNUZ
+//
+// With emulation disabled, extf/truncf remain unconverted (no bitcast).
+// NOEMU-LABEL: func.func @gpu_fnuz_gfx950_emulated
+// NOEMU-SAME:    (%[[ARG0:.*]]: f8E4M3FNUZ)
+// NOEMU:         %[[EXT:.*]] = arith.extf %[[ARG0]] {{.*}} : f8E4M3FNUZ to f32
+// NOEMU:         %[[NEG:.*]] = arith.negf %[[EXT]] : f32
+// NOEMU:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FNUZ
+// NOEMU-NOT:     arith.bitcast
+// NOEMU:         return %[[TRUNC]]
 #executable_target_gfx950_fnuz = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 func.func @gpu_fnuz_gfx950_emulated(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes {
   hal.executable.target = #executable_target_gfx950_fnuz

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_unsupported_float_arith.mlir
@@ -332,7 +332,7 @@ func.func @scaling_truncf_preserved(%arg0 : tensor<16xf32>, %scale : tensor<16xf
 // No bit manipulation (no arith.bitcast) - conversions use hardware
 // CHECK-NOT:     arith.bitcast
 // CHECK:         return %[[TRUNC]]
-#executable_target_gfx942 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+#executable_target_gfx942 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 func.func @gpu_fnuz_gfx942_hw_conversion(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes {
   hal.executable.target = #executable_target_gfx942}
 {
@@ -361,7 +361,7 @@ func.func @gpu_fnuz_gfx942_hw_conversion(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attri
 // NOEMU:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FN
 // NOEMU-NOT:     arith.bitcast
 // NOEMU:         return %[[TRUNC]]
-#executable_target_gfx942_ocp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+#executable_target_gfx942_ocp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 func.func @gpu_ocp_gfx942_emulated(%arg0 : f8E4M3FN) -> f8E4M3FN attributes {
   hal.executable.target = #executable_target_gfx942_ocp
 } {
@@ -386,7 +386,7 @@ func.func @gpu_ocp_gfx942_emulated(%arg0 : f8E4M3FN) -> f8E4M3FN attributes {
 // No bit manipulation (no arith.bitcast) - conversions use hardware
 // CHECK-NOT:     arith.bitcast
 // CHECK:         return %[[TRUNC]]
-#executable_target_gfx950 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+#executable_target_gfx950 = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 func.func @gpu_ocp_gfx950_hw_conversion(%arg0 : f8E4M3FN) -> f8E4M3FN attributes {
   hal.executable.target = #executable_target_gfx950
 } {
@@ -415,7 +415,7 @@ func.func @gpu_ocp_gfx950_hw_conversion(%arg0 : f8E4M3FN) -> f8E4M3FN attributes
 // NOEMU:         %[[TRUNC:.*]] = arith.truncf %[[NEG]] {{.*}} : f32 to f8E4M3FNUZ
 // NOEMU-NOT:     arith.bitcast
 // NOEMU:         return %[[TRUNC]]
-#executable_target_gfx950_fnuz = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+#executable_target_gfx950_fnuz = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "", wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic, subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 func.func @gpu_fnuz_gfx950_emulated(%arg0 : f8E4M3FNUZ) -> f8E4M3FNUZ attributes {
   hal.executable.target = #executable_target_gfx950_fnuz
 } {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
@@ -1,7 +1,8 @@
+// gfx942 (CDNA3) has hardware support for FNUZ types, other chips use software emulation.
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=CDNA3
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
 
 #map = affine_map<(d0) -> (d0)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -41,11 +42,16 @@ hal.executable @ext_fp8_dispatch {
   }
 }
 
-// ERRORS: F8E5M2FNUZ and F8E4M3FNUZ types are not supported on non-gfx942 (MI-300) chipsets; try F8E5M2 or F8E4M3FN instead.
-
+// CDNA3 (gfx942) uses hardware fp8 conversion instructions.
 //   CDNA3-LABEL: hal.executable public @ext_fp8_dispatch {
 //         CDNA3:   hal.executable.variant public @rocm
 // CDNA3-COUNT-8:     rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
 // CDNA3-COUNT-8:     rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
 //         CDNA3:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
 //         CDNA3:     llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
+
+// Other chips use software emulation via integer bit manipulation.
+// EMULATED-LABEL: hal.executable public @ext_fp8_dispatch {
+//       EMULATED:   hal.executable.variant public @rocm
+//       EMULATED:     llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
+//       EMULATED:     llvm.store %{{.*}}, %{{.*}} : vector<16xf32>, !llvm.ptr<7>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
@@ -1,8 +1,12 @@
-// gfx942 (CDNA3) has hardware support for FNUZ types, other chips use software emulation.
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=CDNA3
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+
+// With --iree-llvmgpu-enable-small-float-emulation, unsupported chips use software emulation.
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=EMULATED
 
 #map = affine_map<(d0) -> (d0)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -42,7 +46,8 @@ hal.executable @ext_fp8_dispatch {
   }
 }
 
-// CDNA3 (gfx942) uses hardware fp8 conversion instructions.
+// ERRORS: F8E5M2FNUZ and F8E4M3FNUZ types are not supported on non-gfx942 (MI-300) chipsets; try F8E5M2 or F8E4M3FN instead, or use --iree-llvmgpu-enable-small-float-emulation
+
 //   CDNA3-LABEL: hal.executable public @ext_fp8_dispatch {
 //         CDNA3:   hal.executable.variant public @rocm
 // CDNA3-COUNT-8:     rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
@@ -50,7 +55,6 @@ hal.executable @ext_fp8_dispatch {
 //         CDNA3:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
 //         CDNA3:     llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
 
-// Other chips use software emulation via integer bit manipulation.
 // EMULATED-LABEL: hal.executable public @ext_fp8_dispatch {
 //       EMULATED:   hal.executable.variant public @rocm
 //       EMULATED:     llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -232,6 +232,7 @@ ROCM_SRCS = enforce_glob(
         "index.mlir",
         "narrow_n_matmuls.mlir",
         "pack_i8.mlir",
+        "small_float_arith.mlir",
         "softmax.mlir",
         "subbyte_to_fp.mlir",
         "unpack.mlir",
@@ -243,7 +244,6 @@ ROCM_SRCS = enforce_glob(
         # See bug #20294
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
-        "small_float_arith.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -252,6 +252,7 @@ iree_check_single_backend_test_suite(
     # TODO(kuhar): Drop the timeout after we switch to testing on the actual gfx1250 chip.
     timeout = "moderate",
     srcs = ROCM_SRCS,
+    compiler_flags = ["--iree-llvmgpu-enable-small-float-emulation"],
     driver = "hip",
     target_backend = "rocm",
 )

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -168,6 +168,7 @@ iree_check_single_backend_test_suite(
     "index.mlir"
     "narrow_n_matmuls.mlir"
     "pack_i8.mlir"
+    "small_float_arith.mlir"
     "softmax.mlir"
     "subbyte_to_fp.mlir"
     "unpack.mlir"

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -176,6 +176,8 @@ iree_check_single_backend_test_suite(
     "rocm"
   DRIVER
     "hip"
+  COMPILER_FLAGS
+    "--iree-llvmgpu-enable-small-float-emulation"
   TIMEOUT
     300
 )


### PR DESCRIPTION
Previously, using fp8 types on chips without hardware support would produce a compile error (e.g., f8E5M2 on gfx942 or f8E5M2FNUZ on gfx950).

This change adds a flag to enable software emulation as a fallback, allowing any small float type to be used on any chip. If the flag is not enabled, it emits the error message with the hint of adding the flag.

On ConvertUnsupportedFloatArith pass side, it marks arith.scaling_extf/truncf as legal since they have their own expansion patterns that run in later passes. The revision also fixes a bug that gfx950 does not have FNUZ hardware support. So `<=` is replaced with `<`.

The GPU specific tests are refreshed; all the executable target attributes are removed from existing tests. Three of existing GPU tests are removed because we already have the same tests.

AMDGPU support matrix:

| Type         | gfx908/90a | gfx942 | gfx950 | gfx11xx | gfx12xx |
|--------------|------------|--------|--------|---------|---------|
| f8E4M3FNUZ   |   emu      |   hw   |  emu   |   emu   |   emu   |
| f8E5M2FNUZ   |   emu      |   hw   |  emu   |   emu   |   emu   |
| f8E4M3FN     |   emu      |  emu   |   hw   |   emu   |   hw    |
| f8E5M2       |   emu      |  emu   |   hw   |   emu   |   hw    |
| f4E2M1FN     |   emu      |  emu   |   hw   |   emu   |   hw    |

(hw = hardware instructions, emu = software emulation)

