### PR TITLE
[Flow][NFC] Use region verifier for `flow.executable.export`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1199,7 +1199,7 @@ void ExecutableExportOp::build(OpBuilder &builder, OperationState &state,
         builder.getStringAttr(sym_name), function_ref);
 }
 
-LogicalResult ExecutableExportOp::verify() {
+LogicalResult ExecutableExportOp::verifyRegions() {
   // Workgroup count region is optional.
   if (!getWorkgroupCount().empty()) {
     // Verify the return ops all provide XYZ values.

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -513,7 +513,7 @@ def FLOW_ExecutableExportOp : FLOW_Op<"executable.export", [
       "FlatSymbolRefAttr":$function_ref)>,
   ];
 
-  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 }
 
 } // OpGroupExecutableOps


### PR DESCRIPTION
Noticed during work on https://github.com/iree-org/iree/pull/23262 that the `flow.executable.export` verifier verifies the contents of its region in the regular verifier. However, to ensure that nested operations have been correctly constructed, verification of nested operations should only happen in the region verifier. This moves the verification to the region verifier.