### PR TITLE
[CI] disable failing cts tests

### DIFF
--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run GPU tests
         env:
           CTEST_PARALLEL_LEVEL: 1
+          # TODO: https://github.com/iree-org/iree/issues/23242
+          # These tests are failing on the w7900 runner and are disabled
+          # until the issue is investigated further.
           IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE: |-
             iree/hal/drivers/hip/cts/hip_stream_buffer_mapping_test
             iree/hal/drivers/hip/cts/hip_stream_command_buffer_dispatch_constants_test

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run GPU tests
         env:
           CTEST_PARALLEL_LEVEL: 1
-          IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE: |-
+          IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE: |-
             iree/hal/drivers/hip/cts/hip_stream_buffer_mapping_test
             iree/hal/drivers/hip/cts/hip_stream_command_buffer_dispatch_constants_test
             iree/hal/drivers/hip/cts/hip_stream_command_buffer_fill_buffer_test

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -59,6 +59,25 @@ jobs:
       - name: Run GPU tests
         env:
           CTEST_PARALLEL_LEVEL: 1
+          IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE: |-
+            iree/hal/drivers/hip/cts/hip_stream_buffer_mapping_test
+            iree/hal/drivers/hip/cts/hip_stream_command_buffer_dispatch_constants_test
+            iree/hal/drivers/hip/cts/hip_stream_command_buffer_fill_buffer_test
+            iree/hal/drivers/hip/cts/hip_graph_buffer_mapping_test
+            iree/hal/drivers/hip/cts/hip_graph_command_buffer_dispatch_constants_test
+            iree/hal/drivers/hip/cts/hip_graph_command_buffer_fill_buffer_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_stream_buffer_mapping_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_stream_command_buffer_dispatch_constants_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_stream_command_buffer_fill_buffer_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_graph_buffer_mapping_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_graph_command_buffer_dispatch_constants_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_graph_command_buffer_fill_buffer_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_buffer_mapping_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_command_buffer_dispatch_constants_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_command_buffer_fill_buffer_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_buffer_mapping_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_command_buffer_dispatch_constants_test
+            iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_command_buffer_fill_buffer_test
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=hip$
           IREE_AMD_RDNA3_TESTS_DISABLE: 0
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -120,10 +120,10 @@ fi
 IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"
 label_exclude_args+=(${extra_label_exclude_args[@]})
 
-if [[ -n "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}" ]]; then
+if [[ -n "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE:-}" ]]; then
   while IFS= read -r line; do
     [[ -n "$line" ]] && excluded_tests+=("$line")
-  done <<< "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE}"
+  done <<< "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE}"
 fi
 
 # Some tests are just failing on some platforms and this filtering lets us

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -122,7 +122,7 @@ label_exclude_args+=(${extra_label_exclude_args[@]})
 
 if [[ -n "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}" ]]; then
   while IFS= read -r line; do
-    [[ -n "$line" ]] && label_exclude_args+=("$line")
+    [[ -n "$line" ]] && excluded_tests+=("$line")
   done <<< "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE}"
 fi
 

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -120,6 +120,12 @@ fi
 IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"
 label_exclude_args+=(${extra_label_exclude_args[@]})
 
