### PR TITLE
[VM] Add small float type support to VM conversion.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/test/conversion_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/test/conversion_ops.mlir
@@ -431,11 +431,39 @@ module @bitcast_f32_i32 {
 
 // -----
 
-// expected-error@+1 {{conversion to vm.module failed}}
+// Both f16 and bf16 convert to i32 in VM, so bitcast is a no-op.
+// CHECK-LABEL: @bitcast_f16_bf16
 module @bitcast_f16_bf16 {
+  // CHECK: vm.func private @fn(%[[ARG0:.+]]: i32)
   func.func @fn(%arg0: f16) -> bf16 {
-    // expected-error@+1 {{failed to legalize}}
+    // CHECK: vm.return %[[ARG0]] : i32
     %0 = arith.bitcast %arg0 : f16 to bf16
     return %0 : bf16
+  }
+}
+
+// -----
+
+// Both f8E5M2FNUZ and i8 convert to i32 in VM, so bitcast is a no-op.
+// CHECK-LABEL: @bitcast_f8_i8
+module @bitcast_f8_i8 {
+  // CHECK: vm.func private @fn(%[[ARG0:.+]]: i32)
+  func.func @fn(%arg0: f8E5M2FNUZ) -> i8 {
+    // CHECK: vm.return %[[ARG0]] : i32
+    %0 = arith.bitcast %arg0 : f8E5M2FNUZ to i8
+    return %0 : i8
+  }
+}
+
+// -----
+
+// Both i8 and f8E5M2FNUZ convert to i32 in VM, so bitcast is a no-op.
+// CHECK-LABEL: @bitcast_i8_f8
+module @bitcast_i8_f8 {
+  // CHECK: vm.func private @fn(%[[ARG0:.+]]: i32)
+  func.func @fn(%arg0: i8) -> f8E5M2FNUZ {
+    // CHECK: vm.return %[[ARG0]] : i32
+    %0 = arith.bitcast %arg0 : i8 to f8E5M2FNUZ
+    return %0 : f8E5M2FNUZ
   }
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
@@ -63,14 +63,11 @@ TypeConverter::TypeConverter(TargetOptions targetOptions)
 
   // Convert floating-point types.
   addConversion([this](FloatType floatType) -> std::optional<Type> {
-    if (floatType.getIntOrFloatBitWidth() < 32) {
-      if (targetOptions_.f32Extension) {
-        // Promote f16 -> f32.
-        return Float32Type::get(floatType.getContext());
-      } else {
-        // f32 is not supported; can't compile.
-        return std::nullopt;
-      }
+    unsigned bitWidth = floatType.getIntOrFloatBitWidth();
+    if (bitWidth < 32) {
+      // Sub-32-bit floats are stored as i32 in VM (storage only, no
+      // arithmetic).
+      return IntegerType::get(floatType.getContext(), 32);
     } else if (floatType.isF32()) {
       if (targetOptions_.f32Extension) {
         return floatType;


### PR DESCRIPTION
TypeConverter: Map all sub-32-bit float types (f4, f8, f16, bf16) to i32. These types are storage-only in VM; arithmetic is emulated before reaching VM conversion.

ArithToVM: Add no-op bitcast for types that both convert to i32 (e.g., f16<->bf16, f8<->i8). Previously these would fail with "unsupported bitcast".

It is a step towards https://github.com/iree-org/iree/issues/23371