### PR TITLE
[Encoding] Fix encoding dims propagation in SinkUnsetEncodingOp

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -251,6 +251,9 @@ struct SinkUnsetEncodingOp
                                          "not able to determine propagation "
                                          "attributes for operands and results");
     }
+    // Carry the encoding dims from the original unset_encoding op.
+    propagationEncodings->encodingDims =
+        llvm::to_vector(encodingOp.getEncodingDims());
     auto propagationResult =
         dyn_cast<IREE::Encoding::EncodingPropagationOpInterface>(consumer);
     if (!propagationResult) {


### PR DESCRIPTION
Fixes a bug discovered by introducing the encoding dims verification in https://github.com/iree-org/iree/pull/23245