### PR TITLE
iree-bazel-* improvements for handling multiple targets + options.

### DIFF
--- a/build_tools/bazel/BUILD.bazel
+++ b/build_tools/bazel/BUILD.bazel
@@ -28,3 +28,20 @@ config_setting(
         "iree_is_android": "true",
     },
 )
+
+# OS platform constraints. Used in select() for platform-specific backend
+# selection. bazel_to_cmake maps these to CMAKE_SYSTEM_NAME checks.
+config_setting(
+    name = "iree_is_linux",
+    constraint_values = ["@platforms//os:linux"],
+)
+
+config_setting(
+    name = "iree_is_macos",
+    constraint_values = ["@platforms//os:macos"],
+)
+
+config_setting(
+    name = "iree_is_windows",
+    constraint_values = ["@platforms//os:windows"],
+)

--- a/build_tools/bazel/cc_binary_benchmark.bzl
+++ b/build_tools/bazel/cc_binary_benchmark.bzl
@@ -8,7 +8,7 @@
 
 It's good to test that benchmarks run, but it's really annoying to run a billion
 iterations of them every time you try to run tests. So we create these as
-binaries and then invoke them as tests with `--benchmark_min_time=0`.
+binaries and then invoke them as tests with `--benchmark_min_time=0s`.
 """
 
 load(":native_binary.bzl", "native_test")
@@ -25,13 +25,14 @@ def cc_binary_benchmark(
         testonly = True,
         size = "small",
         timeout = None,
+        args = None,
         **kwargs):
     """Creates a binary and a test for a cc benchmark target.
 
     Arguments passed to the binary target:
       name, srcs, data, deps, copts, defines, linkopts, tags, testonly, **kwargs
     Arguments passed to the test target:
