### PR TITLE
[CodeGen][NFCI] Introduce bass CodegenOption and move tuningSpecPath into it.

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -85,7 +85,6 @@ struct ROCMOptions {
   std::string enableROCMUkernels = "none";
   std::string encodingLayoutResolver =
       GPU::kDataTilingEncodingLayoutResolverName;
-  std::string tuningSpecPath = "";
   bool slpVectorization = true;
   bool globalISel = false;
   bool specializeDispatches = false;
@@ -180,12 +179,6 @@ struct ROCMOptions {
         cl::desc(
             "Deprecated; use --iree-rocm-encoding-layout-resolver instead."),
         Deprecated("use --iree-rocm-encoding-layout-resolver instead"));
-
-    binder.opt<std::string>(
-        "iree-codegen-tuning-spec-path", tuningSpecPath, cl::cat(category),
-        cl::desc("Path to a module containing a tuning spec (transform "
-                 "dialect library). Accepts MLIR text (.mlir) and bytecode "
-                 "(.mlirbc) formats."));
 
     binder.opt<bool>("iree-rocm-llvm-slp-vec", slpVectorization,
                      cl::cat(category),
@@ -531,7 +524,7 @@ public:
     }
     {
       MaterializeTuningSpecsPassOptions passOptions;
-      passOptions.tuningSpecPath = targetOptions.tuningSpecPath;
+      passOptions.tuningSpecPath = codegenOptions.tuningSpecPath;
       modulePassManager.addPass(createMaterializeTuningSpecsPass(passOptions));
     }
     modulePassManager.addPass(createMaterializeUserConfigsPass());

--- a/compiler/plugins/target/ROCM/test/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/test/BUILD.bazel
@@ -4,25 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_test")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
-)
-
-# C API tests for ROCM-specific flags.
-iree_compiler_cc_test(
-    name = "rocm-c-api-test",
-    testonly = True,
-    srcs = ["rocm_c_api_test.cc"],
-    deps = [
-        "//compiler/bindings/c:headers",
-        "//compiler/src/iree/compiler/API:Impl",
-        "//compiler/src/iree/testing:gtest_main",
-        "@com_google_googletest//:gtest",
-    ],
 )
 
 iree_lit_test_suite(

--- a/compiler/plugins/target/ROCM/test/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/test/CMakeLists.txt
@@ -10,19 +10,6 @@
 
 iree_add_all_subdirs()
 
-iree_cc_test(
-  NAME
-    rocm-c-api-test
-  SRCS
-    "rocm_c_api_test.cc"
-  DEPS
-    gmock
-    gtest
-    iree::compiler::API::Impl
-    iree::compiler::bindings::c::headers
-    iree::testing::gtest_main
-)
-
 iree_lit_test_suite(
   NAME
     lit

--- a/compiler/src/iree/compiler/API/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/test/BUILD.bazel
@@ -21,3 +21,15 @@ iree_compiler_cc_test(
         "@llvm-project//mlir:CAPIIRHeaders",
     ],
 )
+
+iree_compiler_cc_test(
+    name = "codegen-flags-test",
+    testonly = True,
+    srcs = ["codegen_flags_test.cc"],
+    deps = [
+        "//compiler/bindings/c:headers",
+        "//compiler/src/iree/compiler/API:Impl",
+        "//compiler/src/iree/testing:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/compiler/src/iree/compiler/API/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/test/CMakeLists.txt
@@ -21,6 +21,19 @@ iree_cc_test(
     iree::compiler::bindings::c::headers
 )
 
+iree_cc_test(
+  NAME
+    codegen-flags-test
+  SRCS
+    "codegen_flags_test.cc"
+  DEPS
+    gmock
+    gtest
+    iree::compiler::API::Impl
+    iree::compiler::bindings::c::headers
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
 # Move to bin/ directory and systematically name more appropriately.

--- a/compiler/src/iree/compiler/API/test/codegen_flags_test.cc
+++ b/compiler/src/iree/compiler/API/test/codegen_flags_test.cc
@@ -4,9 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// C API tests for ROCM-specific flags. This test is in the ROCM plugin
-// directory because these flags are registered by ROCMOptions and only
-// available when ROCM is enabled.
+// C API tests for common codegen flags that should be accessible via the
+// embedding API.
 
 #include <gtest/gtest.h>
 
@@ -14,7 +13,7 @@
 
 namespace {
 
-class ROCMCAPITest : public ::testing::Test {
+class CodegenFlagsCAPITest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() { ireeCompilerGlobalInitialize(); }
   static void TearDownTestSuite() { ireeCompilerGlobalShutdown(); }
@@ -25,14 +24,14 @@ protected:
   iree_compiler_session_t *session = nullptr;
 };
 
-TEST_F(ROCMCAPITest, TuningSpecPathFlagAccepted) {
+TEST_F(CodegenFlagsCAPITest, TuningSpecPathFlagAccepted) {
   const char *flag = "--iree-codegen-tuning-spec-path=/tmp/spec.mlir";
   iree_compiler_error_t *err = ireeCompilerSessionSetFlags(session, 1, &flag);
   ASSERT_EQ(err, nullptr)
       << "Tuning spec path flag should be accepted via C API";
 }
 
-TEST_F(ROCMCAPITest, DefaultTuningSpecsFlagNotRegistered) {
+TEST_F(CodegenFlagsCAPITest, DefaultTuningSpecsFlagNotRegistered) {
   const char *flag = "--iree-codegen-enable-default-tuning-specs";
   iree_compiler_error_t *err = ireeCompilerSessionSetFlags(session, 1, &flag);
   ASSERT_NE(err, nullptr) << "CLI-only flag should not be accessible via C API";

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -6,8 +6,6 @@
 
 #include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 
-#include <mutex>
-
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::CPUCodegenOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
@@ -18,17 +16,11 @@ std::string CodegenOptions::tuningSpecPath = "";
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category("IREE Codegen Options");
 
-  // Use std::call_once to ensure the option is registered exactly once,
-  // even when multiple derived classes (CPU/GPU) call this method.
-  static std::once_flag bindFlag;
-  std::call_once(bindFlag, [&]() {
-    binder.opt<std::string>(
-        "iree-codegen-tuning-spec-path", tuningSpecPath,
-        llvm::cl::cat(category),
-        llvm::cl::desc("Path to a module containing a tuning spec (transform "
-                       "dialect library). Accepts MLIR text (.mlir) and "
-                       "bytecode (.mlirbc) formats."));
-  });
+  binder.opt<std::string>(
+      "iree-codegen-tuning-spec-path", tuningSpecPath, llvm::cl::cat(category),
+      llvm::cl::desc("Path to a module containing a tuning spec (transform "
+                     "dialect library). Accepts MLIR text (.mlir) and "
+                     "bytecode (.mlirbc) formats."));
 }
 
 void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -11,7 +11,21 @@
 
 namespace mlir::iree_compiler {
 
-struct CPUCodegenOptions {
+// A base class that defines common codegen options that are shared across
+// different backends (e.g., CPU and GPU). Derived classes can add
+// backend-specific options as needed.
+//
+// Note: We need static members because they are shared across all derived
+// instances to avoid duplicate LLVM cl::opt registration when multiple backends
+// inherit from this class.
+struct CodegenOptions {
+  // Path to a module containing a tuning spec.
+  static std::string tuningSpecPath;
+
+  void bindOptions(OptionsBinder &binder);
+};
+
+struct CPUCodegenOptions : CodegenOptions {
   llvm::OptimizationLevel optLevel = llvm::OptimizationLevel::O0;
 
   // Disable thread distribution in codegen.
@@ -27,7 +41,7 @@ struct CPUCodegenOptions {
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
 };
 
-struct GPUCodegenOptions {
+struct GPUCodegenOptions : CodegenOptions {
   // Enable prefetch in the vector distribute pipeline.
   bool enablePrefetch = false;
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -16,8 +16,8 @@ namespace mlir::iree_compiler {
 // backend-specific options as needed.
 //
 // Note: We need static members because they are shared across all derived
-// instances to avoid duplicate LLVM cl::opt registration when multiple backends
-// inherit from this class.
+// instances to bind LLVM cl::opt registration at the single storage when
+// multiple backends inherit from this class.
 struct CodegenOptions {
   // Path to a module containing a tuning spec.
   static std::string tuningSpecPath;

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -258,10 +258,8 @@ flags:
   directory or standard output.
 
 !!! note
-    The `--iree-codegen-tuning-spec-path` flag is a part of `ROCMOptions` and
-    only available for the ROCM/HIP backends. It can be set programmatically via
-    the C API using `ireeCompilerSessionSetFlags()`. The other two flags are
-    global options available for all backends.
+    The `--iree-codegen-tuning-spec-path` flag can be set programmatically via
+    the C API using `ireeCompilerSessionSetFlags()`.
 
 Note that both default and user-provided specs can be enabled at the same time.
 The compiler will link them together and invoke the user-provided spec before


### PR DESCRIPTION
The revision creates a bass struct that holds common optimization options, like tuningSpecPath.

Assisted-by: Claude