### PR TITLE
[Encoding] Add encoding_dims flow/stream conversion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -83,6 +83,12 @@ def IREEEncoding_LayoutResolverAttr :
         one of the input encodings - for example, a resolver might return an
         identity encoding for simplicity, or synthesize a new encoding that
         introduces less overheads in relayout.
+
+        When used for global encoding unification (in initializers), the
+        returned encoding must have getNumDynamicEncodingDims() == 0, since
+        dynamic encoding dimensions cannot be tracked across function
+        boundaries. The caller will fall back to identity encoding if this
+        requirement is not met.
       }],
       /*retTy=*/"::mlir::Attribute",
       /*methodName=*/"getUnifiedEncoding",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -44,7 +44,8 @@ LogicalResult SetEncodingOp::verify() {
     return emitOpError("expected to preserve the logical shape of the tensor");
   }
   // Verify encoding_dims count matches what the encoding expects.
-  std::optional<int64_t> expectedDims = encoding.getNumDynamicEncodingDims();
+  std::optional<int64_t> expectedDims =
+      getNumDynamicEncodingDims(getResultType());
   if (expectedDims.has_value() &&
       static_cast<int64_t>(getEncodingDims().size()) != expectedDims.value()) {
     return emitOpError() << "encoding expects " << expectedDims.value()
@@ -94,7 +95,8 @@ LogicalResult UnsetEncodingOp::verify() {
                          << " dimension values are attached";
   }
   // Verify encoding_dims count matches what the encoding expects.
-  std::optional<int64_t> expectedDims = encoding.getNumDynamicEncodingDims();
+  std::optional<int64_t> expectedDims =
+      getNumDynamicEncodingDims(getSourceType());
   if (expectedDims.has_value() &&
       static_cast<int64_t>(getEncodingDims().size()) != expectedDims.value()) {
     return emitOpError() << "encoding expects " << expectedDims.value()

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -192,4 +192,17 @@ MatmulNarrowDim getMatmulNarrowDim(linalg::LinalgOp linalgOp,
   return (narrowM && (!narrowN || mSize <= nSize)) ? narrowM : narrowN;
 }
 
+std::optional<int64_t> getNumDynamicEncodingDims(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  if (!tensorType) {
+    return std::nullopt;
+  }
+  auto encodingAttr =
+      dyn_cast_or_null<SerializableAttr>(tensorType.getEncoding());
+  if (!encodingAttr) {
+    return std::nullopt;
+  }
+  return encodingAttr.getNumDynamicEncodingDims();
+}
+
 } // namespace mlir::iree_compiler::IREE::Encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -62,6 +62,12 @@ struct MatmulNarrowDim {
 MatmulNarrowDim getMatmulNarrowDim(linalg::LinalgOp linalgOp,
                                    int narrowThreshold);
 
+/// Returns the number of dynamic encoding dimensions for a tensor type.
+/// If the type has a SerializableAttr encoding, returns the result of
+/// getNumDynamicEncodingDims(). Returns std::nullopt if the type has no
+/// encoding or the encoding is not a SerializableAttr.
+std::optional<int64_t> getNumDynamicEncodingDims(Type type);
+
 // The structs defined here because they are used by encoding_interfaces.td.
 
 /// Bundles an encoding attribute with its associated dynamic information.

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1306,19 +1306,26 @@ def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
   let summary = [{Performs a full tensor encode operation.}];
   let description = [{
     Encode the input tensor into an encoded output tensor.
+
+    The optional `encoding_dims` operand carries encoding-specific dynamic
+    values (e.g., M, N, K dimensions for matmul encodings). These values are
+    used for runtime layout selection based on problem size.
   }];
 
   let arguments = (ins
     FLOW_Tensor:$operand,
     FLOW_ShapeDynamicDims:$operand_dims,
-    FLOW_ShapeDynamicDims:$result_dims
+    FLOW_ShapeDynamicDims:$result_dims,
+    Variadic<Index>:$encoding_dims
   );
   let results = (outs
     FLOW_Tensor:$result
   );
 
   let assemblyFormat = [{
-    $operand `:`
+    $operand
+    (`encoding_dims` `{` $encoding_dims^ `}`)?
+    `:`
     type($operand) (`{` $operand_dims^ `}`)? `->`
     type($result) (`{` $result_dims^ `}`)?
     attr-dict-with-keyword

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "dispatch_folding.mlir",
             "dispatch_ops.mlir",
             "executable_ops.mlir",
+            "invalid.mlir",
             "resolve_dim_ops.mlir",
             "tensor_folding.mlir",
             "tensor_ops.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "dispatch_folding.mlir"
     "dispatch_ops.mlir"
     "executable_ops.mlir"
+    "invalid.mlir"
     "resolve_dim_ops.mlir"
     "tensor_folding.mlir"
     "tensor_ops.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/invalid.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics %s
+
+// Test: encoding expects 1 encoding dim but 0 provided (encode direction).
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2], iteration_sizes = [?, 128, 64]>
+util.func public @encode_missing_encoding_dims(%arg0 : tensor<?x64xf32>, %m : index) -> tensor<?x64xf32, #encoding> {
+  // expected-error @+1 {{encoding expects 1 encoding dim(s), but 0 provided}}
+  %0 = flow.tensor.encode %arg0 : tensor<?x64xf32>{%m} -> tensor<?x64xf32, #encoding>{%m}
+  util.return %0 : tensor<?x64xf32, #encoding>
+}
+
+// -----
+
+// Test: encoding expects 1 encoding dim but 2 provided (encode direction).
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2], iteration_sizes = [?, 128, 64]>
+util.func public @encode_too_many_encoding_dims(%arg0 : tensor<?x64xf32>, %m : index) -> tensor<?x64xf32, #encoding> {
+  // expected-error @+1 {{encoding expects 1 encoding dim(s), but 2 provided}}
+  %0 = flow.tensor.encode %arg0 encoding_dims{%m, %m} : tensor<?x64xf32>{%m} -> tensor<?x64xf32, #encoding>{%m}
+  util.return %0 : tensor<?x64xf32, #encoding>
+}
+
+// -----
+
+// Test: encoding expects 1 encoding dim but 0 provided (decode direction).
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2], iteration_sizes = [?, 128, 64]>
+util.func public @decode_missing_encoding_dims(%arg0 : tensor<?x64xf32, #encoding>, %m : index) -> tensor<?x64xf32> {
+  // expected-error @+1 {{encoding expects 1 encoding dim(s), but 0 provided}}
+  %0 = flow.tensor.encode %arg0 : tensor<?x64xf32, #encoding>{%m} -> tensor<?x64xf32>{%m}
+  util.return %0 : tensor<?x64xf32>
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/IR/Builders.h"
@@ -44,8 +45,9 @@ static SmallVector<TensorValue> filterTensorValues(ValueRange &&range,
 /// Sets all `Value`s of the `TensorValue`s in `tensorValues` to the row major
 /// layout by inserting flow.tensor.encode ops before any Value that has an
 /// encoding. Populates `decodedIndices` with the indices of `tensorValues` that
-/// were decoded.
-static SmallVector<Value>
+/// were decoded. Returns failure if an encoding with dynamic encoding
+/// dimensions is encountered (not yet supported).
+static FailureOr<SmallVector<Value>>
 getInRowMajorLayout(OpBuilder &builder, SmallVector<TensorValue> tensorValues,
                     SmallVector<int64_t> &decodedIndices) {
   SmallVector<Value> rowMajorTensors;
@@ -55,11 +57,27 @@ getInRowMajorLayout(OpBuilder &builder, SmallVector<TensorValue> tensorValues,
       rowMajorTensors.push_back(v.value);
       continue;
     }
+    // Fail for encodings with dynamic encoding dimensions. We can't retrieve
+    // encoding_dims through dispatch boundaries, so tracing with dynamic
+    // layout specialization is not yet supported.
+    if (auto encodingAttr = dyn_cast<IREE::Encoding::SerializableAttr>(
+            rankedTensorType.getEncoding())) {
+      if (std::optional<int64_t> numDynamic =
+              encodingAttr.getNumDynamicEncodingDims()) {
+        if (*numDynamic > 0) {
+          emitError(v.value.getLoc())
+              << "tracing encoded tensors with dynamic encoding dimensions is "
+                 "not yet supported";
+          return failure();
+        }
+      }
+    }
     OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointAfterValue(v.value);
     Value rowMajorTensor = IREE::Flow::TensorEncodeOp::create(
         builder, v.value.getLoc(), rankedTensorType.dropEncoding(), v.value,
-        /*operand_dims=*/v.dynamicDims, /*result_dims=*/v.dynamicDims);
+        /*operand_dims=*/v.dynamicDims, /*result_dims=*/v.dynamicDims,
+        /*encoding_dims=*/ValueRange{});
     rowMajorTensors.push_back(rowMajorTensor);
     decodedIndices.push_back(idx);
   }
@@ -91,36 +109,42 @@ struct InjectDispatchTracingPass
       SmallVector<TensorValue> inputTensorValues = filterTensorValues(
           dispatchOp.getArguments(), dispatchOp.getArgumentDims());
       SmallVector<int64_t> decodedInputIndices;
-      SmallVector<Value> decodedInputValues =
+      FailureOr<SmallVector<Value>> decodedInputValues =
           getInRowMajorLayout(builder, inputTensorValues, decodedInputIndices);
+      if (failed(decodedInputValues)) {
+        return signalPassFailure();
+      }
       std::string inputsLabelStr = appendDecodedValuesToLabel(
           entryPointName + " inputs", decodedInputIndices);
       StringAttr inputsLabel = builder.getStringAttr(inputsLabelStr);
       IREE::Flow::TensorTraceOp::create(builder, dispatchOp.getLoc(),
-                                        inputsLabel, decodedInputValues);
+                                        inputsLabel, *decodedInputValues);
 
       // Output tensors:
       SmallVector<TensorValue> resultTensorValues = filterTensorValues(
           dispatchOp.getResults(), dispatchOp.getResultDims());
       SmallVector<int64_t> decodedOutputIndices;
