### PR TITLE
[VectorDistribution] Add support for `shape_cast`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -96,6 +96,7 @@ void LayoutInfo::propagateLayoutForward(Value val) {
       Operation *parentOp = cast<vector::MaskOp>(yieldOp->getParentOp());
       Value result = parentOp->getResult(operandIdx);
       setLayoutIfUnset(result, layout);
+      continue;
     }
 
     if (OpTrait::hasElementwiseMappableTraits(user)) {
@@ -183,6 +184,13 @@ void LayoutInfo::propagateLayoutForward(Value val) {
       AffineMap maskMap =
           inversePermutation(compressUnusedDims(write.getPermutationMap()));
       setLayoutOrClone(&mask, layout.apply(maskMap));
+      continue;
+    }
+
+    if (auto shapeCast = dyn_cast<vector::ShapeCastOp>(user)) {
+      setLayoutIfUnset(
+          shapeCast.getResult(),
+          layout.reshape(shapeCast.getResultVectorType().getShape()));
       continue;
     }
   }
@@ -290,10 +298,21 @@ void LayoutInfo::propagateLayoutBackward(Value val) {
     }
     return;
   }
+
+  if (auto shapeCast = dyn_cast<vector::ShapeCastOp>(defOp)) {
+    setLayoutOrClone(
+        &shapeCast.getSourceMutable(),
+        layout.reshape(shapeCast.getSourceVectorType().getShape()));
+    return;
+  }
 }
 
 void LayoutInfo::setLayoutOrClone(OpOperand *val,
                                   VectorLayoutInterface layout) {
+  if (!layout) {
+    // No layout to set.
+    return;
+  }
   if (!isa<ShapedType>(val->get().getType())) {
     // Don't set layouts on non-shaped types. This would anyway be an empty
     // layout.
@@ -322,12 +341,15 @@ void LayoutInfo::setLayoutOrClone(OpOperand *val,
     return;
   }
 
-  // Otherwise, create a to_layout op to change the layout.
-  Value v = val->get();
-  Value layourtedV = ToLayoutOp::create(b, v.getLoc(), v, layout);
-  val->set(layourtedV);
-  layouts[layourtedV] = layout;
-  return;
+  if (getLayout(val->get()) != layout) {
+    // Create `to_layout` op to change layout if it's not the same as the
+    // existing.
+    Value v = val->get();
+    Value layourtedV = ToLayoutOp::create(b, v.getLoc(), v, layout);
+    val->set(layourtedV);
+    layouts[layourtedV] = layout;
+    return;
+  }
 }
 
 LogicalResult propagateVectorLayoutInfo(

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -100,26 +100,6 @@ VectorLayoutInterface NestedLayoutAttr::apply(AffineMap map) const {
                                subgroupStrides, threadStrides);
 }
 
-namespace {
-static SmallVector<int64_t> shuffle(unsigned rank, ArrayRef<int64_t> input,
-                                    bool simple) {
-  if (simple) {
-    SmallVector<int64_t> result(input);
-    std::reverse(result.begin(), result.end());
-    return result;
-  }
-  SmallVector<int64_t> result;
-  result.reserve(input.size());
-  for (unsigned r = 0; r < rank; ++r) {
-    for (unsigned i = r; i < input.size(); i += rank) {
-      result.push_back(input[i]);
-    }
-  }
-  std::reverse(result.begin(), result.end());
-  return result;
-}
-} // anonymous namespace
-
 VectorLayoutInterface
 NestedLayoutAttr::reshape(ArrayRef<int64_t> newShape) const {
   SmallVector<int64_t> subgroupCount;

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -13,7 +13,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
@@ -246,8 +246,8 @@ NestedLayoutAttr::reshape(ArrayRef<int64_t> newShape) const {
         // Check that invariant that we're always moving upwards in the levels
         // of the layout (see above for definition). Bail out if the invariant
         // doesn't hold.
-        LLVM_DEBUG(llvm::dbgs() << "invariant violated, trying to move below "
-                                   "minimum level, aborting layout reshaping");
+        LDBG() << "invariant violated, trying to move below "
+                  "minimum level, aborting layout reshaping";
         return VectorLayoutInterface();
       }
 
@@ -258,8 +258,7 @@ NestedLayoutAttr::reshape(ArrayRef<int64_t> newShape) const {
         // thread level.
         if (strides[0] != 0 &&
             strides[0] * levels[currLevel] != remainingStrides[0]) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "cannot consume stride, aborting layout reshaping");
+          LDBG() << "cannot consume stride, aborting layout reshaping";
           // Cannot consume the stride, bail out.
           return VectorLayoutInterface();
         }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -161,7 +161,6 @@ NestedLayoutAttr::reshape(ArrayRef<int64_t> newShape) const {
         }
         --currDim;
         currLevel = 0;
-        minLevel = 0;
         remainingLevels = llvm::to_vector(
             llvm::reverse(getPackedShapeForUndistributedDim(currDim)));
         // printShape("New rem levels", remainingLevels);

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td
@@ -42,6 +42,12 @@ def VectorLayoutInterface : AttrInterface<"VectorLayoutInterface"> {
       /*args=*/(ins "::mlir::AffineMap":$map)
     >,
     InterfaceMethod<
+      /*description=*/"Reshape the given layout to the new shape",
+      /*retTy=*/"VectorLayoutInterface",
+      /*methodName=*/"reshape",
+      /*args=*/(ins "::llvm::ArrayRef<int64_t>":$newShape)
+    >,
+    InterfaceMethod<
       /*description=*/"Get the expected undistributed shape for the given vector type.",
       /*retTy=*/"SmallVector<int64_t>",
       /*methodName=*/"getUndistributedShape",


### PR DESCRIPTION
Add support for vector distribution of `vector.shape_cast` operations. This includes support for propagating vector layouts through `shape_cast` in vector layout analysis as well as patterns to lower `vector.shape_cast` to a vector-distributed version.

This PR is based on a prototype implementation by @Groverkss.