### PR TITLE
[Codegen] Update InnerTileDescAttrInterface with new methods

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -248,6 +248,46 @@ def IREECodegen_InnerTileDescAttrInterface :
         return failure();
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        For the given operand index, return the sizes of the parallel dimensions
+        in the intrinsic. For a matrix multiplication C = A * B:
+        - LHS (operand 0): parallel dimension is M
+        - RHS (operand 1): parallel dimension is N
+        - ACC (operand 2): parallel dimensions are M and N
+        
+        The returned values are placed into the `result` vector, which will have
+        its existing contents overwritten if there is any.
+      }],
+      /*retType=*/"void",
+      /*methodName=*/"getParallelDimSizes",
+      /*args=*/(ins "int64_t":$operandIndex,
+                    "::llvm::SmallVectorImpl<int64_t>&":$result),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        result.clear();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        For the given operand index, return the sizes of the reduction dimensions
+        in the intrinsic. For a matrix multiplication C = A * B:
+        - LHS (operand 0): reduction dimension is K
+        - RHS (operand 1): reduction dimension is K
+        - ACC (operand 2): no reduction dimensions
+        
+        The returned values are placed into the `result` vector, which will have
+        its existing contents overwritten if there is any.
+      }],
+      /*retType=*/"void",
+      /*methodName=*/"getReductionDimSizes",
+      /*args=*/(ins "int64_t":$operandIndex,
+                    "::llvm::SmallVectorImpl<int64_t>&":$result),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        result.clear();
+      }]
+    >,
   ];
 
   let extraSharedClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -251,41 +251,33 @@ def IREECodegen_InnerTileDescAttrInterface :
     InterfaceMethod<
       /*desc=*/[{
         For the given operand index, return the sizes of the parallel dimensions
-        in the intrinsic. For a matrix multiplication C = A * B:
+        in the intrinsic. For example in a matmul C = A * B:
         - LHS (operand 0): parallel dimension is M
         - RHS (operand 1): parallel dimension is N
         - ACC (operand 2): parallel dimensions are M and N
-        
-        The returned values are placed into the `result` vector, which will have
-        its existing contents overwritten if there is any.
       }],
-      /*retType=*/"void",
+      /*retType=*/"::llvm::SmallVector<int64_t>",
       /*methodName=*/"getParallelDimSizes",
-      /*args=*/(ins "int64_t":$operandIndex,
-                    "::llvm::SmallVectorImpl<int64_t>&":$result),
+      /*args=*/(ins "int64_t":$operandIndex),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        result.clear();
+        return {};
       }]
     >,
     InterfaceMethod<
       /*desc=*/[{
         For the given operand index, return the sizes of the reduction dimensions
-        in the intrinsic. For a matrix multiplication C = A * B:
+        in the intrinsic. For example in a matmul C = A * B:
         - LHS (operand 0): reduction dimension is K
         - RHS (operand 1): reduction dimension is K
         - ACC (operand 2): no reduction dimensions
-        
-        The returned values are placed into the `result` vector, which will have
-        its existing contents overwritten if there is any.
       }],
-      /*retType=*/"void",
+      /*retType=*/"::llvm::SmallVector<int64_t>",
       /*methodName=*/"getReductionDimSizes",
-      /*args=*/(ins "int64_t":$operandIndex,
-                    "::llvm::SmallVectorImpl<int64_t>&":$result),
+      /*args=*/(ins "int64_t":$operandIndex),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        result.clear();
+        return {};
       }]
     >,
   ];

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -250,15 +250,18 @@ def IREECodegen_InnerTileDescAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
-        For the given operand index, return the sizes of the parallel dimensions
-        in the intrinsic. For example in a matmul C = A * B:
+        Return the sizes of the parallel dimensions for each operand.
+        For example in a matmul C = A * B:
         - LHS (operand 0): parallel dimension is M
         - RHS (operand 1): parallel dimension is N
         - ACC (operand 2): parallel dimensions are M and N
+        
+        Returns a vector where each element is a vector of parallel dimension
+        sizes for that operand.
       }],
-      /*retType=*/"::llvm::SmallVector<int64_t>",
+      /*retType=*/"::llvm::SmallVector<::llvm::SmallVector<int64_t>>",
       /*methodName=*/"getParallelDimSizes",
-      /*args=*/(ins "int64_t":$operandIndex),
+      /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return {};
@@ -266,15 +269,18 @@ def IREECodegen_InnerTileDescAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
-        For the given operand index, return the sizes of the reduction dimensions
-        in the intrinsic. For example in a matmul C = A * B:
+        Return the sizes of the reduction dimensions for each operand.
+        For example in a matmul C = A * B:
         - LHS (operand 0): reduction dimension is K
         - RHS (operand 1): reduction dimension is K
         - ACC (operand 2): no reduction dimensions
+        
+        Returns a vector where each element is a vector of reduction dimension
+        sizes for that operand.
       }],
-      /*retType=*/"::llvm::SmallVector<int64_t>",
+      /*retType=*/"::llvm::SmallVector<::llvm::SmallVector<int64_t>>",
       /*methodName=*/"getReductionDimSizes",
