### PR TITLE
[VMVX] Enable sub-byte and small float support in VMVX pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.h
@@ -13,7 +13,7 @@ namespace mlir::iree_compiler {
 using NarrowTypeConversionPopulationFn =
     std::function<void(arith::NarrowTypeEmulationConverter &,
                        RewritePatternSet &, ConversionTarget &)>;
-LogicalResult emulateNarrowType(Operation *root,
+LogicalResult emulateNarrowType(Operation *root, bool disableAtomic,
                                 std::optional<NarrowTypeConversionPopulationFn>
                                     populateCallback = std::nullopt);
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -455,6 +455,13 @@ def EmulateNarrowTypePass :
     A pass to emulate memref load operations that use narrow integer types
     with equivalent operations on supported wide integer types.
   }];
+  let options = [
+    Option<"disableAtomicRMW", "disable-atomic-rmw",
+           "bool", /*default=*/"false",
+           "Indicates that atomic ops are not allowed in the emulation. It can "
+           "be enabled if the target can guarantee no concurrent accesses to "
+           "the same memory location.">
+  ];
 }
 
 def EraseDeadAllocAndStoresPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -70,7 +70,8 @@ struct AMDGPUEmulateNarrowTypePass final
           patterns.add<ConvertRawBufferCast>(typeConverter,
                                              patterns.getContext());
         };
-    if (failed(emulateNarrowType(getOperation(), populateAMDGPUPatterns))) {
+    if (failed(emulateNarrowType(getOperation(), /*disableAtomic=*/true,
+                                 populateAMDGPUPatterns))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1060,8 +1060,10 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
         options.allowSubviewExpansion = true;
         return createIREEExpandStridedMetadataPass(options);
       })
-      .addPass(forROCDL ? createAMDGPUEmulateNarrowTypePass
-                        : createEmulateNarrowTypePass)
+      .addPass([&forROCDL]() {
+        return forROCDL ? createAMDGPUEmulateNarrowTypePass()
+                        : createEmulateNarrowTypePass();
+      })
       .addPass(createIREECodegenAffineExpandIndexOpsPass)
       .addPass(createIREECodegenLowerAffinePass);
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -89,7 +89,10 @@ buildVectorVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
         return arith::createArithExpandOpsPass(options);
       })
       .addPass(createConvertUnsupportedFloatArithPass)
-      .addPass(createEmulateNarrowTypePass);
+      .addPass([]() {
+        return createEmulateNarrowTypePass(
+            EmulateNarrowTypePassOptions{/*disableAtomicRMW=*/true});
+      });
 
   // Handle tensor-type constants.
   modulePassManager.addPass(createIREEBufferizeConstantsPass());

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -82,7 +82,14 @@ buildVectorVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
       .addPass(createCSEPass)
       .addPass([]() { return createConvertVectorToSCFPass(); })
       .addPass(createCanonicalizerPass)
-      .addPass(arith::createArithExpandOpsPass);
+      .addPass([&]() {
+        arith::ArithExpandOpsPassOptions options;
+        options.includeBf16 = true;
+        options.includeF8E8M0 = true;
+        return arith::createArithExpandOpsPass(options);
+      })
+      .addPass(createConvertUnsupportedFloatArithPass)
+      .addPass(createEmulateNarrowTypePass);
 
   // Handle tensor-type constants.
   modulePassManager.addPass(createIREEBufferizeConstantsPass());

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -76,22 +76,22 @@ VMVX_SRCS = enforce_glob(
     [
         "argmax.mlir",
         "conv2d.mlir",
+        "fp4_f32_conversion.mlir",
+        "fp_to_subbyte.mlir",
         "gather_like_ops.mlir",
         "index.mlir",
         "narrow_n_matmuls.mlir",
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
         "pack_i8.mlir",
+        "small_float_arith.mlir",
         "softmax.mlir",
+        "subbyte_to_fp.mlir",
         "unpack.mlir",
     ],
     include = ["*.mlir"],
     exclude = [
-        "fp_to_subbyte.mlir",
-        "fp4_f32_conversion.mlir",
         "large_linalg_matmul.mlir",
-        "small_float_arith.mlir",
-        "subbyte_to_fp.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -58,13 +58,17 @@ iree_check_single_backend_test_suite(
   SRCS
     "argmax.mlir"
     "conv2d.mlir"
+    "fp4_f32_conversion.mlir"
+    "fp_to_subbyte.mlir"
     "gather_like_ops.mlir"
     "index.mlir"
     "narrow_n_matmuls.mlir"
     "pack.mlir"
     "pack_dynamic_inner_tiles.mlir"
     "pack_i8.mlir"
+    "small_float_arith.mlir"
     "softmax.mlir"
+    "subbyte_to_fp.mlir"
     "unpack.mlir"
   TARGET_BACKEND
     "vmvx"


### PR DESCRIPTION
Add passes to VMVX codegen pipline to enable subbyte and small float support.

Pipeline changes:
- Add ArithExpandOps with bf16/f8E8M0 options
- Add ConvertUnsupportedFloatArith pass
- Add EmulateNarrowType pass

Enable the previously excluded e2e tests for VMVX:
- fp4_f32_conversion
- fp_to_subbyte
- small_float_arith
- subbyte_to_fp

The revision exposes an option to disable atomic ops in EmulateNarrowType pass. It is safe to disable it on VMVX because VMVX usually picks tile_size=64 for distribution. There are no races because it does not use cyclic distrubtion. Ideally, we should do an analysis to determine whether atomicRMW ops are needed or not, but it is very involved atm. The pass does not only apply emulation but also linearization.

Fixes https://github.com/iree-org/iree/issues/23371