### PR TITLE
[DO NOT REVIEW] Generalize mlir ukernel with python preprocessing

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
@@ -62,7 +62,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_medium.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
-     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=4 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_large_f16.mlir
 ```
@@ -71,7 +71,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
-     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=8 \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_medium_f16_expanded.mlir
 ```
@@ -80,7 +80,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=bf16 INTRINSIC=MFMA_F32_16x16x16_BF16 \
-     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=4 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_large_bf16.mlir
 ```
@@ -89,7 +89,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=bf16 INTRINSIC=MFMA_F32_16x16x16_BF16 \
-     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=8 \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_medium_bf16_expanded.mlir
 ```
@@ -98,7 +98,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
-     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=16 \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_medium_f8E4M3FNUZ_expanded.mlir
 ```
@@ -107,7 +107,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
-     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=8 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_large_f8E4M3FNUZ_expanded.mlir
 ```
@@ -116,7 +116,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
-     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=16 \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_medium_f8E4M3FN_expanded.mlir
 ```
@@ -125,7 +125,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
-     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=8 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
   -o pingpong_large_f8E4M3FN_expanded.mlir
 ```

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
@@ -22,7 +22,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
-     INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx942 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
      SIZE_MIN_0=64 SIZE_MIN_1=2048 SIZE_MAX_1=8192 \
   -o iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_large.mlir
 ```
@@ -40,7 +40,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_medium.mlir.in \
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
-     INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx950 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx950 \
      SIZE_MIN_0=64 SIZE_MIN_1=2048 SIZE_MAX_1=8192 \
   -o iree_uk_amdgpu_dt_matmul_f8E4M3FN_large.mlir
 ```

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
@@ -5,8 +5,9 @@
 ### `pingpong_dt_medium_f4E2M1FN`
 ```bash
 python mlir_ukernel_gen.py iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in \
-  -D INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=2 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx950 \
-  -o iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir
+  -D INTRINSIC=MFMA_SCALE_F32_16x16x128_B32 \
+     INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=2 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx950 \
+  -o generated/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir
 ```
 
 ### `pingpong_dt_large_f16`
@@ -15,7 +16,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
   -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
      SIZE_MIN_0=512 SIZE_DIV_0=64 SIZE_MIN_1=32832 SIZE_DIV_1=64 SIZE_MIN_2=512 SIZE_DIV_2=64 \
-  -o iree_uk_amdgpu_dt_matmul_f16.mlir
+  -o generated/iree_uk_amdgpu_dt_matmul_f16.mlir
 ```
 
 ### `pingpong_dt_large_f8E4M3FNUZ`
@@ -24,7 +25,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
      SIZE_MIN_0=64 SIZE_MIN_1=2048 SIZE_MAX_1=8192 \
-  -o iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_large.mlir
+  -o generated/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_large.mlir
 ```
 
 ### `pingpong_dt_medium_f8E4M3FNUZ`
@@ -33,7 +34,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_medium.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
      INTRINSICS_M=8 INTRINSICS_N=2 INTRINSICS_K=2 SUBGROUPS_M=1 SUBGROUPS_N=8 ARCH=gfx942 \
      SIZE_MIN_0=32 \
-  -o iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_medium.mlir
+  -o generated/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_medium.mlir
 ```
 
 ### `pingpong_dt_large_f8E4M3FN`
@@ -42,7 +43,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx950 \
      SIZE_MIN_0=64 SIZE_MIN_1=2048 SIZE_MAX_1=8192 \
-  -o iree_uk_amdgpu_dt_matmul_f8E4M3FN_large.mlir
+  -o generated/iree_uk_amdgpu_dt_matmul_f8E4M3FN_large.mlir
 ```
 
 ### `pingpong_dt_medium_f8E4M3FN`
@@ -51,7 +52,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_medium.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
      INTRINSICS_M=8 INTRINSICS_N=2 INTRINSICS_K=2 SUBGROUPS_M=1 SUBGROUPS_N=8 ARCH=gfx950 \
      SIZE_MIN_0=32 \
-  -o iree_uk_amdgpu_dt_matmul_f8E4M3FN_medium.mlir
+  -o generated/iree_uk_amdgpu_dt_matmul_f8E4M3FN_medium.mlir
 ```
 
 ---
@@ -64,7 +65,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_large_f16.mlir
+  -o generated/pingpong_large_f16.mlir
 ```
 
 ### `pingpong_medium_f16_expanded`
@@ -73,7 +74,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
      INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_medium_f16_expanded.mlir
+  -o generated/pingpong_medium_f16_expanded.mlir
 ```
 
 ### `pingpong_large_bf16`
@@ -82,7 +83,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=bf16 INTRINSIC=MFMA_F32_16x16x16_BF16 \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_large_bf16.mlir
+  -o generated/pingpong_large_bf16.mlir
 ```
 
 ### `pingpong_medium_bf16_expanded`
@@ -91,7 +92,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=bf16 INTRINSIC=MFMA_F32_16x16x16_BF16 \
      INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_medium_bf16_expanded.mlir
+  -o generated/pingpong_medium_bf16_expanded.mlir
 ```
 
 ### `pingpong_medium_f8E4M3FNUZ_expanded`
@@ -100,7 +101,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
      INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_medium_f8E4M3FNUZ_expanded.mlir
+  -o generated/pingpong_medium_f8E4M3FNUZ_expanded.mlir
 ```
 
 ### `pingpong_large_f8E4M3FNUZ_expanded`
@@ -109,7 +110,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_large_f8E4M3FNUZ_expanded.mlir
+  -o generated/pingpong_large_f8E4M3FNUZ_expanded.mlir
 ```
 
 ### `pingpong_medium_f8E4M3FN_expanded`
@@ -118,7 +119,7 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
      INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=2 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_medium_f8E4M3FN_expanded.mlir
+  -o generated/pingpong_medium_f8E4M3FN_expanded.mlir
 ```
 
 ### `pingpong_large_f8E4M3FN_expanded`
@@ -127,5 +128,5 @@ python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
   -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
      INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 \
      SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
-  -o pingpong_large_f8E4M3FN_expanded.mlir
+  -o generated/pingpong_large_f8E4M3FN_expanded.mlir
 ```

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/TEMPLATE_GUIDE.md
@@ -1,0 +1,131 @@
+# MLIR Microkernel Template Guide
+
+## Data-Tiled Kernels
+
+### `pingpong_dt_medium_f4E2M1FN`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in \
+  -D INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=2 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx950 \
+  -o iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir
+```
+
+### `pingpong_dt_large_f16`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
+  -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+     SIZE_MIN_0=512 SIZE_DIV_0=64 SIZE_MIN_1=32832 SIZE_DIV_1=64 SIZE_MIN_2=512 SIZE_DIV_2=64 \
+  -o iree_uk_amdgpu_dt_matmul_f16.mlir
+```
+
+### `pingpong_dt_large_f8E4M3FNUZ`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
+  -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
+     INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx942 \
+     SIZE_MIN_0=64 SIZE_MIN_1=2048 SIZE_MAX_1=8192 \
+  -o iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_large.mlir
+```
+
+### `pingpong_dt_medium_f8E4M3FNUZ`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_medium.mlir.in \
+  -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
+     INTRINSICS_M=8 INTRINSICS_N=2 INTRINSICS_K=2 SUBGROUPS_M=1 SUBGROUPS_N=8 ARCH=gfx942 \
+     SIZE_MIN_0=32 \
+  -o iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ_medium.mlir
+```
+
+### `pingpong_dt_large_f8E4M3FN`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_large.mlir.in \
+  -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
+     INTRINSICS_M=4 INTRINSICS_N=8 INTRINSICS_K=1 SUBGROUPS_M=2 SUBGROUPS_N=2 ARCH=gfx950 \
+     SIZE_MIN_0=64 SIZE_MIN_1=2048 SIZE_MAX_1=8192 \
+  -o iree_uk_amdgpu_dt_matmul_f8E4M3FN_large.mlir
+```
+
+### `pingpong_dt_medium_f8E4M3FN`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_dt_matmul_medium.mlir.in \
+  -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
+     INTRINSICS_M=8 INTRINSICS_N=2 INTRINSICS_K=2 SUBGROUPS_M=1 SUBGROUPS_N=8 ARCH=gfx950 \
+     SIZE_MIN_0=32 \
+  -o iree_uk_amdgpu_dt_matmul_f8E4M3FN_medium.mlir
+```
+
+---
+
+## Non-Data-Tiled Kernels
+
+### `pingpong_large_f16`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
+  -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=4 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_large_f16.mlir
+```
+
+### `pingpong_medium_f16_expanded`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
+  -D ELEM_TYPE=f16 INTRINSIC=MFMA_F32_16x16x16_F16 \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=8 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_medium_f16_expanded.mlir
+```
+
+### `pingpong_large_bf16`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
+  -D ELEM_TYPE=bf16 INTRINSIC=MFMA_F32_16x16x16_BF16 \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=4 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_large_bf16.mlir
+```
+
+### `pingpong_medium_bf16_expanded`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
+  -D ELEM_TYPE=bf16 INTRINSIC=MFMA_F32_16x16x16_BF16 \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=8 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_medium_bf16_expanded.mlir
+```
+
+### `pingpong_medium_f8E4M3FNUZ_expanded`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
+  -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=16 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_medium_f8E4M3FNUZ_expanded.mlir
+```
+
+### `pingpong_large_f8E4M3FNUZ_expanded`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
+  -D ELEM_TYPE=f8E4M3FNUZ INTRINSIC=MFMA_F32_16x16x32_F8E4M3FNUZ \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=8 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_large_f8E4M3FNUZ_expanded.mlir
+```
+
+### `pingpong_medium_f8E4M3FN_expanded`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_medium.mlir.in \
+  -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
+     INTRINSICS_M=4 INTRINSICS_N=4 INTRINSICS_K=16 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_medium_f8E4M3FN_expanded.mlir
+```
+
+### `pingpong_large_f8E4M3FN_expanded`
+```bash
+python mlir_ukernel_gen.py iree_uk_amdgpu_matmul_large.mlir.in \
+  -D ELEM_TYPE=f8E4M3FN INTRINSIC=MFMA_F32_16x16x32_F8E4M3FN \
+     INTRINSICS_M=8 INTRINSICS_N=4 INTRINSICS_K=8 \
+     SUBGROUPS_M=2 SUBGROUPS_N=4 ARCH=gfx942 \
+  -o pingpong_large_f8E4M3FN_expanded.mlir
+```

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
@@ -1,0 +1,306 @@
+//  RUN: iree-opt %s
+// Template for large data-tiled matmul kernels
+
+!acc_base_ty = tensor<1x1x${SUBGROUPS_M}x${SUBGROUPS_N}x${INTRINSICS_M}x${INTRINSICS_N}x4x16x4xf32>
+!lhs_base_ty = tensor<1x?x${SUBGROUPS_M}x${INTRINSICS_M}x4x16x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x4x2x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!rhs_base_ty = tensor<1x?x${SUBGROUPS_N}x${INTRINSICS_N}x4x16x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!lhs_in_ty = tensor<?x4x${SUBGROUPS_M * INTRINSICS_M}x32x${128 // ELEM_BITS}x${ELEM_TYPE}>
+!rhs_in_ty = tensor<?x4x${SUBGROUPS_N * INTRINSICS_N}x32x${128 // ELEM_BITS}x${ELEM_TYPE}>
+!lhs_shared_ty = memref<4x${SUBGROUPS_M * INTRINSICS_M}x64x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<4x${SUBGROUPS_N * INTRINSICS_N}x64x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      archs = ["${ARCH}"],
+      types = [${ELEM_TYPE}, ${ELEM_TYPE}, f32],
+      iteration_sizes_constraints = [
+        #rocm.ukernel_interation_size_constraint<
+          index = 0,
+          size_min = ${SIZE_MIN_0},
+          size_max = ${SIZE_MAX_0},
+          size_div = ${SIZE_DIV_0}
+        >,
+        #rocm.ukernel_interation_size_constraint<
+          index = 1,
+          size_min = ${SIZE_MIN_1},
+          size_max = ${SIZE_MAX_1},
+          size_div = ${SIZE_DIV_1}
+        >,
+        #rocm.ukernel_interation_size_constraint<
+          index = 2,
+          size_min = ${SIZE_MIN_2},
+          size_max = ${SIZE_MAX_2},
+          size_div = ${SIZE_DIV_2}
+        >
+      ]
+    },
+    benefit = ${BENEFIT},
+    mma = #iree_gpu.data_tiled_mma_layout<
+      intrinsic = ${INTRINSIC},
+      intrinsics_m = ${INTRINSICS_M},
+      subgroups_m = ${SUBGROUPS_M},
+      intrinsics_n = ${INTRINSICS_N},
+      subgroups_n = ${SUBGROUPS_N},
+      intrinsics_k = ${INTRINSICS_K}
+    >
+  >
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.0 : ${ELEM_TYPE}
+
+  %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
+  %nDim = arith.divui %dim, %c4 : index
+
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6, 7, 8], [9]] output_shape [1, %nDim, 4, ${SUBGROUPS_M}, ${INTRINSICS_M}, 4, 4, 2, 2, ${64 // ELEM_BITS}] : !lhs_base_ty into !lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8]] output_shape [1, %nDim, 4, ${SUBGROUPS_N}, ${INTRINSICS_N}, 4, 8, 2, ${64 // ELEM_BITS}] : !rhs_base_ty into !rhs_expand_ty
+
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6, 7], [8, 9]] : !lhs_expand_ty into !lhs_in_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !rhs_expand_ty into !rhs_in_ty
+
+  %lhs_shared = memref.alloc() : !lhs_shared_ty
+  %rhs_shared = memref.alloc() : !rhs_shared_ty
+
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_local_t = vector.shape_cast %rhs_vec_local : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  gpu.barrier
+
+  %0 = tensor.empty() : !acc_base_ty
+  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !acc_base_ty {
+    %ids:3 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 64) : index, index, index
+    %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
+
+    %m_outer = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
+    %n_outer = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
+
+    %glb:2 = affine.delinearize_index %id into (16, 32) : index, index
+    %glb_inner = arith.muli %glb#1, %c2 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+    %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+      // Global loads of lhs.
+      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_0_t = vector.shape_cast %lhs_vec_local_0 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_1_t = vector.shape_cast %lhs_vec_local_1 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_2 = tensor.extract_slice %lhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_2_t = vector.shape_cast %lhs_vec_local_2 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_3 = tensor.extract_slice %lhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_3_t = vector.shape_cast %lhs_vec_local_3 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_0_t = vector.shape_cast %rhs_vec_local_0 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_1_t = vector.shape_cast %rhs_vec_local_1 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_2_t = vector.shape_cast %rhs_vec_local_2 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_3_t = vector.shape_cast %rhs_vec_local_3 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local stores of lhs and rhs.
+      vector.transfer_write %rhs_vec_local_0_t, %rhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_1_t, %rhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_2_t, %rhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_3_t, %rhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+
+      vector.transfer_write %lhs_vec_local_0_t, %lhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_1_t, %lhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_2_t, %lhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_3_t, %lhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot3 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %empty = tensor.empty() : tensor<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+    %cast = vector.shape_cast %dot3 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+    %4 = vector.transfer_write %cast, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true, true, true, true, true, true]} : vector<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>, tensor<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%c0, %c0, %ids#0, %ids#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, 1, ${INTRINSICS_M}, ${INTRINSICS_N}, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32> into !acc_base_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !acc_base_ty
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
@@ -1,15 +1,15 @@
 //  RUN: iree-opt %s
 // Template for large data-tiled matmul kernels
 
-!acc_base_ty = tensor<1x1x${SUBGROUPS_M}x${SUBGROUPS_N}x${INTRINSICS_M}x${INTRINSICS_N}x4x16x4xf32>
-!lhs_base_ty = tensor<1x?x${SUBGROUPS_M}x${INTRINSICS_M}x4x16x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x4x2x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!rhs_base_ty = tensor<1x?x${SUBGROUPS_N}x${INTRINSICS_N}x4x16x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!lhs_in_ty = tensor<?x4x${SUBGROUPS_M * INTRINSICS_M}x32x${128 // ELEM_BITS}x${ELEM_TYPE}>
-!rhs_in_ty = tensor<?x4x${SUBGROUPS_N * INTRINSICS_N}x32x${128 // ELEM_BITS}x${ELEM_TYPE}>
-!lhs_shared_ty = memref<4x${SUBGROUPS_M * INTRINSICS_M}x64x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared_ty = memref<4x${SUBGROUPS_N * INTRINSICS_N}x64x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!acc_base_ty = tensor<1x1x${fold1(SUBGROUPS_M)}${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_M)}${fold1(INTRINSICS_N)}4x16x4xf32>
+!lhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_M)}${fold1(INTRINSICS_M)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!rhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_N)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x4x2x2x${INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
+!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
+!lhs_in_ty = tensor<?x4x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
+!rhs_in_ty = tensor<?x4x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
+!lhs_shared_ty = memref<4x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS}x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<4x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS}x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -63,8 +63,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
   %c16 = arith.constant 16 : index
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
-  %c128 = arith.constant 128 : index
-  %c256 = arith.constant 256 : index
+  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
 
   %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
@@ -79,16 +78,16 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
   %lhs_shared = memref.alloc() : !lhs_shared_ty
   %rhs_shared = memref.alloc() : !rhs_shared_ty
 
-  scf.forall (%id) in (2048) {
-    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+  scf.forall (%id) in (${2 * SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:3 = affine.delinearize_index %id into (4, ${SUBGROUPS_M * INTRINSICS_M}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
     %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
     %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
     vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (2048) {
-    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+  scf.forall (%id) in (${2 * SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:3 = affine.delinearize_index %id into (4, ${SUBGROUPS_N * INTRINSICS_N}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
     %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
     %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
@@ -99,7 +98,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
   gpu.barrier
 
   %0 = tensor.empty() : !acc_base_ty
-  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !acc_base_ty {
+  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> !acc_base_ty {
     %ids:3 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 64) : index, index, index
     %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
 
@@ -111,8 +110,8 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c256 : index
-    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
@@ -134,8 +133,8 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       // Local loads of lhs and rhs.
       %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -146,7 +145,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -169,8 +168,8 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       // Local loads of lhs and rhs.
       %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -181,7 +180,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -190,13 +189,13 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       // Local loads of lhs and rhs.
       %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -207,7 +206,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } :vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -233,7 +232,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -248,51 +247,51 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
     // Epilogue
     %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %empty = tensor.empty() : tensor<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
     %cast = vector.shape_cast %dot3 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
@@ -1,15 +1,22 @@
-//  RUN: iree-opt %s
-// Template for large data-tiled matmul kernels
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!acc_base_ty = tensor<1x1x${fold1(SUBGROUPS_M)}${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_M)}${fold1(INTRINSICS_N)}4x16x4xf32>
-!lhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_M)}${fold1(INTRINSICS_M)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
-!rhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_N)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
-!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x4x2x2x${INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
-!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
-!lhs_in_ty = tensor<?x4x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
-!rhs_in_ty = tensor<?x4x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
-!lhs_shared_ty = memref<4x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS}x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared_ty = memref<4x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS}x${64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+//  RUN: iree-opt %s
+// AUTO-GENERATED - DO NOT EDIT
+// Generated from iree_uk_amdgpu_dt_matmul_large.mlir.in
+
+!acc_base_ty = tensor<1x1x${FOLD1(SUBGROUPS_M)}${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_N)}4x16x4xf32>
+!lhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!rhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x4x2x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!lhs_in_ty = tensor<?x4x${SUBGROUPS_M*INTRINSICS_M}x32x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!rhs_in_ty = tensor<?x4x${SUBGROUPS_N*INTRINSICS_N}x32x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!lhs_shared_ty = memref<4x${SUBGROUPS_M*INTRINSICS_M}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<4x${SUBGROUPS_N*INTRINSICS_N}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -63,14 +70,14 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
   %c16 = arith.constant 16 : index
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
-  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+  %c256 = arith.constant 256 : index
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
 
   %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
   %nDim = arith.divui %dim, %c4 : index
 
-  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6, 7, 8], [9]] output_shape [1, %nDim, 4, ${SUBGROUPS_M}, ${INTRINSICS_M}, 4, 4, 2, 2, ${64 // ELEM_BITS}] : !lhs_base_ty into !lhs_expand_ty
-  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8]] output_shape [1, %nDim, 4, ${SUBGROUPS_N}, ${INTRINSICS_N}, 4, 8, 2, ${64 // ELEM_BITS}] : !rhs_base_ty into !rhs_expand_ty
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6, 7, 8], [9]] output_shape [1, %nDim, 4, ${SUBGROUPS_M}, ${INTRINSICS_M}, 4, 4, 2, 2, ${INTRINSICS_K*INTERNAL_K}] : !lhs_base_ty into !lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8]] output_shape [1, %nDim, 4, ${SUBGROUPS_N}, ${INTRINSICS_N}, 4, 8, 2, ${INTRINSICS_K*INTERNAL_K}] : !rhs_base_ty into !rhs_expand_ty
 
   %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6, 7], [8, 9]] : !lhs_expand_ty into !lhs_in_ty
   %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !rhs_expand_ty into !rhs_in_ty
@@ -78,63 +85,74 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
   %lhs_shared = memref.alloc() : !lhs_shared_ty
   %rhs_shared = memref.alloc() : !rhs_shared_ty
 
