### PR TITLE
[Encoding] Add verifier for encoding_dims on (Un)SetEncodingOp

### DIFF
--- a/compiler/plugins/target/LLVMCPU/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/materialize_homogeneous_encodings.mlir
@@ -8,13 +8,13 @@
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map1, #map2, #map3], iteration_sizes = [?, ?, ?]>
 #device_target_llvm_cpu = #hal.device.target<"local", [#executable_target_embedded_elf_x86_64_]> : !hal.device
 module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
-  util.func public @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  util.func public @lhs_encoding(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %3 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-    %4 = iree_encoding.unset_encoding %3 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+    %3 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+    %4 = iree_encoding.unset_encoding %3 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
     util.return %4 : tensor<?x?xf32>
   }
 }

--- a/compiler/plugins/target/VulkanSPIRV/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/plugins/target/VulkanSPIRV/test/materialize_homogeneous_encodings.mlir
@@ -7,13 +7,13 @@
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map1, #map2, #map3], iteration_sizes = [?, ?, ?]>
 #device_target_vulkan = #hal.device.target<"vulkan", [#executable_target_vulkan_spirv_fb]> : !hal.device
 module attributes {hal.device.targets = [#device_target_vulkan]} {
-  util.func public @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  util.func public @lhs_encoding(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %3 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-    %4 = iree_encoding.unset_encoding %3 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+    %3 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+    %4 = iree_encoding.unset_encoding %3 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
     util.return %4 : tensor<?x?xf32>
   }
 }
@@ -34,13 +34,13 @@ module attributes {hal.device.targets = [#device_target_vulkan]} {
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">
 #device_target_vulkan = #hal.device.target<"vulkan", [#executable_target_vulkan_spirv_fb]> : !hal.device
 module attributes {hal.device.targets = [#hal.device.select<[#device_target_vulkan, #device_target_llvm_cpu]> : !hal.device]} {
-  util.func public @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  util.func public @lhs_encoding(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %3 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-    %4 = iree_encoding.unset_encoding %3 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+    %3 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+    %4 = iree_encoding.unset_encoding %3 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
     util.return %4 : tensor<?x?xf32>
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
@@ -2,10 +2,10 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding))" --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s --check-prefixes=CHECK,WITH-SVE
 
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [affine_map<(m, n, k) -> (m, k)>, affine_map<(m, n, k) -> (k, n)>, affine_map<(m, n, k) -> (m, n)>], iteration_sizes = [?, ?, ?]>
-func.func @matmul_LHS(%arg0: tensor<8x16xbf16>) -> tensor<8x16xbf16, #encoding> attributes {
+func.func @matmul_LHS(%arg0: tensor<8x16xbf16>, %m: index, %n: index, %k: index) -> tensor<8x16xbf16, #encoding> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+sve", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<8x16xbf16> -> tensor<8x16xbf16, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<8x16xbf16> -> tensor<8x16xbf16, #encoding>
   return %0 : tensor<8x16xbf16, #encoding>
 }
 
@@ -22,10 +22,10 @@ func.func @matmul_LHS(%arg0: tensor<8x16xbf16>) -> tensor<8x16xbf16, #encoding> 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [affine_map<(m, n, k) -> (m, k)>, affine_map<(m, n, k) -> (k, n)>, affine_map<(m, n, k) -> (m, n)>], iteration_sizes = [?, ?, ?]>
-func.func @matmul_RHS(%arg0: tensor<8x16xbf16>) -> tensor<8x16xbf16, #encoding> attributes {
+func.func @matmul_RHS(%arg0: tensor<8x16xbf16>, %m: index, %n: index, %k: index) -> tensor<8x16xbf16, #encoding> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+sve", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<8x16xbf16> -> tensor<8x16xbf16, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<8x16xbf16> -> tensor<8x16xbf16, #encoding>
   return %0 : tensor<8x16xbf16, #encoding>
 }
 /// NOTE: For RHS, the inner tile corresponding to the "N" dimension is
@@ -69,10 +69,10 @@ func.func @matmul_RHS(%arg0: tensor<8x16xbf16>) -> tensor<8x16xbf16, #encoding> 
 #map1 = affine_map<(b, m, n, k) -> (b, k, n)>
 #map2 = affine_map<(b, m, n, k) -> (b, m, n)>
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 32, 320, ?]>
-func.func @batch_matmul_RHS(%arg0: tensor<128x32x320xf32>) -> tensor<128x32x320xf32, #encoding> attributes {
+func.func @batch_matmul_RHS(%arg0: tensor<128x32x320xf32>, %k: index) -> tensor<128x32x320xf32, #encoding> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+sve", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<128x32x320xf32> -> tensor<128x32x320xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<128x32x320xf32> -> tensor<128x32x320xf32, #encoding>
   return %0 : tensor<128x32x320xf32, #encoding>
 }
 
