### PR TITLE
Integrate llvm/llvm-project@3446ff1

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -126,7 +126,7 @@ ExecutableLibraryDI::getConstOf(LLVM::DITypeAttr typeAttr) {
       builder.getContext(), llvm::dwarf::DW_TAG_const_type,
       /*name=*/nullptr, typeAttr, /*sizeInBits=*/0, /*alignInBits=*/0,
       /*offsetInBits=*/0, /*dwarfAddressSpace=*/std::nullopt,
-      /*extraData=*/nullptr);
+      /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);
 }
 
 LLVM::DIDerivedTypeAttr
@@ -137,7 +137,7 @@ ExecutableLibraryDI::getPtrOf(LLVM::DITypeAttr typeAttr) {
       /*alignInBits=*/0,
       /*offsetInBits=*/0,
       /*dwarfAddressSpace=*/std::nullopt,
-      /*extraData=*/nullptr);
+      /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);
 }
 
 LLVM::DICompositeTypeAttr
@@ -166,7 +166,7 @@ ExecutableLibraryDI::getTypedefOf(StringRef name, LLVM::DITypeAttr typeAttr) {
       builder.getContext(), llvm::dwarf::DW_TAG_typedef,
       builder.getStringAttr(name), typeAttr, /*sizeInBits=*/0,
       /*alignInBits=*/0, /*offsetInBits=*/0, /*dwarfAddressSpace=*/std::nullopt,
-      /*extraData=*/nullptr);
+      /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);
 }
 
 LLVM::DIDerivedTypeAttr
@@ -180,7 +180,7 @@ ExecutableLibraryDI::getMemberOf(StringRef name, LLVM::DITypeAttr typeAttr,
       builder.getStringAttr(name), typeAttr,
       /*sizeInBits=*/memberSizeInBits, /*alignInBits=*/0,
       /*offsetInBits=*/memberOffsetInBits, /*dwarfAddressSpace=*/std::nullopt,
-      /*extraData=*/nullptr);
+      /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);
 }
 
 LLVM::DITypeAttr ExecutableLibraryDI::getBasicType(Type type) {

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.cpp
@@ -71,7 +71,7 @@ LogicalResult IntegerDivisibilityAnalysis::visitOperation(
 
 void IntegerDivisibilityAnalysis::visitNonControlFlowArguments(
     Operation *op, const RegionSuccessor &successor, ValueRange successorInputs,
-    ArrayRef<IntegerDivisibilityLattice *> argLattices, unsigned firstIndex) {
+    ArrayRef<IntegerDivisibilityLattice *> argLattices) {
   // Get the constant divisibility, or query the lattice for Values.
   auto getDivFromOfr = [&](std::optional<OpFoldResult> ofr, Block *block,
                            bool isUnsigned) -> uint64_t {
@@ -99,7 +99,7 @@ void IntegerDivisibilityAnalysis::visitNonControlFlowArguments(
     std::optional<SmallVector<OpFoldResult>> steps = loop.getLoopSteps();
     if (!ivs || !lbs || !steps) {
       return SparseForwardDataFlowAnalysis::visitNonControlFlowArguments(
-          op, successor, successorInputs, argLattices, firstIndex);
+          op, successor, successorInputs, argLattices);
     }
     for (auto [iv, lb, step] : llvm::zip_equal(*ivs, *lbs, *steps)) {
       IntegerDivisibilityLattice *ivEntry = getLatticeElement(iv);
@@ -122,7 +122,7 @@ void IntegerDivisibilityAnalysis::visitNonControlFlowArguments(
   }
 
   return SparseForwardDataFlowAnalysis::visitNonControlFlowArguments(
-      op, successor, successorInputs, argLattices, firstIndex);
+      op, successor, successorInputs, argLattices);
 }
 
 } // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h
@@ -43,8 +43,7 @@ public:
   void visitNonControlFlowArguments(
       Operation *op, const RegionSuccessor &successor,
       ValueRange successorInputs,
-      ArrayRef<IntegerDivisibilityLattice *> argLattices,
-      unsigned firstIndex) override;
+      ArrayRef<IntegerDivisibilityLattice *> argLattices) override;
 };
 
 } // namespace mlir::iree_compiler::IREE::Util


### PR DESCRIPTION
Reverts:
- Carries local revert of https://github.com/llvm/llvm-project/pull/169614 due to https://github.com/iree-org/iree/issues/22649.
- Adds revert of https://github.com/llvm/llvm-project/pull/177982. `reifyResultShapes()` is unimplemented for pack ops on memrefs causing a crash in [getPackUnPackIterationDomain](https://github.com/iree-org/llvm-project/blob/b24bd7161ca7eb6e9652c34b92e200ac16af3628/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp#L718)

Fixes:
- Passes `LLVM::DIFlags::Zero` to address the added argument for L`LVM::DIDerivedTypeAttr::get()` [llvm/llvm-project#177889](https://github.com/llvm/llvm-project/pull/177889)
- Removes he `firstIndex` parameter to address the API change to `visitNonControlFlowArguments()` [llvm/llvm-project#175210](https://github.com/llvm/llvm-project/pull/175210)


https://github.com/iree-org/llvm-project/tree/sm-iree-integrates/llvm-20260128
