### PR TITLE
[CI] Update golden time for gfx1201

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
+          ref: d05b49f94d4c93086ff4b55f0d1e028f077a17f4
           path: iree-test-suites
       - name: Install ONNX ops test suite requirements
         run: |
@@ -200,7 +200,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
+          ref: d05b49f94d4c93086ff4b55f0d1e028f077a17f4
           path: iree-test-suites
       - name: Install ONNX models test suite requirements
         run: |

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
+          ref: d05b49f94d4c93086ff4b55f0d1e028f077a17f4
           path: iree-test-suites
           lfs: true
 
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
+          ref: d05b49f94d4c93086ff4b55f0d1e028f077a17f4
           path: iree-test-suites
           lfs: true
 

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
+          ref: d05b49f94d4c93086ff4b55f0d1e028f077a17f4
           path: iree-test-suites
       - name: Install Torch ops test suite requirements
         run: |
@@ -144,7 +144,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: iree-org/iree-test-suites
-          ref: 17ead09be6d84bf46d80e6192dc12e45ba776045
+          ref: d05b49f94d4c93086ff4b55f0d1e028f077a17f4
           path: iree-test-suites
           # Don't need lfs for torch models yet.
           lfs: false

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
@@ -18,12 +18,12 @@
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {
-    "AB/128x128xf32_bench": "0.07",
-    "AB/256x256xf32_bench" : "0.10",
-    "AB/512x512xf32_bench" : "0.16",
-    "AB/1024x1024xf32_bench": "0.59",
-    "AB/2048x2048xf32_bench" : "3.61",
-    "AB/4096x4096xf32_bench": "27.46",
-    "AB/8192x8192xf32_bench": "232.44"
+    "AB/128x128xf32_bench": 0.07,
+    "AB/256x256xf32_bench" : 0.10,
+    "AB/512x512xf32_bench" : 0.16,
+    "AB/1024x1024xf32_bench": 0.59,
+    "AB/2048x2048xf32_bench" : 3.61,
+    "AB/4096x4096xf32_bench": 27.46,
+    "AB/8192x8192xf32_bench": 232.44
   }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
@@ -13,24 +13,17 @@
   ],
   "skip_run_tests": [
     "ABPlusC/64x64xf16",
-    "ATB/64x64xf16",
-    "AB/1024x1024xf32_bench",
-    "AB/128x128xf32_bench",
-    "AB/2048x2048xf32_bench",
-    "AB/256x256xf32_bench",
-    "AB/4096x4096xf32_bench",
-    "AB/512x512xf32_bench",
-    "AB/8192x8192xf32_bench"
+    "ATB/64x64xf16"
   ],
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {
-    "AB/1024x1024xf32_bench" : 0.0,
-    "AB/128x128xf32_bench" : 0.0,
-    "AB/2048x2048xf32_bench" : 0.0,
-    "AB/256x256xf32_bench" : 0.0,
-    "AB/4096x4096xf32_bench" : 0.0,
-    "AB/512x512xf32_bench" : 0.0,
-    "AB/8192x8192xf32_bench" : 0.0
+    "AB/128x128xf32_bench": "0.07",
+    "AB/256x256xf32_bench" : "0.10",
+    "AB/512x512xf32_bench" : "0.16",
+    "AB/1024x1024xf32_bench": "0.59",
+    "AB/2048x2048xf32_bench" : "3.61",
+    "AB/4096x4096xf32_bench": "27.46",
+    "AB/8192x8192xf32_bench": "232.44"
   }
 }


### PR DESCRIPTION
* updates iree-test-suite 
* adds golden time which was previously unset for gfx1201
* numbers are run based on this PkgCI action which ran on an r9700 https://github.com/iree-org/iree/actions/runs/21447525094/job/61768152732