### PR TITLE
[GlobalOpt] Support Img2Col Transformation for Conv2D Including Quantized Types

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
     name = "GlobalOptimization",
     srcs = [
         "CleanupNumericNarrowing.cpp",
+        "ConvertConv2DToImg2Col.cpp",
         "ConvertStridedContractionToContraction.cpp",
         "DataLayoutPropagation.cpp",
         "DecomposeConcat.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     "Utils.h"
   SRCS
     "CleanupNumericNarrowing.cpp"
+    "ConvertConv2DToImg2Col.cpp"
     "ConvertStridedContractionToContraction.cpp"
     "DataLayoutPropagation.cpp"
     "DecomposeConcat.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ConvertConv2DToImg2Col.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Preprocessing/Common/Passes.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -18,10 +18,10 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-namespace mlir::iree_compiler::Preprocessing {
+namespace mlir::iree_compiler::GlobalOptimization {
 
 #define GEN_PASS_DEF_CONVERTCONV2DTOIMG2COLPASS
-#include "iree/compiler/Preprocessing/Common/Passes.h.inc" // IWYU pragma: export
+#include "iree/compiler/GlobalOptimization/Passes.h.inc" // IWYU pragma: export
 
 static bool hasAllOneValues(DenseIntElementsAttr attr) {
   return llvm::all_of(
@@ -554,7 +554,7 @@ public:
 };
 
 class ConvertConv2DToImg2ColPass
-    : public iree_compiler::Preprocessing::impl::ConvertConv2DToImg2ColPassBase<
+    : public impl::ConvertConv2DToImg2ColPassBase<
           ConvertConv2DToImg2ColPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
@@ -569,4 +569,4 @@ class ConvertConv2DToImg2ColPass
 
 } // namespace
 
-} // namespace mlir::iree_compiler::Preprocessing
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ConvertConv2DToImg2Col.cpp
@@ -554,8 +554,7 @@ public:
 };
 
 class ConvertConv2DToImg2ColPass
