### PR TITLE
[e2e] Increase test timeout for gfx1250

### DIFF
--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -30,6 +30,7 @@
 #   TEST_DEFINED: Whether to define a test target.
 #   TEST_DISABLED: The test target will be skipped and its status will be
 #       'Not Run'.
+#   TIMEOUT: Test timeout in seconds. Defaults to the iree_native_test default.
 function(iree_e2e_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -43,7 +44,7 @@ function(iree_e2e_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_TYPE;VARIANT_NAME;TESTS_SRC;TESTS_VMFB;CALLS_SRC;CALLS_VMFB;TRACE;TARGET_BACKEND;DRIVER;TEST_RUNNER;TEST_DEFINED;TEST_DISABLED"
+    "NAME;TEST_TYPE;VARIANT_NAME;TESTS_SRC;TESTS_VMFB;CALLS_SRC;CALLS_VMFB;TRACE;TARGET_BACKEND;DRIVER;TEST_RUNNER;TEST_DEFINED;TEST_DISABLED;TIMEOUT"
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
@@ -119,6 +120,8 @@ function(iree_e2e_runner_test)
         ${_RULE_LABELS}
       DISABLED
         ${_RULE_TEST_DISABLED}
+      TIMEOUT
+        ${_RULE_TIMEOUT}
     )
   endif()
 endfunction()
@@ -145,6 +148,7 @@ endfunction()
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
 #   TEST_RUNNER: trace-runner program to run.
+#   TIMEOUT: Test timeout in seconds. Defaults to the iree_native_test default.
 function(iree_single_backend_e2e_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -157,7 +161,7 @@ function(iree_single_backend_e2e_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_TYPE;GENERATOR;TARGET_BACKEND;DRIVER;TEST_RUNNER"
+    "NAME;TEST_TYPE;GENERATOR;TARGET_BACKEND;DRIVER;TEST_RUNNER;TIMEOUT"
     "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
@@ -306,6 +310,7 @@ function(iree_single_backend_e2e_runner_test)
       LABELS ${_RULE_LABELS}
       TEST_DEFINED ${_TEST_DEFINED}
       TEST_DISABLED ${_TEST_DISABLED}
+      TIMEOUT ${_RULE_TIMEOUT}
     )
     # Note we are relying on the fact that the target created by
     # iree_e2e_runner_test is _NAME, even though we passed _RULE_NAME to it,
@@ -339,6 +344,7 @@ function(iree_single_backend_e2e_runner_test)
         LABELS ${_RULE_LABELS}
         TEST_DEFINED ${_TEST_DEFINED}
         TEST_DISABLED ${_TEST_DISABLED}
+        TIMEOUT ${_RULE_TIMEOUT}
       )
       # Note we are relying on the fact that the target created by
       # iree_e2e_runner_test is _NAME, even though we passed _RULE_NAME to it,
@@ -365,6 +371,7 @@ function(iree_single_backend_e2e_runner_test)
         LABELS ${_RULE_LABELS}
         TEST_DEFINED ${_TEST_DEFINED}
         TEST_DISABLED ${_TEST_DISABLED}
+        TIMEOUT ${_RULE_TIMEOUT}
       )
       # Note we are relying on the fact that the target created by
       # iree_e2e_runner_test is _NAME, even though we passed _RULE_NAME to it,
@@ -415,6 +422,7 @@ endfunction()
 #       and cpu_features is a comma-separated list of LLVM target attributes
 #       to enable. Example:
 #         x86_64:avx2_fma:+avx,+avx2,+fma
+#   TIMEOUT: Test timeout in seconds. Defaults to the iree_native_test default.
 function(iree_generated_e2e_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -423,7 +431,7 @@ function(iree_generated_e2e_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_TYPE;GENERATOR;TEST_RUNNER"
+    "NAME;TEST_TYPE;GENERATOR;TEST_RUNNER;TIMEOUT"
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
@@ -494,6 +502,8 @@ function(iree_generated_e2e_runner_test)
           ${_RULE_RUNNER_ARGS}
         LABELS
           ${_LABELS}
+        TIMEOUT
+          ${_RULE_TIMEOUT}
       )
     endforeach()
   endforeach()

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -170,7 +170,7 @@ function(iree_native_test)
     endif()
   endif()
 
-  if (NOT DEFINED _RULE_TIMEOUT)
+  if (NOT DEFINED _RULE_TIMEOUT OR "${_RULE_TIMEOUT}" STREQUAL "")
     set(_RULE_TIMEOUT 60)
   endif()
 

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -249,6 +249,7 @@ ROCM_SRCS = enforce_glob(
 
 iree_check_single_backend_test_suite(
     name = "check_rocm_hip",
+    timeout = "moderate",
     srcs = ROCM_SRCS,
     driver = "hip",
     target_backend = "rocm",

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -249,6 +249,7 @@ ROCM_SRCS = enforce_glob(
 
 iree_check_single_backend_test_suite(
     name = "check_rocm_hip",
+    # TODO(kuhar): Drop the timeout after we switch to testing on the actual gfx1250 chip.
     timeout = "moderate",
     srcs = ROCM_SRCS,
     driver = "hip",

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -175,6 +175,8 @@ iree_check_single_backend_test_suite(
     "rocm"
   DRIVER
     "hip"
+  TIMEOUT
+    300
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2903,6 +2903,8 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-gfx1250"
+  TIMEOUT
+    120
 )
 
 iree_generated_e2e_runner_test(
@@ -2933,6 +2935,8 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-gfx1250"
+  TIMEOUT
+    120
 )
 
 iree_generated_e2e_runner_test(
@@ -2960,6 +2964,8 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-gfx1250"
+  TIMEOUT
+    120
 )
 
 endif()

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2903,6 +2903,7 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-gfx1250"
+  # TODO(kuhar): Drop the timeout after we switch to testing on the actual gfx1250 chip.
   TIMEOUT
     120
 )
@@ -2935,6 +2936,7 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-gfx1250"
+  # TODO(kuhar): Drop the timeout after we switch to testing on the actual gfx1250 chip.
   TIMEOUT
     120
 )
@@ -2964,6 +2966,7 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-gfx1250"
+  # TODO(kuhar): Drop the timeout after we switch to testing on the actual gfx1250 chip.
   TIMEOUT
     120
 )

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -139,6 +139,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_regression_hip",
+    timeout = "moderate",
     srcs = [
         "dynamic_gather_attention.mlir",
         "linalg_ops_dynamic.mlir",

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -139,6 +139,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_regression_hip",
+    # TODO(kuhar): Drop the timeout after we switch to testing on the actual gfx1250 chip.
     timeout = "moderate",
     srcs = [
         "dynamic_gather_attention.mlir",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -174,6 +174,8 @@ iree_check_single_backend_test_suite(
     "notsan"
     "noubsan"
     "requires-gpu-amd"
+  TIMEOUT
+    300
 )
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
Expose timeout as an optional argument in `iree_native_test` in matmul tests. Regression tests already know how to translate the bazel timeout parameter to seconds.

Assisted-by: claude