@@ -115,10 +115,10 @@ func.func @batch_matmul_RHS(%arg0: tensor<128x32x320xf32>) -> tensor<128x32x320x
 #map1 = affine_map<(b, m, n, k) -> (b, k, n)>
 #map2 = affine_map<(b, m, n, k) -> (b, m, n)>
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 80, 320, ?]>
-func.func @batch_matmul_RETURN_unset(%arg0: tensor<128x80x320xf32, #encoding>) -> tensor<128x80x320xf32> attributes {
+func.func @batch_matmul_RETURN_unset(%arg0: tensor<128x80x320xf32, #encoding>, %k: index) -> tensor<128x80x320xf32> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+sve", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.unset_encoding %arg0 : tensor<128x80x320xf32, #encoding> -> tensor<128x80x320xf32>
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<128x80x320xf32, #encoding> -> tensor<128x80x320xf32>
   return %0 : tensor<128x80x320xf32>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
@@ -572,10 +572,11 @@ func.func @set_encoding_LHS_with_layout() attributes {
   hal.executable.target = #executable_target
 } {
   %c0 = arith.constant 0 : index
+  %c512 = arith.constant 512 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x256xf32>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x256xf32, #encoding>>
   %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x256xf32>> -> tensor<1x256xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<1x256xf32> -> tensor<1x256xf32, #encoding1>
+  %3 = iree_encoding.set_encoding %2 encoding_dims{%c512} : tensor<1x256xf32> -> tensor<1x256xf32, #encoding1>
   iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [1, 256], strides = [1, 1] : tensor<1x256xf32, #encoding1> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x256xf32, #encoding>>
   return
 }
@@ -603,10 +604,11 @@ func.func @set_encoding_RHS_with_layout() attributes {
   hal.executable.target = #executable_target
 } {
   %c0 = arith.constant 0 : index
+  %c512 = arith.constant 512 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x10xf32>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x10xf32, #encoding>>
   %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 10], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x10xf32>> -> tensor<256x10xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<256x10xf32> -> tensor<256x10xf32, #encoding1>
+  %3 = iree_encoding.set_encoding %2 encoding_dims{%c512} : tensor<256x10xf32> -> tensor<256x10xf32, #encoding1>
   iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [256, 10], strides = [1, 1] : tensor<256x10xf32, #encoding1> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x10xf32, #encoding>>
   return
 }
@@ -636,10 +638,11 @@ func.func @unset_encoding_RES_with_layout() attributes {
   hal.executable.target = #executable_target
 } {
   %c0 = arith.constant 0 : index
+  %c512 = arith.constant 512 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32, #encoding>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x10xf32>>
   %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 10], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32, #encoding>> -> tensor<1x10xf32, #encoding1>
-  %3 = iree_encoding.unset_encoding %2 : tensor<1x10xf32, #encoding1> -> tensor<1x10xf32>
+  %3 = iree_encoding.unset_encoding %2 encoding_dims{%c512} : tensor<1x10xf32, #encoding1> -> tensor<1x10xf32>
   iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [1, 10], strides = [1, 1] : tensor<1x10xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x10xf32>>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -27,9 +27,9 @@ func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32() -> tensor<255x
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<255x513xf32>
+    %arg0: tensor<255x513xf32>, %k: index
 ) -> tensor<255x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
   return %0 : tensor<255x513xf32, #encoding>
 }
 
