### PR TITLE
[Stream] Fix EmplaceTransientsPass to handle zero allocas case.

### DIFF
--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -35,6 +35,7 @@ iree_lit_test_suite(
         "libm_linking.mlir",
         "scalar.mlir",
         "trace_dispatch_tensors.mlir",
+        "transients_test.mlir",
         "unused_args.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
@@ -43,6 +44,7 @@ iree_lit_test_suite(
         "hostonly",
     ],
     tools = [
+        "//tools:iree-compile",
         "//tools:iree-opt",
         "//tools:iree-run-mlir",
         "@llvm-project//lld",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -20,10 +20,12 @@ iree_lit_test_suite(
     "libm_linking.mlir"
     "scalar.mlir"
     "trace_dispatch_tensors.mlir"
+    "transients_test.mlir"
     "unused_args.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck
+    iree-compile
     iree-opt
     iree-run-mlir
   LABELS

--- a/tests/e2e/regression/transients_test.mlir
+++ b/tests/e2e/regression/transients_test.mlir
@@ -1,0 +1,80 @@
+// RUN: iree-compile --iree-hal-target-backends=rocm --iree-rocm-target=mi300x --iree-opt-level=O3 --compile-to=stream %s | FileCheck %s
+
+// No transient allocations created.
+util.func @test_no_transients(%arg0 : tensor<128x256xf32>, %arg1 : tensor<256x512xf32>,
+    %arg2 : tensor<128x512xf32> {iree.abi.output  = 0 : index}) -> tensor<128x512xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<128x512xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  util.return %2 : tensor<128x512xf32>
+}
+// CHECK-LABEL: func public @test_no_transients(
+//   CHECK-NOT:   stream.resource.alloca
+
+// -----
+
+// No transient allocations created, and the transient size is set to 0.
+util.func @test_no_transients_external_transient_buffer(%arg0 : tensor<128x256xf32>, %arg1 : tensor<256x512xf32>,
+    %arg2 : tensor<128x512xf32> {iree.abi.output  = 0 : index}, %arg3 : !hal.buffer {iree.abi.transients}) -> tensor<128x512xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<128x512xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  util.return %2 : tensor<128x512xf32>
+}
+// CHECK-LABEL: func public @test_no_transients_external_transient_buffer(
+//  CHECK-SAME:     iree.abi.transients.size = @[[SIZE_FN:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     iree.abi.transients.size.constant = 0
+//   CHECK-NOT:   stream.resource.alloca
+//       CHECK: func public @[[SIZE_FN]](
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   return %[[C0]]
+
+// -----
+
+// Needs transient memory allocation.
+util.func @test_transients(%arg0 : tensor<128x256xf32>, %arg1 : tensor<256x512xf32>,
+    %arg2 : tensor<512x1024xf32>, %arg3 : tensor<128x1024xf32> {iree.abi.output  = 0 : index}) -> tensor<128x1024xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<128x512xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %3 = tensor.empty() : tensor<128x1024xf32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+  %5 = linalg.matmul ins(%2, %arg2 : tensor<128x512xf32>, tensor<512x1024xf32>)
+      outs(%4 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+  util.return %5 : tensor<128x1024xf32>
+}
+// CHECK-LABEL: func public @test_transients(
+//       CHECK:   %[[CST:.+]] = arith.constant 262144 : index
+//       CHECK:   stream.resource.alloca
+//  CHECK-SAME:       !stream.resource<transient>{%[[CST]]}
+
+// -----
+
+// Needs transient memory allocation, but no allocas created.
+util.func @test_transients_external_transient_buffer(%arg0 : tensor<128x256xf32>, %arg1 : tensor<256x512xf32>,
+    %arg2 : tensor<512x1024xf32>, %arg3 : tensor<128x1024xf32> {iree.abi.output  = 0 : index},
+    %arg4 : !hal.buffer {iree.abi.transients}) -> tensor<128x1024xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<128x512xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %3 = tensor.empty() : tensor<128x1024xf32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+  %5 = linalg.matmul ins(%2, %arg2 : tensor<128x512xf32>, tensor<512x1024xf32>)
+      outs(%4 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+  util.return %5 : tensor<128x1024xf32>
+}
+// CHECK-LABEL: func public @test_transients_external_transient_buffer(
+//  CHECK-SAME:     iree.abi.transients.size = @[[SIZE_FN:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     iree.abi.transients.size.constant = 262144
+//   CHECK-NOT:   stream.resource.alloca
+//       CHECK: func public @[[SIZE_FN]](
+//       CHECK:   %[[CST:.+]] = arith.constant 262144 : index
+//       CHECK:   return %[[CST]]


### PR DESCRIPTION
When using `--iree-torch-externalize-transients` with a graph that has no intermediate transient allocations, the `stream.resource.transients` op was left behind and failed to lower to HAL with:
  "failed to legalize operation 'stream.resource.transients'"

The fix removes the transients ops by forwarding their resource and timepoint values when there are no allocas to emplace.

PR Co-authored by using Claude-Opus-4.6

Fixes #23384