### PR TITLE
[Codegen] Use safer hoisting in OptimizeTensorInsertExtractSlices

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/winograd_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/winograd_pipeline_test.mlir
@@ -43,10 +43,10 @@ func.func @winograd_input_transform() {
 }
 //   CHECK-LABEL:  func.func @winograd_input_transform
 //     CHECK-NOT:      memref.alloc
-//         CHECK:      vector.transfer_read
-//         CHECK:      vector.transfer_read
 //         CHECK:      scf.for
 //         CHECK:        scf.for
+//         CHECK:          vector.transfer_read
+//         CHECK:          vector.transfer_read
 //         CHECK:          scf.for
 //         CHECK:          vector.transfer_read
 //         CHECK:          vector.contract
@@ -71,10 +71,10 @@ func.func @winograd_output_transform() {
 }
 //   CHECK-LABEL:  func.func @winograd_output_transform
 //     CHECK-NOT:      memref.alloc
-//         CHECK:      vector.transfer_read
-//         CHECK:      vector.transfer_read
 //         CHECK:      scf.for
 //         CHECK:        scf.for
+//         CHECK:          vector.transfer_read
+//         CHECK:          vector.transfer_read
 //         CHECK:          scf.for
 //         CHECK:          vector.transfer_read
 //         CHECK:          vector.contract


### PR DESCRIPTION
Use the `moveLoopInvariantCodeFromGuaranteedLoops` transform instead of the `moveLoopInvariantCode` transform in the OptimizeTensorInsertExtractSlices pass. This transform is safer, because it validates that loops will be executed at least once before hoisting loop invariant code. Hoisting from loops that may not execute is not an optimization, so this is a better version of the transformation.

The new safer transform also hoists from linalg.generic ops, so the `moveLoopInvariantCodeFromGenericOps` is removed, since it is no longer used.

This PR also removes the `_batch_matmul_narrow_n_2_dispatch_4_unpack_i32` test, which was doing nothing but checking that a tensor.empty op gets hoisted from an scf.for loop (which cannot be guaranteed to execute). Hoisting empty tensors is not the job of this pass, and the test is verbose, so the test is simply removed.