### PR TITLE
Switching iree_time_now() to CLOCK_MONOTONIC + cleanup.

### DIFF
--- a/runtime/src/iree/base/internal/atomic_slist.h
+++ b/runtime/src/iree/base/internal/atomic_slist.h
@@ -222,8 +222,8 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
   static inline void name##_slist_push(name##_slist_t* list, type* entry) {    \
     iree_atomic_slist_push(&list->impl, name##_slist_entry_from_ptr(entry));   \
   }                                                                            \
-  static inline void name##_slist_push_unsafe(name##_slist_t* list,            \
-                                              type* entry) {                   \
+  IREE_ATTRIBUTE_UNUSED static inline void name##_slist_push_unsafe(           \
+      name##_slist_t* list, type* entry) {                                     \
     iree_atomic_slist_push_unsafe(&list->impl,                                 \
                                   name##_slist_entry_from_ptr(entry));         \
   }                                                                            \

--- a/runtime/src/iree/base/internal/memory.h
+++ b/runtime/src/iree/base/internal/memory.h
@@ -68,6 +68,24 @@ void iree_memory_jit_context_end(void);
 // executing code from any pages that have been written during load.
 void iree_memory_flush_icache(void* base_address, iree_host_size_t length);
 
+//===----------------------------------------------------------------------===//
+// C11 aligned_alloc shim
+//===----------------------------------------------------------------------===//
+
+// Allocates |size| bytes of uninitialized storage whose alignment is specified
+// by |alignment|. The |size| parameter must be an integral multiple of
+// |alignment|. The returned pointer must be freed using iree_aligned_free.
+//
+// This is a thin wrapper around C11's aligned_alloc when available:
+// https://en.cppreference.com/w/c/memory/aligned_alloc
+//
+// When not available (such as on MSVC) a fallback will be used:
+// https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_memalign.html
+iree_status_t iree_aligned_alloc(iree_host_size_t alignment,
+                                 iree_host_size_t size, void** out_ptr);
+void iree_aligned_free(void* ptr);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/base/internal/path.c
+++ b/runtime/src/iree/base/internal/path.c
@@ -98,28 +98,9 @@ static iree_status_t iree_string_view_join(iree_host_size_t part_count,
   return iree_ok_status();
 }
 
-static iree_host_size_t iree_file_path_canonicalize_unix(
-    char* path, iree_host_size_t path_length) {
-  char* p = path;
-  iree_host_size_t new_length = path_length;
-
-  // Replace `//` with `/`.
-  if (new_length > 1) {
-    for (iree_host_size_t i = 0; i < new_length - 1; ++i) {
-      if (p[i] == '/' && p[i + 1] == '/') {
-        memmove(&p[i + 1], &p[i + 2], new_length - i - 2);
-        --new_length;
-        --i;
-      }
-    }
-  }
-
-  path[new_length] = 0;  // NUL
-  return new_length;
-}
-
-static iree_host_size_t iree_file_path_canonicalize_win32(
-    char* path, iree_host_size_t path_length) {
+#if defined(IREE_PLATFORM_WINDOWS)
+iree_host_size_t iree_file_path_canonicalize(char* path,
+                                             iree_host_size_t path_length) {
   char* p = path;
   iree_host_size_t new_length = path_length;
 
@@ -142,15 +123,27 @@ static iree_host_size_t iree_file_path_canonicalize_win32(
   path[new_length] = 0;  // NUL
   return new_length;
 }
-
+#else
 iree_host_size_t iree_file_path_canonicalize(char* path,
                                              iree_host_size_t path_length) {
-#if defined(IREE_PLATFORM_WINDOWS)
-  return iree_file_path_canonicalize_win32(path, path_length);
-#else
-  return iree_file_path_canonicalize_unix(path, path_length);
-#endif  // IREE_PLATFORM_WINDOWS
+  char* p = path;
+  iree_host_size_t new_length = path_length;
+
+  // Replace `//` with `/`.
+  if (new_length > 1) {
+    for (iree_host_size_t i = 0; i < new_length - 1; ++i) {
+      if (p[i] == '/' && p[i + 1] == '/') {
+        memmove(&p[i + 1], &p[i + 2], new_length - i - 2);
+        --new_length;
+        --i;
+      }
+    }
+  }
+
+  path[new_length] = 0;  // NUL
+  return new_length;
 }
+#endif  // IREE_PLATFORM_WINDOWS
 
 iree_status_t iree_file_path_join(iree_string_view_t lhs,
                                   iree_string_view_t rhs,

--- a/runtime/src/iree/base/internal/synchronization.h
+++ b/runtime/src/iree/base/internal/synchronization.h
@@ -365,17 +365,6 @@ typedef struct iree_notification_t {
 #endif  // IREE_PLATFORM_*
 } iree_notification_t;
 
-#if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
-#define IREE_NOTIFICATION_INIT \
-  { IREE_ATOMIC_VAR_INIT(0) }
-#elif !defined(IREE_RUNTIME_USE_FUTEX)
-#define IREE_NOTIFICATION_INIT \
-  { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0 }
-#else
-#define IREE_NOTIFICATION_INIT \
-  { IREE_ATOMIC_VAR_INIT(0) }
-#endif  // notification type
-
 // Initializes a notification to no waiters and an initial epoch of 0.
 void iree_notification_initialize(iree_notification_t* out_notification);
 

--- a/runtime/src/iree/base/internal/time.c
+++ b/runtime/src/iree/base/internal/time.c
@@ -15,24 +15,31 @@ int64_t iree_platform_time_now(void) {
 #if defined(IREE_TIME_NOW_FN)
   IREE_TIME_NOW_FN
 #elif defined(IREE_PLATFORM_WINDOWS)
-  // GetSystemTimePreciseAsFileTime requires Windows 8, add a fallback
-  // (such as using std::chrono) if older support is needed.
-  FILETIME system_time;
-  GetSystemTimePreciseAsFileTime(&system_time);
-  const int64_t kUnixEpochStartTicks = 116444736000000000ll;
-  const int64_t kFtToNanoSec = 100;
-  LARGE_INTEGER li;
-  li.LowPart = system_time.dwLowDateTime;
-  li.HighPart = system_time.dwHighDateTime;
-  li.QuadPart -= kUnixEpochStartTicks;
-  li.QuadPart *= kFtToNanoSec;
-  return li.QuadPart;
+  // QueryPerformanceCounter provides a high-resolution monotonic timer.
+  // QPC frequency is fixed at boot and doesn't change.
+  static LARGE_INTEGER frequency = {0};
+  if (frequency.QuadPart == 0) {
+    QueryPerformanceFrequency(&frequency);
+  }
+  LARGE_INTEGER counter;
+  QueryPerformanceCounter(&counter);
+  // Convert to nanoseconds: counter * 1e9 / frequency.
+  // Split into seconds and remainder to avoid overflow without 128-bit math.
+  int64_t seconds = counter.QuadPart / frequency.QuadPart;
+  int64_t remainder = counter.QuadPart % frequency.QuadPart;
+  return seconds * 1000000000ll +
+         (remainder * 1000000000ll) / frequency.QuadPart;
 #elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_APPLE) || \
     defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_EMSCRIPTEN)
+  // CLOCK_MONOTONIC is used across all POSIX platforms for consistency.
+  // CLOCK_MONOTONIC_RAW exists on Linux but can't be used with
+  // pthread_cond_timedwait (only CLOCK_MONOTONIC and CLOCK_REALTIME are
+  // supported). The difference is minimal: RAW excludes NTP rate adjustments
+  // which are typically <0.05%.
   struct timespec clock_time;
-  clock_gettime(CLOCK_REALTIME, &clock_time);
+  clock_gettime(CLOCK_MONOTONIC, &clock_time);
   return clock_time.tv_sec * 1000000000ull + clock_time.tv_nsec;
 #else
-#error "IREE system clock needs to be set up for your platform"
+#error "IREE monotonic clock needs to be set up for your platform"
 #endif  // IREE_PLATFORM_*
 }

--- a/runtime/src/iree/base/internal/time.h
+++ b/runtime/src/iree/base/internal/time.h
@@ -13,7 +13,14 @@
 extern "C" {
 #endif  // __cplusplus
 
-// Implementation for the public iree_time_now() function.
+// Returns monotonically increasing time in nanoseconds.
+// The epoch is arbitrary (typically system boot) and values are only meaningful
+// relative to other timestamps from the same process.
+//
+// Implementations:
+//   POSIX (Linux/Android/Apple/Emscripten): CLOCK_MONOTONIC
+//   Windows: QueryPerformanceCounter
+//
 // Also available to other libraries under base/ to avoid circular dependencies.
 int64_t iree_platform_time_now(void);
 

--- a/runtime/src/iree/base/internal/wait_handle_posix.c
+++ b/runtime/src/iree/base/internal/wait_handle_posix.c
@@ -39,9 +39,7 @@ static iree_status_t iree_wait_primitive_create_eventfd(
 
   return iree_ok_status();
 }
-#endif  // IREE_HAVE_WAIT_TYPE_EVENTFD
-
-#if defined(IREE_HAVE_WAIT_TYPE_PIPE)
+#elif defined(IREE_HAVE_WAIT_TYPE_PIPE)
 static iree_status_t iree_wait_primitive_create_pipe(
     bool initial_state, iree_wait_handle_t* out_handle) {
   memset(out_handle, 0, sizeof(*out_handle));

--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -20,11 +20,7 @@ static inline size_t iree_min_host_size(iree_host_size_t a,
 }
 
 // Here to ensure that we don't pull in locale-specific code:
-static bool iree_isupper(char c) { return (unsigned)c - 'A' < 26; }
-static bool iree_islower(char c) { return (unsigned)c - 'a' < 26; }
-static inline char iree_toupper(char c) {
-  return iree_islower(c) ? (c & 0x5F) : c;
-}
+static inline bool iree_isupper(char c) { return (unsigned)c - 'A' < 26; }
 static inline char iree_tolower(char c) {
   return iree_isupper(c) ? (c | 32) : c;
 }

--- a/runtime/src/iree/base/target_platform.h
+++ b/runtime/src/iree/base/target_platform.h
@@ -43,6 +43,7 @@
 // IREE_PLATFORM_ANDROID
 // IREE_PLATFORM_ANDROID_EMULATOR
 // IREE_PLATFORM_APPLE (IOS | MACOS)
+// IREE_PLATFORM_BSD (FreeBSD | NetBSD | OpenBSD | DragonFlyBSD)
 // IREE_PLATFORM_EMSCRIPTEN
 // IREE_PLATFORM_GENERIC
 // IREE_PLATFORM_IOS
@@ -292,13 +293,24 @@ enum iree_arch_enum_e {
 #endif  // IREE_PLATFORM_WINDOWS
 
 //==============================================================================
+// IREE_PLATFORM_BSD
+// FreeBSD, NetBSD, OpenBSD, DragonFlyBSD.
+// These share the POSIX socket API with Apple-style sockaddr length fields.
+//==============================================================================
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__DragonFly__)
+#define IREE_PLATFORM_BSD 1
+#endif  // BSD variants
+
+//==============================================================================
 // Fallthrough for unsupported platforms
 //==============================================================================
 
-#if !defined(IREE_PLATFORM_ANDROID) && !defined(IREE_PLATFORM_EMSCRIPTEN) && \
-    !defined(IREE_PLATFORM_GENERIC) && !defined(IREE_PLATFORM_IOS) &&        \
-    !defined(IREE_PLATFORM_LINUX) && !defined(IREE_PLATFORM_MACOS) &&        \
-    !defined(IREE_PLATFORM_WINDOWS)
+#if !defined(IREE_PLATFORM_ANDROID) && !defined(IREE_PLATFORM_BSD) &&        \
+    !defined(IREE_PLATFORM_EMSCRIPTEN) && !defined(IREE_PLATFORM_GENERIC) && \
+    !defined(IREE_PLATFORM_IOS) && !defined(IREE_PLATFORM_LINUX) &&          \
+    !defined(IREE_PLATFORM_MACOS) && !defined(IREE_PLATFORM_WINDOWS)
 #error Unknown platform.
 #endif  // all archs
 

--- a/runtime/src/iree/base/time.c
+++ b/runtime/src/iree/base/time.c
@@ -105,7 +105,7 @@ static bool iree_wait_until_impl(iree_time_t deadline_ns) {
       .tv_sec = (time_t)(deadline_ns / 1000000000ull),
       .tv_nsec = (long)(deadline_ns % 1000000000ull),
   };
-  int ret = clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &ts, NULL);
+  int ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, NULL);
   return ret == 0;
 }
 


### PR DESCRIPTION
We were assuming it _was_ monotonic everywhere but it never was. Oops.

ci-extra: all