### PR TITLE
[GPU] Don't swap expand with slice in the same block

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -190,8 +190,10 @@ void populateIREEResolveExtractStridedMetadataPatterns(
 void populateReplaceSlowMinMaxOpsPatterns(RewritePatternSet &patterns);
 
 /// Populate pattern to convert `tensor.extract_slice(tensor.expand_shape)` to
-/// `tensor.expand_shape(tensor.extract_slice)`.
-void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns);
+/// `tensor.expand_shape(tensor.extract_slice)`. The optional `controlFn` can be
+/// used to restrict when the pattern applies.
+void populateSwapExtractWithExpandPattern(
+    RewritePatternSet &patterns, linalg::ControlFusionFn controlFn = nullptr);
 
 /// Populate pattern to fold `tensor.extract_slice(linalg.broadcast)` into the
 /// broadcast input when the extract_slice undoes the broadcast.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -154,7 +154,7 @@ hal.executable private @main {
 //      CHECK-DAG:       vector.transfer_read {{.*}} vector<4xf16>
 //      CHECK-DAG:       vector.transfer_read {{.*}} vector<4xf16>
 // CHECK-COUNT-1:       amdgpu.mfma 16x16x16
-//          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x1x4x1xf32> to vector<4xf32>
+//          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]]
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
 //          CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>


### PR DESCRIPTION
Prevents swapping tensor.extract_slice ops with tensor.expand_shape ops when they are in the same block during GPUFuseAndHoistParallelLoops. This pattern is intended to be a tiling fusion pattern for tensor.expand_shape operations, which always begin with the ops in different blocks. When the ops are in the same block, this does not open up more fusions, and instead moves the extract_slice further compute ops that produce loads. This can block later optimizations that fold the slice into loading operations like vector.transfer_read.

This restriction is done through a control function to maintain the ability to swap same-block slice + expand ops, in case it is needed for other use cases.

ci-extra: test_torch