@@ -54,9 +54,9 @@ func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<255x513xf32>
+    %arg0: tensor<255x513xf32>, %k: index
 ) -> tensor<255x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
   return %0 : tensor<255x513xf32, #encoding>
 }
 
@@ -81,9 +81,9 @@ func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [?, ?, ?]>
 func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<?x?xf32>
+    %arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index
 ) -> tensor<?x?xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
   return %0 : tensor<?x?xf32, #encoding>
 }
 
@@ -108,9 +108,9 @@ func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<255x513xf32>
+    %arg0: tensor<255x513xf32>, %k: index
 ) -> tensor<255x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
   return %0 : tensor<255x513xf32, #encoding>
 }
 
@@ -135,9 +135,9 @@ func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<255x513xf32>
+    %arg0: tensor<255x513xf32>, %k: index
 ) -> tensor<255x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
   return %0 : tensor<255x513xf32, #encoding>
 }
 
@@ -162,9 +162,9 @@ func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<255x513xf32>
+    %arg0: tensor<255x513xf32>, %k: index
 ) -> tensor<255x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
   return %0 : tensor<255x513xf32, #encoding>
 }
 
@@ -188,8 +188,8 @@ func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [?, 513, ?]>
-func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<?x513xf32>) -> tensor<?x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<?x513xf32> -> tensor<?x513xf32, #encoding>
+func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<?x513xf32>, %m: index, %k: index) -> tensor<?x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %k} : tensor<?x513xf32> -> tensor<?x513xf32, #encoding>
   return %0 : tensor<?x513xf32, #encoding>
 }
 // CHECK-LABEL: func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32
@@ -211,8 +211,8 @@ func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<?x513x
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, ?, ?]>
-func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?xf32>) -> tensor<255x?xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x?xf32> -> tensor<255x?xf32, #encoding>
+func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?xf32>, %n: index, %k: index) -> tensor<255x?xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%n, %k} : tensor<255x?xf32> -> tensor<255x?xf32, #encoding>
   return %0 : tensor<255x?xf32, #encoding>
 }
 
@@ -236,8 +236,8 @@ func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?x
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [32, 524288, ?]>
-func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x524288xf32>) -> tensor<32x524288xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<32x524288xf32> -> tensor<32x524288xf32, #encoding>
+func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x524288xf32>, %k: index) -> tensor<32x524288xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<32x524288xf32> -> tensor<32x524288xf32, #encoding>
   return %0 : tensor<32x524288xf32, #encoding>
 }
 
@@ -250,8 +250,8 @@ func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x5242
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [524288, 32, ?]>
-func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<524288x32xf32>) -> tensor<524288x32xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<524288x32xf32> -> tensor<524288x32xf32, #encoding>
+func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<524288x32xf32>, %k: index) -> tensor<524288x32xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<524288x32xf32> -> tensor<524288x32xf32, #encoding>
   return %0 : tensor<524288x32xf32, #encoding>
 }
 
@@ -265,9 +265,9 @@ func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<524288x
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<255x513xf32, #encoding>
+    %arg0: tensor<255x513xf32, #encoding>, %k: index
 ) -> tensor<255x513xf32> {
-  %0 = iree_encoding.unset_encoding %arg0 : tensor<255x513xf32, #encoding> -> tensor<255x513xf32>
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<255x513xf32, #encoding> -> tensor<255x513xf32>
   return %0 : tensor<255x513xf32>
 }
 
@@ -292,9 +292,9 @@ func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [?, ?, ?]>
 func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
-    %arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index
+    %arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index, %m: index, %n: index, %k: index
 ) -> tensor<?x?xf32> {
-  %2 = iree_encoding.unset_encoding %arg0 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  %2 = iree_encoding.unset_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
   return %2 : tensor<?x?xf32>
 }
 
@@ -391,9 +391,9 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
-    %arg0: tensor<255x513xi8>
+    %arg0: tensor<255x513xi8>, %k: index
 ) -> tensor<255x513xi8, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
   return %0 : tensor<255x513xi8, #encoding>
 }
 
