### PR TITLE
[StreamToHal] Use rewriter to create block

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -1399,11 +1399,11 @@ struct CmdExecuteOpPattern
       auto memoizeOp = IREE::HAL::DeviceMemoizeOp::create(
           rewriter, loc, rewriter.getType<IREE::HAL::CommandBufferType>(),
           device, queueAffinity);
-      auto ip = rewriter.saveInsertionPoint();
-      rewriter.setInsertionPointToStart(&memoizeOp.getBody().emplaceBlock());
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(
+          rewriter.createBlock(&memoizeOp.getBody()));
       IREE::HAL::ReturnOp::create(
           rewriter, loc, recordCommandBuffer(device, queueAffinity, rewriter));
-      rewriter.restoreInsertionPoint(ip);
       commandBuffer = memoizeOp.getResult(0);
     } else {
       commandBuffer = recordCommandBuffer(device, queueAffinity, rewriter);


### PR DESCRIPTION
In the lowering for `CmdExecuteOp`, use the rewriter to create blocks to avoid memory leak in case the conversion fails and IR modifications needs to be rolled back.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22972.