### PR TITLE
Integrate LLVM@7a10fc8d542

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
@@ -241,7 +241,7 @@ struct ShardAllGatherToFlow
   LogicalResult matchAndRewrite(shard::AllGatherOp op,
                                 PatternRewriter &rewriter) const override {
     if (!cast<RankedTensorType>(op.getOperand().getType()).hasStaticShape() ||
-        !op.getResult().getType().hasStaticShape()) {
+        !cast<ShapedType>(op.getResult().getType()).hasStaticShape()) {
       // TODO: add dynamic support.
       return rewriter.notifyMatchFailure(op->getLoc(),
                                          "Dynamic tensor case is unsupported.");
@@ -260,9 +260,9 @@ struct ShardAllGatherToFlow
 
     RankedTensorType flowAllGatherResultType = transpose(
         cast<RankedTensorType>(op.getResult().getType()), 0, gatherAxis);
-    Value target =
-        tensor::EmptyOp::create(builder, flowAllGatherResultType.getShape(),
-                                op.getResult().getType().getElementType());
+    Value target = tensor::EmptyOp::create(
+        builder, flowAllGatherResultType.getShape(),
+        cast<ShapedType>(op.getResult().getType()).getElementType());
     auto flowAllGather = IREE::Flow::CollectiveAllGatherOp::create(
         builder, getCollectiveElementTypeAttr(flowAllGatherResultType), target,
         flowAllGatherOperand, channel);


### PR DESCRIPTION
Reverts carried forward:
* Local revert of https://github.com/llvm/llvm-project/pull/169614 due to https://github.com/iree-org/iree/issues/22649

Other changes:
* cast shard.all_gather result type to `ShapedType` due to its result changing types to be `AnyTypeOf<[AnyMemRef, AnyRankedTensor]>` in https://github.com/llvm/llvm-project/pull/177202
