### PR TITLE
[Codegen][GPU] Modify constraint on swizzle_hint ops to allow for multiple types of swizzles

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt /home/muzasyed/iree/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-fuse-and-hoist-parallel-loops))' --split-input-file --verify-diagnostics | FileCheck %s
+// RUN: iree-opt %s --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-fuse-and-hoist-parallel-loops))' --split-input-file --verify-diagnostics | FileCheck %s
 
 #translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 
@@ -964,86 +964,32 @@ func.func @no_swap_same_block_expand_slice(%arg0: tensor<64xf16>) -> tensor<4x4x
 
 // -----
 
-// func.func @no_fuse_multi_use_swizzled_destinations(%2: tensor<128x128xf16>, %3: tensor<128x128xf16>) -> tensor<128x128xf16> {
-//   %c4 = arith.constant 4 : index
-//   %c128 = arith.constant 128 : index
-//   %c0 = arith.constant 0 : index
-//   %empty = tensor.empty() : tensor<128x128xf16>
-//   %swizzle_1 = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<64, 8>] : tensor<128x128xf16>
-//   %swizzle_2 = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<64, 16>] : tensor<128x128xf16>
-//   %10:2 = scf.forall (%arg5, %arg6) in (32, 32) shared_outs(%arg7 = %swizzle_1, %arg8 = %swizzle_2) -> (tensor<128x128xf16>, tensor<128x128xf16>) {
-//     %extracted_slice_1 = tensor.extract_slice %2[%arg5, %arg6] [2, 2] [1, 1] : tensor<128x128xf16> to tensor<2x2xf16>
-//     %extracted_slice_2 = tensor.extract_slice %arg7[%arg5, %arg6] [2, 2] [1, 1] : tensor<128x128xf16> to tensor<2x2xf16>
-//     %extracted_slice_3 = tensor.extract_slice %arg8[%arg6, %arg5] [2, 2] [1, 1] : tensor<128x128xf16> to tensor<2x2xf16>
-//     %16 = linalg.copy ins(%extracted_slice_1 : tensor<2x2xf16>) outs(%extracted_slice_2 : tensor<2x2xf16>) -> tensor<2x2xf16>
-//     scf.forall.in_parallel {
-//       tensor.parallel_insert_slice %16 into %arg7[%arg5, %arg6] [2, 2] [1, 1] : tensor<2x2xf16> into tensor<128x128xf16>
-//       tensor.parallel_insert_slice %16 into %arg8[%arg5, %arg6] [2, 2] [1, 1] : tensor<2x2xf16> into tensor<128x128xf16>
-//     }
-//   } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-//   %add = linalg.add
-//     ins(%10#0, %10#1 : tensor<128x128xf16>, tensor<128x128xf16>)
-//     outs(%empty: tensor<128x128xf16>) -> tensor<128x128xf16>
-//   return %add : tensor<128x128xf16>
-// }
-
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
-
-#map = affine_map<(d0) -> (d0 * 2)>
-#map1 = affine_map<(d0) -> (d0 * 4)>
-#map2 = affine_map<(d0)[s0] -> (d0 * 4 + s0)>
-#map3 = affine_map<(d0)[s0] -> (d0 * 2 + s0)>
-#map4 = affine_map<(d0) -> (d0 * 16)>
-func.func @forall_fuse_then_hoist_with_swizzle(%3: tensor<128x128xf16>, %4: tensor<128x128xf16>, %5: tensor<128x128xf16>) -> tensor<128x128xf16>
-    attributes {translation_info = #translation_info} {
-  // CHECK-DAG: %[[EMPTY:.+]] = tensor.empty() : tensor<128x4xf16>
-  // CHECK-DAG: %[[SWIZZLE1:.+]] = iree_codegen.swizzle_hint %[[EMPTY]][#iree_codegen.xor_shuffle<64, 8>]
-  // CHECK-DAG: %[[SWIZZLE2:.+]] = iree_codegen.swizzle_hint %[[EMPTY]][#iree_codegen.xor_shuffle<64, 4>]
-  %c4 = arith.constant 4 : index
-  %c128 = arith.constant 128 : index
-  %c0 = arith.constant 0 : index
-  %6 = tensor.empty() : tensor<128x4xf16>
-  %swizzle_1 = iree_codegen.swizzle_hint %6[#iree_codegen.xor_shuffle<64, 8>] : tensor<128x4xf16>
-  %swizzle_2 = iree_codegen.swizzle_hint %6[#iree_codegen.xor_shuffle<64, 4>] : tensor<128x4xf16>
-  %8 = scf.for %arg0 = %c0 to %c128 step %c4 iter_args(%arg1 = %5) -> (tensor<128x128xf16>) {
-    // CHECK: scf.forall {{.*}} shared_outs(%{{.+}} = %[[SWIZZLE1]])
-    %9 = scf.forall (%arg2, %arg3) in (64, 1) shared_outs(%arg4 = %swizzle_1) -> (tensor<128x4xf16>) {
-      %12 = affine.apply #map(%arg2)
-      %13 = affine.apply #map1(%arg3)
-      %14 = affine.apply #map(%arg2)
-      %15 = affine.apply #map2(%arg3)[%arg0]
-      %extracted_slice = tensor.extract_slice %3[%14, %15] [2, 4] [1, 1] : tensor<128x128xf16> to tensor<2x4xf16>
-      %extracted_slice_0 = tensor.extract_slice %arg4[%12, %13] [2, 4] [1, 1] : tensor<128x4xf16> to tensor<2x4xf16>
-      %16 = linalg.copy ins(%extracted_slice : tensor<2x4xf16>) outs(%extracted_slice_0 : tensor<2x4xf16>) -> tensor<2x4xf16>
-      scf.forall.in_parallel {
-        tensor.parallel_insert_slice %16 into %arg4[%12, %13] [2, 4] [1, 1] : tensor<2x4xf16> into tensor<128x4xf16>
-      }
-    } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-    // CHECK: scf.forall {{.*}} shared_outs(%{{.+}} = %[[SWIZZLE2]])
-    %10 = scf.forall (%arg2, %arg3) in (2, 32) shared_outs(%arg4 = %swizzle_2) -> (tensor<128x4xf16>) {
-      %12 = affine.apply #map(%arg2)
-      %13 = affine.apply #map1(%arg3)
-      %14 = affine.apply #map(%arg2)
-      %15 = affine.apply #map2(%arg3)[%arg0]
-      %extracted_slice = tensor.extract_slice %4[%14, %15] [2, 4] [1, 1] : tensor<128x128xf16> to tensor<2x4xf16>
-      %extracted_slice_0 = tensor.extract_slice %arg4[%12, %13] [2, 4] [1, 1] : tensor<128x4xf16> to tensor<2x4xf16>
-      %16 = linalg.copy ins(%extracted_slice : tensor<2x4xf16>) outs(%extracted_slice_0 : tensor<2x4xf16>) -> tensor<2x4xf16>
-      scf.forall.in_parallel {
-        tensor.parallel_insert_slice %16 into %arg4[%12, %13] [2, 4] [1, 1] : tensor<2x4xf16> into tensor<128x4xf16>
-      }
-    } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-    %11 = scf.forall (%arg2, %arg3) in (8, 8) shared_outs(%arg4 = %arg1) -> (tensor<128x128xf16>) {
-      %12 = affine.apply #map4(%arg2)
-      %13 = affine.apply #map4(%arg3)
-      %extracted_slice = tensor.extract_slice %9[%12, 0] [16, 4] [1, 1] : tensor<128x4xf16> to tensor<16x4xf16>
-      %extracted_slice_0 = tensor.extract_slice %10[%13, 0] [16, 4] [1, 1] : tensor<128x4xf16> to tensor<16x4xf16>
-      %extracted_slice_1 = tensor.extract_slice %arg4[%12, %13] [16, 4] [1, 1] : tensor<128x128xf16> to tensor<16x4xf16>
-      %add = linalg.add ins(%extracted_slice, %extracted_slice_0 : tensor<16x4xf16>, tensor<16x4xf16>) outs(%extracted_slice_1: tensor<16x4xf16>) -> tensor<16x4xf16>
-      scf.forall.in_parallel {
-        tensor.parallel_insert_slice %add into %arg4[%12, %13] [16, 4] [1, 1] : tensor<16x4xf16> into tensor<128x128xf16>
-      }
-    } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-    scf.yield %11 : tensor<128x128xf16>
-  }
-  return %8 : tensor<128x128xf16>
+// Check that one tensor.empty can have multiple different swizzle hints.
+// CHECK-LABEL: func.func @multi_swizzle
+// CHECK: %[[EMPTY:.+]] = tensor.empty()
+// CHECK: %[[SWIZZLE1:.+]] = iree_codegen.swizzle_hint %[[EMPTY]][#iree_codegen.xor_shuffle<64, 8>]
+// CHECK: %[[SWIZZLE2:.+]] = iree_codegen.swizzle_hint %[[EMPTY]][#iree_codegen.xor_shuffle<64, 16>]
+// CHECK: scf.forall {{.*}} shared_outs(%{{.+}} = %[[SWIZZLE1]])
+// CHECK: scf.forall {{.*}} shared_outs(%{{.+}} = %[[SWIZZLE2]])
+func.func @multi_swizzle(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128xf16>) -> (tensor<128x128xf16>, tensor<128x128xf16>) {
+  %empty = tensor.empty() : tensor<128x128xf16>
+  %swizzle_1 = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<64, 8>] : tensor<128x128xf16>
+  %swizzle_2 = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<64, 16>] : tensor<128x128xf16>
+  %0 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %swizzle_1) -> (tensor<128x128xf16>) {
+    %slice = tensor.extract_slice %arg0[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %slice_out = tensor.extract_slice %out[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %copy = linalg.copy ins(%slice : tensor<4x4xf16>) outs(%slice_out : tensor<4x4xf16>) -> tensor<4x4xf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %copy into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
+    }
+  } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  %1 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %swizzle_2) -> (tensor<128x128xf16>) {
+    %slice = tensor.extract_slice %arg1[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %slice_out = tensor.extract_slice %out[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %copy = linalg.copy ins(%slice : tensor<4x4xf16>) outs(%slice_out : tensor<4x4xf16>) -> tensor<4x4xf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %copy into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
+    }
+  } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  return %0, %1 : tensor<128x128xf16>, tensor<128x128xf16>
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -979,7 +979,7 @@ func.func @swizzle_with_fusion(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128
       tensor.parallel_insert_slice %copy into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
     }
   } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-  
+
   %empty2 = tensor.empty() : tensor<128x128xf16>
   %swizzle_2 = iree_codegen.swizzle_hint %empty2[#iree_codegen.xor_shuffle<64, 16>] : tensor<128x128xf16>
   %1 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %swizzle_2) -> (tensor<128x128xf16>) {
@@ -990,7 +990,7 @@ func.func @swizzle_with_fusion(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128
       tensor.parallel_insert_slice %copy into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
     }
   } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-  
+
   %empty3 = tensor.empty() : tensor<128x128xf16>
   %2 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %empty3) -> (tensor<128x128xf16>) {
     %slice0 = tensor.extract_slice %0[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -964,17 +964,13 @@ func.func @no_swap_same_block_expand_slice(%arg0: tensor<64xf16>) -> tensor<4x4x
 
 // -----
 
-// Check that one tensor.empty can have multiple different swizzle hints.
-// CHECK-LABEL: func.func @multi_swizzle
-// CHECK: %[[EMPTY:.+]] = tensor.empty()
-// CHECK: %[[SWIZZLE1:.+]] = iree_codegen.swizzle_hint %[[EMPTY]][#iree_codegen.xor_shuffle<64, 8>]
-// CHECK: %[[SWIZZLE2:.+]] = iree_codegen.swizzle_hint %[[EMPTY]][#iree_codegen.xor_shuffle<64, 16>]
-// CHECK: scf.forall {{.*}} shared_outs(%{{.+}} = %[[SWIZZLE1]])
-// CHECK: scf.forall {{.*}} shared_outs(%{{.+}} = %[[SWIZZLE2]])
-func.func @multi_swizzle(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128xf16>) -> (tensor<128x128xf16>, tensor<128x128xf16>) {
-  %empty = tensor.empty() : tensor<128x128xf16>
-  %swizzle_1 = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<64, 8>] : tensor<128x128xf16>
-  %swizzle_2 = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<64, 16>] : tensor<128x128xf16>
+// Check that when fusing two separate producer foralls (each with different swizzle hints)
+// into a consumer, each producer creates a bufferization.alloc_tensor with its correct swizzle.
+#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1024, 1, 1] subgroup_size = 64>
+func.func @swizzle_with_fusion(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128xf16>) -> tensor<128x128xf16>
+    attributes {translation_info = #translation_info} {
+  %empty1 = tensor.empty() : tensor<128x128xf16>
+  %swizzle_1 = iree_codegen.swizzle_hint %empty1[#iree_codegen.xor_shuffle<64, 8>] : tensor<128x128xf16>
   %0 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %swizzle_1) -> (tensor<128x128xf16>) {
     %slice = tensor.extract_slice %arg0[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
     %slice_out = tensor.extract_slice %out[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
@@ -983,6 +979,9 @@ func.func @multi_swizzle(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128xf16>)
       tensor.parallel_insert_slice %copy into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
     }
   } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  
+  %empty2 = tensor.empty() : tensor<128x128xf16>
+  %swizzle_2 = iree_codegen.swizzle_hint %empty2[#iree_codegen.xor_shuffle<64, 16>] : tensor<128x128xf16>
   %1 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %swizzle_2) -> (tensor<128x128xf16>) {
     %slice = tensor.extract_slice %arg1[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
     %slice_out = tensor.extract_slice %out[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
@@ -991,5 +990,32 @@ func.func @multi_swizzle(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128xf16>)
       tensor.parallel_insert_slice %copy into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
     }
   } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-  return %0, %1 : tensor<128x128xf16>, tensor<128x128xf16>
+  
+  %empty3 = tensor.empty() : tensor<128x128xf16>
+  %2 = scf.forall (%i, %j) in (32, 32) shared_outs(%out = %empty3) -> (tensor<128x128xf16>) {
+    %slice0 = tensor.extract_slice %0[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %slice1 = tensor.extract_slice %1[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %slice_out = tensor.extract_slice %out[%i, %j] [4, 4] [1, 1] : tensor<128x128xf16> to tensor<4x4xf16>
+    %add = linalg.add ins(%slice0, %slice1 : tensor<4x4xf16>, tensor<4x4xf16>) outs(%slice_out : tensor<4x4xf16>) -> tensor<4x4xf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %add into %out[%i, %j] [4, 4] [1, 1] : tensor<4x4xf16> into tensor<128x128xf16>
+    }
+  } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  return %2 : tensor<128x128xf16>
 }
+
+// CHECK-LABEL: func @swizzle_with_fusion(
+//       CHECK:   %[[ALLOC1:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<128x128xf16>
+//       CHECK:   %[[SWIZZLE1:.+]] = iree_codegen.swizzle_hint %[[ALLOC1]][#iree_codegen.xor_shuffle<64, 8>] : tensor<128x128xf16>
+//       CHECK:   %[[ALLOC2:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<128x128xf16>
+//       CHECK:   %[[SWIZZLE2:.+]] = iree_codegen.swizzle_hint %[[ALLOC2]][#iree_codegen.xor_shuffle<64, 16>] : tensor<128x128xf16>
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<128x128xf16>
+//       CHECK:   scf.forall {{.*}} shared_outs(%[[OUT:.+]] = %[[EMPTY]]) -> (tensor<128x128xf16>) {
+//       CHECK:     %[[BARRIER1:.+]] = iree_gpu.barrier_region ins(%[[SWIZZLE1]] : tensor<128x128xf16>) {
+//       CHECK:       scf.for
+//       CHECK:         linalg.copy
+//       CHECK:     %[[BARRIER2:.+]] = iree_gpu.barrier_region ins(%[[SWIZZLE2]] : tensor<128x128xf16>) {
+//       CHECK:       scf.for
+//       CHECK:         linalg.copy
+//       CHECK:     linalg.add
+//       CHECK:   return

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands,cse),canonicalize)" | FileCheck %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands),canonicalize)" | FileCheck %s
 
 #lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1]}>
 
@@ -392,28 +392,3 @@ func.func @swizzle_operand_no_promote_fill(%b: tensor<128x128xf32>) -> tensor<4x
 //   CHECK-NOT:   tensor.expand_shape
 //       CHECK:   linalg.matmul
 //       CHECK: return
-
-// -----
-
-#lowering_config = #iree_gpu.lowering_config<{
-  promote_operands = [0, 1],
-  promotion_types = [
-    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<128, 16>>,
-    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>]}>
-
-func.func @promote_with_multiple_swizzle_operand(%a: tensor<64x64xf32>, %b: tensor<64x64xf32>) -> tensor<64x64xf32> {
-  %cst = arith.constant 0.000000e+00 : f32
-  %empty = tensor.empty() : tensor<64x64xf32>
-  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>) -> tensor<64x64xf32>
-  %mm = linalg.matmul {lowering_config = #lowering_config}
-    ins(%a, %b : tensor<64x64xf32>, tensor<64x64xf32>) outs(%fill : tensor<64x64xf32>) -> tensor<64x64xf32>
-  return %mm : tensor<64x64xf32>
-}
-
-// SwizzleOperand attribute creates swizzle_hint op with xor_shuffle
-// and flattens/expands the tensor for shared memory swizzling.
-// CHECK-LABEL: func.func @promote_with_multiple_swizzle_operand
-//       CHECK:   %[[EMPTY_A:.+]] = tensor.empty() : tensor<4096xf32>
-//       CHECK:   %[[SWIZZLE_A:.+]] = iree_codegen.swizzle_hint %[[EMPTY_A]][#iree_codegen.xor_shuffle<128, 16>] : tensor<4096xf32>
-//       CHECK:   %[[SWIZZLE_B:.+]] = iree_codegen.swizzle_hint %[[EMPTY_A]][#iree_codegen.xor_shuffle<256, 32>] : tensor<4096xf32>
-


### PR DESCRIPTION
At the tensor level, when you apply the same swizzle hint on a matmul transpose b with operands of the same shape CSE can cause the following pattern to emerge.

```
%extracted_slice_0 = tensor.extract_slice %global_load_operand_0
%extracted_slice_1 = tensor.extract_slice %global_load_operand_1
%empty = tensor.empty()
%swizzle = iree_codegen.swizzle_hint **XORShuffle<256, 32>** %empty
%copy_0 = linalg.copy {lowering_config = ...} ins(%extracted_slice_0) outs(%swizzle)
%pack_0 = linalg.pack %copy_0  {...}
%copy_1 = linalg.copy {...} ins(%extracted_slice_1) outs(%swizzle)
%pack_1 = linalg.pack %copy_1  {...}
%matmul = matmul_transpose_b(%pack_0, %pack_2) 
```

However, this only applies if the XOR shuffle is the same across both operands. The CSE happens differently when different shuffles apply to different operands. In this case we get the following pattern.

```
%extracted_slice_0 = tensor.extract_slice %global_load_operand_0
%extracted_slice_1 = tensor.extract_slice %global_load_operand_1
%empty = tensor.empty()
%swizzle_0 = iree_codegen.swizzle_hint **XORShuffle<256, 32>** %empty
%swizzle_1 = iree_codegen.swizzle_hint **XORShuffle<128, 16>** %empty
%copy_0 = linalg.copy {lowering_config = ...} ins(%extracted_slice_0) outs(%swizzle_0)
%pack_0 = linalg.pack %copy_0  {...}
%copy_1 = linalg.copy {...} ins(%extracted_slice_1) outs(%swizzle_1 )
%pack_1 = linalg.pack %copy_1  {...}
%matmul = matmul_transpose_b(%pack_0, %pack_2) 
```

This means that for any given tensor.empty op that is swizzled, we must allow it to have multiple swizzle hint op users (this PR) or remove CSE for tensor.empty ops (no way).