### PR TITLE
[LinalgExt] Rewriter for Torch::HigherOrderFlexAttentionOp -> LinalgExt::OnlineAttentionOp

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
@@ -44,8 +44,11 @@ iree_cc_library(
   DEPS
     ::PassHeaders
     ::PassesIncGen
+    MLIRArithDialect
     MLIRFuncDialect
     MLIRIR
+    MLIRLinalgDialect
+    MLIRMathDialect
     MLIRMemRefDialect
     MLIRPass
     MLIRTensorDialect

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -397,24 +397,20 @@ struct FlexAttentionOpConversion
     Value rowRedEmpty =
         tensor::EmptyOp::create(rewriter, loc, rowRedShape, floatType);
 
-    Value accInit = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getFloatAttr(floatType, 0.0));
-    Value maxInit = arith::ConstantOp::create(
-        rewriter, loc,
-        rewriter.getFloatAttr(floatType,
-                              APFloat::getLargest(floatType.getFloatSemantics(),
-                                                  /*Negative=*/true)));
-    Value sumInit = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getFloatAttr(floatType, 0.0));
+    Value zeroInit = arith::getIdentityValue(arith::AtomicRMWKind::addf,
+                                             floatType, rewriter, loc);
+    Value maxInit = arith::getIdentityValue(arith::AtomicRMWKind::maximumf,
+                                            floatType, rewriter, loc,
+                                            /*useOnlyFiniteValue=*/true);
 
     Value accFill =
-        linalg::FillOp::create(rewriter, loc, ValueRange{accInit}, outputEmpty)
+        linalg::FillOp::create(rewriter, loc, ValueRange{zeroInit}, outputEmpty)
             .getResult(0);
     Value maxFill =
         linalg::FillOp::create(rewriter, loc, ValueRange{maxInit}, rowRedEmpty)
             .getResult(0);
     Value sumFill =
-        linalg::FillOp::create(rewriter, loc, ValueRange{sumInit}, rowRedEmpty)
+        linalg::FillOp::create(rewriter, loc, ValueRange{zeroInit}, rowRedEmpty)
             .getResult(0);
 
     // Create OnlineAttentionOp without a mask operand.
@@ -466,26 +462,13 @@ struct FlexAttentionOpConversion
     Value torchOutput = torch::TorchConversion::FromBuiltinTensorOp::create(
         rewriter, loc, torchOutputType, normalizedOutput);
 
-    // Helper to extract ValueTensorType from a possibly-optional result type.
-    auto getTensorType = [](Type type) -> torch::Torch::ValueTensorType {
-      if (auto vtt = dyn_cast<torch::Torch::ValueTensorType>(type)) {
-        return vtt;
-      }
-      if (auto opt = dyn_cast<torch::Torch::OptionalType>(type)) {
-        return dyn_cast<torch::Torch::ValueTensorType>(opt.getContainedType());
-      }
-      return nullptr;
-    };
-
     // Handle logsumexp: log(sum) + max, shape [B, H, M]
     Value logsumexpResult;
