### PR TITLE
[Codegen] Extend generated E2E attention tests

### DIFF
--- a/tests/e2e/attention/CMakeLists.txt
+++ b/tests/e2e/attention/CMakeLists.txt
@@ -93,6 +93,29 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_attention_cpu_f16_f16_f16_decode_medium
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=decode_medium"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "hostonly"
+    "local"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_attention_cpu_f16_f16_f16_decode_large
   TEST_TYPE
     attention
@@ -141,7 +164,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_attention_cpu_f16_f16_f16_prefill_large
+    e2e_attention_cpu_f16_f16_f16_prefill_medium
   TEST_TYPE
     attention
   GENERATOR
@@ -150,7 +173,7 @@ iree_generated_e2e_runner_test(
     "--query_type=f16"
     "--key_type=f16"
     "--value_type=f16"
-    "--shapes=prefill_large"
+    "--shapes=prefill_medium"
     "--mask_type=causal"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-attention-test
@@ -286,6 +309,34 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_attention_gpu_cdna3_f16_f16_f16_decode_medium
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=decode_medium"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_attention_gpu_cdna3_f16_f16_f16_decode_large
   TEST_TYPE
     attention
@@ -344,7 +395,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_attention_gpu_cdna3_f16_f16_f16_prefill_large
+    e2e_attention_gpu_cdna3_f16_f16_f16_prefill_medium
   TEST_TYPE
     attention
   GENERATOR
@@ -353,7 +404,7 @@ iree_generated_e2e_runner_test(
     "--query_type=f16"
     "--key_type=f16"
     "--value_type=f16"
-    "--shapes=prefill_large"
+    "--shapes=prefill_medium"
     "--mask_type=causal"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-attention-test

--- a/tests/e2e/attention/CMakeLists.txt
+++ b/tests/e2e/attention/CMakeLists.txt
@@ -67,6 +67,104 @@ iree_generated_e2e_runner_test(
     "local"
 )
 
+# Decode tests: m=1 (single token attending to cached KV) with all-ones mask
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_cpu_f16_f16_f16_decode_small
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=decode_small"
+    "--mask_type=all_ones"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "hostonly"
+    "local"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_cpu_f16_f16_f16_decode_large
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=decode_large"
+    "--mask_type=all_ones"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "hostonly"
+    "local"
+)
+
+# Prefill tests: m=k2 (self-attention) with causal mask
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_cpu_f16_f16_f16_prefill_small
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=prefill_small"
+    "--mask_type=causal"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "hostonly"
+    "local"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_cpu_f16_f16_f16_prefill_large
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=prefill_large"
+    "--mask_type=causal"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  LABELS
+    "hostonly"
+    "local"
+)
+
 # To distinguish between CDNA(gfx9) and RDNA3(gfx11)
 if(IREE_ROCM_TEST_TARGET_CHIP MATCHES "^gfx9")
 
@@ -158,4 +256,123 @@ iree_generated_e2e_runner_test(
     "noubsan"
     "requires-gpu-cdna3"
 )
+
+# GPU Decode tests: m=1 (single token attending to cached KV) with all-ones mask
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_gpu_cdna3_f16_f16_f16_decode_small
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=decode_small"
+    "--mask_type=all_ones"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_gpu_cdna3_f16_f16_f16_decode_large
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=decode_large"
+    "--mask_type=all_ones"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+# GPU Prefill tests: m=k2 (self-attention) with causal mask
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_gpu_cdna3_f16_f16_f16_prefill_small
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=prefill_small"
+    "--mask_type=causal"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_attention_gpu_cdna3_f16_f16_f16_prefill_large
+  TEST_TYPE
+    attention
+  GENERATOR
+    "generate_e2e_attention_tests.py"
+  GENERATOR_ARGS
+    "--query_type=f16"
+    "--key_type=f16"
+    "--value_type=f16"
+    "--shapes=prefill_large"
+    "--mask_type=causal"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-attention-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
 endif()

