### PR TITLE
[Codegen][Common] Add InsertBatchDimForBatchlessConv pass for 2D Conv

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -253,6 +253,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgInterfaces",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",
         "@llvm-project//mlir:LoopLikeInterface",

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -124,6 +124,7 @@ iree_compiler_cc_library(
         "IREEExpandStridedMetadata.cpp",
         "IREEInjectAssumeAlignment.cpp",
         "IREELoopInvariantCodeMotion.cpp",
+        "InsertBatchDimForBatchlessConv.cpp",
         "InstrumentMemoryAccesses.cpp",
         "LinkTuningSpecsPass.cpp",
         "LowerExecutableUsingTransformDialect.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -198,6 +198,7 @@ iree_cc_library(
     MLIRLLVMCommonConversion
     MLIRLLVMDialect
     MLIRLinalgDialect
+    MLIRLinalgInterfacesIncGenLib
     MLIRLinalgTransforms
     MLIRLinalgUtils
     MLIRLoopLikeInterface

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -117,6 +117,7 @@ iree_cc_library(
     "IREEExpandStridedMetadata.cpp"
     "IREEInjectAssumeAlignment.cpp"
     "IREELoopInvariantCodeMotion.cpp"
+    "InsertBatchDimForBatchlessConv.cpp"
     "InstrumentMemoryAccesses.cpp"
     "LinkTuningSpecsPass.cpp"
     "LowerExecutableUsingTransformDialect.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/InsertBatchDimForBatchlessConv.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/InsertBatchDimForBatchlessConv.cpp
@@ -1,0 +1,278 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// InsertBatchDimForBatchlessConv Pass
+//===----------------------------------------------------------------------===//
+//
+// This pass detects 2D convolution operations that have been generalized and
+// had their batch dimension (N=1) stripped by IREE codegen transformations.
+// It restores the batch dimension by inserting tensor.expand_shape and
+// tensor.collapse_shape operations, enabling upstream convolution-specific
+// patterns (like DownscaleConv and vectorization) to match and apply.
+//
+// Note: This pass currently only handles 2D convolutions (conv_2d, pooling_2d,
+// depthwise_conv_2d).
+//
+// The reshape operations are expected to be folded into dispatch tensor
+// load/store operations by the PropagateReshapesByExpansion pass, resulting
+// in zero runtime cost.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-insert-batch-dim-for-batchless-conv"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_INSERTBATCHDIMFORBATCHLESSCONVPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+/// Detects if the given linalg op is a batch-less 2D convolution (a convolution
+/// where the batch dimension N=1 was stripped by IREE's unit dim folding).
+///
+/// Returns success if this is a batch-less 2D convolution that should be
+/// transformed, failure otherwise.
+static LogicalResult isBatchlessConv(linalg::LinalgOp op) {
+  // Must be a convolution operation (uses upstream MLIR's convolution
+  // detection)
+  if (!linalg::isaConvolutionOpInterface(op)) {
+    return failure();
+  }
+
+  auto dimsOr = linalg::inferConvolutionDims(op);
+  if (failed(dimsOr)) {
+    return failure();
+  }
+  linalg::ConvolutionDimensions dims = *dimsOr;
+
+  // Must be 2D spatial convolution
+  if (dims.outputImage.size() != 2 || dims.filterLoop.size() != 2) {
+    return failure();
+  }
+
+  // Detect operation kind based on channel dimensions
+  bool isRegularConv =
+      !dims.inputChannel.empty() && !dims.outputChannel.empty();
+  bool isDepthwise = !dims.depth.empty();
+  bool isPooling = dims.inputChannel.empty() && dims.outputChannel.empty() &&
+                   dims.depth.empty();
+
+  // Check if batch dimension is missing
+  bool isBatchless = false;
+
+  if (isRegularConv || isDepthwise) {
+    // For conv/depthwise: batch should be non-empty when present
+    isBatchless = dims.batch.empty();
+  } else if (isPooling) {
+    // For pooling: batch contains [N, C], without N it's just [C]
+    // So batch.size() == 1 means only channel, no real batch
+    isBatchless = (dims.batch.size() == 1);
+  }
+
+  if (!isBatchless) {
+    return failure();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Helper functions for batch dimension insertion
+//===----------------------------------------------------------------------===//
+
+/// Builds reassociation indices to prepend a unit batch dimension at position
+/// 0. For a tensor of rank R, produces: [[0, 1], [2], [3], ..., [R]]
+static SmallVector<ReassociationIndices> buildBatchReassociation(int64_t rank) {
+  SmallVector<ReassociationIndices> reassoc;
+  reassoc.push_back({0, 1}); // New batch dim groups with first existing dim
+  for (int64_t i = 1; i < rank; ++i) {
+    reassoc.push_back({i + 1});
+  }
+  return reassoc;
+}
+
+/// Expands a tensor by prepending a unit batch dimension at position 0.
+/// tensor<AxBxC> -> tensor<1xAxBxC>
+static Value expandWithBatchDim(PatternRewriter &rewriter, Location loc,
+                                Value tensor) {
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
+  SmallVector<int64_t> newShape = {1};
+  llvm::append_range(newShape, tensorType.getShape());
+  auto newType = RankedTensorType::get(newShape, tensorType.getElementType());
+  auto reassoc = buildBatchReassociation(tensorType.getRank());
+  return tensor::ExpandShapeOp::create(rewriter, loc, newType, tensor, reassoc);
+}
+
+/// Transforms an indexing map to account for a new batch dimension.
+/// Shifts all existing dimensions by 1 and prepends d0 (batch).
+/// (d0, d1, ...) -> (...) becomes (d0, d1, d2, ...) -> (d0, ...)
+static AffineMap prependBatchDimToMap(AffineMap oldMap, unsigned newNumLoops,
+                                      MLIRContext *ctx) {
+  AffineMap shifted = oldMap.shiftDims(1);
+  SmallVector<AffineExpr> newResults;
+  newResults.push_back(getAffineDimExpr(0, ctx)); // batch dim
+  llvm::append_range(newResults, shifted.getResults());
+  return AffineMap::get(newNumLoops, 0, newResults, ctx);
+}
+
+//===----------------------------------------------------------------------===//
+// InsertBatchDimForConvPattern
+//===----------------------------------------------------------------------===//
+
+/// Pattern to insert batch dimension for batch-less convolutions.
+///
+/// This transforms a 6D linalg.generic (3 parallel + 3 reduction) representing
+/// a batch-less conv into a 7D linalg.generic (4 parallel + 3 reduction) with
+/// the batch dimension restored:
+///
+///   expand_shape(image_input) -> linalg.generic (with batch) ->
+///   collapse_shape(output)
+///
+/// Note: The filter tensor does NOT get a batch dimension - it's the same
+/// filter applied across the batch. Only the input and output tensors get
+/// expanded.
+struct InsertBatchDimForConvPattern
+    : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp op,
+                                PatternRewriter &rewriter) const override {
+    if (failed(isBatchlessConv(op))) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    MLIRContext *ctx = rewriter.getContext();
+    unsigned newNumLoops = op.getNumLoops() + 1;
+
+    // --- Image input (operand 0): expand and add batch dim to map ---
+    OpOperand *imageOperand = op.getDpsInputOperand(0);
+    Value image = imageOperand->get();
+    if (!isa<RankedTensorType>(image.getType())) {
+      return rewriter.notifyMatchFailure(op,
+                                         "image input is not a ranked tensor");
+    }
+    Value expandedImage = expandWithBatchDim(rewriter, loc, image);
+    AffineMap newImageMap = prependBatchDimToMap(
+        op.getMatchingIndexingMap(imageOperand), newNumLoops, ctx);
+
+    // --- Filter (operand 1): keep tensor as-is, only shift map indices ---
+    OpOperand *filterOperand = op.getDpsInputOperand(1);
+    Value filter = filterOperand->get();
+    AffineMap newFilterMap =
+        op.getMatchingIndexingMap(filterOperand).shiftDims(1);
+
+    // --- Output: expand and add batch dim to map ---
+    OpOperand *outputOperand = op.getDpsInitOperand(0);
+    Value output = outputOperand->get();
+    auto outputType = dyn_cast<RankedTensorType>(output.getType());
+    if (!outputType) {
+      return rewriter.notifyMatchFailure(op, "output is not a ranked tensor");
+    }
+    Value expandedOutput = expandWithBatchDim(rewriter, loc, output);
+    AffineMap newOutputMap = prependBatchDimToMap(
+        op.getMatchingIndexingMap(outputOperand), newNumLoops, ctx);
+
+    // Collect inputs and maps
+    SmallVector<Value> newInputs = {expandedImage, filter};
+    SmallVector<AffineMap> newMaps = {newImageMap, newFilterMap, newOutputMap};
+
+    // New iterator types: prepend parallel (batch) to existing types
+    SmallVector<utils::IteratorType> newIterTypes;
+    newIterTypes.push_back(utils::IteratorType::parallel);
+    llvm::append_range(newIterTypes, op.getIteratorTypesArray());
+
+    // Create new generic with batch dimension
+    auto newOutputType = cast<RankedTensorType>(expandedOutput.getType());
+    auto newOp = linalg::GenericOp::create(
+        rewriter, loc, TypeRange{newOutputType}, newInputs,
+        ValueRange{expandedOutput}, newMaps, newIterTypes,
+        [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
+          // Clone the body
+          IRMapping mapping;
+          for (auto [oldArg, newArg] :
+               llvm::zip(op.getBody()->getArguments(), args)) {
+            mapping.map(oldArg, newArg);
+          }
+          for (Operation &bodyOp : op.getBody()->without_terminator()) {
+            b.clone(bodyOp, mapping);
+          }
+          auto yield = cast<linalg::YieldOp>(op.getBody()->getTerminator());
+          linalg::YieldOp::create(b, nestedLoc,
+                                  mapping.lookup(yield.getOperand(0)));
+        });
+
+    // Collapse result to remove the batch dimension we added
+    auto reassoc = buildBatchReassociation(outputType.getRank());
+    auto collapsed = tensor::CollapseShapeOp::create(
+        rewriter, loc, outputType, newOp.getResult(0), reassoc);
+
+    rewriter.replaceOp(op, collapsed);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass definition
+//===----------------------------------------------------------------------===//
+
+struct InsertBatchDimForBatchlessConvPass final
+    : impl::InsertBatchDimForBatchlessConvPassBase<
+          InsertBatchDimForBatchlessConvPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<InsertBatchDimForConvPattern>(context);
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    // Run reshape propagation to push the expand/collapse shapes to boundaries
+    {
+      RewritePatternSet reshapePatterns(context);
+      populateReshapeToInterfaceTensorPatterns(reshapePatterns);
+      linalg::ControlFusionFn bubbleUpExpansionControlFn =
+          [](OpOperand *fusedOperand) {
+            // Allow fusion through all ops
+            return true;
+          };
+      linalg::populateFoldReshapeOpsByExpansionPatterns(
+          reshapePatterns, bubbleUpExpansionControlFn);
+      tensor::CollapseShapeOp::getCanonicalizationPatterns(reshapePatterns,
+                                                           context);
+      tensor::ExpandShapeOp::getCanonicalizationPatterns(reshapePatterns,
+                                                         context);
+
+      if (failed(applyPatternsGreedily(getOperation(),
+                                       std::move(reshapePatterns)))) {
+        return signalPassFailure();
+      }
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -745,6 +745,25 @@ def InstrumentMemoryAccessesPass :
   let summary = "Instruments memory reads and writes for address tracking when dispatch instrumentation is enabled.";
 }
 
+def InsertBatchDimForBatchlessConvPass :
+    InterfacePass<"iree-codegen-insert-batch-dim-for-batchless-conv", "mlir::FunctionOpInterface"> {
+  let summary = "Inserts batch dimension for batch-less convolutions.";
+  let description = [{
+    Detects convolution operations that have been generalized and had their
+    batch dimension (N=1) stripped by upstream IREE transformations. It
+    restores the batch dimension by inserting tensor.expand_shape and
+    tensor.collapse_shape operations, enabling downstream convolution-specific
+    patterns (like DownscaleConv and vectorization) to match and apply.
+
+    The reshape operations are propagated to the boundary and folded into
+    dispatch tensor load/store operations, resulting in zero runtime cost.
+  }];
+  let dependentDialects = [
+    "linalg::LinalgDialect",
+    "tensor::TensorDialect"
+  ];
+}
+
 def LinkTuningSpecsPass : Pass<"iree-codegen-link-tuning-specs", "ModuleOp"> {
   let summary =
       "Link nested transform dialect tuning specs named sequences into a single entry point";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -66,6 +66,7 @@ iree_lit_test_suite(
             "generic_vectorization.mlir",
             "hoist_statically_bound_allocations.mlir",
             "hoist_unrolled_vector_extract_insert_slice.mlir",
+            "insert_batch_dim_for_batchless_conv.mlir",
             "iree_codegen_canonicalize.mlir",
             "iree_comprehensive_bufferize.mlir",
             "iree_expand_strided_metadata.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_lit_test_suite(
     "generic_vectorization.mlir"
     "hoist_statically_bound_allocations.mlir"
     "hoist_unrolled_vector_extract_insert_slice.mlir"
+    "insert_batch_dim_for_batchless_conv.mlir"
     "iree_codegen_canonicalize.mlir"
     "iree_comprehensive_bufferize.mlir"
     "iree_expand_strided_metadata.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/insert_batch_dim_for_batchless_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/insert_batch_dim_for_batchless_conv.mlir
@@ -1,0 +1,313 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-insert-batch-dim-for-batchless-conv))" --split-input-file %s | FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0 + d3, d1 + d4, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+
+func.func @batchless_conv_2d_nhwc_hwcf(%input: tensor<16x16x4xf32>, %filter: tensor<3x3x4x16xf32>, %output: tensor<14x14x16xf32>) -> tensor<14x14x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%output : tensor<14x14x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %mul = arith.mulf %in, %f : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<14x14x16xf32>
+  return %0 : tensor<14x14x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_conv_2d_nhwc_hwcf
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<16x16x4xf32>
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9]+]]: tensor<3x3x4x16xf32>
+// CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]+]]: tensor<14x14x16xf32>
+// CHECK:       %[[EXPANDED_INPUT:.+]] = tensor.expand_shape %[[INPUT]] {{\[}}[0, 1], [2], [3]{{\]}} output_shape [1, 16, 16, 4] : tensor<16x16x4xf32> into tensor<1x16x16x4xf32>
+// CHECK:       %[[EXPANDED_OUTPUT:.+]] = tensor.expand_shape %[[OUTPUT]] {{\[}}[0, 1], [2], [3]{{\]}} output_shape [1, 14, 14, 16] : tensor<14x14x16xf32> into tensor<1x14x14x16xf32>
+// CHECK:       %[[CONV:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+// CHECK-SAME:    ins(%[[EXPANDED_INPUT]], %[[FILTER]] : tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+// CHECK-SAME:    outs(%[[EXPANDED_OUTPUT]] : tensor<1x14x14x16xf32>)
+// CHECK:       %[[RESULT:.+]] = tensor.collapse_shape %[[CONV]] {{\[}}[0, 1], [2], [3]{{\]}} : tensor<1x14x14x16xf32> into tensor<14x14x16xf32>
+// CHECK:       return %[[RESULT]] : tensor<14x14x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d0 + d4, d1 + d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d3, d4, d5)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d1)>
+
+func.func @batchless_conv_2d_nchw_fchw(%input: tensor<16x18x18xf32>, %filter: tensor<32x16x3x3xf32>, %output: tensor<32x16x16xf32>) -> tensor<32x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<16x18x18xf32>, tensor<32x16x3x3xf32>)
+    outs(%output : tensor<32x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %mul = arith.mulf %in, %f : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<32x16x16xf32>
+  return %0 : tensor<32x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_conv_2d_nchw_fchw
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<16x18x18xf32>
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9]+]]: tensor<32x16x3x3xf32>
+// CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]+]]: tensor<32x16x16xf32>
+// CHECK:       %[[EXPANDED_INPUT:.+]] = tensor.expand_shape %[[INPUT]] {{\[}}[0, 1], [2], [3]{{\]}} output_shape [1, 16, 18, 18] : tensor<16x18x18xf32> into tensor<1x16x18x18xf32>
+// CHECK:       %[[EXPANDED_OUTPUT:.+]] = tensor.expand_shape %[[OUTPUT]] {{\[}}[0, 1], [2], [3]{{\]}} output_shape [1, 32, 16, 16] : tensor<32x16x16xf32> into tensor<1x32x16x16xf32>
+// CHECK:       %[[CONV:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+// CHECK-SAME:    ins(%[[EXPANDED_INPUT]], %[[FILTER]] : tensor<1x16x18x18xf32>, tensor<32x16x3x3xf32>)
+// CHECK-SAME:    outs(%[[EXPANDED_OUTPUT]] : tensor<1x32x16x16xf32>)
+// CHECK:       %[[RESULT:.+]] = tensor.collapse_shape %[[CONV]] {{\[}}[0, 1], [2], [3]{{\]}} : tensor<1x32x16x16xf32> into tensor<32x16x16xf32>
+// CHECK:       return %[[RESULT]] : tensor<32x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0 + d3, d1 + d4, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+
+func.func @batchless_pooling_nhwc_sum(%input: tensor<18x18x16xf32>, %filter: tensor<3x3xf32>, %output: tensor<16x16x16xf32>) -> tensor<16x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<18x18x16xf32>, tensor<3x3xf32>)
+    outs(%output : tensor<16x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %add = arith.addf %out, %in : f32
+    linalg.yield %add : f32
+  } -> tensor<16x16x16xf32>
+  return %0 : tensor<16x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nhwc_sum
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<18x18x16xf32>
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9]+]]: tensor<3x3xf32>
+// CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]+]]: tensor<16x16x16xf32>
+// CHECK:       %[[EXPANDED_INPUT:.+]] = tensor.expand_shape %[[INPUT]] {{\[}}[0, 1], [2], [3]{{\]}} output_shape [1, 18, 18, 16] : tensor<18x18x16xf32> into tensor<1x18x18x16xf32>
+// CHECK:       %[[EXPANDED_OUTPUT:.+]] = tensor.expand_shape %[[OUTPUT]] {{\[}}[0, 1], [2], [3]{{\]}} output_shape [1, 16, 16, 16] : tensor<16x16x16xf32> into tensor<1x16x16x16xf32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK-SAME:    ins(%[[EXPANDED_INPUT]], %[[FILTER]] : tensor<1x18x18x16xf32>, tensor<3x3xf32>)
+// CHECK-SAME:    outs(%[[EXPANDED_OUTPUT]] : tensor<1x16x16x16xf32>)
+// CHECK:       %[[RESULT:.+]] = tensor.collapse_shape %[[POOL]] {{\[}}[0, 1], [2], [3]{{\]}} : tensor<1x16x16x16xf32> into tensor<16x16x16xf32>
+// CHECK:       return %[[RESULT]] : tensor<16x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0 + d3, d1 + d4, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+
+func.func @batchless_pooling_nhwc_max(%input: tensor<18x18x16xf32>, %filter: tensor<3x3xf32>, %output: tensor<16x16x16xf32>) -> tensor<16x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<18x18x16xf32>, tensor<3x3xf32>)
+    outs(%output : tensor<16x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %max = arith.maximumf %out, %in : f32
+    linalg.yield %max : f32
+  } -> tensor<16x16x16xf32>
+  return %0 : tensor<16x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nhwc_max
+// CHECK:       tensor.expand_shape {{.*}} : tensor<18x18x16xf32> into tensor<1x18x18x16xf32>
+// CHECK:       tensor.expand_shape {{.*}} : tensor<16x16x16xf32> into tensor<1x16x16x16xf32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[POOL]] {{.*}} : tensor<1x16x16x16xf32> into tensor<16x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0 + d3, d1 + d4, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+
+func.func @batchless_pooling_nhwc_max_unsigned(%input: tensor<18x18x16xi32>, %filter: tensor<3x3xi32>, %output: tensor<16x16x16xi32>) -> tensor<16x16x16xi32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<18x18x16xi32>, tensor<3x3xi32>)
+    outs(%output : tensor<16x16x16xi32>) {
+  ^bb0(%in: i32, %f: i32, %out: i32):
+    %max = arith.maxui %out, %in : i32
+    linalg.yield %max : i32
+  } -> tensor<16x16x16xi32>
+  return %0 : tensor<16x16x16xi32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nhwc_max_unsigned
+// CHECK:       tensor.expand_shape {{.*}} : tensor<18x18x16xi32> into tensor<1x18x18x16xi32>
+// CHECK:       tensor.expand_shape {{.*}} : tensor<16x16x16xi32> into tensor<1x16x16x16xi32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[POOL]] {{.*}} : tensor<1x16x16x16xi32> into tensor<16x16x16xi32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0 + d3, d1 + d4, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+
+func.func @batchless_pooling_nhwc_min(%input: tensor<18x18x16xf32>, %filter: tensor<3x3xf32>, %output: tensor<16x16x16xf32>) -> tensor<16x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<18x18x16xf32>, tensor<3x3xf32>)
+    outs(%output : tensor<16x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %min = arith.minimumf %out, %in : f32
+    linalg.yield %min : f32
+  } -> tensor<16x16x16xf32>
+  return %0 : tensor<16x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nhwc_min
+// CHECK:       tensor.expand_shape {{.*}} : tensor<18x18x16xf32> into tensor<1x18x18x16xf32>
+// CHECK:       tensor.expand_shape {{.*}} : tensor<16x16x16xf32> into tensor<1x16x16x16xf32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[POOL]] {{.*}} : tensor<1x16x16x16xf32> into tensor<16x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0 + d3, d1 + d4, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+
+func.func @batchless_pooling_nhwc_min_unsigned(%input: tensor<18x18x16xi32>, %filter: tensor<3x3xi32>, %output: tensor<16x16x16xi32>) -> tensor<16x16x16xi32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<18x18x16xi32>, tensor<3x3xi32>)
+    outs(%output : tensor<16x16x16xi32>) {
+  ^bb0(%in: i32, %f: i32, %out: i32):
+    %min = arith.minui %out, %in : i32
+    linalg.yield %min : i32
+  } -> tensor<16x16x16xi32>
+  return %0 : tensor<16x16x16xi32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nhwc_min_unsigned
+// CHECK:       tensor.expand_shape {{.*}} : tensor<18x18x16xi32> into tensor<1x18x18x16xi32>
+// CHECK:       tensor.expand_shape {{.*}} : tensor<16x16x16xi32> into tensor<1x16x16x16xi32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[POOL]] {{.*}} : tensor<1x16x16x16xi32> into tensor<16x16x16xi32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d0 + d3, d1 + d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d0, d1)>
+
+func.func @batchless_pooling_nchw_sum(%input: tensor<16x18x18xf32>, %filter: tensor<3x3xf32>, %output: tensor<16x16x16xf32>) -> tensor<16x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<16x18x18xf32>, tensor<3x3xf32>)
+    outs(%output : tensor<16x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %add = arith.addf %out, %in : f32
+    linalg.yield %add : f32
+  } -> tensor<16x16x16xf32>
+  return %0 : tensor<16x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nchw_sum
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<16x18x18xf32>
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9]+]]: tensor<3x3xf32>
+// CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]+]]: tensor<16x16x16xf32>
+// CHECK:       tensor.expand_shape {{.*}} output_shape [1, 16, 18, 18] : tensor<16x18x18xf32> into tensor<1x16x18x18xf32>
+// CHECK:       tensor.expand_shape {{.*}} output_shape [1, 16, 16, 16] : tensor<16x16x16xf32> into tensor<1x16x16x16xf32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[POOL]] {{.*}} : tensor<1x16x16x16xf32> into tensor<16x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d0 + d3, d1 + d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d0, d1)>
+
+func.func @batchless_pooling_nchw_max(%input: tensor<16x18x18xf32>, %filter: tensor<3x3xf32>, %output: tensor<16x16x16xf32>) -> tensor<16x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<16x18x18xf32>, tensor<3x3xf32>)
+    outs(%output : tensor<16x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %max = arith.maximumf %out, %in : f32
+    linalg.yield %max : f32
+  } -> tensor<16x16x16xf32>
+  return %0 : tensor<16x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_pooling_nchw_max
+// CHECK:       tensor.expand_shape {{.*}} : tensor<16x18x18xf32> into tensor<1x16x18x18xf32>
+// CHECK:       tensor.expand_shape {{.*}} : tensor<16x16x16xf32> into tensor<1x16x16x16xf32>
+// CHECK:       %[[POOL:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[POOL]] {{.*}} : tensor<1x16x16x16xf32> into tensor<16x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0 + d3, d1 + d4, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+
+func.func @batchless_depthwise_conv_2d_nhwc_hwc(%input: tensor<18x18x16xf32>, %filter: tensor<3x3x16xf32>, %output: tensor<16x16x16xf32>) -> tensor<16x16x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<18x18x16xf32>, tensor<3x3x16xf32>)
+    outs(%output : tensor<16x16x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %mul = arith.mulf %in, %f : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<16x16x16xf32>
+  return %0 : tensor<16x16x16xf32>
+}
+
+// CHECK-LABEL: func.func @batchless_depthwise_conv_2d_nhwc_hwc
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<18x18x16xf32>
+// CHECK-SAME:    %[[FILTER:[a-zA-Z0-9]+]]: tensor<3x3x16xf32>
+// CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]+]]: tensor<16x16x16xf32>
+// CHECK:       tensor.expand_shape {{.*}} output_shape [1, 18, 18, 16] : tensor<18x18x16xf32> into tensor<1x18x18x16xf32>
+// CHECK:       tensor.expand_shape {{.*}} output_shape [1, 16, 16, 16] : tensor<16x16x16xf32> into tensor<1x16x16x16xf32>
+// CHECK:       %[[CONV:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK:       tensor.collapse_shape %[[CONV]] {{.*}} : tensor<1x16x16x16xf32> into tensor<16x16x16xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+func.func @conv_with_batch_not_transformed(%input: tensor<1x16x16x4xf32>, %filter: tensor<3x3x4x16xf32>, %output: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%output : tensor<1x14x14x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %mul = arith.mulf %in, %f : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<1x14x14x16xf32>
+  return %0 : tensor<1x14x14x16xf32>
+}
+
+// CHECK-LABEL: func.func @conv_with_batch_not_transformed
+// CHECK-NOT:   tensor.expand_shape
+// CHECK-NOT:   tensor.collapse_shape
+// CHECK:       %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+// CHECK:       return %[[RESULT]]


