### PR TITLE
Introduce `iree_cpu_set_t`, a better `cpu_set_t`

### DIFF
--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -378,6 +378,24 @@ iree_runtime_cc_test(
     ],
 )
 
+iree_runtime_cc_library(
+    name = "cpu_set",
+    hdrs = ["cpu_set.h"],
+    deps = [
+        "//runtime/src/iree/base",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "cpu_set_test",
+    srcs = ["cpu_set_test.cc"],
+    deps = [
+        ":cpu_set",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 #===------------------------------------------------------------------------===#
 # Utilities with thread dependencies
 #===------------------------------------------------------------------------===#

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -409,6 +409,27 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_library(
+  NAME
+    cpu_set
+  HDRS
+    "cpu_set.h"
+  DEPS
+    iree::base
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    cpu_set_test
+  SRCS
+    "cpu_set_test.cc"
+  DEPS
+    ::cpu_set
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 if(NOT IREE_ENABLE_THREADING)
   return()
 endif()

--- a/runtime/src/iree/base/internal/cpu.h
+++ b/runtime/src/iree/base/internal/cpu.h
@@ -79,4 +79,4 @@ void iree_cpu_requery_processor_id(iree_cpu_processor_tag_t* IREE_RESTRICT tag,
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // IREE_BASE_INTERNAL_ARENA_H_
+#endif  // IREE_BASE_INTERNAL_CPU_H_

--- a/runtime/src/iree/base/internal/cpu_set.h
+++ b/runtime/src/iree/base/internal/cpu_set.h
@@ -1,0 +1,231 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_INTERNAL_CPU_SET_H_
+#define IREE_BASE_INTERNAL_CPU_SET_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/math.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Rationale for using uint64 instead of uintptr:
+// * On 64-bit archs, this makes no difference.
+// * On 32-bit archs, this ensures that we can use the top bit for tagging.
+//   Otherwise, as 32-bit archs can use up all their pointer bits, we would have
+//   to perform more complicated low-bit tagging.
+// * This uniformity is useful as the direct storage access leaks the word size.
+// * This also ensures that we always have inline storage up to the same bit
+//   count.
+typedef uint64_t iree_cpu_set_word_t;
+
+#define IREE_CPU_SET_BITS_PER_WORD (8 * sizeof(iree_cpu_set_word_t))
+#define IREE_CPU_SET_INLINE_VALUE_IS_INLINE_SHIFT \
+  (IREE_CPU_SET_BITS_PER_WORD - 1)
+#define IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_SHIFT \
+  (IREE_CPU_SET_BITS_PER_WORD - 8)
+#define IREE_CPU_SET_INLINE_VALUE_IS_INLINE_MASK \
+  (((iree_cpu_set_word_t)1) << IREE_CPU_SET_INLINE_VALUE_IS_INLINE_SHIFT)
+#define IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_MASK \
+  (IREE_CPU_SET_INLINE_VALUE_IS_INLINE_MASK -   \
+   (((iree_cpu_set_word_t)1) << IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_SHIFT))
+#define IREE_CPU_SET_INLINE_VALUE_BITS_MASK     \
+  (~(IREE_CPU_SET_INLINE_VALUE_IS_INLINE_MASK | \
+     IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_MASK))
+
+// iree_cpu_set_t: a better cpu_set_t.
+//
+// Standard cpu_set_t is hampered by compatibility requirements:
+// * It grew in an era where inline storage was all one'd ever need. Now it is
+//   stranded with both a large static size (1024 bit in glibc) AND a dynamic
+//   mode.
+// * Its bit layout is opaque, forcing inefficient bitwise access.
+//
+// iree_cpu_set adresses these issues:
+// * Explicit layout by 64-bit words similar to iree_bitmap_t (but owning
+//   its data, unlike iree_bitmap_t which is non-owning).
+// * Direct word addressing.
+// * Static size just a single word. Storage is inline up to 56 bits.
+//   * Inline-storage case: Indicated by bit 63 set to 1. Bit storage in bits
+//     0-55. bit size encoded in bits 56-62.
+//   * Dynamic-storage case: Indicated by bit 63 set to 0. Then the whole
+//     64-bit value is directly a pointer (not even a tagged pointer) to
+//     out-of-line storage. The out-of-line storage starts with one uint64
+//     holding the bit size, followed by the bits storage itself.
+// * The only assumption on pointers is that bit 63 is 0. No tagged pointer is
+//   stored in memory and no additional pointer bits are used.
+//
+typedef struct iree_cpu_set_t {
+  iree_cpu_set_word_t raw;
+} iree_cpu_set_t;
+
+// Returns true if storage is inline. Equivalent to: bit_size <= 56.
+static inline bool iree_cpu_set_is_inline(iree_cpu_set_t cpu_set) {
+  return cpu_set.raw & IREE_CPU_SET_INLINE_VALUE_IS_INLINE_MASK;
+}
+
+// Returns the bit size. This is set once during allocation, immutable after.
+// Warning: this returns the storage size, NOT the number of bits that are one.
+// See iree_cpu_set_population_count.
+static inline iree_host_size_t iree_cpu_set_get_bit_size(
+    iree_cpu_set_t cpu_set) {
+  if (iree_cpu_set_is_inline(cpu_set)) {
+    return (cpu_set.raw & IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_MASK) >>
+           IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_SHIFT;
+  }
+  return ((const iree_cpu_set_word_t*)cpu_set.raw)[0];
+}
+
+// Returns the number of iree_cpu_set_word_t words needed to store the given
+// number of bits.
+// This may return 1 even if storage is out-of-line (for bit sizes 57..64).
+// This does not include the header storing bit size in out-of-line storage,
+// so this isn't the allocation size.
+static inline iree_host_size_t iree_cpu_set_word_count(
+    iree_host_size_t bit_size) {
+  return (bit_size + IREE_CPU_SET_BITS_PER_WORD - 1) /
+         IREE_CPU_SET_BITS_PER_WORD;
+}
+
+// Returns a pointer to the words storing the bits. Bit 0 in this cpu set is
+// bit 0 in the returned words[0].
+static inline iree_cpu_set_word_t* iree_cpu_set_get_mutable_words(
+    iree_cpu_set_t* cpu_set) {
+  if (iree_cpu_set_is_inline(*cpu_set)) {
+    return &cpu_set->raw;
+  }
+  return ((iree_cpu_set_word_t*)cpu_set->raw) + 1;
+}
+
+// Returns a pointer to the words storing the bits. Bit 0 in this cpu set is
+// bit 0 in the returned words[0].
+static inline const iree_cpu_set_word_t* iree_cpu_set_get_const_words(
+    const iree_cpu_set_t* cpu_set) {
+  if (iree_cpu_set_is_inline(*cpu_set)) {
+    return &cpu_set->raw;
+  }
+  return ((const iree_cpu_set_word_t*)cpu_set->raw) + 1;
+}
+
+// Sets the specified bit to 1. Like CPU_SET.
+static inline void iree_cpu_set_set_bit(iree_cpu_set_t* cpu_set,
+                                        iree_host_size_t bit_pos) {
+  iree_cpu_set_word_t* words = iree_cpu_set_get_mutable_words(cpu_set);
+  iree_host_size_t word_index = bit_pos / IREE_CPU_SET_BITS_PER_WORD;
+  iree_host_size_t bit_index = bit_pos % IREE_CPU_SET_BITS_PER_WORD;
+  words[word_index] |= (((iree_cpu_set_word_t)1) << bit_index);
+}
+
+// Sets the specified bit to 0. Like CPU_CLR.
+static inline void iree_cpu_set_clear_bit(iree_cpu_set_t* cpu_set,
+                                          iree_host_size_t bit_pos) {
+  iree_cpu_set_word_t* words = iree_cpu_set_get_mutable_words(cpu_set);
+  iree_host_size_t word_index = bit_pos / IREE_CPU_SET_BITS_PER_WORD;
+  iree_host_size_t bit_index = bit_pos % IREE_CPU_SET_BITS_PER_WORD;
+  words[word_index] &= ~(((iree_cpu_set_word_t)1) << bit_index);
+}
+
+// Returns the specified bit. Like CPU_ISSET.
+static inline bool iree_cpu_set_get_bit(iree_cpu_set_t cpu_set,
+                                        iree_host_size_t bit_pos) {
+  const iree_cpu_set_word_t* words = iree_cpu_set_get_const_words(&cpu_set);
+  iree_host_size_t word_index = bit_pos / IREE_CPU_SET_BITS_PER_WORD;
+  iree_host_size_t bit_index = bit_pos % IREE_CPU_SET_BITS_PER_WORD;
+  return 0 != (words[word_index] & (((iree_cpu_set_word_t)1) << bit_index));
+}
+
+// Resets all bits to 0. Like CPU_ZERO.
+static inline void iree_cpu_set_clear(iree_cpu_set_t* cpu_set) {
+  if (iree_cpu_set_is_inline(*cpu_set)) {
+    cpu_set->raw &= ~IREE_CPU_SET_INLINE_VALUE_BITS_MASK;
+    return;
+  }
+  iree_host_size_t bit_size = iree_cpu_set_get_bit_size(*cpu_set);
+  iree_host_size_t word_count = iree_cpu_set_word_count(bit_size);
+  iree_cpu_set_word_t* words = iree_cpu_set_get_mutable_words(cpu_set);
+  memset(words, 0, word_count * sizeof(iree_cpu_set_word_t));
+}
+
+// Returns the number of bits set to 1. Like CPU_COUNT.
+static inline iree_host_size_t iree_cpu_set_population_count(
+    iree_cpu_set_t cpu_set) {
+  if (iree_cpu_set_is_inline(cpu_set)) {
+    return iree_math_count_ones_u64(cpu_set.raw &
+                                    IREE_CPU_SET_INLINE_VALUE_BITS_MASK);
+  }
+  iree_host_size_t bit_size = iree_cpu_set_get_bit_size(cpu_set);
+  iree_host_size_t word_count = iree_cpu_set_word_count(bit_size);
+  const iree_cpu_set_word_t* words = iree_cpu_set_get_const_words(&cpu_set);
+  iree_host_size_t popcount = 0;
+  for (iree_host_size_t i = 0; i < word_count; ++i) {
+    popcount += iree_math_count_ones_u64(words[i]);
+  }
+  return popcount;
+}
+
+// Returns true if the sets are equal. Like CPU_EQUAL.
+static inline bool iree_cpu_set_equal(iree_cpu_set_t cpu_set_1,
+                                      iree_cpu_set_t cpu_set_2) {
+  // Early return when both sets are inline. Important as that's the most common
+  // case, and it's far cheaper as it's a single word comparison.
+  if (iree_cpu_set_is_inline(cpu_set_1) && iree_cpu_set_is_inline(cpu_set_2)) {
+    return cpu_set_1.raw == cpu_set_2.raw;
+  }
+
+  iree_host_size_t bit_size = iree_cpu_set_get_bit_size(cpu_set_1);
+  iree_host_size_t bit_size_2 = iree_cpu_set_get_bit_size(cpu_set_2);
+  if (bit_size_2 != bit_size) {
+    return false;
+  }
+  const iree_cpu_set_word_t* words_1 = iree_cpu_set_get_const_words(&cpu_set_1);
+  const iree_cpu_set_word_t* words_2 = iree_cpu_set_get_const_words(&cpu_set_2);
+  iree_host_size_t word_count = iree_cpu_set_word_count(bit_size);
+  return 0 ==
+         memcmp(words_1, words_2, word_count * sizeof(iree_cpu_set_word_t));
+}
+
+// Allocates a new set with the given bit size. Like CPU_ALLOC, but also
+// initializing all bits to 0 in the allocated words, even past the bit size.
+static inline iree_status_t iree_cpu_set_allocate(iree_allocator_t allocator,
+                                                  iree_host_size_t bit_size,
+                                                  iree_cpu_set_t* out_cpu_set) {
+  if (bit_size <= IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_SHIFT) {
+    // Initialize all stored bits to 0, even past bit_size.
+    out_cpu_set->raw = IREE_CPU_SET_INLINE_VALUE_IS_INLINE_MASK |
+                       (((iree_cpu_set_word_t)bit_size)
+                        << IREE_CPU_SET_INLINE_VALUE_BIT_SIZE_SHIFT);
+    return iree_ok_status();
+  }
+  iree_host_size_t words_to_allocate =
+      /*header: bit size*/ 1 + iree_cpu_set_word_count(bit_size);
+  iree_cpu_set_word_t* words = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      allocator, words_to_allocate * sizeof(iree_cpu_set_word_t),
+      (void**)&words));
+  // Initialize all stored bits to 0, even past bit_size.
+  memset(words, 0, words_to_allocate * sizeof(iree_cpu_set_word_t));
+  words[0] = bit_size;  // header: bit size
+  out_cpu_set->raw = (iree_cpu_set_word_t)(uintptr_t)words;
+  assert(!iree_cpu_set_is_inline(*out_cpu_set) &&
+         "Malloc'd pointer has high bit set!");
+  return iree_ok_status();
+}
+
+// Deallocates a set. Like CPU_FREE.
+static inline void iree_cpu_set_free(iree_allocator_t allocator,
+                                     iree_cpu_set_t* cpu_set) {
+  if (!iree_cpu_set_is_inline(*cpu_set)) {
+    iree_allocator_free(allocator, (void*)(uintptr_t)(cpu_set->raw));
+  }
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_INTERNAL_CPU_SET_H_

--- a/runtime/src/iree/base/internal/cpu_set_test.cc
+++ b/runtime/src/iree/base/internal/cpu_set_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/cpu_set.h"
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+TEST(CpuSet, Generalities) {
+  const iree_allocator_t allocator = iree_allocator_system();
+  const std::vector<iree_host_size_t> bit_counts = {0,  1,  56,   57,
+                                                    64, 65, 1000, 1024};
+  iree_host_size_t bit_counts_count = bit_counts.size();
+  std::vector<iree_cpu_set_t> cpu_sets(bit_counts_count);
+
+  for (iree_host_size_t i = 0; i < bit_counts_count; ++i) {
+    IREE_EXPECT_OK(
+        iree_cpu_set_allocate(allocator, bit_counts[i], &cpu_sets[i]));
+    EXPECT_EQ(iree_cpu_set_is_inline(cpu_sets[i]), (bit_counts[i] <= 56));
+    EXPECT_EQ(iree_cpu_set_get_bit_size(cpu_sets[i]), bit_counts[i]);
+    for (iree_host_size_t b = 0; b < bit_counts[i]; ++b) {
+      EXPECT_EQ(b, iree_cpu_set_population_count(cpu_sets[i]));
+      EXPECT_EQ(false, iree_cpu_set_get_bit(cpu_sets[i], b));
+      iree_cpu_set_set_bit(&cpu_sets[i], b);
+      EXPECT_EQ(true, iree_cpu_set_get_bit(cpu_sets[i], b));
+      EXPECT_EQ(b + 1, iree_cpu_set_population_count(cpu_sets[i]));
+    }
+    for (iree_host_size_t b = 0; b < bit_counts[i]; ++b) {
+      EXPECT_EQ(bit_counts[i] - b, iree_cpu_set_population_count(cpu_sets[i]));
+      EXPECT_EQ(true, iree_cpu_set_get_bit(cpu_sets[i], b));
+      iree_cpu_set_clear_bit(&cpu_sets[i], b);
+      EXPECT_EQ(false, iree_cpu_set_get_bit(cpu_sets[i], b));
+      EXPECT_EQ(bit_counts[i] - b - 1,
+                iree_cpu_set_population_count(cpu_sets[i]));
+    }
+    EXPECT_EQ(iree_cpu_set_get_const_words(&cpu_sets[i]),
+              iree_cpu_set_get_mutable_words(&cpu_sets[i]));
+
+    for (iree_host_size_t b = 1; b < bit_counts[i]; b += 2) {
+      iree_cpu_set_set_bit(&cpu_sets[i], b);
+    }
+    EXPECT_EQ(bit_counts[i] / 2, iree_cpu_set_population_count(cpu_sets[i]));
+    iree_cpu_set_clear(&cpu_sets[i]);
+    EXPECT_EQ(0, iree_cpu_set_population_count(cpu_sets[i]));
+  }
+
+  for (iree_host_size_t i = 0; i < bit_counts_count; ++i) {
+    for (iree_host_size_t j = 0; j < bit_counts_count; ++j) {
+      EXPECT_EQ(i == j, iree_cpu_set_equal(cpu_sets[i], cpu_sets[j]));
+    }
+  }
+
+  for (iree_host_size_t i = 0; i < bit_counts_count; ++i) {
+    iree_cpu_set_free(allocator, &cpu_sets[i]);
+  }
+}
+
+TEST(CpuSet, InlineExample) {
+  const iree_allocator_t allocator = iree_allocator_system();
+  iree_cpu_set_t s1, s2;
+  IREE_EXPECT_OK(iree_cpu_set_allocate(allocator, 56, &s1));
+  IREE_EXPECT_OK(iree_cpu_set_allocate(allocator, 56, &s2));
+  EXPECT_EQ(iree_cpu_set_get_bit_size(s1), 56);
+  EXPECT_TRUE(iree_cpu_set_is_inline(s1));
+  EXPECT_TRUE(iree_cpu_set_equal(s1, s2));
+  EXPECT_EQ(0, iree_cpu_set_population_count(s1));
+  iree_cpu_set_set_bit(&s1, 55);
+  EXPECT_EQ(1, iree_cpu_set_population_count(s1));
+  EXPECT_TRUE(iree_cpu_set_get_const_words(&s1)[0] & (1ull << (55)));
+  EXPECT_FALSE(iree_cpu_set_equal(s1, s2));
+  iree_cpu_set_get_mutable_words(&s2)[0] |= 1ull << 55;
+  EXPECT_TRUE(iree_cpu_set_get_bit(s2, 55));
+  EXPECT_TRUE(iree_cpu_set_equal(s1, s2));
+  iree_cpu_set_free(allocator, &s1);
+  iree_cpu_set_free(allocator, &s2);
+}
+
+TEST(CpuSet, OutOfLineExample) {
+  const iree_allocator_t allocator = iree_allocator_system();
+  iree_cpu_set_t s1, s2;
+  IREE_EXPECT_OK(iree_cpu_set_allocate(allocator, 200, &s1));
+  IREE_EXPECT_OK(iree_cpu_set_allocate(allocator, 200, &s2));
+  EXPECT_EQ(iree_cpu_set_get_bit_size(s1), 200);
+  EXPECT_FALSE(iree_cpu_set_is_inline(s1));
+  EXPECT_TRUE(iree_cpu_set_equal(s1, s2));
+  EXPECT_EQ(0, iree_cpu_set_population_count(s1));
+  iree_cpu_set_set_bit(&s1, 199);
+  EXPECT_EQ(1, iree_cpu_set_population_count(s1));
+  EXPECT_TRUE(iree_cpu_set_get_const_words(&s1)[199 / 64] &
+              (1ull << (199 % 64)));
+  EXPECT_FALSE(iree_cpu_set_equal(s1, s2));
+  iree_cpu_set_get_mutable_words(&s2)[199 / 64] |= 1ull << (199 % 64);
+  EXPECT_TRUE(iree_cpu_set_get_bit(s2, 199));
+  EXPECT_TRUE(iree_cpu_set_equal(s1, s2));
+  iree_cpu_set_free(allocator, &s1);
+  iree_cpu_set_free(allocator, &s2);
+}
+
+}  // namespace


### PR DESCRIPTION
The POSIX standard structure, `cpu_set_t`, has issues:
* It was designed in an era of low core counts, when something like uint64_t felt like it would be enough. It gradually grew to its current size of 1024 bits (glibc) while dynamic-size extensions were also introduced, resulting in a worst-of-both-worlds: it has a large static size AND it still had to mode-switch to dynamic.
* Its bit layout is opaque, so bits can only be addressed individually, which is inefficient unless the compiler is able to coalesce 32 or 64 consecutive accesses, which is not trivial as it relies on loop tiling.

`iree_cpu_set_t` addresses these issues:
* Explicit layout by 64-bit words with bit-to-word mapping given by division (word_idx = bit_idx / 64) as in `iree_bitmap_t`, aka "little endian" word order.
* Direct word addressing.
* Static size just a single word. Storage is inline up to bit count 56, dynamic after that. When using dynamic storage, the bit-count is stored in the first word of dynamic storage.
  * This relies on bit 63 being 0 in pointers: the top bit is reserved to indicate inline storage.  Thus the only assumption here is that pointers never have bit 63 set.
     * The bit-count is intentionally NOT stored in the static storage so as to avoid any issues with large address space hosts (5-level paging => 57-bit address space).
     * Pointers stored in memory are still true pointers, not tagged pointers: bit 63 is set only when *not* storing a pointer.
     * On 32-bit pointer architectures, the whole 32 bits are available for the pointer, which is stored in the low 32 bits, not overlapping with bit 63.