@@ -418,9 +418,9 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
-    %arg0: tensor<255x513xi8>
+    %arg0: tensor<255x513xi8>, %k: index
 ) -> tensor<255x513xi8, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
   return %0 : tensor<255x513xi8, #encoding>
 }
 
@@ -445,9 +445,9 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
-    %arg0: tensor<255x513xi32>
+    %arg0: tensor<255x513xi32>, %k: index
 ) -> tensor<255x513xi32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
   return %0 : tensor<255x513xi32, #encoding>
 }
 
@@ -472,9 +472,9 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
-    %arg0: tensor<255x513xi32, #encoding>
+    %arg0: tensor<255x513xi32, #encoding>, %k: index
 ) -> tensor<255x513xi32> {
-  %0 = iree_encoding.unset_encoding %arg0 : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
   return %0 : tensor<255x513xi32>
 }
 
@@ -1104,9 +1104,9 @@ func.func @missing_user_indexing_maps() {
                                             user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                             iteration_sizes = [?, ?, ?]>
 func.func @set_encoding_rhs_bitcast_f16_to_f32(
-    %arg0: tensor<?x?xf32>
+    %arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index
 ) -> tensor<?x?xf32, #encoding_bitcast> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_bitcast>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_bitcast>
   return %0 : tensor<?x?xf32, #encoding_bitcast>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -12,9 +12,9 @@
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
-    %src: tensor<255x513xi8>
+    %src: tensor<255x513xi8>, %k: index
 ) -> tensor<255x513xi8, #encoding> {
-  %0 = iree_encoding.set_encoding %src : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  %0 = iree_encoding.set_encoding %src encoding_dims{%k} : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
   return %0 : tensor<255x513xi8, #encoding>
 }
 
@@ -38,9 +38,9 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
-    %arg0: tensor<255x513xi8>
+    %arg0: tensor<255x513xi8>, %k: index
 ) -> tensor<255x513xi8, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
   return %0 : tensor<255x513xi8, #encoding>
 }
 
@@ -65,9 +65,9 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
-    %arg0: tensor<255x513xi32>
+    %arg0: tensor<255x513xi32>, %k: index
 ) -> tensor<255x513xi32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
   return %0 : tensor<255x513xi32, #encoding>
 }
 
@@ -92,9 +92,9 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
 func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
