### PR TITLE
[GPU] Introduce and plumb through GPUCodegenOptions.

### DIFF
--- a/compiler/plugins/target/ROCM/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/BUILD.bazel
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMGPU",
         "//compiler/src/iree/compiler/Codegen/Utils",
+        "//compiler/src/iree/compiler/Codegen/Utils:CodegenOptions",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",

--- a/compiler/plugins/target/ROCM/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/CMakeLists.txt
@@ -60,6 +60,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::LLVMGPU
     iree::compiler::Codegen::Utils
+    iree::compiler::Codegen::Utils::CodegenOptions
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::Target

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -43,6 +43,7 @@ iree_compiler_cc_library(
     deps = [
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Utils:CodegenOptions",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//mlir:LinalgTransforms",
@@ -145,6 +146,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/LLVMGPU/Utils",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",
+        "//compiler/src/iree/compiler/Codegen/Utils:CodegenOptions",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/Transforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     MLIRPass
     MLIRTransforms
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Utils::CodegenOptions
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Utils
   PUBLIC
@@ -188,6 +189,7 @@ iree_cc_library(
     iree::compiler::Codegen::LLVMGPU::Utils
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils
+    iree::compiler::Codegen::Utils::CodegenOptions
     iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::Transforms

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -7,11 +7,13 @@
 #ifndef IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 #define IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 
+#include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir::iree_compiler {
 
-LogicalResult initGPULaunchConfig(mlir::FunctionOpInterface funcOp);
+LogicalResult initGPULaunchConfig(mlir::FunctionOpInterface funcOp,
+                                  const GPUCodegenOptions &gpuOpts);
 
 } // namespace mlir::iree_compiler
 #endif // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -77,7 +77,7 @@ verifyEntryPoint(FunctionOpInterface funcOp,
 void LLVMGPUSelectLoweringStrategyPass::runOnOperation() {
   mlir::ModuleOp moduleOp = getOperation();
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
-    if (failed(initGPULaunchConfig(funcOp))) {
+    if (failed(initGPULaunchConfig(funcOp, gpuOptions.getValue()))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
+#include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Pass/Pass.h"
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -109,6 +109,11 @@ def ROCDLPrefetchSharedMemoryPass :
 def LLVMGPUSelectLoweringStrategyPass :
     Pass<"iree-llvmgpu-select-lowering-strategy", "ModuleOp"> {
   let summary = "Select a IREE::HAL::DispatchLoweringPassPipeline for lowering the target variant";
+  let options = [
+    Option<"gpuOptions", "gpu-options", "GPUCodegenOptions",
+      /*default=*/"GPUCodegenOptions::FromFlags::get()",
+      "Session-scoped GPU codegen options controlling prefetch, etc.">,
+  ];
 }
 
 def LLVMGPUTensorCoreVectorizationPass :

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::CPUCodegenOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
 namespace mlir::iree_compiler {
 
@@ -35,6 +36,15 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
                     initAtOpt(llvm::OptimizationLevel::O2, true)},
                    llvm::cl::desc("Enables reassociation for FP reductions."),
                    llvm::cl::cat(category));
+}
+
+void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {
+  static llvm::cl::OptionCategory category("IREE GPU Codegen Options");
+
+  binder.opt<bool>(
+      "iree-llvmgpu-enable-prefetch", enablePrefetch,
+      llvm::cl::desc("Enable prefetch in the vector distribute pipeline."),
+      llvm::cl::cat(category));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -27,6 +27,14 @@ struct CPUCodegenOptions {
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
 };
 
+struct GPUCodegenOptions {
+  // Enable prefetch in the vector distribute pipeline.
+  bool enablePrefetch = false;
+
+  void bindOptions(OptionsBinder &binder);
+  using FromFlags = OptionsFromFlags<GPUCodegenOptions>;
+};
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_CODEGENOPTIONS_H_

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
@@ -31,7 +31,7 @@
         "--iree-opt-level=O3",
         "--iree-opt-const-eval=false",
         "--iree-vm-target-truncate-unsupported-floats",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_rocm.json
@@ -18,7 +18,7 @@
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",
         "--iree-opt-const-eval=false",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
@@ -40,7 +40,7 @@
         "--iree-opt-level=O3",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
@@ -40,7 +40,7 @@
         "--iree-opt-level=O3",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_rocm.json
@@ -3,7 +3,7 @@
     "compiler_flags": [
         "--iree-hal-target-device=hip",
         "--iree-opt-const-eval=false",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
@@ -33,7 +33,7 @@
         "--iree-opt-level=O3",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
@@ -33,7 +33,7 @@
         "--iree-opt-level=O3",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_rocm.json
@@ -18,7 +18,7 @@
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",
         "--iree-opt-const-eval=false",
-        "--iree-llvmgpu-enable-prefetch=true",
+        "--iree-llvmgpu-enable-prefetch",
         "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",


### PR DESCRIPTION
The revision mirrors the CPUCodegenOptions pattern from the LLVMCPU backend. For now, it only expose `enablePrefetch` to public because it is the only flag used in `tests/external/iree-test-suites`. Other flags can be exposed base on needs. The remaining flags are supposed to be hidden from CLI helpers, since they are either for testing purpose or experiments.

It also drops `=true` from `tests/external/iree-test-suites/*` because it is redundant and we want consistency.