### PR TITLE
[Codegen][GPU] Add multi-buffering support for gather_to_lds async copy mode

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -95,7 +95,10 @@ def ROCDLPrefetchSharedMemoryPass :
     InterfacePass<"iree-llvmgpu-prefetch-shared-memory", "mlir::FunctionOpInterface"> {
       let summary = "Rotate scf.for loops to prefetch shared memory with distance 1. This pass is only applicable"
           "to ROCDL targets because its effectiveness on non-AMD GPUs lacks testing and evaluation.";
-  let dependentDialects = ["amdgpu::AMDGPUDialect"];
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect",
+    "amdgpu::AMDGPUDialect"
+  ];
   let options = [
     Option<"numStages", "num-stages", "unsigned",
            /*default=*/"2",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/IR/PatternMatch.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/BUILD.bazel
@@ -52,11 +52,13 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:NVGPUDialect",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:VectorDialect",
+        "@llvm-project//mlir:ViewLikeInterface",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/CMakeLists.txt
@@ -36,12 +36,14 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRMathDialect
     MLIRMemRefDialect
+    MLIRMemRefTransforms
     MLIRNVGPUDialect
     MLIRSCFDialect
     MLIRSCFTransforms
     MLIRSideEffectInterfaces
     MLIRSupport
     MLIRVectorDialect
+    MLIRViewLikeInterface
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::GPU::CommonGPUPasses
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -27,6 +28,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #define DEBUG_TYPE "iree-codegen-llvmgpu-prefetch-shared-memory-copy"
 
@@ -40,6 +42,217 @@ struct StageClassification {
   SmallVector<Operation *> computeStage;
 };
 } // namespace