-  scf.forall (%id) in (${2 * SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:3 = affine.delinearize_index %id into (4, ${SUBGROUPS_M * INTRINSICS_M}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
+  scf.forall (%id) in (${128*SUBGROUPS_M*INTRINSICS_M}) {
+    %delin:3 = affine.delinearize_index %id into (4, ${SUBGROUPS_M*INTRINSICS_M}, 32) : index, index, index
     %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
-    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+    $assert (2*INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (${2 * SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:3 = affine.delinearize_index %id into (4, ${SUBGROUPS_N * INTRINSICS_N}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
+  scf.forall (%id) in (${128*SUBGROUPS_N*INTRINSICS_N}) {
+    %delin:3 = affine.delinearize_index %id into (4, ${SUBGROUPS_N*INTRINSICS_N}, 32) : index, index, index
     %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
-    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_local_t = vector.shape_cast %rhs_vec_local : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+    $assert (2*INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_local_t = vector.shape_cast %rhs_vec_local : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
   gpu.barrier
 
   %0 = tensor.empty() : !acc_base_ty
-  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> !acc_base_ty {
+  $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
+  %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> !acc_base_ty {
     %ids:3 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 64) : index, index, index
     %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
 
     %m_outer = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
     %n_outer = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
 
-    %glb:2 = affine.delinearize_index %id into (16, 32) : index, index
+    %glb:2 = affine.delinearize_index %id into (${2*SUBGROUPS_M*SUBGROUPS_N}, 32) : index, index
+    %glb0_lhs = arith.muli %glb#0, %c${SUBGROUPS_M*INTRINSICS_M//2//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %glb0_rhs = arith.muli %glb#0, %c${SUBGROUPS_N*INTRINSICS_N//2//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_M*INTRINSICS_M//2//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_lhs = arith.addi %glb${j-1}_lhs, %c1 overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_N*INTRINSICS_N//2//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_rhs = arith.addi %glb${j-1}_rhs, %c1 overflow<nsw, nuw> : index
     %glb_inner = arith.muli %glb#1, %c2 overflow<nsw, nuw> : index
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
-    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
     %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
       // Global loads of lhs.
-      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_0_t = vector.shape_cast %lhs_vec_local_0 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_1_t = vector.shape_cast %lhs_vec_local_1 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_2 = tensor.extract_slice %lhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_2_t = vector.shape_cast %lhs_vec_local_2 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_3 = tensor.extract_slice %lhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_3_t = vector.shape_cast %lhs_vec_local_3 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      $assert (2*INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+      $for j in range(SUBGROUPS_M*INTRINSICS_M//2//SUBGROUPS_M//SUBGROUPS_N):
+        %lhs_thread_${4*j} = tensor.extract_slice %lhs [%i, %c0, %glb${j}_lhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j} = vector.transfer_read %lhs_thread_${4*j} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j}_t = vector.shape_cast %lhs_vec_local_${4*j} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_thread_${4*j+1} = tensor.extract_slice %lhs [%i, %c1, %glb${j}_lhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j+1} = vector.transfer_read %lhs_thread_${4*j+1} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j+1}_t = vector.shape_cast %lhs_vec_local_${4*j+1} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_thread_${4*j+2} = tensor.extract_slice %lhs [%i, %c2, %glb${j}_lhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j+2} = vector.transfer_read %lhs_thread_${4*j+2} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j+2}_t = vector.shape_cast %lhs_vec_local_${4*j+2} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_thread_${4*j+3} = tensor.extract_slice %lhs [%i, %c3, %glb${j}_lhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j+3} = vector.transfer_read %lhs_thread_${4*j+3} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${4*j+3}_t = vector.shape_cast %lhs_vec_local_${4*j+3} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       // Local loads of lhs and rhs.
-      %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -152,24 +170,26 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
-      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_0_t = vector.shape_cast %rhs_vec_local_0 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_1_t = vector.shape_cast %rhs_vec_local_1 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_2_t = vector.shape_cast %rhs_vec_local_2 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_3_t = vector.shape_cast %rhs_vec_local_3 : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      $assert (2*INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+      $for j in range(SUBGROUPS_N*INTRINSICS_N//2//SUBGROUPS_M//SUBGROUPS_N):
+        %rhs_thread_${4*j} = tensor.extract_slice %rhs [%i, %c0, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j} = vector.transfer_read %rhs_thread_${4*j} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j}_t = vector.shape_cast %rhs_vec_local_${4*j} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_thread_${4*j+1} = tensor.extract_slice %rhs [%i, %c1, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j+1} = vector.transfer_read %rhs_thread_${4*j+1} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j+1}_t = vector.shape_cast %rhs_vec_local_${4*j+1} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_thread_${4*j+2} = tensor.extract_slice %rhs [%i, %c2, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j+2} = vector.transfer_read %rhs_thread_${4*j+2} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j+2}_t = vector.shape_cast %rhs_vec_local_${4*j+2} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_thread_${4*j+3} = tensor.extract_slice %rhs [%i, %c3, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j+3} = vector.transfer_read %rhs_thread_${4*j+3} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${4*j+3}_t = vector.shape_cast %rhs_vec_local_${4*j+3} : vector<1x1x1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       // Local loads of lhs and rhs.
-      %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -187,15 +207,15 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       rocdl.sched.barrier 0
 
       // Local loads of lhs and rhs.
-      %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -213,15 +233,17 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       rocdl.sched.barrier 0
 
       // Local stores of lhs and rhs.
-      vector.transfer_write %rhs_vec_local_0_t, %rhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
-      vector.transfer_write %rhs_vec_local_1_t, %rhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
-      vector.transfer_write %rhs_vec_local_2_t, %rhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
-      vector.transfer_write %rhs_vec_local_3_t, %rhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared_ty
+      $for j in range(SUBGROUPS_N*INTRINSICS_N//2//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %rhs_vec_local_${4*j}_t, %rhs_shared [%c0, %glb${j}_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared_ty
+        vector.transfer_write %rhs_vec_local_${4*j+1}_t, %rhs_shared [%c1, %glb${j}_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared_ty
+        vector.transfer_write %rhs_vec_local_${4*j+2}_t, %rhs_shared [%c2, %glb${j}_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared_ty
+        vector.transfer_write %rhs_vec_local_${4*j+3}_t, %rhs_shared [%c3, %glb${j}_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared_ty
 
-      vector.transfer_write %lhs_vec_local_0_t, %lhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
-      vector.transfer_write %lhs_vec_local_1_t, %lhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
-      vector.transfer_write %lhs_vec_local_2_t, %lhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
-      vector.transfer_write %lhs_vec_local_3_t, %lhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${64 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared_ty
+      $for j in range(SUBGROUPS_M*INTRINSICS_M//2//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %lhs_vec_local_${4*j}_t, %lhs_shared [%c0, %glb${j}_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
+        vector.transfer_write %lhs_vec_local_${4*j+1}_t, %lhs_shared [%c1, %glb${j}_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
+        vector.transfer_write %lhs_vec_local_${4*j+2}_t, %lhs_shared [%c2, %glb${j}_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
+        vector.transfer_write %lhs_vec_local_${4*j+3}_t, %lhs_shared [%c3, %glb${j}_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -245,10 +267,10 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
     }
 
     // Epilogue
-    %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
       indexing_maps = #contraction_accesses,
@@ -257,10 +279,10 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
     } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
       indexing_maps = #contraction_accesses,
@@ -269,10 +291,10 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
     } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
       indexing_maps = #contraction_accesses,
@@ -281,10 +303,10 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
     } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
       indexing_maps = #contraction_accesses,

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_large.mlir.in
@@ -11,8 +11,8 @@
 !acc_base_ty = tensor<1x1x${FOLD1(SUBGROUPS_M)}${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_N)}4x16x4xf32>
 !lhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
 !rhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
-!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x4x2x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!lhs_expand_ty = tensor<1x?x4x${SUBGROUPS_M}x${INTRINSICS_M}x4x8x2x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+!rhs_expand_ty = tensor<1x?x4x${SUBGROUPS_N}x${INTRINSICS_N}x4x8x2x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
 !lhs_in_ty = tensor<?x4x${SUBGROUPS_M*INTRINSICS_M}x32x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 !rhs_in_ty = tensor<?x4x${SUBGROUPS_N*INTRINSICS_N}x32x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 !lhs_shared_ty = memref<4x${SUBGROUPS_M*INTRINSICS_M}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
@@ -76,11 +76,11 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
   %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
   %nDim = arith.divui %dim, %c4 : index
 
-  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6, 7, 8], [9]] output_shape [1, %nDim, 4, ${SUBGROUPS_M}, ${INTRINSICS_M}, 4, 4, 2, 2, ${INTRINSICS_K*INTERNAL_K}] : !lhs_base_ty into !lhs_expand_ty
-  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8]] output_shape [1, %nDim, 4, ${SUBGROUPS_N}, ${INTRINSICS_N}, 4, 8, 2, ${INTRINSICS_K*INTERNAL_K}] : !rhs_base_ty into !rhs_expand_ty
+  %lhs_expand = tensor.expand_shape %lhs_base ${EXPAND_REASSOC_FOLD1([[1], ["?", 4], [SUBGROUPS_M], [INTRINSICS_M], [4], [8, 2], [INTRINSICS_K], [INTERNAL_K]])} output_shape [1, %nDim, 4, ${SUBGROUPS_M}, ${INTRINSICS_M}, 4, 8, 2, ${INTRINSICS_K}, ${INTERNAL_K}] : !lhs_base_ty into !lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base ${EXPAND_REASSOC_FOLD1([[1], ["?", 4], [SUBGROUPS_N], [INTRINSICS_N], [4], [8, 2], [INTRINSICS_K], [INTERNAL_K]])} output_shape [1, %nDim, 4, ${SUBGROUPS_N}, ${INTRINSICS_N}, 4, 8, 2, ${INTRINSICS_K}, ${INTERNAL_K}] : !rhs_base_ty into !rhs_expand_ty
 
-  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6, 7], [8, 9]] : !lhs_expand_ty into !lhs_in_ty
-  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !rhs_expand_ty into !rhs_in_ty
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8, 9]] : !lhs_expand_ty into !lhs_in_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8, 9]] : !rhs_expand_ty into !rhs_in_ty
 
   %lhs_shared = memref.alloc() : !lhs_shared_ty
   %rhs_shared = memref.alloc() : !rhs_shared_ty
@@ -104,7 +104,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
     vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
-  gpu.barrier
+  gpu.barrier memfence [#gpu.address_space<workgroup>]
 
   %0 = tensor.empty() : !acc_base_ty
   $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
@@ -154,7 +154,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -166,7 +166,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
@@ -191,7 +191,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -203,7 +203,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       // Local loads of lhs and rhs.
@@ -217,7 +217,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -229,7 +229,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       } :vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       // Local stores of lhs and rhs.
@@ -245,7 +245,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
         vector.transfer_write %lhs_vec_local_${4*j+2}_t, %lhs_shared [%c2, %glb${j}_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
         vector.transfer_write %lhs_vec_local_${4*j+3}_t, %lhs_shared [%c3, %glb${j}_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared_ty
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -257,7 +257,7 @@ util.func @pingpong_dt_large_${ELEM_TYPE}(%lhs_base: !lhs_base_ty, %rhs_base: !r
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       scf.yield %dot3 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
@@ -1,15 +1,15 @@
 //  RUN: iree-opt %s
 // Template for medium data-tiled matmul kernels
 
-!m_acc_base_ty = tensor<1x1x${SUBGROUPS_N}x${INTRINSICS_M}x${INTRINSICS_N}x4x16x4xf32>
-!m_lhs_base_ty = tensor<1x?x${INTRINSICS_M}x4x16x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!m_lhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x4x4x4x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!m_rhs_base_ty = tensor<1x?x${INTRINSICS_M}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!m_rhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-!m_lhs_ty = tensor<?x2x${INTRINSICS_M}x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-!m_rhs_ty = tensor<?x2x16x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-!m_lhs_shared_ty = memref<2x${INTRINSICS_M}x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!m_rhs_shared_ty = memref<2x16x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!m_acc_base_ty = tensor<1x1x${fold1(SUBGROUPS_M)}${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_M)}${fold1(INTRINSICS_N)}4x16x4xf32>
+!m_lhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_M)}${fold1(INTRINSICS_M)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!m_rhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_N)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!m_lhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x4x4x4x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+!m_rhs_expand_ty = tensor<1x?x2x${SUBGROUPS_N}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+!m_lhs_ty = tensor<?x2x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
+!m_rhs_ty = tensor<?x2x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
+!m_lhs_shared_ty = memref<2x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!m_rhs_shared_ty = memref<2x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -63,15 +63,15 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
-  %c256 = arith.constant 256 : index
+  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
   %c4096 = arith.constant 4096 : index
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
 
   %dim = tensor.dim %rhs_base, %c1 : !m_rhs_base_ty
   %nDim = arith.divui %dim, %c2 : index
 
-  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5, 6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, 4, 4, 4, 2, 8] : !m_lhs_base_ty into !m_lhs_expand_ty
-  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, ${INTRINSICS_N}, 4, 16, 2, 8] : !m_rhs_base_ty into !m_rhs_expand_ty
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5, 6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, 4, 4, 4, 2, ${64 // ELEM_BITS}] : !m_lhs_base_ty into !m_lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, ${INTRINSICS_N}, 4, 16, 2, ${64 // ELEM_BITS}] : !m_rhs_base_ty into !m_rhs_expand_ty
 
   %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3], [4, 5, 6], [7, 8]] : !m_lhs_expand_ty into !m_lhs_ty
   %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !m_rhs_expand_ty into !m_rhs_ty
@@ -79,21 +79,21 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
   %lhs_shared = memref.alloc() : !m_lhs_shared_ty
   %rhs_shared = memref.alloc() : !m_rhs_shared_ty
 
-  scf.forall (%id) in (1024) {
-    %delin:3 = affine.delinearize_index %id into (2, ${INTRINSICS_M}, 64) : index, index, index
-    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1]  : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
+  scf.forall (%id) in (${2 * SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:3 = affine.delinearize_index %id into (2, ${SUBGROUPS_M * INTRINSICS_M}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1]  : !m_lhs_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (2048) {
-    %delin:3 = affine.delinearize_index %id into (2, 16, 64) : index, index, index
-    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+  scf.forall (%id) in (${2 * SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:3 = affine.delinearize_index %id into (2, ${SUBGROUPS_N * INTRINSICS_N}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
   %0 = tensor.empty() : !m_acc_base_ty
-  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !m_acc_base_ty {
+  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> !m_acc_base_ty {
     %ids:3 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 64) : index, index, index
     %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
 
@@ -102,8 +102,8 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c256 : index
-    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
@@ -113,8 +113,8 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
       %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
@@ -130,8 +130,8 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
       %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
@@ -154,7 +154,7 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -178,7 +178,7 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -194,28 +194,28 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
     %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
     %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
     %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %empty = tensor.empty() : tensor<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
     %cast = vector.shape_cast %dot2 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
@@ -1,0 +1,228 @@
+//  RUN: iree-opt %s
+// Template for medium data-tiled matmul kernels
+
+!m_acc_base_ty = tensor<1x1x${SUBGROUPS_N}x${INTRINSICS_M}x${INTRINSICS_N}x4x16x4xf32>
+!m_lhs_base_ty = tensor<1x?x${INTRINSICS_M}x4x16x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!m_lhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x4x4x4x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!m_rhs_base_ty = tensor<1x?x${INTRINSICS_M}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!m_rhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+!m_lhs_ty = tensor<?x2x${INTRINSICS_M}x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+!m_rhs_ty = tensor<?x2x16x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+!m_lhs_shared_ty = memref<2x${INTRINSICS_M}x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!m_rhs_shared_ty = memref<2x16x64x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %rhs_base: !m_rhs_base_ty, %unused_acc: !m_acc_base_ty) -> !m_acc_base_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      archs = ["${ARCH}"],
+      types = [${ELEM_TYPE}, ${ELEM_TYPE}, f32],
+      iteration_sizes_constraints = [
+        #rocm.ukernel_interation_size_constraint<
+          index = 0,
+          size_min = ${SIZE_MIN_0},
+          size_max = ${SIZE_MAX_0},
+          size_div = ${SIZE_DIV_0}
+        >,
+        #rocm.ukernel_interation_size_constraint<
+          index = 1,
+          size_min = ${SIZE_MIN_1},
+          size_max = ${SIZE_MAX_1},
+          size_div = ${SIZE_DIV_1}
+        >,
+        #rocm.ukernel_interation_size_constraint<
+          index = 2,
+          size_min = ${SIZE_MIN_2},
+          size_max = ${SIZE_MAX_2},
+          size_div = ${SIZE_DIV_2}
+        >
+      ]
+    },
+    mma = #iree_gpu.data_tiled_mma_layout<
+      intrinsic = ${INTRINSIC},
+      intrinsics_m = ${INTRINSICS_M},
+      subgroups_m = ${SUBGROUPS_M},
+      intrinsics_n = ${INTRINSICS_N},
+      subgroups_n = ${SUBGROUPS_N},
+      intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]
+    >
+  >
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %c4096 = arith.constant 4096 : index
+  %cst = arith.constant 0.0 : ${ELEM_TYPE}
+
+  %dim = tensor.dim %rhs_base, %c1 : !m_rhs_base_ty
+  %nDim = arith.divui %dim, %c2 : index
+
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5, 6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, 4, 4, 4, 2, 8] : !m_lhs_base_ty into !m_lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, ${INTRINSICS_N}, 4, 16, 2, 8] : !m_rhs_base_ty into !m_rhs_expand_ty
+
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3], [4, 5, 6], [7, 8]] : !m_lhs_expand_ty into !m_lhs_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !m_rhs_expand_ty into !m_rhs_ty
+
+  %lhs_shared = memref.alloc() : !m_lhs_shared_ty
+  %rhs_shared = memref.alloc() : !m_rhs_shared_ty
+
+  scf.forall (%id) in (1024) {
+    %delin:3 = affine.delinearize_index %id into (2, ${INTRINSICS_M}, 64) : index, index, index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1]  : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (2, 16, 64) : index, index, index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  %0 = tensor.empty() : !m_acc_base_ty
+  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !m_acc_base_ty {
+    %ids:3 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 64) : index, index, index
+    %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
+
+    %glb0_rhs = arith.muli %ids#1, %c2 overflow<nsw, nuw> : index
+    %glb1_rhs = arith.addi %glb0_rhs, %c1 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+
+    %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+      // Local loads of lhs.
+      %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      rocdl.sched.barrier 0
+
+      // Global loads of lhs.
+      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %ids#1, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %ids#1, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      rocdl.sched.barrier 0
+
+      // Local loads of rhs.
+      %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb0_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c0, %glb1_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c1, %glb0_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c1, %glb1_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local stores of lhs and rhs.
+      vector.transfer_write %rhs_vec_local_0, %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_1, %rhs_shared[%c0, %glb1_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_2, %rhs_shared[%c1, %glb0_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_3, %rhs_shared[%c1, %glb1_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+
+      vector.transfer_write %lhs_vec_local_0, %lhs_shared[%c0, %ids#1, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_1, %lhs_shared[%c1, %ids#1, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot2 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x2x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %empty = tensor.empty() : tensor<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+    %cast = vector.shape_cast %dot2 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+    %4 = vector.transfer_write %cast, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true, true, true, true, true]} : vector<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>, tensor<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%c0, %c0, %ids#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, ${INTRINSICS_M}, ${INTRINSICS_N}, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32> into !m_acc_base_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !m_acc_base_ty
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
@@ -11,7 +11,7 @@
 !m_acc_base_ty = tensor<1x1x${FOLD1(SUBGROUPS_M)}${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_N)}4x16x4xf32>
 !m_lhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
 !m_rhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
-!m_lhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x4x4x4x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+!m_lhs_expand_ty = tensor<1x?x2x${SUBGROUPS_M}x${INTRINSICS_M}x4x16x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
 !m_rhs_expand_ty = tensor<1x?x2x${SUBGROUPS_N}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
 !m_lhs_ty = tensor<?x2x${SUBGROUPS_M*INTRINSICS_M}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 !m_rhs_ty = tensor<?x2x${SUBGROUPS_N*INTRINSICS_N}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
@@ -77,10 +77,10 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
   %dim = tensor.dim %rhs_base, %c1 : !m_rhs_base_ty
   %nDim = arith.divui %dim, %c2 : index
 
-  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5, 6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, 4, 4, 4, ${INTRINSICS_K}, ${INTERNAL_K}] : !m_lhs_base_ty into !m_lhs_expand_ty
-  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, ${INTRINSICS_N}, 4, 16, ${INTRINSICS_K}, ${INTERNAL_K}] : !m_rhs_base_ty into !m_rhs_expand_ty
+  %lhs_expand = tensor.expand_shape %lhs_base ${EXPAND_REASSOC_FOLD1([[1], ["?", 2], [SUBGROUPS_M], [INTRINSICS_M], [4], [16], [INTRINSICS_K], [INTERNAL_K]])} output_shape [1, %nDim, 2, ${SUBGROUPS_M}, ${INTRINSICS_M}, 4, 16, ${INTRINSICS_K}, ${INTERNAL_K}] : !m_lhs_base_ty into !m_lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base ${EXPAND_REASSOC_FOLD1([[1], ["?", 2], [SUBGROUPS_N], [INTRINSICS_N], [4], [16], [INTRINSICS_K], [INTERNAL_K]])} output_shape [1, %nDim, 2, ${SUBGROUPS_N}, ${INTRINSICS_N}, 4, 16, ${INTRINSICS_K}, ${INTERNAL_K}] : !m_rhs_base_ty into !m_rhs_expand_ty
 
-  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3], [4, 5, 6], [7, 8]] : !m_lhs_expand_ty into !m_lhs_ty
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !m_lhs_expand_ty into !m_lhs_ty
   %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !m_rhs_expand_ty into !m_rhs_ty
 
   %lhs_shared = memref.alloc() : !m_lhs_shared_ty
