### PR TITLE
[Util] Fix LiftCFGtoSCF pass for empty functions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/LiftCFGToSCF.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/LiftCFGToSCF.cpp
@@ -219,7 +219,7 @@ struct LiftCFGToSCFPass final : impl::LiftCFGToSCFPassBase<LiftCFGToSCFPass> {
     for (auto callableOp : moduleOp.getOps<mlir::CallableOpInterface>()) {
       // Skip if the region is empty (usually a declaration/extern).
       Region *region = callableOp.getCallableRegion();
-      if (region->empty()) {
+      if (!region || region->empty()) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/lift_cfg_to_scf.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/lift_cfg_to_scf.mlir
@@ -880,3 +880,11 @@ util.func public @multi_entry_loop(%cond: i1) {
 // CHECK: }
 // CHECK: util.call @process(%{{.*}}#1)
 // CHECK: util.return
+
+// -----
+
+// Test that the pass doesn't break on empty (i.e., no region) functions as
+// previously reported in https://github.com/iree-org/iree/issues/22971.
+
+// CHECK-LABEL: flow.func private @empty_function
+flow.func private @empty_function()


### PR DESCRIPTION
Fixes the pass to avoid null pointer dereference when processing an empty function, i.e., a function without a region.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22971.