-    auto lseType = getTensorType(op.getLogsumexp().getType());
-    if (returnLse && lseType) {
-      auto builtinLseType = lseType.toBuiltinTensor();
-      Type lseElemType =
-          cast<RankedTensorType>(builtinLseType).getElementType();
-      Value lseInit =
-          tensor::EmptyOp::create(rewriter, loc, rowRedShape, lseElemType);
+    if (returnLse) {
+      auto lseType =
+          cast<torch::Torch::ValueTensorType>(op.getLogsumexp().getType());
+      Value lseInit = tensor::EmptyOp::create(rewriter, loc, rowRedShape,
+                                              lseType.getDtype());
 
       auto identityMap3D =
           AffineMap::getMultiDimIdentityMap(3, rewriter.getContext());
@@ -499,45 +482,21 @@ struct FlexAttentionOpConversion
           [&](OpBuilder &b, Location loc, ValueRange args) {
             Value logSum = math::LogOp::create(b, loc, args[0]);
             Value lse = arith::AddFOp::create(b, loc, logSum, args[1]);
-            lse = convertScalarToDtype(b, loc, lse, args[2].getType(),
-                                       /*isUnsignedCast=*/false);
             linalg::YieldOp::create(b, loc, lse);
           });
-      Value torchLse = torch::TorchConversion::FromBuiltinTensorOp::create(
+      logsumexpResult = torch::TorchConversion::FromBuiltinTensorOp::create(
           rewriter, loc, lseType, lseOp.getResult(0));
-      logsumexpResult = torchLse;
     } else {
       logsumexpResult = torch::Torch::ConstantNoneOp::create(rewriter, loc);
     }
 
     // Handle max_scores: directly from max result.
     Value maxScoresResult;
-    auto maxType = getTensorType(op.getMaxScores().getType());
-    if (returnMaxScores && maxType) {
-      auto builtinMaxType = maxType.toBuiltinTensor();
-      Type maxElemType =
-          cast<RankedTensorType>(builtinMaxType).getElementType();
-
-      Value maxVal = maxResult;
-      if (maxElemType != floatType) {
-        Value castInit =
-            tensor::EmptyOp::create(rewriter, loc, rowRedShape, maxElemType);
-        auto identityMap3D =
-            AffineMap::getMultiDimIdentityMap(3, rewriter.getContext());
-        auto castOp = linalg::GenericOp::create(
-            rewriter, loc, castInit.getType(), ValueRange{maxVal},
-            ValueRange{castInit}, SmallVector<AffineMap>(2, identityMap3D),
-            SmallVector<utils::IteratorType>(3, utils::IteratorType::parallel),
-            [&](OpBuilder &b, Location loc, ValueRange args) {
-              Value casted =
-                  convertScalarToDtype(b, loc, args[0], args[1].getType(),
-                                       /*isUnsignedCast=*/false);
-              linalg::YieldOp::create(b, loc, casted);
-            });
-        maxVal = castOp.getResult(0);
-      }
+    if (returnMaxScores) {
+      auto maxType =
+          cast<torch::Torch::ValueTensorType>(op.getMaxScores().getType());
       maxScoresResult = torch::TorchConversion::FromBuiltinTensorOp::create(
-          rewriter, loc, maxType, maxVal);
+          rewriter, loc, maxType, maxResult);
     } else {
       maxScoresResult = torch::Torch::ConstantNoneOp::create(rewriter, loc);
     }

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -184,16 +184,18 @@ static Value convertToBuiltinTensor(PatternRewriter &rewriter, Location loc,
 }
 
 /// Inline a single-block torch function's body at the current insertion point.
-/// Returns the result value. Falls back to func.call for multi-block functions.
-static Value inlineTorchFunction(PatternRewriter &rewriter, Location loc,
-                                 FlatSymbolRefAttr funcSymbol, ValueRange args,
-                                 Operation *contextOp) {
+/// Falls back to func.call for multi-block or external functions.
+static SmallVector<Value> inlineTorchFunction(PatternRewriter &rewriter,
+                                              Location loc,
+                                              FlatSymbolRefAttr funcSymbol,
+                                              ValueRange args,
+                                              Operation *contextOp) {
   auto module = contextOp->getParentOfType<ModuleOp>();
   auto funcOp = module.lookupSymbol<func::FuncOp>(funcSymbol);
   if (!funcOp || funcOp.isExternal() || !funcOp.getBody().hasOneBlock()) {
     auto callOp = func::CallOp::create(rewriter, loc, funcSymbol,
                                        funcOp.getResultTypes(), args);
-    return callOp.getResult(0);
+    return SmallVector<Value>(callOp->getResults());
   }
 
   Block &entryBlock = funcOp.getBody().front();
@@ -207,7 +209,11 @@ static Value inlineTorchFunction(PatternRewriter &rewriter, Location loc,
   }
 
   auto returnOp = cast<func::ReturnOp>(entryBlock.getTerminator());
-  return mapper.lookupOrDefault(returnOp.getOperand(0));
+  SmallVector<Value> results;
+  for (Value operand : returnOp.getOperands()) {
+    results.push_back(mapper.lookupOrDefault(operand));
+  }
+  return results;
 }
 
 /// Build the score modification region inside the OnlineAttention op.
@@ -257,7 +263,7 @@ createScoreModificationRegion(PatternRewriter &rewriter, Location loc,
   // Inline mask_mod: compute mask and apply select(mask, score, -inf).
   if (maskModSymbol) {
     Value maskResult = inlineTorchFunction(rewriter, loc, maskModSymbol,
-                                           torchIndices, contextOp);
+                                           torchIndices, contextOp)[0];
 
     auto boolType = rewriter.getIntegerType(1);
     Value builtinBool = torch::TorchConversion::ToBuiltinTensorOp::create(
@@ -286,7 +292,7 @@ createScoreModificationRegion(PatternRewriter &rewriter, Location loc,
     SmallVector<Value> scoreArgs = {torchScore};
     scoreArgs.append(torchIndices.begin(), torchIndices.end());
     Value torchResult = inlineTorchFunction(rewriter, loc, scoreModSymbol,
-                                            scoreArgs, contextOp);
+                                            scoreArgs, contextOp)[0];
 
     Value builtinResult = torch::TorchConversion::ToBuiltinTensorOp::create(
         rewriter, loc, f32ScalarTensor, torchResult);

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -542,16 +542,6 @@ struct FlexAttentionOpConversion
       maxScoresResult = torch::Torch::ConstantNoneOp::create(rewriter, loc);
     }
 
-    // Wrap with DerefineOp if the result type is Optional.
-    if (logsumexpResult.getType() != op.getLogsumexp().getType()) {
-      logsumexpResult = torch::Torch::DerefineOp::create(
-          rewriter, loc, op.getLogsumexp().getType(), logsumexpResult);
-    }
-    if (maxScoresResult.getType() != op.getMaxScores().getType()) {
-      maxScoresResult = torch::Torch::DerefineOp::create(
-          rewriter, loc, op.getMaxScores().getType(), maxScoresResult);
-    }
-
     rewriter.replaceOp(op, {torchOutput, logsumexpResult, maxScoresResult});
     return success();
   }

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -6,7 +6,17 @@
 
 #include "compiler/plugins/input/Torch/InputConversion/Passes.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "llvm/ADT/APFloat.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
@@ -162,6 +172,390 @@ struct FftRfftOpConversion : OpRewritePattern<torch::Torch::AtenFftRfftOp> {
   }
 };
 
+//===----------------------------------------------------------------------===//
+// FlexAttention -> OnlineAttention conversion
+//===----------------------------------------------------------------------===//
+
+static Value convertToBuiltinTensor(PatternRewriter &rewriter, Location loc,
+                                    Value torchTensor) {
+  auto tensorType = cast<torch::Torch::ValueTensorType>(torchTensor.getType());
+  return torch::TorchConversion::ToBuiltinTensorOp::create(
+      rewriter, loc, tensorType.toBuiltinTensor(), torchTensor);
+}
+
+/// Inline a single-block torch function's body at the current insertion point.
+/// Returns the result value. Falls back to func.call for multi-block functions.
+static Value inlineTorchFunction(PatternRewriter &rewriter, Location loc,
+                                 FlatSymbolRefAttr funcSymbol, ValueRange args,
+                                 Operation *contextOp) {
+  auto module = contextOp->getParentOfType<ModuleOp>();
+  auto funcOp = module.lookupSymbol<func::FuncOp>(funcSymbol);
+  if (!funcOp || funcOp.isExternal() || !funcOp.getBody().hasOneBlock()) {
+    auto callOp = func::CallOp::create(rewriter, loc, funcSymbol,
+                                       funcOp.getResultTypes(), args);
+    return callOp.getResult(0);
+  }
+
+  Block &entryBlock = funcOp.getBody().front();
+  IRMapping mapper;
+  for (auto [blockArg, callArg] : llvm::zip(entryBlock.getArguments(), args)) {
+    mapper.map(blockArg, callArg);
+  }
+
+  for (Operation &op : entryBlock.without_terminator()) {
+    rewriter.clone(op, mapper);
+  }
+
+  auto returnOp = cast<func::ReturnOp>(entryBlock.getTerminator());
+  return mapper.lookupOrDefault(returnOp.getOperand(0));
+}
+
+/// Build the score modification region inside the OnlineAttention op.
+/// Both mask_mod and score_mod are inlined into the region to avoid separate
+/// mask materialization and to enable fusion during attention decomposition.
+///
+/// The region computes:
+///   1. mask = mask_mod_fn(b, h, q_idx, kv_idx)  [if mask_mod present]
+///   2. score = select(mask, score, -inf)         [if mask_mod present]
+///   3. score = score_mod_fn(score, b, h, q, kv)  [if score_mod present]
+///   4. yield score
+static void
+createScoreModificationRegion(PatternRewriter &rewriter, Location loc,
+                              IREE::LinalgExt::OnlineAttentionOp onlineAttnOp,
+                              FlatSymbolRefAttr scoreModSymbol,
+                              FlatSymbolRefAttr maskModSymbol,
+                              FloatType floatType, Operation *contextOp) {
+  Region &region = onlineAttnOp.getRegion();
+  OpBuilder::InsertionGuard guard(rewriter);
+  Block *block =
+      rewriter.createBlock(&region, region.end(), {floatType}, {loc});
+
+  Value score = block->getArgument(0);
+  bool needIndices = scoreModSymbol || maskModSymbol;
+
+  // Build index torch tensors: b, h, q_idx, kv_idx (dims 0-3).
+  SmallVector<Value> torchIndices;
+  if (needIndices) {
+    auto signlessI32 = rewriter.getIntegerType(32);
+    auto signedI32 =
+        IntegerType::get(rewriter.getContext(), 32, IntegerType::Signed);
+    auto torchI32Scalar = torch::Torch::ValueTensorType::get(
+        rewriter.getContext(), ArrayRef<int64_t>{}, signedI32);
+    for (int dim : {0, 1, 2, 3}) {
+      Value idx = IREE::LinalgExt::IndexOp::create(rewriter, loc, dim);
+      Value idxI32 =
+          arith::IndexCastOp::create(rewriter, loc, signlessI32, idx);
+      Value idxTensor = tensor::FromElementsOp::create(
+          rewriter, loc, RankedTensorType::get({}, signlessI32),
+          ValueRange{idxI32});
+      Value torchIdx = torch::TorchConversion::FromBuiltinTensorOp::create(
+          rewriter, loc, torchI32Scalar, idxTensor);
+      torchIndices.push_back(torchIdx);
+    }
+  }
+
+  // Inline mask_mod: compute mask and apply select(mask, score, -inf).
+  if (maskModSymbol) {
+    Value maskResult = inlineTorchFunction(rewriter, loc, maskModSymbol,
+                                           torchIndices, contextOp);
+
+    auto boolType = rewriter.getIntegerType(1);
+    Value builtinBool = torch::TorchConversion::ToBuiltinTensorOp::create(
+        rewriter, loc, RankedTensorType::get({}, boolType), maskResult);
+    Value boolScalar =
+        tensor::ExtractOp::create(rewriter, loc, builtinBool, ValueRange{});
+
+    Value negInf = arith::ConstantOp::create(
+        rewriter, loc,
+        rewriter.getFloatAttr(
+            floatType,
+            APFloat::getInf(floatType.getFloatSemantics(), /*Negative=*/true)));
+    score = arith::SelectOp::create(rewriter, loc, boolScalar, score, negInf);
+  }
+
+  // Inline score_mod: transform the (possibly masked) score.
+  if (scoreModSymbol) {
+    auto f32ScalarTensor = RankedTensorType::get({}, floatType);
+    auto torchF32Scalar = torch::Torch::ValueTensorType::get(
+        rewriter.getContext(), ArrayRef<int64_t>{}, floatType);
+    Value scoreTensor = tensor::FromElementsOp::create(
+        rewriter, loc, f32ScalarTensor, ValueRange{score});
+    Value torchScore = torch::TorchConversion::FromBuiltinTensorOp::create(
+        rewriter, loc, torchF32Scalar, scoreTensor);
+
+    SmallVector<Value> scoreArgs = {torchScore};
+    scoreArgs.append(torchIndices.begin(), torchIndices.end());
+    Value torchResult = inlineTorchFunction(rewriter, loc, scoreModSymbol,
+                                            scoreArgs, contextOp);
+
+    Value builtinResult = torch::TorchConversion::ToBuiltinTensorOp::create(
+        rewriter, loc, f32ScalarTensor, torchResult);
+    score =
+        tensor::ExtractOp::create(rewriter, loc, builtinResult, ValueRange{});
+  }
+
+  IREE::LinalgExt::YieldOp::create(rewriter, loc, score);
+}
+
+struct FlexAttentionOpConversion
+    : OpRewritePattern<torch::Torch::HigherOrderFlexAttentionOp> {
+  using Base::Base;
+
+  static constexpr int64_t kAttentionRank = 4;
+
+  LogicalResult matchAndRewrite(torch::Torch::HigherOrderFlexAttentionOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    Value query = op.getQuery();
+    Value key = op.getKey();
+    Value value = op.getValue();
+    Value scaleVal = op.getScale();
+
+    auto scoreModSymbol = op.getScoreModFnAttr();
+    auto maskModSymbol = op.getMaskModFnAttr();
+
+    // Extract return_lse and return_max_scores.
+    bool returnLse, returnMaxScores;
+    if (!matchPattern(op.getReturnLse(),
+                      torch::Torch::m_TorchConstantBool(&returnLse))) {
+      return rewriter.notifyMatchFailure(
+          op, "expected return_lse to be a constant bool");
+    }
+    if (!matchPattern(op.getReturnMaxScores(),
+                      torch::Torch::m_TorchConstantBool(&returnMaxScores))) {
+      return rewriter.notifyMatchFailure(
+          op, "expected return_max_scores to be a constant bool");
+    }
+
+    // Extract shapes from Q, K, V.
+    auto queryType = cast<torch::Torch::ValueTensorType>(query.getType());
+    auto valueType = cast<torch::Torch::ValueTensorType>(value.getType());
+
+    ArrayRef<int64_t> queryShape = queryType.getSizes();
+    ArrayRef<int64_t> valueShape = valueType.getSizes();
+
+    // Q: [B, H, M, K1], K: [B, H, N, K1], V: [B, H, N, K2]
+    int64_t batch = queryShape[0];
+    int64_t numHeads = queryShape[1];
+    int64_t seqLenQ = queryShape[2];
+    int64_t headDim = queryShape[3];
+    int64_t valueDim = valueShape[3];
+
+    if (headDim == torch::Torch::kUnknownSize) {
+      return rewriter.notifyMatchFailure(
+          op, "dynamic head dimension not supported");
+    }
+
+    auto floatType = Float32Type::get(rewriter.getContext());
+
+    // Resolve scale: try constant float, else default to 1/sqrt(headDim).
+    double scaleDouble;
+    if (!matchPattern(scaleVal,
+                      torch::Torch::m_TorchConstantFloat(&scaleDouble))) {
+      scaleDouble = 1.0 / std::sqrt(static_cast<double>(headDim));
+    }
+    Value scale = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getFloatAttr(floatType, scaleDouble));
+
+    // Convert Q, K, V to builtin tensors.
+    Value builtinQ = convertToBuiltinTensor(rewriter, loc, query);
+    Value builtinK = convertToBuiltinTensor(rewriter, loc, key);
+    Value builtinV = convertToBuiltinTensor(rewriter, loc, value);
+
+    // 6D iteration space: (b, h, m, n, k1, k2)
+    AffineExpr b, h, m, n, k1, k2;
+    bindDims(rewriter.getContext(), b, h, m, n, k1, k2);
+    int64_t numDims = 6;
+
+    auto getMap = [&](ArrayRef<AffineExpr> results) {
+      return AffineMap::get(numDims, 0, results, rewriter.getContext());
+    };
+
+    AffineMap qMap = getMap({b, h, m, k1});
+    AffineMap kMap = getMap({b, h, n, k1});
+    AffineMap vMap = getMap({b, h, n, k2});
+    AffineMap scaleMap = AffineMap::get(numDims, 0, rewriter.getContext());
+    AffineMap outputMap = getMap({b, h, m, k2});
+    AffineMap maxMap = getMap({b, h, m});
+    AffineMap sumMap = getMap({b, h, m});
+
+    // No mask operand: mask_mod is inlined into the score region.
+    SmallVector<AffineMap> indexingMaps = {qMap, kMap, vMap, scaleMap};
+    indexingMaps.push_back(outputMap);
+    indexingMaps.push_back(maxMap);
+    indexingMaps.push_back(sumMap);
+
+    // Create output tensor.
+    auto outputShape = SmallVector<int64_t>{batch, numHeads, seqLenQ, valueDim};
+    Value outputEmpty =
+        tensor::EmptyOp::create(rewriter, loc, outputShape, floatType);
+
+    // Create and fill max/sum tensors.
+    auto rowRedShape = SmallVector<int64_t>{batch, numHeads, seqLenQ};
+    Value rowRedEmpty =
+        tensor::EmptyOp::create(rewriter, loc, rowRedShape, floatType);
+
+    Value accInit = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getFloatAttr(floatType, 0.0));
+    Value maxInit = arith::ConstantOp::create(
+        rewriter, loc,
+        rewriter.getFloatAttr(floatType,
+                              APFloat::getLargest(floatType.getFloatSemantics(),
+                                                  /*Negative=*/true)));
+    Value sumInit = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getFloatAttr(floatType, 0.0));
+
+    Value accFill =
+        linalg::FillOp::create(rewriter, loc, ValueRange{accInit}, outputEmpty)
+            .getResult(0);
+    Value maxFill =
+        linalg::FillOp::create(rewriter, loc, ValueRange{maxInit}, rowRedEmpty)
+            .getResult(0);
+    Value sumFill =
+        linalg::FillOp::create(rewriter, loc, ValueRange{sumInit}, rowRedEmpty)
+            .getResult(0);
+
+    // Create OnlineAttentionOp without a mask operand.
+    auto onlineAttnOp = IREE::LinalgExt::OnlineAttentionOp::create(
+        rewriter, loc,
+        TypeRange{accFill.getType(), maxFill.getType(), sumFill.getType()},
+        builtinQ, builtinK, builtinV, scale, /*mask=*/Value(), accFill, maxFill,
+        sumFill, rewriter.getAffineMapArrayAttr(indexingMaps),
+        /*decomposition_config=*/DictionaryAttr::get(rewriter.getContext()));
+
+    // Build score modification region with inlined mask_mod and score_mod.
+    createScoreModificationRegion(rewriter, loc, onlineAttnOp, scoreModSymbol,
+                                  maskModSymbol, floatType, op);
+
+    Value attnResult = onlineAttnOp.getResult(0);
+    Value maxResult = onlineAttnOp.getResult(1);
+    Value sumResult = onlineAttnOp.getResult(2);
+
+    // Post-process: output = (1/sum) * attnResult
+    SmallVector<AffineMap> postMaps = compressUnusedDims(
+        SmallVector<AffineMap>{sumMap, outputMap, outputMap});
+    SmallVector<utils::IteratorType> postIterTypes(
+        postMaps[0].getNumDims(), utils::IteratorType::parallel);
+
+    // Determine the output element type from the torch result type.
+    auto torchOutputType =
+        cast<torch::Torch::ValueTensorType>(op.getOutput().getType());
+    auto builtinOutputType = torchOutputType.toBuiltinTensor();
+    Type outputElemType =
+        cast<RankedTensorType>(builtinOutputType).getElementType();
+    Value outputInit =
+        tensor::EmptyOp::create(rewriter, loc, outputShape, outputElemType);
+
+    auto normalizeOp = linalg::GenericOp::create(
+        rewriter, loc, outputInit.getType(), ValueRange{sumResult, attnResult},
+        ValueRange{outputInit}, postMaps, postIterTypes,
+        [&](OpBuilder &b, Location loc, ValueRange args) {
+          Value one = arith::ConstantOp::create(
+              b, loc, b.getFloatAttr(args[0].getType(), 1.0));
+          Value reciprocal = arith::DivFOp::create(b, loc, one, args[0]);
+          Value result = arith::MulFOp::create(b, loc, reciprocal, args[1]);
+          result = convertScalarToDtype(b, loc, result, args[2].getType(),
+                                        /*isUnsignedCast=*/false);
+          linalg::YieldOp::create(b, loc, result);
+        });
+    Value normalizedOutput = normalizeOp.getResult(0);
+
+    // Convert output back to torch tensor.
+    Value torchOutput = torch::TorchConversion::FromBuiltinTensorOp::create(
+        rewriter, loc, torchOutputType, normalizedOutput);
+
+    // Helper to extract ValueTensorType from a possibly-optional result type.
+    auto getTensorType = [](Type type) -> torch::Torch::ValueTensorType {
+      if (auto vtt = dyn_cast<torch::Torch::ValueTensorType>(type)) {
+        return vtt;
+      }
+      if (auto opt = dyn_cast<torch::Torch::OptionalType>(type)) {
+        return dyn_cast<torch::Torch::ValueTensorType>(opt.getContainedType());
+      }
+      return nullptr;
+    };
+
+    // Handle logsumexp: log(sum) + max, shape [B, H, M]
+    Value logsumexpResult;
+    auto lseType = getTensorType(op.getLogsumexp().getType());
+    if (returnLse && lseType) {
+      auto builtinLseType = lseType.toBuiltinTensor();
+      Type lseElemType =
+          cast<RankedTensorType>(builtinLseType).getElementType();
+      Value lseInit =
+          tensor::EmptyOp::create(rewriter, loc, rowRedShape, lseElemType);
+
+      auto identityMap3D =
+          AffineMap::getMultiDimIdentityMap(3, rewriter.getContext());
+      SmallVector<AffineMap> lseMaps(3, identityMap3D);
+      SmallVector<utils::IteratorType> lseIterTypes(
+          3, utils::IteratorType::parallel);
+
+      auto lseOp = linalg::GenericOp::create(
+          rewriter, loc, lseInit.getType(), ValueRange{sumResult, maxResult},
+          ValueRange{lseInit}, lseMaps, lseIterTypes,
+          [&](OpBuilder &b, Location loc, ValueRange args) {
+            Value logSum = math::LogOp::create(b, loc, args[0]);
+            Value lse = arith::AddFOp::create(b, loc, logSum, args[1]);
+            lse = convertScalarToDtype(b, loc, lse, args[2].getType(),
+                                       /*isUnsignedCast=*/false);
+            linalg::YieldOp::create(b, loc, lse);
+          });
+      Value torchLse = torch::TorchConversion::FromBuiltinTensorOp::create(
+          rewriter, loc, lseType, lseOp.getResult(0));
+      logsumexpResult = torchLse;
+    } else {
+      logsumexpResult = torch::Torch::ConstantNoneOp::create(rewriter, loc);
+    }
+
+    // Handle max_scores: directly from max result.
+    Value maxScoresResult;
+    auto maxType = getTensorType(op.getMaxScores().getType());
+    if (returnMaxScores && maxType) {
+      auto builtinMaxType = maxType.toBuiltinTensor();
+      Type maxElemType =
+          cast<RankedTensorType>(builtinMaxType).getElementType();
+
+      Value maxVal = maxResult;
+      if (maxElemType != floatType) {
+        Value castInit =
+            tensor::EmptyOp::create(rewriter, loc, rowRedShape, maxElemType);
+        auto identityMap3D =
+            AffineMap::getMultiDimIdentityMap(3, rewriter.getContext());
+        auto castOp = linalg::GenericOp::create(
+            rewriter, loc, castInit.getType(), ValueRange{maxVal},
+            ValueRange{castInit}, SmallVector<AffineMap>(2, identityMap3D),
+            SmallVector<utils::IteratorType>(3, utils::IteratorType::parallel),
+            [&](OpBuilder &b, Location loc, ValueRange args) {
+              Value casted =
+                  convertScalarToDtype(b, loc, args[0], args[1].getType(),
+                                       /*isUnsignedCast=*/false);
+              linalg::YieldOp::create(b, loc, casted);
+            });
+        maxVal = castOp.getResult(0);
+      }
+      maxScoresResult = torch::TorchConversion::FromBuiltinTensorOp::create(
+          rewriter, loc, maxType, maxVal);
+    } else {
+      maxScoresResult = torch::Torch::ConstantNoneOp::create(rewriter, loc);
+    }
+
+    // Wrap with DerefineOp if the result type is Optional.
+    if (logsumexpResult.getType() != op.getLogsumexp().getType()) {
+      logsumexpResult = torch::Torch::DerefineOp::create(
+          rewriter, loc, op.getLogsumexp().getType(), logsumexpResult);
+    }
+    if (maxScoresResult.getType() != op.getMaxScores().getType()) {
+      maxScoresResult = torch::Torch::DerefineOp::create(
+          rewriter, loc, op.getMaxScores().getType(), maxScoresResult);
+    }
+
+    rewriter.replaceOp(op, {torchOutput, logsumexpResult, maxScoresResult});
+    return success();
+  }
+};
+
 class ConvertTorchUnstructuredToLinalgExtPass final
     : public impl::ConvertTorchUnstructuredToLinalgExtPassBase<
           ConvertTorchUnstructuredToLinalgExtPass> {
@@ -170,6 +564,7 @@ public:
     registry.insert<IREE::LinalgExt::IREELinalgExtDialect,
                     torch::Torch::TorchDialect, tensor::TensorDialect,
                     linalg::LinalgDialect, arith::ArithDialect,
+                    math::MathDialect, func::FuncDialect,
                     torch::TorchConversion::TorchConversionDialect>();
   }
   void runOnOperation() override {
@@ -177,6 +572,7 @@ public:
     RewritePatternSet patterns(context);
 
     patterns.add<FftRfftOpConversion>(context);
+    patterns.add<FlexAttentionOpConversion>(context);
 
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -339,29 +339,30 @@ struct FlexAttentionOpConversion
     int64_t batch = queryShape[0];
     int64_t numHeads = queryShape[1];
     int64_t seqLenQ = queryShape[2];
-    int64_t headDim = queryShape[3];
     int64_t valueDim = valueShape[3];
-
-    if (headDim == torch::Torch::kUnknownSize) {
-      return rewriter.notifyMatchFailure(
-          op, "dynamic head dimension not supported");
-    }
 
     auto floatType = Float32Type::get(rewriter.getContext());
 
-    // Resolve scale: try constant float, else default to 1/sqrt(headDim).
-    double scaleDouble;
-    if (!matchPattern(scaleVal,
-                      torch::Torch::m_TorchConstantFloat(&scaleDouble))) {
-      scaleDouble = 1.0 / std::sqrt(static_cast<double>(headDim));
-    }
-    Value scale = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getFloatAttr(floatType, scaleDouble));
-
-    // Convert Q, K, V to builtin tensors.
     Value builtinQ = convertToBuiltinTensor(rewriter, loc, query);
     Value builtinK = convertToBuiltinTensor(rewriter, loc, key);
     Value builtinV = convertToBuiltinTensor(rewriter, loc, value);