@@ -161,7 +161,7 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
         %rhs_thread_${2*j+1} = tensor.extract_slice %rhs [%i, %c1, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
         %rhs_vec_local_${2*j+1} = vector.transfer_read %rhs_thread_${2*j+1} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -173,7 +173,7 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       // Local stores of lhs and rhs.
@@ -185,7 +185,7 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
         vector.transfer_write %lhs_vec_local_${2*j}, %lhs_shared[%c0, %glb${j}_lhs, %glb#1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_lhs_shared_ty
         vector.transfer_write %lhs_vec_local_${2*j}, %lhs_shared[%c1, %glb${j}_lhs, %glb#1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_lhs_shared_ty
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -197,7 +197,7 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       scf.yield %dot2 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_medium.mlir.in
@@ -1,15 +1,22 @@
-//  RUN: iree-opt %s
-// Template for medium data-tiled matmul kernels
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!m_acc_base_ty = tensor<1x1x${fold1(SUBGROUPS_M)}${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_M)}${fold1(INTRINSICS_N)}4x16x4xf32>
-!m_lhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_M)}${fold1(INTRINSICS_M)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
-!m_rhs_base_ty = tensor<1x?x${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_N)}4x16x${fold1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+//  RUN: iree-opt %s
+// AUTO-GENERATED - DO NOT EDIT
+// Generated from iree_uk_amdgpu_dt_matmul_medium.mlir.in
+
+!m_acc_base_ty = tensor<1x1x${FOLD1(SUBGROUPS_M)}${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_N)}4x16x4xf32>
+!m_lhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
+!m_rhs_base_ty = tensor<1x?x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}4x16x${FOLD1(INTRINSICS_K)}${INTERNAL_K}x${ELEM_TYPE}>
 !m_lhs_expand_ty = tensor<1x?x2x${INTRINSICS_M}x4x4x4x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
 !m_rhs_expand_ty = tensor<1x?x2x${SUBGROUPS_N}x${INTRINSICS_N}x4x16x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
-!m_lhs_ty = tensor<?x2x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
-!m_rhs_ty = tensor<?x2x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}>
-!m_lhs_shared_ty = memref<2x${SUBGROUPS_M * INTRINSICS_M}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!m_rhs_shared_ty = memref<2x${SUBGROUPS_N * INTRINSICS_N}x${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}x${128 // ELEM_BITS}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!m_lhs_ty = tensor<?x2x${SUBGROUPS_M*INTRINSICS_M}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!m_rhs_ty = tensor<?x2x${SUBGROUPS_N*INTRINSICS_N}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!m_lhs_shared_ty = memref<2x${SUBGROUPS_M*INTRINSICS_M}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!m_rhs_shared_ty = memref<2x${SUBGROUPS_N*INTRINSICS_N}x64x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -63,15 +70,15 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
-  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+  %c256 = arith.constant 256 : index
   %c4096 = arith.constant 4096 : index
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
 
   %dim = tensor.dim %rhs_base, %c1 : !m_rhs_base_ty
   %nDim = arith.divui %dim, %c2 : index
 
-  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5, 6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, 4, 4, 4, 2, ${64 // ELEM_BITS}] : !m_lhs_base_ty into !m_lhs_expand_ty
-  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, ${INTRINSICS_N}, 4, 16, 2, ${64 // ELEM_BITS}] : !m_rhs_base_ty into !m_rhs_expand_ty
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5, 6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, 4, 4, 4, ${INTRINSICS_K}, ${INTERNAL_K}] : !m_lhs_base_ty into !m_lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, ${INTRINSICS_M}, ${INTRINSICS_N}, 4, 16, ${INTRINSICS_K}, ${INTERNAL_K}] : !m_rhs_base_ty into !m_rhs_expand_ty
 
   %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3], [4, 5, 6], [7, 8]] : !m_lhs_expand_ty into !m_lhs_ty
   %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !m_rhs_expand_ty into !m_rhs_ty
@@ -79,71 +86,80 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
   %lhs_shared = memref.alloc() : !m_lhs_shared_ty
   %rhs_shared = memref.alloc() : !m_rhs_shared_ty
 