-    : public impl::ConvertConv2DToImg2ColPassBase<
-          ConvertConv2DToImg2ColPass> {
+    : public impl::ConvertConv2DToImg2ColPassBase<ConvertConv2DToImg2ColPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(&getContext());

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -118,6 +118,8 @@ void buildGlobalOptimizationPassPipeline(
       .addPass(IREE::Util::createOptimizeIntArithmeticPass)
       .addPass(createLinalgQuantizedConvToConvPass)
       .addPass(createLinalgQuantizedMatmulToMatmulPass)
+      .addPredicatedPass(transformOptions.enableConv2DToImg2Col,
+                         createConvertConv2DToImg2ColPass)
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(createRemoveZeroExtentTensorsPass)
       .addPass(createDetachElementwiseFromNamedOpsPass)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -118,7 +118,7 @@ void buildGlobalOptimizationPassPipeline(
       .addPass(IREE::Util::createOptimizeIntArithmeticPass)
       .addPass(createLinalgQuantizedConvToConvPass)
       .addPass(createLinalgQuantizedMatmulToMatmulPass)
-      .addPredicatedPass(transformOptions.enableConv2DToImg2Col,
+      .addPredicatedPass(transformOptions.useIm2colForConvs,
                          createConvertConv2DToImg2ColPass)
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(createRemoveZeroExtentTensorsPass)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 
+#include "iree/compiler/Pipelines/Options.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -118,6 +119,13 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
       *this,
       "generalize-matmul",
       llvm::cl::desc("Converts linalg named matmul ops to linalg generic ops."),
+      llvm::cl::init(false),
+  };
+  Option<bool> enableConv2DToImg2Col{
+      *this,
+      "enable-conv2d-to-img2col",
+      llvm::cl::desc("Enables conversion of Conv2D operations to img2col + "
+                     "matmul form to leverage optimized matmul implementations."),
       llvm::cl::init(false),
   };
   Option<bool> constExprHoisting{

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -124,8 +124,9 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
   Option<bool> useIm2colForConvs{
       *this,
       "use-im2col-for-convs",
-      llvm::cl::desc("Enables converting convolution operations to im2col + "
-                     "matmul form to leverage optimized matmul implementations."),
+      llvm::cl::desc(
+          "Enables converting convolution operations to im2col + "
+          "matmul form to leverage optimized matmul implementations."),
       llvm::cl::init(false),
   };
   Option<bool> constExprHoisting{

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -121,10 +121,10 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
       llvm::cl::desc("Converts linalg named matmul ops to linalg generic ops."),
       llvm::cl::init(false),
   };
-  Option<bool> enableConv2DToImg2Col{
+  Option<bool> useIm2colForConvs{
       *this,
-      "enable-conv2d-to-img2col",
-      llvm::cl::desc("Enables conversion of Conv2D operations to img2col + "
+      "use-im2col-for-convs",
+      llvm::cl::desc("Enables converting convolution operations to im2col + "
                      "matmul form to leverage optimized matmul implementations."),
       llvm::cl::init(false),
   };

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -14,6 +14,15 @@ def CleanupNumericNarrowingPass :
   let summary = "Cleans up any numeric narrowing ops inserted by iree-global-opt-infer-numeric-narrowing.";
 }
 
+def ConvertConv2DToImg2ColPass :
+    Pass<"iree-global-opt-convert-conv2d-to-img2col", ""> {
+  let summary = "Convert linalg convolution ops to matmul img2col based implementation";
+  let dependentDialects = [
+    "mlir::linalg::LinalgDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
 def ConvertStridedContractionToContractionPass:
     Pass<"iree-global-opt-convert-strided-contraction-to-contraction", ""> {
   let summary = "Factors out an extract_slice from contraction-like ops with strided inputs.";

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         # keep sorted
         [
             "cleanup_numeric_narrowing.mlir",
+            "conv2d_to_img2col.mlir",
             "data_layout_propagation.mlir",
             "demote_contraction_inputs_to_bf16.mlir",
             "detach_elementwise_from_named_ops.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "cleanup_numeric_narrowing.mlir"
+    "conv2d_to_img2col.mlir"
     "data_layout_propagation.mlir"
     "demote_contraction_inputs_to_bf16.mlir"
     "detach_elementwise_from_named_ops.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/conv2d_to_img2col.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/conv2d_to_img2col.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file -iree-preprocessing-convert-conv2d-to-img2col %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-global-opt-convert-conv2d-to-img2col %s | FileCheck %s
 
 func.func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
     %0 = linalg.conv_2d_nhwc_hwcf

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -302,6 +302,11 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc("Convert named matmul ops to linalg generic ops during "
                      "global optimization to enable better fusion."),
       llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-global-opt-enable-conv2d-to-img2col", enableConv2DToImg2Col,
+      llvm::cl::desc("Enables conversion of Conv2D operations to img2col + "
+                     "matmul form to leverage optimized matmul implementations."),
+      llvm::cl::cat(category));
 }
 
 void SchedulingOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -304,8 +304,9 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-global-opt-use-im2col-for-convs", useIm2colForConvs,
-      llvm::cl::desc("Enables converting convolution operations to im2col + "
-                     "matmul form to leverage optimized matmul implementations."),
+      llvm::cl::desc(
+          "Enables converting convolution operations to im2col + "
+          "matmul form to leverage optimized matmul implementations."),
       llvm::cl::cat(category));
 }
 

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -303,8 +303,8 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
                      "global optimization to enable better fusion."),
       llvm::cl::cat(category));
   binder.opt<bool>(
-      "iree-global-opt-enable-conv2d-to-img2col", enableConv2DToImg2Col,
-      llvm::cl::desc("Enables conversion of Conv2D operations to img2col + "
+      "iree-global-opt-use-im2col-for-convs", useIm2colForConvs,
+      llvm::cl::desc("Enables converting convolution operations to im2col + "
                      "matmul form to leverage optimized matmul implementations."),
       llvm::cl::cat(category));
 }

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -187,6 +187,9 @@ struct GlobalOptimizationOptions {
   // Converts linalg named matmul ops to linalg generic ops.
   bool generalizeMatmul = false;
 
+  // Enables conversion of Conv2D operations to img2col + matmul form.
+  bool enableConv2DToImg2Col = false;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GlobalOptimizationOptions>;
 };

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -187,8 +187,8 @@ struct GlobalOptimizationOptions {
   // Converts linalg named matmul ops to linalg generic ops.
   bool generalizeMatmul = false;
 
-  // Enables conversion of Conv2D operations to img2col + matmul form.
-  bool enableConv2DToImg2Col = false;
+  // Enables converting convolution operations to im2col + matmul form.
+  bool useIm2colForConvs = false;
 
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GlobalOptimizationOptions>;

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -212,6 +212,8 @@ void buildIREEPrecompileTransformPassPipeline(
       globalOptimizationOptions.stripAssertions;
   globalTransformOptions.generalizeMatmul =
       globalOptimizationOptions.generalizeMatmul;
+  globalTransformOptions.enableConv2DToImg2Col =
+      globalOptimizationOptions.enableConv2DToImg2Col;
   globalTransformOptions.constExprHoisting = pipelineOptions.constExprHoisting;
   globalTransformOptions.constExprMaxSizeIncreaseThreshold =
       pipelineOptions.constExprMaxSizeIncreaseThreshold;

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -212,8 +212,8 @@ void buildIREEPrecompileTransformPassPipeline(
       globalOptimizationOptions.stripAssertions;
   globalTransformOptions.generalizeMatmul =
       globalOptimizationOptions.generalizeMatmul;
-  globalTransformOptions.enableConv2DToImg2Col =
-      globalOptimizationOptions.enableConv2DToImg2Col;
+  globalTransformOptions.useIm2colForConvs =
+      globalOptimizationOptions.useIm2colForConvs;
   globalTransformOptions.constExprHoisting = pipelineOptions.constExprHoisting;
   globalTransformOptions.constExprMaxSizeIncreaseThreshold =
       pipelineOptions.constExprMaxSizeIncreaseThreshold;

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -38,7 +38,6 @@ iree_compiler_cc_library(
         "ApplyPDLPatterns.cpp",
         "AttrBasedPipelinePass.cpp",
         "Convert1X1FilterConv2DToMatmul.cpp",
-        "ConvertConv2DToImg2Col.cpp",
         "ConvertConvFilterToChannelsLast.cpp",
         "ConvertConvToChannelsLast.cpp",
         "FoldAttentionWithTranspose.cpp",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -29,7 +29,6 @@ iree_cc_library(
     "ApplyPDLPatterns.cpp"
     "AttrBasedPipelinePass.cpp"
     "Convert1X1FilterConv2DToMatmul.cpp"
-    "ConvertConv2DToImg2Col.cpp"
     "ConvertConvFilterToChannelsLast.cpp"
     "ConvertConvToChannelsLast.cpp"
     "FoldAttentionWithTranspose.cpp"

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -48,14 +48,6 @@ def Convert1X1FilterConv2DToMatmulPass:
   ];
 }
 
-def ConvertConv2DToImg2ColPass :
-    Pass<"iree-preprocessing-convert-conv2d-to-img2col", ""> {
-  let summary = "Convert linalg convolution ops to matmul img2col based implementation";
-  let dependentDialects = [
-    "mlir::linalg::LinalgDialect",
-    "mlir::tensor::TensorDialect",
-  ];
-}
 
 def ConvertConvFilterToChannelsLastPass:
     Pass<"iree-preprocessing-convert-conv-filter-to-channels-last", ""> {

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
@@ -19,7 +19,6 @@ iree_lit_test_suite(
         [
             "attr_based_pipeline.mlir",
             "conv1x1_to_matmul.mlir",
-            "conv2d_to_img2col.mlir",
             "conv_filter_to_channels_last.mlir",
             "conv_to_channels_last.mlir",
             "fold_attention_with_transpose.mlir",

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
@@ -16,7 +16,6 @@ iree_lit_test_suite(
   SRCS
     "attr_based_pipeline.mlir"
     "conv1x1_to_matmul.mlir"
-    "conv2d_to_img2col.mlir"
     "conv_filter_to_channels_last.mlir"
     "conv_to_channels_last.mlir"
     "fold_attention_with_transpose.mlir"

--- a/tests/compiler_driver/preprocessing_flags.mlir
+++ b/tests/compiler_driver/preprocessing_flags.mlir
@@ -2,8 +2,8 @@
 // RUN:   --iree-hal-target-device=local \
 // RUN:   --iree-hal-local-target-device-backends=llvm-cpu \
 // RUN:   --compile-to=preprocessing \
-// RUN:   --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-convert-conv2d-to-img2col,iree-preprocessing-pad-linalg-ops{pad-size=16}))" \
-// RUN:   --mlir-print-ir-after=iree-preprocessing-convert-conv2d-to-img2col --mlir-print-ir-after=iree-preprocessing-pad-linalg-ops %s 2>&1 \
+// RUN:   --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-pad-linalg-ops{pad-size=16}))" \
+// RUN:   --mlir-print-ir-after=iree-preprocessing-pad-linalg-ops %s 2>&1 \
 // RUN:   | FileCheck %s
 
 func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : tensor<10x30xf32>) -> tensor<10x30xf32> {
@@ -13,7 +13,6 @@ func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : te
 }
 
 // Just check that the pass runs, and that the compilation finishes
-//       CHECK: ConvertConv2DToImg2ColPass (iree-preprocessing-convert-conv2d-to-img2col)
 //       CHECK: PadLinalgOpsPass (iree-preprocessing-pad-linalg-ops)
 // CHECK-LABEL: module
 //       CHECK:   util.func public @test(


### PR DESCRIPTION
Move the Conv2D to Img2Col transformation pass from Preprocessing to GlobalOptimization phase. This allows the pass to run after LinalgQuantizedConvToConvPass, enabling quantized convolutions to benefit from the img2col transformation.
