### PR TITLE
[CPU][NFCI] Adjust CPU codegen pipeline for small float and subbyte support.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -622,16 +622,15 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
       .addPass([&]() {
         arith::ArithExpandOpsPassOptions options;
         options.includeBf16 = true;
-        options.includeF4E2M1 = true;
         options.includeF8E8M0 = true;
         return arith::createArithExpandOpsPass(options);
       })
+      .addPass(createConvertUnsupportedFloatArithPass)
       .addPass(createEmulateNarrowTypePass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
       .addPredicatedPass(clInstrumentMemoryAccesses,
-                         createInstrumentMemoryAccessesPass)
-      .addPass(createConvertUnsupportedFloatArithPass);
+                         createInstrumentMemoryAccessesPass);
 
   if (enableAArch64SME) {
     FunctionLikeNest(modulePassManager).addPass([&] {


### PR DESCRIPTION
It moves the expanding passes closer and relies on in-tree emulation patterns.

F8E8M0 is not emulated like runtime code, so it is not disabled yet.

https://github.com/iree-org/iree/blob/10720456fdbad603ed47a5edcc77c7b664be2410/runtime/src/iree/base/internal/math.h#L588-L615

No new tests are added because the `small_float_arith.mlir`, `fp4_f32_conversion.mlir`, and `subbyte_to_fp.mlir` tests cover the case.