-      /*args=*/(ins "int64_t":$operandIndex),
+      /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return {};

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -250,13 +250,17 @@ def IREECodegen_InnerTileDescAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Return the iterator types of the dimensions for each operand.
+        Returns a vector where each element is a vector of iterator types for
+        each dimension of each operand.
         For example in a matmul C = A * B:
         - LHS (operand 0): {"parallel", "reduction"}
-        - RHS (operand 1): {"parallel", "reduction"}
+        - RHS (operand 1): {"reduction", "parallel"}
         - ACC (operand 2): {"parallel", "parallel"}
-
-        Returns a vector where each element is a vector of iterator types for that operand.
+        Returns: {
+          {"parallel", "reduction"}, 
+          {"reduction", "parallel"}, 
+          {"parallel", "parallel"}
+        }
       }],
       /*retType=*/"::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>>",
       /*methodName=*/"getOperandIteratorTypes",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -257,8 +257,8 @@ def IREECodegen_InnerTileDescAttrInterface :
         - RHS (operand 1): {"reduction", "parallel"}
         - ACC (operand 2): {"parallel", "parallel"}
         Returns: {
-          {"parallel", "reduction"}, 
-          {"reduction", "parallel"}, 
+          {"parallel", "reduction"},
+          {"reduction", "parallel"},
           {"parallel", "parallel"}
         }
       }],

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -252,6 +252,8 @@ def IREECodegen_InnerTileDescAttrInterface :
       /*desc=*/[{
         Returns a vector where each element is a vector of iterator types for
         each dimension of each operand.
+        These dimensions are taken from the unexpanded, undistributed tile
+        shapes of each operand.
         For example in a matmul C = A * B:
         - LHS (operand 0): {"parallel", "reduction"}
         - RHS (operand 1): {"reduction", "parallel"}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -250,7 +250,7 @@ def IREECodegen_InnerTileDescAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Return the iterator types of the parallel dimensions for each operand.
+        Return the iterator types of the dimensions for each operand.
         For example in a matmul C = A * B:
         - LHS (operand 0): {"parallel", "reduction"}
         - RHS (operand 1): {"parallel", "reduction"}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -255,7 +255,7 @@ def IREECodegen_InnerTileDescAttrInterface :
         - LHS (operand 0): parallel dimension is M
         - RHS (operand 1): parallel dimension is N
         - ACC (operand 2): parallel dimensions are M and N
-        
+
         Returns a vector where each element is a vector of parallel dimension
         sizes for that operand.
       }],
@@ -274,7 +274,7 @@ def IREECodegen_InnerTileDescAttrInterface :
         - LHS (operand 0): reduction dimension is K
         - RHS (operand 1): reduction dimension is K
         - ACC (operand 2): no reduction dimensions
-        
+
         Returns a vector where each element is a vector of reduction dimension
         sizes for that operand.
       }],

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -250,36 +250,16 @@ def IREECodegen_InnerTileDescAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Return the sizes of the parallel dimensions for each operand.
+        Return the iterator types of the parallel dimensions for each operand.
         For example in a matmul C = A * B:
-        - LHS (operand 0): parallel dimension is M
-        - RHS (operand 1): parallel dimension is N
-        - ACC (operand 2): parallel dimensions are M and N
+        - LHS (operand 0): {"parallel", "reduction"}
+        - RHS (operand 1): {"parallel", "reduction"}
+        - ACC (operand 2): {"parallel", "parallel"}
 
-        Returns a vector where each element is a vector of parallel dimension
-        sizes for that operand.
+        Returns a vector where each element is a vector of iterator types for that operand.
       }],