-    %arg0: tensor<255x513xi32, #encoding>
+    %arg0: tensor<255x513xi32, #encoding>, %k: index
 ) -> tensor<255x513xi32> {
-  %0 = iree_encoding.unset_encoding %arg0 : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
   return %0 : tensor<255x513xi32>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
@@ -13,15 +13,16 @@ func.func @matmul_lowering_f32f32f32_riscv(%lhs: tensor<?x?xf32>, %rhs: tensor<?
   %c1 = arith.constant 1 : index
   %M = tensor.dim %acc, %c0 : tensor<?x?xf32>
   %N = tensor.dim %acc, %c1 : tensor<?x?xf32>
-  %0 = iree_encoding.set_encoding %lhs : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_lhs>
-  %1 = iree_encoding.set_encoding %rhs : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_rhs>
-  %2 = iree_encoding.set_encoding %acc : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_result>
+  %K = tensor.dim %lhs, %c1 : tensor<?x?xf32>
+  %0 = iree_encoding.set_encoding %lhs encoding_dims{%M, %N, %K} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_lhs>
+  %1 = iree_encoding.set_encoding %rhs encoding_dims{%M, %N, %K} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_rhs>
+  %2 = iree_encoding.set_encoding %acc encoding_dims{%M, %N, %K} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_result>
   %3 = linalg.matmul
       ins(%0, %1 : tensor<?x?xf32, #encoding_lhs>,
                    tensor<?x?xf32, #encoding_rhs>)
       outs(%2 : tensor<?x?xf32, #encoding_result>)
       -> tensor<?x?xf32, #encoding_result>
-  %4 = iree_encoding.unset_encoding %3 : tensor<?x?xf32, #encoding_result> -> tensor<?x?xf32>{%M, %N}
+  %4 = iree_encoding.unset_encoding %3 encoding_dims{%M, %N, %K} : tensor<?x?xf32, #encoding_result> -> tensor<?x?xf32>{%M, %N}
   return %4 : tensor<?x?xf32>
 }
 // RISC-V targets does not implement data-tiling yet.

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_vmvx.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_vmvx.mlir
@@ -68,10 +68,10 @@ func.func @fill_matmul(
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-func.func @set_encoding_dynamic(%input: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding_lhs> attributes {
+func.func @set_encoding_dynamic(%input: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32, #encoding_lhs> attributes {
   hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.set_encoding %input : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_lhs>
+  %0 = iree_encoding.set_encoding %input encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_lhs>
   return %0 : tensor<?x?xf32, #encoding_lhs>
 }
 //       CHECK: func @set_encoding_dynamic(
@@ -89,10 +89,10 @@ func.func @set_encoding_dynamic(%input: tensor<?x?xf32>) -> tensor<?x?xf32, #enc
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-func.func @unset_encoding_dynamic(%input: tensor<?x?xf32, #encoding_lhs>, %d0: index, %d1: index) -> tensor<?x?xf32> attributes {
+func.func @unset_encoding_dynamic(%input: tensor<?x?xf32, #encoding_lhs>, %d0: index, %d1: index, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
   hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.unset_encoding %input : tensor<?x?xf32, #encoding_lhs> -> tensor<?x?xf32>{%d0, %d1}
+  %0 = iree_encoding.unset_encoding %input encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding_lhs> -> tensor<?x?xf32>{%d0, %d1}
   return %0 : tensor<?x?xf32>
 }
 //       CHECK: func @unset_encoding_dynamic(

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -5,9 +5,9 @@
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [1, 1000, ?]>
 #executable_target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>, target_triple = "x86_64-xyz-xyz"}>
-func.func @set_encoding_with_padding_semantics_bf16_x86_64_avx512f(%arg0: tensor<1x1000xbf16>)
+func.func @set_encoding_with_padding_semantics_bf16_x86_64_avx512f(%arg0: tensor<1x1000xbf16>, %k: index)
     -> tensor<1x1000xbf16, #encoding> attributes { hal.executable.target = #executable_target } {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<1x1000xbf16> -> tensor<1x1000xbf16, #encoding>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<1x1000xbf16> -> tensor<1x1000xbf16, #encoding>
   return %0 : tensor<1x1000xbf16, #encoding>
 }
 // This tests that
@@ -49,10 +49,10 @@ func.func @set_encoding_7x7x7_matmul_LHS(%14: tensor<7x7xf32>) -> tensor<7x7xf32
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 80, 32, ?]>
-func.func @set_encoding_128x80x32_batch_matmul_LHS(%14: tensor<128x80x32xf32>) -> tensor<128x80x32xf32, #encoding> attributes {
+func.func @set_encoding_128x80x32_batch_matmul_LHS(%14: tensor<128x80x32xf32>, %k: index) -> tensor<128x80x32xf32, #encoding> attributes {
    hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %17 = iree_encoding.set_encoding %14 : tensor<128x80x32xf32> -> tensor<128x80x32xf32, #encoding>
+  %17 = iree_encoding.set_encoding %14 encoding_dims{%k} : tensor<128x80x32xf32> -> tensor<128x80x32xf32, #encoding>
   return %17 : tensor<128x80x32xf32, #encoding>
 }
 // CHECK-LABEL:    func @set_encoding_128x80x32_batch_matmul_LHS(
@@ -67,10 +67,10 @@ func.func @set_encoding_128x80x32_batch_matmul_LHS(%14: tensor<128x80x32xf32>) -
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 32, 320, ?]>
-func.func @set_encoding_128x32x320_batch_matmul_RHS(%16: tensor<128x32x320xf32>) -> tensor<128x32x320xf32, #encoding> attributes {
+func.func @set_encoding_128x32x320_batch_matmul_RHS(%16: tensor<128x32x320xf32>, %k: index) -> tensor<128x32x320xf32, #encoding> attributes {
    hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %19 = iree_encoding.set_encoding %16 : tensor<128x32x320xf32> -> tensor<128x32x320xf32, #encoding>
+  %19 = iree_encoding.set_encoding %16 encoding_dims{%k} : tensor<128x32x320xf32> -> tensor<128x32x320xf32, #encoding>
   return %19 : tensor<128x32x320xf32, #encoding>
 }
 // CHECK-LABEL:    func @set_encoding_128x32x320_batch_matmul_RHS(
@@ -85,10 +85,10 @@ func.func @set_encoding_128x32x320_batch_matmul_RHS(%16: tensor<128x32x320xf32>)
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 80, 320, ?]>
-func.func @unset_encoding_128x80x320_batch_matmul_RESULT(%arg0: tensor<128x80x320xf32, #encoding>) -> tensor<128x80x320xf32> attributes {
+func.func @unset_encoding_128x80x320_batch_matmul_RESULT(%arg0: tensor<128x80x320xf32, #encoding>, %k: index) -> tensor<128x80x320xf32> attributes {
    hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %0 = iree_encoding.unset_encoding %arg0 : tensor<128x80x320xf32, #encoding> -> tensor<128x80x320xf32>
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<128x80x320xf32, #encoding> -> tensor<128x80x320xf32>
   return %0 : tensor<128x80x320xf32>
 }
 // CHECK-LABEL: func @unset_encoding_128x80x320_batch_matmul_RESULT(
@@ -106,7 +106,7 @@ func.func @unset_encoding_128x80x320_batch_matmul_RESULT(%arg0: tensor<128x80x32
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> attributes {
+func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
    hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
@@ -114,14 +114,14 @@ func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf3
   %cst = arith.constant 0.0 : f32
   %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
-  %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_lhs>
-  %1 = iree_encoding.set_encoding %arg1 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_rhs>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding_rhs>
   %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #encoding_result>
   %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #encoding_result>)
       -> tensor<?x?xf32, #encoding_result>
   %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #encoding_lhs>, tensor<?x?xf32, #encoding_rhs>)
       outs(%3 : tensor<?x?xf32, #encoding_result>) -> tensor<?x?xf32, #encoding_result>
-  %5 = iree_encoding.unset_encoding %4 : tensor<?x?xf32, #encoding_result> -> tensor<?x?xf32>{%d0, %d1}
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding_result> -> tensor<?x?xf32>{%d0, %d1}
   return %5 : tensor<?x?xf32>
 }
 //   CHECK-DAG: #[[$MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
@@ -1552,13 +1552,13 @@ func.func @scaled_matmul_f4E2M1FN_f8E8M0FNU_f32(
 #map2_bitcast = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding_rhs_bitcast = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i16, ui4, i32], original_element_type = ui4, user_indexing_maps = [#map_bitcast, #map1_bitcast, #map2_bitcast], iteration_sizes = [?, ?, ?]>
 func.func @set_encoding_rhs_bitcast_ui4_to_i8(
-    %rhs: tensor<?x?xi8>
+    %rhs: tensor<?x?xi8>, %m: index, %n: index, %k: index
 ) -> tensor<?x?xi8, #encoding_rhs_bitcast> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   // The input has i8 storage type but encoding records ui4 as original type.
   // Shape: tensor<?x?xi8> where the K dimension is halved compared to ui4.
-  %encoded = iree_encoding.set_encoding %rhs : tensor<?x?xi8> -> tensor<?x?xi8, #encoding_rhs_bitcast>
+  %encoded = iree_encoding.set_encoding %rhs encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #encoding_rhs_bitcast>
   return %encoded : tensor<?x?xi8, #encoding_rhs_bitcast>
 }
 // For i16ui4i32 with avx512vnni, the normal RHS tile would be 32x8 (N=32, K=8).

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
@@ -7,7 +7,7 @@
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32768, 1280, ?]>
 module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
   hal.executable private @executable {
@@ -19,10 +19,13 @@ module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} 
       builtin.module {
         func.func @set_encoding() {
           %c0 = arith.constant 0 : index
+          %k_i32 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+          %k = arith.index_castui %k_i32 : i32 to index
+          %k_workload = iree_tensor_ext.dispatch.workload.ordinal %k, 0 : index
           %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32768x1280xi8>>
           %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32768x1280xi8, #encoding>>
           %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32768, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32768x1280xi8>> -> tensor<32768x1280xi8>
-          %3 = iree_encoding.set_encoding %2 : tensor<32768x1280xi8> -> tensor<32768x1280xi8, #encoding>
+          %3 = iree_encoding.set_encoding %2 encoding_dims{%k_workload} : tensor<32768x1280xi8> -> tensor<32768x1280xi8, #encoding>
           iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [32768, 1280], strides = [1, 1] : tensor<32768x1280xi8, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32768x1280xi8, #encoding>>
           return
         }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -395,6 +395,16 @@ EncodingAttr::cloneWithNewOperandIndexingMap(AffineMap newIndexingMap) {
 
 bool EncodingAttr::isSerialized() const { return false; }
 
+std::optional<int64_t> EncodingAttr::getNumDynamicEncodingDims() const {
+  ArrayAttr iterationSizes = getIterationSizes();
+  if (!iterationSizes) {
+    return 0;
+  }
+  return llvm::count_if(iterationSizes, [](Attribute attr) {
+    return ShapedType::isDynamic(cast<IntegerAttr>(attr).getInt());
+  });
+}
+
 Attribute EncodingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
   MLIRContext *ctx = getContext();
   return LayoutAttr::get(ctx, ArrayAttr::get(ctx, layouts));

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -115,6 +115,7 @@ def EncodingAttr :
         "isSerialized",
         "cloneWithLayouts",
         "convertForBitcast",
+        "getNumDynamicEncodingDims",
       ]>,
       DeclareAttrInterfaceMethods<IREEEncoding_ContractionEncodingAttrInterface, [
         "getReductionDims",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -258,6 +258,24 @@ def IREEEncoding_SerializableAttr :
         assert(false && "unimplemented interface method");
         return failure();
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the number of dynamic encoding dimensions expected for this
+        encoding. This is used to validate `encoding_dims` operands on
+        `set_encoding` and `unset_encoding` ops.
+        Only dynamic dimensions need to be carried as operands.
+        For example, a matmul encoding with iteration_sizes = [?, 128, 64]
+        has 1 dynamic encoding dim (the M dimension).
+        Returns std::nullopt if the number cannot be determined.
+      }],
+      /*retTy=*/"std::optional<int64_t>",
+      /*methodName=*/"getNumDynamicEncodingDims",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return std::nullopt;
+      }]
     >
   ];
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -164,10 +164,10 @@ func.func @set_encoding_ops_with_indexing_maps(%arg0: tensor<?x?xf32>) -> tensor
 #encoding = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map, #map], iteration_sizes = [1, 1, 1]>
 #encoding1 = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map, #map], iteration_sizes = [?, ?, ?]>
 #encoding2 = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map, #map], iteration_sizes = [?, 1, ?]>
