### PR TITLE
[Codegen][Common] Allow generic conv ops to decompose to lower dim ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
@@ -21,9 +21,9 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-static bool foldHDim(linalg::DepthwiseConv2DNhwcHwcOp convOp) {
-  Value kernel = convOp.getInputs().back();
-  Value output = convOp.getOutputs().front();
+static bool foldHDim(linalg::LinalgOp convOp) {
+  Value kernel = convOp.getDpsInputs().back();
+  Value output = convOp.getDpsInits().front();
 
   auto kernelType = dyn_cast<RankedTensorType>(kernel.getType());
   auto outputType = dyn_cast<RankedTensorType>(output.getType());
@@ -62,9 +62,13 @@ computeDecomposedLoweringConfig(ArrayRef<Operation *> computeOps,
   // 1. Get the conv Op to update
   // ATM only 2D depthwise HWC convs are supported.
   // TODO: Add support for other convs
-  linalg::DepthwiseConv2DNhwcHwcOp convOp;
+  linalg::LinalgOp convOp;
   for (Operation *op : computeOps) {
-    if ((convOp = dyn_cast<linalg::DepthwiseConv2DNhwcHwcOp>(op))) {
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+    if (linalgOp &&
+        linalg::isaConvolutionOpOfType<linalg::DepthwiseConv2DNhwcHwcOp>(
+            linalgOp)) {
+      convOp = linalgOp;
       break;
     }
   }
@@ -166,7 +170,10 @@ class DecomposeConvolutionToLowerDimOpsPass final
     if (numConvOps == 1 && succeeded(newLoweringConfig)) {
       auto computeOps = getComputeOps(funcOp);
       for (auto computeOp : computeOps) {
-        if (isa<linalg::DepthwiseConv1DNwcWcOp>(computeOp)) {
+        auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp);
+        if (linalgOp &&
+            linalg::isaConvolutionOpOfType<linalg::DepthwiseConv1DNwcWcOp>(
+                linalgOp)) {
           setLoweringConfig(computeOp, newLoweringConfig.value());
         }
       }

--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
 // Test the same patterns on generic convolution ops by first generalizing the
 // named ops. This ensures decomposition works on both named and generic convs.
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(linalg-generalize-named-ops,iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s --check-prefix=GENERIC
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(linalg-generalize-named-ops,iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0, 0, 0, 0], [1, 1, 1, 4, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
 module {
@@ -27,77 +27,3 @@ module {
 // CHECK:       linalg.depthwise_conv_1d_nwc_wc
 // CHECK-SAME:    ins(%[[INPUT_SLICE]], %[[FILTER_SLICE]] : tensor<1x4x4xf32>, tensor<4x4xf32>)
 // CHECK-SAME:    outs({{.+}} : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-
-// For the generalized path: verify that the generic 2D conv is decomposed to 1D conv.
-// GENERIC-LABEL: func.func @restrict_num_workgroups
-// GENERIC-DAG:   %[[INPUT_SLICE:.+]] = tensor.extract_slice {{.+}} : tensor<1x1x4x4xf32> to tensor<1x4x4xf32>
-// GENERIC-DAG:   %[[FILTER_SLICE:.+]] = tensor.extract_slice {{.+}} : tensor<1x4x4xf32> to tensor<4x4xf32>
-// GENERIC:       linalg.depthwise_conv_1d_nwc_wc
-// GENERIC-SAME:    ins(%[[INPUT_SLICE]], %[[FILTER_SLICE]] : tensor<1x4x4xf32>, tensor<4x4xf32>)
-// GENERIC-SAME:    outs({{.+}} : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-
-// -----
-
-// Test case where output H > 1: should NOT decompose to 1D conv.
-module {
-  func.func @no_decompose_output_h_not_1(%input: tensor<1x4x4x4xf32>, %filter: tensor<1x4x4xf32>) -> tensor<1x4x1x4xf32> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %empty = tensor.empty() : tensor<1x4x1x4xf32>
-    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x4x1x4xf32>) -> tensor<1x4x1x4xf32>
-    %conv = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>,
-            strides = dense<1> : tensor<2xi64>} ins(%input, %filter : tensor<1x4x4x4xf32>, tensor<1x4x4xf32>) outs(%fill : tensor<1x4x1x4xf32>) -> tensor<1x4x1x4xf32>
-    return %conv : tensor<1x4x1x4xf32>
-  }
-}
-
-// CHECK-LABEL: func.func @no_decompose_output_h_not_1
-// CHECK:       linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-NOT:   linalg.depthwise_conv_1d_nwc_wc
-
-// GENERIC-LABEL: func.func @no_decompose_output_h_not_1
-// GENERIC:       linalg.generic
-// GENERIC-NOT:   linalg.depthwise_conv_1d_nwc_wc
-
-// -----
-
-// Test case where kernel H > 1: should NOT decompose to 1D conv.
-module {
-  func.func @no_decompose_kernel_h_not_1(%input: tensor<1x4x4x4xf32>, %filter: tensor<2x4x4xf32>) -> tensor<1x1x1x4xf32> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %empty = tensor.empty() : tensor<1x1x1x4xf32>
-    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
-    %conv = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>,
-            strides = dense<1> : tensor<2xi64>} ins(%input, %filter : tensor<1x4x4x4xf32>, tensor<2x4x4xf32>) outs(%fill : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
-    return %conv : tensor<1x1x1x4xf32>
-  }
-}
-
-// CHECK-LABEL: func.func @no_decompose_kernel_h_not_1
-// CHECK:       linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-NOT:   linalg.depthwise_conv_1d_nwc_wc
-
-// GENERIC-LABEL: func.func @no_decompose_kernel_h_not_1
-// GENERIC:       linalg.generic
-// GENERIC-NOT:   linalg.depthwise_conv_1d_nwc_wc
-
-// -----
-
-// Test decomposition without lowering config.
-module {
-  func.func @decompose_without_config(%input: tensor<1x1x4x4xf32>, %filter: tensor<1x4x4xf32>) -> tensor<1x1x1x4xf32> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %empty = tensor.empty() : tensor<1x1x1x4xf32>
-    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
-    %conv = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>,
-            strides = dense<1> : tensor<2xi64>} ins(%input, %filter : tensor<1x1x4x4xf32>, tensor<1x4x4xf32>) outs(%fill : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
-    return %conv : tensor<1x1x1x4xf32>
-  }
-}
-
-// Verify decomposition works even without lowering config.
-// CHECK-LABEL: func.func @decompose_without_config
-// CHECK:       linalg.depthwise_conv_1d_nwc_wc
-// CHECK-NOT:   lowering_config
-
-// GENERIC-LABEL: func.func @decompose_without_config
-// GENERIC:       linalg.depthwise_conv_1d_nwc_wc


### PR DESCRIPTION
-- This commit makes use of `isaConvolutionOpInterface` which works
   for both named and generic convolution ops.
-- This is needed to enable generalizing convolution ops as part of
   https://github.com/iree-org/iree/issues/21955