### PR TITLE
[GPU] Support some collapse_shape ops in GPUReduceBankConflicts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/pad_dynamic_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/pad_dynamic_alloc.mlir
@@ -57,15 +57,15 @@ func.func @dynamic_alloc_collapse_consumer(%id : index) {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
   %0 = util.assume.int %id<umin = 0, umax =  32> : index
-  %1 = memref.alloc(%0, %0) : memref<?x?xf32, 3>
-  %2 = memref.collapse_shape %1 [[0, 1]] : memref<?x?xf32, 3> into memref<?xf32, 3>
+  %1 = memref.alloc(%0) : memref<?x32xf32, 3>
+  %2 = memref.collapse_shape %1 [[0, 1]] : memref<?x32xf32, 3> into memref<?xf32, 3>
   memref.store %cst, %2[%c0] : memref<?xf32, 3>
   return
 }
 // CHECK-LABEL: func @dynamic_alloc_collapse_consumer(
 //       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<32x32xf32, 3>
 //       CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[ALLOC]]
-//  CHECK-SAME:     [0, 0] [{{.*}}] [1, 1] : memref<32x32xf32, 3> to memref<?x?xf32, strided<[32, 1]>, 3>
+//  CHECK-SAME:     [0, 0] [{{.*}}] [1, 1] : memref<32x32xf32, 3> to memref<?x32xf32, strided<[32, 1]>, 3>
 //       CHECK:   %[[COLLAPSE:.+]] = memref.collapse_shape %[[SUBVIEW]] {{\[}}[0, 1]]
