### PR TITLE
[LLVMGPU] Add ROCDLLoadToTransposeLoadPass to TileAndFuse pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -88,6 +88,11 @@ static llvm::cl::opt<bool> clCombineLayoutTransformation(
     llvm::cl::desc("Combine relayout ops during dispatch configuration"),
     llvm::cl::init(true), llvm::cl::Hidden);
 
+static llvm::cl::opt<bool> clROCDLLoadToTransposeLoad(
+    "iree-llvmgpu-test-load-to-transpose-load",
+    llvm::cl::desc("Enable amdgpu.transpose_load targeting for ROCDL"),
+    llvm::cl::init(true), llvm::cl::Hidden);
+
 static llvm::cl::opt<IREE::Codegen::WorkgroupId>
     clSetWorkgroupDistributionAlong(
         "iree-llvmgpu-set-workgroup-distribution-along",
@@ -580,6 +585,9 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(IREE::GPU::createUnrollToIntrinsicsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  if (forROCDL && clROCDLLoadToTransposeLoad) {
+    funcPassManager.addPass(createROCDLLoadToTransposeLoadPass());
+  }
 
   // Step 9. Remaining post-bufferization optimizations/lowerings.
   funcPassManager.addPass(createFlattenSwizzleHintAllocsPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "pipeline_elementwise_f8fnuz.mlir",
             "pipeline_elementwise_f8ocp.mlir",
             "pipeline_igemm_tile_and_fuse.mlir",
+            "pipeline_igemm_tile_and_fuse_gfx950.mlir",
             "pipeline_lower_to_llvmgpu.mlir",
             "pipeline_scaled_truncation_gfx950.mlir",
             "pipeline_tile_and_fuse.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "pipeline_elementwise_f8fnuz.mlir"
     "pipeline_elementwise_f8ocp.mlir"
     "pipeline_igemm_tile_and_fuse.mlir"
+    "pipeline_igemm_tile_and_fuse_gfx950.mlir"
     "pipeline_lower_to_llvmgpu.mlir"
     "pipeline_scaled_truncation_gfx950.mlir"
     "pipeline_tile_and_fuse.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse_gfx950.mlir
@@ -1,0 +1,205 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#translation = #iree_codegen.translation_info<pipeline =
+  LLVMGPUTileAndFuse
+  workgroup_size = [256, 1, 1]
+  subgroup_size = 64,
+  {
+     gpu_pipeline_options = #iree_gpu.pipeline_options<
+       prefetch_num_stages = 0,
+       no_reduce_shared_memory_bank_conflicts = false,
+       use_igemm_convolution = true>
+  }>
+#config = #iree_gpu.lowering_config<{
+  workgroup = [1, 4, 16, 256, 0],
+  reduction = [0, 0, 0, 0, 2],
+  subgroup = [1, 4, 1, 4, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>,
+  promote_operands = [0, 1]
+}>
+hal.executable private @conv_nhwc_f16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @conv_nhwc_f16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @conv_nhwc_f16() attributes {translation_info = #translation} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x34x34x1280xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x1280x1280xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x32x1280xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 1280], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x34x34x1280xf16>> -> tensor<2x34x34x1280xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 1280, 1280], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x1280x1280xf16>> -> tensor<3x3x1280x1280xf16>
+        %5 = tensor.empty() : tensor<2x32x32x1280xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x32x32x1280xf32>) -> tensor<2x32x32x1280xf32>
+        %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, lowering_config = #config} ins(%3, %4 : tensor<2x34x34x1280xf16>, tensor<3x3x1280x1280xf16>) outs(%6 : tensor<2x32x32x1280xf32>) -> tensor<2x32x32x1280xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 32, 32, 1280], strides = [1, 1, 1, 1] : tensor<2x32x32x1280xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x32x1280xf32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @conv_nhwc_f16
+//          CHECK:   scf.forall
+//          CHECK:     scf.for {{.*}} iter_args
+//      CHECK-DAG:       vector.transfer_read {{.*}}memref<2x34x34x1280xf16, #amdgpu.address_space<fat_raw_buffer>>{{.*}}vector<8xf16>
+//      CHECK-DAG:       vector.transfer_write {{.*}}memref<1x4x16x{{.*}}xf16, {{.*}}#gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_read {{.*}}memref<11520x1280xf16, #amdgpu.address_space<fat_raw_buffer>>{{.*}}vector<8xf16>
+//      CHECK-DAG:       vector.transfer_write {{.*}}memref<64x{{.*}}xf16, {{.*}}#gpu.address_space<workgroup>>
+//          CHECK:       gpu.barrier
+//          CHECK:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>
+//          CHECK:       amdgpu.transpose_load {{.*}}#gpu.address_space<workgroup>{{.*}}vector<4xf16>
+//          CHECK:       amdgpu.mfma 16x16x32 {{.*}} vector<8xf16>, vector<8xf16>, vector<4xf32>
+//          CHECK:       scf.yield
+
+// -----
+
+#pipeline_layout_unaligned = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#translation_unaligned = #iree_codegen.translation_info<pipeline =
+  LLVMGPUTileAndFuse
+  workgroup_size = [256, 1, 1]
+  subgroup_size = 64,
+  {
+     gpu_pipeline_options = #iree_gpu.pipeline_options<
+       prefetch_num_stages = 0,
+       no_reduce_shared_memory_bank_conflicts = false,
+       use_igemm_convolution = true>
+  }>
+#config_unaligned = #iree_gpu.lowering_config<{
+  padding = [2, 1, 32, 16, 32],
+  workgroup = [2, 1, 32, 16, 0],
+  reduction = [0, 0, 0, 0, 1],
+  subgroup = [1, 1, 1, 1, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>,
+  promote_operands = [0, 1]
+}>
+hal.executable private @conv_nhwc_unaligned_f16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @conv_nhwc_unaligned_f16 ordinal(0) layout(#pipeline_layout_unaligned) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @conv_nhwc_unaligned_f16() attributes {translation_info = #translation_unaligned} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_unaligned) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x35x35x1281xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_unaligned) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x1281x1281xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_unaligned) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x17x17x1281xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 35, 35, 1281], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x35x35x1281xf16>> -> tensor<2x35x35x1281xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 1281, 1281], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x1281x1281xf16>> -> tensor<3x3x1281x1281xf16>
+        %5 = tensor.empty() : tensor<2x17x17x1281xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x17x17x1281xf32>) -> tensor<2x17x17x1281xf32>
+        %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>, lowering_config = #config_unaligned} ins(%3, %4 : tensor<2x35x35x1281xf16>, tensor<3x3x1281x1281xf16>) outs(%6 : tensor<2x17x17x1281xf32>) -> tensor<2x17x17x1281xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 17, 17, 1281], strides = [1, 1, 1, 1] : tensor<2x17x17x1281xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x17x17x1281xf32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @conv_nhwc_unaligned_f16
+//          CHECK:   scf.forall
+//          CHECK:     scf.for {{.*}} iter_args
+//      CHECK-DAG:       vector.transfer_read {{.*}}memref<2x35x35x1281xf16, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:       vector.transfer_write {{.*}}memref<2x1x32x{{.*}}xf16, {{.*}}#gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_read {{.*}}memref<11529x1281xf16, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:       vector.transfer_write {{.*}}memref<32x{{.*}}xf16, {{.*}}#gpu.address_space<workgroup>>
+//          CHECK:       gpu.barrier
+//          CHECK:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>
+//          CHECK:       amdgpu.transpose_load {{.*}}#gpu.address_space<workgroup>{{.*}}vector<4xf16>
+//          CHECK:       amdgpu.mfma 16x16x32 {{.*}} vector<8xf16>, vector<8xf16>, vector<4xf32>
+//          CHECK:       scf.yield
+
+// -----
+
+#pipeline_layout_backward = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#translation_backward = #iree_codegen.translation_info<pipeline =
+  LLVMGPUTileAndFuse
+  workgroup_size = [256, 1, 1]
+  subgroup_size = 64,
+  {
+     gpu_pipeline_options = #iree_gpu.pipeline_options<
+       prefetch_num_stages = 0,
+       no_reduce_shared_memory_bank_conflicts = false,
+       use_igemm_convolution = true>
+  }>
+#config_backward = #iree_gpu.lowering_config<{
+  padding = [2, 32, 64, 64],
+  workgroup = [2, 32, 64, 0],
+  reduction = [0, 0, 0, 2],
+  subgroup = [2, 2, 1, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_BF16>,
+  promote_operands = [0, 1]
+}>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+hal.executable private @conv_input_backward_bf16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @conv_input_backward_bf16 ordinal(0) layout(#pipeline_layout_backward) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @conv_input_backward_bf16() attributes {translation_info = #translation_backward} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_backward) binding(0) alignment(64) offset(%c0) flags("ReadOnly") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x21x384xbf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_backward) binding(1) alignment(64) offset(%c0) flags("ReadOnly") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<384x192xbf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_backward) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x21x192xbf16>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 21, 384], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x21x384xbf16>> -> tensor<16x21x384xbf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [384, 192], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<384x192xbf16>> -> tensor<384x192xbf16>
+        %5 = tensor.empty() : tensor<16x21x192xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<16x21x192xf32>) -> tensor<16x21x192xf32>
+        %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<16x21x384xbf16>, tensor<384x192xbf16>) outs(%6 : tensor<16x21x192xf32>) attrs =  {lowering_config = #config_backward} {
+        ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+          %10 = arith.extf %in : bf16 to f32
+          %11 = arith.extf %in_0 : bf16 to f32
+          %12 = arith.mulf %10, %11 : f32
+          %13 = arith.addf %out, %12 : f32
+          linalg.yield %13 : f32
+        } -> tensor<16x21x192xf32>
+        %8 = tensor.empty() : tensor<16x21x192xbf16>
+        %9 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel"]} ins(%7 : tensor<16x21x192xf32>) outs(%8 : tensor<16x21x192xbf16>) {
+        ^bb0(%in: f32, %out: bf16):
+          %10 = arith.truncf %in : f32 to bf16
+          linalg.yield %10 : bf16
+        } -> tensor<16x21x192xbf16>
+        iree_tensor_ext.dispatch.tensor.store %9, %2, offsets = [0, 0, 0], sizes = [16, 21, 192], strides = [1, 1, 1] : tensor<16x21x192xbf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x21x192xbf16>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @conv_input_backward_bf16
+//          CHECK:   scf.forall
+//          CHECK:     scf.for {{.*}} iter_args
+//      CHECK-DAG:       vector.transfer_read {{.*}}memref<16x21x384xbf16, #amdgpu.address_space<fat_raw_buffer>>{{.*}}vector<8xbf16>
+//      CHECK-DAG:       vector.transfer_write {{.*}}memref<2x32x{{.*}}xbf16, {{.*}}#gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_read {{.*}}memref<384x192xbf16, #amdgpu.address_space<fat_raw_buffer>>{{.*}}vector<8xbf16>
+//      CHECK-DAG:       vector.transfer_write {{.*}}memref<64x{{.*}}xbf16, {{.*}}#gpu.address_space<workgroup>>
+//          CHECK:       gpu.barrier
+//          CHECK:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>
+//          CHECK:       amdgpu.transpose_load {{.*}}#gpu.address_space<workgroup>{{.*}}vector<4xbf16>
+//          CHECK:       amdgpu.mfma 16x16x32 {{.*}} vector<8xbf16>, vector<8xbf16>, vector<4xf32>
+//          CHECK:       scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
-// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" %s | FileCheck %s
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
@@ -150,3 +150,273 @@ hal.executable public @main {
 // CHECK:      vector.transfer_read %[[BUFFER_C]]
 // CHECK:      arith.addf
 // CHECK:      vector.transfer_write
+
+// -----
+
+#pipeline_layout_f16_transb = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config_f16_transb = #iree_gpu.lowering_config<{
+  workgroup = [128, 128, 0],
+  reduction = [0, 0, 1],
+  subgroup = [4, 4, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>,
+  promote_operands = [0, 1]
+}>
+hal.executable public @matmul_transpose_b_f16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_transpose_b_f16 ordinal(0) layout(#pipeline_layout_f16_transb) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_f16()
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_f16_transb) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_f16_transb) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10240x1280xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_f16_transb) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>> -> tensor<2048x1280xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [10240, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10240x1280xf16>> -> tensor<10240x1280xf16>
+        %5 = tensor.empty() : tensor<2048x10240xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        %7 = linalg.matmul
+          indexing_maps = [
+            affine_map<(d0, d1, d2) -> (d0, d2)>,
+            affine_map<(d0, d1, d2) -> (d1, d2)>,
+            affine_map<(d0, d1, d2) -> (d0, d1)>
+          ]
+          {lowering_config = #config_f16_transb}
+          ins(%3, %4 : tensor<2048x1280xf16>, tensor<10240x1280xf16>)
+          outs(%6 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @matmul_transpose_b_f16
+//      CHECK-DAG:   %[[ALLOC_A:.+]] = memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[ALLOC_B:.+]] = memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[GLOBAL_A:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<2048x1280xf16{{.*}}> to memref<2048x1280xf16, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_B:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<10240x1280xf16{{.*}}> to memref<10240x1280xf16, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_C:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<{{.*}}xf32{{.*}}> to memref<{{.*}}xf32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   scf.forall ({{.*}}) in (16, 80) {
+//          CHECK:     scf.for {{.*}} -> (vector<4x4x4x1xf32>) {
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_A]]{{.*}} : memref<2048x1280xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xf16>
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_B]]{{.*}} : memref<10240x1280xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xf16>
+//          CHECK:       gpu.barrier
+//      CHECK-DAG:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>{{.*}} vector<4x1x1x8xf16>
+//      CHECK-DAG:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>{{.*}} vector<4x1x1x8xf16>
+// CHECK-COUNT-16:       amdgpu.mfma 16x16x32
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_A]]{{.*}} : vector<8xf16>, memref<128x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_B]]{{.*}} : vector<8xf16>, memref<128x36xf16, #gpu.address_space<workgroup>>
+//          CHECK:       scf.yield
+//          CHECK:     }
+//          CHECK:     vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xf32>, memref<{{.*}}xf32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+#pipeline_layout_i8_transb = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config_i8_transb = #iree_gpu.lowering_config<{
+  workgroup = [128, 128, 0],
+  reduction = [0, 0, 1],
+  subgroup = [4, 4, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8>,
+  promote_operands = [0, 1]
+}>
+
+hal.executable public @matmul_transpose_b_i8 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_transpose_b_i8 ordinal(0) layout(#pipeline_layout_i8_transb) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_i8()
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        %cst = arith.constant 0 : i32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_i8_transb) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xi8>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_i8_transb) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10240x1280xi8>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_i8_transb) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xi32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xi8>> -> tensor<2048x1280xi8>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [10240, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10240x1280xi8>> -> tensor<10240x1280xi8>
+        %5 = tensor.empty() : tensor<2048x10240xi32>
+        %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<2048x10240xi32>) -> tensor<2048x10240xi32>
+        %7 = linalg.matmul
+          indexing_maps = [
+            affine_map<(d0, d1, d2) -> (d0, d2)>,
+            affine_map<(d0, d1, d2) -> (d1, d2)>,
+            affine_map<(d0, d1, d2) -> (d0, d1)>
+          ]
+          {lowering_config = #config_i8_transb}
+          ins(%3, %4 : tensor<2048x1280xi8>, tensor<10240x1280xi8>)
+          outs(%6 : tensor<2048x10240xi32>) -> tensor<2048x10240xi32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xi32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @matmul_transpose_b_i8
+//      CHECK-DAG:   %[[ALLOC_A:.+]] = memref.alloc() : memref<128x72xi8, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[ALLOC_B:.+]] = memref.alloc() : memref<128x72xi8, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[GLOBAL_A:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<2048x1280xi8{{.*}}> to memref<2048x1280xi8, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_B:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<10240x1280xi8{{.*}}> to memref<10240x1280xi8, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_C:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<{{.*}}xi32{{.*}}> to memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   scf.forall ({{.*}}) in (16, 80) {
+//          CHECK:     scf.for {{.*}} -> (vector<4x4x4x1xi32>) {
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_A]]{{.*}} : memref<2048x1280xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<16xi8>
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_B]]{{.*}} : memref<10240x1280xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<16xi8>
+//          CHECK:       gpu.barrier
+//      CHECK-DAG:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>{{.*}} vector<4x1x1x16xi8>
+//      CHECK-DAG:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>{{.*}} vector<4x1x1x16xi8>
+// CHECK-COUNT-16:       amdgpu.mfma 16x16x64
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_A]]{{.*}} : vector<16xi8>, memref<128x72xi8, #gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_B]]{{.*}} : vector<16xi8>, memref<128x72xi8, #gpu.address_space<workgroup>>
+//          CHECK:       scf.yield
+//          CHECK:     }
+//          CHECK:     vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xi32>, memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+// regular matmul (non-transpose-b) with f16 using gfx950 config
+#pipeline_layout_f16 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config_f16 = #iree_gpu.lowering_config<{
+  workgroup = [128, 128, 0],
+  reduction = [0, 0, 1],
+  subgroup = [4, 4, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>,
+  promote_operands = [0, 1]
+}>
+
+hal.executable public @matmul_f16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_f16 ordinal(0) layout(#pipeline_layout_f16) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_f16()
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_f16) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_f16) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x10240xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_f16) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>> -> tensor<2048x1280xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1280, 10240], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x10240xf16>> -> tensor<1280x10240xf16>
+        %5 = tensor.empty() : tensor<2048x10240xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        %7 = linalg.matmul
+          {lowering_config = #config_f16}
+          ins(%3, %4 : tensor<2048x1280xf16>, tensor<1280x10240xf16>)
+          outs(%6 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @matmul_f16
+//      CHECK-DAG:   %[[ALLOC_B:.+]] = memref.alloc() : memref<32x132xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[ALLOC_A:.+]] = memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[GLOBAL_A:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<2048x1280xf16{{.*}}> to memref<2048x1280xf16, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_B:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<1280x10240xf16{{.*}}> to memref<1280x10240xf16, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_C:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<{{.*}}xf32{{.*}}> to memref<{{.*}}xf32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   scf.forall ({{.*}}) in (16, 80) {
+//          CHECK:     scf.for {{.*}} -> (vector<4x4x4x1xf32>) {
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_A]]{{.*}} : memref<2048x1280xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xf16>
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_B]]{{.*}} : memref<1280x10240xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xf16>
+//          CHECK:       gpu.barrier
+//          CHECK:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>{{.*}} vector<4x1x1x8xf16>
+//  CHECK-COUNT-8:       amdgpu.transpose_load {{.*}}#gpu.address_space<workgroup>{{.*}} -> vector<4xf16>
+// CHECK-COUNT-16:       amdgpu.mfma 16x16x32
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_A]]{{.*}} : vector<8xf16>, memref<128x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_B]]{{.*}} : vector<8xf16>, memref<32x132xf16, #gpu.address_space<workgroup>>
+//          CHECK:       scf.yield
+//          CHECK:     }
+//          CHECK:     vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xf32>, memref<{{.*}}xf32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+#pipeline_layout_i8 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config_i8 = #iree_gpu.lowering_config<{
+  workgroup = [128, 128, 0],
+  reduction = [0, 0, 1],
+  subgroup = [4, 4, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8>,
+  promote_operands = [0, 1]
+}>
+
+hal.executable public @matmul_i8 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_i8 ordinal(0) layout(#pipeline_layout_i8) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_i8()
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        %cst = arith.constant 0 : i32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_i8) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xi8>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_i8) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x10240xi8>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_i8) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xi32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xi8>> -> tensor<2048x1280xi8>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1280, 10240], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x10240xi8>> -> tensor<1280x10240xi8>
+        %5 = tensor.empty() : tensor<2048x10240xi32>
+        %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<2048x10240xi32>) -> tensor<2048x10240xi32>
+        %7 = linalg.matmul
+          {lowering_config = #config_i8}
+          ins(%3, %4 : tensor<2048x1280xi8>, tensor<1280x10240xi8>)
+          outs(%6 : tensor<2048x10240xi32>) -> tensor<2048x10240xi32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xi32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @matmul_i8
+//      CHECK-DAG:   %[[ALLOC_B:.+]] = memref.alloc() : memref<64x136xi8, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[ALLOC_A:.+]] = memref.alloc() : memref<128x72xi8, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[GLOBAL_A:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<2048x1280xi8{{.*}}> to memref<2048x1280xi8, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_B:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<1280x10240xi8{{.*}}> to memref<1280x10240xi8, #amdgpu.address_space<fat_raw_buffer>>
+//      CHECK-DAG:   %[[GLOBAL_C:.+]] = amdgpu.fat_raw_buffer_cast {{.*}} : memref<{{.*}}xi32{{.*}}> to memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   scf.forall ({{.*}}) in (16, 80) {
+//          CHECK:     scf.for {{.*}} -> (vector<4x4x4x1xi32>) {
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_A]]{{.*}} : memref<2048x1280xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<16xi8>
+//      CHECK-DAG:       vector.transfer_read %[[GLOBAL_B]]{{.*}} : memref<1280x10240xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<16xi8>
+//          CHECK:       gpu.barrier
+//          CHECK:       vector.transfer_read {{.*}}#gpu.address_space<workgroup>{{.*}} vector<4x1x1x16xi8>
+//  CHECK-COUNT-8:       amdgpu.transpose_load {{.*}}#gpu.address_space<workgroup>{{.*}} -> vector<8xi8>
+// CHECK-COUNT-16:       amdgpu.mfma 16x16x64
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_A]]{{.*}} : vector<16xi8>, memref<128x72xi8, #gpu.address_space<workgroup>>
+//      CHECK-DAG:       vector.transfer_write {{.*}} %[[ALLOC_B]]{{.*}} : vector<16xi8>, memref<64x136xi8, #gpu.address_space<workgroup>>
+//          CHECK:       scf.yield
+//          CHECK:     }
+//          CHECK:     vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xi32>, memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}