-      SmallVector<Value> decodedResultValues = getInRowMajorLayout(
+      FailureOr<SmallVector<Value>> decodedResultValues = getInRowMajorLayout(
           builder, resultTensorValues, decodedOutputIndices);
+      if (failed(decodedResultValues)) {
+        return signalPassFailure();
+      }
       std::string outputsLabelStr = appendDecodedValuesToLabel(
           entryPointName + " outputs", decodedOutputIndices);
       StringAttr outputsLabel = builder.getStringAttr(outputsLabelStr);
 
       // Set insertion point to the last decoded value before creating the
       // trace op.
-      Operation *lastResult = decodedResultValues.front().getDefiningOp();
+      Operation *lastResult = decodedResultValues->front().getDefiningOp();
       DominanceInfo domInfo(funcOp);
-      for (Value v : decodedResultValues) {
+      for (Value v : *decodedResultValues) {
         if (domInfo.dominates(lastResult, v.getDefiningOp())) {
           lastResult = v.getDefiningOp();
         }
       }
       builder.setInsertionPointAfter(lastResult);
       IREE::Flow::TensorTraceOp::create(builder, dispatchOp.getLoc(),
-                                        outputsLabel, decodedResultValues);
+                                        outputsLabel, *decodedResultValues);
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -257,7 +257,8 @@ struct ConvertTensorEncodeOp
         rewriter, op.getLoc(), unknownType, operand.resource,
         op.getOperand().getType(), op.getOperandDims(), operand.resourceSize,
         op.getResult().getType(), flattenValues(adaptor.getResultDims()),
-        resultSize, executionAffinityAttr);
+        resultSize, flattenValues(adaptor.getEncodingDims()),
+        executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{encodeOp, resultSize}});
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -204,6 +204,29 @@ util.func public @tensorEncodeChangeEncoding(%arg0 : tensor<?x4xf32, #encoding>,
   // CHECK:      util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
   util.return %0 : tensor<?x4xf32, #encoding1>
 }
