### PR TITLE
[GlobalOptimization] Fix output_shape handling in SinkTransposeThroughExpandShape

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -577,9 +577,13 @@ public:
 
     RankedTensorType expandedType = getPermutedTensorType(
         cast<RankedTensorType>(expandOp.getType()), newInvPerm);
+    // Permute the output shape to match the permuted type.
+    SmallVector<OpFoldResult> permutedOutputShape =
+        expandOp.getMixedOutputShape();
+    applyPermutationToVector(permutedOutputShape, newInvPerm);
     Value transposedReshape = tensor::ExpandShapeOp::create(
         rewriter, expandOp.getLoc(), expandedType, transposeOp.getInput(),
-        newReassociations);
+        newReassociations, permutedOutputShape);
     Value originalReshape =
         createTranspose(rewriter, transposedReshape, newPerm);
     rewriter.replaceOp(expandOp, originalReshape);


### PR DESCRIPTION
The SinkTransposeThroughExpandShape pattern was not properly setting the output_shape field when constructing the new tensor.expand_shape op. This caused issues when the expand_shape had dynamic dimensions, as the output_shape values need to be permuted along with the result type.