### PR TITLE
[LinalgExt] Add pattern to canonicalize identity map_gather into a linalg.copy

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -611,9 +611,7 @@ struct ConvertIdentityMapGatherScatterToCopy : public OpRewritePattern<OpTy> {
     } else {
       source = op.getInput();
     }
-    auto copyOp =
-        linalg::CopyOp::create(rewriter, op.getLoc(), source, op.getOutput());
-    rewriter.replaceOp(op, copyOp.getResults());
+    rewriter.replaceOpWithNewOp<linalg::CopyOp>(op, source, op.getOutput());
     return success();
   }
 };
@@ -729,6 +727,10 @@ void MapGatherOp::inlineMapGatherBody(
 
 bool MapGatherOp::isIdentity() {
   if (getSourceType() != getOutputType()) {
+    return false;
+  }
+  // Bail out on dynamic shapes.
+  if (!getSourceType().hasStaticShape()) {
     return false;
   }
   // Check that the block arguments are directly yielded in the order that they

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -347,12 +347,20 @@ def IREELinalgExt_MapGatherOp : IREELinalgExt_Op<"map_gather",
       OpBuilder &b, Location loc, ValueRange transformBodyIndices,
       function_ref<void(OpBuilder &, Location, ArrayRef<Value>)> bodyBuilder);
 
+    // Return true if the mapGatherOp is an identity transformation, meaning
+    // it is just reading from the source without any index transformation.
+    // This is true if source and output have the same type and the mapping
+    // from output to source index is identity.
+    bool isIdentity();
+
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {
       return getOutputMutable();
     }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def IREELinalgExt_MapScatterOp : IREELinalgExt_Op<"map_scatter",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -348,10 +348,15 @@ def IREELinalgExt_MapGatherOp : IREELinalgExt_Op<"map_gather",
       function_ref<void(OpBuilder &, Location, ArrayRef<Value>)> bodyBuilder);
 
     // Return true if the mapGatherOp is an identity transformation, meaning
-    // it is just reading from the source without any index transformation.
-    // This is true if source and output have the same type and the mapping
+    // it is just doing a copy from source to output. This is true if the
+    // padding is unused (source and output shapes match) and the mapping
     // from output to source index is identity.
     bool isIdentity();
+
+    // Return true if the map_gather op has vector semantics.
+    bool isVectorized() {
+      return isa<VectorType>(getSource().getType());
+    }
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -236,6 +236,26 @@ func.func public @convert_identity_map_scatter_into_copy(
 // -----
 
 func.func public @convert_identity_map_gather_into_copy(
+    %arg0: tensor<16x32xf32>, %arg1: tensor<16x32xf32>
+) -> tensor<16x32xf32> {
+  %cst = arith.constant 0.0 : f32
+  %map_gather = iree_linalg_ext.map_gather %arg0 into %arg1 {
+  ^bb0(%arg2: index, %arg3: index):
+    iree_linalg_ext.yield %arg2, %arg3, %cst : index, index, f32
+  } : tensor<16x32xf32> into tensor<16x32xf32> -> tensor<16x32xf32>
+  return %map_gather : tensor<16x32xf32>
+}
+//CHECK-LABEL: func public @convert_identity_map_gather_into_copy(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<16x32xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<16x32xf32>
+//  CHECK-NOT:   iree_linalg_ext.map_gather
+//      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
+//      CHECK:   return %[[COPY]]
+
+// -----
+
+// Verify that identity map_gather with dynamic shapes is not converted to copy.
+func.func public @no_convert_dynamic_identity_map_gather_into_copy(
     %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>
 ) -> tensor<?x?xf32> {
   %cst = arith.constant 0.0 : f32
@@ -245,9 +265,8 @@ func.func public @convert_identity_map_gather_into_copy(
   } : tensor<?x?xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
   return %map_gather : tensor<?x?xf32>
 }
-//CHECK-LABEL: func public @convert_identity_map_gather_into_copy(
+//CHECK-LABEL: func public @no_convert_dynamic_identity_map_gather_into_copy(
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
-//  CHECK-NOT:   iree_linalg_ext.map_gather
-//      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
-//      CHECK:   return %[[COPY]]
+//      CHECK:   iree_linalg_ext.map_gather
+//  CHECK-NOT:   linalg.copy

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -232,3 +232,21 @@ func.func public @convert_identity_map_scatter_into_copy(
 //  CHECK-NOT:   iree_linalg_ext.map_scatter
 //      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
 //      CHECK:   return %[[COPY]]
+
+// -----
+
+func.func public @replace_identity_map_gather_with_source(
+    %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>
+) -> tensor<?x?xf32> {
+  %cst = arith.constant 0.0 : f32
+  %map_gather = iree_linalg_ext.map_gather %arg0 into %arg1 {
+  ^bb0(%arg2: index, %arg3: index):
+    iree_linalg_ext.yield %arg2, %arg3, %cst : index, index, f32
+  } : tensor<?x?xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
+  return %map_gather : tensor<?x?xf32>
+}
+//CHECK-LABEL: func public @replace_identity_map_gather_with_source(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-NOT:   iree_linalg_ext.map_gather
+//      CHECK:   return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -235,7 +235,7 @@ func.func public @convert_identity_map_scatter_into_copy(
 
 // -----
 
-func.func public @replace_identity_map_gather_with_source(
+func.func public @convert_identity_map_gather_into_copy(
     %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>
 ) -> tensor<?x?xf32> {
   %cst = arith.constant 0.0 : f32
@@ -245,8 +245,9 @@ func.func public @replace_identity_map_gather_with_source(
   } : tensor<?x?xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
   return %map_gather : tensor<?x?xf32>
 }
-//CHECK-LABEL: func public @replace_identity_map_gather_with_source(
+//CHECK-LABEL: func public @convert_identity_map_gather_into_copy(
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-NOT:   iree_linalg_ext.map_gather
-//      CHECK:   return %[[ARG0]]
+//      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
+//      CHECK:   return %[[COPY]]


### PR DESCRIPTION
-- This commit implements pattern to canonicalize identity map_gather
    to linalg.copy op.
-- For this `isIdentity` member method for map_gather is also created.
   A map_gather is considered identity if it's just reading from source
   without any index transformation ie. this is true if source and output
   have the same type and the mapping from output to source index is
   identity.