-      /*retType=*/"::llvm::SmallVector<::llvm::SmallVector<int64_t>>",
-      /*methodName=*/"getParallelDimSizes",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return {};
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
-        Return the sizes of the reduction dimensions for each operand.
-        For example in a matmul C = A * B:
-        - LHS (operand 0): reduction dimension is K
-        - RHS (operand 1): reduction dimension is K
-        - ACC (operand 2): no reduction dimensions
-
-        Returns a vector where each element is a vector of reduction dimension
-        sizes for that operand.
-      }],
-      /*retType=*/"::llvm::SmallVector<::llvm::SmallVector<int64_t>>",
-      /*methodName=*/"getReductionDimSizes",
+      /*retType=*/"::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>>",
+      /*methodName=*/"getOperandIteratorTypes",
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -690,16 +690,6 @@ int64_t MMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<SmallVector<int64_t>> MMAAttr::getParallelDimSizes() const {
-  auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  return {{m}, {n}, {m, n}};
-}
-
-SmallVector<SmallVector<int64_t>> MMAAttr::getReductionDimSizes() const {
-  auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  return {{k}, {k}, {}};
-}
-
 Attribute MMAAttr::getDistributionMappingKind() const {
   // Explicit distribution currently unsupported for NV intrinsics.
   MMAIntrinsic intrinsic = getIntrinsic();
@@ -966,23 +956,6 @@ int64_t DataTiledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<SmallVector<int64_t>>
-DataTiledMMAAttr::getParallelDimSizes() const {
-  auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  // Scale by the number of intrinsics and subgroups
-  m *= getIntrinsicsM() * getSubgroupsM();
-  n *= getIntrinsicsN() * getSubgroupsN();
-  return {{m}, {n}, {m, n}};
-}
-
-SmallVector<SmallVector<int64_t>>
-DataTiledMMAAttr::getReductionDimSizes() const {
-  auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  // Scale by the number of intrinsics and subgroups
-  k *= getIntrinsicsK() * getSubgroupsK();
-  return {{k}, {k}, {}};
-}
-
 int64_t DataTiledMMAAttr::getFlatWorkgroupSize() const {
   return getSubgroupSize() * getSubgroupsM() * getSubgroupsN() *
          getSubgroupsK();
@@ -1243,16 +1216,6 @@ int64_t VirtualMMAAttr::getSubgroupSize() const {
   }
   assert(false && "unhandled virtual mma layout type.");
   return 0;
-}
-
-SmallVector<SmallVector<int64_t>> VirtualMMAAttr::getParallelDimSizes() const {
-  auto [m, n, k] = getMNKShape();
-  return {{m}, {n}, {m, n}};
-}
-
-SmallVector<SmallVector<int64_t>> VirtualMMAAttr::getReductionDimSizes() const {
-  auto [m, n, k] = getMNKShape();
-  return {{k}, {k}, {}};
 }
 
 Attribute VirtualMMAAttr::getDistributionMappingKind() const {
@@ -1518,18 +1481,6 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
 
 int64_t ScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
-}
-
-SmallVector<SmallVector<int64_t>> ScaledMMAAttr::getParallelDimSizes() const {
-  int64_t m = getMSize(getIntrinsic());
-  int64_t n = getNSize(getIntrinsic());
-  return {{m}, {n}, {m}, {n}, {m, n}};
-}
-
-SmallVector<SmallVector<int64_t>> ScaledMMAAttr::getReductionDimSizes() const {
-  int64_t k = getKSize(getIntrinsic());
-  int64_t kb = getKbSize(getIntrinsic());
-  return {{k, kb}, {k, kb}, {k}, {k}, {}};
 }
 
 SmallVector<Type> ScaledMMAAttr::getSupportedInputTypes(MLIRContext *ctx) {
@@ -1925,25 +1876,6 @@ int64_t DataTiledScaledMMAAttr::getExpectedNumOutputs() const { return 1; }
 
 int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
-}
-
-SmallVector<SmallVector<int64_t>>
-DataTiledScaledMMAAttr::getParallelDimSizes() const {
-  int64_t m = getMSize(getIntrinsic());
-  int64_t n = getNSize(getIntrinsic());
-  // Scale by the number of intrinsics and subgroups
-  m *= getIntrinsicsM() * getSubgroupsM();
-  n *= getIntrinsicsN() * getSubgroupsN();
-  return {{m}, {n}, {m}, {n}, {m, n}};
-}
-
-SmallVector<SmallVector<int64_t>>
-DataTiledScaledMMAAttr::getReductionDimSizes() const {
-  int64_t k = getKSize(getIntrinsic());
-  int64_t kb = getKbSize(getIntrinsic());
-  // Scale by the number of intrinsics and subgroups
-  k *= getIntrinsicsK() * getSubgroupsK();
-  return {{k, kb}, {k, kb}, {k}, {k}, {}};
 }
 
 int64_t DataTiledScaledMMAAttr::getFlatWorkgroupSize() const {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -690,32 +690,14 @@ int64_t MMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<int64_t> MMAAttr::getParallelDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> MMAAttr::getParallelDimSizes() const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  switch (operandIndex) {
-  case kMMAOperandLhs:
-    return {m};
-  case kMMAOperandRhs:
-    return {n};
-  case kMMAOperandAcc:
-    return {m, n};
-  default:
-    return {};
-  }
+  return {{m}, {n}, {m, n}};
 }
 
-SmallVector<int64_t> MMAAttr::getReductionDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> MMAAttr::getReductionDimSizes() const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  switch (operandIndex) {
-  case kMMAOperandLhs:
-  case kMMAOperandRhs:
-    return {k};
-  case kMMAOperandAcc:
-    // Accumulator has no reduction dimensions
-    return {};
-  default:
-    return {};
-  }
+  return {{k}, {k}, {}};
 }
 
 Attribute MMAAttr::getDistributionMappingKind() const {
@@ -984,43 +966,19 @@ int64_t DataTiledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<int64_t>
-DataTiledMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> DataTiledMMAAttr::getParallelDimSizes() const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  
   // Scale by the number of intrinsics and subgroups
   m *= getIntrinsicsM() * getSubgroupsM();
   n *= getIntrinsicsN() * getSubgroupsN();
-  
-  switch (operandIndex) {
-  case kMMAOperandLhs:
-    return {m};
-  case kMMAOperandRhs:
-    return {n};
-  case kMMAOperandAcc:
-    return {m, n};
-  default:
-    return {};
-  }
+  return {{m}, {n}, {m, n}};
 }
 
-SmallVector<int64_t>
-DataTiledMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> DataTiledMMAAttr::getReductionDimSizes() const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
-  
   // Scale by the number of intrinsics and subgroups
   k *= getIntrinsicsK() * getSubgroupsK();