+
+// -----
+
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<>
+// CHECK-LABEL: @tensorEncodeWithEncodingDims
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[D0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[D1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[M:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[N:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[K:[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.testing<>
+util.func public @tensorEncodeWithEncodingDims(%input: tensor<?x?xf32>, %d0: index, %d1: index, %m: index, %n: index, %k: index) -> tensor<?x?xf32, #encoding> {
+  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<?x?xf32, #[[$ENCODING]]>{%[[D0]], %[[D1]]} : index
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+  // CHECK-SAME:   : tensor<?x?xf32>{%[[D0]], %[[D1]]} in !stream.resource<*>{%[[ARG1]]}
+  // CHECK-SAME:   -> tensor<?x?xf32, #[[$ENCODING]]>{%[[D0]], %[[D1]]} in !stream.resource<*>{%[[SIZE]]}
+  %0 = flow.tensor.encode %input encoding_dims{%m, %n, %k} : tensor<?x?xf32>{%d0, %d1} -> tensor<?x?xf32, #encoding>{%d0, %d1}
+  // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<?x?xf32, #encoding>
+}
+
 // -----
 
 // CHECK-LABEL: @tensorAlloca

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2281,6 +2281,18 @@ LogicalResult TensorEncodeOp::verify() {
       failed(verifyOpValueSizes(op, op.getResult(), op.getResultSize()))) {
     return failure();
   }
+  // Verify encoding_dims count matches what the encoding expects.
+  // Check both source (for decode) and result (for encode) encodings.
+  for (Type type : {op.getSourceEncoding(), op.getResultEncoding()}) {
+    std::optional<int64_t> expectedDims =
+        IREE::Encoding::getNumDynamicEncodingDims(type);
+    if (expectedDims.has_value() &&
+        static_cast<int64_t>(op.getEncodingDims().size()) != *expectedDims) {
+      return op.emitOpError()
+             << "encoding expects " << *expectedDims << " encoding dim(s), but "
+             << op.getEncodingDims().size() << " provided";
+    }
+  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1359,10 +1359,14 @@ def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
 ]> {
   let summary = [{Encodes the contents of a value.}];
   let description = [{
-    Elones the contents of a value at a snapshot in time. Future changes to the
+    Encodes the contents of a value at a snapshot in time. Future changes to the
     identity encoding will not effect the result. Acts as a copy-on-write
     operation. Otherwise, an executable for encoding the value is generated
     during lowering.
+
+    The optional `encoding_dims` operand carries encoding-specific dynamic
+    values (e.g., M, N, K dimensions for matmul encodings). These values are
+    used for runtime layout selection based on problem size.
   }];
 
   let arguments = (ins
@@ -1373,6 +1377,7 @@ def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
     TypeAttr:$result_encoding,
     Stream_ShapeDynamicDims:$result_encoding_dims,
     Stream_Size:$result_size,
+    Variadic<Index>:$encoding_dims,
     OptionalAttr<Stream_AffinityAttr>:$affinity
   );
   let results = (outs
@@ -1381,7 +1386,9 @@ def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
 
   let assemblyFormat = [{
     (`on` `(` $affinity^ `)`)?
-    $source `:`
+    $source
+    (`encoding_dims` `{` $encoding_dims^ `}`)?
+    `:`
     $source_encoding (`` `{` $source_encoding_dims^ `}`)?
     `in`
     type($source) `` `{` $source_size `}`

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/BUILD.bazel
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "context_ops.mlir",
             "executable_ops.mlir",
             "file_ops.mlir",
+            "invalid.mlir",
             "resource_folding.mlir",
             "resource_ops.mlir",
             "tensor_folding.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_lit_test_suite(
     "context_ops.mlir"
     "executable_ops.mlir"
     "file_ops.mlir"
+    "invalid.mlir"
     "resource_folding.mlir"
     "resource_ops.mlir"
     "tensor_folding.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/invalid.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics %s
+
+// Test: encoding expects 1 encoding dim but 0 provided (encode direction).
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2], iteration_sizes = [?, 128, 64]>
+util.func private @encode_missing_encoding_dims(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  // expected-error @+1 {{encoding expects 1 encoding dim(s), but 0 provided}}
+  %0 = stream.tensor.encode %arg0 : tensor<?x64xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x64xf32, #encoding>{%arg1} in !stream.resource<*>{%arg3}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+// Test: encoding expects 1 encoding dim but 2 provided (encode direction).
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2], iteration_sizes = [?, 128, 64]>
+util.func private @encode_too_many_encoding_dims(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %m: index) -> !stream.resource<*> {
+  // expected-error @+1 {{encoding expects 1 encoding dim(s), but 2 provided}}
+  %0 = stream.tensor.encode %arg0 encoding_dims{%m, %m} : tensor<?x64xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x64xf32, #encoding>{%arg1} in !stream.resource<*>{%arg3}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+// Test: encoding expects 1 encoding dim but 0 provided (decode direction).
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2], iteration_sizes = [?, 128, 64]>
+util.func private @decode_missing_encoding_dims(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  // expected-error @+1 {{encoding expects 1 encoding dim(s), but 0 provided}}
+  %0 = stream.tensor.encode %arg0 : tensor<?x64xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x64xf32>{%arg1} in !stream.resource<*>{%arg3}
+  util.return %0 : !stream.resource<*>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -460,6 +460,12 @@ updateTensorEncodeOp(RewriterBase &rewriter, IREE::Stream::TensorEncodeOp op,
       failed(updateSourceEncoding(rewriter, op, layoutResolvers))) {
     return failure();
   }
+  // Clear encoding_dims after serialization. The serialized encoding (e.g.,
+  // LayoutAttr) no longer needs encoding_dims because the layout information
+  // is fully resolved. Keeping them would unnecessarily block hoisting of
+  // encoding dispatches into __init. Note that this might need to change in the
+  // future for dynamically specialized encodings.
+  rewriter.modifyOpInPlace(op, [&] { op.getEncodingDimsMutable().clear(); });
   return success();
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/ConvertEncodingToFlow.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ConvertEncodingToFlow.cpp
@@ -45,7 +45,8 @@ void ConvertEncodingToFlowPass::runOnOperation() {
     std::tie(std::ignore, dynamicDimSizes) = decomposeMixedValues(mixedSizes);
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorEncodeOp>(
         encodingOp, encodingOp.getResultType(), source,
-        /*operand_dims=*/dynamicDimSizes, /*result_dims=*/dynamicDimSizes);
+        /*operand_dims=*/dynamicDimSizes, /*result_dims=*/dynamicDimSizes,
+        /*encoding_dims=*/encodingOp.getEncodingDims());
   });
 
   // Convert the unset_encoding ops.
@@ -57,7 +58,8 @@ void ConvertEncodingToFlowPass::runOnOperation() {
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorEncodeOp>(
         encodingOp, encodingOp.getResultType(), encodingOp.getSource(),
         /*operand_dims=*/encodingOp.getResultDims(),
-        /*result_dims=*/encodingOp.getResultDims());
+        /*result_dims=*/encodingOp.getResultDims(),
+        /*encoding_dims=*/encodingOp.getEncodingDims());
   });
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/convert_encoding_to_flow.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/convert_encoding_to_flow.mlir
@@ -81,3 +81,41 @@ util.func public @unset_encoding_in_flow_region(%arg0: tensor<123x456xf32, #enco
 }
 // CHECK-LABEL: @unset_encoding_in_flow_region(
 // CHECK-NOT:     flow.tensor.encode
+
+// -----
+
+#encoding = #iree_encoding.testing<>
+util.func public @set_encoding_with_encoding_dims(%arg0: tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims {%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  util.return %0 : tensor<?x?xf32, #encoding>
+}
+// CHECK-DAG:    #[[$ENC:.+]] = #iree_encoding.testing<>
+// CHECK-LABEL:  @set_encoding_with_encoding_dims(
+// CHECK-SAME:     %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[M:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[N:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]
+// CHECK-DAG:      %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:      %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:      %[[D0:.+]] = tensor.dim %[[SRC]], %[[C0]]
+// CHECK-DAG:      %[[D1:.+]] = tensor.dim %[[SRC]], %[[C1]]
+// CHECK:          %[[RES:.+]] = flow.tensor.encode %[[SRC]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+// CHECK-SAME:       : tensor<?x?xf32>{%[[D0]], %[[D1]]} -> tensor<?x?xf32, #[[$ENC]]>{%[[D0]], %[[D1]]}
+
+// -----
+
+#encoding = #iree_encoding.testing<>
+util.func public @unset_encoding_with_encoding_dims(%arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index, %m: index, %n: index, %k: index) -> tensor<?x?xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims {%m, %n, %k} : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  util.return %0 : tensor<?x?xf32>
+}
+// CHECK-DAG:    #[[$ENC:.+]] = #iree_encoding.testing<>
+// CHECK-LABEL:  @unset_encoding_with_encoding_dims(
+// CHECK-SAME:     %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[D1:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[M:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[N:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]
+// CHECK:          %[[RES:.+]] = flow.tensor.encode %[[SRC]] encoding_dims{%[[M]], %[[N]], %[[K]]}
+// CHECK-SAME:       : tensor<?x?xf32, #[[$ENC]]>{%[[D0]], %[[D1]]} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}


### PR DESCRIPTION
Implements phase 4 for adding specialization support on dynamic values for data-tiling: https://github.com/iree-org/iree/issues/22370. This carries the encoding dynamic values through Flow and Stream dialects.

Assisted-by: Claude