### PR TITLE
[GPU] MmaSchedule configuration crashes when lacking PerfTflops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -196,20 +196,22 @@ static GemmCutoff computeGemmCutoffsForAI(IREE::GPU::TargetAttr target,
   TargetChipAttr chip = target.getChip();
   DictionaryAttr peakPerfTlopsAttr = chip.getPerfTflops();
   llvm::DenseMap<ComputeBitwidths, float> peakPerfTflops;
-  for (NamedAttribute namedAttr : peakPerfTlopsAttr) {
-    StringRef bitwidthStr = namedAttr.getName().strref();
-    auto floatAttr = dyn_cast<FloatAttr>(namedAttr.getValue());
-    if (!floatAttr) {
-      continue;
-    }
+  if (peakPerfTlopsAttr) {
+    for (NamedAttribute namedAttr : peakPerfTlopsAttr) {
+      StringRef bitwidthStr = namedAttr.getName().strref();
+      auto floatAttr = dyn_cast<FloatAttr>(namedAttr.getValue());
+      if (!floatAttr) {
+        continue;
+      }
 
-    std::optional<ComputeBitwidths> bitwidth =
-        symbolizeComputeBitwidths(bitwidthStr);
-    if (!bitwidth) {
-      continue;
-    }
+      std::optional<ComputeBitwidths> bitwidth =
+          symbolizeComputeBitwidths(bitwidthStr);
+      if (!bitwidth) {
+        continue;
+      }
 
-    peakPerfTflops[*bitwidth] = floatAttr.getValue().convertToFloat();
+      peakPerfTflops[*bitwidth] = floatAttr.getValue().convertToFloat();
+    }
   }
 
   bool peakPerfTflopsFound = false;


### PR DESCRIPTION
getPerfTflops may return a null dictionary. In these cases we should treat it as empty.