-  
-  switch (operandIndex) {
-  case kMMAOperandLhs:
-  case kMMAOperandRhs:
-    return {k};
-  case kMMAOperandAcc:
-    // Accumulator has no reduction dimensions
-    return {};
-  default:
-    return {};
-  }
+  return {{k}, {k}, {}};
 }
 
 int64_t DataTiledMMAAttr::getFlatWorkgroupSize() const {
@@ -1285,34 +1243,14 @@ int64_t VirtualMMAAttr::getSubgroupSize() const {
   return 0;
 }
 
-SmallVector<int64_t>
-VirtualMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> VirtualMMAAttr::getParallelDimSizes() const {
   auto [m, n, k] = getMNKShape();
-  switch (operandIndex) {
-  case kMMAOperandLhs:
-    return {m};
-  case kMMAOperandRhs:
-    return {n};
-  case kMMAOperandAcc:
-    return {m, n};
-  default:
-    return {};
-  }
+  return {{m}, {n}, {m, n}};
 }
 
-SmallVector<int64_t>
-VirtualMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> VirtualMMAAttr::getReductionDimSizes() const {
   auto [m, n, k] = getMNKShape();
-  switch (operandIndex) {
-  case kMMAOperandLhs:
-  case kMMAOperandRhs:
-    return {k};
-  case kMMAOperandAcc:
-    // Accumulator has no reduction dimensions
-    return {};
-  default:
-    return {};
-  }
+  return {{k}, {k}, {}};
 }
 
 Attribute VirtualMMAAttr::getDistributionMappingKind() const {
@@ -1580,47 +1518,16 @@ int64_t ScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<int64_t>
-ScaledMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> ScaledMMAAttr::getParallelDimSizes() const {
   int64_t m = getMSize(getIntrinsic());
   int64_t n = getNSize(getIntrinsic());
-  
-  switch (operandIndex) {
-  case kScaledMMAOperandLhs:
-    return {m};
-  case kScaledMMAOperandRhs:
-    return {n};
-  case kScaledMMAOperandLhsScale:
-    return {m};
-  case kScaledMMAOperandRhsScale:
-    return {n};
-  case kScaledMMAOperandAcc:
-    return {m, n};
-  default:
-    return {};
-  }
+  return {{m}, {n}, {m}, {n}, {m, n}};
 }
 
-SmallVector<int64_t>
-ScaledMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>> ScaledMMAAttr::getReductionDimSizes() const {
   int64_t k = getKSize(getIntrinsic());
   int64_t kb = getKbSize(getIntrinsic());
-  
-  switch (operandIndex) {
-  case kScaledMMAOperandLhs:
-    return {k, kb};
-  case kScaledMMAOperandRhs:
-    return {k, kb};
-  case kScaledMMAOperandLhsScale:
-    return {kb};
-  case kScaledMMAOperandRhsScale:
-    return {kb};
-  case kScaledMMAOperandAcc:
-    // Accumulator has no reduction dimensions
-    return {};
-  default:
-    return {};
-  }
+  return {{k, kb}, {k, kb}, {k}, {k}, {}};
 }
 
 SmallVector<Type> ScaledMMAAttr::getSupportedInputTypes(MLIRContext *ctx) {
@@ -2018,54 +1925,23 @@ int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<int64_t>
-DataTiledScaledMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>>
+DataTiledScaledMMAAttr::getParallelDimSizes() const {
   int64_t m = getMSize(getIntrinsic());
   int64_t n = getNSize(getIntrinsic());
-  
   // Scale by the number of intrinsics and subgroups
   m *= getIntrinsicsM() * getSubgroupsM();
   n *= getIntrinsicsN() * getSubgroupsN();
-  
-  switch (operandIndex) {
-  case kScaledMMAOperandLhs:
-    return {m};
-  case kScaledMMAOperandRhs:
-    return {n};
-  case kScaledMMAOperandLhsScale:
-    return {m};
-  case kScaledMMAOperandRhsScale:
-    return {n};
-  case kScaledMMAOperandAcc:
-    return {m, n};
-  default:
-    return {};
-  }
+  return {{m}, {n}, {m}, {n}, {m, n}};
 }
 
-SmallVector<int64_t>
-DataTiledScaledMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
+SmallVector<SmallVector<int64_t>>
+DataTiledScaledMMAAttr::getReductionDimSizes() const {
   int64_t k = getKSize(getIntrinsic());
   int64_t kb = getKbSize(getIntrinsic());
-  
   // Scale by the number of intrinsics and subgroups
   k *= getIntrinsicsK() * getSubgroupsK();
-  
-  switch (operandIndex) {
-  case kScaledMMAOperandLhs:
-    return {k, kb};
-  case kScaledMMAOperandRhs:
-    return {k, kb};
-  case kScaledMMAOperandLhsScale:
-    return {kb};
-  case kScaledMMAOperandRhsScale:
-    return {kb};
-  case kScaledMMAOperandAcc:
-    // Accumulator has no reduction dimensions
-    return {};
-  default:
-    return {};
-  }
+  return {{k, kb}, {k, kb}, {k}, {k}, {}};
 }
 
 int64_t DataTiledScaledMMAAttr::getFlatWorkgroupSize() const {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -690,11 +690,11 @@ int64_t MMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<SmallVector<utils::IteratorType>> MMAAttr::getOperandIteratorTypes() const {
-  return {
-    {utils::IteratorType::parallel, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+SmallVector<SmallVector<utils::IteratorType>>
+MMAAttr::getOperandIteratorTypes() const {
+  return {{utils::IteratorType::parallel, utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
 Attribute MMAAttr::getDistributionMappingKind() const {
@@ -968,11 +968,11 @@ int64_t DataTiledMMAAttr::getFlatWorkgroupSize() const {
          getSubgroupsK();
 }
 
-SmallVector<SmallVector<utils::IteratorType>> DataTiledMMAAttr::getOperandIteratorTypes() const {
-  return {
-    {utils::IteratorType::parallel, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+SmallVector<SmallVector<utils::IteratorType>>
+DataTiledMMAAttr::getOperandIteratorTypes() const {
+  return {{utils::IteratorType::parallel, utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
 /// Increment the mutable vector `indices` to traverse the index space below
@@ -1351,11 +1351,11 @@ int64_t VirtualMMAAttr::getBlockSize() const {
   return 0;
 }
 
-SmallVector<SmallVector<utils::IteratorType>> VirtualMMAAttr::getOperandIteratorTypes() const {
-  return {
-    {utils::IteratorType::parallel, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+SmallVector<SmallVector<utils::IteratorType>>
+VirtualMMAAttr::getOperandIteratorTypes() const {
+  return {{utils::IteratorType::parallel, utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(VirtualMMAIntrinsic intrinsic,
@@ -1702,13 +1702,15 @@ LogicalResult ScaledMMAAttr::buildUnderlyingOperations(
   return success();
 }
 
-SmallVector<SmallVector<utils::IteratorType>> ScaledMMAAttr::getOperandIteratorTypes() const {
-  return {
-    {utils::IteratorType::parallel, utils::IteratorType::reduction, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+SmallVector<SmallVector<utils::IteratorType>>
+ScaledMMAAttr::getOperandIteratorTypes() const {
+  return {{utils::IteratorType::parallel, utils::IteratorType::reduction,
+           utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::reduction,
+           utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
 //===----------------------------------------------------------------------===//
@@ -1920,13 +1922,13 @@ DataTiledScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
 
 SmallVector<SmallVector<utils::IteratorType>>
 DataTiledScaledMMAAttr::getOperandIteratorTypes() const {
-  return {
-    {utils::IteratorType::parallel, utils::IteratorType::reduction, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::reduction},
-    {utils::IteratorType::reduction, utils::IteratorType::parallel},
-    {utils::IteratorType::parallel, utils::IteratorType::parallel}
-  };
+  return {{utils::IteratorType::parallel, utils::IteratorType::reduction,
+           utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::reduction,
+           utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -966,7 +966,8 @@ int64_t DataTiledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-SmallVector<SmallVector<int64_t>> DataTiledMMAAttr::getParallelDimSizes() const {
+SmallVector<SmallVector<int64_t>>
+DataTiledMMAAttr::getParallelDimSizes() const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
   // Scale by the number of intrinsics and subgroups
   m *= getIntrinsicsM() * getSubgroupsM();
@@ -974,7 +975,8 @@ SmallVector<SmallVector<int64_t>> DataTiledMMAAttr::getParallelDimSizes() const 
   return {{m}, {n}, {m, n}};
 }
 
-SmallVector<SmallVector<int64_t>> DataTiledMMAAttr::getReductionDimSizes() const {
+SmallVector<SmallVector<int64_t>>
+DataTiledMMAAttr::getReductionDimSizes() const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
   // Scale by the number of intrinsics and subgroups
   k *= getIntrinsicsK() * getSubgroupsK();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1920,18 +1920,12 @@ DataTiledScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
 
 SmallVector<SmallVector<utils::IteratorType>>
 DataTiledScaledMMAAttr::getOperandIteratorTypes() const {
-  // Scaled MMA has 4 inputs: lhs, rhs, lhs_scales, rhs_scales
-  // lhs: M×K (parallel, reduction)
-  // rhs: K×N (reduction, parallel)
-  // lhs_scales: M×K (parallel, reduction) - follows lhs
-  // rhs_scales: K×N (reduction, parallel) - follows rhs
-  // acc: M×N (parallel, parallel)
   return {
-    {utils::IteratorType::parallel, utils::IteratorType::reduction, utils::IteratorType::reduction},  // lhs
-    {utils::IteratorType::reduction, utils::IteratorType::reduction, utils::IteratorType::parallel},  // rhs
-    {utils::IteratorType::parallel, utils::IteratorType::reduction},  // lhs_scales
-    {utils::IteratorType::reduction, utils::IteratorType::parallel},  // rhs_scales
-    {utils::IteratorType::parallel, utils::IteratorType::parallel}    // acc
+    {utils::IteratorType::parallel, utils::IteratorType::reduction, utils::IteratorType::reduction},
+    {utils::IteratorType::reduction, utils::IteratorType::reduction, utils::IteratorType::parallel},
+    {utils::IteratorType::parallel, utils::IteratorType::reduction},
+    {utils::IteratorType::reduction, utils::IteratorType::parallel},
+    {utils::IteratorType::parallel, utils::IteratorType::parallel}
   };
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -690,40 +690,31 @@ int64_t MMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-void MMAAttr::getParallelDimSizes(int64_t operandIndex,
-                                  SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t> MMAAttr::getParallelDimSizes(int64_t operandIndex) const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
   switch (operandIndex) {
   case kMMAOperandLhs:
-    result.push_back(m);
-    break;
+    return {m};
   case kMMAOperandRhs:
-    result.push_back(n);
-    break;
+    return {n};
   case kMMAOperandAcc:
-    result.push_back(m);
-    result.push_back(n);
-    break;
+    return {m, n};
   default:
-    break;
+    return {};
   }
 }
 
-void MMAAttr::getReductionDimSizes(int64_t operandIndex,
-                                   SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t> MMAAttr::getReductionDimSizes(int64_t operandIndex) const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
   switch (operandIndex) {
   case kMMAOperandLhs:
   case kMMAOperandRhs:
-    result.push_back(k);
-    break;
+    return {k};
   case kMMAOperandAcc:
     // Accumulator has no reduction dimensions
-    break;
+    return {};
   default:
-    break;
+    return {};
   }
 }
 
@@ -993,9 +984,8 @@ int64_t DataTiledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-void DataTiledMMAAttr::getParallelDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+DataTiledMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
   
   // Scale by the number of intrinsics and subgroups
@@ -1004,23 +994,18 @@ void DataTiledMMAAttr::getParallelDimSizes(
   
   switch (operandIndex) {
   case kMMAOperandLhs:
-    result.push_back(m);
-    break;
+    return {m};
   case kMMAOperandRhs:
-    result.push_back(n);
-    break;
+    return {n};
   case kMMAOperandAcc:
-    result.push_back(m);
-    result.push_back(n);
-    break;
+    return {m, n};
   default:
-    break;
+    return {};
   }
 }
 
-void DataTiledMMAAttr::getReductionDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+DataTiledMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
   auto [m, n, k] = getMNKShapeFromIntrinsic(getIntrinsic());
   
   // Scale by the number of intrinsics and subgroups
@@ -1029,13 +1014,12 @@ void DataTiledMMAAttr::getReductionDimSizes(
   switch (operandIndex) {
   case kMMAOperandLhs:
   case kMMAOperandRhs:
-    result.push_back(k);
-    break;
+    return {k};
   case kMMAOperandAcc:
     // Accumulator has no reduction dimensions
-    break;
+    return {};
   default:
-    break;
+    return {};
   }
 }
 
@@ -1301,40 +1285,33 @@ int64_t VirtualMMAAttr::getSubgroupSize() const {
   return 0;
 }
 
-void VirtualMMAAttr::getParallelDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+VirtualMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
   auto [m, n, k] = getMNKShape();
   switch (operandIndex) {
   case kMMAOperandLhs:
-    result.push_back(m);
-    break;
+    return {m};
   case kMMAOperandRhs:
-    result.push_back(n);
-    break;
+    return {n};
   case kMMAOperandAcc:
-    result.push_back(m);
-    result.push_back(n);
-    break;
+    return {m, n};
   default:
-    break;
+    return {};
   }
 }
 
-void VirtualMMAAttr::getReductionDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+VirtualMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
   auto [m, n, k] = getMNKShape();
   switch (operandIndex) {
   case kMMAOperandLhs:
   case kMMAOperandRhs:
-    result.push_back(k);
-    break;
+    return {k};
   case kMMAOperandAcc:
     // Accumulator has no reduction dimensions
-    break;
+    return {};
   default:
-    break;
+    return {};
   }
 }
 
@@ -1603,60 +1580,46 @@ int64_t ScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-void ScaledMMAAttr::getParallelDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+ScaledMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
   int64_t m = getMSize(getIntrinsic());
   int64_t n = getNSize(getIntrinsic());
   
   switch (operandIndex) {
   case kScaledMMAOperandLhs:
-    result.push_back(m);
-    break;
+    return {m};
   case kScaledMMAOperandRhs:
-    result.push_back(n);
-    break;
+    return {n};
   case kScaledMMAOperandLhsScale:
-    result.push_back(m);
-    break;
+    return {m};
   case kScaledMMAOperandRhsScale:
-    result.push_back(n);
-    break;
+    return {n};
   case kScaledMMAOperandAcc:
-    result.push_back(m);
-    result.push_back(n);
-    break;
+    return {m, n};
   default:
-    break;
+    return {};
   }
 }
 
-void ScaledMMAAttr::getReductionDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+ScaledMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
   int64_t k = getKSize(getIntrinsic());
   int64_t kb = getKbSize(getIntrinsic());
   
   switch (operandIndex) {
   case kScaledMMAOperandLhs:
-    result.push_back(k);
-    result.push_back(kb);
-    break;
+    return {k, kb};
   case kScaledMMAOperandRhs:
-    result.push_back(k);
-    result.push_back(kb);
-    break;
+    return {k, kb};
   case kScaledMMAOperandLhsScale:
-    result.push_back(kb);
-    break;
+    return {kb};
   case kScaledMMAOperandRhsScale:
-    result.push_back(kb);
-    break;
+    return {kb};
   case kScaledMMAOperandAcc:
     // Accumulator has no reduction dimensions
-    break;
+    return {};
   default:
-    break;
+    return {};
   }
 }
 
@@ -2055,9 +2018,8 @@ int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
-void DataTiledScaledMMAAttr::getParallelDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+DataTiledScaledMMAAttr::getParallelDimSizes(int64_t operandIndex) const {
   int64_t m = getMSize(getIntrinsic());
   int64_t n = getNSize(getIntrinsic());
   
@@ -2067,29 +2029,22 @@ void DataTiledScaledMMAAttr::getParallelDimSizes(
   
   switch (operandIndex) {
   case kScaledMMAOperandLhs:
-    result.push_back(m);
-    break;
+    return {m};
   case kScaledMMAOperandRhs:
-    result.push_back(n);
-    break;
+    return {n};
   case kScaledMMAOperandLhsScale:
-    result.push_back(m);
-    break;
+    return {m};
   case kScaledMMAOperandRhsScale:
-    result.push_back(n);
-    break;
+    return {n};
   case kScaledMMAOperandAcc:
-    result.push_back(m);
-    result.push_back(n);
-    break;
+    return {m, n};
   default:
-    break;
+    return {};
   }
 }
 
-void DataTiledScaledMMAAttr::getReductionDimSizes(
-    int64_t operandIndex, SmallVectorImpl<int64_t> &result) const {
-  result.clear();
+SmallVector<int64_t>
+DataTiledScaledMMAAttr::getReductionDimSizes(int64_t operandIndex) const {
   int64_t k = getKSize(getIntrinsic());
   int64_t kb = getKbSize(getIntrinsic());
   
@@ -2098,24 +2053,18 @@ void DataTiledScaledMMAAttr::getReductionDimSizes(
   
   switch (operandIndex) {
   case kScaledMMAOperandLhs:
-    result.push_back(k);
-    result.push_back(kb);
-    break;
+    return {k, kb};
   case kScaledMMAOperandRhs:
-    result.push_back(k);
-    result.push_back(kb);
-    break;
+    return {k, kb};
   case kScaledMMAOperandLhsScale:
-    result.push_back(kb);
-    break;
+    return {kb};
   case kScaledMMAOperandRhsScale:
-    result.push_back(kb);
-    break;
+    return {kb};
   case kScaledMMAOperandAcc:
     // Accumulator has no reduction dimensions
-    break;
+    return {};
   default:
-    break;
+    return {};
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -260,6 +260,7 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
     "populateOperandOffsetsSizesStrides",
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
+    "getOperandIteratorTypes",
     "buildUnderlyingOperations",
   ]>
 ]> {
@@ -302,13 +303,6 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
     int64_t getBlockSize() const;
 
     SmallVector<VirtualMMAIntrinsic> getVirtualIntrinsics() const;
-
-    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
-      return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction},
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
-    }
   }];
 }
 
@@ -327,6 +321,7 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
         "populateOperandOffsetsSizesStrides",
         "getDistributionMappingKind",
         "getDistributionWorkerCount",
+        "getOperandIteratorTypes",
       ]>,
       DeclareAttrInterfaceMethods<IREEGPU_DataTiledMMAInterfaceAttr, [
         "getTileSwizzle",
@@ -396,6 +391,7 @@ def IREEGPU_DataTiledMMAAttr :
     "getExpectedNumInputs",
     "getExpectedNumOutputs",
     "verifyIndexingMaps",
+    "getOperandIteratorTypes",
     "buildUnderlyingOperations",
   ]>
 ]> {
@@ -460,15 +456,6 @@ def IREEGPU_DataTiledMMAAttr :
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_n,
           OptionalParameter<
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k);
-
-  let extraClassDeclaration = [{
-    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
-      return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction},
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
-    }
-  }];
 }
 
 def IREEGPU_DataTiledScaledMMAAttr :
@@ -543,6 +530,7 @@ def IREEGPU_VirtualMMAAttr :
     "getDistributedTileTypes",
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
+    "getOperandIteratorTypes",
     "populateOperandOffsetsSizesStrides",
     "buildUnderlyingOperations",
   ]>
@@ -584,13 +572,6 @@ def IREEGPU_VirtualMMAAttr :
     // e.g MFMA_F32_16x16x16 has K of 16, while VMFMA_F32_16x16x32 has K of 32
     // in this example, intrinsicsK = 32/16 = 2.
     int64_t getIntrinsicsK() const;
-
-    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
-      return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction},
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
-    }
   }];
 }
 
@@ -616,6 +597,7 @@ def IREEGPU_ScaledMMAAttr :
     "populateOperandOffsetsSizesStrides",
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
+    "getOperandIteratorTypes",
     "buildUnderlyingOperations",
   ]>
 ]> {
@@ -676,12 +658,6 @@ def IREEGPU_ScaledMMAAttr :
       ::llvm::ArrayRef<int64_t> accShape = preThreadTypes[4].getShape();
       ::llvm::ArrayRef<int64_t> lhsShape = preThreadTypes[0].getShape();
       return {accShape[0], accShape[1], lhsShape[1], lhsShape[2]};
-    }
-    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
-      return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction},
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -261,6 +261,8 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
     "buildUnderlyingOperations",
+    "getParallelDimSizes",
+    "getReductionDimSizes",
   ]>
 ]> {
   let mnemonic = "mma_layout";
@@ -320,6 +322,8 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
         "populateOperandOffsetsSizesStrides",
         "getDistributionMappingKind",
         "getDistributionWorkerCount",
+        "getParallelDimSizes",
+        "getReductionDimSizes",
       ]>,
       DeclareAttrInterfaceMethods<IREEGPU_DataTiledMMAInterfaceAttr, [
         "getTileSwizzle",
@@ -529,6 +533,8 @@ def IREEGPU_VirtualMMAAttr :
     "getDistributionWorkerCount",
     "populateOperandOffsetsSizesStrides",
     "buildUnderlyingOperations",
+    "getParallelDimSizes",
+    "getReductionDimSizes",
   ]>
 ]> {
   let mnemonic = "virtual_mma_layout";
@@ -594,6 +600,8 @@ def IREEGPU_ScaledMMAAttr :
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
     "buildUnderlyingOperations",
+    "getParallelDimSizes",
+    "getReductionDimSizes",
   ]>
 ]> {
   let mnemonic = "scaled_mma_layout";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -261,8 +261,6 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
     "buildUnderlyingOperations",
-    "getParallelDimSizes",
-    "getReductionDimSizes",
   ]>
 ]> {
   let mnemonic = "mma_layout";
@@ -304,6 +302,13 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
     int64_t getBlockSize() const;
 
     SmallVector<VirtualMMAIntrinsic> getVirtualIntrinsics() const;
+
+    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
+      return {
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction}, 
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
+    }
   }];
 }
 
@@ -322,8 +327,6 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
         "populateOperandOffsetsSizesStrides",
         "getDistributionMappingKind",
         "getDistributionWorkerCount",
-        "getParallelDimSizes",
-        "getReductionDimSizes",
       ]>,
       DeclareAttrInterfaceMethods<IREEGPU_DataTiledMMAInterfaceAttr, [
         "getTileSwizzle",
@@ -457,6 +460,15 @@ def IREEGPU_DataTiledMMAAttr :
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_n,
           OptionalParameter<
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k);
+
+  let extraClassDeclaration = [{
+    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
+      return {
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction}, 
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
+    }
+  }];
 }
 
 def IREEGPU_DataTiledScaledMMAAttr :
@@ -533,8 +545,6 @@ def IREEGPU_VirtualMMAAttr :
     "getDistributionWorkerCount",
     "populateOperandOffsetsSizesStrides",
     "buildUnderlyingOperations",
-    "getParallelDimSizes",
-    "getReductionDimSizes",
   ]>
 ]> {
   let mnemonic = "virtual_mma_layout";
@@ -574,6 +584,13 @@ def IREEGPU_VirtualMMAAttr :
     // e.g MFMA_F32_16x16x16 has K of 16, while VMFMA_F32_16x16x32 has K of 32
     // in this example, intrinsicsK = 32/16 = 2.
     int64_t getIntrinsicsK() const;
+
+    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
+      return {
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction}, 
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
+    }
   }];
 }
 
