### PR TITLE
[LLVMCPU] Allow generic conv ops too in KernelDispatch

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3195,14 +3195,6 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
                 IREE::LinalgExt::WinogradInputTransformOp,
                 IREE::LinalgExt::WinogradOutputTransformOp>(
               [&](auto op) { return setWinogradRootConfig(entryPointFn, op); })
-          .Case<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp,
-                linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
-                linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
-                linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
-                linalg::PoolingNchwMaxOp, linalg::DepthwiseConv2DNhwcHwcOp>(
-              [&](auto op) {
-                return setConvInterfaceRootConfig(entryPointFn, op);
-              })
           .Default([&](Operation *op) { return failure(); });
   if (succeeded(result)) {
     return result;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
@@ -2903,19 +2904,23 @@ setGenericRootConfig(mlir::FunctionOpInterface entryPointFn,
   return failure();
 }
 
-static bool is2DConvOp(Operation *op) {
-  return isa<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp>(op);
+static bool is2DConvOp(linalg::LinalgOp op) {
+  return linalg::isaConvolutionOpOfType<linalg::Conv2DNhwcHwcfOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::Conv2DNchwFchwOp>(op);
 }
 
-static bool is2DDepthConvOp(Operation *op) {
-  return isa<linalg::DepthwiseConv2DNhwcHwcOp>(op);
+static bool is2DDepthConvOp(linalg::LinalgOp op) {
+  return linalg::isaConvolutionOpOfType<linalg::DepthwiseConv2DNhwcHwcOp>(op);
 }
 
-static bool is2DPoolingOp(Operation *op) {
-  return isa<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
-             linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
-             linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
-             linalg::PoolingNchwMaxOp>(op);
+static bool is2DPoolingOp(linalg::LinalgOp op) {
+  return linalg::isaConvolutionOpOfType<linalg::PoolingNhwcSumOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMaxOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMaxUnsignedOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMinOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMinUnsignedOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::PoolingNchwSumOp>(op) ||
+         linalg::isaConvolutionOpOfType<linalg::PoolingNchwMaxOp>(op);
 }
 
 /// Helper enum to represent conv2d input traversal order.
@@ -2926,15 +2931,19 @@ enum class Conv2DDimOrder {
   Nhwc
 };
 
-static Conv2DDimOrder getConv2DDimOrder(Operation *op) {
-  if (isa<linalg::Conv2DNchwFchwOp, linalg::PoolingNchwSumOp,
-          linalg::PoolingNchwMaxOp>(op)) {
+static Conv2DDimOrder getConv2DDimOrder(linalg::LinalgOp op) {
+  if (linalg::isaConvolutionOpOfType<linalg::Conv2DNchwFchwOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNchwSumOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNchwMaxOp>(op)) {
     return Conv2DDimOrder::Nchw;
   }
-  if (isa<linalg::Conv2DNhwcHwcfOp, linalg::PoolingNhwcSumOp,
-          linalg::PoolingNhwcMaxOp, linalg::PoolingNhwcMaxUnsignedOp,
-          linalg::PoolingNhwcMinOp, linalg::PoolingNhwcMinUnsignedOp,
-          linalg::DepthwiseConv2DNhwcHwcOp>(op)) {
+  if (linalg::isaConvolutionOpOfType<linalg::Conv2DNhwcHwcfOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNhwcSumOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMaxOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMaxUnsignedOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMinOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::PoolingNhwcMinUnsignedOp>(op) ||
+      linalg::isaConvolutionOpOfType<linalg::DepthwiseConv2DNhwcHwcOp>(op)) {
     return Conv2DDimOrder::Nhwc;
   }
   llvm::llvm_unreachable_internal("unsupported conv op");
@@ -3012,7 +3021,7 @@ setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
 /// convolutions, where the shape is [N, OH, OW, OC, KH, KW, (IC)].
 static SmallVector<int64_t>
 getNhwcConvVectorSizes(mlir::FunctionOpInterface entryPointFn,
-                       linalg::ConvolutionOpInterface op, int64_t vectorSize) {
+                       linalg::LinalgOp op, int64_t vectorSize) {
   bool isSupported = is2DConvOp(op) || is2DDepthConvOp(op) || is2DPoolingOp(op);
   (void)isSupported;
   assert(isSupported && "conv op is not supported");
@@ -3076,7 +3085,7 @@ getNhwcConvVectorSizes(mlir::FunctionOpInterface entryPointFn,
 
 static LogicalResult
 setConvInterfaceRootConfig(mlir::FunctionOpInterface entryPointFn,
-                           linalg::ConvolutionOpInterface convOp) {
+                           linalg::LinalgOp convOp) {
   int64_t vectorSize = getVectorSize(
       entryPointFn, cast<ShapedType>(convOp->getResultTypes()[0]));
   SmallVector<int64_t> targetTileSizes =
@@ -3199,7 +3208,14 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
     return result;
   }
 
+  // Check for linalg.generic ops that match convolution patterns using
+  // isaConvolutionOpOfType. This allows generalized conv ops to use the
+  // specialized CPUConvTileAndDecomposeExpert pipeline.
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
+    if (is2DConvOp(linalgOp) || is2DDepthConvOp(linalgOp) ||
+        is2DPoolingOp(linalgOp)) {
+      return setConvInterfaceRootConfig(entryPointFn, linalgOp);
+    }
     if (linalg::isaContractionOpInterface(linalgOp) &&
         meetLegacyContractionOpInterface(linalgOp)) {
       return setContractionRootConfig(entryPointFn, linalgOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1,4 +1,8 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --split-input-file %s | FileCheck %s
+// Test the same lowering strategy selection on generic convolution ops by first
+// generalizing the named ops. This ensures convolution pipeline selection works
+// on both named and generic convs.
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(linalg-generalize-named-ops),iree-llvmcpu-select-lowering-strategy)' --split-input-file %s | FileCheck %s --check-prefix=GENERIC
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
@@ -268,6 +272,12 @@ func.func @conv_dynamic(%0: index, %1: index, %2: index, %3: index, %4: index, %
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 //      CHECK:         lowering_config = #[[CONFIG]]
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 64, 64, 0, 0, 0], vector_common_parallel = [1, 1, 1, 1, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 1]>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+//      GENERIC: func.func @conv_dynamic(
+// GENERIC-SAME:     translation_info = #[[TRANSLATION]]
+//      GENERIC:     linalg.generic
+//      GENERIC:         lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -284,6 +294,12 @@ func.func @conv_static(%3: tensor<1x225x225x3xf32>, %4: tensor<3x3x3x16xf32>) ->
 //      CHECK: func.func @conv_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 56, 16, 0, 0, 0], vector_common_parallel = [1, 1, 4, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 3]>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+//      GENERIC: func.func @conv_static(
+// GENERIC-SAME:     translation_info = #[[TRANSLATION]]
+//      GENERIC:     linalg.generic
+//      GENERIC:         lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -300,6 +316,12 @@ func.func @conv_nchw_static(%3: tensor<1x128x30x30xf32>, %4: tensor<128x128x3x3x
 //      CHECK: func.func @conv_nchw_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nchw_fchw
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 64, 28, 4, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+//      GENERIC: func.func @conv_nchw_static(
+// GENERIC-SAME:     translation_info = #[[TRANSLATION]]
+//      GENERIC:     linalg.generic
+//      GENERIC:         lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -317,6 +339,12 @@ func.func @depthwise_conv_static(%3: tensor<1x161x161x240xf32>, %4: tensor<3x3x2
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 16, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+//      GENERIC: func.func @depthwise_conv_static(
+// GENERIC-SAME:     translation_info = #[[TRANSLATION]]
+//      GENERIC:     linalg.generic
+//      GENERIC:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -334,6 +362,12 @@ func.func @thin_depthwise_conv_static(%3: tensor<1x57x57x72xf32>, %4: tensor<3x3
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 4, 28, 36, 0, 0], vector_common_parallel = [1, 1, 7, 12, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+//      GENERIC: func.func @thin_depthwise_conv_static(
+// GENERIC-SAME:     translation_info = #[[TRANSLATION]]
+//      GENERIC:     linalg.generic
+//      GENERIC:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -352,6 +386,12 @@ func.func @pooling_nchw_max(%2: tensor<1x64x114x114xf32>) -> tensor<1x64x56x56xf
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.pooling_nchw_max
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 32, 56, 8, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+//      GENERIC: func.func @pooling_nchw_max(
+// GENERIC-SAME:     translation_info = #[[TRANSLATION]]
+//      GENERIC:     linalg.generic
+//      GENERIC:       lowering_config = #[[CONFIG]]
 
 // -----
 


### PR DESCRIPTION
-- Named convolution ops are assigned `CPUConvTileAndDecomposeExpert`
   and we'd need the same to be in the case of generic convolution
   ops as well. Changes in this patch achieves are required to enable
   that.
-- This is needed to enable generalizing convolution ops as part of
   https://github.com/iree-org/iree/issues/21955