-      {name}_test, tags, size, timeout, **kwargs
+      {name}_test, tags, size, timeout, args (merged with --benchmark_min_time=0s), **kwargs
     """
     native.cc_binary(
         name = name,
@@ -46,12 +47,17 @@ def cc_binary_benchmark(
         **kwargs
     )
 
+    # Merge args: enforced flag first, then user args.
+    test_args = ["--benchmark_min_time=0s"]
+    if args:
+        test_args = test_args + args
+
     native_test(
         name = "{}_test".format(name),
         src = name,
         size = size,
         tags = tags,
         timeout = timeout,
-        args = ["--benchmark_min_time=0"],
+        args = test_args,
         **kwargs
     )

--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -57,16 +57,15 @@ build --flag_alias=iree_enable_runtime_tracing=//runtime/src/iree/base/tracing:t
 #
 # Combines several optimizations for faster local iteration:
 # - Skymeld (merged analysis/execution for faster multi-target builds)
-# - Ramdisk sandbox on Linux (reduces I/O bottleneck with many cores)
 #
-# Note: Disk cache is configured in user.bazelrc (created by iree-bazel-configure).
+# Note: Disk cache and platform-specific settings (e.g., Linux ramdisk sandbox)
+# are configured in user.bazelrc (created by iree-bazel-configure).
 ###############################################################################
 
-build:localdev --experimental_merged_skyframe_analysis_execution
+# Default (allows --config=localdev for consistency).
+query:localdev --output=label
 
-# Linux: use ramdisk for sandbox to reduce I/O with many cores.
-# This is a no-op on other platforms.
-build:localdev --sandbox_base=/dev/shm
+build:localdev --experimental_merged_skyframe_analysis_execution
 
 ###############################################################################
 # Options for "generic_gcc" builds

--- a/build_tools/bin/README.md
+++ b/build_tools/bin/README.md
@@ -65,6 +65,7 @@ iree-bazel-run //tools:iree-compile -- --help
 | `iree-bazel-test` | Run tests |
 | `iree-bazel-run` | Build and run executables from current directory |
 | `iree-bazel-query` | Query the build graph |
+| `iree-bazel-cquery` | Configuration-aware query (resolved select(), actual targets) |
 | `iree-bazel-try` | Compile and run C/C++ snippets without BUILD files |
 | `iree-bazel-fuzz` | Run libFuzzer targets with persistent corpus |
 | `iree-bazel-lib` | Shared library (sourced by other tools) |

--- a/build_tools/bin/iree-bazel-build
+++ b/build_tools/bin/iree-bazel-build
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build IREE targets with Bazel.
 #
-# Usage: iree-bazel-build [options] [target] [bazel-args...]
+# Usage: iree-bazel-build [options] [targets...] [bazel-args...]
 #
 # Examples:
 #   iree-bazel-build                      # Build all tools
@@ -23,7 +23,7 @@ show_help() {
 iree-bazel-build - Build IREE with Bazel
 
 USAGE
-    iree-bazel-build [options] [target] [bazel-args...]
+    iree-bazel-build [options] [targets...] [bazel-args...]
 
 OPTIONS
     -n, --dry_run    Show the bazel command without executing
@@ -35,7 +35,7 @@ OPTIONS
     NOTE: Short flags can be combined: -nv is equivalent to -n -v
 
 ARGUMENTS
-    target       Bazel target (required)
+    targets      One or more Bazel targets (at least one required)
     bazel-args   Additional arguments passed to bazel build
 
 EXAMPLES
@@ -86,7 +86,7 @@ EOF
 # Parse arguments.
 KEEP_GOING=0
 WATCH_MODE=0
-TARGET=""
+TARGETS=()
 BAZEL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -120,11 +120,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         *)
-            if [[ -z "${TARGET}" ]]; then
-                TARGET="${1}"
-            else
-                BAZEL_ARGS+=("${1}")
-            fi
+            TARGETS+=("${1}")
             shift
             ;;
     esac
@@ -133,8 +129,8 @@ done
 # Set up worktree (after arg parsing so --help works anywhere).
 iree_setup_worktree
 
-# Target is required.
-if [[ -z "${TARGET}" ]]; then
+# At least one target is required.
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
     iree_error "Target is required for bazel build"
     echo ""
     echo "Examples:"
@@ -152,7 +148,7 @@ CMD=("${BAZEL_BIN}" build "${IREE_BAZEL_DEFAULT_CONFIGS[@]}")
 if [[ "${KEEP_GOING}" == "1" ]]; then
     CMD+=(--keep_going)
 fi
-CMD+=("${TARGET}" "${BAZEL_ARGS[@]}")
+CMD+=("${TARGETS[@]}" "${BAZEL_ARGS[@]}")
 
 # Execute or show.
 if iree_is_verbose || iree_is_dry_run; then
@@ -163,5 +159,5 @@ if iree_is_dry_run; then
     exit 0
 fi
 
-iree_info "Building ${TARGET}"
+iree_info "Building ${TARGETS[*]}"
 exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-configure
+++ b/build_tools/bin/iree-bazel-configure
@@ -113,9 +113,10 @@ if [[ ! -f "user.bazelrc" ]]; then
 build --disk_cache=${CACHE_DIR}
 
 # Garbage collect disk cache to prevent unbounded growth.
-# Max size 50GB, GC runs when Bazel is idle for 5s.
-build --experimental_disk_cache_gc_max_size=50G
-build --experimental_disk_cache_gc_idle_delay=5s
+# Max size 50GB, GC runs when Bazel is idle for some time.
+# TODO(benvanik): disabled until we upgrade bazel version.
+#build --experimental_disk_cache_gc_max_size=50G
+#build --experimental_disk_cache_gc_idle_delay=120s
 
 # Debug config: no optimizations, with assertions.
 build:debug --config=asserts --compilation_mode=opt '--per_file_copt=iree|llvm@-O0' --strip=never
@@ -123,6 +124,17 @@ build:debug --config=asserts --compilation_mode=opt '--per_file_copt=iree|llvm@-
 # Enable assertions (optimized but with runtime checks).
 build:asserts --compilation_mode=opt '--copt=-UNDEBUG'
 EOF
+
+    # Add Linux-specific sandbox optimization.
+    if [[ -d "/dev/shm" ]]; then
+        cat >> user.bazelrc << 'EOF'
+
+# Linux: use ramdisk for sandbox to reduce I/O with many cores.
+build --sandbox_base=/dev/shm
+EOF
+        iree_info "Added /dev/shm sandbox optimization (Linux)"
+    fi
+
     iree_info "Created user.bazelrc with recommended settings"
 else
     iree_info "user.bazelrc already exists, skipping"

--- a/build_tools/bin/iree-bazel-cquery
+++ b/build_tools/bin/iree-bazel-cquery
@@ -1,29 +1,29 @@
 #!/bin/bash
-# Query IREE build graph with Bazel.
+# Configuration-aware query of IREE build graph with Bazel cquery.
 #
-# Usage: iree-bazel-query [options] <query> [bazel-args...]
+# Usage: iree-bazel-cquery [options] <query> [bazel-args...]
 #
 # Examples:
-#   iree-bazel-query 'deps(//tools:iree-compile)'
-#   iree-bazel-query 'rdeps(//..., //runtime/src/iree/base:base)'
-#   iree-bazel-query 'kind(cc_library, //runtime/...)'
+#   iree-bazel-cquery 'deps(//tools:iree-compile)'
+#   iree-bazel-cquery --output=files //tools:iree-compile
+#   iree-bazel-cquery 'kind(cc_library, //runtime/...)'
 
 set -e
 
 # Source shared library.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/iree-bazel-lib"
-iree_bazel_init "iree-bazel-query"
+iree_bazel_init "iree-bazel-cquery"
 
 # Expand combined short flags (e.g., -nv -> -n -v).
 eval "set -- $(iree_expand_combined_flags "$@")"
 
 show_help() {
     cat << 'EOF'
-iree-bazel-query - Query IREE build graph with Bazel
+iree-bazel-cquery - Configuration-aware query of IREE build graph
 
 USAGE
-    iree-bazel-query [options] <query> [bazel-args...]
+    iree-bazel-cquery [options] <query> [bazel-args...]
 
 OPTIONS
     -n, --dry_run    Show the bazel command without executing
@@ -34,26 +34,28 @@ OPTIONS
 
 ARGUMENTS
     query          Bazel query expression (required)
-    bazel-args     Additional arguments passed to bazel query
+    bazel-args     Additional arguments passed to bazel cquery
 
 DESCRIPTION
-    Queries the IREE build graph before configuration. Use this for:
+    Unlike iree-bazel-query, cquery evaluates the build graph after
+    configuration resolution. This means:
 
-    - Finding all targets matching a pattern
-    - Exploring the dependency structure
-    - Fast queries that don't need build configuration
-
-    For configuration-aware queries (resolved select(), actual build
-    targets), use iree-bazel-cquery instead.
+    - Results reflect actual build configuration (select() resolved)
+    - Only targets that would actually be built are shown
+    - Output paths include configuration-specific directory names
+    - Useful for understanding what will actually be compiled
 
 EXAMPLES
-    iree-bazel-query //tools:iree-compile           # Show target
-    iree-bazel-query '//tools/...'                  # List all tools
-    iree-bazel-query 'deps(//tools:iree-compile)'   # Show dependencies
-    iree-bazel-query 'rdeps(//..., //runtime/src/iree/base:base)'
-    iree-bazel-query 'kind(cc_library, //runtime/...)'
-    iree-bazel-query 'somepath(//tools:iree-compile, //runtime/src/iree/vm:vm)'
-    iree-bazel-query -n 'deps(//tools:iree-compile)'  # Show command only
+    iree-bazel-cquery //tools:iree-compile           # Show configured target
+    iree-bazel-cquery 'deps(//tools:iree-compile)'   # Configured dependencies
+    iree-bazel-cquery 'kind(cc_library, //runtime/...)'
+    iree-bazel-cquery -n 'deps(//tools:iree-compile)'  # Show command only
+
+    # Show output files for a target
+    iree-bazel-cquery --output=files //tools:iree-compile
+
+    # Analyze configuration transitions
+    iree-bazel-cquery 'deps(//tools:iree-compile)' --transitions=full
 
 COMMON QUERY FUNCTIONS
     deps(target)           All dependencies of target
@@ -61,18 +63,17 @@ COMMON QUERY FUNCTIONS
     kind(rule, pattern)    Targets of specific rule type
     somepath(from, to)     Path between two targets
     allpaths(from, to)     All paths between targets
-    attr(name, pattern, targets)  Targets with matching attribute
+    config(target, config) Target in specific configuration
 
 OUTPUT OPTIONS
     --output=label         Target labels only (default)
-    --output=package       Package names only
-    --output=build         BUILD file contents
-    --output=graph         Graphviz DOT format
-    --noimplicit_deps      Exclude implicit dependencies
+    --output=files         Output file paths
+    --output=starlark      Custom output via Starlark
+    --transitions=full     Show configuration transitions
 
 SEE ALSO
-    iree-bazel-cquery, iree-bazel-build, iree-bazel-test, iree-bazel-run
-    https://bazel.build/query/guide
+    iree-bazel-query, iree-bazel-build, iree-bazel-test, iree-bazel-run
+    https://bazel.build/query/cquery
 EOF
 }
 
@@ -127,7 +128,7 @@ iree_setup_worktree
 # Build the command with default configs (affects select() in build graph).
 iree_bazel_build_default_configs
 BAZEL_BIN=$(iree_get_bazel_command)
-CMD=("${BAZEL_BIN}" query "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${QUERY}" "${BAZEL_ARGS[@]}")
+CMD=("${BAZEL_BIN}" cquery "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${QUERY}" "${BAZEL_ARGS[@]}")
 
 # Execute or show.
 if iree_is_verbose || iree_is_dry_run; then

--- a/build_tools/bin/iree-bazel-fuzz
+++ b/build_tools/bin/iree-bazel-fuzz
@@ -59,6 +59,12 @@ EXAMPLES
     # Just update dictionary from existing corpus
     iree-bazel-fuzz -d //path/to:target
 
+    # Overnight fuzzing: all fuzz targets under a path (Ctrl+C to stop)
+    iree-bazel-fuzz //runtime/src/iree/tokenizer2/... -- -jobs=128
+
+    # Time-limited multi-target fuzzing
+    iree-bazel-fuzz //runtime/... -- -jobs=64 -max_total_time=3600
+
 CORPUS & DICTIONARY
     Corpus:    ~/.cache/iree-fuzz-cache/<relative-path>/<target>/corpus/
     Artifacts: ~/.cache/iree-fuzz-cache/<relative-path>/<target>/artifacts/
@@ -225,7 +231,8 @@ minimize_corpus() {
     if "${binary}" -set_cover_merge=1 "${temp_corpus}" "${corpus_dir}" 2>/dev/null; then
         local new_count
         new_count=$(ls -1 "${temp_corpus}" | wc -l)
-        rm -rf "${corpus_dir}"/*
+        # Use find -delete to avoid "argument list too long" with large corpora.
+        find "${corpus_dir}" -mindepth 1 -delete
         mv "${temp_corpus}"/* "${corpus_dir}"/ 2>/dev/null || true
         iree_info "Corpus minimized: ${corpus_count} -> ${new_count} files"
     else
@@ -300,6 +307,130 @@ fi
 
 # Set up worktree.
 iree_setup_worktree
+
+#===----------------------------------------------------------------------===#
+# Multi-target pattern support (e.g., //path/to/...)
+#===----------------------------------------------------------------------===#
+
+if [[ "${TARGET}" == *"..."* ]]; then
+    # Expand pattern to all fuzz targets.
+    BAZEL_BIN=$(iree_get_bazel_command)
+
+    iree_info "Discovering fuzz targets matching: ${TARGET}"
+
+    # Query for all targets ending in _fuzz under the pattern.
+    FUZZ_TARGETS=()
+    while IFS= read -r target; do
+        if [[ "${target}" == *"_fuzz" ]]; then
+            FUZZ_TARGETS+=("${target}")
+        fi
+    done < <("${BAZEL_BIN}" query "${TARGET}" 2>/dev/null | sort)
+
+    if [[ ${#FUZZ_TARGETS[@]} -eq 0 ]]; then
+        iree_error "No fuzz targets found matching: ${TARGET}"
+        exit 1
+    fi
+
+    iree_info "Found ${#FUZZ_TARGETS[@]} fuzz targets"
+
+    # Dry-run: just list targets.
+    if iree_is_dry_run; then
+        iree_info "Would run these fuzz targets:"
+        for target in "${FUZZ_TARGETS[@]}"; do
+            echo "  ${target}"
+        done
+        iree_info "Fuzzer args: ${FUZZER_ARGS[*]:-<none>}"
+        exit 0
+    fi
+
+    # Build all targets first.
+    iree_info "Building all fuzz targets..."
+    iree_bazel_build_default_configs
+    BUILD_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "--config=fuzzer" "${BAZEL_ARGS[@]}")
+
+    if ! iree_bazel_build_quiet "${TARGET}" "${BUILD_ARGS[@]}"; then
+        iree_error "Build failed"
+        exit 1
+    fi
+
+    # Track results using indexed arrays (bash 3 compatible).
+    declare -a FUZZ_PIDS=()
+    declare -a FUZZ_TARGETS_RUNNING=()
+    CRASHED_TARGETS=()
+    CLEAN_TARGETS=()
+
+    # Trap Ctrl+C to stop all fuzzers gracefully.
+    cleanup_multi() {
+        echo ""
+        iree_info "Stopping all fuzzers..."
+        for pid in "${FUZZ_PIDS[@]}"; do
+            kill -INT "${pid}" 2>/dev/null || true
+        done
+        wait 2>/dev/null || true
+
+        echo ""
+        iree_info "=== Fuzzing Summary ==="
+        iree_info "Total targets: ${#FUZZ_TARGETS[@]}"
+        if [[ ${#CRASHED_TARGETS[@]} -gt 0 ]]; then
+            iree_warn "Crashed (${#CRASHED_TARGETS[@]}):"
+            for t in "${CRASHED_TARGETS[@]}"; do
+                echo "  - ${t}"
+            done
+        fi
+        if [[ ${#CLEAN_TARGETS[@]} -gt 0 ]]; then
+            iree_info "Clean (${#CLEAN_TARGETS[@]}): ${#CLEAN_TARGETS[@]} targets"
+        fi
+
+        exit 0
+    }
+    trap cleanup_multi INT TERM
+
+    # Build forwarded options for child processes.
+    declare -a FORWARD_ARGS=()
+    [[ "${FUZZ_MINIMIZE}" == "1" ]] && FORWARD_ARGS+=("-m")
+    [[ "${FUZZ_DICT_ONLY}" == "1" ]] && FORWARD_ARGS+=("-d")
+    [[ "${IREE_BAZEL_VERBOSE}" == "1" ]] && FORWARD_ARGS+=("-v")
+    FORWARD_ARGS+=("${BAZEL_ARGS[@]}")
+
+    # Run all fuzzers. They each manage their own corpus/artifacts.
+    iree_info "Starting ${#FUZZ_TARGETS[@]} fuzzers..."
+    echo ""
+
+    for target in "${FUZZ_TARGETS[@]}"; do
+        # Spawn fuzzer in subshell that ignores SIGINT (parent handles cleanup).
+        (
+            trap '' INT
+            exec "${SCRIPT_DIR}/iree-bazel-fuzz" "${FORWARD_ARGS[@]}" "${target}" -- "${FUZZER_ARGS[@]}"
+        ) &
+        FUZZ_PIDS+=($!)
+        FUZZ_TARGETS_RUNNING+=("${target}")
+    done
+
+    # Wait for all fuzzers and collect results.
+    for i in "${!FUZZ_PIDS[@]}"; do
+        local pid="${FUZZ_PIDS[$i]}"
+        local target="${FUZZ_TARGETS_RUNNING[$i]}"
+        if wait "${pid}"; then
+            CLEAN_TARGETS+=("${target}")
+        else
+            CRASHED_TARGETS+=("${target}")
+        fi
+    done
+
+    # Final summary.
+    echo ""
+    iree_info "=== Fuzzing Complete ==="
+    iree_info "Total targets: ${#FUZZ_TARGETS[@]}"
+    if [[ ${#CRASHED_TARGETS[@]} -gt 0 ]]; then
+        iree_warn "Crashed (${#CRASHED_TARGETS[@]}):"
+        for t in "${CRASHED_TARGETS[@]}"; do
+            echo "  - ${t}"
+        done
+    fi
+    iree_info "Clean: ${#CLEAN_TARGETS[@]} targets"
+
+    exit 0
+fi
 
 # Extract target info for directory structure.
 TARGET_NAME=$(get_target_name "${TARGET}")

--- a/build_tools/bin/iree-bazel-lib
+++ b/build_tools/bin/iree-bazel-lib
@@ -22,6 +22,11 @@ _IREE_BAZEL_COLOR_NC='\033[0m'
 # Tool name for logging (set via iree_bazel_init).
 _IREE_BAZEL_TOOL_NAME=""
 
+# Bazel startup args for info/cquery (e.g., --output_base).
+# Tools can set via iree_bazel_set_startup_args.
+declare -a IREE_BAZEL_STARTUP_ARGS=()
+IREE_BAZEL_EXECROOT=""
+
 # -----------------------------------------------------------------------------
 # Logging functions
 # -----------------------------------------------------------------------------
@@ -71,7 +76,7 @@ configuration, provide better defaults, and work from any subdirectory.
 - `iree-bazel-run <target> [bazel-args] [-- program-args]` - Build and run binary
 - `iree-bazel-try [options] -e 'code' [-- program-args]` - Quick C/C++ experiments
 
-**Additional tools:** `iree-bazel-query`, `iree-bazel-fuzz` (see `--help`)
+**Additional tools:** `iree-bazel-query`, `iree-bazel-cquery`, `iree-bazel-fuzz` (see `--help`)
 
 **Examples:**
 ```shell
@@ -158,6 +163,12 @@ iree_bazel_init() {
     IREE_BAZEL_ORIG_CWD="${PWD}"
     IREE_BAZEL_DRY_RUN="${IREE_BAZEL_DRY_RUN:-0}"
     IREE_BAZEL_VERBOSE="${IREE_BAZEL_VERBOSE:-0}"
+}
+
+# Set startup args for bazel info/cquery and clear cached execroot.
+iree_bazel_set_startup_args() {
+    IREE_BAZEL_STARTUP_ARGS=("$@")
+    IREE_BAZEL_EXECROOT=""
 }
 
 # Set up the worktree environment.
@@ -257,10 +268,12 @@ iree_bazel_build_default_configs() {
     fi
 
     # Use mold linker if available (significantly faster than ld/gold).
-    if command -v mold &>/dev/null; then
-        IREE_BAZEL_DEFAULT_CONFIGS+=(--config=mold)
-        iree_debug "Using mold linker"
-    fi
+    # TODO(benvanik): this breaks --features=thin_lto, so leaving it opt-in for
+    #                 now (--config=mold) until I can find a good way to choose.
+    # if command -v mold &>/dev/null; then
+    #     IREE_BAZEL_DEFAULT_CONFIGS+=(--config=mold)
+    #     iree_debug "Using mold linker"
+    # fi
 
     # TODO: Auto-detect available hardware/SDKs.
     # if [[ -n "${HIP_PATH:-}" ]]; then
@@ -277,6 +290,27 @@ iree_bazel_build_default_configs() {
 # Build and execution
 # -----------------------------------------------------------------------------
 
+# Get execroot for the current Bazel server (cached).
+# Must be called from the worktree root directory.
+iree_bazel_get_execroot() {
+    if [[ -n "${IREE_BAZEL_EXECROOT}" ]]; then
+        echo "${IREE_BAZEL_EXECROOT}"
+        return 0
+    fi
+    local BAZEL_BIN
+    BAZEL_BIN=$(iree_get_bazel_command)
+    local info_output execroot
+    info_output=$("${BAZEL_BIN}" "${IREE_BAZEL_STARTUP_ARGS[@]}" info execution_root 2>/dev/null || true)
+    execroot=$(echo "${info_output}" | sed -n 's/^execution_root: //p')
+    if [[ -z "${execroot}" ]]; then
+        execroot="${info_output}"
+    fi
+    if [[ -n "${execroot}" ]]; then
+        IREE_BAZEL_EXECROOT="${execroot}"
+        echo "${IREE_BAZEL_EXECROOT}"
+    fi
+}
+
 # Get the output file path for a bazel target.
 # Must be called from the worktree root directory.
 # Args:
@@ -288,12 +322,18 @@ iree_bazel_get_binary_path() {
     shift
     local BAZEL_BIN
     BAZEL_BIN=$(iree_get_bazel_command)
-    local relative_path
+    local relative_paths relative_path execroot
     # Pass all bazel args to cquery so it uses the same configuration as build.
-    relative_path=$("${BAZEL_BIN}" cquery --output=files "${target}" "$@" 2>/dev/null)
-    # Convert to absolute path (bazel returns paths relative to workspace).
+    relative_paths=$("${BAZEL_BIN}" "${IREE_BAZEL_STARTUP_ARGS[@]}" cquery --output=files "${target}" "$@" 2>/dev/null)
+    relative_path="${relative_paths%%$'\n'*}"
     if [[ -n "${relative_path}" ]]; then
-        echo "${PWD}/${relative_path}"
+        execroot=$(iree_bazel_get_execroot)
+        if [[ -n "${execroot}" ]]; then
+            echo "${execroot}/${relative_path}"
+        else
+            # Fallback to workspace-relative path if execroot is unavailable.
+            echo "${PWD}/${relative_path}"
+        fi
     fi
 }
 
@@ -409,6 +449,12 @@ iree_bazel_build_quiet() {
     trap "rm -f '${log_file}'" RETURN
 
     if "${BAZEL_BIN}" build --color=yes "${target}" "$@" >"${log_file}" 2>&1; then
+        # Check for warnings in log and report count.
+        local warning_count
+        warning_count=$(grep -c -E '(warning:|WARNING:)' "${log_file}" 2>/dev/null || echo 0)
+        if [[ "${warning_count}" -gt 0 ]]; then
+            iree_warn "Build succeeded with ${warning_count} warning(s) (use -v to see)"
+        fi
         return 0
     else
         local exit_code=$?

--- a/build_tools/bin/iree-bazel-run
+++ b/build_tools/bin/iree-bazel-run
@@ -70,7 +70,7 @@ CONFIGURATIONS
     --config=tsan            Thread Sanitizer
 
 SEE ALSO
-    iree-bazel-build, iree-bazel-test, iree-bazel-query
+    iree-bazel-build, iree-bazel-test, iree-bazel-query, iree-bazel-cquery
 EOF
 }
 

--- a/build_tools/bin/iree-bazel-test
+++ b/build_tools/bin/iree-bazel-test
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run IREE tests with Bazel.
 #
-# Usage: iree-bazel-test [options] [target] [bazel-args...]
+# Usage: iree-bazel-test [options] [targets...] [bazel-args...]
 #
 # Examples:
 #   iree-bazel-test                       # Run all tests (CPU only)
@@ -23,7 +23,7 @@ show_help() {
 iree-bazel-test - Run IREE tests with Bazel
 
 USAGE
-    iree-bazel-test [options] [target] [bazel-args...]
+    iree-bazel-test [options] [targets...] [bazel-args...]
 
 OPTIONS
     -n, --dry_run    Show the bazel command without executing
@@ -35,7 +35,7 @@ OPTIONS
     NOTE: --keep_going is always enabled for test runs.
 
 ARGUMENTS
-    target       Bazel target (required)
+    targets      One or more Bazel targets (at least one required)
     bazel-args   Additional arguments passed to bazel test
 
 EXAMPLES
@@ -44,6 +44,9 @@ EXAMPLES
 
     # Test a specific test target
     iree-bazel-test //runtime/src/iree/base:status_test
+
+    # Test multiple targets at once
+    iree-bazel-test //runtime/src/iree/tokenizer2/... //tools/test:iree-tokenize.txt
 
     # Test all tools
     iree-bazel-test //tools/...
@@ -86,7 +89,7 @@ EOF
 
 # Parse arguments.
 WATCH_MODE=0
-TARGET=""
+TARGETS=()
 BAZEL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -116,11 +119,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         *)
-            if [[ -z "${TARGET}" ]]; then
-                TARGET="${1}"
-            else
-                BAZEL_ARGS+=("${1}")
-            fi
+            TARGETS+=("${1}")
             shift
             ;;
     esac
@@ -129,8 +128,8 @@ done
 # Set up worktree (after arg parsing so --help works anywhere).
 iree_setup_worktree
 
-# Target is required.
-if [[ -z "${TARGET}" ]]; then
+# At least one target is required.
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
     iree_error "Target is required for bazel test"
     echo ""
     echo "Examples:"
@@ -150,9 +149,10 @@ BUILD_FILTERS=""
 # Build the command with default configs before user args.
 iree_bazel_build_default_configs
 BAZEL_BIN=$(iree_get_bazel_command "${WATCH_MODE}")
-CMD=("${BAZEL_BIN}" test "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" --keep_going "${TARGET}"
+CMD=("${BAZEL_BIN}" test "${IREE_BAZEL_DEFAULT_CONFIGS[@]}" --keep_going
     --test_tag_filters="${TAG_FILTERS}"
     --build_tag_filters="${BUILD_FILTERS}"
+    "${TARGETS[@]}"
     "${BAZEL_ARGS[@]}")
 
 # Execute or show.
@@ -164,6 +164,6 @@ if iree_is_dry_run; then
     exit 0
 fi
 
-iree_info "Testing ${TARGET}"
+iree_info "Testing ${TARGETS[*]}"
 iree_info "Tag filters: ${TAG_FILTERS}"
 exec "${CMD[@]}"

--- a/build_tools/bin/iree-bazel-try
+++ b/build_tools/bin/iree-bazel-try
@@ -47,8 +47,9 @@ LANGUAGE
 
 COMPILATION
     --config=NAME         Bazel config (debug, asan, msan, tsan)
-    --copt=FLAG           Add compiler flag (repeatable)
-    --linkopt=FLAG        Add linker flag (repeatable)
+    --features=NAME       Bazel feature (thin_lto, etc; repeatable)
+    --copt=FLAG           Compiler flag for all targets (repeatable)
+    --linkopt=FLAG        Linker flag for all targets (repeatable)
     --dep=LABEL           Add explicit Bazel dependency (repeatable)
     --no_infer            Disable automatic dependency inference
     --retry=N             Max build retries for dep fixing (default: 3)
@@ -114,7 +115,7 @@ EXAMPLE: Pass arguments to program
       for (int i = 0; i < argc; i++) printf("%d: %s\n", i, argv[i]);
       return 0;
     }' -- --flag value
-    0: bazel-bin/.iree-bazel-try/.../snippet
+    0: /path/to/.../snippet
     1: --flag
     2: value
 
@@ -256,16 +257,54 @@ EOF
 # Maximum number of cache slots to keep (LRU eviction beyond this).
 MAX_CACHE_SLOTS=8
 
+# Portable hash command: use md5sum on Linux, md5 on macOS/BSD.
+_portable_hash() {
+    if command -v md5sum &>/dev/null; then
+        md5sum | cut -c1-12
+    else
+        md5 -r | cut -c1-12
+    fi
+}
+
+# Portable file locking using mkdir (atomic on all POSIX systems).
+# flock is Linux-specific; mkdir-based locking works everywhere.
+_acquire_lock() {
+    local lock_dir="${1}.d"
+    local timeout="${2:-60}"
+    local waited=0
+    while ! mkdir "${lock_dir}" 2>/dev/null; do
+        sleep 1
+        waited=$((waited + 1))
+        if [[ "${waited}" -ge "${timeout}" ]]; then
+            return 1
+        fi
+    done
+    # Store PID for debugging.
+    echo $$ > "${lock_dir}/pid"
+    return 0
+}
+
+_release_lock() {
+    local lock_dir="${1}.d"
+    rm -rf "${lock_dir}"
+}
+
 # Compute a hash for cache slot naming based on deps-affecting inputs.
-# Hash is based on #includes + explicit deps + build options + language (NOT source content).
+# Hash is based on #includes + explicit deps + build options + language.
+# File inputs also include content hash to avoid stale builds.
 # This allows multiple runs with same deps config to share the cached BUILD.bazel.
-# Args: source_files array (via nameref), extra_deps array, copts array, linkopts array, language
+# Different build flags (copts, linkopts, features) get separate cache slots so Bazel's
+# action cache doesn't thrash when alternating between flag combinations.
+# Args: source_files array, extra_deps array, copts array, linkopts array, language,
+#       bazel_user_flags array, include_contents(0/1)
 compute_cache_hash() {
     local -n _source_files=${1}
     local -n _extra_deps=${2}
     local -n _copts=${3}
     local -n _linkopts=${4}
     local _language=${5:-c}
+    local -n _bazel_user_flags=${6}
+    local _include_contents=${7:-0}
     {
         # Hash language (determines file extension and compilation mode).
         printf 'language:%s\n' "${_language}"
@@ -279,12 +318,22 @@ compute_cache_hash() {
         # Hash explicit deps (user-provided --dep flags).
         printf 'extra_deps:\n'
         printf '%s\n' "${_extra_deps[@]}" | sort -u
-        # Hash build options that affect BUILD.bazel.
+        # Hash build flags that affect compilation output.
         printf 'copts:\n'
         printf '%s\n' "${_copts[@]}" | sort -u
         printf 'linkopts:\n'
         printf '%s\n' "${_linkopts[@]}" | sort -u
-    } | md5sum | cut -c1-12
+        printf 'bazel_flags:\n'
+        printf '%s\n' "${_bazel_user_flags[@]}" | sort -u
+        if [[ "${_include_contents}" == "1" ]]; then
+            printf 'contents:\n'
+            for src in "${_source_files[@]}"; do
+                if [[ -f "${src}" ]]; then
+                    printf '%s:%s\n' "$(basename "${src}")" "$(cat "${src}" | _portable_hash)"
+                fi
+            done | sort -u
+        fi
+    } | _portable_hash
 }
 
 # Ensure cache doesn't exceed MAX_CACHE_SLOTS by evicting oldest slots.
@@ -364,7 +413,7 @@ infer_deps_from_sources() {
         pattern=$(printf '%s\n' "${runtime_patterns[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
             [[ -n "${dep}" ]] && all_deps+=("${dep}")
-        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', //runtime/src/iree/...)" 2>/dev/null)
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', //runtime/src/iree/...)" 2>/dev/null 9>&-)
     fi
 
     if [[ ${#compiler_patterns[@]} -gt 0 ]]; then
@@ -373,7 +422,7 @@ infer_deps_from_sources() {
         pattern=$(printf '%s\n' "${compiler_patterns[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
             [[ -n "${dep}" ]] && all_deps+=("${dep}")
-        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', //compiler/src/iree/compiler/...)" 2>/dev/null)
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', //compiler/src/iree/compiler/...)" 2>/dev/null 9>&-)
     fi
 
     if [[ ${#llvm_files[@]} -gt 0 ]]; then
@@ -382,7 +431,7 @@ infer_deps_from_sources() {
         pattern=$(printf '%s\n' "${llvm_files[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
             [[ -n "${dep}" ]] && all_deps+=("${dep}")
-        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', @llvm-project//llvm/...)" 2>/dev/null)
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', @llvm-project//llvm/...)" 2>/dev/null 9>&-)
     fi
 
     if [[ ${#mlir_files[@]} -gt 0 ]]; then
@@ -391,7 +440,7 @@ infer_deps_from_sources() {
         pattern=$(printf '%s\n' "${mlir_files[@]}" | sed 's/\./\\./g' | sort -u | paste -sd'|' -)
         while IFS= read -r dep; do
             [[ -n "${dep}" ]] && all_deps+=("${dep}")
-        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', @llvm-project//mlir/...)" 2>/dev/null)
+        done < <("${BAZEL_BIN}" query "attr(hdrs, '(${pattern})', @llvm-project//mlir/...)" 2>/dev/null 9>&-)
     fi
 
     # Output unique deps.
@@ -471,6 +520,7 @@ declare -a EXTRA_DEPS=()
 declare -a COPTS=()
 declare -a LINKOPTS=()
 declare -a BAZEL_ARGS=()
+declare -a BAZEL_USER_FLAGS=()
 declare -a PROGRAM_ARGS=()
 
 # Parse arguments.
@@ -563,8 +613,14 @@ while [[ $# -gt 0 ]]; do
             LINKOPTS+=("${1#--linkopt=}")
             shift
             ;;
-        --config=*)
+        --features)
+            BAZEL_ARGS+=("--features=${2}")
+            BAZEL_USER_FLAGS+=("--features=${2}")
+            shift 2
+            ;;
+        --config=*|--features=*)
             BAZEL_ARGS+=("${1}")
+            BAZEL_USER_FLAGS+=("${1}")
             shift
             ;;
         --)
@@ -592,6 +648,45 @@ iree_ensure_configured
 iree_bazel_build_default_configs
 BAZEL_ARGS=("${IREE_BAZEL_DEFAULT_CONFIGS[@]}" "${BAZEL_ARGS[@]}")
 
+# Propagate copts and linkopts to bazel command line so they apply to all
+# transitive dependencies, not just the snippet target.
+for opt in "${COPTS[@]}"; do
+    BAZEL_ARGS+=("--copt=${opt}")
+done
+for opt in "${LINKOPTS[@]}"; do
+    BAZEL_ARGS+=("--linkopt=${opt}")
+done
+
+# Auto-fix ThinLTO backend compile issue: Bazel passes linker flags to the
+# compiler during LTO backend compile, causing -Werror to fire on unused
+# linker arguments. Suppress this automatically.
+declare -a BAZEL_STARTUP_ARGS=()
+HAS_CUSTOM_FLAGS=0
+for flag in "${BAZEL_USER_FLAGS[@]}"; do
+    if [[ "${flag}" == "--features=thin_lto" ]]; then
+        BAZEL_ARGS+=("--copt=-Wno-unused-command-line-argument")
+        break
+    fi
+done
+if [[ ${#COPTS[@]} -gt 0 || ${#LINKOPTS[@]} -gt 0 || ${#BAZEL_USER_FLAGS[@]} -gt 0 ]]; then
+    HAS_CUSTOM_FLAGS=1
+fi
+
+# Use a separate output_base when custom flags are present to avoid polluting
+# the main Bazel server's analysis cache. This ensures that running
+# iree-bazel-try with --copt/--features doesn't cause config invalidation
+# for subsequent iree-bazel-build/test/run invocations.
+# Also redirect workspace symlinks to avoid overwriting the main bazel-bin.
+if [[ "${HAS_CUSTOM_FLAGS}" == "1" ]]; then
+    BAZEL_TRY_OUTPUT_BASE="${IREE_BAZEL_WORKTREE_DIR}/.iree-bazel-try/output_base"
+    mkdir -p "${BAZEL_TRY_OUTPUT_BASE}"
+    BAZEL_STARTUP_ARGS+=("--output_base=${BAZEL_TRY_OUTPUT_BASE}")
+    BAZEL_ARGS+=("--symlink_prefix=${IREE_BAZEL_WORKTREE_DIR}/.iree-bazel-try/bazel-")
+    iree_debug "Using separate output_base for custom flags: ${BAZEL_TRY_OUTPUT_BASE}"
+fi
+# Ensure helper functions use the same Bazel startup args (output_base, etc.).
+iree_bazel_set_startup_args "${BAZEL_STARTUP_ARGS[@]}"
+
 # Determine input source.
 HAS_STDIN=0
 if [[ -z "${INLINE_CODE}" ]] && [[ ${#SOURCE_FILES[@]} -eq 0 ]]; then
@@ -613,16 +708,18 @@ STAGING_DIR="${TRY_BASE}/staging_$$"
 mkdir -p "${STAGING_DIR}"
 
 # Cleanup staging on exit (cache slots are kept).
+# Note: trap is set later, after lock acquisition, to include lock release.
 cleanup_staging() {
     if [[ -n "${STAGING_DIR}" ]] && [[ -d "${STAGING_DIR}" ]]; then
         rm -rf "${STAGING_DIR}"
     fi
 }
-trap cleanup_staging EXIT
 
 # Collect source files in staging directory.
 declare -a BUILD_SRCS=()
 declare -a STAGED_SOURCE_PATHS=()
+declare -a HASH_SOURCE_PATHS=()
+HAS_FILE_INPUT=0
 
 # Read stdin into variable if needed (so we can scan it for auto-detection).
 STDIN_CONTENT=""
@@ -653,6 +750,7 @@ if [[ -n "${INLINE_CODE}" ]]; then
     printf '%s' "${INLINE_CODE}" > "${INLINE_FILE}"
     BUILD_SRCS+=("$(basename "${INLINE_FILE}")")
     STAGED_SOURCE_PATHS+=("${INLINE_FILE}")
+    HASH_SOURCE_PATHS+=("${INLINE_FILE}")
     iree_debug "Wrote inline code to ${INLINE_FILE}"
 fi
 
@@ -666,20 +764,30 @@ if [[ -n "${STDIN_CONTENT}" ]]; then
     printf '%s' "${STDIN_CONTENT}" > "${STDIN_FILE}"
     BUILD_SRCS+=("$(basename "${STDIN_FILE}")")
     STAGED_SOURCE_PATHS+=("${STDIN_FILE}")
+    HASH_SOURCE_PATHS+=("${STDIN_FILE}")
     iree_debug "Wrote stdin to ${STDIN_FILE}"
 fi
 
-# Handle source files.
+if [[ ${#SOURCE_FILES[@]} -gt 0 ]]; then
+    HAS_FILE_INPUT=1
+fi
 for src in "${SOURCE_FILES[@]}"; do
     if [[ ! -f "${src}" ]]; then
         iree_error "Source file not found: ${src}"
         exit 1
     fi
-    # Copy to staging dir.
-    cp "${src}" "${STAGING_DIR}/"
+    # Copy to staging dir with #line for accurate diagnostics.
+    staged_path="${STAGING_DIR}/$(basename "${src}")"
+    escaped_src="${src//\\/\\\\}"
+    escaped_src="${escaped_src//\"/\\\"}"
+    {
+        printf '#line 1 "%s"\n' "${escaped_src}"
+        cat "${src}"
+    } > "${staged_path}"
     BUILD_SRCS+=("$(basename "${src}")")
-    STAGED_SOURCE_PATHS+=("${STAGING_DIR}/$(basename "${src}")")
-    iree_debug "Staged ${src}"
+    STAGED_SOURCE_PATHS+=("${staged_path}")
+    HASH_SOURCE_PATHS+=("${src}")
+    iree_debug "Staged ${src} -> ${staged_path}"
 done
 
 # Determine if this is C++.
@@ -698,9 +806,10 @@ else
 fi
 
 # Compute cache hash BEFORE deps inference.
-# Hash is based on #includes + explicit deps + build options + language (NOT source content).
+# Hash is based on #includes + explicit deps + build options + language.
+# File inputs also include content hash to avoid stale builds.
 # This allows runs with same deps config to share BUILD.bazel analysis cache.
-CACHE_HASH=$(compute_cache_hash STAGED_SOURCE_PATHS EXTRA_DEPS COPTS LINKOPTS "${LANGUAGE}")
+CACHE_HASH=$(compute_cache_hash HASH_SOURCE_PATHS EXTRA_DEPS COPTS LINKOPTS "${LANGUAGE}" BAZEL_USER_FLAGS "${HAS_FILE_INPUT}")
 SLOT_DIR="${CACHE_DIR}/${CACHE_HASH}"
 LOCK_FILE="${CACHE_DIR}/${CACHE_HASH}.lock"
 
@@ -708,12 +817,12 @@ LOCK_FILE="${CACHE_DIR}/${CACHE_HASH}.lock"
 mkdir -p "${CACHE_DIR}"
 
 # Acquire exclusive lock on this slot to prevent parallel runs from clobbering.
-# Lock is released automatically when the script exits.
-exec 9>"${LOCK_FILE}"
-if ! flock -w 60 9; then
+# Uses portable mkdir-based locking (flock is Linux-specific).
+if ! _acquire_lock "${LOCK_FILE}" 60; then
     iree_error "Timeout waiting for lock on cache slot ${CACHE_HASH}"
     exit 1
 fi
+trap "_release_lock '${LOCK_FILE}'; cleanup_staging" EXIT
 iree_debug "Acquired lock on slot ${CACHE_HASH}"
 
 # Check cache AFTER acquiring lock (another process may have created it while we waited).
@@ -791,32 +900,6 @@ generate_build_file() {
             printf '        "%s",\n' "${dep}"
         done
         printf '    ],\n'
-        if [[ ${#COPTS[@]} -gt 0 ]]; then
-            printf '    copts = ['
-            first=1
-            for opt in "${COPTS[@]}"; do
-                if [[ "${first}" == "1" ]]; then
-                    first=0
-                else
-                    printf ', '
-                fi
-                printf '"%s"' "${opt}"
-            done
-            printf '],\n'
-        fi
-        if [[ ${#LINKOPTS[@]} -gt 0 ]]; then
-            printf '    linkopts = ['
-            first=1
-            for opt in "${LINKOPTS[@]}"; do
-                if [[ "${first}" == "1" ]]; then
-                    first=0
-                else
-                    printf ', '
-                fi
-                printf '"%s"' "${opt}"
-            done
-            printf '],\n'
-        fi
         echo ')'
     } > "${build_file}"
 }
@@ -860,12 +943,12 @@ do_build() {
     BAZEL_BIN=$(iree_get_bazel_command)
     if iree_is_verbose; then
         # Verbose mode: show everything, also save to log for retry logic.
-        "${BAZEL_BIN}" build "${TARGET}" "${BAZEL_ARGS[@]}" 2>&1 | tee "${BUILD_LOG}"
+        "${BAZEL_BIN}" "${BAZEL_STARTUP_ARGS[@]}" build "${TARGET}" "${BAZEL_ARGS[@]}" 9>&- 2>&1 | tee "${BUILD_LOG}"
         return "${PIPESTATUS[0]}"
     else
         # Quiet mode: capture output, only show on failure.
         # Force colors since we'll display to terminal on failure.
-        if "${BAZEL_BIN}" build --color=yes "${TARGET}" "${BAZEL_ARGS[@]}" >"${BUILD_LOG}" 2>&1; then
+        if "${BAZEL_BIN}" "${BAZEL_STARTUP_ARGS[@]}" build --color=yes "${TARGET}" "${BAZEL_ARGS[@]}" 9>&- >"${BUILD_LOG}" 2>&1; then
             return 0
         else
             local exit_code=$?
@@ -935,8 +1018,8 @@ if [[ "${COMPILE_ONLY}" == "1" ]] || [[ -n "${OUTPUT_PATH}" ]]; then
 
     # Copy output if requested.
     if [[ -n "${OUTPUT_PATH}" ]]; then
-        BINARY_PATH="${IREE_BAZEL_WORKTREE_DIR}/bazel-bin/.iree-bazel-try/cache/${CACHE_HASH}/snippet"
-        if [[ -f "${BINARY_PATH}" ]]; then
+        BINARY_PATH=$(iree_bazel_get_binary_path "${TARGET}" "${BAZEL_ARGS[@]}")
+        if [[ -n "${BINARY_PATH}" ]] && [[ -f "${BINARY_PATH}" ]]; then
             cp "${BINARY_PATH}" "${OUTPUT_PATH}"
             chmod +x "${OUTPUT_PATH}"
             iree_info "Binary saved to: ${OUTPUT_PATH}"
@@ -973,10 +1056,8 @@ if ! build_with_retry; then
 fi
 
 # Get the binary path and run from original directory.
-# We know the exact structure since we generate the BUILD file, so we can
-# compute the path directly instead of calling bazel cquery (saves ~500ms).
-BINARY_PATH="${IREE_BAZEL_WORKTREE_DIR}/bazel-bin/.iree-bazel-try/cache/${CACHE_HASH}/snippet"
-if [[ ! -x "${BINARY_PATH}" ]]; then
+BINARY_PATH=$(iree_bazel_get_binary_path "${TARGET}" "${BAZEL_ARGS[@]}")
+if [[ -z "${BINARY_PATH}" ]] || [[ ! -x "${BINARY_PATH}" ]]; then
     iree_error "Could not find built binary at ${BINARY_PATH}"
     exit 1
 fi

--- a/build_tools/cmake/iree_cc_binary_benchmark.cmake
+++ b/build_tools/cmake/iree_cc_binary_benchmark.cmake
@@ -10,7 +10,7 @@
 #
 # It's good to test that benchmarks run, but it's really annoying to run a
 # billion iterations of them every time you try to run tests. So we create these
-# as binaries and then invoke them as tests with `--benchmark_min_time=0`.
+# as binaries and then invoke them as tests with `--benchmark_min_time=0s`.
 #
 # Mirrors the bzl function of the same name. See iree_cc_binary and iree_cc_test
 # for more details on those rules
@@ -73,7 +73,7 @@ function(iree_cc_binary_benchmark)
     NAME
       ${_RULE_NAME}_test
     ARGS
-      "--benchmark_min_time=0"
+      "--benchmark_min_time=0s"
     SRC
       ::${_RULE_NAME}
     LABELS

--- a/docs/website/docs/developers/building/bazel.md
+++ b/docs/website/docs/developers/building/bazel.md
@@ -320,6 +320,7 @@ export PATH="$PATH:/path/to/iree/build_tools/bin"
 - `iree-bazel-run <target> [-- args]` - Build and execute from current directory
     (supports `-w` watch mode)
 - `iree-bazel-query <expr>` - Query the build graph
+- `iree-bazel-cquery <expr>` - Configuration-aware query (resolved select())
 - `iree-bazel-try <file>` - Compile/run C++ snippets without BUILD files
 - `iree-bazel-fuzz <target>` - Run fuzzer with corpus management
 

--- a/experimental/web/run_native_benchmarks.sh
+++ b/experimental/web/run_native_benchmarks.sh
@@ -38,7 +38,7 @@ echo "Benchmarking DeepLabV3..."
     --task_topology_group_count=1 \
     --function=main \
     --input=1x257x257x3xf32 \
-    --benchmark_min_time=3
+    --benchmark_min_time=3s
 
 echo ""
 echo "Benchmarking MobileSSD..."
@@ -48,7 +48,7 @@ echo "Benchmarking MobileSSD..."
     --task_topology_group_count=1 \
     --function=main \
     --input=1x320x320x3xf32 \
-    --benchmark_min_time=3
+    --benchmark_min_time=3s
 
 echo ""
 echo "Benchmarking PoseNet..."
@@ -58,7 +58,7 @@ echo "Benchmarking PoseNet..."
     --task_topology_group_count=1 \
     --function=main \
     --input=1x353x257x3xf32 \
-    --benchmark_min_time=3
+    --benchmark_min_time=3s
 
 echo ""
 echo "Benchmarking MobileBertSquad..."
@@ -70,7 +70,7 @@ echo "Benchmarking MobileBertSquad..."
     --input=1x384xi32 \
     --input=1x384xi32 \
     --input=1x384xi32 \
-    --benchmark_min_time=10
+    --benchmark_min_time=10s
 
 echo ""
 echo "Benchmarking MobileNetV2..."
@@ -80,7 +80,7 @@ echo "Benchmarking MobileNetV2..."
     --task_topology_group_count=1 \
     --function=main \
     --input=1x224x224x3xf32 \
-    --benchmark_min_time=3
+    --benchmark_min_time=3s
 
 echo ""
 echo "Benchmarking MobileNetV3Small..."
@@ -90,4 +90,4 @@ echo "Benchmarking MobileNetV3Small..."
     --task_topology_group_count=1 \
     --function=main \
     --input=1x224x224x3xf32 \
-    --benchmark_min_time=3
+    --benchmark_min_time=3s


### PR DESCRIPTION
iree-bazel-try:
- supports --features, useful for --features=thin_lto
- workaround for thin_lto + Wno-unused-command-line-argument
- --copt and --linkopt in a way that ensures the entire build is
  configured with the options (prior only the try target was, which was
  useful in isolated testing but not when benchmarking/etc)
- uses a new output base (so features/copt/linkopt don't pollute the
  normal build, good for concurrent try + build/test)
- fixed caching of files passed in by path
- fixed files passed in by path to have original source locations

iree-bazel-test/build/fuzz:
- support multiple targets (`iree-bazel-test //:a //:b`)
- this allows multiple fuzzers to run in batched mode

iree-bazel-cquery:
- added to match iree-bazel-query so we have the pair

misc:
- `target_compatible_with`/platform `select` support in bazel-to-cmake
- fixing benchmark warnings about missing unit
- fixed a bug in cc_benchmark dropping extra args on benchmark tests