### PR TITLE
[CPU] Enable generalization of linalg.conv

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -630,6 +630,7 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
       .addPass(createMaterializeDeviceEncodingPass)
       .addPass(createCPUPropagateDataLayoutPass)
       .addPass(createRematerializeParallelOpsPass)
+      .addPass(createInsertBatchDimForBatchlessConvPass)
       // TODO(#13888): This(createExpandF16OpToF32Pass()) pass is being added
       // way to late and should instead be be done during lowering to LLVM.
       .addPass(createExpandF16OpToF32Pass)

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -703,3 +703,43 @@ module {
 }
 // CHECK-LABEL: func.func @dequant_lhs_matmul(
 // CHECK:         iree_codegen.ukernel.generic
+
+// -----
+
+// Verify that batchless convolutions (convolutions without batch dimension)
+// are vectorized after batch dimension insertion in the pipeline.
+
+#pipeline_layout_batchless = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target_embedded_elf_x86_64_batchless = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
+#map_batchless_input = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0 + d3, d1 + d4, d5)>
+#map_batchless_filter = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d2)>
+#map_batchless_output = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+func.func @batchless_conv_vectorized() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_batchless} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_batchless) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<225x225x3xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_batchless) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x16xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout_batchless) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<112x112x16xf32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [225, 225, 3], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<225x225x3xf32>> -> tensor<225x225x3xf32>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x16xf32>> -> tensor<3x3x3x16xf32>
+  %5 = tensor.empty() : tensor<112x112x16xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<112x112x16xf32>) -> tensor<112x112x16xf32>
+  %7 = linalg.generic {
+    indexing_maps = [#map_batchless_input, #map_batchless_filter, #map_batchless_output],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%3, %4 : tensor<225x225x3xf32>, tensor<3x3x3x16xf32>)
+    outs(%6 : tensor<112x112x16xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %mul = arith.mulf %in, %f : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<112x112x16xf32>
+  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [112, 112, 16], strides = [1, 1, 1] : tensor<112x112x16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<112x112x16xf32>>
+  return
+}
+// CHECK-LABEL: func.func @batchless_conv_vectorized
+//       CHECK:   vector.fma

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -3,6 +3,9 @@
 // generalizing the named ops. This ensures convolution pipeline selection works
 // on both named and generic convs.
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(linalg-generalize-named-ops),iree-llvmcpu-select-lowering-strategy)' --split-input-file %s | FileCheck %s --check-prefix=GENERIC
+// Test that batchless convolutions (convolutions without batch dimension) also
+// select the conv pipeline after batch dimension insertion.
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-insert-batch-dim-for-batchless-conv),iree-llvmcpu-select-lowering-strategy)' --split-input-file %s | FileCheck %s --check-prefix=BATCHLESS
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
@@ -1565,3 +1568,31 @@ func.func @gather(%source: tensor<16x8x32x128xf16>, %indices: tensor<4xi64>, %ou
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.gather
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Test that CPUConvTileAndDecomposeExpert pipeline is selected after batch dimension insertion.
+
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d0 + d4, d1 + d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+
+#executable_target_embedded_elf_x86_64_batchless = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
+func.func @batchless_conv_nchw_fchw(%input: tensor<128x30x30xf32>, %filter: tensor<3x3x128x64xf32>, %output: tensor<28x28x64xf32>) -> tensor<28x28x64xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_batchless} {
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<128x30x30xf32>, tensor<3x3x128x64xf32>)
+    outs(%output : tensor<28x28x64xf32>) {
+  ^bb0(%in: f32, %f: f32, %out: f32):
+    %mul = arith.mulf %in, %f : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<28x28x64xf32>
+  return %0 : tensor<28x28x64xf32>
+}
+// BATCHLESS-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
+// BATCHLESS:     func.func @batchless_conv_nchw_fchw(
+// BATCHLESS-SAME:    translation_info = #[[TRANSLATION]]
+// BATCHLESS:       linalg.generic
+// BATCHLESS-SAME:      lowering_config = #

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -3,9 +3,6 @@
 // generalizing the named ops. This ensures convolution pipeline selection works
 // on both named and generic convs.
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(linalg-generalize-named-ops),iree-llvmcpu-select-lowering-strategy)' --split-input-file %s | FileCheck %s --check-prefix=GENERIC
-// Test that batchless convolutions (convolutions without batch dimension) also
-// select the conv pipeline after batch dimension insertion.
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-insert-batch-dim-for-batchless-conv),iree-llvmcpu-select-lowering-strategy)' --split-input-file %s | FileCheck %s --check-prefix=BATCHLESS
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
@@ -1568,31 +1565,3 @@ func.func @gather(%source: tensor<16x8x32x128xf16>, %indices: tensor<4xi64>, %ou
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.gather
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
-
-// -----
-
-// Test that CPUConvTileAndDecomposeExpert pipeline is selected after batch dimension insertion.
-
-#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d0 + d4, d1 + d5)>
-#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5, d3, d2)>
-#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
-
-#executable_target_embedded_elf_x86_64_batchless = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
-func.func @batchless_conv_nchw_fchw(%input: tensor<128x30x30xf32>, %filter: tensor<3x3x128x64xf32>, %output: tensor<28x28x64xf32>) -> tensor<28x28x64xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_batchless} {
-  %0 = linalg.generic {
-    indexing_maps = [#map0, #map1, #map2],
-    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
-  } ins(%input, %filter : tensor<128x30x30xf32>, tensor<3x3x128x64xf32>)
-    outs(%output : tensor<28x28x64xf32>) {
-  ^bb0(%in: f32, %f: f32, %out: f32):
-    %mul = arith.mulf %in, %f : f32
-    %add = arith.addf %out, %mul : f32
-    linalg.yield %add : f32
-  } -> tensor<28x28x64xf32>
-  return %0 : tensor<28x28x64xf32>
-}
-// BATCHLESS-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUConvTileAndDecomposeExpert>
-// BATCHLESS:     func.func @batchless_conv_nchw_fchw(
-// BATCHLESS-SAME:    translation_info = #[[TRANSLATION]]
-// BATCHLESS:       linalg.generic
-// BATCHLESS-SAME:      lowering_config = #

--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -21,14 +21,6 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-// TODO(#21955): Adapts the convolution transformations to work with generalized
-// linalg.generic form, but not only when they are named ops. E.g.,
-// DownscaleSizeOneWindowed2DConvolution patterns.
-static llvm::cl::opt<bool> clDisableConvGeneralization(
-    "iree-global-opt-experimental-disable-conv-generalization",
-    llvm::cl::desc("Disable generalization for some conv ops (experimental)."),
-    llvm::cl::init(false));
-
 #define GEN_PASS_DEF_GENERALIZELINALGNAMEDOPSPASS
 #include "iree/compiler/GlobalOptimization/Passes.h.inc"
 
@@ -52,16 +44,6 @@ void GeneralizeLinalgNamedOpsPass::runOnOperation() {
       namedOpCandidates.push_back(linalgOp);
       return;
     }
-    bool generalizeConvOps = linalg::isaConvolutionOpInterface(linalgOp);
-    if (clDisableConvGeneralization &&
-        isa<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp,
-            linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
-            linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
-            linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
-            linalg::PoolingNchwMaxOp, linalg::DepthwiseConv2DNhwcHwcOp>(
-            linalgOp)) {
-      generalizeConvOps = false;
-    }
     if (isa_and_nonnull<linalg::AbsOp, linalg::AddOp, linalg::BroadcastOp,
                         linalg::CeilOp, linalg::CopyOp, linalg::DivOp,
                         linalg::DivUnsignedOp, linalg::ExpOp, linalg::FloorOp,
@@ -69,7 +51,7 @@ void GeneralizeLinalgNamedOpsPass::runOnOperation() {
                         linalg::MulOp, linalg::NegFOp, linalg::ReduceOp,
                         linalg::SubOp, linalg::TransposeOp>(
             linalgOp.getOperation()) ||
-        generalizeConvOps) {
+        linalg::isaConvolutionOpInterface(linalgOp)) {
       namedOpCandidates.push_back(linalgOp);
     }
   });

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
@@ -19,8 +19,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
-        "--iree-opt-data-tiling",
-        "--iree-global-opt-experimental-disable-conv-generalization"
+        "--iree-opt-data-tiling"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.01f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
@@ -32,8 +32,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
-        "--iree-opt-data-tiling",
-        "--iree-global-opt-experimental-disable-conv-generalization"
+        "--iree-opt-data-tiling"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.8f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
@@ -32,8 +32,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
-        "--iree-opt-data-tiling",
-        "--iree-global-opt-experimental-disable-conv-generalization"
+        "--iree-opt-data-tiling"
     ],
     "pipeline_compiler_flags": [
         "--iree-hal-local-target-device-backends=llvm-cpu",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
@@ -19,8 +19,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
-        "--iree-opt-data-tiling",
-        "--iree-global-opt-experimental-disable-conv-generalization"
+        "--iree-opt-data-tiling"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.02f"


### PR DESCRIPTION
-- This commit adds InsertBatchDimForBatchlessConv pass after
   RematerializeParallelOps pass to convert a batchless Conv into
   a Conv with unit batch dim.
-- This is done so that LLVMCPUSelectLoweringStrategy pass can
   correctly assign CPUConvTileAndDecomposeExpert to this unit batch
   dim which was previously batchless.
-- With this we can get rid of the experimental `iree-global-opt-experimental-disable-conv-generalization`
   flag and re-enable linalg.conv generalization.
-- Aims to resolve https://github.com/iree-org/iree/issues/21955 via the short-term approach. Refer [this thread](https://github.com/iree-org/iree/issues/21955#issuecomment-3807719144) for more context.

Performance number with this PR : https://github.com/iree-org/iree/actions/runs/21673429818/job/62488213210?pr=23377:

```
============================== slowest durations ===============================
109.27s call     quality_tests/model_quality_run.py::sdxl :: unet_fp16_cpu
54.44s call     quality_tests/model_quality_run.py::sdxl :: unet_fp16_960_1024_cpu
34.97s call     quality_tests/model_quality_run.py::sd3 :: clip_cpu
18.31s call     quality_tests/model_quality_run.py::sdxl :: vae_cpu
18.22s call     quality_tests/model_quality_run.py::sd3 :: vae_cpu
15.59s call     quality_tests/model_quality_run.py::sdxl :: clip_cpu
12.54s call     quality_tests/model_quality_run.py::sd3 :: mmdit_cpu
1.06s call     quality_tests/model_quality_run.py::sdxl :: scheduler_cpu
```