### PR TITLE
[AMDGPU][LDS] Add in_bounds attribute to CoalescedGatherDMAOp for tensor.pad fusion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -300,6 +300,44 @@ struct LowerCoalescedGatherDMAPattern final
           }
         }
       }
+
+      // For non-outermost dims with OOB (in_bounds=false), the vector read
+      // must not cross row boundaries. Each lane reads `elementsPerLane`
+      // contiguous elements from the source buffer. If the source dim size is
+      // not a multiple of elementsPerLane, a vector read near the end of a row
+      // will wrap into the next row instead of returning zeros.
+      // Example: source 64x62xf32, dest 64x64xf32, vector<4xf32>:
+      //   Lane at [0, 60] reads 4 elements at flat offsets 60..63.
+      //   Offset 62 wraps to [1, 0] instead of returning 0.
+      ArrayRef<int64_t> sourceShape = srcType.getShape();
+      for (int64_t dim = 1; dim < srcType.getRank(); ++dim) {
+        if (dim >= static_cast<int64_t>(inBounds->size())) {
+          break;
+        }
+        bool dimInBounds = cast<BoolAttr>((*inBounds)[dim]).getValue();
+        if (dimInBounds) {
+          continue;
+        }
+        // This non-outermost dim has padding. Check that source dim size is
+        // a multiple of elementsPerLane for every segment to prevent row
+        // crossing.
+        if (ShapedType::isDynamic(sourceShape[dim])) {
+          return rewriter.notifyMatchFailure(
+              dmaOp, "non-outermost OOB dim " + Twine(dim) +
+                         " has dynamic source size; cannot verify vector "
+                         "reads do not cross row boundaries");
+        }
+        for (const TransferSegment &segment : segments) {
+          if (sourceShape[dim] % segment.elementsPerLane != 0) {
+            return rewriter.notifyMatchFailure(
+                dmaOp, "non-outermost OOB dim " + Twine(dim) +
+                           " has source size " + Twine(sourceShape[dim]) +
+                           " not divisible by elementsPerLane " +
+                           Twine(segment.elementsPerLane) +
+                           "; vector reads would cross row boundaries");
+          }
+        }
+      }
     }
 
     // Set up for code generation.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -507,7 +507,11 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
     // ops to be successfully lowered. In the future, a fallback lowering path
     // (e.g., using global_load) could handle ops that don't match the pattern.
     WalkResult result = funcOp.walk([&](IREE::GPU::CoalescedGatherDMAOp op) {
-      op.emitOpError("failed to lower coalesced_gather_dma op");
+      op.emitOpError(
+          "failed to lower to gather_to_lds; possible causes: source "
+          "lacks fat_raw_buffer address space for OOB padding, destination "
+          "is not contiguous, or element sizes are incompatible with "
+          "dma_sizes");
       return WalkResult::interrupt();
     });
     if (result.wasInterrupted()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -294,9 +294,9 @@ struct LowerCoalescedGatherDMAPattern final
       if (!hasAMDGPUFatRawBufferAddressSpace(srcType)) {
         for (Attribute attr : *inBounds) {
           if (!cast<BoolAttr>(attr).getValue()) {
-            dmaOp.emitOpError("in_bounds with OOB dimensions requires "
-                              "fat_raw_buffer address space on source");
-            return failure();
+            return rewriter.notifyMatchFailure(
+                dmaOp, "in_bounds with OOB dimensions requires "
+                       "fat_raw_buffer address space on source");
           }
         }
       }
@@ -503,7 +503,6 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
 
     walkAndApplyPatterns(funcOp, std::move(patterns));
 
-#ifndef NDEBUG
     // Verify all CoalescedGatherDMAOps were lowered. Currently, we require all
     // ops to be successfully lowered. In the future, a fallback lowering path
     // (e.g., using global_load) could handle ops that don't match the pattern.
@@ -514,7 +513,6 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
     if (result.wasInterrupted()) {
       return signalPassFailure();
     }
-#endif // NDEBUG
   }
 };
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -409,8 +409,8 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
       }
     }
 