+
+    // Resolve scale: try constant float, else compute rsqrt(headDim).
+    Value scale;
+    double scaleDouble;
+    if (matchPattern(scaleVal,
+                     torch::Torch::m_TorchConstantFloat(&scaleDouble))) {
+      scale = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getFloatAttr(floatType, scaleDouble));
+    } else {
+      int64_t queryRank = queryShape.size();
+      Value dimIdx =
+          tensor::DimOp::create(rewriter, loc, builtinQ, queryRank - 1);
+      Value dimI64 = arith::IndexCastOp::create(rewriter, loc,
+                                                rewriter.getI64Type(), dimIdx);
+      Value dimF32 = arith::SIToFPOp::create(rewriter, loc, floatType, dimI64);
+      scale = math::RsqrtOp::create(rewriter, loc, dimF32);
+    }
 
     // 6D iteration space: (b, h, m, n, k1, k2)
     AffineExpr b, h, m, n, k1, k2;

--- a/compiler/plugins/input/Torch/InputConversion/test/unstructured_linalg_ext.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/unstructured_linalg_ext.mlir
@@ -118,7 +118,7 @@ func.func private @sdpa_mask0(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vten
 func.func @flex_attn_with_scoremod_and_maskmod(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
   %float1.0 = torch.constant.float 1.000000e+00
   %false = torch.constant.bool false
-  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {score_mod_fn = @sdpa_score0, mask_mod_fn = @sdpa_mask0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {score_mod_fn = @sdpa_score0, mask_mod_fn = @sdpa_mask0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output : !torch.vtensor<[2,4,8,16],f32>
 }
 // Fills for acc, max, sum.
@@ -152,7 +152,7 @@ func.func private @sdpa_score1(%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vten
 func.func @flex_attn_with_scoremod_only(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
   %float1.0 = torch.constant.float 1.000000e+00
   %false = torch.constant.bool false
-  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {score_mod_fn = @sdpa_score1} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {score_mod_fn = @sdpa_score1} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output : !torch.vtensor<[2,4,8,16],f32>
 }
 // No mask_mod ops in region.
@@ -173,7 +173,7 @@ func.func private @sdpa_mask1(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vten
 func.func @flex_attn_with_maskmod_only(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
   %float1.0 = torch.constant.float 1.000000e+00
   %false = torch.constant.bool false
-  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {mask_mod_fn = @sdpa_mask1} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {mask_mod_fn = @sdpa_mask1} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output : !torch.vtensor<[2,4,8,16],f32>
 }
 // OnlineAttention with inlined mask_mod, no score_mod.
@@ -192,7 +192,7 @@ func.func @flex_attn_with_maskmod_only(%arg0: !torch.vtensor<[2,4,8,16],f32>, %a
 func.func @flex_attn_without_mods(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
   %float1.0 = torch.constant.float 1.000000e+00
   %false = torch.constant.bool false
-  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output : !torch.vtensor<[2,4,8,16],f32>
 }
 // No mask_mod or score_mod ops — plain passthrough region.

--- a/compiler/plugins/input/Torch/InputConversion/test/unstructured_linalg_ext.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/unstructured_linalg_ext.mlir
@@ -102,3 +102,127 @@ func.func @fft_rfft.last(%arg0: !torch.vtensor<[3,8,16],f32>) -> !torch.vtensor<
 // CHECK:             %[[VAR13:.*]] = torch.aten.cat %[[VAR12]], %[[INTM1]] : !torch.list<vtensor<[3,8,9,1],f32>>, !torch.int -> !torch.vtensor<[3,8,9,2],f32>
 // CHECK:             %[[VAR14:.*]] = torch.aten.view_as_complex %[[VAR13]] : !torch.vtensor<[3,8,9,2],f32> -> !torch.vtensor<[3,8,9],complex<f32>>
 // CHECK:             return %[[VAR14]] : !torch.vtensor<[3,8,9],complex<f32>>
+
+// -----
+
+// Test flex_attention with both score_mod and mask_mod -> online_attention.
+func.func private @sdpa_score0(%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[],si32>) -> !torch.vtensor<[],f32> {
+  %0 = torch.aten.tanh %arg0 : !torch.vtensor<[],f32> -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+func.func private @sdpa_mask0(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.ge.Tensor %arg2, %arg3 : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+// CHECK-LABEL: func.func @flex_attn_with_scoremod_and_maskmod
+func.func @flex_attn_with_scoremod_and_maskmod(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {score_mod_fn = @sdpa_score0, mask_mod_fn = @sdpa_mask0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output : !torch.vtensor<[2,4,8,16],f32>
+}
+// Fills for acc, max, sum.
+// CHECK:           linalg.fill
+// CHECK:           linalg.fill
+// CHECK:           linalg.fill
+// OnlineAttention with inlined mask_mod and score_mod in region.
+// CHECK:           iree_linalg_ext.online_attention
+// CHECK-SAME:        ins({{.*}} : tensor<2x4x8x16xf32>, tensor<2x4x8x16xf32>, tensor<2x4x8x16xf32>, f32)
+// CHECK-SAME:        outs({{.*}} : tensor<2x4x8x16xf32>, tensor<2x4x8xf32>, tensor<2x4x8xf32>)
+// Inlined mask_mod: ge + select.
+// CHECK:             torch.aten.ge.Tensor
+// CHECK:             arith.select
+// Inlined score_mod: tanh.
+// CHECK:             torch.aten.tanh
+// CHECK:             iree_linalg_ext.yield
+// Normalization: (1/sum) * result.
+// CHECK:           linalg.generic
+// CHECK:             arith.divf
+// CHECK:             arith.mulf
+// CHECK:             linalg.yield
+
+// -----
+
+// Test flex_attention with score_mod only.
+func.func private @sdpa_score1(%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[],si32>) -> !torch.vtensor<[],f32> {
+  %0 = torch.aten.tanh %arg0 : !torch.vtensor<[],f32> -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+// CHECK-LABEL: func.func @flex_attn_with_scoremod_only
+func.func @flex_attn_with_scoremod_only(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {score_mod_fn = @sdpa_score1} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output : !torch.vtensor<[2,4,8,16],f32>
+}
+// No mask_mod ops in region.
+// CHECK:           iree_linalg_ext.online_attention
+// CHECK-NOT:         arith.select
+// Inlined score_mod: tanh.
+// CHECK:             torch.aten.tanh
+// CHECK:             iree_linalg_ext.yield
+
+// -----
+
+// Test flex_attention with mask_mod only.
+func.func private @sdpa_mask1(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.ge.Tensor %arg2, %arg3 : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+// CHECK-LABEL: func.func @flex_attn_with_maskmod_only
+func.func @flex_attn_with_maskmod_only(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {mask_mod_fn = @sdpa_mask1} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output : !torch.vtensor<[2,4,8,16],f32>
+}
+// OnlineAttention with inlined mask_mod, no score_mod.
+// CHECK:           iree_linalg_ext.online_attention
+// Inlined mask_mod: ge + select.
+// CHECK:             torch.aten.ge.Tensor
+// CHECK:             arith.select
+// No score_mod.
+// CHECK-NOT:         torch.aten.tanh
+// CHECK:             iree_linalg_ext.yield
+
+// -----
+
+// Test flex_attention without any modifications.
+// CHECK-LABEL: func.func @flex_attn_without_mods
+func.func @flex_attn_without_mods(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> !torch.vtensor<[2,4,8,16],f32> {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output : !torch.vtensor<[2,4,8,16],f32>
+}
+// No mask_mod or score_mod ops — plain passthrough region.
+// CHECK:           iree_linalg_ext.online_attention
+// CHECK-NOT:         arith.select
+// CHECK-NOT:         torch.aten.tanh
+// CHECK:             iree_linalg_ext.yield
+// Normalization.
+// CHECK:           linalg.generic
+// CHECK:             arith.divf
+
+// -----
+
+// Test flex_attention with return_lse=true and return_max_scores=true.
+// CHECK-LABEL: func.func @flex_attn_return_lse_and_maxscores
+func.func @flex_attn_return_lse_and_maxscores(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>) {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %true = torch.constant.bool true
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %true, %true : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+}
+// OnlineAttention.
+// CHECK:           iree_linalg_ext.online_attention
+// Normalization: (1/sum) * result.
+// CHECK:           linalg.generic
+// CHECK:             arith.divf
+// CHECK:             arith.mulf
+// Logsumexp computation: log(sum) + max.
+// CHECK:           linalg.generic
+// CHECK:             math.log
+// CHECK:             arith.addf
+// Return all three results.
+// CHECK:           return {{.*}} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -199,12 +199,25 @@ static Value applyPostQKMatmulElementwise(OpBuilder &builder, Location loc,
                                 value, indexingMaps, iteratorTypes);
   auto &dstRegion = genericOp.getRegion();
   builder.cloneRegionBefore(region, dstRegion, dstRegion.end());
+
+  // Convert iree_linalg_ext.index -> linalg.index in the cloned region.
+  Block &block = dstRegion.back();
+  for (auto &op : llvm::make_early_inc_range(block)) {
+    if (auto indexOp = dyn_cast<IREE::LinalgExt::IndexOp>(&op)) {
+      OpBuilder::InsertionGuard g(builder);
+      builder.setInsertionPoint(&op);
+      Value replacement =
+          linalg::IndexOp::create(builder, op.getLoc(), indexOp.getDim());
+      indexOp.replaceAllUsesWith(replacement);
+      op.erase();
+    }
+  }
+
   {
     OpBuilder::InsertionGuard withinRegion(builder);
-    builder.setInsertionPoint(dstRegion.back().getTerminator());
-    linalg::YieldOp::create(builder, loc,
-                            dstRegion.back().getTerminator()->getOperands());
-    dstRegion.back().getTerminator()->erase();
+    builder.setInsertionPoint(block.getTerminator());
+    linalg::YieldOp::create(builder, loc, block.getTerminator()->getOperands());
+    block.getTerminator()->erase();
   }
   return genericOp.getResult(0);
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1954,8 +1954,8 @@ void OnlineAttentionOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                               Value sum, ArrayAttr indexingMaps,
                               std::optional<Value> mask) {
   Value maskIn = mask.value_or(Value());
-  build(odsBuilder, odsState, results, query, key, value, maskIn, scale, output,
-        max, sum, indexingMaps, DictionaryAttr());
+  build(odsBuilder, odsState, results, query, key, value, scale, maskIn, output,
+        max, sum, indexingMaps, DictionaryAttr::get(odsBuilder.getContext()));
 }
 
 LogicalResult OnlineAttentionOp::verify() {
@@ -3097,19 +3097,23 @@ CustomOp::reifyResultShapes(OpBuilder &builder,
 
 LogicalResult IREE::LinalgExt::IndexOp::verify() {
   auto parentOp = getOperation()->getParentOp();
-  if (!isa<CustomOp, AttentionOp>(parentOp)) {
+  if (!isa<CustomOp, AttentionOp, OnlineAttentionOp>(parentOp)) {
     return emitOpError(
         "expected parent op to be one of `iree_linalg_ext.custom_op`, "
-        "`iree_linalg_ext.attention`");
+        "`iree_linalg_ext.attention`, `iree_linalg_ext.online_attention`");
   }
-  auto customOp = dyn_cast<CustomOp>(parentOp);
-  auto attentionOp = dyn_cast<AttentionOp>(parentOp);
-  int64_t numLoops =
-      customOp ? customOp.getNumLoops() : attentionOp.getNumLoops();
+  int64_t numLoops;
+  if (auto customOp = dyn_cast<CustomOp>(parentOp)) {
+    numLoops = customOp.getNumLoops();
+  } else if (auto attentionOp = dyn_cast<AttentionOp>(parentOp)) {
+    numLoops = attentionOp.getIterationDomainRank();
+  } else {
+    numLoops = cast<OnlineAttentionOp>(parentOp).getIterationDomainRank();
+  }
   if (numLoops <= getDim()) {
     return emitOpError("expected dim (")
            << getDim() << ") to be lower than the number of loops (" << numLoops
-           << ") of the enclosing CustomOp/AttentionOp";
+           << ") of the enclosing operation";
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1794,7 +1794,7 @@ func.func @index_op_invalid_dim(%arg0 : tensor<?xindex>) -> tensor<?xindex> {
       iterator_types = [#iree_linalg_ext.iterator_type<parallel>]}
       outs(%arg0: tensor<?xindex>) {
     ^bb0(%b0 : tensor<?xindex>):
-      // expected-error @+1 {{expected dim (1) to be lower than the number of loops (1) of the enclosing CustomOp}}
+      // expected-error @+1 {{expected dim (1) to be lower than the number of loops (1) of the enclosing operation}}
       %1 = iree_linalg_ext.index 1 : index
       %2 = linalg.generic {
           indexing_maps = [affine_map<(d0) -> (d0)>],


### PR DESCRIPTION
Following the discussion from https://github.com/iree-org/iree/pull/22441.

I ran the entire flex_attention_hop implementation with randomised input tensors, (Also see https://github.com/llvm/torch-mlir/pull/4366) through aot.export and compared against eager mode, and I noticed no accuracy losses (On CPU)

Test: [Torch ops test PR ](https://github.com/iree-org/iree-test-suites/pull/149)