-  scf.forall (%id) in (${2 * SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:3 = affine.delinearize_index %id into (2, ${SUBGROUPS_M * INTRINSICS_M}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
-    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1]  : !m_lhs_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
+  scf.forall (%id) in (${128*SUBGROUPS_M*INTRINSICS_M}) {
+    %delin:3 = affine.delinearize_index %id into (2, ${SUBGROUPS_M*INTRINSICS_M}, 64) : index, index, index
+    $assert (INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1]  : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_lhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (${2 * SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:3 = affine.delinearize_index %id into (2, ${SUBGROUPS_N * INTRINSICS_N}, ${INTRINSICS_K * INTERNAL_K * ELEM_BITS // 2}) : index, index, index
-    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${128 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+  scf.forall (%id) in (${128*SUBGROUPS_N*INTRINSICS_N}) {
+    %delin:3 = affine.delinearize_index %id into (2, ${SUBGROUPS_N*INTRINSICS_N}, 64) : index, index, index
+    $assert (INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_rhs_shared_ty
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
   %0 = tensor.empty() : !m_acc_base_ty
-  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> !m_acc_base_ty {
+  $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
+  %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> !m_acc_base_ty {
     %ids:3 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 64) : index, index, index
     %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
 
-    %glb0_rhs = arith.muli %ids#1, %c2 overflow<nsw, nuw> : index
-    %glb1_rhs = arith.addi %glb0_rhs, %c1 overflow<nsw, nuw> : index
+    %m_outer = arith.muli %ids#0, %c${INTRINSICS_M} overflow<nsw, nuw> : index
+    %n_outer = arith.muli %ids#1, %c${INTRINSICS_N} overflow<nsw, nuw> : index
+
+    %glb:2 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 64) : index, index
+    %glb0_lhs = arith.muli %glb#0, %c${SUBGROUPS_M*INTRINSICS_M//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %glb0_rhs = arith.muli %glb#0, %c${SUBGROUPS_N*INTRINSICS_N//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_M*INTRINSICS_M//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_lhs = arith.addi %glb${j-1}_lhs, %c1 overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_N*INTRINSICS_N//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_rhs = arith.addi %glb${j-1}_rhs, %c1 overflow<nsw, nuw> : index
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
-    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
 
     %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
       // Local loads of lhs.
-      %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
       // Global loads of lhs.
-      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %ids#1, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %ids#1, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      $for j in range(SUBGROUPS_M*INTRINSICS_M//SUBGROUPS_M//SUBGROUPS_N):
+        %lhs_thread_${2*j} = tensor.extract_slice %lhs [%i, %c0, %glb${j}_lhs, %glb#1, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${2*j} = vector.transfer_read %lhs_thread_${2*j} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_thread_${2*j+1} = tensor.extract_slice %lhs [%i, %c1, %glb${j}_lhs, %glb#1, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${2*j+1} = vector.transfer_read %lhs_thread_${2*j+1} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
       // Local loads of rhs.
-      %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
-      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb0_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c0, %glb1_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c1, %glb0_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c1, %glb1_rhs, %ids#2, %c0] [1, 1, 1, 1, ${INTRINSICS_K * 64 // ELEM_BITS}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
+      $for j in range(SUBGROUPS_N*INTRINSICS_N//SUBGROUPS_M//SUBGROUPS_N):
+        %rhs_thread_${2*j} = tensor.extract_slice %rhs [%i, %c0, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${2*j} = vector.transfer_read %rhs_thread_${2*j} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_thread_${2*j+1} = tensor.extract_slice %rhs [%i, %c1, %glb${j}_rhs, %glb#1, %c0] [1, 1, 1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${2*j+1} = vector.transfer_read %rhs_thread_${2*j+1} [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -161,13 +177,13 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
       rocdl.sched.barrier 0
 
       // Local stores of lhs and rhs.
-      vector.transfer_write %rhs_vec_local_0, %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
-      vector.transfer_write %rhs_vec_local_1, %rhs_shared[%c0, %glb1_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
-      vector.transfer_write %rhs_vec_local_2, %rhs_shared[%c1, %glb0_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
-      vector.transfer_write %rhs_vec_local_3, %rhs_shared[%c1, %glb1_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_rhs_shared_ty
+      $for j in range(SUBGROUPS_N*INTRINSICS_N//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %rhs_vec_local_${2*j}, %rhs_shared[%c0, %glb${j}_rhs, %glb#1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_rhs_shared_ty
+        vector.transfer_write %rhs_vec_local_${2*j}, %rhs_shared[%c1, %glb${j}_rhs, %glb#1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_rhs_shared_ty
 
-      vector.transfer_write %lhs_vec_local_0, %lhs_shared[%c0, %ids#1, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
-      vector.transfer_write %lhs_vec_local_1, %lhs_shared[%c1, %ids#1, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>, !m_lhs_shared_ty
+      $for j in range(SUBGROUPS_M*INTRINSICS_M//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %lhs_vec_local_${2*j}, %lhs_shared[%c0, %glb${j}_lhs, %glb#1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_lhs_shared_ty
+        vector.transfer_write %lhs_vec_local_${2*j}, %lhs_shared[%c1, %glb${j}_lhs, %glb#1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !m_lhs_shared_ty
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -191,17 +207,17 @@ util.func private @pingpong_dt_medium_${ELEM_TYPE}(%lhs_base: !m_lhs_base_ty, %r
     }
 
     // Epilogue
-    %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_M}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x${INTRINSICS_M}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-    %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K * 64 // ELEM_BITS}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
-    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K * 64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, ${INTRINSICS_N}, 1, ${INTRINSICS_K*INTERNAL_K}], strides = [1, 1, 1, 1]} : vector<2x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x${INTRINSICS_N}x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
       indexing_maps = #contraction_accesses,

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
@@ -1,0 +1,340 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Template for scaled f4E2M1FN data-tiled matmul kernels
+// RUN: iree-opt %s
+
+// Input LHS and RHS layouts.
+// Tensor shape uses fold1() to omit dimensions that equal 1
+!lhs_ty = tensor<1x?x1x${fold1(SUBGROUPS_M)}${fold1(INTRINSICS_M)}${fold1(INTRINSICS_K)}4x16x32xf4E2M1FN>
+!rhs_ty = tensor<1x?x1x${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_N)}${fold1(INTRINSICS_K)}4x16x32xf4E2M1FN>
+
+!lhs_byte_ty = tensor<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8>
+!rhs_byte_ty = tensor<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8>
+
+// Buffer types keep all dimensions (no folding) for simpler stride handling
+!lhs_buffer_ty = memref<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}, ${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_K * 4 * 16 * 16}, ${4 * 16 * 16}, ${16 * 16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_buffer_ty = memref<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}, ${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_K * 4 * 16 * 16}, ${4 * 16 * 16}, ${16 * 16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+
+!lhs_buffer_collapse_ty = memref<?x${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_buffer_collapse_ty = memref<?x${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+
+// Shared memory: rows = 2 (double buffer) * intrinsics * subgroups * intrinsics_k
+!lhs_shared_ty = memref<${2 * INTRINSICS_M * SUBGROUPS_M * INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<${2 * INTRINSICS_N * SUBGROUPS_N * INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
+
+!lhs_copy_vec_ty = vector<16xi8>
+!rhs_copy_vec_ty = vector<16xi8>
+
+!lhs_byte_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x16xi8>
+!lhs_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x32xf4E2M1FN>
+
+!rhs_byte_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x16xi8>
+!rhs_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x32xf4E2M1FN>
+
+// Input scale layouts - keep all dimensions for buffer compatibility
+!lhs_scale_ty = tensor<1x?x${SUBGROUPS_M}x4x16x${INTRINSICS_M}x${INTRINSICS_K}xf8E8M0FNU>
+!rhs_scale_ty = tensor<1x?x${SUBGROUPS_N}x4x16x${INTRINSICS_N}x${INTRINSICS_K}xf8E8M0FNU>
+
+!lhs_scale_byte_ty = tensor<1x?x${SUBGROUPS_M}x4x16x${INTRINSICS_M}x${INTRINSICS_K}xi8>
+!rhs_scale_byte_ty = tensor<1x?x${SUBGROUPS_N}x4x16x${INTRINSICS_N}x${INTRINSICS_K}xi8>
+
+// Scale buffer types - keep all dimensions for simpler stride handling
+!lhs_scale_buffer_ty = memref<1x?x${SUBGROUPS_M}x4x16x${INTRINSICS_M}x${INTRINSICS_K}xi8, strided<[?, ${SUBGROUPS_M * 4 * 16 * INTRINSICS_M * INTRINSICS_K}, ${4 * 16 * INTRINSICS_M * INTRINSICS_K}, ${16 * INTRINSICS_M * INTRINSICS_K}, ${INTRINSICS_M * INTRINSICS_K}, ${INTRINSICS_K}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_scale_buffer_ty = memref<1x?x${SUBGROUPS_N}x4x16x${INTRINSICS_N}x${INTRINSICS_K}xi8, strided<[?, ${SUBGROUPS_N * 4 * 16 * INTRINSICS_N * INTRINSICS_K}, ${4 * 16 * INTRINSICS_N * INTRINSICS_K}, ${16 * INTRINSICS_N * INTRINSICS_K}, ${INTRINSICS_N * INTRINSICS_K}, ${INTRINSICS_K}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+
+!lhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_M * 4 * 16 * INTRINSICS_M * INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_N * 4 * 16 * INTRINSICS_N * INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+
+!lhs_scale_copy_vec_ty = vector<16xi8>
+!rhs_scale_copy_vec_ty = vector<16xi8>
+
+// Scale shared memory: rows = 2 (double buffer) * subgroups
+// Width = 4 * 16 * INTRINSICS_M/N * INTRINSICS_K (scale data per subgroup per K)
+!lhs_scale_shared_ty = memref<${2 * SUBGROUPS_M}x${4 * 16 * INTRINSICS_M * INTRINSICS_K}xi8, #gpu.address_space<workgroup>>
+!rhs_scale_shared_ty = memref<${2 * SUBGROUPS_N}x${4 * 16 * INTRINSICS_N * INTRINSICS_K}xi8, #gpu.address_space<workgroup>>
+
+!lhs_scale_byte_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x1xi8>
+!lhs_scale_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x1xf8E8M0FNU>
+
+!rhs_scale_byte_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x1xi8>
+!rhs_scale_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x1xf8E8M0FNU>
+
+!return_ty = tensor<1x1x${SUBGROUPS_M}x${SUBGROUPS_N}x${INTRINSICS_M}x${INTRINSICS_N}x${INTRINSICS_M}x16x4xf32>
+
+!acc_ty = vector<${INTRINSICS_M}x${INTRINSICS_N}x4x1xf32>
+
+!store_ty = vector<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+!tensor_store_ty = tensor<1x1x1x1x${INTRINSICS_M}x${INTRINSICS_N}x1x1x4xf32>
+
+#contraction_accesses = [
+  affine_map<(i, j, k, d) -> (i, d, k)>,
+  affine_map<(i, j, k, d) -> (j, d, k)>,
+  affine_map<(i, j, k, d) -> (i, d, k)>,
+  affine_map<(i, j, k, d) -> (j, d, k)>,
+  affine_map<(i, j, k, d) -> (i, j)>
+]
+
+#iterator_types = [
+  #linalg.iterator_type<parallel>,
+  #linalg.iterator_type<parallel>,
+  #linalg.iterator_type<parallel>,
+  #linalg.iterator_type<reduction>
+]
+
+#mfma_type = #iree_gpu.scaled_mma_layout<
+  intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+  lhs_elem_type = f4E2M1FN,
+  rhs_elem_type = f4E2M1FN,
+  acc_elem_type = f32>
+
+#result_reassoc = [[0, 1], [2, 3]]
+
+util.func @pingpong_dt_medium_f4E2M1FN(
+    %lhs_base: !lhs_ty,
+    %rhs_base: !rhs_ty,
+    %lhs_scale_base: !lhs_scale_ty,
+    %rhs_scale_base: !rhs_scale_ty,
+    %unused_acc: !return_ty) -> !return_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      archs = ["${ARCH}"],
+      types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32]
+    },
+    benefit = 1,
+    // Tile size calculation:
+    // M dimension: 16 (intrinsic) × ${INTRINSICS_M} (intrinsics_m) × ${SUBGROUPS_M} (subgroups_m) = ${16 * INTRINSICS_M * SUBGROUPS_M}.
+    // N dimension: 16 (intrinsic) × ${INTRINSICS_N} (intrinsics_n) × ${SUBGROUPS_N} (subgroups_n) = ${16 * INTRINSICS_N * SUBGROUPS_N}.
+    // KxKB dimension: 128 (intrinsic) × ${INTRINSICS_K} (intrinsics_k) = ${128 * INTRINSICS_K}.
+    mma = #iree_gpu.data_tiled_scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f4E2M1FN,
+      acc_elem_type = f32,
+      intrinsics_m = ${INTRINSICS_M}, operands_interleaving_intrinsics_m = [2],
+      subgroups_m = ${SUBGROUPS_M},
+      intrinsics_n = ${INTRINSICS_N}, operands_interleaving_intrinsics_n = [3],
+      subgroups_n = ${SUBGROUPS_N},
+      intrinsics_k = ${INTRINSICS_K}, operands_interleaving_intrinsics_k = [2, 3]
+    >
+  >
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c16 = arith.constant 16 : index
+  %c256 = arith.constant 256 : index
+  %c1024 = arith.constant 1024 : index
+  %c4096 = arith.constant 4096 : index
+
+  %cINT_M = arith.constant ${INTRINSICS_M} : index
+  %cINT_N = arith.constant ${INTRINSICS_N} : index
+  %cSUB_MN = arith.constant ${SUBGROUPS_M * SUBGROUPS_N} : index
+  %cINT_MK = arith.constant ${INTRINSICS_M * INTRINSICS_K} : index
+  %cINT_NK = arith.constant ${INTRINSICS_N * INTRINSICS_K} : index
+  %cLHS_SHARED = arith.constant ${INTRINSICS_M * SUBGROUPS_M * INTRINSICS_K} : index
+  %cRHS_SHARED = arith.constant ${INTRINSICS_N * SUBGROUPS_N * INTRINSICS_K} : index
+
+  %cst_lhs = arith.constant 0 : i8
+  %cst_rhs = arith.constant 0 : i8
+  %cst_scale = arith.constant 0 : i8
+  %lhs_shared_base = memref.alloc() : !lhs_shared_ty
+  %rhs_shared_base = memref.alloc() : !rhs_shared_ty
+  %lhs_scale_shared = memref.alloc() : !lhs_scale_shared_ty
+  %rhs_scale_shared = memref.alloc() : !rhs_scale_shared_ty
+
+  %k = tensor.dim %lhs_base, %c1 : !lhs_ty
+
+  // Bitcast inputs to i8 type. This is required to use gather_to_lds instructions.
+  %lhs_byte = iree_tensor_ext.bitcast %lhs_base : !lhs_ty{%k} -> !lhs_byte_ty{%k}
+  %rhs_byte = iree_tensor_ext.bitcast %rhs_base : !rhs_ty{%k} -> !rhs_byte_ty{%k}
+
+  %lhs_scale_byte = iree_tensor_ext.bitcast %lhs_scale_base : !lhs_scale_ty{%k} -> !lhs_scale_byte_ty{%k}
+  %rhs_scale_byte = iree_tensor_ext.bitcast %rhs_scale_base : !rhs_scale_ty{%k} -> !rhs_scale_byte_ty{%k}
+
+  %lhs = bufferization.to_buffer %lhs_byte {read_only} : !lhs_byte_ty to !lhs_buffer_ty
+  %rhs = bufferization.to_buffer %rhs_byte {read_only} : !rhs_byte_ty to !rhs_buffer_ty
+
+  %lhs_scale = bufferization.to_buffer %lhs_scale_byte {read_only} : !lhs_scale_byte_ty to !lhs_scale_buffer_ty
+  %rhs_scale = bufferization.to_buffer %rhs_scale_byte {read_only} : !rhs_scale_byte_ty to !rhs_scale_buffer_ty
+
+  // Collapse shapes to reduce memory indexing overhead.
+  %lhs_collapse = memref.collapse_shape %lhs [[0, 1], [2, 3, 4, 5, 6, 7, 8]] : !lhs_buffer_ty into !lhs_buffer_collapse_ty
+  %rhs_collapse = memref.collapse_shape %rhs [[0, 1], [2, 3, 4, 5, 6, 7, 8]] : !rhs_buffer_ty into !rhs_buffer_collapse_ty
+  %lhs_scale_collapse = memref.collapse_shape %lhs_scale [[0, 1], [2, 3, 4, 5, 6]] : !lhs_scale_buffer_ty into !lhs_scale_buffer_collapse_ty
+  %rhs_scale_collapse = memref.collapse_shape %rhs_scale [[0, 1], [2, 3, 4, 5, 6]] : !rhs_scale_buffer_ty into !rhs_scale_buffer_collapse_ty
+
+  scf.forall (%base_id) in (512) {
+    // Make the upper 4 waves start copying data.
+    %cmp = arith.cmpi sge, %base_id, %c256 : index
+    scf.if %cmp {
+      %id = arith.subi %base_id, %c256 : index
+
+      %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M * SUBGROUPS_N}, 64) : index, index
+      %subgroups:2 = affine.delinearize_index %ids#0 into (${SUBGROUPS_M}, ${SUBGROUPS_N}) : index, index
+      %threads:2 = affine.delinearize_index %ids#1 into (2, 32) : index, index
+
+      scf.for %i = %c0 to %k step %c1 {
+        // Double buffering.
+        %buffer_num = arith.andi %i, %c1 : index
+
+        // Copy RHS from global memory to LDS.
+        scf.for %j = %c0 to %cINT_N step %c1 {
+          %buffer_unroll = arith.muli %j, %c4096 : index
+          %buffer_thread = arith.muli %id, %c16 : index
+          %buffer_inner = arith.addi %buffer_unroll, %buffer_thread : index
+
+          %shared_num = arith.muli %buffer_num, %cRHS_SHARED : index
+          %shared_unroll = arith.muli %j, %cSUB_MN : index
+          %shared_subgroup = arith.addi %shared_unroll, %ids#0 : index
+          %shared_outer = arith.addi %shared_num, %shared_subgroup : index
+          %shared_inner = arith.muli %ids#1, %c16 : index
+
+          amdgpu.gather_to_lds %rhs_collapse[%i, %buffer_inner], %rhs_shared_base[%shared_outer, %shared_inner]
+            : !rhs_copy_vec_ty, !rhs_buffer_collapse_ty, !rhs_shared_ty
+        }
+
+        // Copy RHS scale from global memory to LDS.
+        %rhs_scale_buffer_subgroup = arith.muli %subgroups#1, %c1024 : index
+        %rhs_scale_buffer_thread = arith.muli %ids#1, %c16 : index
+        %rhs_scale_buffer_inner = arith.addi %rhs_scale_buffer_subgroup, %rhs_scale_buffer_thread : index
+
+        %rhs_scale_shared_num = arith.muli %buffer_num, %c2 : index
+        %rhs_scale_shared_outer = arith.addi %rhs_scale_shared_num, %subgroups#1 : index
+        %rhs_scale_shared_inner = arith.muli %ids#1, %c16 : index
+
+        amdgpu.gather_to_lds %rhs_scale_collapse[%i, %rhs_scale_buffer_inner], %rhs_scale_shared[%rhs_scale_shared_outer, %rhs_scale_shared_inner]
+          : !rhs_scale_copy_vec_ty, !rhs_scale_buffer_collapse_ty, !rhs_scale_shared_ty
+
+        // There are (${INTRINSICS_N} + 1) gather_to_lds instructions above.
+        amdgpu.memory_counter_wait load(${INTRINSICS_N + 1})
+        rocdl.s.barrier
+
+        // Copy LHS from global memory to LDS.
+        scf.for %j = %c0 to %cINT_M step %c1 {
+          %buffer_unroll = arith.muli %j, %c4096 : index
+          %buffer_thread = arith.muli %id, %c16 : index
+          %buffer_inner = arith.addi %buffer_unroll, %buffer_thread : index
+
+          %shared_num = arith.muli %buffer_num, %cLHS_SHARED : index
+          %shared_unroll = arith.muli %j, %cSUB_MN : index
+          %shared_subgroup = arith.addi %shared_unroll, %ids#0 : index
+          %shared_outer = arith.addi %shared_num, %shared_subgroup : index
+          %shared_inner = arith.muli %ids#1, %c16 : index
+
+          amdgpu.gather_to_lds %lhs_collapse[%i, %buffer_inner], %lhs_shared_base[%shared_outer, %shared_inner]
+            : !lhs_copy_vec_ty, !lhs_buffer_collapse_ty, !lhs_shared_ty
+        }
+
+        // Copy LHS scale from global memory to LDS.
+        %lhs_scale_buffer_inner = arith.muli %ids#1, %c16 : index
+
+        %lhs_scale_shared_num = arith.muli %buffer_num, %c2 : index
+        %lhs_scale_shared_outer = arith.addi %lhs_scale_shared_num, %threads#0 : index
+        %lhs_scale_shared_inner = arith.muli %threads#1, %c16 : index
+
+        amdgpu.gather_to_lds %lhs_scale_collapse[%i, %lhs_scale_buffer_inner], %lhs_scale_shared[%lhs_scale_shared_outer, %lhs_scale_shared_inner]
+          : !lhs_scale_copy_vec_ty, !lhs_scale_buffer_collapse_ty, !lhs_scale_shared_ty
+
+        // There are (${INTRINSICS_M} + 1) gather_to_lds instructions above.
+        amdgpu.memory_counter_wait load(${INTRINSICS_M + 1})
+        rocdl.s.barrier
+
+
+        scf.yield
+      }
+
+      // Realign subgroups and wait on the last group.
+      rocdl.s.waitcnt 0
+      rocdl.s.barrier
+    }
+
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+
+  %0 = tensor.empty() : !return_ty
+  %1 = scf.forall (%id) in (256) shared_outs(%out = %0) -> !return_ty {
+    %init = arith.constant dense<0.0> : !acc_ty
+    %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M * SUBGROUPS_N}, 64) : index, index
+    %subgroups:2 = affine.delinearize_index %ids#0 into (${SUBGROUPS_M}, ${SUBGROUPS_N}) : index, index
+    %threads:2 = affine.delinearize_index %ids#1 into (${INTRINSICS_M}, 16) : index, index
+
+    // Misalign by one group.
+    rocdl.s.barrier
+
+    %loop = scf.for %i = %c0 to %k step %c1 iter_args(%iter = %init) -> !acc_ty {
+      // wait till available.
+      rocdl.s.barrier
+
+      %buffer_num = arith.andi %i, %c1 : index
+
+      %lhs_num = arith.muli %buffer_num, %cLHS_SHARED : index
+      %lhs_subgroup = arith.muli %subgroups#0, %cINT_MK : index
+      %lhs_outer = arith.addi %lhs_num, %lhs_subgroup : index
+      %lhs_inner = arith.muli %ids#1, %c16 : index
+
+      %lhs_scale_num = arith.muli %buffer_num, %c2 : index
+      %lhs_scale_outer = arith.addi %lhs_scale_num, %subgroups#0 : index
+      %lhs_scale_inner = arith.muli %ids#1, %cINT_MK : index
+
+      %rhs_num = arith.muli %buffer_num, %cRHS_SHARED : index
+      %rhs_subgroup = arith.muli %subgroups#1, %cINT_NK : index
+      %rhs_outer = arith.addi %rhs_num, %rhs_subgroup : index
+      %rhs_inner = arith.muli %ids#1, %c16 : index
+
+      %rhs_scale_num = arith.muli %buffer_num, %c2 : index
+      %rhs_scale_outer = arith.addi %rhs_scale_num, %subgroups#1 : index
+      %rhs_scale_inner = arith.muli %ids#1, %c16 : index
+
+      // Load inputs/scales from LDS.
+      %lhs_byte_vec = vector.transfer_read %lhs_shared_base[%lhs_outer, %lhs_inner],
+        %cst_lhs {in_bounds = [true, true]} : !lhs_shared_ty, vector<${INTRINSICS_M * INTRINSICS_K}x16xi8>
+      %lhs_byte_vec_t = vector.shape_cast %lhs_byte_vec : vector<${INTRINSICS_M * INTRINSICS_K}x16xi8> to !lhs_byte_vec_ty
+      %lhs_vec = vector.bitcast %lhs_byte_vec_t : !lhs_byte_vec_ty to !lhs_vec_ty
+
+      %lhs_scale_byte_vec = vector.transfer_read %lhs_scale_shared[%lhs_scale_outer, %lhs_scale_inner],
+        %cst_scale {in_bounds = [true, true]} : !lhs_scale_shared_ty, vector<1x${INTRINSICS_M * INTRINSICS_K}xi8>
+      %lhs_scale_byte_vec_t = vector.shape_cast %lhs_scale_byte_vec : vector<1x${INTRINSICS_M * INTRINSICS_K}xi8> to !lhs_scale_byte_vec_ty
+      %lhs_scale_vec = vector.bitcast %lhs_scale_byte_vec_t : !lhs_scale_byte_vec_ty to !lhs_scale_vec_ty
+
+      rocdl.sched.barrier 0
+
+      %rhs_byte_vec = vector.transfer_read %rhs_shared_base[%rhs_outer, %rhs_inner],
+        %cst_rhs {in_bounds = [true, true]} : !rhs_shared_ty, vector<${INTRINSICS_N * INTRINSICS_K}x16xi8>
+      %rhs_byte_vec_t = vector.shape_cast %rhs_byte_vec : vector<${INTRINSICS_N * INTRINSICS_K}x16xi8> to !rhs_byte_vec_ty
+      %rhs_vec = vector.bitcast %rhs_byte_vec_t : !rhs_byte_vec_ty to !rhs_vec_ty
+
+      %rhs_scale_byte_vec = vector.transfer_read %rhs_scale_shared[%rhs_scale_outer, %rhs_scale_inner],
+        %cst_scale {in_bounds = [true, true]} : !rhs_scale_shared_ty, vector<1x${INTRINSICS_N * INTRINSICS_K}xi8>
+      %rhs_scale_byte_vec_t = vector.shape_cast %rhs_scale_byte_vec : vector<1x${INTRINSICS_N * INTRINSICS_K}xi8> to !rhs_scale_byte_vec_ty
+      %rhs_scale_vec = vector.bitcast %rhs_scale_byte_vec_t : !rhs_scale_byte_vec_ty to !rhs_scale_vec_ty
+
+      amdgpu.lds_barrier
+      rocdl.sched.barrier 0
+
+      %dot = iree_codegen.inner_tiled ins(%lhs_vec, %rhs_vec, %lhs_scale_vec, %rhs_scale_vec) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = #iterator_types,
+        kind = #mfma_type,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : !lhs_vec_ty, !rhs_vec_ty, !lhs_scale_vec_ty, !rhs_scale_vec_ty into !acc_ty
+
+      scf.yield %dot : !acc_ty
+    }
+
+    %t = vector.shape_cast %loop : !acc_ty to !store_ty
+
+    %empty = tensor.empty() : !tensor_store_ty
+    %to_tensor = vector.transfer_write %t, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0]
+      {in_bounds = [true, true, true, true, true, true, true, true, true]} : !store_ty, !tensor_store_ty
+
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %to_tensor into %out[%c0, %c0, %subgroups#0, %subgroups#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, 1, ${INTRINSICS_M}, ${INTRINSICS_N}, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1, 1]
+        : !tensor_store_ty into !return_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !return_ty
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
@@ -15,7 +15,6 @@
 !lhs_byte_ty = tensor<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8>
 !rhs_byte_ty = tensor<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8>
 
-// Buffer types keep all dimensions (no folding) for simpler stride handling
 !lhs_buffer_ty = memref<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8, strided<[?, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${4*16*(INTERNAL_K//2)}, ${16*(INTERNAL_K//2)}, ${INTERNAL_K//2}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 !rhs_buffer_ty = memref<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8, strided<[?, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${4*16*(INTERNAL_K//2)}, ${16*(INTERNAL_K//2)}, ${INTERNAL_K//2}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
@@ -50,7 +49,6 @@ $assert (4*INTERNAL_K) == 128, "load 128 bits per instruction"
 !lhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_M*4*16*INTRINSICS_M*INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 !rhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_N*4*16*INTRINSICS_N*INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
-$assert (4*INTERNAL_K) == 128, "load 128 bits per instruction"
 !lhs_scale_copy_vec_ty = vector<${INTERNAL_K//2}xi8>
 !rhs_scale_copy_vec_ty = vector<${INTERNAL_K//2}xi8>
 
@@ -135,6 +133,7 @@ util.func @pingpong_dt_medium_f4E2M1FN(
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
   %c256 = arith.constant 256 : index
+  %c512 = arith.constant 512 : index
   %c1024 = arith.constant 1024 : index
   %c4096 = arith.constant 4096 : index
 
@@ -173,77 +172,80 @@ util.func @pingpong_dt_medium_f4E2M1FN(
     %cmp = arith.cmpi sge, %base_id, %c${SUBGROUPS_M*SUBGROUPS_N*64} : index
     scf.if %cmp {
       %id = arith.subi %base_id, %c${SUBGROUPS_M*SUBGROUPS_N*64} : index
-
       %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 64) : index, index
-      %subgroups:2 = affine.delinearize_index %ids#0 into (${SUBGROUPS_M}, ${SUBGROUPS_N}) : index, index
-      %threads:2 = affine.delinearize_index %ids#1 into (2, 32) : index, index
+
+      %ids_lhs_scale:3 = affine.delinearize_index %id into (${SUBGROUPS_N*16//INTRINSICS_M//INTRINSICS_K}, ${SUBGROUPS_M}, ${4*INTRINSICS_M*INTRINSICS_K}) : index, index, index
+      %ids_rhs_scale:3 = affine.delinearize_index %id into (${SUBGROUPS_M*16//INTRINSICS_N//INTRINSICS_K}, ${SUBGROUPS_N}, ${4*INTRINSICS_N*INTRINSICS_K}) : index, index, index
 
       scf.for %i = %c0 to %k step %c1 {
         // Double buffering.
         %buffer_num = arith.andi %i, %c1 : index
 
         // Copy RHS from global memory to LDS.
-        scf.for %j = %c0 to %c${INTRINSICS_N} step %c1 {
-          %buffer_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N*64*16}: index
-          %buffer_thread = arith.muli %id, %c16 : index
+        scf.for %j = %c0 to %c${INTRINSICS_N*INTRINSICS_K//SUBGROUPS_M} step %c1 {
+          %buffer_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N*64*INTERNAL_K//2}: index
+          %buffer_thread = arith.muli %id, %c${INTERNAL_K//2} : index
           %buffer_inner = arith.addi %buffer_unroll, %buffer_thread : index
 
           %shared_num = arith.muli %buffer_num, %c${INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K} : index
           %shared_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N} : index
           %shared_subgroup = arith.addi %shared_unroll, %ids#0 : index
           %shared_outer = arith.addi %shared_num, %shared_subgroup : index
-          %shared_inner = arith.muli %ids#1, %c16 : index
+          %shared_inner = arith.muli %ids#1, %c${INTERNAL_K//2} : index
 
+          $assert (4*INTERNAL_K) == 128, "load 128 bits per instruction"
           amdgpu.gather_to_lds %rhs_collapse[%i, %buffer_inner], %rhs_shared_base[%shared_outer, %shared_inner]
             : !rhs_copy_vec_ty, !rhs_buffer_collapse_ty, !rhs_shared_ty
         }
 
         // Copy RHS scale from global memory to LDS.
-        %rhs_scale_buffer_subgroup = arith.muli %subgroups#1, %c1024 : index
-        %rhs_scale_buffer_thread = arith.muli %ids#1, %c16 : index
-        %rhs_scale_buffer_inner = arith.addi %rhs_scale_buffer_subgroup, %rhs_scale_buffer_thread : index
+        %rhs_scale_buffer_outer = arith.muli %ids_rhs_scale#1, %c${64*INTRINSICS_N*INTRINSICS_K} : index
+        %rhs_scale_buffer_inner = arith.muli %ids_rhs_scale#2, %c16 : index
+        %rhs_scale_buffer_offset = arith.addi %rhs_scale_buffer_outer, %rhs_scale_buffer_inner : index
 
         %rhs_scale_shared_num = arith.muli %buffer_num, %c2 : index
-        %rhs_scale_shared_outer = arith.addi %rhs_scale_shared_num, %subgroups#1 : index
-        %rhs_scale_shared_inner = arith.muli %ids#1, %c16 : index
+        %rhs_scale_shared_outer = arith.addi %rhs_scale_shared_num, %ids_rhs_scale#1 : index
+        %rhs_scale_shared_inner = arith.muli %ids_rhs_scale#2, %c16 : index
 
-        amdgpu.gather_to_lds %rhs_scale_collapse[%i, %rhs_scale_buffer_inner], %rhs_scale_shared[%rhs_scale_shared_outer, %rhs_scale_shared_inner]
+        amdgpu.gather_to_lds %rhs_scale_collapse[%i, %rhs_scale_buffer_offset], %rhs_scale_shared[%rhs_scale_shared_outer, %rhs_scale_shared_inner]
           : !rhs_scale_copy_vec_ty, !rhs_scale_buffer_collapse_ty, !rhs_scale_shared_ty
 
-        // There are (${INTRINSICS_N} + 1) gather_to_lds instructions above.
-        amdgpu.memory_counter_wait load(${INTRINSICS_N+1})
+        // There are (${INTRINSICS_N*INTRINSICS_K//SUBGROUPS_M} + 1) gather_to_lds instructions above.
+        amdgpu.memory_counter_wait load(${INTRINSICS_N*INTRINSICS_K//SUBGROUPS_M+1})
         rocdl.s.barrier
 
         // Copy LHS from global memory to LDS.
-        scf.for %j = %c0 to %c${INTRINSICS_M} step %c1 {
-          %buffer_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N*64*16} : index
-          %buffer_thread = arith.muli %id, %c16 : index
+        scf.for %j = %c0 to %c${INTRINSICS_M*INTRINSICS_K//SUBGROUPS_N} step %c1 {
+          %buffer_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N*64*INTERNAL_K//2} : index
+          %buffer_thread = arith.muli %id, %c${INTERNAL_K//2} : index
           %buffer_inner = arith.addi %buffer_unroll, %buffer_thread : index
 
           %shared_num = arith.muli %buffer_num, %c${INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K} : index
           %shared_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N} : index
           %shared_subgroup = arith.addi %shared_unroll, %ids#0 : index
           %shared_outer = arith.addi %shared_num, %shared_subgroup : index
-          %shared_inner = arith.muli %ids#1, %c16 : index
+          %shared_inner = arith.muli %ids#1, %c${INTERNAL_K//2} : index
 
+          $assert (4*INTERNAL_K) == 128, "load 128 bits per instruction"
           amdgpu.gather_to_lds %lhs_collapse[%i, %buffer_inner], %lhs_shared_base[%shared_outer, %shared_inner]
             : !lhs_copy_vec_ty, !lhs_buffer_collapse_ty, !lhs_shared_ty
         }
 
         // Copy LHS scale from global memory to LDS.
-        %lhs_scale_buffer_inner = arith.muli %ids#1, %c16 : index
+        %lhs_scale_buffer_outer = arith.muli %ids_lhs_scale#1, %c${64*INTRINSICS_M*INTRINSICS_K} : index
+        %lhs_scale_buffer_inner = arith.muli %ids_lhs_scale#2, %c16 : index
+        %lhs_scale_buffer_offset = arith.addi %lhs_scale_buffer_outer, %lhs_scale_buffer_inner : index
 
         %lhs_scale_shared_num = arith.muli %buffer_num, %c2 : index
-        %lhs_scale_shared_outer = arith.addi %lhs_scale_shared_num, %threads#0 : index
-        %lhs_scale_shared_inner = arith.muli %threads#1, %c16 : index
+        %lhs_scale_shared_outer = arith.addi %lhs_scale_shared_num, %ids_lhs_scale#1 : index
+        %lhs_scale_shared_inner = arith.muli %ids_lhs_scale#2, %c16 : index
 
-        amdgpu.gather_to_lds %lhs_scale_collapse[%i, %lhs_scale_buffer_inner], %lhs_scale_shared[%lhs_scale_shared_outer, %lhs_scale_shared_inner]
+        amdgpu.gather_to_lds %lhs_scale_collapse[%i, %lhs_scale_buffer_offset], %lhs_scale_shared[%lhs_scale_shared_outer, %lhs_scale_shared_inner]
           : !lhs_scale_copy_vec_ty, !lhs_scale_buffer_collapse_ty, !lhs_scale_shared_ty
 
-        // There are (${INTRINSICS_M} + 1) gather_to_lds instructions above.
-        amdgpu.memory_counter_wait load(${INTRINSICS_M+1})
+        // There are (${INTRINSICS_M*INTRINSICS_K//SUBGROUPS_N} + 1) gather_to_lds instructions above.
+        amdgpu.memory_counter_wait load(${INTRINSICS_M*INTRINSICS_K//SUBGROUPS_N+1})
         rocdl.s.barrier
-
 
         scf.yield
       }
@@ -275,7 +277,7 @@ util.func @pingpong_dt_medium_f4E2M1FN(
       %lhs_num = arith.muli %buffer_num, %c${INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K} : index
       %lhs_subgroup = arith.muli %subgroups#0, %c${INTRINSICS_M*INTRINSICS_K} : index
       %lhs_outer = arith.addi %lhs_num, %lhs_subgroup : index
-      %lhs_inner = arith.muli %ids#1, %c16 : index
+      %lhs_inner = arith.muli %ids#1, %c${INTERNAL_K//2} : index
 
       %lhs_scale_num = arith.muli %buffer_num, %c2 : index
       %lhs_scale_outer = arith.addi %lhs_scale_num, %subgroups#0 : index
@@ -284,16 +286,16 @@ util.func @pingpong_dt_medium_f4E2M1FN(
       %rhs_num = arith.muli %buffer_num, %c${INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K} : index
       %rhs_subgroup = arith.muli %subgroups#1, %c${INTRINSICS_N*INTRINSICS_K} : index
       %rhs_outer = arith.addi %rhs_num, %rhs_subgroup : index
-      %rhs_inner = arith.muli %ids#1, %c16 : index
+      %rhs_inner = arith.muli %ids#1, %c${INTERNAL_K//2} : index
 
       %rhs_scale_num = arith.muli %buffer_num, %c2 : index
       %rhs_scale_outer = arith.addi %rhs_scale_num, %subgroups#1 : index
-      %rhs_scale_inner = arith.muli %ids#1, %c16 : index
+      %rhs_scale_inner = arith.muli %ids#1, %c${INTRINSICS_N*INTRINSICS_K} : index
 
       // Load inputs/scales from LDS.
       %lhs_byte_vec = vector.transfer_read %lhs_shared_base[%lhs_outer, %lhs_inner],
-        %cst_lhs {in_bounds = [true, true]} : !lhs_shared_ty, vector<${INTRINSICS_M*INTRINSICS_K}x16xi8>
-      %lhs_byte_vec_t = vector.shape_cast %lhs_byte_vec : vector<${INTRINSICS_M*INTRINSICS_K}x16xi8> to !lhs_byte_vec_ty
+        %cst_lhs {in_bounds = [true, true]} : !lhs_shared_ty, vector<${INTRINSICS_M*INTRINSICS_K}x${INTERNAL_K//2}xi8>
+      %lhs_byte_vec_t = vector.shape_cast %lhs_byte_vec : vector<${INTRINSICS_M*INTRINSICS_K}x${INTERNAL_K//2}xi8> to !lhs_byte_vec_ty
       %lhs_vec = vector.bitcast %lhs_byte_vec_t : !lhs_byte_vec_ty to !lhs_vec_ty
 
       %lhs_scale_byte_vec = vector.transfer_read %lhs_scale_shared[%lhs_scale_outer, %lhs_scale_inner],
@@ -304,8 +306,8 @@ util.func @pingpong_dt_medium_f4E2M1FN(
       rocdl.sched.barrier 0
 
       %rhs_byte_vec = vector.transfer_read %rhs_shared_base[%rhs_outer, %rhs_inner],
-        %cst_rhs {in_bounds = [true, true]} : !rhs_shared_ty, vector<${INTRINSICS_N*INTRINSICS_K}x16xi8>
-      %rhs_byte_vec_t = vector.shape_cast %rhs_byte_vec : vector<${INTRINSICS_N*INTRINSICS_K}x16xi8> to !rhs_byte_vec_ty
+        %cst_rhs {in_bounds = [true, true]} : !rhs_shared_ty, vector<${INTRINSICS_N*INTRINSICS_K}x${INTERNAL_K//2}xi8>
+      %rhs_byte_vec_t = vector.shape_cast %rhs_byte_vec : vector<${INTRINSICS_N*INTRINSICS_K}x${INTERNAL_K//2}xi8> to !rhs_byte_vec_ty
       %rhs_vec = vector.bitcast %rhs_byte_vec_t : !rhs_byte_vec_ty to !rhs_vec_ty
 
       %rhs_scale_byte_vec = vector.transfer_read %rhs_scale_shared[%rhs_scale_outer, %rhs_scale_inner],

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
@@ -3,28 +3,28 @@
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-// Template for scaled f4E2M1FN data-tiled matmul kernels
-// RUN: iree-opt %s
+
+//  RUN: iree-opt %s
+// AUTO-GENERATED - DO NOT EDIT
+// Generated from iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
 
 // Input LHS and RHS layouts.
-// Tensor shape uses fold1() to omit dimensions that equal 1
-!lhs_ty = tensor<1x?x1x${fold1(SUBGROUPS_M)}${fold1(INTRINSICS_M)}${fold1(INTRINSICS_K)}4x16x32xf4E2M1FN>
-!rhs_ty = tensor<1x?x1x${fold1(SUBGROUPS_N)}${fold1(INTRINSICS_N)}${fold1(INTRINSICS_K)}4x16x32xf4E2M1FN>
+!lhs_ty = tensor<1x?x1x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_K)}4x16x32xf4E2M1FN>
+!rhs_ty = tensor<1x?x1x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}${FOLD1(INTRINSICS_K)}4x16x32xf4E2M1FN>
 
 !lhs_byte_ty = tensor<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8>
 !rhs_byte_ty = tensor<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8>
 
 // Buffer types keep all dimensions (no folding) for simpler stride handling
-!lhs_buffer_ty = memref<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}, ${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_K * 4 * 16 * 16}, ${4 * 16 * 16}, ${16 * 16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-!rhs_buffer_ty = memref<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}, ${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}, ${INTRINSICS_K * 4 * 16 * 16}, ${4 * 16 * 16}, ${16 * 16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!lhs_buffer_ty = memref<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*16}, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*16}, ${INTRINSICS_M*INTRINSICS_K*4*16*16}, ${INTRINSICS_K*4*16*16}, ${4*16*16}, ${16*16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_buffer_ty = memref<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*16}, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*16}, ${INTRINSICS_N*INTRINSICS_K*4*16*16}, ${INTRINSICS_K*4*16*16}, ${4*16*16}, ${16*16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
-!lhs_buffer_collapse_ty = memref<?x${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * 4 * 16 * 16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-!rhs_buffer_collapse_ty = memref<?x${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * 4 * 16 * 16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!lhs_buffer_collapse_ty = memref<?x${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_buffer_collapse_ty = memref<?x${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
 // Shared memory: rows = 2 (double buffer) * intrinsics * subgroups * intrinsics_k
-!lhs_shared_ty = memref<${2 * INTRINSICS_M * SUBGROUPS_M * INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
-!rhs_shared_ty = memref<${2 * INTRINSICS_N * SUBGROUPS_N * INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
+!lhs_shared_ty = memref<${2*INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<${2*INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
 
 !lhs_copy_vec_ty = vector<16xi8>
 !rhs_copy_vec_ty = vector<16xi8>
@@ -43,19 +43,19 @@
 !rhs_scale_byte_ty = tensor<1x?x${SUBGROUPS_N}x4x16x${INTRINSICS_N}x${INTRINSICS_K}xi8>
 
 // Scale buffer types - keep all dimensions for simpler stride handling
-!lhs_scale_buffer_ty = memref<1x?x${SUBGROUPS_M}x4x16x${INTRINSICS_M}x${INTRINSICS_K}xi8, strided<[?, ${SUBGROUPS_M * 4 * 16 * INTRINSICS_M * INTRINSICS_K}, ${4 * 16 * INTRINSICS_M * INTRINSICS_K}, ${16 * INTRINSICS_M * INTRINSICS_K}, ${INTRINSICS_M * INTRINSICS_K}, ${INTRINSICS_K}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-!rhs_scale_buffer_ty = memref<1x?x${SUBGROUPS_N}x4x16x${INTRINSICS_N}x${INTRINSICS_K}xi8, strided<[?, ${SUBGROUPS_N * 4 * 16 * INTRINSICS_N * INTRINSICS_K}, ${4 * 16 * INTRINSICS_N * INTRINSICS_K}, ${16 * INTRINSICS_N * INTRINSICS_K}, ${INTRINSICS_N * INTRINSICS_K}, ${INTRINSICS_K}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!lhs_scale_buffer_ty = memref<1x?x${SUBGROUPS_M}x4x16x${INTRINSICS_M}x${INTRINSICS_K}xi8, strided<[?, ${SUBGROUPS_M*4*16*INTRINSICS_M*INTRINSICS_K}, ${4*16*INTRINSICS_M*INTRINSICS_K}, ${16*INTRINSICS_M*INTRINSICS_K}, ${INTRINSICS_M*INTRINSICS_K}, ${INTRINSICS_K}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_scale_buffer_ty = memref<1x?x${SUBGROUPS_N}x4x16x${INTRINSICS_N}x${INTRINSICS_K}xi8, strided<[?, ${SUBGROUPS_N*4*16*INTRINSICS_N*INTRINSICS_K}, ${4*16*INTRINSICS_N*INTRINSICS_K}, ${16*INTRINSICS_N*INTRINSICS_K}, ${INTRINSICS_N*INTRINSICS_K}, ${INTRINSICS_K}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
-!lhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_M * 4 * 16 * INTRINSICS_M * INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-!rhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_N * 4 * 16 * INTRINSICS_N * INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!lhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_M*4*16*INTRINSICS_M*INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_N*4*16*INTRINSICS_N*INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
 !lhs_scale_copy_vec_ty = vector<16xi8>
 !rhs_scale_copy_vec_ty = vector<16xi8>
 
 // Scale shared memory: rows = 2 (double buffer) * subgroups
-// Width = 4 * 16 * INTRINSICS_M/N * INTRINSICS_K (scale data per subgroup per K)
-!lhs_scale_shared_ty = memref<${2 * SUBGROUPS_M}x${4 * 16 * INTRINSICS_M * INTRINSICS_K}xi8, #gpu.address_space<workgroup>>
-!rhs_scale_shared_ty = memref<${2 * SUBGROUPS_N}x${4 * 16 * INTRINSICS_N * INTRINSICS_K}xi8, #gpu.address_space<workgroup>>
+// Width = 4*16*INTRINSICS_M/N*INTRINSICS_K (scale data per subgroup per K)
+!lhs_scale_shared_ty = memref<${2*SUBGROUPS_M}x${4*16*INTRINSICS_M*INTRINSICS_K}xi8, #gpu.address_space<workgroup>>
+!rhs_scale_shared_ty = memref<${2*SUBGROUPS_N}x${4*16*INTRINSICS_N*INTRINSICS_K}xi8, #gpu.address_space<workgroup>>
 
 !lhs_scale_byte_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x1xi8>
 !lhs_scale_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x1xf8E8M0FNU>
@@ -106,9 +106,9 @@ util.func @pingpong_dt_medium_f4E2M1FN(
     },
     benefit = 1,
     // Tile size calculation:
-    // M dimension: 16 (intrinsic) × ${INTRINSICS_M} (intrinsics_m) × ${SUBGROUPS_M} (subgroups_m) = ${16 * INTRINSICS_M * SUBGROUPS_M}.
-    // N dimension: 16 (intrinsic) × ${INTRINSICS_N} (intrinsics_n) × ${SUBGROUPS_N} (subgroups_n) = ${16 * INTRINSICS_N * SUBGROUPS_N}.
-    // KxKB dimension: 128 (intrinsic) × ${INTRINSICS_K} (intrinsics_k) = ${128 * INTRINSICS_K}.
+    // M dimension: 16 (intrinsic) × ${INTRINSICS_M} (intrinsics_m) × ${SUBGROUPS_M} (subgroups_m) = ${16*INTRINSICS_M*SUBGROUPS_M}.
+    // N dimension: 16 (intrinsic) × ${INTRINSICS_N} (intrinsics_n) × ${SUBGROUPS_N} (subgroups_n) = ${16*INTRINSICS_N*SUBGROUPS_N}.
+    // KxKB dimension: 128 (intrinsic) × ${INTRINSICS_K} (intrinsics_k) = ${128*INTRINSICS_K}.
     mma = #iree_gpu.data_tiled_scaled_mma_layout<
       intrinsic = MFMA_SCALE_F32_16x16x128_B32,
       lhs_elem_type = f4E2M1FN,
@@ -132,11 +132,11 @@ util.func @pingpong_dt_medium_f4E2M1FN(
 
   %cINT_M = arith.constant ${INTRINSICS_M} : index
   %cINT_N = arith.constant ${INTRINSICS_N} : index
-  %cSUB_MN = arith.constant ${SUBGROUPS_M * SUBGROUPS_N} : index
-  %cINT_MK = arith.constant ${INTRINSICS_M * INTRINSICS_K} : index
-  %cINT_NK = arith.constant ${INTRINSICS_N * INTRINSICS_K} : index
-  %cLHS_SHARED = arith.constant ${INTRINSICS_M * SUBGROUPS_M * INTRINSICS_K} : index
-  %cRHS_SHARED = arith.constant ${INTRINSICS_N * SUBGROUPS_N * INTRINSICS_K} : index
+  %cSUB_MN = arith.constant ${SUBGROUPS_M*SUBGROUPS_N} : index
+  %cINT_MK = arith.constant ${INTRINSICS_M*INTRINSICS_K} : index
+  %cINT_NK = arith.constant ${INTRINSICS_N*INTRINSICS_K} : index
+  %cLHS_SHARED = arith.constant ${INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K} : index
+  %cRHS_SHARED = arith.constant ${INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K} : index
 
   %cst_lhs = arith.constant 0 : i8
   %cst_rhs = arith.constant 0 : i8
@@ -167,13 +167,14 @@ util.func @pingpong_dt_medium_f4E2M1FN(
   %lhs_scale_collapse = memref.collapse_shape %lhs_scale [[0, 1], [2, 3, 4, 5, 6]] : !lhs_scale_buffer_ty into !lhs_scale_buffer_collapse_ty
   %rhs_scale_collapse = memref.collapse_shape %rhs_scale [[0, 1], [2, 3, 4, 5, 6]] : !rhs_scale_buffer_ty into !rhs_scale_buffer_collapse_ty
 
-  scf.forall (%base_id) in (512) {
+  $assert (SUBGROUPS_M*SUBGROUPS_N) == 4, "workgroup size must be 2x4x64=512"
+  scf.forall (%base_id) in (${2*SUBGROUPS_M*SUBGROUPS_N*64}) {
     // Make the upper 4 waves start copying data.
-    %cmp = arith.cmpi sge, %base_id, %c256 : index
+    %cmp = arith.cmpi sge, %base_id, %c${SUBGROUPS_M*SUBGROUPS_N*64} : index
     scf.if %cmp {
-      %id = arith.subi %base_id, %c256 : index
+      %id = arith.subi %base_id, %c${SUBGROUPS_M*SUBGROUPS_N*64} : index
 
-      %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M * SUBGROUPS_N}, 64) : index, index
+      %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 64) : index, index
       %subgroups:2 = affine.delinearize_index %ids#0 into (${SUBGROUPS_M}, ${SUBGROUPS_N}) : index, index
       %threads:2 = affine.delinearize_index %ids#1 into (2, 32) : index, index
 
@@ -210,7 +211,7 @@ util.func @pingpong_dt_medium_f4E2M1FN(
           : !rhs_scale_copy_vec_ty, !rhs_scale_buffer_collapse_ty, !rhs_scale_shared_ty
 
         // There are (${INTRINSICS_N} + 1) gather_to_lds instructions above.
-        amdgpu.memory_counter_wait load(${INTRINSICS_N + 1})
+        amdgpu.memory_counter_wait load(${INTRINSICS_N+1})
         rocdl.s.barrier
 
         // Copy LHS from global memory to LDS.
@@ -240,7 +241,7 @@ util.func @pingpong_dt_medium_f4E2M1FN(
           : !lhs_scale_copy_vec_ty, !lhs_scale_buffer_collapse_ty, !lhs_scale_shared_ty
 
         // There are (${INTRINSICS_M} + 1) gather_to_lds instructions above.
-        amdgpu.memory_counter_wait load(${INTRINSICS_M + 1})
+        amdgpu.memory_counter_wait load(${INTRINSICS_M+1})
         rocdl.s.barrier
 
 
@@ -258,7 +259,7 @@ util.func @pingpong_dt_medium_f4E2M1FN(
   %0 = tensor.empty() : !return_ty
   %1 = scf.forall (%id) in (256) shared_outs(%out = %0) -> !return_ty {
     %init = arith.constant dense<0.0> : !acc_ty
-    %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M * SUBGROUPS_N}, 64) : index, index
+    %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 64) : index, index
     %subgroups:2 = affine.delinearize_index %ids#0 into (${SUBGROUPS_M}, ${SUBGROUPS_N}) : index, index
     %threads:2 = affine.delinearize_index %ids#1 into (${INTRINSICS_M}, 16) : index, index
 
@@ -291,25 +292,25 @@ util.func @pingpong_dt_medium_f4E2M1FN(
 
       // Load inputs/scales from LDS.
       %lhs_byte_vec = vector.transfer_read %lhs_shared_base[%lhs_outer, %lhs_inner],
-        %cst_lhs {in_bounds = [true, true]} : !lhs_shared_ty, vector<${INTRINSICS_M * INTRINSICS_K}x16xi8>
-      %lhs_byte_vec_t = vector.shape_cast %lhs_byte_vec : vector<${INTRINSICS_M * INTRINSICS_K}x16xi8> to !lhs_byte_vec_ty
+        %cst_lhs {in_bounds = [true, true]} : !lhs_shared_ty, vector<${INTRINSICS_M*INTRINSICS_K}x16xi8>
+      %lhs_byte_vec_t = vector.shape_cast %lhs_byte_vec : vector<${INTRINSICS_M*INTRINSICS_K}x16xi8> to !lhs_byte_vec_ty
       %lhs_vec = vector.bitcast %lhs_byte_vec_t : !lhs_byte_vec_ty to !lhs_vec_ty
 
       %lhs_scale_byte_vec = vector.transfer_read %lhs_scale_shared[%lhs_scale_outer, %lhs_scale_inner],
-        %cst_scale {in_bounds = [true, true]} : !lhs_scale_shared_ty, vector<1x${INTRINSICS_M * INTRINSICS_K}xi8>
-      %lhs_scale_byte_vec_t = vector.shape_cast %lhs_scale_byte_vec : vector<1x${INTRINSICS_M * INTRINSICS_K}xi8> to !lhs_scale_byte_vec_ty
+        %cst_scale {in_bounds = [true, true]} : !lhs_scale_shared_ty, vector<1x${INTRINSICS_M*INTRINSICS_K}xi8>
+      %lhs_scale_byte_vec_t = vector.shape_cast %lhs_scale_byte_vec : vector<1x${INTRINSICS_M*INTRINSICS_K}xi8> to !lhs_scale_byte_vec_ty
       %lhs_scale_vec = vector.bitcast %lhs_scale_byte_vec_t : !lhs_scale_byte_vec_ty to !lhs_scale_vec_ty
 
       rocdl.sched.barrier 0
 
       %rhs_byte_vec = vector.transfer_read %rhs_shared_base[%rhs_outer, %rhs_inner],
-        %cst_rhs {in_bounds = [true, true]} : !rhs_shared_ty, vector<${INTRINSICS_N * INTRINSICS_K}x16xi8>
-      %rhs_byte_vec_t = vector.shape_cast %rhs_byte_vec : vector<${INTRINSICS_N * INTRINSICS_K}x16xi8> to !rhs_byte_vec_ty
+        %cst_rhs {in_bounds = [true, true]} : !rhs_shared_ty, vector<${INTRINSICS_N*INTRINSICS_K}x16xi8>
+      %rhs_byte_vec_t = vector.shape_cast %rhs_byte_vec : vector<${INTRINSICS_N*INTRINSICS_K}x16xi8> to !rhs_byte_vec_ty
       %rhs_vec = vector.bitcast %rhs_byte_vec_t : !rhs_byte_vec_ty to !rhs_vec_ty
 
       %rhs_scale_byte_vec = vector.transfer_read %rhs_scale_shared[%rhs_scale_outer, %rhs_scale_inner],
-        %cst_scale {in_bounds = [true, true]} : !rhs_scale_shared_ty, vector<1x${INTRINSICS_N * INTRINSICS_K}xi8>
-      %rhs_scale_byte_vec_t = vector.shape_cast %rhs_scale_byte_vec : vector<1x${INTRINSICS_N * INTRINSICS_K}xi8> to !rhs_scale_byte_vec_ty
+        %cst_scale {in_bounds = [true, true]} : !rhs_scale_shared_ty, vector<1x${INTRINSICS_N*INTRINSICS_K}xi8>
+      %rhs_scale_byte_vec_t = vector.shape_cast %rhs_scale_byte_vec : vector<1x${INTRINSICS_N*INTRINSICS_K}xi8> to !rhs_scale_byte_vec_ty
       %rhs_scale_vec = vector.bitcast %rhs_scale_byte_vec_t : !rhs_scale_byte_vec_ty to !rhs_scale_vec_ty
 
       amdgpu.lds_barrier

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
@@ -9,31 +9,32 @@
 // Generated from iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir.in
 
 // Input LHS and RHS layouts.
-!lhs_ty = tensor<1x?x1x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_K)}4x16x32xf4E2M1FN>
-!rhs_ty = tensor<1x?x1x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}${FOLD1(INTRINSICS_K)}4x16x32xf4E2M1FN>
+!lhs_ty = tensor<1x?x1x${FOLD1(SUBGROUPS_M)}${FOLD1(INTRINSICS_M)}${FOLD1(INTRINSICS_K)}4x16x${INTERNAL_K}xf4E2M1FN>
+!rhs_ty = tensor<1x?x1x${FOLD1(SUBGROUPS_N)}${FOLD1(INTRINSICS_N)}${FOLD1(INTRINSICS_K)}4x16x${INTERNAL_K}xf4E2M1FN>
 
-!lhs_byte_ty = tensor<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8>
-!rhs_byte_ty = tensor<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8>
+!lhs_byte_ty = tensor<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8>
+!rhs_byte_ty = tensor<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8>
 
 // Buffer types keep all dimensions (no folding) for simpler stride handling
-!lhs_buffer_ty = memref<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*16}, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*16}, ${INTRINSICS_M*INTRINSICS_K*4*16*16}, ${INTRINSICS_K*4*16*16}, ${4*16*16}, ${16*16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-!rhs_buffer_ty = memref<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x16xi8, strided<[?, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*16}, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*16}, ${INTRINSICS_N*INTRINSICS_K*4*16*16}, ${INTRINSICS_K*4*16*16}, ${4*16*16}, ${16*16}, 16, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!lhs_buffer_ty = memref<1x?x1x${SUBGROUPS_M}x${INTRINSICS_M}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8, strided<[?, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${4*16*(INTERNAL_K//2)}, ${16*(INTERNAL_K//2)}, ${INTERNAL_K//2}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_buffer_ty = memref<1x?x1x${SUBGROUPS_N}x${INTRINSICS_N}x${INTRINSICS_K}x4x16x${INTERNAL_K//2}xi8, strided<[?, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${INTRINSICS_K*4*16*(INTERNAL_K//2)}, ${4*16*(INTERNAL_K//2)}, ${16*(INTERNAL_K//2)}, ${INTERNAL_K//2}, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
-!lhs_buffer_collapse_ty = memref<?x${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-!rhs_buffer_collapse_ty = memref<?x${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*16}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!lhs_buffer_collapse_ty = memref<?x${SUBGROUPS_M*INTRINSICS_M*INTRINSICS_K*4*16*(INTERNAL_K//2)}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+!rhs_buffer_collapse_ty = memref<?x${SUBGROUPS_N*INTRINSICS_N*INTRINSICS_K*4*16*(INTERNAL_K//2)}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
 // Shared memory: rows = 2 (double buffer) * intrinsics * subgroups * intrinsics_k
-!lhs_shared_ty = memref<${2*INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
-!rhs_shared_ty = memref<${2*INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K}x1024xi8, #gpu.address_space<workgroup>>
+!lhs_shared_ty = memref<${2*INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K}x${32*INTERNAL_K}xi8, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<${2*INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K}x${32*INTERNAL_K}xi8, #gpu.address_space<workgroup>>
 
-!lhs_copy_vec_ty = vector<16xi8>
-!rhs_copy_vec_ty = vector<16xi8>
+$assert (4*INTERNAL_K) == 128, "load 128 bits per instruction"
+!lhs_copy_vec_ty = vector<${INTERNAL_K//2}xi8>
+!rhs_copy_vec_ty = vector<${INTERNAL_K//2}xi8>
 
-!lhs_byte_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x16xi8>
-!lhs_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x32xf4E2M1FN>
+!lhs_byte_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K//2}xi8>
+!lhs_vec_ty = vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}xf4E2M1FN>
 
-!rhs_byte_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x16xi8>
-!rhs_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x32xf4E2M1FN>
+!rhs_byte_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K//2}xi8>
+!rhs_vec_ty = vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}xf4E2M1FN>
 
 // Input scale layouts - keep all dimensions for buffer compatibility
 !lhs_scale_ty = tensor<1x?x${SUBGROUPS_M}x4x16x${INTRINSICS_M}x${INTRINSICS_K}xf8E8M0FNU>
@@ -49,8 +50,9 @@
 !lhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_M*4*16*INTRINSICS_M*INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 !rhs_scale_buffer_collapse_ty = memref<?x${SUBGROUPS_N*4*16*INTRINSICS_N*INTRINSICS_K}xi8, strided<[?, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
 
-!lhs_scale_copy_vec_ty = vector<16xi8>
-!rhs_scale_copy_vec_ty = vector<16xi8>
+$assert (4*INTERNAL_K) == 128, "load 128 bits per instruction"
+!lhs_scale_copy_vec_ty = vector<${INTERNAL_K//2}xi8>
+!rhs_scale_copy_vec_ty = vector<${INTERNAL_K//2}xi8>
 
 // Scale shared memory: rows = 2 (double buffer) * subgroups
 // Width = 4*16*INTRINSICS_M/N*INTRINSICS_K (scale data per subgroup per K)
@@ -125,18 +127,16 @@ util.func @pingpong_dt_medium_f4E2M1FN(
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
   %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
   %c256 = arith.constant 256 : index
   %c1024 = arith.constant 1024 : index
   %c4096 = arith.constant 4096 : index
-
-  %cINT_M = arith.constant ${INTRINSICS_M} : index
-  %cINT_N = arith.constant ${INTRINSICS_N} : index
-  %cSUB_MN = arith.constant ${SUBGROUPS_M*SUBGROUPS_N} : index
-  %cINT_MK = arith.constant ${INTRINSICS_M*INTRINSICS_K} : index
-  %cINT_NK = arith.constant ${INTRINSICS_N*INTRINSICS_K} : index
-  %cLHS_SHARED = arith.constant ${INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K} : index
-  %cRHS_SHARED = arith.constant ${INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K} : index
 
   %cst_lhs = arith.constant 0 : i8
   %cst_rhs = arith.constant 0 : i8
@@ -183,13 +183,13 @@ util.func @pingpong_dt_medium_f4E2M1FN(
         %buffer_num = arith.andi %i, %c1 : index
 
         // Copy RHS from global memory to LDS.
-        scf.for %j = %c0 to %cINT_N step %c1 {
-          %buffer_unroll = arith.muli %j, %c4096 : index
+        scf.for %j = %c0 to %c${INTRINSICS_N} step %c1 {
+          %buffer_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N*64*16}: index
           %buffer_thread = arith.muli %id, %c16 : index
           %buffer_inner = arith.addi %buffer_unroll, %buffer_thread : index
 
-          %shared_num = arith.muli %buffer_num, %cRHS_SHARED : index
-          %shared_unroll = arith.muli %j, %cSUB_MN : index
+          %shared_num = arith.muli %buffer_num, %c${INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K} : index
+          %shared_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N} : index
           %shared_subgroup = arith.addi %shared_unroll, %ids#0 : index
           %shared_outer = arith.addi %shared_num, %shared_subgroup : index
           %shared_inner = arith.muli %ids#1, %c16 : index
@@ -215,13 +215,13 @@ util.func @pingpong_dt_medium_f4E2M1FN(
         rocdl.s.barrier
 
         // Copy LHS from global memory to LDS.
-        scf.for %j = %c0 to %cINT_M step %c1 {
-          %buffer_unroll = arith.muli %j, %c4096 : index
+        scf.for %j = %c0 to %c${INTRINSICS_M} step %c1 {
+          %buffer_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N*64*16} : index
           %buffer_thread = arith.muli %id, %c16 : index
           %buffer_inner = arith.addi %buffer_unroll, %buffer_thread : index
 
-          %shared_num = arith.muli %buffer_num, %cLHS_SHARED : index
-          %shared_unroll = arith.muli %j, %cSUB_MN : index
+          %shared_num = arith.muli %buffer_num, %c${INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K} : index
+          %shared_unroll = arith.muli %j, %c${SUBGROUPS_M*SUBGROUPS_N} : index
           %shared_subgroup = arith.addi %shared_unroll, %ids#0 : index
           %shared_outer = arith.addi %shared_num, %shared_subgroup : index
           %shared_inner = arith.muli %ids#1, %c16 : index
@@ -257,11 +257,11 @@ util.func @pingpong_dt_medium_f4E2M1FN(
 
 
   %0 = tensor.empty() : !return_ty
-  %1 = scf.forall (%id) in (256) shared_outs(%out = %0) -> !return_ty {
+  %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> !return_ty {
     %init = arith.constant dense<0.0> : !acc_ty
     %ids:2 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 64) : index, index
     %subgroups:2 = affine.delinearize_index %ids#0 into (${SUBGROUPS_M}, ${SUBGROUPS_N}) : index, index
-    %threads:2 = affine.delinearize_index %ids#1 into (${INTRINSICS_M}, 16) : index, index
+    %threads:2 = affine.delinearize_index %ids#1 into (4, 16) : index, index
 
     // Misalign by one group.
     rocdl.s.barrier
@@ -272,17 +272,17 @@ util.func @pingpong_dt_medium_f4E2M1FN(
 
       %buffer_num = arith.andi %i, %c1 : index
 
-      %lhs_num = arith.muli %buffer_num, %cLHS_SHARED : index
-      %lhs_subgroup = arith.muli %subgroups#0, %cINT_MK : index
+      %lhs_num = arith.muli %buffer_num, %c${INTRINSICS_M*SUBGROUPS_M*INTRINSICS_K} : index
+      %lhs_subgroup = arith.muli %subgroups#0, %c${INTRINSICS_M*INTRINSICS_K} : index
       %lhs_outer = arith.addi %lhs_num, %lhs_subgroup : index
       %lhs_inner = arith.muli %ids#1, %c16 : index
 
       %lhs_scale_num = arith.muli %buffer_num, %c2 : index
       %lhs_scale_outer = arith.addi %lhs_scale_num, %subgroups#0 : index
-      %lhs_scale_inner = arith.muli %ids#1, %cINT_MK : index
+      %lhs_scale_inner = arith.muli %ids#1, %c${INTRINSICS_M*INTRINSICS_K} : index
 
-      %rhs_num = arith.muli %buffer_num, %cRHS_SHARED : index
-      %rhs_subgroup = arith.muli %subgroups#1, %cINT_NK : index
+      %rhs_num = arith.muli %buffer_num, %c${INTRINSICS_N*SUBGROUPS_N*INTRINSICS_K} : index
+      %rhs_subgroup = arith.muli %subgroups#1, %c${INTRINSICS_N*INTRINSICS_K} : index
       %rhs_outer = arith.addi %rhs_num, %rhs_subgroup : index
       %rhs_inner = arith.muli %ids#1, %c16 : index
 

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
@@ -3,17 +3,17 @@
 
 // LHS types
 !lhs_in_ty = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x?x${ELEM_TYPE}>
-!lhs_block_in = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}>
-!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 256 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x4x${4 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_block_in = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
+!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 256 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x${4 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 // RHS types
 !rhs_in_ty = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x?x${ELEM_TYPE}>
-!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}>
-!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 256 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x4x${4 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
+!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 256 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x${4 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -32,7 +32,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
-  %c256 = arith.constant 256 : index
+  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
   %lhs_shared_base = memref.alloc() : !lhs_flat_shared
   %rhs_shared_base = memref.alloc() : !rhs_flat_shared
@@ -45,34 +45,34 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
   %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !lhs_flat_shared
   %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !rhs_flat_shared
 
-  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K}] : !lhs_flat_shared into !lhs_shared
-  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K}] : !rhs_flat_shared into !rhs_shared
+  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] : !lhs_flat_shared into !lhs_shared
+  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] : !rhs_flat_shared into !rhs_shared
 
-  %lhs_init = tensor.extract_slice %lhs [0, 0] [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
-  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+  %lhs_init = tensor.extract_slice %lhs [0, 0] [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
+  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
 
-  scf.forall (%id) in (${SUBGROUPS_M * INTRINSICS_M * 2 * INTRINSICS_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+  scf.forall (%id) in (${2 * SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
     %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
     %lhs_thread_local = tensor.extract_slice %lhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (${SUBGROUPS_N * INTRINSICS_N * 2 * INTRINSICS_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+  scf.forall (%id) in (${2 * SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
     %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
     %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
-  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [16, 16, 4, ${4 * INTRINSICS_K}] : !lhs_shared into !lhs_shared_exp
-  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [16, 16, 4, ${4 * INTRINSICS_K}] : !rhs_shared into !rhs_shared_exp
+  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, ${4 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !lhs_shared into !lhs_shared_exp
+  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, ${4 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !rhs_shared into !rhs_shared_exp
 
   %0 = tensor.empty() : tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
   %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
-    %inner_id = arith.muli %ids#2, %c${INTRINSICS_K} overflow<nsw, nuw> : index
+    %inner_id = arith.muli %ids#2, %c${INTRINSICS_K * INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
     %m_outer_id = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
     %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
@@ -91,15 +91,15 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c256 : index
-    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
-    %3 = scf.for %i = %c${16 * INTRINSICS_K} to %dim step %c${16 * INTRINSICS_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+    %3 = scf.for %i = %c${16 * INTRINSICS_K * INTERNAL_K} to %dim step %c${16 * INTRINSICS_K * INTERNAL_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
 
       // Global loads of lhs.
-      %lhs_block = tensor.extract_slice %lhs [0, %i] [256, ${16 * INTRINSICS_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
+      %lhs_block = tensor.extract_slice %lhs [0, %i] [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
       %lhs_thread_0 = tensor.extract_slice %lhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_thread_1 = tensor.extract_slice %lhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
@@ -109,26 +109,28 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       %lhs_thread_3 = tensor.extract_slice %lhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
 
-      %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-      %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
-      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0, %rhs_vec_0) outs(%iter) {
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
         indexing_maps = #contraction_accesses,
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
-      %rhs_block = tensor.extract_slice %rhs [0, %i] [256, ${16 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
       %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
@@ -138,40 +140,46 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
 
-      %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-      %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_1_t = vector.transpose %lhs_vec_1, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_1_t = vector.transpose %rhs_vec_1, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
-      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1, %rhs_vec_1) outs(%dot0) {
+      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
         indexing_maps = #contraction_accesses,
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
       rocdl.sched.barrier 0
 
-      %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-      %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      %lhs_vec_3 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-      %rhs_vec_3 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %lhs_vec_3 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_3_t = vector.transpose %lhs_vec_3, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_3_t = vector.transpose %rhs_vec_3, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
-      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2, %rhs_vec_2) outs(%dot1) {
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
         indexing_maps = #contraction_accesses,
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -191,12 +199,12 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
-      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3, %rhs_vec_3) outs(%dot2) {
+      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
         indexing_maps = #contraction_accesses,
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -209,38 +217,46 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
     }
 
     // Epilogue
-    %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0, %rhs_vec_0) outs(%3) {
+    %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
-    %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1, %rhs_vec_1) outs(%dot0) {
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_1_t = vector.transpose %lhs_vec_1, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_1_t = vector.transpose %rhs_vec_1, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
-    %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2, %rhs_vec_2) outs(%dot1) {
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
-    %lhs_vec_3 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %rhs_vec_3 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
-    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3, %rhs_vec_3) outs(%dot2) {
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    %lhs_vec_3 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_3_t = vector.transpose %lhs_vec_3, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_3_t = vector.transpose %rhs_vec_3, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %tp = vector.transpose %dot3, [0, 2, 1, 3] : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
     %empty = tensor.empty() : tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
@@ -83,14 +83,14 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
   $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
   %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> tensor<${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
-    %m_outer_id = arith.muli %ids#0, %c${INTERNAL_M} overflow<nsw, nuw> : index
-    %n_outer_id = arith.muli %ids#1, %c${INTERNAL_N} overflow<nsw, nuw> : index
+    %m_outer_id = arith.muli %ids#0, %c${INTRINSICS_M} overflow<nsw, nuw> : index
+    %n_outer_id = arith.muli %ids#1, %c${INTRINSICS_N} overflow<nsw, nuw> : index
     %inner_id = arith.muli %ids#2, %c${INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
 
     %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
-    %bpo_lhs = arith.muli %wt#0, %c{SUBGROUPS_M*INTRINSICS_M*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
-    %bpo_rhs = arith.muli %wt#0, %c{SUBGROUPS_N*INTRINSICS_N*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %bpo_lhs = arith.muli %wt#0, %c${SUBGROUPS_M*INTRINSICS_M*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %bpo_rhs = arith.muli %wt#0, %c${SUBGROUPS_N*INTRINSICS_N*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
     %glb0_lhs = arith.addi %wt#1, %bpo_lhs overflow<nsw, nuw> : index
     %glb0_rhs = arith.addi %wt#1, %bpo_rhs overflow<nsw, nuw> : index
     $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
@@ -119,7 +119,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -131,21 +131,21 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
       %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N*INTRINSICS_N*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
       $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
         %rhs_thread_${j} = tensor.extract_slice %rhs_block [%glb${j}_rhs, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-        %rhs_vec_local_${j} = vector.transfer_read %rhs_thread_${j} [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>`
+        %rhs_vec_local_${j} = vector.transfer_read %rhs_thread_${j} [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %lhs_vec_1_t = vector.transpose %lhs_vec_1, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_1_t = vector.transpose %rhs_vec_1, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -157,7 +157,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
@@ -170,7 +170,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       %lhs_vec_3_t = vector.transpose %lhs_vec_3, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_3_t = vector.transpose %rhs_vec_3, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -182,7 +182,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       $for j in range(SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
@@ -191,7 +191,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
         vector.transfer_write %rhs_vec_local_${j}, %rhs_shared [%glb${j}_rhs, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -203,7 +203,7 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       scf.yield %dot3 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
@@ -1,0 +1,254 @@
+//  RUN: iree-opt %s
+// Template for large non-data-tiled matmul kernels
+
+// LHS types
+!lhs_in_ty = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x?x${ELEM_TYPE}>
+!lhs_block_in = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}>
+!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 256 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x4x${4 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+
+// RHS types
+!rhs_in_ty = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x?x${ELEM_TYPE}>
+!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}>
+!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 256 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x4x${4 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base: !rhs_in_ty, %unused_acc: tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>) -> tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.0 : ${ELEM_TYPE}
+  %lhs_shared_base = memref.alloc() : !lhs_flat_shared
+  %rhs_shared_base = memref.alloc() : !rhs_flat_shared
+
+  %dim = tensor.dim %lhs_base, %c1 : !lhs_in_ty
+  %dim_stride = arith.muli %dim, %c${ELEM_BITS // 8} overflow<nsw, nuw>: index
+  %lhs = iree_gpu.buffer_resource_cast %lhs_base cacheSwizzleStride(%dim_stride) : !lhs_in_ty
+  %rhs = iree_gpu.buffer_resource_cast %rhs_base cacheSwizzleStride(%dim_stride) : !rhs_in_ty
+
+  %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !lhs_flat_shared
+  %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !rhs_flat_shared
+
+  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K}] : !lhs_flat_shared into !lhs_shared
+  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K}] : !rhs_flat_shared into !rhs_shared
+
+  %lhs_init = tensor.extract_slice %lhs [0, 0] [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
+  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+
+  scf.forall (%id) in (${SUBGROUPS_M * INTRINSICS_M * 2 * INTRINSICS_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (${SUBGROUPS_N * INTRINSICS_N * 2 * INTRINSICS_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [16, 16, 4, ${4 * INTRINSICS_K}] : !lhs_shared into !lhs_shared_exp
+  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [16, 16, 4, ${4 * INTRINSICS_K}] : !rhs_shared into !rhs_shared_exp
+
+  %0 = tensor.empty() : tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
+  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> {
+    %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
+    %inner_id = arith.muli %ids#2, %c${INTRINSICS_K} overflow<nsw, nuw> : index
+    %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
+    %m_outer_id = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
+    %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
+    %delin:2 = affine.delinearize_index %id into (64, 8) : index, index
+    %wt:3 = affine.delinearize_index %id into (8, 8, 8) : index, index, index
+
+    // Inner 64 loads 8 threads x VEC_SIZE elements.
+    %gko = arith.muli %wt#2, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    // Each subgroup loads 32 contiguous rows out of 256.
+    %bpo = arith.muli %wt#0, %c32 overflow<nsw, nuw> : index
+    // Base index is remaining outer 8 lanes + subgroup base.
+    %glb0 = arith.addi %wt#1, %bpo overflow<nsw, nuw> : index
+    %glb1 = arith.addi %glb0, %c8 overflow<nsw, nuw> : index
+    %glb2 = arith.addi %glb1, %c8 overflow<nsw, nuw> : index
+    %glb3 = arith.addi %glb2, %c8 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+    %3 = scf.for %i = %c${16 * INTRINSICS_K} to %dim step %c${16 * INTRINSICS_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+
+      // Global loads of lhs.
+      %lhs_block = tensor.extract_slice %lhs [0, %i] [256, ${16 * INTRINSICS_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
+      %lhs_thread_0 = tensor.extract_slice %lhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_1 = tensor.extract_slice %lhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_2 = tensor.extract_slice %lhs_block [%glb2, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_3 = tensor.extract_slice %lhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+
+      %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0, %rhs_vec_0) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_block = tensor.extract_slice %rhs [0, %i] [256, ${16 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+
+      %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1, %rhs_vec_1) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+
+      %lhs_vec_3 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2, %rhs_vec_2) outs(%dot1) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_2, %lhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_3, %lhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+
+      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3, %rhs_vec_3) outs(%dot2) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot3 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0, %rhs_vec_0) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1, %rhs_vec_1) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2, %rhs_vec_2) outs(%dot1) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    %lhs_vec_3 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c3, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>
+    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3, %rhs_vec_3) outs(%dot2) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x1x1x${INTRINSICS_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x1x1x${INTRINSICS_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %tp = vector.transpose %dot3, [0, 2, 1, 3] : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
+    %empty = tensor.empty() : tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
+    %4 = vector.transfer_write %tp, %empty[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>, tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%m_outer_id, %ids#3, %n_outer_id, %inner_id_acc] [${INTRINSICS_M}, 1, ${INTRINSICS_N}, 4] [1, 1, 1, 1] : tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32> into tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  %collapse = tensor.collapse_shape %1 [[0, 1], [2, 3]] : tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> into tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
+  util.return %collapse : tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
@@ -83,21 +83,21 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
   $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
   %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> tensor<${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
+    %m_outer_id = arith.muli %ids#0, %c${INTERNAL_M} overflow<nsw, nuw> : index
+    %n_outer_id = arith.muli %ids#1, %c${INTERNAL_N} overflow<nsw, nuw> : index
     %inner_id = arith.muli %ids#2, %c${INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
-    %m_outer_id = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
-    %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
-    %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
 
-    // Inner 64 loads 8 threads x VEC_SIZE elements.
+    %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
+    %bpo_lhs = arith.muli %wt#0, %c{SUBGROUPS_M*INTRINSICS_M*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %bpo_rhs = arith.muli %wt#0, %c{SUBGROUPS_N*INTRINSICS_N*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %glb0_lhs = arith.addi %wt#1, %bpo_lhs overflow<nsw, nuw> : index
+    %glb0_rhs = arith.addi %wt#1, %bpo_rhs overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_lhs = arith.addi %glb${j-1}_lhs, %c8 overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_rhs = arith.addi %glb${j-1}_rhs, %c8 overflow<nsw, nuw> : index
     %gko = arith.muli %wt#2, %c${2*INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
-    // Each subgroup loads 32 contiguous rows out of 256.
-    %bpo = arith.muli %wt#0, %c32 overflow<nsw, nuw> : index
-    // Base index is remaining outer 8 lanes + subgroup base.
-    %glb0 = arith.addi %wt#1, %bpo overflow<nsw, nuw> : index
-    %glb1 = arith.addi %glb0, %c8 overflow<nsw, nuw> : index
-    %glb2 = arith.addi %glb1, %c8 overflow<nsw, nuw> : index
-    %glb3 = arith.addi %glb2, %c8 overflow<nsw, nuw> : index
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
@@ -110,14 +110,9 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
 
       // Global loads of lhs.
       %lhs_block = tensor.extract_slice %lhs [0, %i] [${SUBGROUPS_M*INTRINSICS_M*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
-      %lhs_thread_0 = tensor.extract_slice %lhs_block [%glb0, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_thread_1 = tensor.extract_slice %lhs_block [%glb1, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_thread_2 = tensor.extract_slice %lhs_block [%glb2, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_thread_3 = tensor.extract_slice %lhs_block [%glb3, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      $for j in range(SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
+        %lhs_thread_${j} = tensor.extract_slice %lhs_block [%glb${j}_lhs, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${j} = vector.transfer_read %lhs_thread_${j} [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
@@ -141,14 +136,9 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
 
       // Global loads of rhs.
       %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N*INTRINSICS_N*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
-      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
+        %rhs_thread_${j} = tensor.extract_slice %rhs_block [%glb${j}_rhs, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${j} = vector.transfer_read %rhs_thread_${j} [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>`
 
       %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
@@ -195,15 +185,11 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       gpu.barrier
       rocdl.sched.barrier 0
 
-      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_2, %lhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_3, %lhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
+      $for j in range(SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %lhs_vec_local_${j}, %lhs_shared [%glb${j}_lhs, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
 
-      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %rhs_vec_local_${j}, %rhs_shared [%glb${j}_rhs, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
 
       gpu.barrier
       rocdl.sched.barrier 0

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_large.mlir.in
@@ -1,19 +1,26 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 //  RUN: iree-opt %s
-// Template for large non-data-tiled matmul kernels
+// AUTO-GENERATED - DO NOT EDIT
+// Generated from iree_uk_amdgpu_matmul_large.mlir.in
 
 // LHS types
-!lhs_in_ty = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x?x${ELEM_TYPE}>
-!lhs_block_in = tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
-!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 256 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x${4 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_in_ty = tensor<${SUBGROUPS_M*INTRINSICS_M*16}x?x${ELEM_TYPE}>
+!lhs_block_in = tensor<${SUBGROUPS_M*INTRINSICS_M*16}x${16*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!lhs_flat_shared = memref<${SUBGROUPS_M*INTRINSICS_M*256*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared = memref<${SUBGROUPS_M*INTRINSICS_M*16}x${16*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared_exp = memref<${SUBGROUPS_M*INTRINSICS_M}x16x${4*INTRINSICS_K}x${4*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 // RHS types
-!rhs_in_ty = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x?x${ELEM_TYPE}>
-!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
-!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 256 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${16 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x${4 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_in_ty = tensor<${SUBGROUPS_N*INTRINSICS_N*16}x?x${ELEM_TYPE}>
+!rhs_block_in = tensor<${SUBGROUPS_N*INTRINSICS_N*16}x${16*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!rhs_flat_shared = memref<${SUBGROUPS_N*INTRINSICS_N*256*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared = memref<${SUBGROUPS_N*INTRINSICS_N*16}x${16*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_exp = memref<${SUBGROUPS_N*INTRINSICS_N}x16x${4*INTRINSICS_K}x${4*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -21,7 +28,7 @@
  affine_map<(i, j, k) -> (i, j)>
 ]
 
-util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base: !rhs_in_ty, %unused_acc: tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>) -> tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32> {
+util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base: !rhs_in_ty, %unused_acc: tensor<${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32>) -> tensor<${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -32,55 +39,58 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
-  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+  %c256 = arith.constant 256 : index
+
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
   %lhs_shared_base = memref.alloc() : !lhs_flat_shared
   %rhs_shared_base = memref.alloc() : !rhs_flat_shared
 
   %dim = tensor.dim %lhs_base, %c1 : !lhs_in_ty
-  %dim_stride = arith.muli %dim, %c${ELEM_BITS // 8} overflow<nsw, nuw>: index
+  %dim_stride = arith.muli %dim, %c${ELEM_BITS//8} overflow<nsw, nuw>: index
   %lhs = iree_gpu.buffer_resource_cast %lhs_base cacheSwizzleStride(%dim_stride) : !lhs_in_ty
   %rhs = iree_gpu.buffer_resource_cast %rhs_base cacheSwizzleStride(%dim_stride) : !rhs_in_ty
 
-  %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !lhs_flat_shared
-  %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !rhs_flat_shared
+  %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024//ELEM_BITS}, ${64//ELEM_BITS}>] : !lhs_flat_shared
+  %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024//ELEM_BITS}, ${64//ELEM_BITS}>] : !rhs_flat_shared
 
-  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] : !lhs_flat_shared into !lhs_shared
-  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] : !rhs_flat_shared into !rhs_shared
+  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M*INTRINSICS_M*16}, ${16*INTRINSICS_K*INTERNAL_K}] : !lhs_flat_shared into !lhs_shared
+  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N*INTRINSICS_N*16}, ${16*INTRINSICS_K*INTERNAL_K}] : !rhs_flat_shared into !rhs_shared
 
-  %lhs_init = tensor.extract_slice %lhs [0, 0] [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
-  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+  %lhs_init = tensor.extract_slice %lhs [0, 0] [${SUBGROUPS_M*INTRINSICS_M*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
+  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N*INTRINSICS_N*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
 
-  scf.forall (%id) in (${2 * SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
-    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
-    %lhs_thread_local = tensor.extract_slice %lhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+  scf.forall (%id) in (${128*SUBGROUPS_M*INTRINSICS_M}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M*INTRINSICS_M*16}, 8) : index, index
+    $assert (2*INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %vec = arith.muli %delin#1, %c${2*INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs_init [%delin#0, %vec] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (${2 * SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
-    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
-    %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+  scf.forall (%id) in (${128*SUBGROUPS_N*INTRINSICS_N}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N*INTRINSICS_N*16}, 8) : index, index
+    $assert (2*INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %vec = arith.muli %delin#1, %c${2*INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
-  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, ${4 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !lhs_shared into !lhs_shared_exp
-  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, ${4 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !rhs_shared into !rhs_shared_exp
+  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M*INTRINSICS_M}, 16, ${4*INTRINSICS_K}, ${4*INTERNAL_K}] : !lhs_shared into !lhs_shared_exp
+  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M*INTRINSICS_M}, 16, ${4*INTRINSICS_K}, ${4*INTERNAL_K}] : !rhs_shared into !rhs_shared_exp
 
-  %0 = tensor.empty() : tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
-  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> {
+  %0 = tensor.empty() : tensor<${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32>
+  $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
+  %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> tensor<${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
-    %inner_id = arith.muli %ids#2, %c${INTRINSICS_K * INTERNAL_K} overflow<nsw, nuw> : index
+    %inner_id = arith.muli %ids#2, %c${INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
     %m_outer_id = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
     %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
-    %delin:2 = affine.delinearize_index %id into (64, 8) : index, index
-    %wt:3 = affine.delinearize_index %id into (8, 8, 8) : index, index, index
+    %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
 
     // Inner 64 loads 8 threads x VEC_SIZE elements.
-    %gko = arith.muli %wt#2, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    %gko = arith.muli %wt#2, %c${2*INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
     // Each subgroup loads 32 contiguous rows out of 256.
     %bpo = arith.muli %wt#0, %c32 overflow<nsw, nuw> : index
     // Base index is remaining outer 8 lanes + subgroup base.
@@ -91,23 +101,23 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
-    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
-    %3 = scf.for %i = %c${16 * INTRINSICS_K * INTERNAL_K} to %dim step %c${16 * INTRINSICS_K * INTERNAL_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+    %3 = scf.for %i = %c${16*INTRINSICS_K*INTERNAL_K} to %dim step %c${16*INTRINSICS_K*INTERNAL_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
 
       // Global loads of lhs.
-      %lhs_block = tensor.extract_slice %lhs [0, %i] [${SUBGROUPS_M * INTRINSICS_M * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
-      %lhs_thread_0 = tensor.extract_slice %lhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_1 = tensor.extract_slice %lhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_2 = tensor.extract_slice %lhs_block [%glb2, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_3 = tensor.extract_slice %lhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !lhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_block = tensor.extract_slice %lhs [0, %i] [${SUBGROUPS_M*INTRINSICS_M*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_in_ty to !lhs_block_in
+      %lhs_thread_0 = tensor.extract_slice %lhs_block [%glb0, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_thread_1 = tensor.extract_slice %lhs_block [%glb1, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_thread_2 = tensor.extract_slice %lhs_block [%glb2, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_thread_3 = tensor.extract_slice %lhs_block [%glb3, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !lhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
@@ -130,15 +140,15 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
-      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${16 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
-      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N*INTRINSICS_N*16}, ${16*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${2*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       %lhs_vec_1 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_1 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c1, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
@@ -185,15 +195,15 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
       gpu.barrier
       rocdl.sched.barrier 0
 
-      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_2, %lhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_3, %lhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_2, %lhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_3, %lhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
 
-      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${2*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -262,9 +272,9 @@ util.func private @pingpong_large_${ELEM_TYPE}(%lhs_base: !lhs_in_ty, %rhs_base:
     %empty = tensor.empty() : tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
     %4 = vector.transfer_write %tp, %empty[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>, tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
     scf.forall.in_parallel {
-      tensor.parallel_insert_slice %4 into %out[%m_outer_id, %ids#3, %n_outer_id, %inner_id_acc] [${INTRINSICS_M}, 1, ${INTRINSICS_N}, 4] [1, 1, 1, 1] : tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32> into tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
+      tensor.parallel_insert_slice %4 into %out[%m_outer_id, %ids#3, %n_outer_id, %inner_id_acc] [${INTRINSICS_M}, 1, ${INTRINSICS_N}, 4] [1, 1, 1, 1] : tensor<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32> into tensor<${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32>
     }
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  %collapse = tensor.collapse_shape %1 [[0, 1], [2, 3]] : tensor<${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> into tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
-  util.return %collapse : tensor<${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
+  %collapse = tensor.collapse_shape %1 [[0, 1], [2, 3]] : tensor<${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> into tensor<${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32>
+  util.return %collapse : tensor<${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32>
 }

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
@@ -3,17 +3,17 @@
 
 // LHS types
 !lhs_in_ty = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x?x${ELEM_TYPE}>
-!lhs_block_in = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}>
-!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 128 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x4x${2 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_block_in = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
+!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 128 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x${2 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 // RHS types
 !rhs_in_ty = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x?x${ELEM_TYPE}>
-!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}>
-!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 128 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x4x${2 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
+!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 128 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x${2 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -32,7 +32,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
-  %c256 = arith.constant 256 : index
+  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
   %lhs_shared_base = memref.alloc() : !lhs_flat_shared
   %rhs_shared_base = memref.alloc() : !rhs_flat_shared
@@ -45,29 +45,29 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
   %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !lhs_flat_shared
   %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !rhs_flat_shared
 
-  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K}] : !lhs_flat_shared into !lhs_shared
-  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K}] : !rhs_flat_shared into !rhs_shared
+  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] : !lhs_flat_shared into !lhs_shared
+  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] : !rhs_flat_shared into !rhs_shared
 
-  %lhs_init = tensor.extract_slice %lhs [0, 0, 0] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
-  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+  %lhs_init = tensor.extract_slice %lhs [0, 0, 0] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
+  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
 
-  scf.forall (%id) in (${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+  scf.forall (%id) in (${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
     %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
     %lhs_thread_local = tensor.extract_slice %lhs_init [0, %delin#0, %vec] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+  scf.forall (%id) in (${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
     %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
     %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
     vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
-  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, 4, ${2 * INTRINSICS_K}] : !lhs_shared into !lhs_shared_exp
-  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_N * INTRINSICS_N}, 16, 4, ${2 * INTRINSICS_K}] : !rhs_shared into !rhs_shared_exp
+  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, ${2 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !lhs_shared into !lhs_shared_exp
+  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_N * INTRINSICS_N}, 16, ${2 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !rhs_shared into !rhs_shared_exp
 
   %0 = tensor.empty() : tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
   %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> {
@@ -95,22 +95,22 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c256 : index
-    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
-    %3 = scf.for %i = %c${8 * INTRINSICS_K} to %dim step %c${8 * INTRINSICS_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+    %3 = scf.for %i = %c${8 * INTRINSICS_K * INTERNAL_K} to %dim step %c${8 * INTRINSICS_K * INTERNAL_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
 
-      %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
-      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
       %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
@@ -122,15 +122,15 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
 
       rocdl.sched.barrier 0
 
-      %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
       // Global loads of lhs.
-      %lhs_block = tensor.extract_slice %lhs [0, 0, %i] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
+      %lhs_block = tensor.extract_slice %lhs [0, 0, %i] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
       %lhs_thread_0 = tensor.extract_slice %lhs_block [0, %glb0_lhs, %gko] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
       %lhs_thread_1 = tensor.extract_slice %lhs_block [0, %glb1_lhs, %gko] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
@@ -145,7 +145,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -168,7 +168,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
         iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
         kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
         semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-      } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
       gpu.barrier
@@ -181,29 +181,29 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
     }
 
     // Epilogue
-    %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>
 
     %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
       indexing_maps = #contraction_accesses,
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
       kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
       semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-    } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
     %tp = vector.transpose %dot2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
     %empty = tensor.empty() : tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
@@ -83,25 +83,21 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
   $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
   %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> tensor<1x${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
+    %m_outer_id = arith.muli %ids#0, %c${INTERNAL_M} overflow<nsw, nuw> : index
+    %n_outer_id = arith.muli %ids#1, %c${INTERNAL_N} overflow<nsw, nuw> : index
     %inner_id = arith.muli %ids#2, %c${INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
-    %m_outer_id = arith.muli %ids#0, %c4 overflow<nsw, nuw> : index
-    %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
-    %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
 
-    // Inner 64 loads 8 threads x VEC_SIZE elements.
-    %gko = arith.muli %wt#2, %c${INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
-    // RHS indexing. Each subgroup loads 32 contiguous rows out of 256.
-    %bpo = arith.muli %wt#0, %c32 overflow<nsw, nuw> : index
-    // Base index is remaining outer 8 lanes + subgroup base.
-    %glb0 = arith.addi %wt#1, %bpo overflow<nsw, nuw> : index
-    %glb1 = arith.addi %glb0, %c8 overflow<nsw, nuw> : index
-    %glb2 = arith.addi %glb1, %c8 overflow<nsw, nuw> : index
-    %glb3 = arith.addi %glb2, %c8 overflow<nsw, nuw> : index
-    // LHS indexing.
-    %bpo_lhs = arith.muli %wt#0, %c16 overflow<nsw, nuw> : index
+    %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
+    %bpo_lhs = arith.muli %wt#0, %c{SUBGROUPS_M*INTRINSICS_M*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %bpo_rhs = arith.muli %wt#0, %c{SUBGROUPS_N*INTRINSICS_N*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
     %glb0_lhs = arith.addi %wt#1, %bpo_lhs overflow<nsw, nuw> : index
-    %glb1_lhs = arith.addi %glb0_lhs, %c8 overflow<nsw, nuw> : index
+    %glb0_rhs = arith.addi %wt#1, %bpo_rhs overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_lhs = arith.addi %glb${j-1}_lhs, %c8 overflow<nsw, nuw> : index
+    $for j in range(1, SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
+      %glb${j}_rhs = arith.addi %glb${j-1}_rhs, %c8 overflow<nsw, nuw> : index
+    %gko = arith.muli %wt#2, %c${INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
@@ -121,14 +117,9 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
 
       // Global loads of rhs.
       %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N*INTRINSICS_N*16}, ${8*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
-      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
+        %rhs_thread_${j} = tensor.extract_slice %rhs_block [%glb${j}_rhs, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %rhs_vec_local_${j} = vector.transfer_read %rhs_thread_${j} [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
@@ -141,10 +132,9 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
 
       // Global loads of lhs.
       %lhs_block = tensor.extract_slice %lhs [0, 0, %i] [1, ${SUBGROUPS_M*INTRINSICS_M*16}, ${8*INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
-      %lhs_thread_0 = tensor.extract_slice %lhs_block [0, %glb0_lhs, %gko] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_thread_1 = tensor.extract_slice %lhs_block [0, %glb1_lhs, %gko] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
-      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
+        %lhs_thread_${j} = tensor.extract_slice %lhs_block [0, %glb${j}_lhs, %gko] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+        %lhs_vec_local_${j} = vector.transfer_read %lhs_thread_${j} [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -161,13 +151,11 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       gpu.barrier
       rocdl.sched.barrier 0
 
-      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %rhs_vec_local_${j}, %rhs_shared [%glb${j}_rhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
 
-      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0_lhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1_lhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
+      $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
+        vector.transfer_write %lhs_vec_local_${j}, %lhs_shared [%glb${j}_lhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
 
       gpu.barrier
       rocdl.sched.barrier 0

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
@@ -1,0 +1,217 @@
+//  RUN: iree-opt %s
+// Template for medium non-data-tiled matmul kernels
+
+// LHS types
+!lhs_in_ty = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x?x${ELEM_TYPE}>
+!lhs_block_in = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}>
+!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 128 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x4x${2 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+
+// RHS types
+!rhs_in_ty = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x?x${ELEM_TYPE}>
+!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}>
+!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 128 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x4x${2 * INTRINSICS_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, %rhs_base: !rhs_in_ty, %unused_acc: tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>) -> tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.0 : ${ELEM_TYPE}
+  %lhs_shared_base = memref.alloc() : !lhs_flat_shared
+  %rhs_shared_base = memref.alloc() : !rhs_flat_shared
+
+  %dim = tensor.dim %rhs_base, %c1 : !rhs_in_ty
+  %dim_stride = arith.muli %dim, %c${ELEM_BITS // 8} overflow<nsw, nuw>: index
+  %lhs = iree_gpu.buffer_resource_cast %lhs_base cacheSwizzleStride(%dim_stride) : !lhs_in_ty
+  %rhs = iree_gpu.buffer_resource_cast %rhs_base cacheSwizzleStride(%dim_stride) : !rhs_in_ty
+
+  %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !lhs_flat_shared
+  %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !rhs_flat_shared
+
+  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K}] : !lhs_flat_shared into !lhs_shared
+  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K}] : !rhs_flat_shared into !rhs_shared
+
+  %lhs_init = tensor.extract_slice %lhs [0, 0, 0] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
+  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+
+  scf.forall (%id) in (${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs_init [0, %delin#0, %vec] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * ELEM_BITS}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * ELEM_BITS // 128}) : index, index
+    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, 4, ${2 * INTRINSICS_K}] : !lhs_shared into !lhs_shared_exp
+  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_N * INTRINSICS_N}, 16, 4, ${2 * INTRINSICS_K}] : !rhs_shared into !rhs_shared_exp
+
+  %0 = tensor.empty() : tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
+  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> {
+    %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
+    %inner_id = arith.muli %ids#2, %c${64 // ELEM_BITS} overflow<nsw, nuw> : index
+    %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
+    %m_outer_id = arith.muli %ids#0, %c4 overflow<nsw, nuw> : index
+    %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
+    %delin:2 = affine.delinearize_index %id into (64, 8) : index, index
+    %wt:3 = affine.delinearize_index %id into (8, 8, 8) : index, index, index
+
+    // Inner 64 loads 8 threads x VEC_SIZE elements.
+    %gko = arith.muli %wt#2, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    // RHS indexing. Each subgroup loads 32 contiguous rows out of 256.
+    %bpo = arith.muli %wt#0, %c32 overflow<nsw, nuw> : index
+    // Base index is remaining outer 8 lanes + subgroup base.
+    %glb0 = arith.addi %wt#1, %bpo overflow<nsw, nuw> : index
+    %glb1 = arith.addi %glb0, %c8 overflow<nsw, nuw> : index
+    %glb2 = arith.addi %glb1, %c8 overflow<nsw, nuw> : index
+    %glb3 = arith.addi %glb2, %c8 overflow<nsw, nuw> : index
+    // LHS indexing.
+    %bpo_lhs = arith.muli %wt#0, %c16 overflow<nsw, nuw> : index
+    %glb0_lhs = arith.addi %wt#1, %bpo_lhs overflow<nsw, nuw> : index
+    %glb1_lhs = arith.addi %glb0_lhs, %c8 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+    %3 = scf.for %i = %c${8 * INTRINSICS_K} to %dim step %c${8 * INTRINSICS_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+
+      %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+
+      rocdl.sched.barrier 0
+
+      %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+      rocdl.sched.barrier 0
+
+      // Global loads of lhs.
+      %lhs_block = tensor.extract_slice %lhs [0, 0, %i] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
+      %lhs_thread_0 = tensor.extract_slice %lhs_block [0, %glb0_lhs, %gko] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_thread_1 = tensor.extract_slice %lhs_block [0, %glb1_lhs, %gko] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+
+      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0_lhs, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1_lhs, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot2 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_0_t = vector.transpose %lhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_0_t = vector.transpose %rhs_vec_0, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %lhs_vec_2 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c2, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %lhs_vec_2_t = vector.transpose %lhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+    %rhs_vec_2_t = vector.transpose %rhs_vec_2, [0, 2, 1, 3] : vector<${INTRINSICS_N}x1x${INTRINSICS_K // (64 // ELEM_BITS)}x${64 // ELEM_BITS}x${ELEM_TYPE}> to vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<${INTRINSIC}, col_major = true>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<${INTRINSICS_M}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K // (64 // ELEM_BITS)}x1x${64 // ELEM_BITS}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
+
+    %tp = vector.transpose %dot2, [0, 2, 1, 3] : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> to vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
+    %empty = tensor.empty() : tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
+    %4 = vector.transfer_write %tp, %empty[%c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>, tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[0, %m_outer_id, %ids#3, %n_outer_id, %inner_id_acc] [1, ${INTRINSICS_M}, 1, ${INTRINSICS_N}, 4] [1, 1, 1, 1, 1] : tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32> into tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  %collapse = tensor.collapse_shape %1 [[0], [1, 2], [3, 4]] : tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> into tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
+  util.return %collapse : tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
@@ -83,14 +83,14 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
   $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
   %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> tensor<1x${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
-    %m_outer_id = arith.muli %ids#0, %c${INTERNAL_M} overflow<nsw, nuw> : index
-    %n_outer_id = arith.muli %ids#1, %c${INTERNAL_N} overflow<nsw, nuw> : index
+    %m_outer_id = arith.muli %ids#0, %c${INTRINSICS_M} overflow<nsw, nuw> : index
+    %n_outer_id = arith.muli %ids#1, %c${INTRINSICS_N} overflow<nsw, nuw> : index
     %inner_id = arith.muli %ids#2, %c${INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
 
     %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
-    %bpo_lhs = arith.muli %wt#0, %c{SUBGROUPS_M*INTRINSICS_M*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
-    %bpo_rhs = arith.muli %wt#0, %c{SUBGROUPS_N*INTRINSICS_N*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %bpo_lhs = arith.muli %wt#0, %c${SUBGROUPS_M*INTRINSICS_M*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
+    %bpo_rhs = arith.muli %wt#0, %c${SUBGROUPS_N*INTRINSICS_N*16//SUBGROUPS_M//SUBGROUPS_N} overflow<nsw, nuw> : index
     %glb0_lhs = arith.addi %wt#1, %bpo_lhs overflow<nsw, nuw> : index
     %glb0_rhs = arith.addi %wt#1, %bpo_rhs overflow<nsw, nuw> : index
     $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
@@ -136,7 +136,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
         %lhs_thread_${j} = tensor.extract_slice %lhs_block [0, %glb${j}_lhs, %gko] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
         %lhs_vec_local_${j} = vector.transfer_read %lhs_thread_${j} [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -148,7 +148,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       $for j in range(SUBGROUPS_N*INTRINSICS_N*2//SUBGROUPS_M//SUBGROUPS_N):
@@ -157,7 +157,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       $for j in range(1, SUBGROUPS_M*INTRINSICS_M*2//SUBGROUPS_M//SUBGROUPS_N):
         vector.transfer_write %lhs_vec_local_${j}, %lhs_shared [%glb${j}_lhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
 
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
       rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
 
@@ -169,7 +169,7 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       } : vector<${INTRINSICS_M}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}>, vector<${INTRINSICS_N}x${INTRINSICS_K}x1x${INTERNAL_K}x${ELEM_TYPE}> into vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
       rocdl.s.setprio 0
-      gpu.barrier
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
       rocdl.sched.barrier 0
 
       scf.yield %dot2 : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_matmul_medium.mlir.in
@@ -1,19 +1,26 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 //  RUN: iree-opt %s
-// Template for medium non-data-tiled matmul kernels
+// AUTO-GENERATED - DO NOT EDIT
+// Generated from iree_uk_amdgpu_matmul_medium.mlir.in
 
 // LHS types
-!lhs_in_ty = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x?x${ELEM_TYPE}>
-!lhs_block_in = tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
-!lhs_flat_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 128 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared = memref<${SUBGROUPS_M * INTRINSICS_M * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!lhs_shared_exp = memref<${SUBGROUPS_M * INTRINSICS_M}x16x${2 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_in_ty = tensor<1x${SUBGROUPS_M*INTRINSICS_M*16}x?x${ELEM_TYPE}>
+!lhs_block_in = tensor<1x${SUBGROUPS_M*INTRINSICS_M*16}x${8*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!lhs_flat_shared = memref<${SUBGROUPS_M*INTRINSICS_M*128*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared = memref<${SUBGROUPS_M*INTRINSICS_M*16}x${8*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!lhs_shared_exp = memref<${SUBGROUPS_M*INTRINSICS_M}x16x${2*INTRINSICS_K}x${4*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 // RHS types
-!rhs_in_ty = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x?x${ELEM_TYPE}>
-!rhs_block_in = tensor<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}>
-!rhs_flat_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 128 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared = memref<${SUBGROUPS_N * INTRINSICS_N * 16}x${8 * INTRINSICS_K * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
-!rhs_shared_exp = memref<${SUBGROUPS_N * INTRINSICS_N}x16x${2 * INTRINSICS_K}x${4 * INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_in_ty = tensor<${SUBGROUPS_N*INTRINSICS_N*16}x?x${ELEM_TYPE}>
+!rhs_block_in = tensor<${SUBGROUPS_N*INTRINSICS_N*16}x${8*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+!rhs_flat_shared = memref<${SUBGROUPS_N*INTRINSICS_N*128*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared = memref<${SUBGROUPS_N*INTRINSICS_N*16}x${8*INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
+!rhs_shared_exp = memref<${SUBGROUPS_N*INTRINSICS_N}x16x${2*INTRINSICS_K}x${4*INTERNAL_K}x${ELEM_TYPE}, #gpu.address_space<workgroup>>
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -21,7 +28,7 @@
  affine_map<(i, j, k) -> (i, j)>
 ]
 
-util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, %rhs_base: !rhs_in_ty, %unused_acc: tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>) -> tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32> {
+util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, %rhs_base: !rhs_in_ty, %unused_acc: tensor<1x${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32>) -> tensor<1x${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -32,55 +39,58 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
-  %c${SUBGROUPS_M * SUBGROUPS_N * 32} = arith.constant ${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+  %c256 = arith.constant 256 : index
+
   %cst = arith.constant 0.0 : ${ELEM_TYPE}
   %lhs_shared_base = memref.alloc() : !lhs_flat_shared
   %rhs_shared_base = memref.alloc() : !rhs_flat_shared
 
   %dim = tensor.dim %rhs_base, %c1 : !rhs_in_ty
-  %dim_stride = arith.muli %dim, %c${ELEM_BITS // 8} overflow<nsw, nuw>: index
+  %dim_stride = arith.muli %dim, %c${ELEM_BITS//8} overflow<nsw, nuw>: index
   %lhs = iree_gpu.buffer_resource_cast %lhs_base cacheSwizzleStride(%dim_stride) : !lhs_in_ty
   %rhs = iree_gpu.buffer_resource_cast %rhs_base cacheSwizzleStride(%dim_stride) : !rhs_in_ty
 
-  %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !lhs_flat_shared
-  %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024 // ELEM_BITS}, ${64 // ELEM_BITS}>] : !rhs_flat_shared
+  %lhs_shared_swizzle = iree_codegen.swizzle_hint %lhs_shared_base[#iree_codegen.rotate_rows<${1024//ELEM_BITS}, ${64//ELEM_BITS}>] : !lhs_flat_shared
+  %rhs_shared_swizzle = iree_codegen.swizzle_hint %rhs_shared_base[#iree_codegen.rotate_rows<${1024//ELEM_BITS}, ${64//ELEM_BITS}>] : !rhs_flat_shared
 
-  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] : !lhs_flat_shared into !lhs_shared
-  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] : !rhs_flat_shared into !rhs_shared
+  %lhs_shared = memref.expand_shape %lhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_M*INTRINSICS_M*16}, ${8*INTRINSICS_K*INTERNAL_K}] : !lhs_flat_shared into !lhs_shared
+  %rhs_shared = memref.expand_shape %rhs_shared_swizzle [[0, 1]] output_shape [${SUBGROUPS_N*INTRINSICS_N*16}, ${8*INTRINSICS_K*INTERNAL_K}] : !rhs_flat_shared into !rhs_shared
 
-  %lhs_init = tensor.extract_slice %lhs [0, 0, 0] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
-  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+  %lhs_init = tensor.extract_slice %lhs [0, 0, 0] [1, ${SUBGROUPS_M*INTRINSICS_M*16}, ${8*INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
+  %rhs_init = tensor.extract_slice %rhs [0, 0] [${SUBGROUPS_N*INTRINSICS_N*16}, ${8*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
 
-  scf.forall (%id) in (${SUBGROUPS_M * INTRINSICS_M * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
-    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
-    %lhs_thread_local = tensor.extract_slice %lhs_init [0, %delin#0, %vec] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+  scf.forall (%id) in (${128*SUBGROUPS_M*INTRINSICS_M}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_M*INTRINSICS_M*16}, 8) : index, index
+    $assert (INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %vec = arith.muli %delin#1, %c${INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs_init [0, %delin#0, %vec] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  scf.forall (%id) in (${SUBGROUPS_N * INTRINSICS_N * INTRINSICS_K * INTERNAL_K * ELEM_BITS}) {
-    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K * ELEM_BITS // 128}) : index, index
-    %vec = arith.muli %delin#1, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
-    %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+  scf.forall (%id) in (${128*SUBGROUPS_N*INTRINSICS_N}) {
+    %delin:2 = affine.delinearize_index %id into (${SUBGROUPS_N*INTRINSICS_N*16}, 8) : index, index
+    $assert (INTRINSICS_K*INTERNAL_K) == (128//ELEM_BITS), "load 128 bits per instruction"
+    %vec = arith.muli %delin#1, %c${INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs_init [%delin#0, %vec] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %vec] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
-  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M * INTRINSICS_M}, 16, ${2 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !lhs_shared into !lhs_shared_exp
-  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_N * INTRINSICS_N}, 16, ${2 * INTRINSICS_K}, ${4 * INTERNAL_K}] : !rhs_shared into !rhs_shared_exp
+  %lhs_shared_expand = memref.expand_shape %lhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_M*INTRINSICS_M}, 16, ${2*INTRINSICS_K}, ${4*INTERNAL_K}] : !lhs_shared into !lhs_shared_exp
+  %rhs_shared_expand = memref.expand_shape %rhs_shared [[0, 1], [2, 3]] output_shape [${SUBGROUPS_N*INTRINSICS_N}, 16, ${2*INTRINSICS_K}, ${4*INTERNAL_K}] : !rhs_shared into !rhs_shared_exp
 
-  %0 = tensor.empty() : tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
-  %1 = scf.forall (%id) in (${SUBGROUPS_M * SUBGROUPS_N * 64}) shared_outs(%out = %0) -> tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> {
+  %0 = tensor.empty() : tensor<1x${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32>
+  $assert (SUBGROUPS_M*SUBGROUPS_N) == 8, "workgroup size must be 8x64=512"
+  %1 = scf.forall (%id) in (${SUBGROUPS_M*SUBGROUPS_N*64}) shared_outs(%out = %0) -> tensor<1x${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> {
     %ids:4 = affine.delinearize_index %id into (${SUBGROUPS_M}, ${SUBGROUPS_N}, 4, 16) : index, index, index, index
-    %inner_id = arith.muli %ids#2, %c${64 // ELEM_BITS} overflow<nsw, nuw> : index
+    %inner_id = arith.muli %ids#2, %c${INTERNAL_K} overflow<nsw, nuw> : index
     %inner_id_acc = arith.muli %ids#2, %c4 overflow<nsw, nuw> : index
     %m_outer_id = arith.muli %ids#0, %c4 overflow<nsw, nuw> : index
     %n_outer_id = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
-    %delin:2 = affine.delinearize_index %id into (64, 8) : index, index
-    %wt:3 = affine.delinearize_index %id into (8, 8, 8) : index, index, index
+    %wt:3 = affine.delinearize_index %id into (${SUBGROUPS_M*SUBGROUPS_N}, 8, 8) : index, index, index
 
     // Inner 64 loads 8 threads x VEC_SIZE elements.
-    %gko = arith.muli %wt#2, %c${128 // ELEM_BITS} overflow<nsw, nuw> : index
+    %gko = arith.muli %wt#2, %c${INTRINSICS_K*INTERNAL_K} overflow<nsw, nuw> : index
     // RHS indexing. Each subgroup loads 32 contiguous rows out of 256.
     %bpo = arith.muli %wt#0, %c32 overflow<nsw, nuw> : index
     // Base index is remaining outer 8 lanes + subgroup base.
@@ -95,12 +105,12 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
 
     %2 = arith.constant dense<0.0> : vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32>
 
-    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
-    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M * SUBGROUPS_N * 32} : index
+    %cmp0 = arith.cmpi slt, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
+    %cmp1 = arith.cmpi sge, %id, %c${SUBGROUPS_M*SUBGROUPS_N*32} : index
     scf.if %cmp0 {
       rocdl.s.barrier
     }
-    %3 = scf.for %i = %c${8 * INTRINSICS_K * INTERNAL_K} to %dim step %c${8 * INTRINSICS_K * INTERNAL_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
+    %3 = scf.for %i = %c${8*INTRINSICS_K*INTERNAL_K} to %dim step %c${8*INTRINSICS_K*INTERNAL_K} iter_args(%iter = %2) -> vector<${INTRINSICS_M}x${INTRINSICS_N}x1x4xf32> {
 
       %lhs_vec_0 = vector.transfer_read %lhs_shared_expand[%m_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_exp, vector<${INTRINSICS_M}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
       %rhs_vec_0 = vector.transfer_read %rhs_shared_expand[%n_outer_id, %ids#3, %c0, %inner_id], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_exp, vector<${INTRINSICS_N}x1x${INTRINSICS_K}x${INTERNAL_K}x${ELEM_TYPE}>
@@ -110,15 +120,15 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       rocdl.sched.barrier 0
 
       // Global loads of rhs.
-      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N * INTRINSICS_N * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
-      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${128 // ELEM_BITS}] [1, 1] : !rhs_block_in to tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %rhs_block = tensor.extract_slice %rhs [0, %i] [${SUBGROUPS_N*INTRINSICS_N*16}, ${8*INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_in_ty to !rhs_block_in
+      %rhs_thread_0 = tensor.extract_slice %rhs_block [%glb0, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_thread_1 = tensor.extract_slice %rhs_block [%glb1, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_thread_2 = tensor.extract_slice %rhs_block [%glb2, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_thread_3 = tensor.extract_slice %rhs_block [%glb3, %gko] [1, ${INTRINSICS_K*INTERNAL_K}] [1, 1] : !rhs_block_in to tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       rocdl.sched.barrier 0
 
@@ -130,11 +140,11 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       rocdl.sched.barrier 0
 
       // Global loads of lhs.
-      %lhs_block = tensor.extract_slice %lhs [0, 0, %i] [1, ${SUBGROUPS_M * INTRINSICS_M * 16}, ${8 * INTRINSICS_K * INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
-      %lhs_thread_0 = tensor.extract_slice %lhs_block [0, %glb0_lhs, %gko] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_thread_1 = tensor.extract_slice %lhs_block [0, %glb1_lhs, %gko] [1, 1, ${128 // ELEM_BITS}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>
-      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${128 // ELEM_BITS}x${ELEM_TYPE}>, vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>
+      %lhs_block = tensor.extract_slice %lhs [0, 0, %i] [1, ${SUBGROUPS_M*INTRINSICS_M*16}, ${8*INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_in_ty to !lhs_block_in
+      %lhs_thread_0 = tensor.extract_slice %lhs_block [0, %glb0_lhs, %gko] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_thread_1 = tensor.extract_slice %lhs_block [0, %glb1_lhs, %gko] [1, 1, ${INTRINSICS_K*INTERNAL_K}] [1, 1, 1] : !lhs_block_in to tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -151,13 +161,13 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
       gpu.barrier
       rocdl.sched.barrier 0
 
-      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
-      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_0, %rhs_shared [%glb0, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_1, %rhs_shared [%glb1, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_2, %rhs_shared [%glb2, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
+      vector.transfer_write %rhs_vec_local_3, %rhs_shared [%glb3, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !rhs_shared
 
-      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0_lhs, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
-      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1_lhs, %gko] {in_bounds = [true, true]} : vector<1x${128 // ELEM_BITS}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_0, %lhs_shared [%glb0_lhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
+      vector.transfer_write %lhs_vec_local_1, %lhs_shared [%glb1_lhs, %gko] {in_bounds = [true, true]} : vector<1x${INTRINSICS_K*INTERNAL_K}x${ELEM_TYPE}>, !lhs_shared
 
       gpu.barrier
       rocdl.sched.barrier 0
@@ -209,9 +219,9 @@ util.func private @pingpong_medium_${ELEM_TYPE}_expanded(%lhs_base: !lhs_in_ty, 
     %empty = tensor.empty() : tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
     %4 = vector.transfer_write %tp, %empty[%c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>, tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32>
     scf.forall.in_parallel {
-      tensor.parallel_insert_slice %4 into %out[0, %m_outer_id, %ids#3, %n_outer_id, %inner_id_acc] [1, ${INTRINSICS_M}, 1, ${INTRINSICS_N}, 4] [1, 1, 1, 1, 1] : tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32> into tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32>
+      tensor.parallel_insert_slice %4 into %out[0, %m_outer_id, %ids#3, %n_outer_id, %inner_id_acc] [1, ${INTRINSICS_M}, 1, ${INTRINSICS_N}, 4] [1, 1, 1, 1, 1] : tensor<1x${INTRINSICS_M}x1x${INTRINSICS_N}x4xf32> into tensor<1x${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32>
     }
   } {mapping = [#gpu.thread<linear_dim_0>]}
-  %collapse = tensor.collapse_shape %1 [[0], [1, 2], [3, 4]] : tensor<1x${SUBGROUPS_M * INTRINSICS_M}x16x${SUBGROUPS_N * INTRINSICS_N}x16xf32> into tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
-  util.return %collapse : tensor<1x${SUBGROUPS_M * INTRINSICS_M * 16}x${SUBGROUPS_N * INTRINSICS_N * 16}xf32>
+  %collapse = tensor.collapse_shape %1 [[0], [1, 2], [3, 4]] : tensor<1x${SUBGROUPS_M*INTRINSICS_M}x16x${SUBGROUPS_N*INTRINSICS_N}x16xf32> into tensor<1x${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32>
+  util.return %collapse : tensor<1x${SUBGROUPS_M*INTRINSICS_M*16}x${SUBGROUPS_N*INTRINSICS_N*16}xf32>
 }

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/mlir_ukernel_gen.py
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/mlir_ukernel_gen.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Template processor for MLIR microkernel code generation.
+
+This script processes .mlir.in template files and generates .mlir output files
+with expression evaluation.
+
+Usage:
+    python mlir_ukernel_gen.py template.mlir.in -o output.mlir \\
+        -D INTRINSICS_M=4 INTRINSICS_N=8 ARCH=gfx942
+
+Template syntax:
+    ${VAR}              - Variable substitution
+    ${VAR * 2}          - Expression evaluation
+    ${VAR1 * VAR2 + 1}  - Complex expressions
+"""
+
+import argparse
+import re
+from typing import Dict, Any
+
+ELEM_TYPE_BITS = {
+    "bf16": 16,
+    "f16": 16,
+    "f32": 32,
+    "f4E2M1FN": 4,
+    "f8E4M3FN": 8,
+    "f8E4M3FNUZ": 8,
+}
+
+
+def fold1(val):
+    """
+    Fold dimension if value is 1.
+    Returns 'valx' if val != 1, else empty string.
+    """
+    return f"{val}x" if val != 1 else ""
+
+
+def process_template(text: str, params: Dict[str, Any]) -> str:
+    """Process ${...} substitutions in template text."""
+    eval_context = params.copy()
+    eval_context["fold1"] = fold1
+
+    def replacer(match):
+        expr = match.group(1).strip()
+        try:
+            result = eval(expr, {"__builtins__": {}}, eval_context)
+            return str(result)
+        except Exception as e:
+            raise ValueError(f"Failed to evaluate expression '${{{expr}}}': {e}")
+
+    return re.sub(r"\$\{([^}]+)\}", replacer, text)
+
+
+def parse_define(define_str: str) -> tuple:
+    """Parse a -D VAR=VALUE string into (var, value)."""
+    if "=" in define_str:
+        var, value = define_str.split("=", 1)
+        # Try to convert to int if possible
+        try:
+            value = int(value)
+        except ValueError:
+            pass
+        return var.strip(), value
+    else:
+        return define_str.strip(), True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Process MLIR microkernel templates",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Example:
+    python mlir_ukernel_gen.py template.mlir.in -o output.mlir \\
+        -D INTRINSICS_M=4 INTRINSICS_N=8 ARCH=gfx942
+        """,
+    )
+
+    parser.add_argument("template", type=str, help="Path to the .mlir.in template file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=True,
+        help="Output file path",
+    )
+    parser.add_argument(
+        "-D",
+        "--define",
+        type=str,
+        nargs="+",
+        default=[],
+        help="Define parameters: -D VAR1=VALUE1 VAR2=VALUE2 ...",
+    )
+
+    args = parser.parse_args()
+
+    # Default parameter values
+    DEFAULT_PARAMS = {
+        # Common defaults
+        "ARCH": "gfx942",
+        "ELEM_TYPE": "f16",
+        "INTRINSIC": "MFMA_F32_16x16x16_F16",
+        # Benefit
+        "BENEFIT": 1,
+        # Constraint 0: size_min=0, size_max=INT32_MAX, size_div=1
+        "SIZE_MIN_0": 0,
+        "SIZE_MAX_0": 2147483647,
+        "SIZE_DIV_0": 1,
+        # Constraint 1: size_min=0, size_max=INT32_MAX, size_div=1
+        "SIZE_MIN_1": 0,
+        "SIZE_MAX_1": 2147483647,
+        "SIZE_DIV_1": 1,
+        # Constraint 2: size_min=0, size_max=INT32_MAX, size_div=1
+        "SIZE_MIN_2": 0,
+        "SIZE_MAX_2": 2147483647,
+        "SIZE_DIV_2": 1,
+        # MMA layout attributes
+        "INTRINSICS_M": 1,
+        "INTRINSICS_N": 1,
+        "INTRINSICS_K": 1,
+        "SUBGROUPS_M": 1,
+        "SUBGROUPS_N": 1,
+    }
+
+    # Start with defaults, then override with user params
+    params = DEFAULT_PARAMS.copy()
+    for define in args.define:
+        var, value = parse_define(define)
+        params[var] = value
+
+    # Derive ELEM_BITS from ELEM_TYPE
+    elem_type = params["ELEM_TYPE"]
+    assert elem_type in ELEM_TYPE_BITS, f"Invalid element type: {elem_type}"
+    params["ELEM_BITS"] = ELEM_TYPE_BITS[elem_type]
+
+    # Read template
+    with open(args.template, "r") as f:
+        template = f.read()
+
+    # Process template
+    output = process_template(template, params)
+
+    # Write output
+    with open(args.output, "w") as f:
+        f.write(output)
+    print(f"Generated: {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR generalizes MLIR ukernel generation by introducing a Python preprocessing approach to reduce code duplication and improve maintainability.

## Motivation

**Before:** We currently have 7 hand-written MLIR ukernels,  totaling ~3k lines of repetitive code with significant boilerplate:
- `iree_uk_amdgpu_dt_matmul_f16.mlir`
- `iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir`
- `iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir`
- `iree_uk_amdgpu_matmul_bf16.mlir`
- `iree_uk_amdgpu_matmul_f16.mlir`
- `iree_uk_amdgpu_matmul_f8E4M3FN.mlir`
- `iree_uk_amdgpu_matmul_f8E4M3FNUZ.mlir` 

Each ukernel variant required manual duplication with minor parameter changes (element types, intrinsics, unroll configurations, etc.).

**After:** This PR introduces a template-based generation system where we only need to maintain some template files (`.mlir.in`, around 1k lines at the moment).

See `TEMPLATE_GUIDE.md` for all generation commands.

## Plan

- Using the infrastructure to develop non-data-tiled MXFP4 ukernel
- Tune tile sizes for gfx950 ukernels https://github.com/iree-org/iree/pull/22825
- Discuss checking in these templates
- Integrate generation into build system (CMake/Bazel)

**Assisted-by:** Cursor AI