### PR TITLE
[Codegen] Preserve DPS when vectorizing iree_vector_ext.to_layout

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -76,15 +76,11 @@ struct VectorizeToLayoutOpPattern final
     int64_t rank = tensorTy.getShape().size();
     auto inBounds = rewriter.getBoolArrayAttr(SmallVector<bool>(rank, true));
     auto identityMap = rewriter.getMultiDimIdentityMap(tensorTy.getRank());
-    auto empty = tensor::EmptyOp::create(
-        rewriter, loc,
-        tensor::getMixedSizes(rewriter, loc, tensorLayoutOp.getInput()),
-        tensorTy.getElementType());
     return vector::TransferWriteOp::create(
         rewriter, loc,
         /*result=*/resType,
         /*vector=*/vectorLayoutOp,
-        /*source=*/empty,
+        /*source=*/tensorLayoutOp.getInput(),
         /*indices=*/ValueRange{SmallVector<Value>(rank, zero)},
         /*permutation_map=*/identityMap,
         /*mask=*/mask,


### PR DESCRIPTION
The iree_vector_ext.to_layout op is just a hint, so it should not break DPS when vectorizing. In order to preserve DPS, the source tensor is used as the destination for the transfer_write as opposed to a tensor.empty op.

Fixes https://github.com/iree-org/iree/issues/23283