+if [[ -n "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && label_exclude_args+=("$line")
+  done <<< "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_LABELS_TO_EXCLUDE}"
+fi
+
 # Some tests are just failing on some platforms and this filtering lets us
 # exclude any type of test. Ideally each test would be tagged with the
 # platforms it doesn't support, but that would require editing through layers

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -120,12 +120,6 @@ fi
 IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"
 label_exclude_args+=(${extra_label_exclude_args[@]})
 
-if [[ -n "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE:-}" ]]; then
-  while IFS= read -r line; do
-    [[ -n "$line" ]] && excluded_tests+=("$line")
-  done <<< "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE}"
-fi
-
 # Some tests are just failing on some platforms and this filtering lets us
 # exclude any type of test. Ideally each test would be tagged with the
 # platforms it doesn't support, but that would require editing through layers
@@ -165,6 +159,12 @@ excluded_tests+=(
   "iree/samples/custom_dispatch/cpu/embedded/example_stream.mlir.test"
   "iree/samples/custom_dispatch/cpu/embedded/example_transform.mlir.test"
 )
+
+if [[ -n "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE:-}" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && excluded_tests+=("$line")
+  done <<< "${IREE_EXTRA_NEWLINE_SEPARATED_CTEST_TESTS_TO_EXCLUDE}"
+fi
 
 ctest_args=(
   "--test-dir ${BUILD_DIR}"

--- a/runtime/src/iree/hal/drivers/hip/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/cts/CMakeLists.txt
@@ -38,14 +38,6 @@ iree_hal_cts_test_suite(
     # TODO: implement executable reflection.
     "executable"
     # These tests fail with:
-    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
-    # Expected: error code OK
-    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
-    # See https://github.com/iree-org/iree/issues/23242
-    "buffer_mapping"
-    "command_buffer_dispatch_constants"
-    "command_buffer_fill_buffer"
-    # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
     "command_buffer_copy_buffer"
@@ -81,14 +73,6 @@ iree_hal_cts_test_suite(
     "event"
     # TODO: implement executable reflection.
     "executable"
-    # These tests fail with:
-    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
-    # Expected: error code OK
-    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
-    # See https://github.com/iree-org/iree/issues/23242
-    "buffer_mapping"
-    "command_buffer_dispatch_constants"
-    "command_buffer_fill_buffer"
     # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
@@ -129,14 +113,6 @@ iree_hal_cts_test_suite(
     # TODO: implement executable reflection.
     "executable"
     # These tests fail with:
-    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
-    # Expected: error code OK
-    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
-    # See https://github.com/iree-org/iree/issues/23242
-    "buffer_mapping"
-    "command_buffer_dispatch_constants"
-    "command_buffer_fill_buffer"
-    # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
     "command_buffer_copy_buffer"
@@ -176,14 +152,6 @@ iree_hal_cts_test_suite(
     "event"
     # TODO: implement executable reflection.
     "executable"
-    # These tests fail with:
-    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
-    # Expected: error code OK
-    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
-    # See https://github.com/iree-org/iree/issues/23242
-    "buffer_mapping"
-    "command_buffer_dispatch_constants"
-    "command_buffer_fill_buffer"
     # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
@@ -226,14 +194,6 @@ iree_hal_cts_test_suite(
     # TODO: implement executable reflection.
     "executable"
     # These tests fail with:
-    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
-    # Expected: error code OK
-    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
-    # See https://github.com/iree-org/iree/issues/23242
-    "buffer_mapping"
-    "command_buffer_dispatch_constants"
-    "command_buffer_fill_buffer"
-    # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
     "command_buffer_copy_buffer"
@@ -275,14 +235,6 @@ iree_hal_cts_test_suite(
     "event"
     # TODO: implement executable reflection.
     "executable"
-    # These tests fail with:
-    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
-    # Expected: error code OK
-    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
-    # See https://github.com/iree-org/iree/issues/23242
-    "buffer_mapping"
-    "command_buffer_dispatch_constants"
-    "command_buffer_fill_buffer"
     # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer

--- a/runtime/src/iree/hal/drivers/hip/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/cts/CMakeLists.txt
@@ -38,6 +38,14 @@ iree_hal_cts_test_suite(
     # TODO: implement executable reflection.
     "executable"
     # These tests fail with:
+    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
+    # Expected: error code OK
+    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
+    # See https://github.com/iree-org/iree/issues/23242
+    "buffer_mapping"
+    "command_buffer_dispatch_constants"
+    "command_buffer_fill_buffer"
+    # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
     "command_buffer_copy_buffer"
@@ -73,6 +81,14 @@ iree_hal_cts_test_suite(
     "event"
     # TODO: implement executable reflection.
     "executable"
+    # These tests fail with:
+    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
+    # Expected: error code OK
+    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
+    # See https://github.com/iree-org/iree/issues/23242
+    "buffer_mapping"
+    "command_buffer_dispatch_constants"
+    "command_buffer_fill_buffer"
     # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
@@ -113,6 +129,14 @@ iree_hal_cts_test_suite(
     # TODO: implement executable reflection.
     "executable"
     # These tests fail with:
+    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
+    # Expected: error code OK
+    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
+    # See https://github.com/iree-org/iree/issues/23242
+    "buffer_mapping"
+    "command_buffer_dispatch_constants"
+    "command_buffer_fill_buffer"
+    # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
     "command_buffer_copy_buffer"
@@ -152,6 +176,14 @@ iree_hal_cts_test_suite(
     "event"
     # TODO: implement executable reflection.
     "executable"
+    # These tests fail with:
+    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
+    # Expected: error code OK
+    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
+    # See https://github.com/iree-org/iree/issues/23242
+    "buffer_mapping"
+    "command_buffer_dispatch_constants"
+    "command_buffer_fill_buffer"
     # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
@@ -194,6 +226,14 @@ iree_hal_cts_test_suite(
     # TODO: implement executable reflection.
     "executable"
     # These tests fail with:
+    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
+    # Expected: error code OK
+    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
+    # See https://github.com/iree-org/iree/issues/23242
+    "buffer_mapping"
+    "command_buffer_dispatch_constants"
+    "command_buffer_fill_buffer"
+    # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer
     "command_buffer_copy_buffer"
@@ -235,6 +275,14 @@ iree_hal_cts_test_suite(
     "event"
     # TODO: implement executable reflection.
     "executable"
+    # These tests fail with:
+    # Value of: (iree_hal_allocator_allocate_buffer( iree_hal_device_allocator(device_), params, buffer_size, &device_buffer))
+    # Expected: error code OK
+    # Actual: 0x5b21d0c53508, whose error code is RESOURCE_EXHAUSTED: iree/runtime/src/iree/hal/drivers/hip/hip_allocator.c:488: RESOURCE_EXHAUSTED; HIP driver error 'hipErrorOutOfMemory' (2): out of memory
+    # See https://github.com/iree-org/iree/issues/23242
+    "buffer_mapping"
+    "command_buffer_dispatch_constants"
+    "command_buffer_fill_buffer"
     # These tests fail with:
     #     UNAVAILABLE; missing hipDrvGraphAddMemcpyNode symbol;
     #     cannot use graph-based command buffer


### PR DESCRIPTION
Following a discussion on https://github.com/iree-org/iree/issues/23242, it was stated that disabling cts tests should be disabled until they are fixed. This PR disables the following tests:

```
The following tests FAILED:
	 71 - iree/hal/drivers/hip/cts/hip_stream_buffer_mapping_test (Subprocess aborted)
	 73 - iree/hal/drivers/hip/cts/hip_stream_command_buffer_dispatch_constants_test (Failed)
	 74 - iree/hal/drivers/hip/cts/hip_stream_command_buffer_fill_buffer_test (Subprocess aborted)
	 81 - iree/hal/drivers/hip/cts/hip_graph_buffer_mapping_test (Subprocess aborted)
	 83 - iree/hal/drivers/hip/cts/hip_graph_command_buffer_dispatch_constants_test (Failed)
	 84 - iree/hal/drivers/hip/cts/hip_graph_command_buffer_fill_buffer_test (Subprocess aborted)
	 91 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_buffer_mapping_test (Subprocess aborted)
	 93 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_command_buffer_dispatch_constants_test (Failed)
	 94 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_command_buffer_fill_buffer_test (Subprocess aborted)
	101 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_buffer_mapping_test (Subprocess aborted)
	103 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_command_buffer_dispatch_constants_test (Failed)
	104 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_command_buffer_fill_buffer_test (Subprocess aborted)
	111 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_buffer_mapping_test (Subprocess aborted)
	113 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_command_buffer_dispatch_constants_test (Failed)
	114 - iree/hal/drivers/hip/cts/hip_multi_queue_stream_queue_1_command_buffer_fill_buffer_test (Subprocess aborted)
	121 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_buffer_mapping_test (Subprocess aborted)
	123 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_command_buffer_dispatch_constants_test (Failed)
	124 - iree/hal/drivers/hip/cts/hip_multi_queue_graph_queue_1_command_buffer_fill_buffer_test (Subprocess aborted)
```