### PR TITLE
Remove IREECodegenDialect dependency from LinalgExt

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
@@ -26,7 +26,6 @@ iree_compiler_cc_library(
         "WinogradConstants.h",
     ],
     deps = [
-        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:Analysis",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
@@ -37,7 +37,6 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorUtils
     MLIRTransformUtils
-    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
@@ -6,7 +6,6 @@
 
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 
-#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/SmallBitVector.h"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_DIALECT_LINALGEXT_UTILS_MATCHUTILS_H_
 #define IREE_COMPILER_DIALECT_LINALGEXT_UTILS_MATCHUTILS_H_
 
-#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -20,9 +19,6 @@ namespace detail {
 /// contraction.
 enum class MatchContractionResult;
 } // namespace detail
-
-Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
-                           Attribute attr);
 
 /// Positions of a Linalg op loops that correspond to different kinds of
 /// contraction dimension for scaled contractions.


### PR DESCRIPTION
Removes the unused dependency on `IREECodegenDialect` and deletes the declaration for `defaultPromotionImpl`.