### PR DESCRIPTION
Adds the ROCDLLoadToTransposeLoad pass to the LLVMGPUTileAndFuse pipeline. This is only enabled for ROCDL, and a test flag is added to turn off the feature if needed (mainly for benchmark testing).

## Convolution Benchmark Results ##

The data below is all for bf16 convolutions. I didn't put comprehensive GEMM (`MxK @ KxN`) data in a spreadsheet, but for GEMM, the speedup is in the range of `0-17%` for f16 and `0-60%` for i8 GEMMs.

Full spreadsheet of results: https://docs.google.com/spreadsheets/d/1QEwemqviUzk4GginGdaDT7u8pP9x_Bku7r1aAvOUOCk/edit?usp=sharing

### Weight Backward Convolutions ###
Equates to `KxM @ KxN` GEMM layout.

**Benchmark Summary:**
Total benchmarks: 162
Significant changes (>2.0%): 142
  Improvements (transpose_load faster): 133
  Regressions (default faster):         9
Mean % change: -20.44%
Range: -56.29% to 12.22%

### Input Backward Convolutions ###
Equates to `MxK @ KxN` GEMM layout.

**Benchmark Summary:**
Total benchmarks: 146
Significant changes (>2.0%): 43
  Improvements (transpose_load faster): 24
  Regressions (default faster):         19
Mean % change: -1.09%
Range: -34.02% to 12.08%

### Additional notes ###

 - All benchmarks were collected on a single MI355 GPU
 - There are "regressions, but the top regressions appear to be from noise. Retesting them did not show real regressions.
 - Forward convolution data is not included, since forward convolutions do not target transpose_load instructions.

ci-extra: test_torch