### PR TITLE
[StableHLO] Disable ReorderElementwiseAndShapeOP pattern for iree-stablehlo-to-iree-input

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -1176,9 +1176,9 @@ struct StableHLOCanonicalize final
 };
 
 } // namespace
-void populateCanonicalizationPatterns(MLIRContext *context,
-                                      RewritePatternSet *patterns,
-                                      PatternBenefit benefit) {
+void populateCanonicalizationPatternsNoReorder(MLIRContext *context,
+                                               RewritePatternSet *patterns,
+                                               PatternBenefit benefit) {
   patterns->add<
       // Arithmetic ops.
       AddOpCanon, SubtractOpCanon, MulOpCanon, CompareOpCanon, SelectOpCanon,
@@ -1197,6 +1197,12 @@ void populateCanonicalizationPatterns(MLIRContext *context,
       ReshapeOpCanon, MergeConsecutiveReshapes, TransposeIsReshape,
       // Types.
       ZeroExtentTensorCanon>(context, benefit);
+}
+
+void populateCanonicalizationPatterns(MLIRContext *context,
+                                      RewritePatternSet *patterns,
+                                      PatternBenefit benefit) {
+  populateCanonicalizationPatternsNoReorder(context, patterns, benefit);
   patterns->add<ReorderElementwiseAndShapeOp>(context);
 }
 } // namespace mlir::iree_compiler::stablehlo

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Rewriters.h
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Rewriters.h
@@ -20,6 +20,11 @@ namespace mlir::iree_compiler::stablehlo {
 void populateCanonicalizationPatterns(MLIRContext *context,
                                       RewritePatternSet *patterns,
                                       PatternBenefit benefit = 1);
+/// Collection of canonicalization patterns for StableHLO
+/// without ReorderElementwiseAndShapeOp.
+void populateCanonicalizationPatternsNoReorder(MLIRContext *context,
+                                               RewritePatternSet *patterns,
+                                               PatternBenefit benefit = 1);
 
 /// Collection of rewrite patterns for lowering of StableHLO dot general
 /// operations.

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
@@ -511,7 +511,8 @@ struct ConvertStableHloToIreeInputDialects final
 
     // Run stablehlo canonicalization patterns with a high benefit to avoid some
     // expensive expansions.
-    populateCanonicalizationPatterns(context, &patterns, /*benefit=*/1024);
+    populateCanonicalizationPatternsNoReorder(context, &patterns,
+                                              /*benefit=*/1024);
 
     // Run custom patterns with a high benefit to override stablehlo patterns.
     patterns.add<ConcatenateOpConversion, FftOpConversion,

--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_iree_input_dialects.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_iree_input_dialects.mlir
@@ -140,3 +140,20 @@ func.func @select_conversion(%arg0: tensor<i1>, %arg1: tensor<?xui16>, %arg2: te
   %0 = arith.select %extracted, %arg1, %arg2 : tensor<?xui16>
   return %0 : tensor<?xui16>
 }
+
+// -----
+
+// Tests whether the pass fails on ReorderElementwiseAndShapeOp pattern.
+
+// CHECK:       func.func @reorder_elementwise_and_shape
+// CHECK-SAME:    %[[ARG0:[^:]+]]: tensor<2048xi1>
+// CHECK-SAME:    %[[ARG1:[^:]+]]: tensor<1x2048xi32>
+func.func @reorder_elementwise_and_shape(%arg0: tensor<2048xi1>, %arg1: tensor<1x2048xi32>) -> tensor<1x2048xi32> {
+  // CHECK: tensor.expand_shape
+  %0 = stablehlo.reshape %arg0 : (tensor<2048xi1>) -> tensor<1x2048xi1>
+  // CHECK: linalg.generic
+  %1 = stablehlo.convert %0 : (tensor<1x2048xi1>) -> tensor<1x2048xi32>
+  // CHECK: linalg.generic
+  %2 = stablehlo.subtract %arg1, %1 : tensor<1x2048xi32>
+  return %2 : tensor<1x2048xi32>
+}


### PR DESCRIPTION
The `ReorderElementwiseAndShapeOP` pattern is not compatible with the rewriter used by iree-stablehlo-to-iree-input pass - as some modifications are applied immediately and others (e.g. `replaceAllUsesWith`) are delayed, it produces invalid state resulting with errors like:
```
compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_iree_input_dialects.mlir:157:8: error: failed to legalize operation 'stablehlo.subtract' that was explicitly marked illegal
  %2 = stablehlo.subtract %arg1, %1 : tensor<1x2048xi32>
       ^
compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_iree_input_dialects.mlir:157:8: note: see current operation: %3 = "stablehlo.subtract"(%arg1, %1) : (tensor<1x2048xi32>, tensor<2048xi32>) -> tensor<1x2048xi32>
```

This PR adds a test showcasing this error and disables the `ReorderElementwiseAndShapeOP` pattern for the iree-stablehlo-to-iree-input pass.