### PR TITLE
[VectorExt] Add iree_vector_ext.arg_compare operation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/BUILD.bazel
@@ -34,6 +34,7 @@ iree_td_library(
     ),
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:MaskableOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -76,6 +77,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MaskableOpInterface",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     ::IREEVectorExtOpsGen
     LLVMSupport
     MLIRAffineDialect
+    MLIRControlFlowInterfaces
     MLIRIR
     MLIRMaskableOpInterface
     MLIRSideEffectInterfaces

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Vector/Interfaces/MaskableOpInterface.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -689,23 +689,7 @@ Type TransferGatherOp::getExpectedMaskType() {
 LogicalResult ArgCompareOp::verify() {
   Operation *op = getOperation();
 
-  unsigned numInputs = llvm::size(getInputs());
-  if (numInputs != 1 && numInputs != 2) {
-    return op->emitOpError("expected 1 or 2 input operands, but got ")
-           << numInputs;
-  }
-
-  unsigned numInits = llvm::size(getInits());
-  if (numInits != 2) {
-    return op->emitOpError("expected 2 init operands, but got ") << numInits;
-  }
-
-  unsigned numResults = llvm::size(getResults());
-  if (numResults != 2) {
-    return op->emitOpError("expected 2 results, but got ") << numResults;
-  }
-
-  VectorType inputType = getInputType();
+  VectorType inputType = getInputValueType();
   VectorType initValueType = getInitValueType();
   VectorType initIndexType = getInitIndexType();
 
@@ -836,16 +820,17 @@ LogicalResult ArgCompareOp::verify() {
            << yieldType;
   }
 
-  TypeRange resultTypes = getResultTypes();
-  if (resultTypes[0] != initValueType) {
-    return op->emitOpError("result type 0 doesn't match init value type. ")
-           << "Result type: " << resultTypes[0]
+  Type resultValueType = getResult(0).getType();
+  if (resultValueType != initValueType) {
+    return op->emitOpError("result value type doesn't match init value type. ")
+           << "Result type: " << resultValueType
            << ", init value type: " << initValueType;
   }
 
-  if (resultTypes[1] != initIndexType) {
-    return op->emitOpError("result type 1 doesn't match init index type. ")
-           << "Result type: " << resultTypes[1]
+  Type resultIndexType = getResult(1).getType();
+  if (resultIndexType != initIndexType) {
+    return op->emitOpError("result index type doesn't match init index type. ")
+           << "Result type: " << resultIndexType
            << ", init index type: " << initIndexType;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -282,12 +282,21 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
     dimension of a vector, returning both the selected value and its
     corresponding index.
 
-    This operation is created by vectorizing `iree_linalg_ext.arg_compare`
-    through the GenericVectorizationPass. It wraps the operation with
-    vector.transfer_read/write but keeps the core reduction semantics intact.
+    **Comparator region semantics:**
 
-    The comparator region defines the selection rule (e.g., "greater than"
-    for argmax or "less than" for argmin).
+    The comparator region defines the predication logic that determines the
+    selection rule for the reduction (e.g., "greater than" for argmax or
+    "less than" for argmin). The region takes two scalar values of the input
+    element type as arguments and returns a single `i1` result via
+    `iree_vector_ext.yield`.
+
+    The region is invoked during the reduction to determine which element to
+    select: when the comparison yields `true`, the first argument is selected;
+    otherwise, the second argument is selected.
+
+    The region must contain only pure operations (operations with the `Pure`
+    trait). This ensures the comparator can be safely executed in any order
+    during the reduction.
 
     Example (implicit-index mode - argmax over dim 1):
     ```mlir
@@ -320,22 +329,28 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
     } -> vector<4xf32>, vector<4xi32>
     ```
 
-    The `index_base` is optional and is preserved from the tensor version
-    when applicable.
+    The `index_base` is an optional offset value that, when specified, is added
+    to the computed indices in the result. This is useful when reducing over a
+    sliced subregion where the indices need to be adjusted to reflect their
+    position in the original vector. The `index_base` can only be used in
+    implicit-index mode (single input).
 
     The `inits` operands provide the initial accumulator values for the
     reduction (initial max/min value and index).
   }];
 
   let arguments = (ins
-    Variadic<AnyVectorOfAnyRank>:$inputs,
-    Variadic<AnyVectorOfAnyRank>:$inits,
+    AnyVectorOfAnyRank:$input_value,
+    Optional<AnyVectorOfAnyRank>:$input_index,
+    AnyVectorOfAnyRank:$init_value,
+    AnyVectorOfAnyRank:$init_index,
     Optional<Index>:$index_base,
     I64Attr:$dimension
   );
 
   let results = (outs
-    Variadic<AnyVectorOfAnyRank>:$results
+    AnyVectorOfAnyRank:$result_value,
+    AnyVectorOfAnyRank:$result_index
   );
 
   let regions = (region SizedRegion<1>:$region);
@@ -343,41 +358,18 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   let assemblyFormat = [{
     attr-dict
     `dimension` `(` $dimension `)`
-    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `inits` `(` $inits `:` type($inits) `)`
+    `ins` `(` $input_value (`,` $input_index^)? `:` type($input_value) (`,` type($input_index)^)? `)`
+    `inits` `(` $init_value `,` $init_index `:` type($init_value) `,` type($init_index) `)`
     (`index_base` `(` $index_base^ `:` type($index_base) `)`)?
-    $region (`->` type($results)^)?
+    $region `->` type($result_value) `,` type($result_index)
   }];
 
   let extraClassDeclaration = [{
-    Value getInputValue() {
-      return getInputs()[0];
-    }
-
     bool hasExplicitIndexInput() {
-      return getInputs().size() == 2;
+      return getInputIndex() != nullptr;
     }
 
-    Value getInputIndex() {
-      if (!hasExplicitIndexInput()) {
-        return nullptr;
-      }
-      return getInputs()[1];
-    }
-
-    ValueRange getInitValues() {
-      return getInits();
-    }
-
-    Value getInitValue() {
-      return getInits()[0];
-    }
-
-    Value getInitIndex() {
-      return getInits()[1];
-    }
-
-    VectorType getInputType() {
+    VectorType getInputValueType() {
       return cast<VectorType>(getInputValue().getType());
     }
 
@@ -403,6 +395,10 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
       return nullptr;
     }
 
+    Type getInputValueElementType() {
+      return getInputValueType().getElementType();
+    }
+
     Type getInitValueElementType() {
       return getInitValueType().getElementType();
     }
@@ -412,7 +408,7 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
     }
 
     int64_t getInputRank() {
-      return getInputType().getRank();
+      return getInputValueType().getRank();
     }
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -250,7 +250,8 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
 def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
     Pure,
     ReturnLike,
-    Terminator
+    Terminator,
+    ParentOneOf<["ArgCompareOp"]>
   ]> {
   let summary = "Yield operation for VectorExt operations with regions";
   let description = [{
@@ -273,7 +274,36 @@ def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
 def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   Pure,
   AttrSizedOperandSegments,
-  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::VectorExt::YieldOp">
+  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::VectorExt::YieldOp">,
+  AllElementTypesMatch<["input_value", "init_value"]>,
+  AllTypesMatch<["init_value", "result_value"]>,
+  AllTypesMatch<["init_index", "result_index"]>,
+  PredOpTrait<"dimension must be in range [0, input_rank)",
+    CPred<"$dimension >= 0 && $dimension < "
+          "::llvm::cast<::mlir::VectorType>($input_value.getType()).getRank()">>,
+  // Reduction removes one dimension, so init rank = input rank - 1.
+  PredOpTrait<"init value rank must be input rank - 1",
+    CPred<"::llvm::cast<::mlir::VectorType>($input_value.getType()).getRank() - 1 == "
+          "::llvm::cast<::mlir::VectorType>($init_value.getType()).getRank()">>,
+  PredOpTrait<"init index rank must be input rank - 1",
+    CPred<"::llvm::cast<::mlir::VectorType>($input_value.getType()).getRank() - 1 == "
+          "::llvm::cast<::mlir::VectorType>($init_index.getType()).getRank()">>,
+  // Init shape matches input shape with reduction dimension removed.
+  // E.g., reducing vector<4x128xf32> on dim 1 produces vector<4xf32>.
+  TypesMatchWith<"init value shape must match input shape with reduction dimension removed",
+                 "input_value", "init_value",
+                 "ArgCompareOp::getExpectedInitType(::llvm::cast<::mlir::VectorType>($_self), "
+                 "getDimension(), $init_value.getType())">,
+  TypesMatchWith<"init index shape must match input shape with reduction dimension removed",
+                 "input_value", "init_index",
+                 "ArgCompareOp::getExpectedInitType(::llvm::cast<::mlir::VectorType>($_self), "
+                 "getDimension(), $init_index.getType())">,
+  // Indices must be integer or index type.
+  PredOpTrait<"init index must have integer or index element type",
+    CPred<"::mlir::isa<::mlir::IntegerType>("
+          "::llvm::cast<::mlir::VectorType>($init_index.getType()).getElementType()) || "
+          "::mlir::isa<::mlir::IndexType>("
+          "::llvm::cast<::mlir::VectorType>($init_index.getType()).getElementType())">>
 ]> {
   let summary = "Vectorized arg-reduction using a user-defined comparator.";
   let description = [{
@@ -365,6 +395,25 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   }];
 
   let extraClassDeclaration = [{
+    // Helper for TypesMatchWith: compute expected init type based on input type and reduction dimension.
+    // If dimension is out of bounds, return initType unchanged to let the dimension bounds check fail.
+    static Type getExpectedInitType(VectorType inputType, int64_t dimension, Type initType) {
+      int64_t rank = inputType.getRank();
+      // Return initType if dimension is invalid - let the dimension bounds check catch this.
+      if (dimension < 0 || dimension >= rank) {
+        return initType;
+      }
+
+      SmallVector<int64_t> expectedShape;
+      for (int64_t i = 0; i < rank; ++i) {
+        if (i != dimension) {
+          expectedShape.push_back(inputType.getDimSize(i));
+        }
+      }
+      Type initElemType = ::llvm::cast<VectorType>(initType).getElementType();
+      return VectorType::get(expectedShape, initElemType);
+    }
+
     bool hasExplicitIndexInput() {
       return getInputIndex() != nullptr;
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -242,4 +242,141 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
   let hasVerifier = 1;
 }
 
+def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
+  Pure,
+  AttrSizedOperandSegments
+]> {
+  let summary = "Vectorized arg-reduction using a user-defined comparator.";
+  let description = [{
+    The `iree_vector_ext.arg_compare` op is the vectorized form of
+    `iree_linalg_ext.arg_compare`. It performs a reduction over a given
+    dimension of a vector, returning both the selected value and its
+    corresponding index.
+
+    This operation is created by vectorizing `iree_linalg_ext.arg_compare`
+    through the GenericVectorizationPass. It wraps the operation with
+    vector.transfer_read/write but keeps the core reduction semantics intact.
+
+    The comparator region defines the selection rule (e.g., "greater than"
+    for argmax or "less than" for argmin).
+
+    Example (implicit-index mode - argmax over dim 1):
+    ```mlir
+    %input_vec = vector<4x128xf32>
+    %out_val_vec = vector<4xf32>
+    %out_idx_vec = vector<4xi32>
+    %result:2 = iree_vector_ext.arg_compare
+      dimension(1)
+      ins(%input_vec : vector<4x128xf32>)
+      outs(%out_val_vec, %out_idx_vec : vector<4xf32>, vector<4xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+    } -> vector<4xf32>, vector<4xi32>
+    ```
+
+    Example (explicit-index mode):
+    ```mlir
+    %partial_vals = vector<4x32xf32>
+    %partial_idxs = vector<4x32xi32>
+    %out_val = vector<4xf32>
+    %out_idx = vector<4xi32>
+    %result:2 = iree_vector_ext.arg_compare
+      dimension(1)
+      ins(%partial_vals, %partial_idxs : vector<4x32xf32>, vector<4x32xi32>)
+      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+    } -> vector<4xf32>, vector<4xi32>
+    ```
+
+    The `index_base` is optional and is preserved from the tensor version
+    when applicable.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyVectorOfAnyRank>:$inputs,
+    Variadic<AnyVectorOfAnyRank>:$outputs,
+    Optional<Index>:$index_base,
+    I64Attr:$dimension
+  );
+
+  let results = (outs
+    Variadic<AnyVectorOfAnyRank>:$results
+  );
+
+  let regions = (region SizedRegion<1>:$region);
+
+  let assemblyFormat = [{
+    attr-dict
+    `dimension` `(` $dimension `)`
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`index_base` `(` $index_base^ `:` type($index_base) `)`)?
+    $region (`->` type($results)^)?
+  }];
+
+  let extraClassDeclaration = [{
+    Value getInputValue() {
+      return getInputs()[0];
+    }
+
+    bool hasExplicitIndexInput() {
+      return getInputs().size() == 2;
+    }
+
+    Value getInputIndex() {
+      if (!hasExplicitIndexInput()) {
+        return nullptr;
+      }
+      return getInputs()[1];
+    }
+
+    Value getOutputValue() {
+      return getOutputs()[0];
+    }
+
+    Value getOutputIndex() {
+      return getOutputs()[1];
+    }
+
+    VectorType getInputType() {
+      return cast<VectorType>(getInputValue().getType());
+    }
+
+    VectorType getOutputValueType() {
+      return cast<VectorType>(getOutputValue().getType());
+    }
+
+    VectorType getOutputIndexType() {
+      return cast<VectorType>(getOutputIndex().getType());
+    }
+
+    VectorType getInputIndexType() {
+      if (Value idx = getInputIndex()) {
+        return cast<VectorType>(idx.getType());
+      }
+      return nullptr;
+    }
+
+    Type getInputIndexElementType() {
+      if (VectorType idxType = getInputIndexType()) {
+        return idxType.getElementType();
+      }
+      return nullptr;
+    }
+
+    Type getOutputIndexElementType() {
+      return getOutputIndexType().getElementType();
+    }
+
+    int64_t getInputRank() {
+      return getInputType().getRank();
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif  // IREE_DIALECT_VECTOREXT_OPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -13,6 +13,7 @@ include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td"
 include "mlir/Dialect/Vector/Interfaces/MaskableOpInterface.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
@@ -242,9 +243,37 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
   let hasVerifier = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// Terminator ops.
+//===----------------------------------------------------------------------===//
+
+def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
+    Pure,
+    ReturnLike,
+    Terminator
+  ]> {
+  let summary = "Yield operation for VectorExt operations with regions";
+  let description = [{
+    Yields values from regions in VectorExt operations.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$values);
+
+  let builders = [
+    OpBuilder<(ins), [{ /* nothing to do */ }]>
+  ];
+
+  let assemblyFormat = "attr-dict ($values^ `:` type($values))?";
+}
+
+//===----------------------------------------------------------------------===//
+// LinalgExt-style ops.
+//===----------------------------------------------------------------------===//
+
 def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   Pure,
-  AttrSizedOperandSegments
+  AttrSizedOperandSegments,
+  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::VectorExt::YieldOp">
 ]> {
   let summary = "Vectorized arg-reduction using a user-defined comparator.";
   let description = [{
@@ -268,10 +297,10 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
     %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input_vec : vector<4x128xf32>)
-      outs(%out_val_vec, %out_idx_vec : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val_vec, %out_idx_vec : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
     } -> vector<4xf32>, vector<4xi32>
     ```
 
@@ -284,20 +313,23 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
     %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%partial_vals, %partial_idxs : vector<4x32xf32>, vector<4x32xi32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
     } -> vector<4xf32>, vector<4xi32>
     ```
 
     The `index_base` is optional and is preserved from the tensor version
     when applicable.
+
+    The `inits` operands provide the initial accumulator values for the
+    reduction (initial max/min value and index).
   }];
 
   let arguments = (ins
     Variadic<AnyVectorOfAnyRank>:$inputs,
-    Variadic<AnyVectorOfAnyRank>:$outputs,
+    Variadic<AnyVectorOfAnyRank>:$inits,
     Optional<Index>:$index_base,
     I64Attr:$dimension
   );
@@ -312,7 +344,7 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
     attr-dict
     `dimension` `(` $dimension `)`
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `inits` `(` $inits `:` type($inits) `)`
     (`index_base` `(` $index_base^ `:` type($index_base) `)`)?
     $region (`->` type($results)^)?
   }];
@@ -333,24 +365,28 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
       return getInputs()[1];
     }
 
-    Value getOutputValue() {
-      return getOutputs()[0];
+    ValueRange getInitValues() {
+      return getInits();
     }
 
-    Value getOutputIndex() {
-      return getOutputs()[1];
+    Value getInitValue() {
+      return getInits()[0];
+    }
+
+    Value getInitIndex() {
+      return getInits()[1];
     }
 
     VectorType getInputType() {
       return cast<VectorType>(getInputValue().getType());
     }
 
-    VectorType getOutputValueType() {
-      return cast<VectorType>(getOutputValue().getType());
+    VectorType getInitValueType() {
+      return cast<VectorType>(getInitValue().getType());
     }
 
-    VectorType getOutputIndexType() {
-      return cast<VectorType>(getOutputIndex().getType());
+    VectorType getInitIndexType() {
+      return cast<VectorType>(getInitIndex().getType());
     }
 
     VectorType getInputIndexType() {
@@ -367,8 +403,12 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
       return nullptr;
     }
 
-    Type getOutputIndexElementType() {
-      return getOutputIndexType().getElementType();
+    Type getInitValueElementType() {
+      return getInitValueType().getElementType();
+    }
+
+    Type getInitIndexElementType() {
+      return getInitIndexType().getElementType();
     }
 
     int64_t getInputRank() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -265,6 +265,7 @@ def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
   ];
 
   let assemblyFormat = "attr-dict ($values^ `:` type($values))?";
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -274,36 +275,10 @@ def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
 def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   Pure,
   AttrSizedOperandSegments,
-  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::VectorExt::YieldOp">,
+  SingleBlockImplicitTerminator<"IREE::VectorExt::YieldOp">,
   AllElementTypesMatch<["input_value", "init_value"]>,
   AllTypesMatch<["init_value", "result_value"]>,
-  AllTypesMatch<["init_index", "result_index"]>,
-  PredOpTrait<"dimension must be in range [0, input_rank)",
-    CPred<"$dimension >= 0 && $dimension < "
-          "::llvm::cast<::mlir::VectorType>($input_value.getType()).getRank()">>,
-  // Reduction removes one dimension, so init rank = input rank - 1.
-  PredOpTrait<"init value rank must be input rank - 1",
-    CPred<"::llvm::cast<::mlir::VectorType>($input_value.getType()).getRank() - 1 == "
-          "::llvm::cast<::mlir::VectorType>($init_value.getType()).getRank()">>,
-  PredOpTrait<"init index rank must be input rank - 1",
-    CPred<"::llvm::cast<::mlir::VectorType>($input_value.getType()).getRank() - 1 == "
-          "::llvm::cast<::mlir::VectorType>($init_index.getType()).getRank()">>,
-  // Init shape matches input shape with reduction dimension removed.
-  // E.g., reducing vector<4x128xf32> on dim 1 produces vector<4xf32>.
-  TypesMatchWith<"init value shape must match input shape with reduction dimension removed",
-                 "input_value", "init_value",
-                 "ArgCompareOp::getExpectedInitType(::llvm::cast<::mlir::VectorType>($_self), "
-                 "getDimension(), $init_value.getType())">,
-  TypesMatchWith<"init index shape must match input shape with reduction dimension removed",
-                 "input_value", "init_index",
-                 "ArgCompareOp::getExpectedInitType(::llvm::cast<::mlir::VectorType>($_self), "
-                 "getDimension(), $init_index.getType())">,
-  // Indices must be integer or index type.
-  PredOpTrait<"init index must have integer or index element type",
-    CPred<"::mlir::isa<::mlir::IntegerType>("
-          "::llvm::cast<::mlir::VectorType>($init_index.getType()).getElementType()) || "
-          "::mlir::isa<::mlir::IndexType>("
-          "::llvm::cast<::mlir::VectorType>($init_index.getType()).getElementType())">>
+  AllTypesMatch<["init_index", "result_index"]>
 ]> {
   let summary = "Vectorized arg-reduction using a user-defined comparator.";
   let description = [{
@@ -395,39 +370,20 @@ def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   }];
 
   let extraClassDeclaration = [{
-    // Helper for TypesMatchWith: compute expected init type based on input type and reduction dimension.
-    // If dimension is out of bounds, return initType unchanged to let the dimension bounds check fail.
-    static Type getExpectedInitType(VectorType inputType, int64_t dimension, Type initType) {
-      int64_t rank = inputType.getRank();
-      // Return initType if dimension is invalid - let the dimension bounds check catch this.
-      if (dimension < 0 || dimension >= rank) {
-        return initType;
-      }
-
-      SmallVector<int64_t> expectedShape;
-      for (int64_t i = 0; i < rank; ++i) {
-        if (i != dimension) {
-          expectedShape.push_back(inputType.getDimSize(i));
-        }
-      }
-      Type initElemType = ::llvm::cast<VectorType>(initType).getElementType();
-      return VectorType::get(expectedShape, initElemType);
-    }
-
     bool hasExplicitIndexInput() {
       return getInputIndex() != nullptr;
     }
 
     VectorType getInputValueType() {
-      return cast<VectorType>(getInputValue().getType());
+      return getInputValue().getType();
     }
 
     VectorType getInitValueType() {
-      return cast<VectorType>(getInitValue().getType());
+      return getInitValue().getType();
     }
 
     VectorType getInitIndexType() {
-      return cast<VectorType>(getInitIndex().getType());
+      return getInitIndex().getType();
     }
 
     VectorType getInputIndexType() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -84,59 +84,6 @@ func.func @indexing_map_invalid_index_vector_shape(%indices: vector<128x64xindex
 
 // -----
 
-func.func @arg_compare_no_inputs(%out_val: vector<4xf32>,
-                                 %out_idx: vector<4xi32>)
-    -> (vector<4xf32>, vector<4xi32>) {
-  // expected-error @+1 {{expected 1 or 2 input operands, but got 0}}
-  %result:2 = iree_vector_ext.arg_compare
-      dimension(0)
-      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_vector_ext.yield %cmp : i1
-  } -> vector<4xf32>, vector<4xi32>
-  return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
-}
-
-// -----
-
-func.func @arg_compare_too_many_inputs(%input1: vector<4x128xf32>,
-                                       %input2: vector<4x128xi32>,
-                                       %input3: vector<4x128xf32>,
-                                       %out_val: vector<4xf32>,
-                                       %out_idx: vector<4xi32>)
-    -> (vector<4xf32>, vector<4xi32>) {
-  // expected-error @+1 {{expected 1 or 2 input operands, but got 3}}
-  %result:2 = iree_vector_ext.arg_compare
-      dimension(1)
-      ins(%input1, %input2, %input3 : vector<4x128xf32>, vector<4x128xi32>, vector<4x128xf32>)
-      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_vector_ext.yield %cmp : i1
-  } -> vector<4xf32>, vector<4xi32>
-  return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
-}
-
-// -----
-
-func.func @arg_compare_wrong_output_count(%input: vector<4x128xf32>,
-                                          %out_val: vector<4xf32>)
-    -> vector<4xf32> {
-  // expected-error @+1 {{expected 2 init operands, but got 1}}
-  %result = iree_vector_ext.arg_compare
-      dimension(1)
-      ins(%input : vector<4x128xf32>)
-      inits(%out_val : vector<4xf32>) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_vector_ext.yield %cmp : i1
-  } -> vector<4xf32>
-  return %result : vector<4xf32>
-}
-
-// -----
-
 func.func @arg_compare_dimension_out_of_bounds(%input: vector<4x128xf32>,
                                                %out_val: vector<4xf32>,
                                                %out_idx: vector<4xi32>)
@@ -345,7 +292,7 @@ func.func @arg_compare_result_value_type_mismatch(%input: vector<4x128xf32>,
                                                    %out_val: vector<4xf32>,
                                                    %out_idx: vector<4xi32>)
     -> (vector<4xf16>, vector<4xi32>) {
-  // expected-error @+1 {{result type 0 doesn't match init value type. Result type: 'vector<4xf16>', init value type: 'vector<4xf32>'}}
+  // expected-error @+1 {{result value type doesn't match init value type. Result type: 'vector<4xf16>', init value type: 'vector<4xf32>'}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
@@ -363,7 +310,7 @@ func.func @arg_compare_result_index_type_mismatch(%input: vector<4x128xf32>,
                                                    %out_val: vector<4xf32>,
                                                    %out_idx: vector<4xi32>)
     -> (vector<4xf32>, vector<4xi64>) {
-  // expected-error @+1 {{result type 1 doesn't match init index type. Result type: 'vector<4xi64>', init index type: 'vector<4xi32>'}}
+  // expected-error @+1 {{result index type doesn't match init index type. Result type: 'vector<4xi64>', init index type: 'vector<4xi32>'}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -90,10 +90,10 @@ func.func @arg_compare_no_inputs(%out_val: vector<4xf32>,
   // expected-error @+1 {{expected 1 or 2 input operands, but got 0}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(0)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -110,10 +110,10 @@ func.func @arg_compare_too_many_inputs(%input1: vector<4x128xf32>,
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input1, %input2, %input3 : vector<4x128xf32>, vector<4x128xi32>, vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -123,14 +123,14 @@ func.func @arg_compare_too_many_inputs(%input1: vector<4x128xf32>,
 func.func @arg_compare_wrong_output_count(%input: vector<4x128xf32>,
                                           %out_val: vector<4xf32>)
     -> vector<4xf32> {
-  // expected-error @+1 {{expected 2 output operands, but got 1}}
+  // expected-error @+1 {{expected 2 init operands, but got 1}}
   %result = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val : vector<4xf32>) {
+      inits(%out_val : vector<4xf32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>
   return %result : vector<4xf32>
 }
@@ -145,10 +145,10 @@ func.func @arg_compare_dimension_out_of_bounds(%input: vector<4x128xf32>,
   %result:2 = iree_vector_ext.arg_compare
       dimension(2)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -163,10 +163,10 @@ func.func @arg_compare_negative_dimension(%input: vector<4x128xf32>,
   %result:2 = iree_vector_ext.arg_compare
       dimension(-1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -177,14 +177,14 @@ func.func @arg_compare_wrong_output_rank(%input: vector<4x128xf32>,
                                          %out_val: vector<4x8xf32>,
                                          %out_idx: vector<4xi32>)
     -> (vector<4x8xf32>, vector<4xi32>) {
-  // expected-error @+1 {{output value rank (2) should be input rank - 1 (2 - 1)}}
+  // expected-error @+1 {{init value rank (2) should be input rank - 1 (2 - 1)}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4x8xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4x8xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4x8xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4x8xf32>, vector<4xi32>
 }
@@ -195,14 +195,14 @@ func.func @arg_compare_wrong_output_shape(%input: vector<4x128xf32>,
                                           %out_val: vector<8xf32>,
                                           %out_idx: vector<8xi32>)
     -> (vector<8xf32>, vector<8xi32>) {
-  // expected-error @+1 {{output value shape must match input shape with reduction dimension removed. Expected: [4], but got: [8]}}
+  // expected-error @+1 {{init value shape must match input shape with reduction dimension removed. Expected: [4], but got: [8]}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<8xf32>, vector<8xi32>) {
+      inits(%out_val, %out_idx : vector<8xf32>, vector<8xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<8xf32>, vector<8xi32>
   return %result#0, %result#1 : vector<8xf32>, vector<8xi32>
 }
@@ -213,14 +213,14 @@ func.func @arg_compare_wrong_output_element_type(%input: vector<4x128xf32>,
                                                   %out_val: vector<4xf16>,
                                                   %out_idx: vector<4xi32>)
     -> (vector<4xf16>, vector<4xi32>) {
-  // expected-error @+1 {{input and output value element types must match. Input type: 'f32', output value type: 'f16'}}
+  // expected-error @+1 {{input and init value element types must match. Input type: 'f32', init value type: 'f16'}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf16>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf16>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf16>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf16>, vector<4xi32>
 }
@@ -236,10 +236,10 @@ func.func @arg_compare_explicit_index_shape_mismatch(%input_val: vector<4x128xf3
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input_val, %input_idx : vector<4x128xf32>, vector<8x128xi32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -251,14 +251,14 @@ func.func @arg_compare_explicit_index_element_type_mismatch(%input_val: vector<4
                                                             %out_val: vector<4xf32>,
                                                             %out_idx: vector<4xi32>)
     -> (vector<4xf32>, vector<4xi32>) {
-  // expected-error @+1 {{explicit-index mode: input and output index element types must match. Input index type: 'i64', output index type: 'i32'}}
+  // expected-error @+1 {{explicit-index mode: input and init index element types must match. Input index type: 'i64', init index type: 'i32'}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input_val, %input_idx : vector<4x128xf32>, vector<4x128xi64>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -273,10 +273,10 @@ func.func @arg_compare_wrong_comparator_args(%input: vector<4x128xf32>,
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32, %c: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -287,14 +287,14 @@ func.func @arg_compare_output_index_not_integer(%input: vector<4x128xf32>,
                                                  %out_val: vector<4xf32>,
                                                  %out_idx: vector<4xf32>)
     -> (vector<4xf32>, vector<4xf32>) {
-  // expected-error @+1 {{output index must have integer or index element type, but got 'f32'}}
+  // expected-error @+1 {{init index must have integer or index element type, but got 'f32'}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xf32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xf32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xf32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xf32>
 }
@@ -310,10 +310,10 @@ func.func @arg_compare_explicit_index_not_integer(%input_val: vector<4x128xf32>,
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input_val, %input_idx : vector<4x128xf32>, vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -330,11 +330,47 @@ func.func @arg_compare_index_base_with_explicit_index(%input_val: vector<4x128xf
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input_val, %input_idx : vector<4x128xf32>, vector<4x128xi32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>)
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>)
       index_base(%base : index) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
+}
+
+// -----
+
+func.func @arg_compare_result_value_type_mismatch(%input: vector<4x128xf32>,
+                                                   %out_val: vector<4xf32>,
+                                                   %out_idx: vector<4xi32>)
+    -> (vector<4xf16>, vector<4xi32>) {
+  // expected-error @+1 {{result type 0 doesn't match init value type. Result type: 'vector<4xf16>', init value type: 'vector<4xf32>'}}
+  %result:2 = iree_vector_ext.arg_compare
+      dimension(1)
+      ins(%input : vector<4x128xf32>)
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf16>, vector<4xi32>
+  return %result#0, %result#1 : vector<4xf16>, vector<4xi32>
+}
+
+// -----
+
+func.func @arg_compare_result_index_type_mismatch(%input: vector<4x128xf32>,
+                                                   %out_val: vector<4xf32>,
+                                                   %out_idx: vector<4xi32>)
+    -> (vector<4xf32>, vector<4xi64>) {
+  // expected-error @+1 {{result type 1 doesn't match init index type. Result type: 'vector<4xi64>', init index type: 'vector<4xi32>'}}
+  %result:2 = iree_vector_ext.arg_compare
+      dimension(1)
+      ins(%input : vector<4x128xf32>)
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi64>
+  return %result#0, %result#1 : vector<4xf32>, vector<4xi64>
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -88,7 +88,7 @@ func.func @arg_compare_dimension_out_of_bounds(%input: vector<4x128xf32>,
                                                %out_val: vector<4xf32>,
                                                %out_idx: vector<4xi32>)
     -> (vector<4xf32>, vector<4xi32>) {
-  // expected-error @+1 {{dimension 2 is out of range [0, 2)}}
+  // expected-error @+1 {{failed to verify that dimension must be in range [0, input_rank)}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(2)
       ins(%input : vector<4x128xf32>)
@@ -106,7 +106,7 @@ func.func @arg_compare_negative_dimension(%input: vector<4x128xf32>,
                                           %out_val: vector<4xf32>,
                                           %out_idx: vector<4xi32>)
     -> (vector<4xf32>, vector<4xi32>) {
-  // expected-error @+1 {{dimension -1 is out of range [0, 2)}}
+  // expected-error @+1 {{failed to verify that dimension must be in range [0, input_rank)}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(-1)
       ins(%input : vector<4x128xf32>)
@@ -124,7 +124,7 @@ func.func @arg_compare_wrong_output_rank(%input: vector<4x128xf32>,
                                          %out_val: vector<4x8xf32>,
                                          %out_idx: vector<4xi32>)
     -> (vector<4x8xf32>, vector<4xi32>) {
-  // expected-error @+1 {{init value rank (2) should be input rank - 1 (2 - 1)}}
+  // expected-error @+1 {{failed to verify that init value rank must be input rank - 1}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
@@ -142,7 +142,7 @@ func.func @arg_compare_wrong_output_shape(%input: vector<4x128xf32>,
                                           %out_val: vector<8xf32>,
                                           %out_idx: vector<8xi32>)
     -> (vector<8xf32>, vector<8xi32>) {
-  // expected-error @+1 {{init value shape must match input shape with reduction dimension removed. Expected: [4], but got: [8]}}
+  // expected-error @+1 {{failed to verify that init value shape must match input shape with reduction dimension removed}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
@@ -160,7 +160,7 @@ func.func @arg_compare_wrong_output_element_type(%input: vector<4x128xf32>,
                                                   %out_val: vector<4xf16>,
                                                   %out_idx: vector<4xi32>)
     -> (vector<4xf16>, vector<4xi32>) {
-  // expected-error @+1 {{input and init value element types must match. Input type: 'f32', init value type: 'f16'}}
+  // expected-error @+1 {{failed to verify that all of {input_value, init_value} have same element type}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
@@ -234,7 +234,7 @@ func.func @arg_compare_output_index_not_integer(%input: vector<4x128xf32>,
                                                  %out_val: vector<4xf32>,
                                                  %out_idx: vector<4xf32>)
     -> (vector<4xf32>, vector<4xf32>) {
-  // expected-error @+1 {{init index must have integer or index element type, but got 'f32'}}
+  // expected-error @+1 {{failed to verify that init index must have integer or index element type}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
@@ -292,7 +292,7 @@ func.func @arg_compare_result_value_type_mismatch(%input: vector<4x128xf32>,
                                                    %out_val: vector<4xf32>,
                                                    %out_idx: vector<4xi32>)
     -> (vector<4xf16>, vector<4xi32>) {
-  // expected-error @+1 {{result value type doesn't match init value type. Result type: 'vector<4xf16>', init value type: 'vector<4xf32>'}}
+  // expected-error @+1 {{failed to verify that all of {init_value, result_value} have same type}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
@@ -310,7 +310,7 @@ func.func @arg_compare_result_index_type_mismatch(%input: vector<4x128xf32>,
                                                    %out_val: vector<4xf32>,
                                                    %out_idx: vector<4xi32>)
     -> (vector<4xf32>, vector<4xi64>) {
-  // expected-error @+1 {{result index type doesn't match init index type. Result type: 'vector<4xi64>', init index type: 'vector<4xi32>'}}
+  // expected-error @+1 {{failed to verify that all of {init_index, result_index} have same type}}
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -200,14 +200,14 @@ func.func @arg_compare_implicit_index(%input: vector<4x128xf32>,
   // CHECK: iree_vector_ext.arg_compare
   // CHECK-SAME: dimension(1)
   // CHECK-SAME: ins(%{{.*}} : vector<4x128xf32>)
-  // CHECK-SAME: outs(%{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>)
+  // CHECK-SAME: inits(%{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>)
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -223,14 +223,14 @@ func.func @arg_compare_explicit_index(%input_val: vector<4x32xf32>,
   // CHECK: iree_vector_ext.arg_compare
   // CHECK-SAME: dimension(1)
   // CHECK-SAME: ins(%{{.*}}, %{{.*}} : vector<4x32xf32>, vector<4x32xi32>)
-  // CHECK-SAME: outs(%{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>)
+  // CHECK-SAME: inits(%{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>)
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input_val, %input_idx : vector<4x32xf32>, vector<4x32xi32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -248,11 +248,11 @@ func.func @arg_compare_with_index_base(%input: vector<4x128xf32>,
   %result:2 = iree_vector_ext.arg_compare
       dimension(1)
       ins(%input : vector<4x128xf32>)
-      outs(%out_val, %out_idx : vector<4xf32>, vector<4xi32>)
+      inits(%out_val, %out_idx : vector<4xf32>, vector<4xi32>)
       index_base(%base : index) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<4xf32>, vector<4xi32>
   return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
 }
@@ -267,14 +267,14 @@ func.func @arg_compare_1d_to_0d(%input: vector<128xf32>,
   // CHECK: iree_vector_ext.arg_compare
   // CHECK-SAME: dimension(0)
   // CHECK-SAME: ins(%{{.*}} : vector<128xf32>)
-  // CHECK-SAME: outs(%{{.*}}, %{{.*}} : vector<f32>, vector<i32>)
+  // CHECK-SAME: inits(%{{.*}}, %{{.*}} : vector<f32>, vector<i32>)
   %result:2 = iree_vector_ext.arg_compare
       dimension(0)
       ins(%input : vector<128xf32>)
-      outs(%out_val, %out_idx : vector<f32>, vector<i32>) {
+      inits(%out_val, %out_idx : vector<f32>, vector<i32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
+      iree_vector_ext.yield %cmp : i1
   } -> vector<f32>, vector<i32>
   return %result#0, %result#1 : vector<f32>, vector<i32>
 }


### PR DESCRIPTION
**Context**: I am in the process of adding vectorization support for `iree_linalg_ext.arg_compare` operation. 
I plan to split the work into two PRs: 
- adds the `iree_vector_ext.arg_compare` operation (this PR)
- vectorizes `iree_linalg_ext.arg_compare`, converted to `iree_vector_ext.arg_compare`.

Refer to Issue: #23005 and [discord discussion](https://discord.com/channels/689900678990135345/1461079481803608158) for more context.  

Assisted-by:  [Claude Code](https://claude.ai/code)