@@ -600,8 +617,6 @@ def IREEGPU_ScaledMMAAttr :
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
     "buildUnderlyingOperations",
-    "getParallelDimSizes",
-    "getReductionDimSizes",
   ]>
 ]> {
   let mnemonic = "scaled_mma_layout";
@@ -661,6 +676,12 @@ def IREEGPU_ScaledMMAAttr :
       ::llvm::ArrayRef<int64_t> accShape = preThreadTypes[4].getShape();
       ::llvm::ArrayRef<int64_t> lhsShape = preThreadTypes[0].getShape();
       return {accShape[0], accShape[1], lhsShape[1], lhsShape[2]};
+    }
+    ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
+      return {
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction}, 
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -305,8 +305,8 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
 
     ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
       return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction}, 
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction},
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
         {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
     }
   }];
@@ -464,8 +464,8 @@ def IREEGPU_DataTiledMMAAttr :
   let extraClassDeclaration = [{
     ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
       return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction}, 
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction},
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
         {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
     }
   }];
@@ -587,8 +587,8 @@ def IREEGPU_VirtualMMAAttr :
 
     ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
       return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction}, 
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction},
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
         {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
     }
   }];
@@ -679,8 +679,8 @@ def IREEGPU_ScaledMMAAttr :
     }
     ::llvm::SmallVector<::llvm::SmallVector<::mlir::utils::IteratorType>> getOperandIteratorTypes() const {
       return {
-        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction}, 
-        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel}, 
+        {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction},
+        {::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::reduction, ::mlir::utils::IteratorType::parallel},
         {::mlir::utils::IteratorType::parallel, ::mlir::utils::IteratorType::parallel}};
     }
   }];


### PR DESCRIPTION
This PR introduces two new interface methods for the `InnerTileDescAttrInterface` called `getParallelDimsSize` and `getReductionDimsSize` which returns a list of the parallel / reduction dims per operand. This allows us a generalized way to access various dimensions of interest (like `getMNKShape` but for a generic inner tiled op).