### PR TITLE
[Bazel][ConstEval] Add missing tool dependency to LITs

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/ConstEval/test/BUILD.bazel
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     cfg = "//compiler:lit.cfg.py",
     tools = [
         "//tools:iree-opt",
+        "@llvm-project//lld",
         "@llvm-project//llvm:FileCheck",
     ],
 )

--- a/compiler/src/iree/compiler/ConstEval/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ConstEval/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "jit_globals_vmvx_errors.mlir"
     "scalar_values.mlir"
   TOOLS
+    ${IREE_LLD_TARGET}
     FileCheck
     iree-opt
   TIMEOUT


### PR DESCRIPTION
In some Bazel environments, this guards against:
```
error: required embedded linker tool (typically `lld`) not found after searching:
  * --iree-llvmcpu-embedded-linker-path= flag
  * IREE_LLVM_EMBEDDED_LINKER_PATH environment variable
  * common locations at relative file paths
  * system PATH
```