### PR TITLE
[LLVMCPU] Fix crash in limitVectorTileSizes with dynamic operand shapes.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -777,8 +777,8 @@ static void limitVectorTileSizes(SmallVectorImpl<int64_t> &vecTileSizes,
 
       if (oldVal == 0) {
         // Skip updating tile sizes of 0, we want to preserve these values. If
-        // we have enough information about the upper bound of this tile size,
-        // use it.
+        // we do not have enough information about the upper bound of this tile
+        // size, don't use it.
         if (!bounds.empty() && !ShapedType::isDynamic(bounds[loopNum])) {
           tileBits[i] *= bounds[loopNum];
         }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -776,10 +776,10 @@ static void limitVectorTileSizes(SmallVectorImpl<int64_t> &vecTileSizes,
       }
 
       if (oldVal == 0) {
-        // Skip updating tile sizes of 0, we want to preserve these values.
-        if (!bounds.empty()) {
-          // If we have enough information about the upper bound of this tile
-          // size, use it.
+        // Skip updating tile sizes of 0, we want to preserve these values. If
+        // we have enough information about the upper bound of this tile size,
+        // use it.
+        if (!bounds.empty() && !ShapedType::isDynamic(bounds[loopNum])) {
           tileBits[i] *= bounds[loopNum];
         }
       } else {


### PR DESCRIPTION
It did not take dynamic shape into account, which leads to a crash. The revision does not adjust the tile size if the bound is dynamic.

Fixes https://github.com/iree-org/iree/issues/23277