### PR TITLE
[NFC] Make status test macros take ownership of iree_status_t.

### DIFF
--- a/runtime/src/iree/base/allocator_test.cc
+++ b/runtime/src/iree/base/allocator_test.cc
@@ -417,18 +417,18 @@ TEST(StructLayout, ZeroCountField) {
 
 TEST(StructLayout, OverflowOnMultiply) {
   iree_host_size_t total = 0;
-  iree_status_t status = IREE_STRUCT_LAYOUT(
-      0, &total, IREE_STRUCT_FIELD(SIZE_MAX, TestElement, NULL));
-  EXPECT_TRUE(iree_status_is_out_of_range(status));
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      IREE_STRUCT_LAYOUT(0, &total,
+                         IREE_STRUCT_FIELD(SIZE_MAX, TestElement, NULL)));
 }
 
 TEST(StructLayout, OverflowOnAdd) {
   iree_host_size_t total = 0;
-  iree_status_t status = IREE_STRUCT_LAYOUT(
-      SIZE_MAX - 10, &total, IREE_STRUCT_FIELD(100, uint8_t, NULL));
-  EXPECT_TRUE(iree_status_is_out_of_range(status));
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      IREE_STRUCT_LAYOUT(SIZE_MAX - 10, &total,
+                         IREE_STRUCT_FIELD(100, uint8_t, NULL)));
 }
 
 TEST(StructLayout, SingleField) {

--- a/runtime/src/iree/base/internal/json_test.cc
+++ b/runtime/src/iree/base/internal/json_test.cc
@@ -61,44 +61,39 @@ TEST(JsonConsumeStringTest, WithUnicodeEscape) {
 TEST(JsonConsumeStringTest, Unterminated) {
   iree_string_view_t str = IREE_SV("\"hello");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_string(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_string(&str, &value));
 }
 
 TEST(JsonConsumeStringTest, MissingPrefix) {
   iree_string_view_t str = IREE_SV("hello\"");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_string(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_string(&str, &value));
 }
 
 TEST(JsonConsumeStringTest, ControlCharacter) {
   // Control characters (0x00-0x1F) must be escaped per RFC 8259.
   iree_string_view_t str = IREE_SV("\"hello\tworld\"");  // Tab is 0x09.
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_string(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_string(&str, &value));
 }
 
 TEST(JsonConsumeStringTest, ControlCharacterNewline) {
   // Unescaped newline is invalid.
   iree_string_view_t str = IREE_SV("\"hello\nworld\"");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_string(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_string(&str, &value));
 }
 
 TEST(JsonConsumeStringTest, InvalidHexDigitInUnicode) {
   // \uNNNN requires valid hex digits.
   iree_string_view_t str = IREE_SV("\"\\u00GX\"");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_string(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_string(&str, &value));
 }
 
 TEST(JsonConsumeStringTest, TrailingContent) {
@@ -180,17 +175,15 @@ TEST(JsonConsumeNumberTest, TrailingContent) {
 TEST(JsonConsumeNumberTest, Empty) {
   iree_string_view_t str = IREE_SV("");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_number(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_number(&str, &value));
 }
 
 TEST(JsonConsumeNumberTest, JustMinus) {
   iree_string_view_t str = IREE_SV("-");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_number(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_number(&str, &value));
 }
 
 //===----------------------------------------------------------------------===//
@@ -221,10 +214,9 @@ TEST(JsonConsumeKeywordTest, Null) {
 TEST(JsonConsumeKeywordTest, WrongKeyword) {
   iree_string_view_t str = IREE_SV("false");
   iree_string_view_t value;
-  iree_status_t status =
-      iree_json_consume_keyword(&str, IREE_SV("true"), &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_consume_keyword(&str, IREE_SV("true"), &value));
 }
 
 //===----------------------------------------------------------------------===//
@@ -262,9 +254,8 @@ TEST(JsonConsumeObjectTest, Nested) {
 TEST(JsonConsumeObjectTest, MissingBrace) {
   iree_string_view_t str = IREE_SV("{\"key\": 123");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_object(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_object(&str, &value));
 }
 
 TEST(JsonConsumeObjectTest, TrailingComma) {
@@ -319,9 +310,8 @@ TEST(JsonConsumeObjectTest, UnterminatedComment) {
   // Unterminated multi-line comments should error.
   iree_string_view_t str = IREE_SV("{/* unterminated \"key\": 123}");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_object(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_object(&str, &value));
 }
 
 //===----------------------------------------------------------------------===//
@@ -366,9 +356,8 @@ TEST(JsonConsumeArrayTest, Nested) {
 TEST(JsonConsumeArrayTest, MissingBracket) {
   iree_string_view_t str = IREE_SV("[1, 2, 3");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_array(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_array(&str, &value));
 }
 
 TEST(JsonConsumeArrayTest, TrailingComma) {
@@ -492,18 +481,16 @@ TEST(JsonConsumeValueTest, Empty) {
   // Empty input should return an error.
   iree_string_view_t str = IREE_SV("");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_value(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_value(&str, &value));
 }
 
 TEST(JsonConsumeValueTest, WhitespaceOnly) {
   // Whitespace-only input should return an error (no actual value).
   iree_string_view_t str = IREE_SV("   \n\t  ");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_value(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_value(&str, &value));
 }
 
 //===----------------------------------------------------------------------===//
@@ -614,8 +601,7 @@ TEST(JsonLookupObjectValueTest, NotFound) {
   iree_string_view_t value;
   iree_status_t status = iree_json_lookup_object_value(
       IREE_SV("{\"key\": 123}"), IREE_SV("missing"), &value);
-  EXPECT_TRUE(iree_status_is_not_found(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, status);
   EXPECT_EQ(value.size, 0);
 }
 
@@ -736,11 +722,11 @@ TEST(JsonTryLookupStringTest, EmptyString) {
 TEST(JsonTryLookupStringTest, NumberValueReturnsError) {
   char buffer[32];
   iree_host_size_t length = 0;
-  iree_status_t status = iree_json_try_lookup_string(
-      IREE_SV("{\"key\": 123}"), IREE_SV("key"), iree_string_view_empty(),
-      buffer, sizeof(buffer), &length);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_try_lookup_string(IREE_SV("{\"key\": 123}"), IREE_SV("key"),
+                                  iree_string_view_empty(), buffer,
+                                  sizeof(buffer), &length));
 }
 
 TEST(JsonTryLookupStringTest, BufferTooSmall) {
@@ -749,10 +735,9 @@ TEST(JsonTryLookupStringTest, BufferTooSmall) {
   iree_status_t status = iree_json_try_lookup_string(
       IREE_SV("{\"key\": \"hello\"}"), IREE_SV("key"), iree_string_view_empty(),
       buffer, sizeof(buffer), &length);
-  EXPECT_TRUE(iree_status_is_resource_exhausted(status));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
   // Length should still indicate required size.
   EXPECT_EQ(length, 5);
-  iree_status_ignore(status);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1095,17 +1080,15 @@ TEST(JsonArrayGetTest, LastElement) {
 
 TEST(JsonArrayGetTest, OutOfRange) {
   iree_string_view_t value;
-  iree_status_t status =
-      iree_json_array_get(IREE_SV("[10, 20, 30]"), 3, &value);
-  EXPECT_TRUE(iree_status_is_out_of_range(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_json_array_get(IREE_SV("[10, 20, 30]"), 3, &value));
 }
 
 TEST(JsonArrayGetTest, EmptyArrayOutOfRange) {
   iree_string_view_t value;
-  iree_status_t status = iree_json_array_get(IREE_SV("[]"), 0, &value);
-  EXPECT_TRUE(iree_status_is_out_of_range(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        iree_json_array_get(IREE_SV("[]"), 0, &value));
 }
 
 TEST(JsonArrayGetTest, StringElement) {
@@ -1281,10 +1264,10 @@ TEST(JsonEnumerateLinesTest, MixedLineEndings) {
 TEST(JsonEnumerateLinesTest, TrailingContentOnLine) {
   std::vector<LineEntry> entries;
   // After parsing "123", there's " extra" remaining on the line.
-  iree_status_t status = iree_json_enumerate_lines(
-      IREE_SV("123 extra\n456"), CollectLineEntries, &entries);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_enumerate_lines(IREE_SV("123 extra\n456"), CollectLineEntries,
+                                &entries));
 }
 
 TEST(JsonEnumerateLinesTest, EarlyTermination) {
@@ -1296,11 +1279,11 @@ TEST(JsonEnumerateLinesTest, EarlyTermination) {
 
 TEST(JsonEnumerateLinesTest, InvalidJson) {
   std::vector<LineEntry> entries;
-  iree_status_t status = iree_json_enumerate_lines(
-      IREE_SV("{\"valid\": 1}\ninvalid json\n{\"also\": 2}"),
-      CollectLineEntries, &entries);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_enumerate_lines(
+          IREE_SV("{\"valid\": 1}\ninvalid json\n{\"also\": 2}"),
+          CollectLineEntries, &entries));
 }
 
 TEST(JsonEnumerateLinesTest, CommentLinesSkipped) {
@@ -1434,8 +1417,7 @@ TEST(JsonUnescapeStringTest, BufferTooSmall) {
   iree_host_size_t len;
   iree_status_t status =
       iree_json_unescape_string(IREE_SV("hello"), sizeof(buf), buf, &len);
-  EXPECT_TRUE(iree_status_is_resource_exhausted(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
   EXPECT_EQ(len, 5);  // Required size.
 }
 
@@ -1449,39 +1431,35 @@ TEST(JsonUnescapeStringTest, LengthOnly) {
 TEST(JsonUnescapeStringTest, InvalidEscape) {
   char buf[64];
   iree_host_size_t len;
-  iree_status_t status =
-      iree_json_unescape_string(IREE_SV("\\x"), sizeof(buf), buf, &len);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_unescape_string(IREE_SV("\\x"), sizeof(buf), buf, &len));
 }
 
 TEST(JsonUnescapeStringTest, TruncatedUnicode) {
   char buf[64];
   iree_host_size_t len;
-  iree_status_t status =
-      iree_json_unescape_string(IREE_SV("\\u00"), sizeof(buf), buf, &len);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_unescape_string(IREE_SV("\\u00"), sizeof(buf), buf, &len));
 }
 
 TEST(JsonUnescapeStringTest, LoneSurrogate) {
   char buf[64];
   iree_host_size_t len;
   // High surrogate without low surrogate.
-  iree_status_t status =
-      iree_json_unescape_string(IREE_SV("\\uD83D"), sizeof(buf), buf, &len);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_unescape_string(IREE_SV("\\uD83D"), sizeof(buf), buf, &len));
 }
 
 TEST(JsonUnescapeStringTest, InvalidHexDigit) {
   char buf[64];
   iree_host_size_t len;
   // 'G' is not a valid hex digit.
-  iree_status_t status =
-      iree_json_unescape_string(IREE_SV("\\u00GX"), sizeof(buf), buf, &len);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_unescape_string(IREE_SV("\\u00GX"), sizeof(buf), buf, &len));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1521,17 +1499,15 @@ TEST(JsonParseInt64Test, Min) {
 
 TEST(JsonParseInt64Test, Overflow) {
   int64_t value;
-  iree_status_t status =
-      iree_json_parse_int64(IREE_SV("9223372036854775808"), &value);
-  EXPECT_TRUE(iree_status_is_out_of_range(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_json_parse_int64(IREE_SV("9223372036854775808"), &value));
 }
 
 TEST(JsonParseInt64Test, Float) {
   int64_t value;
-  iree_status_t status = iree_json_parse_int64(IREE_SV("3.14"), &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_parse_int64(IREE_SV("3.14"), &value));
 }
 
 TEST(JsonParseUint64Test, Zero) {
@@ -1555,9 +1531,8 @@ TEST(JsonParseUint64Test, Max) {
 
 TEST(JsonParseUint64Test, Negative) {
   uint64_t value;
-  iree_status_t status = iree_json_parse_uint64(IREE_SV("-1"), &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_parse_uint64(IREE_SV("-1"), &value));
 }
 
 TEST(JsonParseDoubleTest, Integer) {
@@ -1608,23 +1583,20 @@ TEST(JsonParseBoolTest, False) {
 
 TEST(JsonParseBoolTest, Null) {
   bool value;
-  iree_status_t status = iree_json_parse_bool(IREE_SV("null"), &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_parse_bool(IREE_SV("null"), &value));
 }
 
 TEST(JsonParseBoolTest, Number) {
   bool value;
-  iree_status_t status = iree_json_parse_bool(IREE_SV("1"), &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_parse_bool(IREE_SV("1"), &value));
 }
 
 TEST(JsonParseBoolTest, String) {
   bool value;
-  iree_status_t status = iree_json_parse_bool(IREE_SV("\"true\""), &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_parse_bool(IREE_SV("\"true\""), &value));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1670,18 +1642,18 @@ TEST(JsonTryLookupBoolTest, InvalidValueReturnsError) {
   bool value;
   // Note: JSON string values have quotes stripped by lookup, so "yes" becomes
   // just "yes" which is not a valid boolean.
-  iree_status_t status = iree_json_try_lookup_bool(
-      IREE_SV("{\"key\": \"yes\"}"), IREE_SV("key"), false, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_try_lookup_bool(IREE_SV("{\"key\": \"yes\"}"), IREE_SV("key"),
+                                false, &value));
 }
 
 TEST(JsonTryLookupBoolTest, NumberValueReturnsError) {
   bool value;
-  iree_status_t status = iree_json_try_lookup_bool(
-      IREE_SV("{\"key\": 1}"), IREE_SV("key"), false, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_try_lookup_bool(IREE_SV("{\"key\": 1}"), IREE_SV("key"), false,
+                                &value));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1732,20 +1704,19 @@ TEST(JsonTryLookupInt64Test, EmptyObjectUsesDefault) {
 
 TEST(JsonTryLookupInt64Test, FloatValueReturnsError) {
   int64_t value;
-  iree_status_t status = iree_json_try_lookup_int64(IREE_SV("{\"key\": 3.14}"),
-                                                    IREE_SV("key"), 0, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_try_lookup_int64(IREE_SV("{\"key\": 3.14}"),
+                                                   IREE_SV("key"), 0, &value));
 }
 
 TEST(JsonTryLookupInt64Test, NonNumericStringValueReturnsError) {
   // Note: JSON strings have quotes stripped by lookup, so "123" becomes "123"
   // which parses as a valid int. Use a truly non-numeric string.
   int64_t value;
-  iree_status_t status = iree_json_try_lookup_int64(
-      IREE_SV("{\"key\": \"hello\"}"), IREE_SV("key"), 0, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_try_lookup_int64(IREE_SV("{\"key\": \"hello\"}"),
+                                 IREE_SV("key"), 0, &value));
 }
 
 TEST(JsonTryLookupInt64Test, LargePositiveValue) {
@@ -1831,9 +1802,8 @@ TEST(JsonDepthTest, DeeplyNestedArrays) {
   iree_string_view_t str =
       iree_make_string_view(deep_json.data(), deep_json.size());
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_value(&str, &value);
-  EXPECT_TRUE(iree_status_is_resource_exhausted(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        iree_json_consume_value(&str, &value));
 }
 
 TEST(JsonDepthTest, DeeplyNestedObjects) {
@@ -1846,9 +1816,8 @@ TEST(JsonDepthTest, DeeplyNestedObjects) {
   iree_string_view_t str =
       iree_make_string_view(deep_json.data(), deep_json.size());
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_value(&str, &value);
-  EXPECT_TRUE(iree_status_is_resource_exhausted(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        iree_json_consume_value(&str, &value));
 }
 
 TEST(JsonDepthTest, MixedNestedStructures) {
@@ -1865,9 +1834,8 @@ TEST(JsonDepthTest, MixedNestedStructures) {
   iree_string_view_t str =
       iree_make_string_view(deep_json.data(), deep_json.size());
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_value(&str, &value);
-  EXPECT_TRUE(iree_status_is_resource_exhausted(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        iree_json_consume_value(&str, &value));
 }
 
 TEST(JsonDepthTest, AcceptableDepth) {
@@ -1925,28 +1893,28 @@ TEST(JsonEnumerateLinesTest, MultiLineBlockCommentOnSameLine) {
 
 TEST(JsonEnumerateLinesTest, UnterminatedMultiLineComment) {
   std::vector<LineEntry> entries;
-  iree_status_t status = iree_json_enumerate_lines(
-      IREE_SV("/* unterminated\ncomment\n123"), CollectLineEntries, &entries);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_enumerate_lines(IREE_SV("/* unterminated\ncomment\n123"),
+                                CollectLineEntries, &entries));
 }
 
 TEST(JsonEnumerateLinesTest, MultipleValuesOnSameLine) {
   // JSONL requires one value per line - multiple values should fail.
   std::vector<LineEntry> entries;
-  iree_status_t status = iree_json_enumerate_lines(
-      IREE_SV("123 456\n789"), CollectLineEntries, &entries);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_enumerate_lines(IREE_SV("123 456\n789"), CollectLineEntries,
+                                &entries));
 }
 
 TEST(JsonEnumerateLinesTest, MultipleValuesWithCommentBetween) {
   // Even with a comment between, multiple values on same line should fail.
   std::vector<LineEntry> entries;
-  iree_status_t status = iree_json_enumerate_lines(
-      IREE_SV("123 /* comment */ 456"), CollectLineEntries, &entries);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_enumerate_lines(IREE_SV("123 /* comment */ 456"),
+                                CollectLineEntries, &entries));
 }
 
 TEST(JsonEnumerateLinesTest, CROnlyLineEndings) {
@@ -2084,9 +2052,8 @@ TEST(JsonConsumeValueTest, CommentOnly) {
   // Input with only comments should fail (no value).
   iree_string_view_t str = IREE_SV("// just a comment\n/* another */");
   iree_string_view_t value;
-  iree_status_t status = iree_json_consume_value(&str, &value);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_consume_value(&str, &value));
 }
 
 TEST(JsonConsumeObjectTest, CommentInsideString) {
@@ -2130,22 +2097,20 @@ TEST(JsonValidateObjectKeysTest, SingleUnknownKey) {
       IREE_SVL("type"),
       IREE_SVL("value"),
   };
-  iree_status_t status = iree_json_validate_object_keys(
-      IREE_SV("{\"type\": \"foo\", \"unknown\": 123}"), kAllowedKeys,
-      IREE_ARRAYSIZE(kAllowedKeys));
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_validate_object_keys(
+                            IREE_SV("{\"type\": \"foo\", \"unknown\": 123}"),
+                            kAllowedKeys, IREE_ARRAYSIZE(kAllowedKeys)));
 }
 
 TEST(JsonValidateObjectKeysTest, MultipleUnknownKeys) {
   static const iree_string_view_t kAllowedKeys[] = {
       IREE_SVL("type"),
   };
-  iree_status_t status = iree_json_validate_object_keys(
-      IREE_SV("{\"foo\": 1, \"bar\": 2, \"type\": 3}"), kAllowedKeys,
-      IREE_ARRAYSIZE(kAllowedKeys));
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_json_validate_object_keys(
+                            IREE_SV("{\"foo\": 1, \"bar\": 2, \"type\": 3}"),
+                            kAllowedKeys, IREE_ARRAYSIZE(kAllowedKeys)));
 }
 
 TEST(JsonValidateObjectKeysTest, NestedObjectsNotValidated) {
@@ -2160,10 +2125,9 @@ TEST(JsonValidateObjectKeysTest, NestedObjectsNotValidated) {
 
 TEST(JsonValidateObjectKeysTest, NoAllowedKeys) {
   // With no allowed keys, any key is unknown.
-  iree_status_t status =
-      iree_json_validate_object_keys(IREE_SV("{\"key\": 123}"), NULL, 0);
-  EXPECT_TRUE(iree_status_is_invalid_argument(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_json_validate_object_keys(IREE_SV("{\"key\": 123}"), NULL, 0));
 }
 
 TEST(JsonValidateObjectKeysTest, EmptyObjectNoAllowedKeys) {

--- a/runtime/src/iree/base/internal/wait_handle_test.cc
+++ b/runtime/src/iree/base/internal/wait_handle_test.cc
@@ -249,10 +249,10 @@ TEST(WaitSet, Lifetime) {
 
 TEST(WaitSet, UnreasonableCapacity) {
   iree_wait_set_t* wait_set = NULL;
-  iree_status_t status = iree_wait_set_allocate(
-      1 * 1024 * 1024, iree_allocator_system(), &wait_set);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_wait_set_allocate(1 * 1024 * 1024, iree_allocator_system(),
+                             &wait_set));
 }
 
 // Tests that inserting the same handles multiple times is tracked correctly.

--- a/runtime/src/iree/base/testing/dynamic_library_test.cc
+++ b/runtime/src/iree/base/testing/dynamic_library_test.cc
@@ -85,11 +85,10 @@ TEST_F(DynamicLibraryTest, LoadLibrarySuccess) {
 
 TEST_F(DynamicLibraryTest, LoadLibraryFailure) {
   iree_dynamic_library_t* library = NULL;
-  iree_status_t status = iree_dynamic_library_load_from_file(
-      kUnknownName, IREE_DYNAMIC_LIBRARY_FLAG_NONE, iree_allocator_system(),
-      &library);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND,
+                        iree_dynamic_library_load_from_file(
+                            kUnknownName, IREE_DYNAMIC_LIBRARY_FLAG_NONE,
+                            iree_allocator_system(), &library));
 }
 
 TEST_F(DynamicLibraryTest, LoadLibraryTwice) {
@@ -127,10 +126,9 @@ TEST_F(DynamicLibraryTest, GetSymbolFailure) {
       iree_allocator_system(), &library));
 
   int (*fn_ptr)(int);
-  iree_status_t status =
-      iree_dynamic_library_lookup_symbol(library, "unknown", (void**)&fn_ptr);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_NOT_FOUND,
+      iree_dynamic_library_lookup_symbol(library, "unknown", (void**)&fn_ptr));
   EXPECT_EQ(nullptr, fn_ptr);
 
   iree_dynamic_library_release(library);

--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -278,6 +278,7 @@ class CTSTestBase : public BaseType, public CTSTestResources {
   // Check that a contains b.
   // That is the codes of a and b are equal and the message of b is contained
   // in the message of a.
+  // Takes ownership of both statuses.
   void CheckStatusContains(iree_status_t a, iree_status_t b) {
     EXPECT_EQ(iree_status_code(a), iree_status_code(b));
     iree_allocator_t allocator = iree_allocator_system();
@@ -291,6 +292,8 @@ class CTSTestBase : public BaseType, public CTSTestResources {
                 std::string_view::npos);
     iree_allocator_free(allocator, a_str);
     iree_allocator_free(allocator, b_str);
+    iree_status_ignore(a);
+    iree_status_ignore(b);
   }
 };
 

--- a/runtime/src/iree/hal/cts/semaphore_submission_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_submission_test.h
@@ -904,7 +904,7 @@ TEST_F(SemaphoreSubmissionTest, PropagateFailSignal) {
       iree_hal_semaphore_wait(semaphore2, semaphore2_signal_value,
                               iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
                               IREE_HAL_WAIT_FLAG_DEFAULT);
-  EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, wait_status);
   uint64_t value = 1234;
   iree_status_t query_status = iree_hal_semaphore_query(semaphore2, &value);
   EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
@@ -914,9 +914,6 @@ TEST_F(SemaphoreSubmissionTest, PropagateFailSignal) {
   iree_hal_semaphore_release(semaphore1);
   iree_hal_semaphore_release(semaphore2);
   iree_hal_command_buffer_release(command_buffer);
-  iree_status_ignore(status);
-  iree_status_ignore(wait_status);
-  iree_status_ignore(query_status);
 }
 
 // Submit an invalid dispatch and check that the wait semaphore fails.

--- a/runtime/src/iree/hal/cts/semaphore_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_test.h
@@ -443,16 +443,13 @@ TEST_F(SemaphoreTest, FailThenWait) {
   iree_status_t wait_status = iree_hal_semaphore_wait(
       semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
       IREE_HAL_WAIT_FLAG_DEFAULT);
-  EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, wait_status);
   uint64_t value = 1234;
   iree_status_t query_status = iree_hal_semaphore_query(semaphore, &value);
   EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
   CheckStatusContains(query_status, status);
 
   iree_hal_semaphore_release(semaphore);
-  iree_status_ignore(status);
-  iree_status_ignore(wait_status);
-  iree_status_ignore(query_status);
 }
 
 // Wait on a semaphore that is then failed.
@@ -469,7 +466,7 @@ TEST_F(SemaphoreTest, WaitThenFail) {
   iree_status_t wait_status = iree_hal_semaphore_wait(
       semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
       IREE_HAL_WAIT_FLAG_DEFAULT);
-  EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, wait_status);
   uint64_t value = 1234;
   iree_status_t query_status = iree_hal_semaphore_query(semaphore, &value);
   EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
@@ -477,9 +474,6 @@ TEST_F(SemaphoreTest, WaitThenFail) {
 
   signal_thread.join();
   iree_hal_semaphore_release(semaphore);
-  iree_status_ignore(status);
-  iree_status_ignore(wait_status);
-  iree_status_ignore(query_status);
 }
 
 // Wait 2 semaphores then fail one of them.
@@ -505,7 +499,7 @@ TEST_F(SemaphoreTest, MultiWaitThenFail) {
   iree_status_t wait_status = iree_hal_semaphore_list_wait(
       semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
       IREE_HAL_WAIT_FLAG_DEFAULT);
-  EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, wait_status);
   uint64_t value = 1234;
   iree_status_t semaphore1_query_status =
       iree_hal_semaphore_query(semaphore1, &value);
@@ -520,9 +514,6 @@ TEST_F(SemaphoreTest, MultiWaitThenFail) {
   signal_thread.join();
   iree_hal_semaphore_release(semaphore1);
   iree_hal_semaphore_release(semaphore2);
-  iree_status_ignore(status);
-  iree_status_ignore(wait_status);
-  iree_status_ignore(semaphore1_query_status);
 }
 
 // Wait 2 semaphores using iree_hal_device_wait_semaphores then fail
@@ -550,7 +541,7 @@ TEST_F(SemaphoreTest, DeviceMultiWaitThenFail) {
       device_, IREE_HAL_WAIT_MODE_ANY, semaphore_list,
       iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
       IREE_HAL_WAIT_FLAG_DEFAULT);
-  EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, wait_status);
   uint64_t value = 1234;
   iree_status_t semaphore1_query_status =
       iree_hal_semaphore_query(semaphore1, &value);
@@ -565,9 +556,6 @@ TEST_F(SemaphoreTest, DeviceMultiWaitThenFail) {
   signal_thread.join();
   iree_hal_semaphore_release(semaphore1);
   iree_hal_semaphore_release(semaphore2);
-  iree_status_ignore(status);
-  iree_status_ignore(wait_status);
-  iree_status_ignore(semaphore1_query_status);
 }
 
 }  // namespace iree::hal::cts

--- a/runtime/src/iree/task/scope_test.cc
+++ b/runtime/src/iree/task/scope_test.cc
@@ -12,6 +12,7 @@
 #include "iree/task/submission.h"
 #include "iree/task/task_impl.h"
 #include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
 
 namespace {
 
@@ -45,9 +46,8 @@ TEST(ScopeTest, AbortEmpty) {
 
   // Enter aborted state.
   iree_task_scope_abort(&scope);
-  iree_status_t consumed_status = iree_task_scope_consume_status(&scope);
-  EXPECT_TRUE(iree_status_is_aborted(consumed_status));
-  iree_status_ignore(consumed_status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED,
+                        iree_task_scope_consume_status(&scope));
 
   // Ensure aborted state is sticky.
   EXPECT_TRUE(iree_status_is_aborted(iree_task_scope_consume_status(&scope)));
@@ -69,9 +69,8 @@ TEST(ScopeTest, FailEmpty) {
   failed_task.scope = &scope;
   iree_task_scope_fail(failed_task.scope,
                        iree_make_status(IREE_STATUS_DATA_LOSS, "whoops!"));
-  iree_status_t consumed_status = iree_task_scope_consume_status(&scope);
-  EXPECT_TRUE(iree_status_is_data_loss(consumed_status));
-  iree_status_ignore(consumed_status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS,
+                        iree_task_scope_consume_status(&scope));
 
   // Ensure failure state is sticky.
   EXPECT_TRUE(iree_status_is_data_loss(iree_task_scope_consume_status(&scope)));
@@ -95,9 +94,8 @@ TEST(ScopeTest, FailAgain) {
   failed_task_a.scope = &scope;
   iree_task_scope_fail(failed_task_a.scope,
                        iree_make_status(IREE_STATUS_DATA_LOSS, "whoops 1"));
-  iree_status_t consumed_status_a = iree_task_scope_consume_status(&scope);
-  EXPECT_TRUE(iree_status_is_data_loss(consumed_status_a));
-  iree_status_ignore(consumed_status_a);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS,
+                        iree_task_scope_consume_status(&scope));
 
   // Ensure failure s tate is sticky.
   EXPECT_TRUE(iree_status_is_data_loss(iree_task_scope_consume_status(&scope)));
@@ -108,9 +106,8 @@ TEST(ScopeTest, FailAgain) {
   iree_task_scope_fail(
       failed_task_b.scope,
       iree_make_status(IREE_STATUS_FAILED_PRECONDITION, "whoops 2"));
-  iree_status_t consumed_status_b = iree_task_scope_consume_status(&scope);
-  EXPECT_TRUE(iree_status_is_data_loss(consumed_status_b));
-  iree_status_ignore(consumed_status_b);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS,
+                        iree_task_scope_consume_status(&scope));
 
   // Still the first failure status.
   EXPECT_TRUE(iree_status_is_data_loss(iree_task_scope_consume_status(&scope)));

--- a/runtime/src/iree/task/topology_test.cc
+++ b/runtime/src/iree/task/topology_test.cc
@@ -85,9 +85,8 @@ TEST(TopologyTest, MaxCapacity) {
   // Try adding one more - it should it fail because we are at capacity.
   iree_task_topology_group_t extra_group;
   iree_task_topology_group_initialize(UINT8_MAX, &extra_group);
-  iree_status_t status = iree_task_topology_push_group(&topology, &extra_group);
-  EXPECT_TRUE(iree_status_is_resource_exhausted(status));
-  iree_status_ignore(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        iree_task_topology_push_group(&topology, &extra_group));
 
   // Confirm that the only groups we have are the valid ones we added above.
   for (iree_host_size_t i = 0; i < 8; ++i) {

--- a/runtime/src/iree/testing/status_matchers.h
+++ b/runtime/src/iree/testing/status_matchers.h
@@ -345,36 +345,20 @@ inline internal::IsOkMatcherGenerator IsOk() {
 // iree::Status, or iree::StatusOr<T>. These macros take ownership of raw
 // iree_status_t values and free them automatically via the Status destructor,
 // preventing leaks on test failure.
-#define IREE_EXPECT_OK(rexpr)                                                \
-  do {                                                                       \
-    ::iree::Status iree_status_for_test_ =                                   \
-        ::iree::internal::ConsumeForTest(rexpr);                             \
-    EXPECT_THAT(iree_status_for_test_,                                       \
-                ::iree::testing::status::StatusIs(::iree::StatusCode::kOk)); \
-  } while (false)
-#define IREE_ASSERT_OK(rexpr)                                                \
-  do {                                                                       \
-    ::iree::Status iree_status_for_test_ =                                   \
-        ::iree::internal::ConsumeForTest(rexpr);                             \
-    ASSERT_THAT(iree_status_for_test_,                                       \
-                ::iree::testing::status::StatusIs(::iree::StatusCode::kOk)); \
-  } while (false)
-#define IREE_EXPECT_STATUS_IS(expected_code, expr)                    \
-  do {                                                                \
-    ::iree::Status iree_status_for_test_ =                            \
-        ::iree::internal::ConsumeForTest(expr);                       \
-    EXPECT_THAT(iree_status_for_test_,                                \
-                ::iree::testing::status::StatusIs(                    \
-                    static_cast<::iree::StatusCode>(expected_code))); \
-  } while (false)
-#define IREE_ASSERT_STATUS_IS(expected_code, expr)                    \
-  do {                                                                \
-    ::iree::Status iree_status_for_test_ =                            \
-        ::iree::internal::ConsumeForTest(expr);                       \
-    ASSERT_THAT(iree_status_for_test_,                                \
-                ::iree::testing::status::StatusIs(                    \
-                    static_cast<::iree::StatusCode>(expected_code))); \
-  } while (false)
+#define IREE_EXPECT_OK(rexpr)                          \
+  EXPECT_THAT(::iree::internal::ConsumeForTest(rexpr), \
+              ::iree::testing::status::StatusIs(::iree::StatusCode::kOk))
+#define IREE_ASSERT_OK(rexpr)                          \
+  ASSERT_THAT(::iree::internal::ConsumeForTest(rexpr), \
+              ::iree::testing::status::StatusIs(::iree::StatusCode::kOk))
+#define IREE_EXPECT_STATUS_IS(expected_code, expr)    \
+  EXPECT_THAT(::iree::internal::ConsumeForTest(expr), \
+              ::iree::testing::status::StatusIs(      \
+                  static_cast<::iree::StatusCode>(expected_code)))
+#define IREE_ASSERT_STATUS_IS(expected_code, expr)    \
+  ASSERT_THAT(::iree::internal::ConsumeForTest(expr), \
+              ::iree::testing::status::StatusIs(      \
+                  static_cast<::iree::StatusCode>(expected_code)))
 
 // Executes an expression that returns an iree::StatusOr<T>, and assigns the
 // contained variable to lhs if the error code is OK.

--- a/runtime/src/iree/testing/status_matchers.h
+++ b/runtime/src/iree/testing/status_matchers.h
@@ -21,28 +21,28 @@ namespace internal {
 // status and that the contained T value matches another matcher.
 template <typename T>
 class IsOkAndHoldsMatcher
-    : public ::testing::MatcherInterface<const StatusOr<T> &> {
+    : public ::testing::MatcherInterface<const StatusOr<T>&> {
  public:
   template <typename MatcherT>
-  IsOkAndHoldsMatcher(MatcherT &&value_matcher)
-      : value_matcher_(::testing::SafeMatcherCast<const T &>(value_matcher)) {}
+  IsOkAndHoldsMatcher(MatcherT&& value_matcher)
+      : value_matcher_(::testing::SafeMatcherCast<const T&>(value_matcher)) {}
 
   // From testing::MatcherInterface.
-  void DescribeTo(std::ostream *os) const override {
+  void DescribeTo(std::ostream* os) const override {
     *os << "is OK and contains a value that ";
     value_matcher_.DescribeTo(os);
   }
 
   // From testing::MatcherInterface.
-  void DescribeNegationTo(std::ostream *os) const override {
+  void DescribeNegationTo(std::ostream* os) const override {
     *os << "is not OK or contains a value that ";
     value_matcher_.DescribeNegationTo(os);
   }
 
   // From testing::MatcherInterface.
   bool MatchAndExplain(
-      const StatusOr<T> &status_or,
-      ::testing::MatchResultListener *listener) const override {
+      const StatusOr<T>& status_or,
+      ::testing::MatchResultListener* listener) const override {
     if (!status_or.ok()) {
       *listener << "which is not OK";
       return false;
@@ -60,7 +60,7 @@ class IsOkAndHoldsMatcher
   }
 
  private:
-  const ::testing::Matcher<const T &> value_matcher_;
+  const ::testing::Matcher<const T&> value_matcher_;
 };
 
 // A polymorphic IsOkAndHolds() matcher.
@@ -79,7 +79,7 @@ class IsOkAndHoldsGenerator {
       : value_matcher_(std::move(value_matcher)) {}
 
   template <typename T>
-  operator ::testing::Matcher<const StatusOr<T> &>() const {
+  operator ::testing::Matcher<const StatusOr<T>&>() const {
     return ::testing::MakeMatcher(new IsOkAndHoldsMatcher<T>(value_matcher_));
   }
 
@@ -98,7 +98,7 @@ class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
   // From testing::MatcherInterface.
   //
   // Describes the expected error code.
-  void DescribeTo(std::ostream *os) const override {
+  void DescribeTo(std::ostream* os) const override {
     *os << "error code " << StatusCodeToString(code_);
     if (!message_.empty()) {
       *os << "::'" << message_ << "'";
@@ -112,8 +112,8 @@ class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
   // also tests that |matchee| has an error message that matches that
   // expectation.
   bool MatchAndExplain(
-      Matchee &matchee,
-      ::testing::MatchResultListener *listener) const override {
+      Matchee& matchee,
+      ::testing::MatchResultListener* listener) const override {
     if (GetCode(matchee) != code_) {
       *listener << "whose error code is "
                 << StatusCodeToString(GetCode(matchee)) << ": "
@@ -129,30 +129,30 @@ class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
 
  private:
   template <typename T>
-  StatusCode GetCode(const T &matchee) const {
+  StatusCode GetCode(const T& matchee) const {
     return GetCode(matchee.status());
   }
 
-  StatusCode GetCode(const iree_status_code_t &status_code) const {
+  StatusCode GetCode(const iree_status_code_t& status_code) const {
     return static_cast<StatusCode>(status_code);
   }
 
-  StatusCode GetCode(const iree_status_t &status) const {
+  StatusCode GetCode(const iree_status_t& status) const {
     return static_cast<StatusCode>(iree_status_code(status));
   }
 
-  StatusCode GetCode(const Status &status) const { return status.code(); }
+  StatusCode GetCode(const Status& status) const { return status.code(); }
 
   template <typename T>
-  std::string GetMessage(const T &matchee) const {
+  std::string GetMessage(const T& matchee) const {
     return GetMessage(matchee.status());
   }
 
-  std::string GetMessage(const iree_status_t &status) const {
+  std::string GetMessage(const iree_status_t& status) const {
     return Status::ToString(status);
   }
 
-  std::string GetMessage(const Status &status) const {
+  std::string GetMessage(const Status& status) const {
     return status.ToString();
   }
 
@@ -175,27 +175,26 @@ class StatusIsMatcherGenerator {
   StatusIsMatcherGenerator(Enum code, std::string message)
       : code_(code), message_(std::move(message)) {}
 
-  operator ::testing::Matcher<const StatusCode &>() const {
+  operator ::testing::Matcher<const StatusCode&>() const {
     return ::testing::MakeMatcher(
-        new internal::StatusMatcher<Enum, const StatusCode &>(code_, message_));
+        new internal::StatusMatcher<Enum, const StatusCode&>(code_, message_));
   }
 
-  operator ::testing::Matcher<const iree_status_t &>() const {
+  operator ::testing::Matcher<const iree_status_t&>() const {
     return ::testing::MakeMatcher(
-        new internal::StatusMatcher<Enum, const iree_status_t &>(code_,
-                                                                 message_));
+        new internal::StatusMatcher<Enum, const iree_status_t&>(code_,
+                                                                message_));
   }
 
-  operator ::testing::Matcher<const Status &>() const {
+  operator ::testing::Matcher<const Status&>() const {
     return ::testing::MakeMatcher(
-        new internal::StatusMatcher<Enum, const Status &>(code_, message_));
+        new internal::StatusMatcher<Enum, const Status&>(code_, message_));
   }
 
   template <class T>
-  operator ::testing::Matcher<const StatusOr<T> &>() const {
+  operator ::testing::Matcher<const StatusOr<T>&>() const {
     return ::testing::MakeMatcher(
-        new internal::StatusMatcher<Enum, const StatusOr<T> &>(code_,
-                                                               message_));
+        new internal::StatusMatcher<Enum, const StatusOr<T>&>(code_, message_));
   }
 
  private:
@@ -216,12 +215,12 @@ class IsOkMatcherImpl : public ::testing::MatcherInterface<T> {
   // From testing::MatcherInterface.
   //
   // Describes the OK expectation.
-  void DescribeTo(std::ostream *os) const override { *os << "is OK"; }
+  void DescribeTo(std::ostream* os) const override { *os << "is OK"; }
 
   // From testing::MatcherInterface.
   //
   // Describes the negative OK expectation.
-  void DescribeNegationTo(std::ostream *os) const override {
+  void DescribeNegationTo(std::ostream* os) const override {
     *os << "is not OK";
   }
 
@@ -230,8 +229,8 @@ class IsOkMatcherImpl : public ::testing::MatcherInterface<T> {
   // Tests whether |status_container|'s OK value meets this matcher's
   // expectation.
   bool MatchAndExplain(
-      const T &status_container,
-      ::testing::MatchResultListener *listener) const override {
+      const T& status_container,
+      ::testing::MatchResultListener* listener) const override {
     if (!::iree::IsOk(status_container)) {
       *listener << "which is not OK";
       return false;
@@ -247,22 +246,48 @@ class IsOkMatcherImpl : public ::testing::MatcherInterface<T> {
 // container.
 class IsOkMatcherGenerator {
  public:
-  operator ::testing::Matcher<const iree_status_t &>() const {
+  operator ::testing::Matcher<const iree_status_t&>() const {
     return ::testing::MakeMatcher(
-        new internal::IsOkMatcherImpl<const iree_status_t &>());
+        new internal::IsOkMatcherImpl<const iree_status_t&>());
   }
 
-  operator ::testing::Matcher<const Status &>() const {
+  operator ::testing::Matcher<const Status&>() const {
     return ::testing::MakeMatcher(
-        new internal::IsOkMatcherImpl<const Status &>());
+        new internal::IsOkMatcherImpl<const Status&>());
   }
 
   template <class T>
-  operator ::testing::Matcher<const StatusOr<T> &>() const {
+  operator ::testing::Matcher<const StatusOr<T>&>() const {
     return ::testing::MakeMatcher(
-        new internal::IsOkMatcherImpl<const StatusOr<T> &>());
+        new internal::IsOkMatcherImpl<const StatusOr<T>&>());
   }
 };
+
+// Takes ownership of an lvalue iree_status_t for testing. Clears the source
+// to a code-only value so any subsequent iree_status_ignore/free is a no-op.
+inline Status ConsumeForTest(iree_status_t& status) {
+  iree_status_t owned = status;
+  status = iree_status_from_code(iree_status_code(status));
+  return Status(std::move(owned));
+}
+
+// Takes ownership of an rvalue iree_status_t (e.g. function call return).
+inline Status ConsumeForTest(iree_status_t&& status) {
+  return Status(std::move(status));
+}
+
+// Consumes a non-const Status via the existing consuming copy constructor.
+inline Status ConsumeForTest(Status& status) { return Status(status); }
+
+// Moves from a Status rvalue.
+inline Status ConsumeForTest(Status&& status) {
+  return Status(std::move(status));
+}
+
+// Code-only copy from const Status& (cannot steal storage from const).
+inline Status ConsumeForTest(const Status& status) {
+  return Status(status.code());
+}
 
 }  // namespace internal
 
@@ -316,20 +341,40 @@ inline internal::IsOkMatcherGenerator IsOk() {
 }  // namespace status
 }  // namespace testing
 
-// Macros for testing the results of functions that return iree::Status or
-// iree::StatusOr<T> (for any type T).
-#define IREE_EXPECT_OK(rexpr) \
-  EXPECT_THAT((rexpr),        \
-              ::iree::testing::status::StatusIs(::iree::StatusCode::kOk))
-#define IREE_ASSERT_OK(rexpr) \
-  ASSERT_THAT((rexpr),        \
-              ::iree::testing::status::StatusIs(::iree::StatusCode::kOk))
-#define IREE_EXPECT_STATUS_IS(expected_code, expr)       \
-  EXPECT_THAT((expr), ::iree::testing::status::StatusIs( \
-                          static_cast<::iree::StatusCode>(expected_code)))
-#define IREE_ASSERT_STATUS_IS(expected_code, expr)       \
-  ASSERT_THAT((expr), ::iree::testing::status::StatusIs( \
-                          static_cast<::iree::StatusCode>(expected_code)))
+// Macros for testing the results of functions that return iree_status_t,
+// iree::Status, or iree::StatusOr<T>. These macros take ownership of raw
+// iree_status_t values and free them automatically via the Status destructor,
+// preventing leaks on test failure.
+#define IREE_EXPECT_OK(rexpr)                                                \
+  do {                                                                       \
+    ::iree::Status iree_status_for_test_ =                                   \
+        ::iree::internal::ConsumeForTest(rexpr);                             \
+    EXPECT_THAT(iree_status_for_test_,                                       \
+                ::iree::testing::status::StatusIs(::iree::StatusCode::kOk)); \
+  } while (false)
+#define IREE_ASSERT_OK(rexpr)                                                \
+  do {                                                                       \
+    ::iree::Status iree_status_for_test_ =                                   \
+        ::iree::internal::ConsumeForTest(rexpr);                             \
+    ASSERT_THAT(iree_status_for_test_,                                       \
+                ::iree::testing::status::StatusIs(::iree::StatusCode::kOk)); \
+  } while (false)
+#define IREE_EXPECT_STATUS_IS(expected_code, expr)                    \
+  do {                                                                \
+    ::iree::Status iree_status_for_test_ =                            \
+        ::iree::internal::ConsumeForTest(expr);                       \
+    EXPECT_THAT(iree_status_for_test_,                                \
+                ::iree::testing::status::StatusIs(                    \
+                    static_cast<::iree::StatusCode>(expected_code))); \
+  } while (false)
+#define IREE_ASSERT_STATUS_IS(expected_code, expr)                    \
+  do {                                                                \
+    ::iree::Status iree_status_for_test_ =                            \
+        ::iree::internal::ConsumeForTest(expr);                       \
+    ASSERT_THAT(iree_status_for_test_,                                \
+                ::iree::testing::status::StatusIs(                    \
+                    static_cast<::iree::StatusCode>(expected_code))); \
+  } while (false)
 
 // Executes an expression that returns an iree::StatusOr<T>, and assigns the
 // contained variable to lhs if the error code is OK.
@@ -348,9 +393,10 @@ inline internal::IsOkMatcherGenerator IsOk() {
       IREE_STATUS_MACROS_CONCAT_NAME(_status_or_value, __COUNTER__), lhs, \
       rexpr);
 
-#define IREE_ASSERT_OK_AND_ASSIGN_IMPL(statusor, lhs, rexpr) \
-  auto statusor = (rexpr);                                   \
-  IREE_ASSERT_OK(statusor.status());                         \
+#define IREE_ASSERT_OK_AND_ASSIGN_IMPL(statusor, lhs, rexpr)               \
+  auto statusor = (rexpr);                                                 \
+  ASSERT_THAT(statusor.status(),                                           \
+              ::iree::testing::status::StatusIs(::iree::StatusCode::kOk)); \
   lhs = std::move(statusor.value())
 #define IREE_STATUS_MACROS_CONCAT_NAME(x, y) \
   IREE_STATUS_MACROS_CONCAT_IMPL(x, y)
@@ -361,7 +407,7 @@ inline internal::IsOkMatcherGenerator IsOk() {
 // implementation relies on gUnit for printing values of T when a
 // iree::StatusOr<T> object is OK and contains a value.
 template <typename T>
-void PrintTo(const StatusOr<T> &statusor, std::ostream *os) {
+void PrintTo(const StatusOr<T>& statusor, std::ostream* os) {
   if (!statusor.ok()) {
     *os << statusor.status().ToString();
   } else {

--- a/runtime/src/iree/vm/ref_test.cc
+++ b/runtime/src/iree/vm/ref_test.cc
@@ -197,10 +197,9 @@ TEST(VMRefTest, WrappingRetainExistingSame) {
 TEST(VMRefTest, CheckNull) {
   iree_vm_ref_t null_ref = {0};
   IREE_EXPECT_OK(iree_vm_ref_check(null_ref, IREE_VM_REF_TYPE_NULL));
-  iree_status_t status =
-      iree_vm_ref_check(null_ref, static_cast<iree_vm_ref_type_t>(1234));
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_vm_ref_check(null_ref, static_cast<iree_vm_ref_type_t>(1234)));
 }
 
 // Tests type checks.
@@ -208,9 +207,8 @@ TEST(VMRefTest, Check) {
   auto instance = MakeInstance();
   iree_vm_ref_t a_ref = MakeRef<A>(instance, "AType");
   IREE_EXPECT_OK(iree_vm_ref_check(a_ref, A::kTypeID));
-  iree_status_t status = iree_vm_ref_check(a_ref, B::kTypeID);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_vm_ref_check(a_ref, B::kTypeID));
   iree_vm_ref_release(&a_ref);
 }
 
@@ -374,10 +372,9 @@ TEST(VMRefTest, RetainOrMoveCheckedMismatch) {
   // Retain.
   iree_vm_ref_t a_ref_0 = MakeRef<A>(instance, "AType");
   iree_vm_ref_t a_ref_1 = {0};
-  iree_status_t status = iree_vm_ref_retain_or_move_checked(
-      /*is_move=*/0, &a_ref_0, B::kTypeID, &a_ref_1);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_vm_ref_retain_or_move_checked(
+                            /*is_move=*/0, &a_ref_0, B::kTypeID, &a_ref_1));
   EXPECT_EQ(0, iree_vm_ref_equal(&a_ref_0, &a_ref_1));
   EXPECT_EQ(1, ReadCounter(&a_ref_0));
   iree_vm_ref_release(&a_ref_0);
@@ -385,10 +382,9 @@ TEST(VMRefTest, RetainOrMoveCheckedMismatch) {
   // Move.
   iree_vm_ref_t b_ref_0 = MakeRef<B>(instance, "BType");
   iree_vm_ref_t b_ref_1 = {0};
-  status = iree_vm_ref_retain_or_move_checked(
-      /*is_move=*/1, &b_ref_0, A::kTypeID, &b_ref_1);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_vm_ref_retain_or_move_checked(
+                            /*is_move=*/1, &b_ref_0, A::kTypeID, &b_ref_1));
   EXPECT_EQ(1, ReadCounter(&b_ref_0));
   iree_vm_ref_release(&b_ref_0);
 }

--- a/runtime/src/iree/vm/stack_test.cc
+++ b/runtime/src/iree/vm/stack_test.cc
@@ -126,9 +126,8 @@ TEST(VMStackTest, UnbalancedPop) {
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
                                   state_resolver, iree_allocator_system());
 
-  iree_status_t status = iree_vm_stack_function_leave(stack);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_vm_stack_function_leave(stack));
 
   iree_vm_stack_deinitialize(stack);
 }
@@ -192,10 +191,11 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
   iree_vm_stack_frame_t* frame_a = nullptr;
-  iree_status_t status = iree_vm_stack_function_enter(
-      stack, &function_a, IREE_VM_STACK_FRAME_NATIVE, 0, NULL, &frame_a);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_INTERNAL, status);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INTERNAL,
+      iree_vm_stack_function_enter(stack, &function_a,
+                                   IREE_VM_STACK_FRAME_NATIVE, 0, NULL,
+                                   &frame_a));
   iree_vm_stack_deinitialize(stack);
 }
 

--- a/runtime/src/iree/vm/stack_test.cc
+++ b/runtime/src/iree/vm/stack_test.cc
@@ -193,9 +193,8 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
   iree_vm_stack_frame_t* frame_a = nullptr;
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_INTERNAL,
-      iree_vm_stack_function_enter(stack, &function_a,
-                                   IREE_VM_STACK_FRAME_NATIVE, 0, NULL,
-                                   &frame_a));
+      iree_vm_stack_function_enter(
+          stack, &function_a, IREE_VM_STACK_FRAME_NATIVE, 0, NULL, &frame_a));
   iree_vm_stack_deinitialize(stack);
 }
 


### PR DESCRIPTION
Adds `ConsumeForTest` overloads that wrap raw `iree_status_t` in `iree::Status` RAII wrappers, ensuring automatic cleanup on test failure. The macros `IREE_EXPECT_OK`, `IREE_ASSERT_OK`, `IREE_EXPECT_STATUS_IS`, and `IREE_ASSERT_STATUS_IS` now consume the status they test.

For lvalue status variables, the source is cleared to a code-only value so any existing `iree_status_ignore`/`iree_status_free` calls become harmless no-ops. This allows incremental migration without breaking existing tests.

Most tests (outside of tokenizer) have been updated. tokenizer is being reworked and the next feature branch merge will adopt this behavior.