### PR TITLE
Revert "[Codegen][Common] Allow generic conv ops to decompose to lower dim ops (#23294)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
@@ -9,7 +9,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -21,9 +20,9 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-static bool foldHDim(linalg::LinalgOp convOp) {
-  Value kernel = convOp.getDpsInputs().back();
-  Value output = convOp.getDpsInits().front();
+static bool foldHDim(linalg::DepthwiseConv2DNhwcHwcOp convOp) {
+  Value kernel = convOp.getInputs().back();
+  Value output = convOp.getOutputs().front();
 
   auto kernelType = dyn_cast<RankedTensorType>(kernel.getType());
   auto outputType = dyn_cast<RankedTensorType>(output.getType());
@@ -53,22 +52,16 @@ computeDecomposedLoweringConfig(ArrayRef<Operation *> computeOps,
   // TODO: Make this hook work with multiple conv Ops
   assert(llvm::count_if(computeOps,
                         [](Operation *op) {
-                          auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-                          return linalgOp &&
-                                 linalg::isaConvolutionOpInterface(linalgOp);
+                          return isa<linalg::ConvolutionOpInterface>(op);
                         }) == 1 &&
          "Exactly 1 Linalg Conv Op is expected");
 
   // 1. Get the conv Op to update
   // ATM only 2D depthwise HWC convs are supported.
   // TODO: Add support for other convs
-  linalg::LinalgOp convOp;
+  linalg::DepthwiseConv2DNhwcHwcOp convOp;
   for (Operation *op : computeOps) {
-    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-    if (linalgOp &&
-        linalg::isaConvolutionOpOfType<linalg::DepthwiseConv2DNhwcHwcOp>(
-            linalgOp)) {
-      convOp = linalgOp;
+    if ((convOp = dyn_cast<linalg::DepthwiseConv2DNhwcHwcOp>(op))) {
       break;
     }
   }
@@ -144,8 +137,7 @@ class DecomposeConvolutionToLowerDimOpsPass final
     // compute the "decomposed" version of its lowering config attribute.
     // TODO: Add support for cases with multiple convs per function
     int64_t numConvOps = llvm::count_if(computeOps, [](Operation *op) {
-      auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-      return linalgOp && linalg::isaConvolutionOpInterface(linalgOp);
+      return isa<linalg::ConvolutionOpInterface>(op);
     });
 
     if (numConvOps == 0) {
@@ -170,10 +162,7 @@ class DecomposeConvolutionToLowerDimOpsPass final
     if (numConvOps == 1 && succeeded(newLoweringConfig)) {
       auto computeOps = getComputeOps(funcOp);
       for (auto computeOp : computeOps) {
-        auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp);
-        if (linalgOp &&
-            linalg::isaConvolutionOpOfType<linalg::DepthwiseConv1DNwcWcOp>(
-                linalgOp)) {
+        if (isa<linalg::DepthwiseConv1DNwcWcOp>(computeOp)) {
           setLoweringConfig(computeOp, newLoweringConfig.value());
         }
       }

--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
@@ -1,7 +1,4 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
-// Test the same patterns on generic convolution ops by first generalizing the
-// named ops. This ensures decomposition works on both named and generic convs.
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(linalg-generalize-named-ops,iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0, 0, 0, 0], [1, 1, 1, 4, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
 module {


### PR DESCRIPTION
Commit e1f3811 caused compilation failure in iree-turbine ci test. 

Summarized the issue in https://github.com/iree-org/iree/issues/23382.