### PR TITLE
[LinalgExt] Add mixed tensor-buffer semantics for map_scatter

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3220,3 +3220,24 @@ func.func @drop_fusion_barrier() -> memref<6xf32> {
 // CHECK-LABEL: func.func @drop_fusion_barrier
 // CHECK:         %[[ALLOC:.+]] = memref.alloc() : memref<6xf32>
 // CHECK:         return %[[ALLOC]]
+
+// -----
+
+// Test bufferization of map_scatter with mixed tensor-buffer semantics.
+// The tensor input should be bufferized while the memref output stays as-is.
+func.func @map_scatter_mixed_semantics(%input: tensor<16xf32>, %output: memref<16xf32>) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : tensor<16xf32> into memref<16xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @map_scatter_mixed_semantics
+//  CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<16xf32>
+//  CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9_]+]]: memref<16xf32>
+//       CHECK:   %[[INPUT_BUF:.+]] = bufferization.to_buffer %[[INPUT]]
+//       CHECK:   iree_linalg_ext.map_scatter %[[INPUT_BUF]] into %[[OUTPUT]]
+//       CHECK:   } : memref<16xf32> into memref<16xf32>
+//       CHECK:   return

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -23,10 +24,14 @@ IREE::LinalgExt::detail::verifyLinalgExtOpInterface(Operation *op) {
         "expected operation that implements LinalgExtInterface to also "
         "implement DestinationStyleOpInterface");
   }
-  if (!dpsOp.hasPureBufferSemantics() && !dpsOp.hasPureTensorSemantics()) {
-    return op->emitOpError(
-        "expected operation that implements LinalgExtInterface to have "
-        "either pure buffer semantics or pure tensor semantics");
+  // MapScatterOp allows mixed semantics (tensor input with memref output, or
+  // memref input with tensor output).
+  if (!isa<MapScatterOp>(op)) {
+    if (!dpsOp.hasPureBufferSemantics() && !dpsOp.hasPureTensorSemantics()) {
+      return op->emitOpError(
+          "expected operation that implements LinalgExtInterface to have "
+          "either pure buffer semantics or pure tensor semantics");
+    }
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -855,6 +855,27 @@ func.func @map_scatter_vector(
 
 // -----
 
+func.func @map_scatter_mixed_tensor_memref(
+    %input: tensor<16xf32>, %output: memref<16xf32>) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : tensor<16xf32> into memref<16xf32>
+  return
+}
+// CHECK-LABEL: func.func @map_scatter_mixed_tensor_memref(
+//  CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<16xf32>
+//  CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9_]+]]: memref<16xf32>
+//       CHECK:   iree_linalg_ext.map_scatter %[[INPUT]] into %[[OUTPUT]] {
+//       CHECK:     ^bb0(%[[IDX0:.+]]: index):
+//       CHECK:       %[[MASK:.+]] = arith.constant true
+//       CHECK:       iree_linalg_ext.yield %[[IDX0]], %[[MASK]]
+//       CHECK:   } : tensor<16xf32> into memref<16xf32>
+//       CHECK:   return
+
+// -----
+
 func.func @arg_compare_static(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>, %outi : tensor<2xindex>


### PR DESCRIPTION
This commit allows for mixed tensor-buffer semantics of map_scatter. This is required to avoid materializing the full scattered result of the map_scatter when distributed.