-    // Fallback: original behavior without tensor.pad fusion.
-    // Only trace through ONE level of extract_slice (the immediate input).
+    // Fallback: no tensor.pad fusion. The input is an extract_slice from
+    // tiling; trace through it to get the actual source.
     if (!source) {
       if (auto extractSlice = input.getDefiningOp<tensor::ExtractSliceOp>()) {
         source = extractSlice.getSource();
@@ -545,19 +545,19 @@ struct ConvertPadFusionCopyToCoalescedDMA
 
   LogicalResult matchAndRewrite(linalg::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
-    // Only match copies with use_global_load_dma config
+    // Only match copies with use_global_load_dma config.
     auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp);
     if (!config) {
       return failure();
     }
 
-    // Check if this is a tensor.pad fusion case
+    // Check if this is a tensor.pad fusion case.
     auto pad = traceToTensorPad(copyOp.getInputs()[0]);
     if (!pad) {
       return failure(); // Not a pad fusion case
     }
 
-    // Check if padding exists (non-zero low/high pad)
+    // Check if padding exists (non-zero low/high pad).
     bool hasPadding = false;
     for (auto [low, high] :
          llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
@@ -974,7 +974,7 @@ private:
     bool isPadFusion = false;
     if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
       if (auto pad = traceToTensorPad(copyOp.getInputs()[0])) {
-        // Check if padding exists (non-zero low/high pad)
+        // Check if padding exists (non-zero low/high pad).
         for (auto [low, high] :
              llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
           if (!isConstantIntValue(low, 0) || !isConstantIntValue(high, 0)) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -56,6 +57,15 @@ static SmallVector<Attribute> getThreadMapping(MLIRContext *ctx) {
   // Map it to gpu.lane_id<0>.
   mapping.push_back(IREE::GPU::LaneIdAttr::get(ctx, 0));
   return mapping;
+}
+
+/// Trace through extract_slice operations to find an underlying tensor.pad.
+/// Returns the PadOp if found, nullptr otherwise.
+static tensor::PadOp traceToTensorPad(Value source) {
+  while (auto extractSlice = source.getDefiningOp<tensor::ExtractSliceOp>()) {
+    source = extractSlice.getSource();
+  }
+  return source.getDefiningOp<tensor::PadOp>();
 }
 
 /// Check if a value traces back to tensor.empty (possibly through forall args).
@@ -339,14 +349,74 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
 
   Location loc = innerOp.getLoc();
   Value source, indices;
+  SmallVector<bool> inBoundsVec;
 
   // Extract source and indices based on op type.
   if constexpr (std::is_same_v<OpTy, linalg::CopyOp>) {
     Value input = innerOp.getInputs()[0];
-    if (auto extractSlice = input.getDefiningOp<tensor::ExtractSliceOp>()) {
-      source = extractSlice.getSource();
-    } else {
-      return failure();
+
+    // After tiling, the input is typically:
+    //   tensor.extract_slice %padded[...] [...] [1, 1]
+    // We need to trace through extract_slice to find if source is tensor.pad.
+    if (auto pad = traceToTensorPad(input)) {
+      // Verify pad constraints: low padding must be all zeros, pad value must
+      // be 0.
+      bool validPad = true;
+      for (OpFoldResult low : pad.getMixedLowPad()) {
+        if (!isConstantIntValue(low, 0)) {
+          validPad = false;
+          break;
+        }
+      }
+      Value padVal = pad.getConstantPaddingValue();
+      if (!padVal || !(matchPattern(padVal, m_AnyZeroFloat()) ||
+                       matchPattern(padVal, m_Zero()))) {
+        validPad = false;
+      }
+
+      if (validPad) {
+        // Use pad.getSource() directly as the DMA source.
+        // This is the tensor.extract_slice result (e.g., tensor<?x64xf32>).
+        source = pad.getSource();
+
+        // Check if source tensor's innermost row size is DWORD (4-byte)
+        // aligned. On AMD CDNA, per-component range checking is performed for
+        // each DWORD. If a DWORD is partially out-of-bounds, the entire DWORD
+        // returns zero, causing incorrect results. Additionally, partial OOB
+        // triggers the slow path with multi-cycling and instruction issue
+        // penalties.
+        auto sourceType = cast<RankedTensorType>(source.getType());
+        int64_t innermostDim = sourceType.getShape().back();
+        if (!ShapedType::isDynamic(innermostDim)) {
+          Type elemType = sourceType.getElementType();
+          int64_t elemBytes = elemType.getIntOrFloatBitWidth() / 8;
+          int64_t rowBytes = innermostDim * elemBytes;
+          if (rowBytes % 4 != 0) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "Skipping DMA: row size " << rowBytes
+                       << " bytes not DWORD-aligned (slow path)\n");
+            return failure();
+          }
+        }
+
+        // Compute in_bounds based on whether padding was added per dimension.
+        for (auto [low, high] :
+             llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
+          bool isInBounds =
+              isConstantIntValue(low, 0) && isConstantIntValue(high, 0);
+          inBoundsVec.push_back(isInBounds);
+        }
+      }
+    }
+
+    // Fallback: original behavior without tensor.pad fusion.
+    // Only trace through ONE level of extract_slice (the immediate input).
+    if (!source) {
+      if (auto extractSlice = input.getDefiningOp<tensor::ExtractSliceOp>()) {
+        source = extractSlice.getSource();
+      } else {
+        return failure();
+      }
     }
   } else if constexpr (std::is_same_v<OpTy, IREE::LinalgExt::GatherOp>) {
     source = innerOp.getSource();
@@ -395,15 +465,22 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
 
   // Create the DMA op in the in_parallel region.
   rewriter.setInsertionPointToStart(&inParallelBlock);
-  SmallVector<Value, 1> indicesVec;
+  SmallVector<Value, 1> indicesOperands;
   if (indices) {
-    indicesVec.push_back(indices);
+    indicesOperands.push_back(indices);
+  }
+
+  // Create in_bounds attribute if we fused a tensor.pad.
+  ArrayAttr inBoundsAttr;
+  if (!inBoundsVec.empty()) {
+    inBoundsAttr = rewriter.getBoolArrayAttr(inBoundsVec);
   }
 
   // When used in forall.in_parallel, the op doesn't return a result
   // as it performs an in-place update to the shared_outs tensor.
   IREE::GPU::CoalescedGatherDMAOp::create(rewriter, loc, Type(), source,
-                                          indicesVec, sharedOut, laneId);
+                                          indicesOperands, sharedOut, laneId,
+                                          inBoundsAttr);
 
   // Erase the parallel_insert_slice ops and inner operation.
   for (tensor::ParallelInsertSliceOp &insertOp : toErase) {
@@ -457,6 +534,58 @@ protected:
                           linalg::CopyOp copyOp) const override {
     auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
     return computeThreadNumThreadsImpl(builder, copyOp, outputType);
+  }
+};
+
+/// Pattern to convert tensor.pad fusion cases directly without requiring
+/// warp-mapped forall parent.
+struct ConvertPadFusionCopyToCoalescedDMA
+    : public OpRewritePattern<linalg::CopyOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::CopyOp copyOp,
+                                PatternRewriter &rewriter) const override {
+    // Only match copies with use_global_load_dma config
+    auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp);
+    if (!config) {
+      return failure();
+    }
+
+    // Check if this is a tensor.pad fusion case
+    auto pad = traceToTensorPad(copyOp.getInputs()[0]);
+    if (!pad) {
+      return failure(); // Not a pad fusion case
+    }
+
+    // Check if padding exists (non-zero low/high pad)
+    bool hasPadding = false;
+    for (auto [low, high] :
+         llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
+      if (!isConstantIntValue(low, 0) || !isConstantIntValue(high, 0)) {
+        hasPadding = true;
+        break;
+      }
+    }
+    if (!hasPadding) {
+      return failure(); // No actual padding
+    }
+
+    // This is a tensor.pad fusion case. Convert directly to
+    // coalesced_gather_dma without requiring warp-mapped forall.
+    auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
+    SmallVector<OpFoldResult> threadNumThreads =
+        computeThreadNumThreadsImpl(rewriter, copyOp, outputType);
+    if (threadNumThreads.empty()) {
+      return failure();
+    }
+
+    scf::ForallOp threadForallOp =
+        tileToThreadLevel(copyOp, rewriter, threadNumThreads);
+    if (!threadForallOp) {
+      return failure();
+    }
+
+    return createDMAInForall<linalg::CopyOp>(threadForallOp, rewriter);
   }
 };
 
@@ -612,7 +741,8 @@ struct ConvertGatherToCoalescedDMA
     rewriter.setInsertionPointToStart(&inParallelBlock);
 
     IREE::GPU::CoalescedGatherDMAOp::create(rewriter, loc, Type(), source,
-                                            indicesVec, sharedOut, laneId);
+                                            indicesVec, sharedOut, laneId,
+                                            /*in_bounds=*/nullptr);
 
     // Erase parallel_insert_slice ops and gather op.
     SmallVector<tensor::ParallelInsertSliceOp> toErase;
@@ -685,9 +815,11 @@ struct GPUConvertToCoalescedDMAPass final
     }
 
     // Only tile and convert ops within forall ops with warp mapping.
+    // Also handle tensor.pad fusion cases that don't have warp mapping.
     RewritePatternSet patterns(context);
     patterns.add<ConvertGatherToCoalescedDMA>(context);
     patterns.add<ConvertCopyToCoalescedDMA>(context);
+    patterns.add<ConvertPadFusionCopyToCoalescedDMA>(context);
 
     walkAndApplyPatterns(funcOp, std::move(patterns));
   }
@@ -838,9 +970,42 @@ private:
       return failure();
     }
 
-    // Compute tile sizes for subgroup-level distribution.
-    auto [tileSizes, numTiledDims] =
-        computeSubgroupTileSizes(rewriter, shape, numWarps);
+    // Check if this is a tensor.pad fusion case.
+    bool isPadFusion = false;
+    if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
+      if (auto pad = traceToTensorPad(copyOp.getInputs()[0])) {
+        // Check if padding exists (non-zero low/high pad)
+        for (auto [low, high] :
+             llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
+          if (!isConstantIntValue(low, 0) || !isConstantIntValue(high, 0)) {
+            isPadFusion = true;
+            break;
+          }
+        }
+      }
+    }
+
+    SmallVector<OpFoldResult> tileSizes;
+    int64_t numTiledDims = 0;
+
+    if (isPadFusion) {
+      // For tensor.pad fusion, create a single-iteration wrapper forall
+      // by setting tile sizes to the full shape. This allows the DMA to
+      // operate on the full buffer while satisfying the warp-mapped parent
+      // requirement.
+      // Bail out if any dimension is dynamic since we need static tile sizes.
+      if (llvm::any_of(shape, ShapedType::isDynamic)) {
+        return failure();
+      }
+      for (int64_t i = 0; i < rank; ++i) {
+        tileSizes.push_back(rewriter.getIndexAttr(shape[i]));
+        ++numTiledDims;
+      }
+    } else {
+      // Compute tile sizes for subgroup-level distribution.
+      std::tie(tileSizes, numTiledDims) =
+          computeSubgroupTileSizes(rewriter, shape, numWarps);
+    }
 
     if (numTiledDims == 0) {
       return failure();
@@ -878,6 +1043,9 @@ private:
     });
 
     // Apply subgroup-level tiling to each op.