-//  CHECK-SAME:     : memref<?x?xf32, strided<[32, 1]>, 3> into memref<?xf32, strided<[?]>, 3>
-//       CHECK:   memref.store {{.*}} %[[COLLAPSE]]{{.*}} : memref<?xf32, strided<[?]>, 3>
+//  CHECK-SAME:     : memref<?x32xf32, strided<[32, 1]>, 3> into memref<?xf32, strided<[1]>, 3>
+//       CHECK:   memref.store {{.*}} %[[COLLAPSE]]{{.*}} : memref<?xf32, strided<[1]>, 3>

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1430,84 +1430,152 @@ void addConfigDenormalFpMathF32(MLIRContext *context,
 // Replace Memref users (transitively)
 //===---------------------------------------------------------------------===//
 
+/// Computes the result types for a non-trivial use replacement. This function
+/// determines what the new result types should be when replacing a memref
+/// operand with one of a different type.
+///
+/// Returns nullopt if:
+/// - The operation is not one of the supported types (CastOp, SubViewOp,
+///   ExpandShapeOp, CollapseShapeOp)
+/// - The replacement type computation fails (e.g., for ExpandShapeOp or
+///   CollapseShapeOp with incompatible layouts)
+static std::optional<SmallVector<Type>>
+computeNonTrivialReplacementResultTypes(OpOperand &use, Type replacementType) {
+  Operation *user = use.getOwner();
+  auto newSourceType = cast<MemRefType>(replacementType);
+  return llvm::TypeSwitch<Operation *, std::optional<SmallVector<Type>>>(user)
+      .Case([&](memref::CastOp castOp) {
+        auto currentResultType = cast<MemRefType>(castOp.getResult().getType());
+        auto newResultType = MemRefType::get(
+            currentResultType.getShape(), currentResultType.getElementType(),
+            newSourceType.getLayout(), newSourceType.getMemorySpace());
+        return SmallVector<Type>{newResultType};
+      })
+      .Case([&](memref::SubViewOp subviewOp) {
+        auto currResultType = cast<MemRefType>(subviewOp.getResult().getType());
+        SmallVector<OpFoldResult> offsets = subviewOp.getMixedOffsets();
+        SmallVector<OpFoldResult> sizes = subviewOp.getMixedSizes();
+        SmallVector<OpFoldResult> strides = subviewOp.getMixedStrides();
+        // Use rank-reduced inference if the result rank differs from source,
+        // otherwise use regular inference.
+        MemRefType newResultType =
+            (currResultType.getRank() != newSourceType.getRank()
+                 ? cast<MemRefType>(
+                       memref::SubViewOp::inferRankReducedResultType(
+                           currResultType.getShape(), newSourceType, offsets,
+                           sizes, strides))
+                 : cast<MemRefType>(memref::SubViewOp::inferResultType(
+                       newSourceType, offsets, sizes, strides)));
+        return SmallVector<Type>{newResultType};
+      })
+      .Case([&](memref::ExpandShapeOp expandOp)
+                -> std::optional<SmallVector<Type>> {
+        auto currResultType = cast<MemRefType>(expandOp.getResult().getType());
+        FailureOr<MemRefType> newResultType =
+            memref::ExpandShapeOp::computeExpandedType(
+                newSourceType, currResultType.getShape(),
+                expandOp.getReassociationIndices());
+        if (failed(newResultType)) {
+          return std::nullopt;
+        }
+        return SmallVector<Type>{*newResultType};
+      })
+      .Case([&](memref::CollapseShapeOp collapseOp)
+                -> std::optional<SmallVector<Type>> {
+        // Check if the collapse would be valid before computing the type.
+        // computeCollapsedType has an internal assertion that fires on invalid
+        // layouts, so we must check validity first.
+        if (!memref::CollapseShapeOp::isGuaranteedCollapsible(
+                newSourceType, collapseOp.getReassociationIndices())) {
+          return std::nullopt;
+        }
+        MemRefType newResultType =
+            memref::CollapseShapeOp::computeCollapsedType(
+                newSourceType, collapseOp.getReassociationIndices());
+        return SmallVector<Type>{newResultType};
+      })
+      .Default([](Operation *) { return std::nullopt; });
+}
+
+/// Checks whether a non-trivial replacement would be needed for this operation.
+/// Returns true if the operation is one of the known memref reshaping
+/// operations (CastOp, SubViewOp, ExpandShapeOp, CollapseShapeOp) that requires
+/// result type propagation when the source type changes.
+static bool isNonTrivialMemrefReshapeOp(Operation *op) {
+  return isa<memref::CastOp, memref::SubViewOp, memref::ExpandShapeOp,
+             memref::CollapseShapeOp>(op);
+}
+
 /// Replaces a `use` with the `replacement` for cases where a simple
-/// substition might lead to verification errors.
+/// substitution might lead to verification errors. Clones the operation
+/// with the new operand and computed result types.
 static std::optional<SmallVector<Value>>
-replaceNonTrivialUse(RewriterBase &rewriter, Location loc, OpOperand &use,
+replaceNonTrivialUse(RewriterBase &rewriter, OpOperand &use,
                      Value replacement) {
   Operation *user = use.getOwner();
+  std::optional<SmallVector<Type>> resultTypes =
+      computeNonTrivialReplacementResultTypes(use, replacement.getType());
+  if (!resultTypes) {
+    return std::nullopt;
+  }
+
+  // If the result types are the same, no need to create a new op.
+  LDBG() << "\tReplacing in user by creating new user : " << *user;
+  if (llvm::equal(user->getResultTypes(), *resultTypes)) {
+    rewriter.modifyOpInPlace(user, [&]() { use.set(replacement); });
+    LDBG() << "\t\tUpdated operand in place : " << *user;
+    return llvm::to_vector_of<Value>(user->getResults());
+  }
+
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(user);
+  SmallVector<Value> newOperands = llvm::to_vector(user->getOperands());
+  newOperands[use.getOperandNumber()] = replacement;
+  Operation *newOp =
+      mlir::clone(rewriter, user, llvm::to_vector(*resultTypes), newOperands);
+  LDBG() << "\t\tNew user : " << *newOp;
+  return llvm::to_vector_of<Value>(newOp->getResults());
+}
 
-  LDBG() << "\tReplacing in user by creating new user : " << *user;
-  if (auto castOp = dyn_cast<memref::CastOp>(user)) {
-    auto replacementType = cast<MemRefType>(replacement.getType());
-    auto currentResultType = cast<MemRefType>(castOp.getResult().getType());
-    if (replacementType == currentResultType) {
-      // Cast is a no op, just return the replacement.
-      return SmallVector<Value>{replacement};
+LogicalResult canReplaceMemrefUsesAndPropagateType(Value origValue,
+                                                   Type replacementType) {
+  SmallVector<std::pair<Value, Type>> worklist;
+  worklist.push_back({origValue, replacementType});
+  while (!worklist.empty()) {
+    auto [original, newType] = worklist.pop_back_val();
+    if (original.getType() == newType) {
+      continue;
     }
-    auto newResultType = MemRefType::get(
-        currentResultType.getShape(), currentResultType.getElementType(),
-        replacementType.getLayout(), replacementType.getMemorySpace());
-    auto newCastOp =
-        memref::CastOp::create(rewriter, loc, newResultType, replacement);
-    LDBG() << "\t\tNew user : " << *newCastOp;
-    return SmallVector<Value>(newCastOp->result_begin(),
-                              newCastOp->result_end());
-  }
-  if (auto subviewOp = dyn_cast<memref::SubViewOp>(user)) {
-    auto currResultType = cast<MemRefType>(subviewOp.getResult().getType());
-    auto newSourceType = cast<MemRefType>(replacement.getType());
-    SmallVector<OpFoldResult> offsets = subviewOp.getMixedOffsets();
-    SmallVector<OpFoldResult> sizes = subviewOp.getMixedSizes();
-    SmallVector<OpFoldResult> strides = subviewOp.getMixedStrides();
-    MemRefType newResultType =
-        (currResultType.getRank() != newSourceType.getRank()
-             ? cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
-                   currResultType.getShape(), newSourceType, offsets, sizes,
-                   strides))
-             : nullptr);
-    auto newSubviewOp = memref::SubViewOp::create(
-        rewriter, loc, newResultType, replacement, offsets, sizes, strides);
+    for (OpOperand &use : original.getUses()) {
+      // ReturnLike operations cannot have their operand types changed.
+      // If we can't replace the user, we can't cleanly propagate the type.
+      Operation *user = use.getOwner();
+      if (user->hasTrait<OpTrait::ReturnLike>()) {
+        LDBG() << "canReplaceMemrefUsesAndPropagateType: cannot replace "
+                  "return-like op: "
+               << *user;
+        return failure();
+      }
+      // Non-reshape operations can accept the new operand type directly.
+      if (!isNonTrivialMemrefReshapeOp(user)) {
+        continue;
+      }
 
-    LDBG() << "\t\tNew user : " << *newSubviewOp;
-    return llvm::to_vector_of<Value>(newSubviewOp->getResults());
-  }
-  if (auto expandOp = dyn_cast<memref::ExpandShapeOp>(user)) {
-    auto currResultType = cast<MemRefType>(expandOp.getResult().getType());
-    auto newSourceType = cast<MemRefType>(replacement.getType());
-
-    FailureOr<MemRefType> newResultType =
-        memref::ExpandShapeOp::computeExpandedType(
-            newSourceType, currResultType.getShape(),
-            expandOp.getReassociationIndices());
-    if (failed(newResultType)) {
-      return std::nullopt;
+      std::optional<SmallVector<Type>> resultTypes =
+          computeNonTrivialReplacementResultTypes(use, newType);
+      if (!resultTypes) {
+        LDBG() << "canReplaceMemrefUsesAndPropagateType: failed to compute "
+                  "result types for: "
+               << *user;
+        return failure();
+      }
+      for (auto [result, resultType] :
+           llvm::zip_equal(user->getResults(), *resultTypes)) {
+        worklist.push_back({result, resultType});
+      }
     }
-
-    auto newExpandOp = memref::ExpandShapeOp::create(
-        rewriter, loc, *newResultType, replacement, expandOp.getReassociation(),
-        expandOp.getOutputShape(), expandOp.getStaticOutputShape());
-    LDBG() << "\t\tNew user : " << *newExpandOp;
-    return llvm::to_vector_of<Value>(newExpandOp->getResults());
   }
-  if (auto collapseOp = dyn_cast<memref::CollapseShapeOp>(user)) {
-    auto newSourceType = cast<MemRefType>(replacement.getType());
-    FailureOr<MemRefType> newResultType =
-        memref::CollapseShapeOp::computeCollapsedType(
-            newSourceType, collapseOp.getReassociationIndices());
-    if (failed(newResultType)) {
-      return std::nullopt;
-    }
-
-    auto newCollapseOp = memref::CollapseShapeOp::create(
-        rewriter, loc, *newResultType, replacement,
-        collapseOp.getReassociation());
-    LDBG() << "\t\tNew user : " << *newCollapseOp;
-    return llvm::to_vector_of<Value>(newCollapseOp->getResults());
-  }
-  return std::nullopt;
+  return success();
 }
 
 void replaceMemrefUsesAndPropagateType(RewriterBase &rewriter, Location loc,
@@ -1536,7 +1604,7 @@ void replaceMemrefUsesAndPropagateType(RewriterBase &rewriter, Location loc,
         // Some uses might be replace-able but require creating new versions
         // of the users to pass verification.
         std::optional<SmallVector<Value>> nonTrivialUse =
-            replaceNonTrivialUse(rewriter, loc, use, replacement);
+            replaceNonTrivialUse(rewriter, use, replacement);
         if (nonTrivialUse) {
           // Add the results of the new users created as replacements
           // for the old users. Push this back on the to worklist.

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1540,8 +1540,7 @@ replaceNonTrivialUse(RewriterBase &rewriter, OpOperand &use,
 
 LogicalResult canReplaceMemrefUsesAndPropagateType(Value origValue,
                                                    Type replacementType) {
-  SmallVector<std::pair<Value, Type>> worklist;
-  worklist.push_back({origValue, replacementType});
+  SmallVector<std::pair<Value, Type>> worklist = {{origValue, replacementType}};
   while (!worklist.empty()) {
     auto [original, newType] = worklist.pop_back_val();
     if (original.getType() == newType) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -279,6 +279,15 @@ Operation *dropEncodingAndCloneOp(OpBuilder &builder, Operation *op,
                                   ValueRange convertedInputOperands,
                                   ValueRange convertedOutputOperands);
 
+/// Check if the uses of memref value `origValue` can be replaced with a value
+/// of `replacementType`. This validates that all transitive uses through
+/// reshape operations (CastOp, SubViewOp, ExpandShapeOp, CollapseShapeOp) can
+/// have their result types correctly computed. Returns failure if any reshape
+/// operation would fail to compute valid result types (e.g., ExpandShapeOp or
+/// CollapseShapeOp with incompatible layouts).
+LogicalResult canReplaceMemrefUsesAndPropagateType(Value origValue,
+                                                   Type replacementType);
+
 /// Replace the uses of memref value `origValue` with the given
 /// `replacementValue`. Some uses of the memref value might require changes to
 /// the operation itself. Create new operations which can carry the change, and


### PR DESCRIPTION
GPUReduceBankConflicts would always fail if there was a memref.collapse_shape in the use chain of the memref.alloc op. However, there are some cases where padding the allocation is possible, but the pattern matching was too conservative.

This PR relaxes the constraint by verifying that `replaceMemrefUsesAndPropagateType` will succeed before generating any new IR. If the type propagation is possible, then the padded allocation and subview are generated and the new strided type is propagated.

There was also a bug in the original implementation of `replaceMemrefUsesAndPropagateType` for collapse_shape, which was exposed by a failing test in pad_dynamic_alloc.mlir. The test was testing an invalid transformation, so this PR updates the test as well.