### PR TITLE
Add additional search paths for tools and bitcode

### DIFF
--- a/compiler/src/iree/compiler/Utils/ToolUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ToolUtils.cpp
@@ -286,7 +286,7 @@ std::string findPlatformLibDirectory(StringRef platformName) {
   }
 
   SmallString<256> libPath(dylibPath);
-  // Trim patth to lib dir: some/path/lib/libIREECompiler.so -> some/path/lib
+  // Trim path to lib dir: some/path/lib/libIREECompiler.so -> some/path/lib
   llvm::sys::path::remove_filename(libPath);
 
   // Try IREE's convention: lib/iree_platform_libs/<platform>/


### PR DESCRIPTION
When `libIREECompiler.so` is distributed as part of [`TheRock`](https://github.com/ROCm/TheRock) tools and bitcode will be in different default locations. Add additional fallback search paths corresponding to install locations used in `TheRock`.