+
+/// Checks if a loop contains gather_to_lds operations directly in the loop
+/// body. Returns false if any gather_to_lds is inside a nested region (e.g.,
+/// scf.if), as conditional async copies can't be reliably pipelined.
+static bool hasGatherToLDS(scf::ForOp forOp) {
+  bool found = false;
+  forOp.getBody()->walk([&](amdgpu::GatherToLDSOp gatherOp) {
+    if (gatherOp->getParentOp() == forOp.getOperation()) {
+      found = true;
+    } else {
+      // gather_to_lds is inside a nested region - can't use async copy mode
+      found = false;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+/// Checks if a loop contains stream copy operations (global read + shared
+/// write). This is mutually exclusive with async copy mode.
+static bool hasStreamCopyOps(scf::ForOp forOp) {
+  bool hasGlobalRead = false;
+  bool hasSharedWrite = false;
+
+  forOp->walk([&](vector::TransferReadOp readOp) {
+    auto srcType = dyn_cast<MemRefType>(readOp.getBase().getType());
+    if (hasGlobalMemoryAddressSpace(srcType)) {
+      hasGlobalRead = true;
+    }
+  });
+
+  forOp->walk([&](vector::TransferWriteOp writeOp) {
+    auto dstType = dyn_cast<MemRefType>(writeOp.getBase().getType());
+    if (hasSharedMemoryAddressSpace(dstType)) {
+      hasSharedWrite = true;
+    }
+  });
+
+  return hasGlobalRead && hasSharedWrite;
+}
+
+/// Trace through view-like ops to find the root allocation.
+static memref::AllocOp traceToAllocation(Value base) {
+  while (base) {
+    if (auto alloc = base.getDefiningOp<memref::AllocOp>()) {
+      return alloc;
+    }
+    if (auto viewOp = base.getDefiningOp<ViewLikeOpInterface>()) {
+      base = viewOp.getViewSource();
+    } else {
+      break;
+    }
+  }
+  return nullptr;
+}
+
+/// Collect all view-like ops that need to be cloned inside the loop.
+/// Returns ops in topological order (dependencies first).
+/// Returns failure if any use escapes the target loop.
+static FailureOr<SmallVector<Operation *>>
+collectViewOpsToClone(memref::AllocOp alloc, scf::ForOp forOp) {
+  SetVector<Operation *> viewOpsToClone;
+  SmallVector<Value> worklist;
+
+  worklist.push_back(alloc.getResult());
+
+  // Collect all view-like ops outside the loop reachable from the allocation.
+  while (!worklist.empty()) {
+    Value val = worklist.pop_back_val();
+    for (Operation *user : val.getUsers()) {
+      if (forOp->isAncestor(user)) {
+        continue;
+      }
+      if (auto viewOp = dyn_cast<ViewLikeOpInterface>(user)) {
+        if (viewOpsToClone.insert(user)) {
+          worklist.push_back(viewOp.getViewDest());
+        }
+      }
+    }
+  }
+
+  auto validateUses = [&](Value val) -> LogicalResult {
+    for (Operation *user : val.getUsers()) {
+      if (forOp->isAncestor(user)) {
+        continue;
+      }
+      if (viewOpsToClone.contains(user)) {
+        continue;
+      }
+      LDBG() << "Cannot clone view ops: found use outside loop: " << *user;
+      return failure();
+    }
+    return success();
+  };
+
+  if (failed(validateUses(alloc.getResult()))) {
+    return failure();
+  }
+
+  for (Operation *op : viewOpsToClone) {
+    auto viewOp = cast<ViewLikeOpInterface>(op);
+    if (failed(validateUses(viewOp.getViewDest()))) {
+      return failure();
+    }
+  }
+
+  SmallVector<Operation *> result(viewOpsToClone.begin(), viewOpsToClone.end());
+
+  // Sort in topological order - ops must come after their dependencies
+  llvm::stable_sort(
+      result, [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
+
+  return result;
+}
+
+/// Clone view-like operations inside the loop body.
+/// This is necessary for multi-buffering to work when view ops are defined
+/// outside the target loop but used inside it.
+static LogicalResult cloneViewOpsInsideLoop(memref::AllocOp alloc,
+                                            scf::ForOp forOp) {
+  auto viewOpsOr = collectViewOpsToClone(alloc, forOp);
+  if (failed(viewOpsOr)) {
+    return failure();
+  }
+
+  SmallVector<Operation *> &viewOps = *viewOpsOr;
+  if (viewOps.empty()) {
+    return success();
+  }
+
+  LDBG() << "Cloning " << viewOps.size()
+         << " view ops inside loop for allocation: " << *alloc;
+
+  // Create clones at the beginning of the loop body
+  Block *loopBody = forOp.getBody();
+  OpBuilder builder(forOp.getContext());
+  builder.setInsertionPointToStart(loopBody);
+
+  IRMapping mapping;
+  SmallVector<Operation *> opsToErase;
+  for (Operation *op : viewOps) {
+    Operation *clone = builder.clone(*op, mapping);
+    LDBG() << "  Cloned: " << *op << " -> " << *clone;
+
+    Value origResult = op->getResult(0);
+    Value cloneResult = clone->getResult(0);
+    // Only replace uses inside this loop
+    origResult.replaceUsesWithIf(cloneResult, [&](OpOperand &use) {
+      return forOp->isAncestor(use.getOwner());
+    });
+
+    // Add to mapping so dependent ops will use the cloned version
+    mapping.map(origResult, cloneResult);
+
+    opsToErase.push_back(op);
+  }
+
+  // Erase original ops (in reverse order to handle dependencies).
+  for (auto it = opsToErase.rbegin(); it != opsToErase.rend(); ++it) {
+    Operation *op = *it;
+    op->erase();
+  }
+
+  return success();
+}
+
+/// Multi-buffer LDS allocations used by gather_to_lds operations.
+/// This enables double-buffering for pipelined async copies.
+static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
+                                               unsigned numBuffers) {
+  SetVector<memref::AllocOp> sharedAllocs;
+
+  // Find all LDS allocations used by gather_to_lds
+  forOp->walk([&](amdgpu::GatherToLDSOp gatherOp) {
+    if (auto alloc = traceToAllocation(gatherOp.getDst())) {
+      if (hasSharedMemoryAddressSpace(alloc.getType())) {
+        sharedAllocs.insert(alloc);
+      }
+    }
+  });
+
+  if (sharedAllocs.empty()) {
+    LDBG() << "No LDS allocations found for multi-buffering";
+    return failure();
+  }
+
+  LDBG() << "Multi-buffering " << sharedAllocs.size() << " LDS allocations";
+
+  // First, clone view ops inside the loop for each allocation
+  for (memref::AllocOp alloc : sharedAllocs) {
+    if (failed(cloneViewOpsInsideLoop(alloc, forOp))) {
+      LDBG() << "Failed to clone view ops for: " << *alloc;
+      return failure();
+    }
+  }
+
+  // Now apply multi-buffering
+  for (memref::AllocOp alloc : sharedAllocs) {
+    Location loc = alloc.getLoc();
+    if (failed(memref::multiBuffer(alloc, numBuffers,
+                                   /*skipOverrideAnalysis=*/true))) {
+      LDBG() << "Failed to multi-buffer LDS allocation at " << loc;
+      return failure();
+    }
+    LDBG() << "Multi-buffered LDS allocation with " << numBuffers
+           << " buffers at " << loc;
+  }
+
+  return success();
+}
 
 // Helper function to check if a transfer_read is from global memory.
 static bool isGlobalMemoryRead(vector::TransferReadOp read) {
@@ -690,8 +903,31 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
     return forOp;
   }
 
-  // For global->shared->register data flow, we have 3 operation groups (read,
-  // write, compute), so 3 stages is the maximum meaningful pipeline depth.
+  // Check for mixed mode: both gather_to_lds and stream copy ops.
+  // This is unsupported - bail out entirely without any pipelining.
+  bool hasAsyncCopy = hasGatherToLDS(forOp);
+  bool hasStreamCopy = hasStreamCopyOps(forOp);
+  if (hasAsyncCopy && hasStreamCopy) {
+    LDBG() << "Loop has both gather_to_lds and stream copy ops - "
+           << "skipping pipelining entirely";
+    return forOp;
+  }
+
+  if (hasAsyncCopy) {
+    LDBG() << "Async copy mode detected (gather_to_lds present)";
+
+    // Multi-buffer LDS allocations for double buffering
+    if (failed(multiBufferLDSAllocations(forOp, /*numBuffers=*/2))) {
+      return failure();
+    }
+
+    // TODO: Full async copy pipelining will be added in a follow-up commit.
+    // For now, just perform multi-buffering without pipelining.
+    return forOp;
+  }
+
+  // Stream copy mode: global->shared->register data flow with 3 operation
+  // groups (read, write, compute), so 3 stages is the maximum pipeline depth.
   if (numStages > 3) {
     LDBG() << "numStages=" << numStages
            << " requested but capping to 3 (maximum for read, write, compute)";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -405,6 +405,7 @@ func.func @prefetch_nested_loop(%arg0: memref<128xf32>) {
 
 // CHECK-LABEL: @prefetch_gather_to_lds_two_operands
 // CHECK-SAME: (%[[A_GLOBAL:.*]]: memref<128x128xf32>, %[[B_GLOBAL:.*]]: memref<128x128xf32>, %[[C_GLOBAL:.*]]: memref<128xf32>)
+// CHECK-3STAGE-LABEL: @prefetch_gather_to_lds_two_operands
 func.func @prefetch_gather_to_lds_two_operands(
     %A_global: memref<128x128xf32>,
     %B_global: memref<128x128xf32>,
@@ -415,9 +416,13 @@ func.func @prefetch_gather_to_lds_two_operands(
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
 
+  // 2-stage pipelining: 2 buffers for double-buffering
   // CHECK: %[[A_ALLOC:.*]] = memref.alloc() : memref<2x1xf32, #gpu.address_space<workgroup>>
+  // 3-stage pipelining: 3 buffers for triple-buffering
+  // CHECK-3STAGE: memref.alloc() : memref<3x1xf32, #gpu.address_space<workgroup>>
   %A_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
   // CHECK: %[[B_ALLOC:.*]] = memref.alloc() : memref<2x1xf32, #gpu.address_space<workgroup>>
+  // CHECK-3STAGE: memref.alloc() : memref<3x1xf32, #gpu.address_space<workgroup>>
   %B_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
 
   %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/176941. Since upstream limitation on multi-buffering is addressed, I can then manually clone all lds subview like ops inside the K loop and start to multi-buffer un-ambiguously. Note, this PR does multi-buffering only. The new pipelining code that take advantage of multi-buffering in async copy mode will come in successive PRs. Brief summary of changes:
- Add detection for `gather_to_lds` async copy patterns vs. stream copy patterns (global read + shared write)
- Bail on mixed-mode loops where both patterns exist
- Skip multi-buffering when `gather_to_lds` is inside conditional regions (e.g., `scf.if`)
- Clone view-like ops (subview, etc.) into the loop body when needed for `memref::multiBuffer` to work
- Skip multi-buffering when view ops have uses outside the target loop

Added unit tests covering:
- Multi-buffering with multiple LDS allocations - typical GEMM K loop case with two operands
- Conditional `gather_to_lds` (no multi-buffering)
- Mixed async/stream copy (no pipelining)
- View op escape scenarios (no multi-buffering)