+    // For tensor.pad fusion cases, tileAtSubgroupLevel creates a
+    // single-iteration wrapper forall to maintain the expected structure while
+    // allowing the DMA to operate on the full buffer.
     IRRewriter rewriter(context);
     for (Operation *op : opsToTile) {
       FailureOr<scf::SCFTilingResult> tilingResult =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -358,7 +358,7 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     // After tiling, the input is typically:
     //   tensor.extract_slice %padded[...] [...] [1, 1]
     // We need to trace through extract_slice to find if source is tensor.pad.
-    if (auto pad = traceToTensorPad(input)) {
+    if (tensor::PadOp pad = traceToTensorPad(input)) {
       // Verify pad constraints: low padding must be all zeros, pad value must
       // be 0.
       bool validPad = true;
@@ -973,7 +973,7 @@ private:
     // Check if this is a tensor.pad fusion case.
     bool isPadFusion = false;
     if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
-      if (auto pad = traceToTensorPad(copyOp.getInputs()[0])) {
+      if (tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0])) {
         // Check if padding exists (non-zero low/high pad).
         for (auto [low, high] :
              llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -150,8 +150,7 @@ static bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
   if (!target) {
     return false;
   }
-  FailureOr<amdgpu::Chipset> chipset =
-      amdgpu::Chipset::parse(target.getArch());
+  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(target.getArch());
   if (failed(chipset)) {
     return false;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
@@ -47,7 +47,8 @@ bool isDefinitelyShared(bufferization::AllocTensorOp alloc) {
     auto forallOp = dyn_cast<scf::ForallOp>(user);
     if (!forallOp ||
         !forallOpHasMappingType<gpu::GPUThreadMappingAttr,
-                                gpu::GPUWarpMappingAttr>(forallOp)) {
+                                gpu::GPUWarpMappingAttr, IREE::GPU::LaneIdAttr>(
+            forallOp)) {
       return false;
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1224,3 +1224,61 @@ func.func @gather_dma_non_outermost_oob_check(
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return
 }
+
+// -----
+
+// Test: Inner-dim padding OOB check with <64x62xf32> source padded to <64x64xf32>.
+// Only inner dim (dim 1) has padding: 62 → 64. in_bounds = [true, false].
+// Raw buffer OOB is 1D (linear): reading <4 x f32> at [0, 60] would compute a
+// linear offset within the buffer and wrap to [1, 0], [1, 1] instead of returning 0.
+// Fix: when srcIndices[1] >= 62, replace srcIndices[0] with 64 (past buffer end)
+// so the linearized offset exceeds buffer size → hardware returns 0.
+
+#executable_target_rocm_hsaco_fb_inner_pad = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_64_inner_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @gather_dma_inner_dim_oob_64x62
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<64x64xf32, #gpu.address_space<workgroup>>
+func.func @gather_dma_inner_dim_oob_64x62(
+    %source: memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<64x64xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_inner_pad,
+    translation_info = #translation_64_inner_pad} {
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (64)
+  scf.forall (%arg6) in (64) {
+    // Each lane transfers vector<4xf32> (dma_sizes [128] = 128 bits = 4 x f32).
+    // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
+    // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
+    //
+    // Transfer 1: linearOffset = 0
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
+    // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (64, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (64, 64)
+    //
+    // Bounds check: compare srcIndices[1] >= 62 (source inner dim size).
+    // CHECK: %[[C62:.+]] = arith.constant 62 : index
+    // CHECK: %[[OOB:.+]] = arith.cmpi uge, %[[SRC_DELIN0]]#1, %[[C62]] : index
+    // Replace outermost index with 64 (source dim 0 size) to force hardware OOB.
+    // CHECK: %[[C64_OOB:.+]] = arith.constant 64 : index
+    // CHECK: %[[FIXED_IDX:.+]] = arith.select %[[OOB]], %[[C64_OOB]], %[[SRC_DELIN0]]#0 : index
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[FIXED_IDX]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [true, false] :
+      memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<64x64xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1291,7 +1291,6 @@ func.func @no_lower_oob_without_fat_raw_buffer(
     attributes {hal.executable.target = #executable_target_rocm_hsaco_fb,
                 translation_info = #translation_64} {
   scf.forall (%arg6) in (64) {
-    // expected-error @+2 {{in_bounds with OOB dimensions requires fat_raw_buffer address space on source}}
     // expected-error @+1 {{failed to lower coalesced_gather_dma op}}
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [false, true] :
       memref<2x128xf32>,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1218,12 +1218,10 @@ func.func @gather_dma_non_outermost_oob_check(
 
 // -----
 
-// Test: Inner-dim padding OOB check with <64x62xf32> source padded to <64x64xf32>.
-// Only inner dim (dim 1) has padding: 62 → 64. in_bounds = [true, false].
-// Raw buffer OOB is 1D (linear): reading <4 x f32> at [0, 60] would compute a
-// linear offset within the buffer and wrap to [1, 0], [1, 1] instead of returning 0.
-// Fix: when srcIndices[1] >= 62, replace srcIndices[0] with 64 (past buffer end)
-// so the linearized offset exceeds buffer size → hardware returns 0.
+// Test: Inner-dim padding where source dim is aligned with vector width.
+// Source 64x60 padded to 64x64, in_bounds = [true, false].
+// elementsPerLane = 4 (128-bit DMA with f32), 60 % 4 = 0, so no vector
+// read crosses a row boundary. The OOB check correctly handles dim 1.
 
 #executable_target_rocm_hsaco_fb_inner_pad = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
@@ -1238,11 +1236,11 @@ func.func @gather_dma_non_outermost_oob_check(
 
 #translation_64_inner_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 
-// CHECK-LABEL: func.func @gather_dma_inner_dim_oob_64x62
-// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-LABEL: func.func @gather_dma_inner_dim_oob_64x60
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<64x60xf32, #amdgpu.address_space<fat_raw_buffer>>
 // CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<64x64xf32, #gpu.address_space<workgroup>>
-func.func @gather_dma_inner_dim_oob_64x62(
-    %source: memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>,
+func.func @gather_dma_inner_dim_oob_64x60(
+    %source: memref<64x60xf32, #amdgpu.address_space<fat_raw_buffer>>,
     %dest: memref<64x64xf32, #gpu.address_space<workgroup>>)
   attributes {
     hal.executable.target = #executable_target_rocm_hsaco_fb_inner_pad,
@@ -1259,16 +1257,52 @@ func.func @gather_dma_inner_dim_oob_64x62(
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (64, 64)
     // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (64, 64)
     //
-    // Bounds check: compare srcIndices[1] >= 62 (source inner dim size).
+    // Bounds check: compare srcIndices[1] >= 60 (source inner dim size).
     // CHECK: %[[FALSE:.+]] = arith.constant false
-    // CHECK: %[[C62:.+]] = arith.constant 62 : index
-    // CHECK: %[[CMP:.+]] = arith.cmpi uge, %[[SRC_DELIN0]]#1, %[[C62]] : index
+    // CHECK: %[[C60:.+]] = arith.constant 60 : index
+    // CHECK: %[[CMP:.+]] = arith.cmpi uge, %[[SRC_DELIN0]]#1, %[[C60]] : index
     // CHECK: %[[OOB:.+]] = arith.ori %[[FALSE]], %[[CMP]] : i1
     // Replace outermost index with 64 (source dim 0 size) to force hardware OOB.
     // CHECK: %[[C64_OOB:.+]] = arith.constant 64 : index
     // CHECK: %[[FIXED_IDX:.+]] = arith.select %[[OOB]], %[[C64_OOB]], %[[SRC_DELIN0]]#0 : index
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[FIXED_IDX]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [true, false] :
+      memref<64x60xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<64x64xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
+// Test: Inner-dim padding rejected when source dim is not aligned with vector width.
+// Source 64x62 padded to 64x64, in_bounds = [true, false].
+// elementsPerLane = 4 (128-bit DMA with f32), 62 % 4 != 0.
+// A vector read at [0, 60] would span elements 60..63 in the flat buffer,
+// wrapping into the next row (offset 62 = [1, 0]) instead of returning 0.
+
+#executable_target_rocm_hsaco_fb_inner_pad_unaligned = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_64_inner_pad_unaligned = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+func.func @gather_dma_inner_dim_oob_64x62_rejected(
+    %source: memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<64x64xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_inner_pad_unaligned,
+    translation_info = #translation_64_inner_pad_unaligned} {
+  scf.forall (%arg6) in (64) {
+    // expected-error @+1 {{failed to lower to gather_to_lds; possible causes: source lacks fat_raw_buffer address space for OOB padding, destination is not contiguous, or element sizes are incompatible with dma_sizes}}
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [true, false] :
       memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>,
       memref<64x64xf32, #gpu.address_space<workgroup>>, index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1164,3 +1164,63 @@ func.func @lower_coalesced_dma_4x64_tensor_pad_fusion(
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return
 }
+
+// -----
+
+// Test: Non-outermost dimension padding with in_bounds = [false, false].
+// Source: 4x6, dest: 4x8. Dim 1 has padding (6 → 8).
+// Raw buffer OOB is linear/1D, so for non-outermost dim OOB, we must
+// replace the outermost index with sourceShape[0] to force hardware OOB.
+//
+// Without the fix: reading at [0, 6] computes a byte offset within the
+// buffer and wraps to [1, 0] instead of returning 0.
+// With the fix: when srcIndices[1] >= 6, srcIndices[0] is replaced with 4
+// (source dim 0 size), guaranteeing linear offset >= buffer size → returns 0.
+
+#executable_target_rocm_hsaco_fb_pad = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32]>>}>
+
+#translation_32_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+// CHECK-LABEL: func.func @gather_dma_non_outermost_oob_check
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x6xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<4x8xf32, #gpu.address_space<workgroup>>
+func.func @gather_dma_non_outermost_oob_check(
+    %source: memref<4x6xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<4x8xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_pad,
+    translation_info = #translation_32_pad} {
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
+  scf.forall (%arg6) in (32) {
+    // CHECK: %[[C1:[a-zA-Z0-9_]+]] = arith.constant 1
+    // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C1]]
+    //
+    // Transfer 1: linearOffset = 0
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
+    // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 8)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 8)
+    //
+    // Bounds check: compare srcIndices[1] >= 6 (source dim 1 size)
+    // CHECK: %[[C6:.+]] = arith.constant 6 : index
+    // CHECK: %[[OOB:.+]] = arith.cmpi uge, %[[SRC_DELIN0]]#1, %[[C6]] : index
+    // Replace outermost index with 4 (source dim 0 size) to force hardware OOB
+    // CHECK: %[[C4_OOB:.+]] = arith.constant 4 : index
+    // CHECK: %[[FIXED_IDX:.+]] = arith.select %[[OOB]], %[[C4_OOB]], %[[SRC_DELIN0]]#0 : index
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[FIXED_IDX]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<1xf32>
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [false, false] :
+      memref<4x6xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<4x8xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -586,19 +586,19 @@ func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x124xf16>
 func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init: tensor<4x124xf16>, %off: index, %sz: index, %high_m: index) -> tensor<4x124xf16>
   attributes {hal.executable.target = #exec_target_pad_unaligned, translation_info = #translation_pad_unaligned} {
-  // Extract a dynamic slice: tensor<?x121xf16>
-  // Row size = 121 * 2 bytes = 242 bytes, NOT 4-byte aligned
+  // Extract a dynamic slice: tensor<?x121xf16>.
+  // Row size = 121 * 2 bytes = 242 bytes, NOT 4-byte aligned.
   %extracted = tensor.extract_slice %source[%off, 0] [%sz, 121] [1, 1]
       : tensor<65x121xf16> to tensor<?x121xf16>
 
-  // Pad to static size
+  // Pad to static size.
   %cst = arith.constant 0.0 : f16
   %padded = tensor.pad %extracted low[0, 0] high[%high_m, 3] {
   ^bb0(%arg0: index, %arg1: index):
     tensor.yield %cst : f16
   } : tensor<?x121xf16> to tensor<4x124xf16>
 
-  // Copy from padded tensor
+  // Copy from padded tensor.
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%padded : tensor<4x124xf16>)
     outs(%init : tensor<4x124xf16>) -> tensor<4x124xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-convert-to-coalesced-dma,canonicalize))" %s --split-input-file | FileCheck %s
 
-#gpu_target_copy = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_copy = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [32],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -49,7 +49,7 @@ func.func @copy(%source: tensor<64x512xf32>, %init: tensor<64x512xf32>) -> tenso
 
 // -----
 
-#gpu_target_gather = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_gather = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -103,7 +103,7 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
 // Negative test: Skip coalesced DMA when innermost dimension < subgroup size. This is to ensure we do not go down
 // the slow path (which is not implemented yet).
 
-#gpu_target_small_inner = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_small_inner = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -176,7 +176,7 @@ func.func @copy_not_aligned_to_dma(%source_buffer: memref<320xbf16, #amdgpu.addr
 // - Instead, we should tile rows to 16 (64/4) and keep columns whole (128)
 // This ensures subviews are contiguous in memory.
 
-#gpu_target_contiguous = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_contiguous = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -236,7 +236,7 @@ func.func @copy_prefer_contiguous_subview(%source: tensor<64x128xf32>, %init: te
 // When output comes from tensor.empty(), we can use total elements instead of
 // innermost dimension for the size check, enabling coalesced DMA.
 
-#gpu_target_linearize = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_linearize = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -296,7 +296,7 @@ func.func @copy_small_innermost_linearized(%source: tensor<128x16xf32>) -> tenso
 // Test: 1D tensor copy distributes warps across the single dimension.
 // This tests the 1D tile size computation logic for flattened copies.
 
-#gpu_target_1d = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_1d = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -358,7 +358,7 @@ func.func @copy_1d_tensor(%source: tensor<2048xf32>) -> tensor<2048xf32>
 // 1. Innermost dim (16) < minElementsPerTransfer (64)
 // 2. Output is a function argument, not tensor.empty, so we can't linearize
 
-#gpu_target_no_linearize = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_no_linearize = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -395,7 +395,7 @@ func.func @copy_small_innermost_no_linearize(%source: tensor<128x16xf32>, %dest:
 // The copy should be converted to coalesced DMA when the input comes from an
 // extract_slice with contiguous innermost dimensions.
 
-#gpu_target_extract_input = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_extract_input = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -451,7 +451,7 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
 // When linalg.copy reads from tensor.pad, trace through to the original source
 // and set in_bounds attribute based on padding.
 
-#gpu_target_pad = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_pad = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -467,24 +467,24 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x64xf32>
 func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tensor<4x64xf32>, %off: index, %sz: index, %high: index) -> tensor<4x64xf32>
   attributes {hal.executable.target = #exec_target_pad, translation_info = #translation_pad} {
-  // Extract a dynamic slice
+  // Extract a dynamic slice.
   %extracted = tensor.extract_slice %source[%off, 0] [%sz, 64] [1, 1]
       : tensor<121x64xf32> to tensor<?x64xf32>
 
-  // Pad to static size (only M dimension has padding)
+  // Pad to static size (only M dimension has padding).
   %cst = arith.constant 0.0 : f32
   %padded = tensor.pad %extracted low[0, 0] high[%high, 0] {
   ^bb0(%arg0: index, %arg1: index):
     tensor.yield %cst : f32
   } : tensor<?x64xf32> to tensor<4x64xf32>
 
-  // Copy from padded tensor
+  // Copy from padded tensor.
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%padded : tensor<4x64xf32>)
     outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
 
-  // Key check: tensor.pad is fused - source is the extract_slice result, not the padded tensor
-  // in_bounds = [false, true] because M dim has dynamic padding, K dim has no padding
+  // Key check: tensor.pad is fused - source is the extract_slice result, not the padded tensor.
+  // in_bounds = [false, true] because M dim has dynamic padding, K dim has no padding.
   // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
   // CHECK: scf.forall {{.*}} shared_outs(%[[OUTER_INIT:.+]] = %[[INIT]])
   // CHECK:   scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[OUTER_INIT]])
@@ -504,7 +504,7 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
 // operates on the full padded buffer shape, not on smaller subviews.
 // This is critical for correct delinearization in the lowering pass.
 
-#gpu_target_pad_multi_warp = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_pad_multi_warp = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -520,18 +520,18 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x64xf32>
 func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %init: tensor<4x64xf32>, %off: index, %sz: index, %high: index) -> tensor<4x64xf32>
   attributes {hal.executable.target = #exec_target_pad_multi_warp, translation_info = #translation_pad_multi_warp} {
-  // Extract a dynamic slice
+  // Extract a dynamic slice.
   %extracted = tensor.extract_slice %source[%off, 0] [%sz, 64] [1, 1]
       : tensor<121x64xf32> to tensor<?x64xf32>
 
-  // Pad to static size (only M dimension has padding)
+  // Pad to static size (only M dimension has padding).
   %cst = arith.constant 0.0 : f32
   %padded = tensor.pad %extracted low[0, 0] high[%high, 0] {
   ^bb0(%arg0: index, %arg1: index):
     tensor.yield %cst : f32
   } : tensor<?x64xf32> to tensor<4x64xf32>
 
-  // Copy from padded tensor with 4 warps (256/64=4)
+  // Copy from padded tensor with 4 warps (256/64=4).
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%padded : tensor<4x64xf32>)
     outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
@@ -570,7 +570,7 @@ func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %
 // If a DWORD is partially out-of-bounds, the entire DWORD returns zero,
 // causing incorrect results. We bail out to avoid the slow path.
 
-#gpu_target_pad_unaligned = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_pad_unaligned = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -24,10 +24,8 @@ func.func @copy(%source: tensor<64x512xf32>, %init: tensor<64x512xf32>) -> tenso
   // With 16 warps (128*512/64/64) and 64 rows: step = ceil(64/16) = 4 rows, 512 cols (whole)
   // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 512) step (4, 512)
   // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<64x512xf32>) {
-  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [4, 512] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<4x512xf32>
-  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [4, 512] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<4x512xf32>
+  // CHECK-DAG:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [4, 512] [1, 1]
+  // CHECK-DAG:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [4, 512] [1, 1]
 
   // Thread-level forall:
   // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64)
@@ -36,14 +34,12 @@ func.func @copy(%source: tensor<64x512xf32>, %init: tensor<64x512xf32>) -> tenso
   // CHECK:       iree_gpu.coalesced_gather_dma %[[SLICE_SRC]] into %[[THREAD_INIT]] lane(%[[LANE]])
   // CHECK-SAME:       : tensor<4x512xf32>, tensor<4x512xf32>, index
   // CHECK:     }
-
   // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
 
   // CHECK:   scf.forall.in_parallel {
   // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [4, 512] [1, 1]
-  // CHECK-SAME:     : tensor<4x512xf32> into tensor<64x512xf32>
   // CHECK:   }
-  // CHECK: }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
 
   // CHECK: return %[[WARP_RESULT]]
   // CHECK-NOT: linalg.copy
@@ -79,10 +75,8 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
   // With 64 warps and 64 rows: step = ceil(64/64) = 1 row, 512 cols (whole)
   // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (64, 512) step (1, 512)
   // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<64x512xf32>) {
-  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [1, 512] [1, 1]
-  // CHECK-SAME:   : tensor<64x512xf32> to tensor<1x512xf32>
-  // CHECK:   %[[SLICE_INDICES:.+]] = tensor.extract_slice %[[INDICES]][%[[IV0]]] [1] [1]
-  // CHECK-SAME:   : tensor<64xi32> to tensor<1xi32>
+  // CHECK-DAG:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [1, 512] [1, 1]
+  // CHECK-DAG:   %[[SLICE_INDICES:.+]] = tensor.extract_slice %[[INDICES]][%[[IV0]]] [1] [1]
 
   // Thread-level forall:
   // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64)
@@ -95,9 +89,8 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
 
   // CHECK:   scf.forall.in_parallel {
   // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [1, 512] [1, 1]
-  // CHECK-SAME:     : tensor<1x512xf32> into tensor<64x512xf32>
   // CHECK:   }
-  // CHECK: }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
 
   // CHECK: return %[[WARP_RESULT]]
   // CHECK-NOT: iree_linalg_ext.gather
@@ -211,9 +204,9 @@ func.func @copy_prefer_contiguous_subview(%source: tensor<64x128xf32>, %init: te
   // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<64x128xf32>) {
 
   // Key check: subviews are 16x128 (contiguous) not 64x64 (non-contiguous)
-  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [16, 128] [1, 1]
+  // CHECK-DAG:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [16, 128] [1, 1]
   // CHECK-SAME:   : tensor<64x128xf32> to tensor<16x128xf32>
-  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [16, 128] [1, 1]
+  // CHECK-DAG:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [16, 128] [1, 1]
   // CHECK-SAME:   : tensor<64x128xf32> to tensor<16x128xf32>
 
   // Thread-level forall distributes across lanes:
@@ -229,7 +222,7 @@ func.func @copy_prefer_contiguous_subview(%source: tensor<64x128xf32>, %init: te
   // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [16, 128] [1, 1]
   // CHECK-SAME:     : tensor<16x128xf32> into tensor<64x128xf32>
   // CHECK:   }
-  // CHECK: }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
 
   // CHECK: return %[[WARP_RESULT]]
   // CHECK-NOT: linalg.copy
@@ -272,9 +265,9 @@ func.func @copy_small_innermost_linearized(%source: tensor<128x16xf32>) -> tenso
   // Warp-level forall: step (32, 16) distributes 128 rows across 4 warps
   // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (128, 16) step (32, 16)
   // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[EMPTY]]) -> (tensor<128x16xf32>) {
-  // CHECK:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [32, 16] [1, 1]
+  // CHECK-DAG:   %[[SLICE_SRC:.+]] = tensor.extract_slice %[[SRC]][%[[IV0]], 0] [32, 16] [1, 1]
   // CHECK-SAME:   : tensor<128x16xf32> to tensor<32x16xf32>
-  // CHECK:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [32, 16] [1, 1]
+  // CHECK-DAG:   %[[SLICE_DST:.+]] = tensor.extract_slice %[[INIT_TILE]][%[[IV0]], 0] [32, 16] [1, 1]
   // CHECK-SAME:   : tensor<128x16xf32> to tensor<32x16xf32>
 
   // Thread-level forall with 64 lanes
@@ -290,7 +283,7 @@ func.func @copy_small_innermost_linearized(%source: tensor<128x16xf32>) -> tenso
   // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][%[[IV0]], 0] [32, 16] [1, 1]
   // CHECK-SAME:     : tensor<32x16xf32> into tensor<128x16xf32>
   // CHECK:   }
-  // CHECK: }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
 
   // CHECK: return %[[WARP_RESULT]]
   // CHECK-NOT: linalg.copy
@@ -454,10 +447,11 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
 
 // -----
 
-// Test: Two copies both with use_global_load_dma and both DMA-convertible.
-// Both should be converted to coalesced DMA.
+// Test: tensor.pad fusion into coalesced_gather_dma.
+// When linalg.copy reads from tensor.pad, trace through to the original source
+// and set in_bounds attribute based on padding.
 
-#gpu_target_pair = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_pad = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -465,36 +459,52 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
   dma_sizes = [32, 128]
 >>
 
-#exec_target_pair = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pair}>
-#translation_pair = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#exec_target_pad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad}>
+#translation_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_pair_both_convertible
-func.func @copy_pair_both_convertible(
-    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
-    %src1: tensor<32x256xf32>, %init1: tensor<32x256xf32>)
-    -> (tensor<64x128xf32>, tensor<32x256xf32>)
-  attributes {hal.executable.target = #exec_target_pair, translation_info = #translation_pair} {
-  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
-    ins(%src0 : tensor<64x128xf32>)
-    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
-  %r1 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
-    ins(%src1 : tensor<32x256xf32>)
-    outs(%init1 : tensor<32x256xf32>) -> tensor<32x256xf32>
+// CHECK-LABEL: func.func @copy_with_tensor_pad_fusion
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<121x64xf32>
+// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x64xf32>
+func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tensor<4x64xf32>, %off: index, %sz: index, %high: index) -> tensor<4x64xf32>
+  attributes {hal.executable.target = #exec_target_pad, translation_info = #translation_pad} {
+  // Extract a dynamic slice
+  %extracted = tensor.extract_slice %source[%off, 0] [%sz, 64] [1, 1]
+      : tensor<121x64xf32> to tensor<?x64xf32>
 
-  // Both copies should be converted since both are DMA-convertible.
-  // CHECK: iree_gpu.coalesced_gather_dma
-  // CHECK: iree_gpu.coalesced_gather_dma
-  // CHECK-NOT: linalg.copy
+  // Pad to static size (only M dimension has padding)
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %extracted low[0, 0] high[%high, 0] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : f32
+  } : tensor<?x64xf32> to tensor<4x64xf32>
 
-  return %r0, %r1 : tensor<64x128xf32>, tensor<32x256xf32>
+  // Copy from padded tensor
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<4x64xf32>)
+    outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
+
+  // Key check: tensor.pad is fused - source is the extract_slice result, not the padded tensor
+  // in_bounds = [false, true] because M dim has dynamic padding, K dim has no padding
+  // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
+  // CHECK: scf.forall {{.*}} shared_outs(%[[OUTER_INIT:.+]] = %[[INIT]])
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[OUTER_INIT]])
+  // CHECK:     scf.forall.in_parallel {
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[EXTRACTED]] into %[[INNER_INIT]] lane(%[[LANE]]) in_bounds [false, true]
+  // CHECK-SAME:     : tensor<?x64xf32>, tensor<4x64xf32>, index
+  // CHECK:     }
+  // CHECK-NOT: tensor.pad
+
+  return %result : tensor<4x64xf32>
 }
 
 // -----
 
-// Negative test: Two copies with use_global_load_dma, but one has misaligned
-// innermost dimension. Neither should be converted.
+// Test: tensor.pad fusion with multiple warps creates single-iteration wrapper forall.
+// When tensor.pad is fused, subgroup-level tiling is skipped to ensure the DMA
+// operates on the full padded buffer shape, not on smaller subviews.
+// This is critical for correct delinearization in the lowering pass.
 
-#gpu_target_pair_one_bad = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+#gpu_target_pad_multi_warp = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
   max_load_instruction_bits = 128, subgroup_size_choices = [64],
   max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
@@ -502,150 +512,103 @@ func.func @copy_pair_both_convertible(
   dma_sizes = [32, 128]
 >>
 
-#exec_target_pair_one_bad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pair_one_bad}>
-#translation_pair_one_bad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#exec_target_pad_multi_warp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_multi_warp}>
+#translation_pad_multi_warp = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_pair_one_unconvertible
-func.func @copy_pair_one_unconvertible(
-    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
-    %src1: tensor<64x32xf32>, %init1: tensor<64x32xf32>)
-    -> (tensor<64x128xf32>, tensor<64x32xf32>)
-  attributes {hal.executable.target = #exec_target_pair_one_bad, translation_info = #translation_pair_one_bad} {
-  // minElementsPerTransfer = subgroupSize(64) * minElementsPerLane(32/32=1) = 64.
-  // First copy is DMA-convertible (128 % 64 == 0), but second is not (32 % 64 != 0).
-  // Since not ALL copies are convertible, neither should be converted.
-  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
-    ins(%src0 : tensor<64x128xf32>)
-    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
-  %r1 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
-    ins(%src1 : tensor<64x32xf32>)
-    outs(%init1 : tensor<64x32xf32>) -> tensor<64x32xf32>
+// CHECK-LABEL: func.func @copy_with_tensor_pad_fusion_multi_warp
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<121x64xf32>
+// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x64xf32>
+func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %init: tensor<4x64xf32>, %off: index, %sz: index, %high: index) -> tensor<4x64xf32>
+  attributes {hal.executable.target = #exec_target_pad_multi_warp, translation_info = #translation_pad_multi_warp} {
+  // Extract a dynamic slice
+  %extracted = tensor.extract_slice %source[%off, 0] [%sz, 64] [1, 1]
+      : tensor<121x64xf32> to tensor<?x64xf32>
 
+  // Pad to static size (only M dimension has padding)
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %extracted low[0, 0] high[%high, 0] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : f32
+  } : tensor<?x64xf32> to tensor<4x64xf32>
+
+  // Copy from padded tensor with 4 warps (256/64=4)
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<4x64xf32>)
+    outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
+
+  // Key check: With 4 warps available, normal tiling would create a warp-level
+  // forall with step (1, 64) producing 4 iterations with 1x64 subviews.
+  // For tensor.pad fusion, we instead create a single-iteration wrapper forall
+  // with step (4, 64) - the full shape - so the DMA operates on 4x64 directly.
+  // After canonicalization, identity extract_slices are eliminated.
+  //
+  // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
+  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (4, 64) step (4, 64)
+  // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<4x64xf32>) {
+  //
+  // Thread-level forall with 64 lanes (uses outer forall's shared_out directly):
+  // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[INIT_TILE]])
+  // CHECK:     scf.forall.in_parallel {
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[EXTRACTED]] into %[[INNER_INIT]] lane(%[[LANE]]) in_bounds [false, true]
+  // CHECK-SAME:     : tensor<?x64xf32>, tensor<4x64xf32>, index
+  // CHECK:     }
+  // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
+  //
+  // CHECK:   scf.forall.in_parallel {
+  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][0, 0] [4, 64] [1, 1]
+  // CHECK:   }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  // CHECK-NOT: tensor.pad
+
+  return %result : tensor<4x64xf32>
+}
+
+// -----
+
+// Test: tensor.pad fusion bails out when source row size is not DWORD-aligned.
+// On AMD CDNA, per-component range checking is performed for each DWORD.
+// If a DWORD is partially out-of-bounds, the entire DWORD returns zero,
+// causing incorrect results. We bail out to avoid the slow path.
+
+#gpu_target_pad_unaligned = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_pad_unaligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_unaligned}>
+#translation_pad_unaligned = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_with_tensor_pad_unaligned_row
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<65x121xf16>
+// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x124xf16>
+func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init: tensor<4x124xf16>, %off: index, %sz: index, %high_m: index) -> tensor<4x124xf16>
+  attributes {hal.executable.target = #exec_target_pad_unaligned, translation_info = #translation_pad_unaligned} {
+  // Extract a dynamic slice: tensor<?x121xf16>
+  // Row size = 121 * 2 bytes = 242 bytes, NOT 4-byte aligned
+  %extracted = tensor.extract_slice %source[%off, 0] [%sz, 121] [1, 1]
+      : tensor<65x121xf16> to tensor<?x121xf16>
+
+  // Pad to static size
+  %cst = arith.constant 0.0 : f16
+  %padded = tensor.pad %extracted low[0, 0] high[%high_m, 3] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : f16
+  } : tensor<?x121xf16> to tensor<4x124xf16>
+
+  // Copy from padded tensor
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<4x124xf16>)
+    outs(%init : tensor<4x124xf16>) -> tensor<4x124xf16>
+
+  // Source row size (121 * 2 = 242 bytes) is not DWORD-aligned.
+  // Coalesced DMA bails out to avoid partial OOB in per-DWORD range checking.
+  // The linalg.copy should remain unchanged.
+  // CHECK: tensor.pad
+  // CHECK: linalg.copy
   // CHECK-NOT: iree_gpu.coalesced_gather_dma
-  // CHECK: linalg.copy
-  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
-  // CHECK: linalg.copy
-  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
 
-  return %r0, %r1 : tensor<64x128xf32>, tensor<64x32xf32>
-}
-
-// -----
-
-// Test: Mixed attributes (1 use_global_load_dma + 1 derived_thread_config),
-// both DMA-convertible. Both should be upgraded and converted to DMA.
-
-#gpu_target_mixed_ok = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
-  compute = fp32, storage = b32, subgroup = shuffle,
-  max_load_instruction_bits = 128, subgroup_size_choices = [64],
-  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
-  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-  dma_sizes = [32, 128]
->>
-
-#exec_target_mixed_ok = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_mixed_ok}>
-#translation_mixed_ok = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
-
-// CHECK-LABEL: func.func @copy_mixed_attrs_both_convertible
-func.func @copy_mixed_attrs_both_convertible(
-    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
-    %src1: tensor<32x256xf32>, %init1: tensor<32x256xf32>)
-    -> (tensor<64x128xf32>, tensor<32x256xf32>)
-  attributes {hal.executable.target = #exec_target_mixed_ok, translation_info = #translation_mixed_ok} {
-  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
-    ins(%src0 : tensor<64x128xf32>)
-    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
-  // This copy has derived_thread_config but IS DMA-convertible.
-  // The pass should upgrade it to use_global_load_dma and convert both.
-  %r1 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-    ins(%src1 : tensor<32x256xf32>)
-    outs(%init1 : tensor<32x256xf32>) -> tensor<32x256xf32>
-
-  // Both copies should be converted since both are DMA-convertible.
-  // CHECK: iree_gpu.coalesced_gather_dma
-  // CHECK: iree_gpu.coalesced_gather_dma
-  // CHECK-NOT: linalg.copy
-
-  return %r0, %r1 : tensor<64x128xf32>, tensor<32x256xf32>
-}
-
-// -----
-
-// Negative test: Mixed attributes (1 use_global_load_dma + 1 derived_thread_config),
-// but the derived_thread_config copy is NOT DMA-convertible. Neither should be
-// converted.
-
-#gpu_target_mixed_bad = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
-  compute = fp32, storage = b32, subgroup = shuffle,
-  max_load_instruction_bits = 128, subgroup_size_choices = [64],
-  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
-  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-  dma_sizes = [32, 128]
->>
-
-#exec_target_mixed_bad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_mixed_bad}>
-#translation_mixed_bad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
-
-// CHECK-LABEL: func.func @copy_mixed_attrs_one_unconvertible
-func.func @copy_mixed_attrs_one_unconvertible(
-    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
-    %src1: tensor<64x32xf32>, %init1: tensor<64x32xf32>)
-    -> (tensor<64x128xf32>, tensor<64x32xf32>)
-  attributes {hal.executable.target = #exec_target_mixed_bad, translation_info = #translation_mixed_bad} {
-  // minElementsPerTransfer = subgroupSize(64) * minElementsPerLane(32/32=1) = 64.
-  // First copy is DMA-convertible, but second is not (32 % 64 != 0).
-  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
-    ins(%src0 : tensor<64x128xf32>)
-    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
-  %r1 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-    ins(%src1 : tensor<64x32xf32>)
-    outs(%init1 : tensor<64x32xf32>) -> tensor<64x32xf32>
-
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-  // CHECK: linalg.copy
-  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
-  // CHECK: linalg.copy
-  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
-
-  return %r0, %r1 : tensor<64x128xf32>, tensor<64x32xf32>
-}
-
-// -----
-
-// Negative test: No DMA intent — all copies have only derived_thread_config.
-// The pre-check should be skipped entirely, leaving copies unchanged.
-
-#gpu_target_no_intent = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
-  compute = fp32, storage = b32, subgroup = shuffle,
-  max_load_instruction_bits = 128, subgroup_size_choices = [64],
-  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
-  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-  dma_sizes = [32, 128]
->>
-
-#exec_target_no_intent = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_no_intent}>
-#translation_no_intent = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
-
-// CHECK-LABEL: func.func @copy_no_dma_intent
-func.func @copy_no_dma_intent(
-    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
-    %src1: tensor<32x256xf32>, %init1: tensor<32x256xf32>)
-    -> (tensor<64x128xf32>, tensor<32x256xf32>)
-  attributes {hal.executable.target = #exec_target_no_intent, translation_info = #translation_no_intent} {
-  // Both copies are DMA-convertible by size, but neither has use_global_load_dma.
-  // Without DMA intent the pre-check is skipped and copies stay as-is.
-  %r0 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-    ins(%src0 : tensor<64x128xf32>)
-    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
-  %r1 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-    ins(%src1 : tensor<32x256xf32>)
-    outs(%init1 : tensor<32x256xf32>) -> tensor<32x256xf32>
-
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-  // CHECK: linalg.copy
-  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
-  // CHECK: linalg.copy
-  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
-
-  return %r0, %r1 : tensor<64x128xf32>, tensor<32x256xf32>
+  return %result : tensor<4x124xf16>
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -339,7 +339,9 @@ LogicalResult CoalescedGatherDMAOp::verify() {
     }
 
     // If in_bounds is present and this dimension allows OOB (in_bounds=false),
-    // skip the size matching check - hardware OOB returns 0 for padding.
+    // skip the size matching check. For non-outermost dimensions, the lowering
+    // adds explicit bounds checks since raw buffer OOB only provides 1D
+    // (linear) clamping, not per-dimension clamping.
     if (inBoundsAttr) {
       auto inBoundsArray = *inBoundsAttr;
       if (dim < inBoundsArray.size()) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -218,7 +218,7 @@ void CoalescedGatherDMAOp::getEffects(
   Value source = getSource();
   Value init = getInit();
 
-  // The operation reads from the source
+  // The operation reads from the source.
   if (isa<MemRefType>(source.getType())) {
     effects.emplace_back(MemoryEffects::Read::get(),
                          &getOperation()->getOpOperand(sourceOperandIdx),
@@ -235,7 +235,7 @@ void CoalescedGatherDMAOp::getEffects(
                          SideEffects::DefaultResource::get());
   } else if (isa<RankedTensorType>(init.getType()) &&
              getOperation()->getNumResults() == 0) {
-    // Tensor combiner case: declare write effect to prevent DCE
+    // Tensor combiner case: declare write effect to prevent DCE.
     effects.emplace_back(MemoryEffects::Write::get(),
                          &getOperation()->getOpOperand(initOperandIdx),
                          SideEffects::DefaultResource::get());
@@ -339,9 +339,8 @@ LogicalResult CoalescedGatherDMAOp::verify() {
     }
 
     // If in_bounds is present and this dimension allows OOB (in_bounds=false),
-    // skip the size matching check. For non-outermost dimensions, the lowering
-    // adds explicit bounds checks since raw buffer OOB only provides 1D
-    // (linear) clamping, not per-dimension clamping.
+    // skip the size matching check. The source may be smaller than init along
+    // this dimension, and reads beyond the source extent return zero.
     if (inBoundsAttr) {
       auto inBoundsArray = *inBoundsAttr;
       if (dim < inBoundsArray.size()) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -228,6 +228,7 @@ def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<ParallelCombiningOpInterface,
        ["getUpdatedDestinations", "getIteratingParent"]>]> {
   let summary = "Coalesced gather DMA operation for efficient GPU memory access";
@@ -319,13 +320,15 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     AnyRankedTensorOrMemRef:$source,
     Variadic<RankedTensorOrVectorOrMemRefOf<[I32, Index]>>:$indices,
     AnyRankedTensorOrMemRef:$init,
-    Index:$lane
+    Index:$lane,
+    OptionalAttr<BoolArrayAttr>:$in_bounds
   );
 
   let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
 
   let assemblyFormat = [{
     $source (`[` $indices^ `]`)? `into` $init `lane` `(` $lane `)`
+    (`in_bounds` $in_bounds^)?
     attr-dict `:` type(operands) ( `->` type($result)^ )?
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -300,6 +300,19 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     * `lane`: The lane that specifies the coalescing store's offset within the
       workgroup/shared memory.
 
+    ## In-Bounds Attribute
+
+    The optional `in_bounds` attribute is a boolean array with one entry per
+    dimension of `init`. When not present, all dimensions are treated as
+    in-bounds (source and init must have matching sizes for non-indexed dims).
+
+    When present, `in_bounds[i] = false` indicates that the source may be
+    smaller than init along dimension `i`. Reads beyond the source extent
+    return zero (padding semantics). This enables fusion of `tensor.pad`
+    with zero padding into the DMA operation.
+
+    `in_bounds[i] = true` means the source and init sizes match along that
+    dimension, and no padding is needed.
 
     ## Example of a single subgroup using coalesced_gather_dma in copy mode
        for transferring tensor<4x128xf32>, with an intended DMA width of 128 bits

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
@@ -73,3 +73,18 @@ func.func @bufferize_coalesced_gather_dma_multiple_indices(%idx0: tensor<4xi32>,
 
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_multiple_indices
 //       CHECK:   iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}, %{{.+}}] into %{{.+}} lane(%{{.+}}) : memref<64x128xf32{{.+}}>, memref<4xi32{{.+}}>, memref<4xi32{{.+}}>, memref<4x128xf32{{.+}}>, index
+
+// -----
+
+// Test bufferization with in_bounds attribute (for fused tensor.pad).
+func.func @bufferize_coalesced_gather_dma_in_bounds(%source: tensor<4x32xf32>,
+                                                     %dest: tensor<4x64xf32>,
+                                                     %lane: index) -> tensor<4x64xf32> {
+  %result = iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)
+    in_bounds [true, false]
+    : tensor<4x32xf32>, tensor<4x64xf32>, index -> tensor<4x64xf32>
+  return %result : tensor<4x64xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_in_bounds
+//       CHECK:   iree_gpu.coalesced_gather_dma %{{.+}} into %{{.+}} lane(%{{.+}}) in_bounds [true, false] : memref<4x32xf32{{.+}}>, memref<4x64xf32{{.+}}>, index

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -436,10 +436,10 @@ struct CoalescedGatherDMAOpBufferizationInterface
     // terminator (not inside the in_parallel region which will be removed).
     auto inParallelOp = gatherOp->getParentOfType<scf::InParallelOp>();
     if (inParallelOp) {
-      // Insert before the in_parallel terminator (in the forall body)
+      // Insert before the in_parallel terminator (in the forall body).
       rewriter.setInsertionPoint(inParallelOp);
     } else {
-      // Not in in_parallel, just insert at current location
+      // Not in in_parallel, just insert at current location.
       rewriter.setInsertionPoint(gatherOp);
     }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -317,7 +317,8 @@ LogicalResult fuseForallIntoConsumer(RewriterBase &rewriter,
     auto newGatherOp = IREE::GPU::CoalescedGatherDMAOp::create(
         rewriter, loc, coalescedGather.getInit().getType(),
         coalescedGather.getSource(), coalescedGather.getIndices(),
-        coalescedGather.getInit(), coalescedGather.getLane());
+        coalescedGather.getInit(), coalescedGather.getLane(),
+        coalescedGather.getInBoundsAttr());
     Value gatherResult = newGatherOp.getResult();
 
     // Use a tensor.insert_slice to insert the gather result back into the
@@ -455,7 +456,7 @@ static void composeCoalescedGatherDMA(
     auto dmaOp = IREE::GPU::CoalescedGatherDMAOp::create(
         rewriter, warpInsert.getLoc(), destSlice.getType(),
         laneInsert.getSource(), laneInsert.getIndices(), destSlice,
-        laneInsert.getLane());
+        laneInsert.getLane(), laneInsert.getInBoundsAttr());
 
     // Replace the warp parallel_insert_slice with one that inserts the DMA
     // result.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -482,8 +482,6 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createCSEPass());
   }
 
-  funcPassManager.addPass(createGPUConvertToCoalescedDMAPass());
-
   // Step 3. Decompose pack and unpack ops and propagate the resulting reshapes.
   funcPassManager.addPass(createDecomposePackUnPackOpsPass(
       DecomposePackUnPackOpsPassOptions{/*tileOuterToOne=*/false,
@@ -503,6 +501,9 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createPropagateReshapesByExpansionPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+
+  // Convert global load DMAs after pack decomposition but before thread tiling.
+  funcPassManager.addPass(createGPUConvertToCoalescedDMAPass());
 
   // Step 4. Tile and fuse tileable ops to subgroups/threads.
   {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -482,6 +482,11 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createCSEPass());
   }
 
+  // Convert global load DMAs after reduction tiling but before pack
+  // decomposition. DecomposePackUnPackOps introduces linalg.transpose which
+  // breaks the source tracing in the coalesced DMA conversion.
+  funcPassManager.addPass(createGPUConvertToCoalescedDMAPass());
+
   // Step 3. Decompose pack and unpack ops and propagate the resulting reshapes.
   funcPassManager.addPass(createDecomposePackUnPackOpsPass(
       DecomposePackUnPackOpsPassOptions{/*tileOuterToOne=*/false,
@@ -501,9 +506,6 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createPropagateReshapesByExpansionPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-
-  // Convert global load DMAs after pack decomposition but before thread tiling.
-  funcPassManager.addPass(createGPUConvertToCoalescedDMAPass());
 
   // Step 4. Tile and fuse tileable ops to subgroups/threads.
   {

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1534,6 +1534,97 @@ iree_generated_e2e_runner_test(
     "requires-gpu-${_CDNA_ARCH}"
 )
 
+# Unaligned matmul tests for coalesced DMA with tensor.pad fusion
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_coalesced_dma_f32_unaligned_65x64x121
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=65,64,121"
+    "--mnk_dynamicities=static,static,static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-llvmgpu-use-direct-load"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_coalesced_dma_f32_unaligned_133x97x65
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=133,97,65"
+    "--mnk_dynamicities=static,static,static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-llvmgpu-use-direct-load"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_coalesced_dma_f32_unaligned_123x321x231
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=123,321,231"
+    "--mnk_dynamicities=static,static,static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-llvmgpu-use-direct-load"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
 iree_generated_e2e_runner_test(
   NAME
     e2e_matmul_${_CDNA_ARCH}_vecdistmfma_f16


### PR DESCRIPTION
## Summary
- Add `in_bounds` attribute to `CoalescedGatherDMAOp` to indicate which dimensions may have out-of-bounds reads
- Fuse `tensor.pad` into `coalesced_gather_dma` by tracing through to the original source tensor
- Enable coalesced DMA for unaligned matmuls that require padding

## Motivation

When matmul dimensions don't align with tile sizes, `tensor.pad` is inserted to pad operands. Previously, this caused `coalesced_gather_dma` to fail because:
1. The padded tensor becomes a private memory allocation during bufferization
2. `amdgpu.gather_to_lds` requires source to be `fat_raw_buffer` or global memory

This PR fuses `tensor.pad` into the DMA operation, allowing it to read directly from buffer memory. AMD hardware's OOB behavior (returns 0 for out-of-bounds reads with `boundsCheck=true`) provides implicit padding.

## Example

Before:
```
%extracted_slice_0 = tensor.extract_slice %6[%22, %19] [%17, %20] [1, 1] : tensor<65x121xf32> to tensor<?x?xf32>
%padded_3 = tensor.pad %extracted_slice_2 low[0, 0] high[%21, 0] {
      ^bb0(%arg4: index, %arg5: index):
        tensor.yield %cst : f32
} : tensor<?x64xf32> to tensor<4x64xf32>
%26 = tensor.empty() : tensor<4x64xf32>
%27 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma} ins(%padded_3 : tensor<4x64xf32>) outs(%26 : tensor<4x64xf32>) -> tensor<4x64xf32> 
```
We cannot handle such case because:
* When inferring address space of `tensor.pad`, it will always be assigned to `private`.
* global load DMA cannot handle `private` sources.

Notice that the semantics of the op is basically to extract a slice of an unaligned tensor to an aligned tensor. We can still do a DMA from the buffer pointer to utilize the address clamping, as long as the source is inferred to use fat raw pointer.

So the solution is to just fuse `tensor.pad` into `coalesced_gather_dma` when we are converting `linalg.copy` to `iree_gpu.coalesced_gather_dma`:
```
%extracted_slice_0 = tensor.extract_slice %6[%22, %19] [%17, %20] [1, 1] : tensor<65x121xf32> to tensor<?x?xf32>
%23 = tensor.empty() : tensor<32x4xf32>
%24 = scf.forall (%arg4, %arg5) = (0, 0) to (32, 4) step (32, 4) shared_outs(%arg6 = %23) -> (tensor<32x4xf32>) {
    %extracted_slice_7 = tensor.extract_slice %arg6[%arg4, %arg5] [32, 4] [1, 1] : tensor<32x4xf32> to tensor<32x4xf32>
    %30 = scf.forall (%arg7) in (64) shared_outs(%arg8 = %extracted_slice_7) -> (tensor<32x4xf32>) {
     ...
     %extracted_slice_9 = tensor.extract_slice %arg8[0, %arg7] [32, %33] [1, 1] : tensor<32x4xf32> to tensor<32x?xf32>
      ...
      scf.forall.in_parallel {
        iree_gpu.coalesced_gather_dma %extracted_slice_0 into %arg8 lane(%arg7) in_bounds [false, false] : tensor<?x?xf32>, tensor<32x4xf32>, index
      }
    } {mapping = [#iree_gpu.lane_id<0>]}
    scf.forall.in_parallel {
      tensor.parallel_insert_slice %30 into %arg6[%arg4, %arg5] [32, 4] [1, 1] : tensor<32x4xf32> into tensor<32x4xf32>
    }
} {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
```

* The implicit fusing happens when we convert `linalg.copy` to `iree_gpu.coalesced_gather_dma` op (along with tiling).
* `iree_gpu.coalesced_gather_dma` now has attribute `in_bounds` which tells whether we are loading in bounds, so it now supports masking.
* make sure we source tensor is inferred to use buffer pointer.