### PR DESCRIPTION
Most of it has been taken from : https://github.com/iree-org/iree/issues/21955#issuecomment-3807719144 (CC: @hanhanW )- refactored the logic, cleaned up and tested for the generic conv tests locally.

Context: 
Upstream MLIR's linalg::inferConvolutionDims and related APIs (matchConvolutionOpOfType, isaConvolutionOpInterface) expect convolutions to have a batch dimension. These APIs are used by DownscaleConv patterns and vectorization to recognize and optimize convolution operations.

However, IREE's dispatch formation pipeline strips unit dimensions (including N=1 batch dimensions) via fold-unit-extent-dims. So after generalization step, a conv_2d_nhwc_hwcf with N=1 becomes a 6-loop generic op instead of the expected 7-loop structure, causing the upstream APIs to fail pattern matching.

This pass restores the batch dimension for such "batchless" 2D convolutions by inserting tensor.expand_shape on inputs/outputs and tensor.collapse_shape on results. This allows the upstream convolution detection APIs to recognize the operation, enabling DownscaleConv and vectorization patterns to apply.

The reshape operations are propagated to dispatch boundaries and folded into dispatch tensor load/store operations, resulting in zero runtime cost.

Lit tests added for supported operations:
- Conv2DNhwcHwcf, Conv2DNchwFchw
- PoolingNhwcSum/Max/Min, PoolingNhwcMaxUnsigned/MinUnsigned
- PoolingNchwSum/Max
- DepthwiseConv2DNhwcHwc