### PR TITLE
[CodeGen] Improve scf.for bufferization and make hoisting allocation work

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -151,6 +151,13 @@ static IREEOneShotBufferizationOptions getBufferizationOptions() {
   // as is and insert bufferization.to_buffer to convert the tensor to memref.
   options.opFilter.denyOperation<arith::ConstantOp>();
 
+  // Allow returning allocs from loops. This is needed for patterns like online
+  // attention where scf.for yield operands cannot be buffer-equivalent to their
+  // corresponding iter bbArgs (e.g., the new max value is computed from both
+  // the old max and new data). This matches MLIR upstream's
+  // EmptyTensorElimination pass behavior.
+  options.allowReturnAllocsFromLoops = true;
+
   // This type converter converts tensor types to memref types when no exact
   // memref type can be inferred from the context.
   options.unknownTypeConverterFn = [](TensorType tensorType,


### PR DESCRIPTION
The revision enables `allowReturnAllocsFromLoops` in bufferization, which matches the upstream behavior. Otherwise, it can trigger an error like:

```
error: Yield operand #1 is not equivalent to the corresponding iter bbArg
```

In this context, a `memref.alloca` can be created inside the loop and the dynamic size can be queried from iter_arg. The ValueBoundsConstraintSet check does not support the analysis, because the runtime dimension values can still differ. E.g.,

```mlir
%result = scf.for ... iter_args(%iter = %init) -> (memref<?xf32>) {
  %new_buf = memref.alloca(%some_other_size) : memref<?xf32>
  scf.yield %new_buf : memref<?xf32>  // same type, different runtime size
}
```

It is weird, but it is allowed. Thus, we need to handle such case in `hoistOneStaticallyBoundAllocation`.

The revision verifies the dimension is preserved, via:
1. The yield operand (after walking through cast/subview) is the iter_arg.
2. The yield operand traces to an alloca whose shape matches the iter_arg and whose dynamic size at `dimIndex` is `memref.dim` of the iter_arg.
3. The yield operand is a scf.for result whose init arg is the iter_arg and the inner loop also preserves the dimension (recursive).

Fixes https://github.com/iree-org/iree/issues/16956

ci-extra: test_torch