### PR TITLE
[Codegen] Switch narrow type emulation to use nonAtomic operations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -164,10 +164,11 @@ LogicalResult emulateNarrowType(
   memref::populateFlattenMemrefsPatterns(patterns);
 
   arith::populateArithNarrowTypeEmulationPatterns(typeConverter, patterns);
-  memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns);
+  memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns,
+                                                    /*disableAtomicRMW=*/true);
   populateIREEResolveExtractStridedMetadataPatterns(patterns);
   vector::populateVectorNarrowTypeEmulationPatterns(typeConverter, patterns,
-                                                    /*disableAtomicRMW=*/false,
+                                                    /*disableAtomicRMW=*/true,
                                                     /*assumeAligned=*/true);
   populateIreeNarrowTypeEmulationPatterns(typeConverter, patterns);
   if (populateCallback) {


### PR DESCRIPTION
ci-extra: test_torch

Signed-off-by: hanhanW <hanhan0912@gmail.com>