--- a/tests/e2e/attention/CMakeLists.txt
+++ b/tests/e2e/attention/CMakeLists.txt
@@ -80,7 +80,6 @@ iree_generated_e2e_runner_test(
     "--key_type=f16"
     "--value_type=f16"
     "--shapes=decode_small"
-    "--mask_type=all_ones"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-attention-test
   TARGET_BACKENDS
@@ -104,7 +103,6 @@ iree_generated_e2e_runner_test(
     "--key_type=f16"
     "--value_type=f16"
     "--shapes=decode_large"
-    "--mask_type=all_ones"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-attention-test
   TARGET_BACKENDS
@@ -270,7 +268,6 @@ iree_generated_e2e_runner_test(
     "--key_type=f16"
     "--value_type=f16"
     "--shapes=decode_small"
-    "--mask_type=all_ones"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-attention-test
   TARGET_BACKENDS
@@ -299,7 +296,6 @@ iree_generated_e2e_runner_test(
     "--key_type=f16"
     "--value_type=f16"
     "--shapes=decode_large"
-    "--mask_type=all_ones"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-attention-test
   TARGET_BACKENDS

--- a/tests/e2e/attention/CMakeLists.txt
+++ b/tests/e2e/attention/CMakeLists.txt
@@ -67,7 +67,7 @@ iree_generated_e2e_runner_test(
     "local"
 )
 
-# Decode tests: m=1 (single token attending to cached KV) with all-ones mask
+# Decode tests: m=1 (single token attending to cached KV) with all-ones mask.
 iree_generated_e2e_runner_test(
   NAME
     e2e_attention_cpu_f16_f16_f16_decode_small
@@ -114,7 +114,7 @@ iree_generated_e2e_runner_test(
     "local"
 )
 
-# Prefill tests: m=k2 (self-attention) with causal mask
+# Prefill tests: m=k2 (self-attention) with causal mask.
 iree_generated_e2e_runner_test(
   NAME
     e2e_attention_cpu_f16_f16_f16_prefill_small
@@ -255,7 +255,7 @@ iree_generated_e2e_runner_test(
     "requires-gpu-cdna3"
 )
 
-# GPU Decode tests: m=1 (single token attending to cached KV) with all-ones mask
+# GPU Decode tests: m=1 (single token attending to cached KV) with all-ones mask.
 iree_generated_e2e_runner_test(
   NAME
     e2e_attention_gpu_cdna3_f16_f16_f16_decode_small
@@ -312,7 +312,7 @@ iree_generated_e2e_runner_test(
     "requires-gpu-cdna3"
 )
 
-# GPU Prefill tests: m=k2 (self-attention) with causal mask
+# GPU Prefill tests: m=k2 (self-attention) with causal mask.
 iree_generated_e2e_runner_test(
   NAME
     e2e_attention_gpu_cdna3_f16_f16_f16_prefill_small

--- a/tests/e2e/attention/generate_e2e_attention_tests.py
+++ b/tests/e2e/attention/generate_e2e_attention_tests.py
@@ -48,6 +48,19 @@ class ShapesId(enum.Enum):
     SMALL = "small"
     MEDIUM = "medium"
     LARGE = "large"
+    DECODE_SMALL = "decode_small"
+    DECODE_LARGE = "decode_large"
+    PREFILL_SMALL = "prefill_small"
+    PREFILL_LARGE = "prefill_large"
+
+
+# Enumerates the types of masks that can be applied to attention.
+# The values are the accepted values for the --mask_type= flag.
+@enum.unique
+class MaskType(enum.Enum):
+    NONE = "none"  # No mask
+    ALL_ONES = "all_ones"  # All positions can attend (for decode)
+    CAUSAL = "causal"  # Lower triangular mask (for prefill)
 
 
 # batch: Batch dimension
@@ -79,6 +92,24 @@ def get_test_shapes(shapes_id: ShapesId):
     if shapes_id == ShapesId.LARGE:
         return [
             TestShapeAndScale(batch=2, m=1024, k1=128, k2=128, n=64, scale=1.0),
+        ]
+    # Decode: m = 1 (single token attending to cached KV)
+    if shapes_id == ShapesId.DECODE_SMALL:
+        return [
+            TestShapeAndScale(batch=2, m=1, k1=64, k2=128, n=64, scale=1.0),
+        ]
+    if shapes_id == ShapesId.DECODE_LARGE:
+        return [
+            TestShapeAndScale(batch=2, m=1, k1=64, k2=512, n=64, scale=1.0),
+        ]
+    # Prefill: m = k2 (self-attention on full sequence)
+    if shapes_id == ShapesId.PREFILL_SMALL:
+        return [
+            TestShapeAndScale(batch=2, m=128, k1=64, k2=128, n=64, scale=1.0),
+        ]
+    if shapes_id == ShapesId.PREFILL_LARGE:
+        return [
+            TestShapeAndScale(batch=2, m=512, k1=64, k2=512, n=64, scale=1.0),
         ]
 
     raise ValueError(shapes_id)
@@ -117,7 +148,7 @@ def generate_shapes_and_scale(shape: TestShapeAndScale):
     return shapes_scale
 
 
-# Helper to return input, kernel and output shapes based on the layout and the Attention Params.
+# Helper to return input, kernel, output, and mask shapes based on the layout and the Attention Params.
 def get_tensor_shapes(
     shapes_scale: TestShapeAndScale,
 ):
@@ -126,14 +157,20 @@ def get_tensor_shapes(
     k1 = shapes_scale.k1
     k2 = shapes_scale.k2
     n = shapes_scale.n
-    scale = shapes_scale.scale
 
     query_tensor_shape = [batch, m, k1]
     key_tensor_shape = [batch, k2, k1]
     value_tensor_shape = [batch, k2, n]
     result_tensor_shape = [batch, m, n]
+    mask_tensor_shape = [batch, m, k2]
 
-    return query_tensor_shape, key_tensor_shape, value_tensor_shape, result_tensor_shape
+    return (
+        query_tensor_shape,
+        key_tensor_shape,
+        value_tensor_shape,
+        result_tensor_shape,
+        mask_tensor_shape,
+    )
 
 
 # Helper for generate_function.
@@ -179,6 +216,7 @@ def generate_function(
     key_type: KeyElemTypeId,
     value_type: ValueElemTypeId,
     shape_scale: TestShapeAndScale,
+    mask_type: MaskType,
 ):
     shapes_scale = generate_shapes_and_scale(shape_scale)
     func_name = generate_function_name(
@@ -187,8 +225,13 @@ def generate_function(
         value_type,
         shapes_scale,
     )
+    use_mask = mask_type != MaskType.NONE
+    if use_mask:
+        func_name = func_name + "_masked"
 
-    query_shape, key_shape, value_shape, result_shape = get_tensor_shapes(shapes_scale)
+    query_shape, key_shape, value_shape, result_shape, mask_shape = get_tensor_shapes(
+        shapes_scale
+    )
     query_tensor_type = (
         f"tensor<{query_shape[0]}x{query_shape[1]}x{query_shape[2]}x{query_type.value}>"
     )
@@ -199,6 +242,7 @@ def generate_function(
         f"tensor<{value_shape[0]}x{value_shape[1]}x{value_shape[2]}x{value_type.value}>"
     )
     result_tensor_type = f"tensor<{result_shape[0]}x{result_shape[1]}x{result_shape[2]}x{value_type.value}>"
+    mask_tensor_type = f"tensor<{mask_shape[0]}x{mask_shape[1]}x{mask_shape[2]}xi1>"
     F32 = "f32"
     F16 = "f16"
     op_name = "iree_linalg_ext.attention"
@@ -206,26 +250,51 @@ def generate_function(
     # Compilation info is optional; prints empty string by default.
     func_definition = ""
 
-    signature = f"({query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {result_tensor_type}) -> {result_tensor_type}"
-    import_declaration = f"func.func private @module.{func_name}(%query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %scale: {F32}) -> !hal.buffer_view"
-    func_definition = func_definition + (
-        f"func.func @{func_name}(%query: {query_tensor_type}, %key: {key_tensor_type}, %value: {value_tensor_type}, %scale: {F32}) -> {result_tensor_type} {{\n"
-        f"  %result0 = tensor.empty(): {result_tensor_type}\n"
-        f"  %scale_f16 = arith.truncf %scale : {F32} to {F16} \n"
-        f"  %result1 = {op_name} {{\n"
-        f"      indexing_maps = [affine_map<(batch, m, n, k1, k2) -> (batch, m, k1)>,\n"
-        f"                       affine_map<(batch, m, n, k1, k2) -> (batch, k2, k1)>,\n"
-        f"                       affine_map<(batch, m, n, k1, k2) -> (batch, k2, n)>,\n"
-        f"                       affine_map<(batch, m, n, k1, k2) -> ()>,\n"
-        f"                       affine_map<(batch, m, n, k1, k2) -> (batch, m, n)>]\n}}"
-        f"      ins(%query, %key, %value, %scale_f16: {query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {F16})\n"
-        f"      outs(%result0: {result_tensor_type}) {{\n"
-        f"   ^bb0(%score: f32): \n"
-        f"   iree_linalg_ext.yield %score : f32\n"
-        f" }} -> {result_tensor_type}\n"
-        f" return %result1: {result_tensor_type}\n"
-        f"}}\n"
-    )
+    if use_mask:
+        # Function with mask parameter
+        signature = f"({query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {mask_tensor_type}, {result_tensor_type}) -> {result_tensor_type}"
+        import_declaration = f"func.func private @module.{func_name}(%query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %mask: !hal.buffer_view, %scale: {F32}) -> !hal.buffer_view"
+        func_definition = func_definition + (
+            f"func.func @{func_name}(%query: {query_tensor_type}, %key: {key_tensor_type}, %value: {value_tensor_type}, %mask: {mask_tensor_type}, %scale: {F32}) -> {result_tensor_type} {{\n"
+            f"  %result0 = tensor.empty(): {result_tensor_type}\n"
+            f"  %scale_f16 = arith.truncf %scale : {F32} to {F16} \n"
+            f"  %result1 = {op_name} {{\n"
+            f"      indexing_maps = [affine_map<(batch, m, n, k1, k2) -> (batch, m, k1)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, k2, k1)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, k2, n)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> ()>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, m, k2)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, m, n)>]\n}}"
+            f"      ins(%query, %key, %value, %scale_f16, %mask: {query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {F16}, {mask_tensor_type})\n"
+            f"      outs(%result0: {result_tensor_type}) {{\n"
+            f"   ^bb0(%score: f32): \n"
+            f"   iree_linalg_ext.yield %score : f32\n"
+            f" }} -> {result_tensor_type}\n"
+            f" return %result1: {result_tensor_type}\n"
+            f"}}\n"
+        )
+    else:
+        # Function without mask
+        signature = f"({query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {result_tensor_type}) -> {result_tensor_type}"
+        import_declaration = f"func.func private @module.{func_name}(%query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %scale: {F32}) -> !hal.buffer_view"
+        func_definition = func_definition + (
+            f"func.func @{func_name}(%query: {query_tensor_type}, %key: {key_tensor_type}, %value: {value_tensor_type}, %scale: {F32}) -> {result_tensor_type} {{\n"
+            f"  %result0 = tensor.empty(): {result_tensor_type}\n"
+            f"  %scale_f16 = arith.truncf %scale : {F32} to {F16} \n"
+            f"  %result1 = {op_name} {{\n"
+            f"      indexing_maps = [affine_map<(batch, m, n, k1, k2) -> (batch, m, k1)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, k2, k1)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, k2, n)>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> ()>,\n"
+            f"                       affine_map<(batch, m, n, k1, k2) -> (batch, m, n)>]\n}}"
+            f"      ins(%query, %key, %value, %scale_f16: {query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {F16})\n"
+            f"      outs(%result0: {result_tensor_type}) {{\n"
+            f"   ^bb0(%score: f32): \n"
+            f"   iree_linalg_ext.yield %score : f32\n"
+            f" }} -> {result_tensor_type}\n"
+            f" return %result1: {result_tensor_type}\n"
+            f"}}\n"
+        )
     return MLIRFunction(
         name=func_name,
         signature=signature,
@@ -287,19 +356,42 @@ def generate_random_3d_tensor(
 call_id = 0
 
 
+# Generate causal mask as i8 tensor (0 or 1 values) for shape [batch, m, k2]
+# Causal pattern: mask[b, i, j] = 1 if j <= i, else 0
+def generate_causal_mask_values(batch: int, m: int, k2: int) -> list:
+    mask = []
+    for b in range(batch):
+        for i in range(m):
+            for j in range(k2):
+                mask.append(1 if j <= i else 0)
+    return mask
+
+
+# Generate all-ones mask as i8 tensor for shape [batch, m, k2]
+# All positions can attend to all positions
+def generate_all_ones_mask_values(batch: int, m: int, k2: int) -> list:
+    return [1] * (batch * m * k2)
+
+
 def generate_call(
     function: MLIRFunction,
     query_type: QueryElemTypeId,
     key_type: KeyElemTypeId,
     value_type: ValueElemTypeId,
     shapes_scale: TestShapeAndScale,
+    mask_type: MaskType,
 ):
     global call_id
     func_name = f"{function.name}_{shapes_scale.batch}_{shapes_scale.m}_{shapes_scale.k1}_{shapes_scale.k2}_{shapes_scale.n}_{shapes_scale.k1}_{shapes_scale.scale}"
     func_name = f"{func_name}_{call_id}"
     call_id = call_id + 1
 
+    use_mask = mask_type != MaskType.NONE
     description = f"Attention shape (BATCHxMxK1xK2xN): {shapes_scale.batch}x{shapes_scale.m}x{shapes_scale.k1}x{shapes_scale.k2}x{shapes_scale.k1}x{shapes_scale.n}"
+    if mask_type == MaskType.ALL_ONES:
+        description = description + " (all-ones masked)"
+    elif mask_type == MaskType.CAUSAL:
+        description = description + " (causal masked)"
     op = (
         f"func.func @{func_name}() attributes {{\n"
         f'  iree.reflection = {{description = "{description}"}}\n'
@@ -308,7 +400,7 @@ def generate_call(
         "  %device = hal.devices.get %device_index : !hal.device\n"
     )
 
-    query_shape, key_shape, value_shape, result_shape = get_tensor_shapes(
+    query_shape, key_shape, value_shape, result_shape, mask_shape = get_tensor_shapes(
         shapes_scale,
     )
 
@@ -316,12 +408,38 @@ def generate_call(
     op = op + generate_random_3d_tensor("key", key_shape, key_type)
     op = op + generate_random_3d_tensor("value", value_shape, value_type)
 
+    if use_mask:
+        batch, m, k2 = mask_shape
+        mask_size = batch * m * k2
+        # Generate mask as i8, then convert to i1 for attention op
+        if mask_type == MaskType.ALL_ONES:
+            mask_values = generate_all_ones_mask_values(batch, m, k2)
+        elif mask_type == MaskType.CAUSAL:
+            mask_values = generate_causal_mask_values(batch, m, k2)
+        mask_values_str = ", ".join(str(v) for v in mask_values)
+        op = op + (
+            f"  %mask_i8 = arith.constant dense<[{mask_values_str}]> : tensor<{mask_size}xi8>\n"
+            f"  %mask_i8_reshaped = tensor.expand_shape %mask_i8 [[0, 1, 2]] output_shape [{batch}, {m}, {k2}] : tensor<{mask_size}xi8> into tensor<{batch}x{m}x{k2}xi8>\n"
+            f"  %c0_i8 = arith.constant 0 : i8\n"
+            f"  %zeros_i8 = tensor.empty() : tensor<{batch}x{m}x{k2}xi8>\n"
+            f"  %zeros_i8_filled = linalg.fill ins(%c0_i8 : i8) outs(%zeros_i8 : tensor<{batch}x{m}x{k2}xi8>) -> tensor<{batch}x{m}x{k2}xi8>\n"
+            f"  %mask_i1 = arith.cmpi ne, %mask_i8_reshaped, %zeros_i8_filled : tensor<{batch}x{m}x{k2}xi8>\n"
+            f"  %mask = hal.tensor.export %mask_i1 : tensor<{batch}x{m}x{k2}xi1> -> !hal.buffer_view\n"
+        )
+
     global pseudorandom_generator_seed
     pseudorandom_generator_seed = pseudorandom_generator_seed - 1
-    op = op + (
-        f"  %scale = arith.constant {shapes_scale.scale} : f32\n"
-        f"  %result = call @module.{function.name}(%query, %key, %value, %scale) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view, f32) -> !hal.buffer_view\n"
-    )
+
+    if use_mask:
+        op = op + (
+            f"  %scale = arith.constant {shapes_scale.scale} : f32\n"
+            f"  %result = call @module.{function.name}(%query, %key, %value, %mask, %scale) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, f32) -> !hal.buffer_view\n"
+        )
+    else:
+        op = op + (
+            f"  %scale = arith.constant {shapes_scale.scale} : f32\n"
+            f"  %result = call @module.{function.name}(%query, %key, %value, %scale) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view, f32) -> !hal.buffer_view\n"
+        )
 
     op = op + (
         f"  %batch = arith.constant {shapes_scale.batch} : i64 \n"
@@ -341,8 +459,18 @@ def generate_call(
         f"  %keyExtBufferView = hal.tensor.export %keyExt : tensor<{shapes_scale.batch}x{shapes_scale.k2}x{shapes_scale.k1}xf32> -> !hal.buffer_view \n"
         f"  %valueExtBufferView = hal.tensor.export %valueExt : tensor<{shapes_scale.batch}x{shapes_scale.k2}x{shapes_scale.n}xf32> -> !hal.buffer_view \n"
         f"  %resultExtBufferView = hal.tensor.export %resultExt : tensor<{shapes_scale.batch}x{shapes_scale.m}x{shapes_scale.n}xf32> -> !hal.buffer_view \n"
-        f"  call @attention_test.check_attention_results(%device, %batch, %m, %k1, %k2, %n, %queryExtBufferView, %keyExtBufferView, %valueExtBufferView, %resultExtBufferView) : (!hal.device, i64, i64, i64, i64, i64, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
     )
+
+    if use_mask:
+        # Export mask as i8 for the reference implementation
+        op = op + (
+            f"  %mask_i8_export = hal.tensor.export %mask_i8_reshaped : tensor<{batch}x{m}x{k2}xi8> -> !hal.buffer_view\n"
+            f"  call @attention_test.check_attention_results_with_mask(%device, %batch, %m, %k1, %k2, %n, %queryExtBufferView, %keyExtBufferView, %valueExtBufferView, %mask_i8_export, %resultExtBufferView) : (!hal.device, i64, i64, i64, i64, i64, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
+        )
+    else:
+        op = op + (
+            f"  call @attention_test.check_attention_results(%device, %batch, %m, %k1, %k2, %n, %queryExtBufferView, %keyExtBufferView, %valueExtBufferView, %resultExtBufferView) : (!hal.device, i64, i64, i64, i64, i64, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
+        )
 
     op = op + "  return\n"
     op = op + "}\n"
@@ -356,6 +484,7 @@ def generate(
     key_type: KeyElemTypeId,
     value_type: ValueElemTypeId,
     shapes_id: ShapesId,
+    mask_type: MaskType,
 ):
     functions = {}
     calls = []
@@ -366,6 +495,7 @@ def generate(
             key_type,
             value_type,
             shape,
+            mask_type,
         )
         if function.name not in functions:
             functions[function.name] = function
@@ -376,6 +506,7 @@ def generate(
                 key_type,
                 value_type,
                 shape,
+                mask_type,
             )
         )
 
@@ -418,7 +549,7 @@ def parse_arguments():
         required=True,
     )
     parser.add_argument(
-        "--shapes_scale",
+        "--shapes",
         type=str,
         choices=[s.value for s in ShapesId],
         help="Collection of tensor shapes to test",
@@ -429,6 +560,13 @@ def parse_arguments():
         type=str,
         help="Target requirements for this module. Comma-separated. As in -iree-llvmcpu-target-cpu-features. If the target device does not meet all of the requirements, the test will be skipped.",
         required=False,
+    )
+    parser.add_argument(
+        "--mask_type",
+        type=str,
+        choices=[m.value for m in MaskType],
+        default="none",
+        help="Type of attention mask to generate: none, all_ones (for decode), or causal (for prefill)",
     )
     return parser.parse_args()
 
@@ -458,6 +596,7 @@ def write_calls_file(functions, calls, filename, requirements):
     module_definition = module_definition + (
         "func.func private @attention_test.generate_random_tensor(%device: !hal.device, %dim0: i64, %dim1: i64, %dim2: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view\n"
         "func.func private @attention_test.check_attention_results(%device: !hal.device, %batch: i64, %m: i64, %k1: i64, %k2: i64, %n: i64, %query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %result: !hal.buffer_view)\n"
+        "func.func private @attention_test.check_attention_results_with_mask(%device: !hal.device, %batch: i64, %m: i64, %k1: i64, %k2: i64, %n: i64, %query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %mask: !hal.buffer_view, %result: !hal.buffer_view)\n"
         "\n"
     )
 
@@ -480,13 +619,15 @@ def main(args):
     query_type = QueryElemTypeId(args.query_type)
     key_type = KeyElemTypeId(args.key_type)
     value_type = ValueElemTypeId(args.value_type)
-    shapes_id = ShapesId(args.shapes_scale)
+    shapes_id = ShapesId(args.shapes)
+    mask_type = MaskType(args.mask_type)
 
     (functions, calls) = generate(
         query_type,
         key_type,
         value_type,
         shapes_id,
+        mask_type,
     )
 
     write_code_file(functions, args.output_attention_mlir)

--- a/tests/e2e/attention/generate_e2e_attention_tests.py
+++ b/tests/e2e/attention/generate_e2e_attention_tests.py
@@ -251,7 +251,7 @@ def generate_function(
     func_definition = ""
 
     if use_mask:
-        # Function with mask parameter
+        # Function with mask parameter.
         signature = f"({query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {mask_tensor_type}, {result_tensor_type}) -> {result_tensor_type}"
         import_declaration = f"func.func private @module.{func_name}(%query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %mask: !hal.buffer_view, %scale: {F32}) -> !hal.buffer_view"
         func_definition = func_definition + (
@@ -274,7 +274,7 @@ def generate_function(
             f"}}\n"
         )
     else:
-        # Function without mask
+        # Function without mask.
         signature = f"({query_tensor_type}, {key_tensor_type}, {value_tensor_type}, {result_tensor_type}) -> {result_tensor_type}"
         import_declaration = f"func.func private @module.{func_name}(%query: !hal.buffer_view, %key: !hal.buffer_view, %value: !hal.buffer_view, %scale: {F32}) -> !hal.buffer_view"
         func_definition = func_definition + (
@@ -368,7 +368,7 @@ def generate_causal_mask_values(batch: int, m: int, k2: int) -> list:
 
 
 # Generate all-ones mask as i8 tensor for shape [batch, m, k2]
-# All positions can attend to all positions
+# All positions can attend to all positions.
 def generate_all_ones_mask_values(batch: int, m: int, k2: int) -> list:
     return [1] * (batch * m * k2)
 
@@ -411,7 +411,7 @@ def generate_call(
     if use_mask:
         batch, m, k2 = mask_shape
         mask_size = batch * m * k2
-        # Generate mask as i8, then convert to i1 for attention op
+        # Generate mask as i8, then convert to i1 for attention op.
         if mask_type == MaskType.ALL_ONES:
             mask_values = generate_all_ones_mask_values(batch, m, k2)
         elif mask_type == MaskType.CAUSAL:
@@ -462,7 +462,7 @@ def generate_call(
     )
 
     if use_mask:
-        # Export mask as i8 for the reference implementation
+        # Export mask as i8 for the reference implementation.
         op = op + (
             f"  %mask_i8_export = hal.tensor.export %mask_i8_reshaped : tensor<{batch}x{m}x{k2}xi8> -> !hal.buffer_view\n"
             f"  call @attention_test.check_attention_results_with_mask(%device, %batch, %m, %k1, %k2, %n, %queryExtBufferView, %keyExtBufferView, %valueExtBufferView, %mask_i8_export, %resultExtBufferView) : (!hal.device, i64, i64, i64, i64, i64, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"

--- a/tests/e2e/attention/generate_e2e_attention_tests.py
+++ b/tests/e2e/attention/generate_e2e_attention_tests.py
@@ -49,8 +49,10 @@ class ShapesId(enum.Enum):
     MEDIUM = "medium"
     LARGE = "large"
     DECODE_SMALL = "decode_small"
+    DECODE_MEDIUM = "decode_medium"
     DECODE_LARGE = "decode_large"
     PREFILL_SMALL = "prefill_small"
+    PREFILL_MEDIUM = "prefill_medium"
     PREFILL_LARGE = "prefill_large"
 
 
@@ -96,20 +98,29 @@ def get_test_shapes(shapes_id: ShapesId):
     # Decode: m = 1 (single token attending to cached KV)
     if shapes_id == ShapesId.DECODE_SMALL:
         return [
-            TestShapeAndScale(batch=2, m=1, k1=64, k2=128, n=64, scale=1.0),
+            TestShapeAndScale(batch=2, m=1, k1=128, k2=128, n=128, scale=1.0),
+        ]
+    if shapes_id == ShapesId.DECODE_MEDIUM:
+        return [
+            TestShapeAndScale(batch=2, m=1, k1=128, k2=2048, n=128, scale=1.0),
         ]
     if shapes_id == ShapesId.DECODE_LARGE:
         return [
-            TestShapeAndScale(batch=2, m=1, k1=64, k2=512, n=64, scale=1.0),
+            TestShapeAndScale(batch=2, m=1, k1=128, k2=16384, n=128, scale=1.0),
         ]
     # Prefill: m = k2 (self-attention on full sequence)
     if shapes_id == ShapesId.PREFILL_SMALL:
         return [
-            TestShapeAndScale(batch=2, m=128, k1=64, k2=128, n=64, scale=1.0),
+            TestShapeAndScale(batch=2, m=128, k1=128, k2=128, n=128, scale=1.0),
+        ]
+    if shapes_id == ShapesId.PREFILL_MEDIUM:
+        return [
+            TestShapeAndScale(batch=2, m=2048, k1=128, k2=2048, n=128, scale=1.0),
         ]
     if shapes_id == ShapesId.PREFILL_LARGE:
+        # Currently not used due to time-out.
         return [
-            TestShapeAndScale(batch=2, m=512, k1=64, k2=512, n=64, scale=1.0),
+            TestShapeAndScale(batch=2, m=16384, k1=128, k2=16384, n=128, scale=1.0),
         ]
 
     raise ValueError(shapes_id)

--- a/tools/testing/e2e/iree-e2e-attention-test.cc
+++ b/tools/testing/e2e/iree-e2e-attention-test.cc
@@ -68,7 +68,7 @@ static void reference_attention_f32_f32_f32_f32(
     }
   }
 
-  // Apply mask before softmax if provided
+  // Apply mask before softmax if provided.
   // mask_data is a boolean mask where 1 = attend, 0 = mask out (-inf)
   if (mask_data != nullptr) {
     for (int m = 0; m < M; ++m) {
@@ -161,7 +161,7 @@ static iree_status_t reference_attention(
 
   iree_host_size_t count = 0;
   float* Attention = allocate_tensor(1, M, K2);
-  // mask_data is nullptr if no mask is provided
+  // mask_data is nullptr if no mask is provided.
   const uint8_t* mask_data = mask_contents.data_length > 0
                                  ? (const uint8_t*)mask_contents.data
                                  : nullptr;
@@ -200,7 +200,7 @@ typedef struct {
   iree_byte_span_t value_contents;
   iree_byte_span_t actual_contents;
   iree_byte_span_t expected_contents;
-  iree_byte_span_t mask_contents;  // Optional: empty if no mask
+  iree_byte_span_t mask_contents;  // Optional: empty if no mask.
 } attention_results_t;
 
 static void attention_results_deinitialize(attention_results_t* results);
@@ -210,7 +210,7 @@ static iree_status_t attention_results_initialize(
     iree_hal_dim_t k1_size, iree_hal_dim_t k2_size, iree_hal_dim_t n_size,
     iree_hal_buffer_view_t* query, iree_hal_buffer_view_t* key,
     iree_hal_buffer_view_t* value, iree_hal_buffer_view_t* result,
-    iree_hal_buffer_view_t* mask,  // Optional: can be nullptr
+    iree_hal_buffer_view_t* mask,  // Optional: can be nullptr.
     iree_allocator_t host_allocator, attention_results_t* out_results) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -297,7 +297,7 @@ static iree_status_t attention_results_initialize(
         host_allocator, out_results->expected_contents.data_length,
         (void**)&out_results->expected_contents.data);
   }
-  // Transfer mask data if mask is provided
+  // Transfer mask data if mask is provided.
   if (iree_status_is_ok(status) && mask_buffer != nullptr) {
     out_results->mask_contents.data_length =
         iree_hal_buffer_byte_length(mask_buffer);

--- a/tools/testing/e2e/iree-e2e-attention-test.cc
+++ b/tools/testing/e2e/iree-e2e-attention-test.cc
@@ -52,7 +52,7 @@ static void reference_attention_f32_f32_f32_f32(
     iree_hal_dim_t M, iree_hal_dim_t K1, iree_hal_dim_t K2, iree_hal_dim_t N,
     iree_hal_dim_t B, const float* query_data, const float* key_data,
     const float* value_data, float* result_data, iree_hal_dim_t b,
-    float* Attention) {
+    float* Attention, const uint8_t* mask_data) {
   // Compute Q * K^T
   for (int m = 0; m < M; ++m) {
     for (int k2 = 0; k2 < K2; ++k2) {
@@ -65,6 +65,20 @@ static void reference_attention_f32_f32_f32_f32(
       }
       int att_idx = index_3d(0, m, k2, M, K2);
       Attention[att_idx] = sum / sqrt(K1);  // Scale by sqrt(K1)
+    }
+  }
+
+  // Apply mask before softmax if provided
+  // mask_data is a boolean mask where 1 = attend, 0 = mask out (-inf)
+  if (mask_data != nullptr) {
+    for (int m = 0; m < M; ++m) {
+      for (int k2 = 0; k2 < K2; ++k2) {
+        int mask_idx = index_3d(b, m, k2, M, K2);
+        int att_idx = index_3d(0, m, k2, M, K2);
+        if (mask_data[mask_idx] == 0) {
+          Attention[att_idx] = -INFINITY;
+        }
+      }
     }
   }
 
@@ -112,13 +126,13 @@ static iree_status_t reference_attention_element(
     iree_hal_element_type_t key_elem_type,
     iree_hal_element_type_t value_elem_type, void* query_data, void* key_data,
     void* value_data, void* actual_data, void* result_data, iree_hal_dim_t b,
-    float* Attention) {
+    float* Attention, const uint8_t* mask_data) {
   if (query_elem_type == IREE_HAL_ELEMENT_TYPE_FLOAT_32 &&
       key_elem_type == IREE_HAL_ELEMENT_TYPE_FLOAT_32 &&
       value_elem_type == IREE_HAL_ELEMENT_TYPE_FLOAT_32) {
     reference_attention_f32_f32_f32_f32(
         M, K1, K2, N, B, (const float*)query_data, (const float*)key_data,
-        (const float*)value_data, (float*)result_data, b, Attention);
+        (const float*)value_data, (float*)result_data, b, Attention, mask_data);
 
   } else {
     return iree_make_status(
@@ -137,7 +151,7 @@ static iree_status_t reference_attention(
     iree_hal_element_type_t value_elem_type, iree_byte_span_t query_contents,
     iree_byte_span_t key_contents, iree_byte_span_t value_contents,
     iree_byte_span_t actual_contents, iree_byte_span_t result_contents,
-    int compute_every) {
+    iree_byte_span_t mask_contents, int compute_every) {
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, B);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, M);
@@ -147,15 +161,19 @@ static iree_status_t reference_attention(
 
   iree_host_size_t count = 0;
   float* Attention = allocate_tensor(1, M, K2);
+  // mask_data is nullptr if no mask is provided
+  const uint8_t* mask_data = mask_contents.data_length > 0
+                                 ? (const uint8_t*)mask_contents.data
+                                 : nullptr;
   for (iree_hal_dim_t b = 0; b < B; ++b) {
     if (++count < compute_every) continue;
     count = 0;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0,
-        reference_attention_element(
-            M, K1, K2, N, B, query_elem_type, key_elem_type, value_elem_type,
-            query_contents.data, key_contents.data, value_contents.data,
-            actual_contents.data, result_contents.data, b, Attention));
+        z0, reference_attention_element(
+                M, K1, K2, N, B, query_elem_type, key_elem_type,
+                value_elem_type, query_contents.data, key_contents.data,
+                value_contents.data, actual_contents.data, result_contents.data,
+                b, Attention, mask_data));
   }
   free_tensor(Attention);
 
@@ -182,6 +200,7 @@ typedef struct {
   iree_byte_span_t value_contents;
   iree_byte_span_t actual_contents;
   iree_byte_span_t expected_contents;
+  iree_byte_span_t mask_contents;  // Optional: empty if no mask
 } attention_results_t;
 
 static void attention_results_deinitialize(attention_results_t* results);
@@ -191,6 +210,7 @@ static iree_status_t attention_results_initialize(
     iree_hal_dim_t k1_size, iree_hal_dim_t k2_size, iree_hal_dim_t n_size,
     iree_hal_buffer_view_t* query, iree_hal_buffer_view_t* key,
     iree_hal_buffer_view_t* value, iree_hal_buffer_view_t* result,
+    iree_hal_buffer_view_t* mask,  // Optional: can be nullptr
     iree_allocator_t host_allocator, attention_results_t* out_results) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -212,6 +232,8 @@ static iree_status_t attention_results_initialize(
   iree_hal_buffer_t* key_buffer = iree_hal_buffer_view_buffer(key);
   iree_hal_buffer_t* value_buffer = iree_hal_buffer_view_buffer(value);
   iree_hal_buffer_t* result_buffer = iree_hal_buffer_view_buffer(result);
+  iree_hal_buffer_t* mask_buffer =
+      mask ? iree_hal_buffer_view_buffer(mask) : nullptr;
 
   iree_status_t status = iree_ok_status();
 
@@ -275,6 +297,20 @@ static iree_status_t attention_results_initialize(
         host_allocator, out_results->expected_contents.data_length,
         (void**)&out_results->expected_contents.data);
   }
+  // Transfer mask data if mask is provided
+  if (iree_status_is_ok(status) && mask_buffer != nullptr) {
+    out_results->mask_contents.data_length =
+        iree_hal_buffer_byte_length(mask_buffer);
+    status = iree_allocator_malloc(host_allocator,
+                                   out_results->mask_contents.data_length,
+                                   (void**)&out_results->mask_contents.data);
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_device_transfer_d2h(
+          device, mask_buffer, 0, out_results->mask_contents.data,
+          out_results->mask_contents.data_length,
+          IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+    }
+  }
   if (!iree_status_is_ok(status)) {
     attention_results_deinitialize(out_results);
   }
@@ -289,6 +325,7 @@ static void attention_results_deinitialize(attention_results_t* results) {
   iree_allocator_free(results->host_allocator, results->value_contents.data);
   iree_allocator_free(results->host_allocator, results->actual_contents.data);
   iree_allocator_free(results->host_allocator, results->expected_contents.data);
+  iree_allocator_free(results->host_allocator, results->mask_contents.data);
 
   IREE_TRACE_ZONE_END(z0);
 }
@@ -306,7 +343,8 @@ static iree_status_t check_attention_results_impl(
                               results->key_elem_type, results->value_elem_type,
                               results->query_contents, results->key_contents,
                               results->value_contents, results->actual_contents,
-                              results->expected_contents, check_every));
+                              results->expected_contents,
+                              results->mask_contents, check_every));
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -415,7 +453,25 @@ class AttentionTestModuleState final {
     IREE_RETURN_IF_ERROR(attention_results_initialize(
         device, (iree_hal_dim_t)b, (iree_hal_dim_t)m, (iree_hal_dim_t)k1,
         (iree_hal_dim_t)k2, (iree_hal_dim_t)n, query, key, value, actual_result,
+        nullptr,  // No mask
         host_allocator_, &results));
+    iree_status_t status = check_attention_results(stderr, &results);
+    attention_results_deinitialize(&results);
+    return status;
+  }
+
+  Status CheckAttentionResultsWithMask(iree_hal_device_t* device, int64_t b,
+                                       int64_t m, int64_t k1, int64_t k2,
+                                       int64_t n, iree_hal_buffer_view_t* query,
+                                       iree_hal_buffer_view_t* key,
+                                       iree_hal_buffer_view_t* value,
+                                       iree_hal_buffer_view_t* mask,
+                                       iree_hal_buffer_view_t* actual_result) {
+    attention_results_t results = {};
+    IREE_RETURN_IF_ERROR(attention_results_initialize(
+        device, (iree_hal_dim_t)b, (iree_hal_dim_t)m, (iree_hal_dim_t)k1,
+        (iree_hal_dim_t)k2, (iree_hal_dim_t)n, query, key, value, actual_result,
+        mask, host_allocator_, &results));
     iree_status_t status = check_attention_results(stderr, &results);
     attention_results_deinitialize(&results);
     return status;
@@ -433,6 +489,9 @@ static const vm::NativeFunction<AttentionTestModuleState>
         vm::MakeNativeFunction(
             "check_attention_results",
             &AttentionTestModuleState::CheckAttentionResults),
+        vm::MakeNativeFunction(
+            "check_attention_results_with_mask",
+            &AttentionTestModuleState::CheckAttentionResultsWithMask),
 };
 
 struct AttentionTestModule final


### PR DESCRIPTION
Increase the test coverage of the generated E2E attention tests by adding additional shapes reflecting prefill (`m == k2`) and decode (`m == 1`) use cases. For the prefill case, this also adds support for masks.

The new tests are running on CPU and CDNA3.

This is part of https://github.com/iree-org/iree/issues/23323.

Assisted-by: Claude Code