### PR TITLE
[Input] Do not attempt to convert LLVM dialect functions

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
@@ -257,7 +257,13 @@ struct ConvertTypesPass : public Base {
     SmallVector<std::pair<mlir::FunctionOpInterface, FunctionType>>
         exportedFuncOps;
     for (auto funcOp : moduleOp.template getOps<mlir::FunctionOpInterface>()) {
-      const auto funcType = cast<FunctionType>(funcOp.getFunctionType());
+      const auto funcType = dyn_cast<FunctionType>(funcOp.getFunctionType());
+      if (!funcType) {
+        funcOp.emitError()
+            << "cannot determine function type of function; do not use the "
+               "pass or manually convert the function prior to running it";
+        return this->signalPassFailure();
+      }
       if (funcOp.isExternal() && !typeConverter.isSignatureLegal(funcType)) {
         funcOp.emitError()
             << "external functions with types that are being demoted are not "

--- a/compiler/src/iree/compiler/InputConversion/Common/test/demote_f64_to_f32.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/demote_f64_to_f32.mlir
@@ -95,3 +95,13 @@ util.func public @complexTypesF64(%arg0 : complex<f64>) -> complex<f64> {
   // CHECK-NEXT: util.return %arg0 : complex<f32>
   util.return %arg0 : complex<f64>
 }
+
+// -----
+
+// LLVM dialect functions are not supported.
+
+// expected-error @+1 {{cannot determine function type of function}}
+llvm.func @unsupported_llvm_func() -> f32 {
+  %0 = llvm.mlir.constant(3.000000e+00 : f32) : f32
+  llvm.return %0 : f32
+}


### PR DESCRIPTION
LLVM dialect functions do not use the `mlir::FunctionType`, so attempts to cast would fail. As we currently do not expect LLVM dialect functions in the input, just fail gracefully for LLVM dialect functions.

This is based on the bug reported from fuzzing and fixes https://github.com/iree-org/iree/issues/22976.