-func.func @set_encoding_ops_with_iteration_sizes(%arg0: tensor<?x?xf32>) {
+func.func @set_encoding_ops_with_iteration_sizes(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) {
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-  %1 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding1>
-  %2 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding2>
+  %1 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding1>
+  %2 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding2>
   return
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -175,10 +175,13 @@ func.func @set_encoding_ops_with_iteration_sizes(%arg0: tensor<?x?xf32>) {
 //  CHECK-DAG: #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [?, ?, ?]>
 //  CHECK-DAG: #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [?, 1, ?]>
 //      CHECK:  func.func @set_encoding_ops_with_iteration_sizes(
-// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]:
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:      %[[M:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:      %[[N:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:      %[[K:[a-zA-Z0-9]+]]: index
 //      CHECK:    iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
-//      CHECK:    iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING1]]>
-//      CHECK:    iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING2]]>
+//      CHECK:    iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]} : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING1]]>
+//      CHECK:    iree_encoding.set_encoding %[[ARG0]] encoding_dims{%[[M]], %[[K]]} : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING2]]>
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
@@ -548,7 +548,7 @@ util.func public @dont_propagate_non_projected_permutation(%arg0: tensor<?x4096x
 #map_bubble2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map_bubble3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map_bubble4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-#encoding_bubble = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_bubble2, #map_bubble3, #map_bubble4]>
+#encoding_bubble = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_bubble2, #map_bubble3, #map_bubble4], iteration_sizes = [2, ?, ?, ?]>
 util.func public @bubble_through_dequant_with_encoding_dims(
     %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>,
     %m: index, %n: index, %k: index) -> tensor<2x11008x128xf32, #encoding_bubble> {
@@ -577,9 +577,9 @@ util.func public @bubble_through_dequant_with_encoding_dims(
 // CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-DAG:   #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 // CHECK-DAG:   #[[MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]>
-// CHECK-DAG:   #[[$ENCODING_IBMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP3]]], #[[MAP2]]]>
-// CHECK-DAG:   #[[$ENCODING_BMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP4]]], #[[MAP2]]]>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], iteration_sizes = [2, ?, ?, ?]>
+// CHECK-DAG:   #[[$ENCODING_IBMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP3]]], #[[MAP2]]], iteration_sizes = [2, ?, ?, ?]>
+// CHECK-DAG:   #[[$ENCODING_BMAP:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], [#[[MAP1]], #[[MAP4]]], #[[MAP2]]], iteration_sizes = [2, ?, ?, ?]>
 // CHECK-LABEL: @bubble_through_dequant_with_encoding_dims
 // CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>,
 // CHECK-SAME:    %[[ARG1:.+]]: tensor<2x11008xf32>, %[[ARG2:.+]]: tensor<2x11008xf32>,
@@ -606,7 +606,7 @@ util.func public @bubble_through_dequant_with_encoding_dims(
 #map_remat2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map_remat3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map_remat4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-#encoding_remat = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_remat2, #map_remat3, #map_remat4]>
+#encoding_remat = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_remat2, #map_remat3, #map_remat4], iteration_sizes = [2, ?, ?, ?]>
 util.func public @bubble_with_rematerialized_encoding_dims(
     %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>) -> tensor<2x11008x128xf32, #encoding_remat> {
   %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding_remat>) {
@@ -667,7 +667,7 @@ util.func public @bubble_with_rematerialized_encoding_dims(
 #map_dom2 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map_dom3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map_dom4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-#encoding_dom = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_dom2, #map_dom3, #map_dom4]>
+#encoding_dom = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_dom2, #map_dom3, #map_dom4], iteration_sizes = [2, ?, ?, ?]>
 util.func public @bubble_with_recursive_rematerialization(
     %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>,
     %dominating: tensor<?x?xf32>) -> tensor<2x11008x128xf32, #encoding_dom> {
@@ -749,7 +749,7 @@ module {
         %10 = arith.addf %9, %out : f32
         linalg.yield %10 : f32
       } -> tensor<2x4096x64xf32, #result_encoding_affine>
-      %unset = iree_encoding.unset_encoding %matmul : tensor<2x4096x64xf32, #result_encoding_affine> -> tensor<2x4096x64xf32>
+      %unset = iree_encoding.unset_encoding %matmul encoding_dims{%m} : tensor<2x4096x64xf32, #result_encoding_affine> -> tensor<2x4096x64xf32>
       flow.return %unset : tensor<2x4096x64xf32>
     }
     util.return %result : tensor<2x4096x64xf32>


### PR DESCRIPTION
Only review the second commit, the first commit fixes an issue and is raised in this PR: https://github.com/iree-org/iree/pull/23265

This PR adds verification that the number of `encoding_dims` operands provided to `set_encoding` and `unset_encoding` operations matches the number of dynamic expected dimensions by the encoding and updates the tests accordingly.

Assisted-by: Claude