### PR TITLE
[Stream] Handle util.list with unconvertible element type

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/structural_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/structural_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-stream-conversion %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-stream-conversion --verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL: @functionExpansion
 //  CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<*>, %[[ARG0_SIZE:.+]]: index,
@@ -19,3 +19,16 @@ util.func private @callee(%arg0: tensor<4x?xf32>, %arg1: i1, %arg2: tensor<i32>)
     -> (tensor<4x?xf32>, i1, tensor<i32>) {
   util.return %arg0, %arg1, %arg2 : tensor<4x?xf32>, i1, tensor<i32>
 }
+
+// -----
+
+// This is a regression test for https://github.com/iree-org/iree/issues/22974.
+// The following should fail the conversion, but not give a segfault or any
+// other unexpected error.
+
+// expected-error @+1 {{failed to legalize operation 'util.func' that was explicitly marked illegal}}
+util.func public @test(%arg0: !util.list<tensor<*xf32>>) {
+    %c10 = arith.constant 10 : index
+    %0 = util.list.get %arg0[%c10] : !util.list<tensor<*xf32>> -> tensor<?xf32>
+    util.return
+  }

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
@@ -47,8 +47,11 @@ void populateUtilConversionPatterns(MLIRContext *context,
     return success();
   });
 
-  typeConverter.addConversion([&](IREE::Util::ListType type) {
+  typeConverter.addConversion([&](IREE::Util::ListType type) -> Type {
     auto elementType = typeConverter.convertType(type.getElementType());
+    if (!elementType) {
+      return nullptr;
+    }
     return IREE::Util::ListType::get(elementType);
   });
   patterns.insert<GenericConvertTypesPattern<IREE::Util::ListCreateOp>,

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -1846,6 +1846,9 @@ void IREE::Util::FuncOp::expandSignature(
     size_t newIndex = newArgumentTypes.size();
     expandArgument(oldIndex, argType, newArgumentTypes);
     size_t expandedCount = newArgumentTypes.size() - newIndex;
+    if (expandedCount == 0) {
+      continue;
+    }
     for (size_t i = 0; i < adjustedTiedOperands.size(); ++i) {
       if (adjustedTiedOperands[i] == oldIndex) {
         adjustedTiedOperands[i] = newIndex;
@@ -1863,6 +1866,9 @@ void IREE::Util::FuncOp::expandSignature(
     size_t newIndex = newResultTypes.size();
     expandResult(oldIndex, resultType, newResultTypes);
     size_t expandedCount = newResultTypes.size() - newIndex;
+    if (expandedCount == 0) {
+      continue;
+    }
     newTiedOperands.push_back(adjustedTiedOperands[oldIndex]);
     newTiedOperands.append(expandedCount - 1,
                            IREE::Util::TiedOpInterface::kUntiedIndex);


### PR DESCRIPTION
Fail the Util-to-Stream conversion for `util.list` with an element type that can't be converted. Previously, this scenario would cause a segmentation fault, now the conversion will fail gracefully.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22974.