### PR TITLE
Use map_to_vector and filter_to_vector utilities. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -4119,8 +4119,8 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
       return failure();
     }
 
-    auto prunedComputeOps = llvm::to_vector(
-        llvm::make_filter_range(computeOps, shouldSetLoweringConfig));
+    auto prunedComputeOps =
+        llvm::filter_to_vector(computeOps, shouldSetLoweringConfig);
     if (failed(setLoweringConfigForComputeOps(entryPointFn, prunedComputeOps,
                                               rootOperation))) {
       return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -474,8 +475,7 @@ private:
       dimToRes[map.getDimPosition(res)] = res;
     }
 
-    return to_vector(
-        llvm::map_range(indices, [&](int64_t i) { return dimToRes[i]; }));
+    return map_to_vector(indices, [&](int64_t i) { return dimToRes[i]; });
   }
 
   static int64_t productOfDims(VectorType vt, unsigned lo, unsigned hi) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 
+#include "llvm/ADT/SmallVectorExtras.h"
+
 namespace mlir::iree_compiler::IREE::HAL {
 
 //===----------------------------------------------------------------------===//
@@ -116,8 +118,8 @@ TargetRegistry::getTargetDevices(ArrayRef<std::string> targetNames) const {
   // To ensure deterministic builds we sort matches by name.
   std::sort(matches.begin(), matches.end(),
             [](const auto &a, const auto &b) { return a.first < b.first; });
-  return llvm::to_vector(llvm::map_range(
-      matches, [](auto match) { return std::move(match.second); }));
+  return llvm::map_to_vector(
+      matches, [](auto match) { return std::move(match.second); });
 }
 
 SmallVector<std::shared_ptr<TargetBackend>>
@@ -132,8 +134,8 @@ TargetRegistry::getTargetBackends(ArrayRef<std::string> targetNames) const {
   // To ensure deterministic builds we sort matches by name.
   std::sort(matches.begin(), matches.end(),
             [](const auto &a, const auto &b) { return a.first < b.first; });
-  return llvm::to_vector(llvm::map_range(
-      matches, [](auto match) { return std::move(match.second); }));
+  return llvm::map_to_vector(
+      matches, [](auto match) { return std::move(match.second); });
 }
 
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -112,14 +113,13 @@ struct SwitchOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     // Expand any resource operands to resource + size.
     auto defaultOperands = flattenValues(adaptor.getDefaultOperands());
-    auto caseOperands = llvm::to_vector(llvm::map_range(
-        adaptor.getCaseOperands(), [&](ArrayRef<ValueRange> operands) {
-          return flattenValues(operands);
-        }));
+    auto caseOperands = llvm::map_to_vector(
+        adaptor.getCaseOperands(),
+        [&](ArrayRef<ValueRange> operands) { return flattenValues(operands); });
     rewriter.replaceOpWithNewOp<mlir::cf::SwitchOp>(
         op, adaptor.getFlag().front(), op.getDefaultDestination(),
         defaultOperands, op.getCaseValuesAttr(), op.getCaseDestinations(),
-        llvm::to_vector(llvm::map_range(caseOperands, asValueRange)));
+        llvm::map_to_vector(caseOperands, asValueRange));
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -4855,8 +4856,8 @@ Value TimepointJoinOp::join(Location loc, ValueRange timepoints,
 
 // static
 Value TimepointJoinOp::join(ValueRange timepoints, OpBuilder &builder) {
-  return join(builder.getFusedLoc(llvm::to_vector(llvm::map_range(
-                  timepoints, [](Value value) { return value.getLoc(); }))),
+  return join(builder.getFusedLoc(llvm::map_to_vector(
+                  timepoints, [](Value value) { return value.getLoc(); })),
               timepoints, builder);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -563,18 +564,18 @@ static void expandSwitchOp(mlir::cf::SwitchOp op,
     return;
   }
   OpBuilder builder(op);
-  auto caseOperands = llvm::to_vector(
-      llvm::map_range(op.getCaseOperands(), [&](ValueRange operands) {
+  auto caseOperands =
+      llvm::map_to_vector(op.getCaseOperands(), [&](ValueRange operands) {
         return expandOperands(op.getLoc(), operands, resourceTimepointMap,
                               builder);
-      }));
+      });
   auto asValueRange = [](ArrayRef<Value> ref) -> ValueRange { return ref; };
   mlir::cf::SwitchOp::create(
       builder, op.getLoc(), op.getFlag(), op.getDefaultDestination(),
       expandOperands(op.getLoc(), op.getDefaultOperands(), resourceTimepointMap,
                      builder),
       op.getCaseValuesAttr(), op.getCaseDestinations(),
-      llvm::to_vector(llvm::map_range(caseOperands, asValueRange)));
+      llvm::map_to_vector(caseOperands, asValueRange));
   op.erase();
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Utils/IntegerSet.h"
 #include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -588,17 +589,17 @@ static void expandSwitchOp(mlir::cf::SwitchOp op, IndexSet &indexSet,
     return;
   }
   OpBuilder builder(op);
-  auto caseOperands = llvm::to_vector(
-      llvm::map_range(op.getCaseOperands(), [&](ValueRange operands) {
+  auto caseOperands =
+      llvm::map_to_vector(op.getCaseOperands(), [&](ValueRange operands) {
         return expandOperands(op.getLoc(), operands, subrangeMap, indexSet,
                               builder);
-      }));
+      });
   mlir::cf::SwitchOp::create(
       builder, op.getLoc(), op.getFlag(), op.getDefaultDestination(),
       expandOperands(op.getLoc(), op.getDefaultOperands(), subrangeMap,
                      indexSet, builder),
       op.getCaseValuesAttr(), op.getCaseDestinations(),
-      llvm::to_vector(llvm::map_range(caseOperands, asValueRange)));
+      llvm::map_to_vector(caseOperands, asValueRange));
   op.erase();
 }
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -69,22 +70,22 @@ struct SoftmaxFusionOpInterfaceAdapter
 public:
   SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
     Builder b(op->getContext());
-    return llvm::to_vector(llvm::map_range(
+    return llvm::map_to_vector(
         cast<linalg::SoftmaxOp>(op).getDpsInputs(),
         [&b](Value operand) -> AffineMap {
           auto rank = cast<ShapedType>(operand.getType()).getRank();
           return b.getMultiDimIdentityMap(rank);
-        }));
+        });
   }
 
   SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
     Builder b(op->getContext());
-    return llvm::to_vector(llvm::map_range(
+    return llvm::map_to_vector(
         cast<linalg::SoftmaxOp>(op).getDpsInits(),
         [&b](Value operand) -> AffineMap {
           auto rank = cast<ShapedType>(operand.getType()).getRank();
           return b.getMultiDimIdentityMap(rank);
-        }));
+        });
   }
 
   SmallVector<int64_t> getStaticLoopRanges(Operation *op) const {

--- a/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
@@ -13,6 +13,7 @@
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
 #include "iree/compiler/GlobalOptimization/Passes.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -47,9 +48,9 @@ struct DetachElementwisePattern
     // Nothing to do if the output tensor operand is already a fill op.
     SmallVector<OpOperand *> outputOperands;
     if (!linalgOp.hasPureBufferSemantics()) {
-      outputOperands = llvm::to_vector(
-          llvm::map_range(linalgOp.getDpsInitsMutable(),
-                          [](OpOperand &opOperand) { return &opOperand; }));
+      outputOperands =
+          llvm::map_to_vector(linalgOp.getDpsInitsMutable(),
+                              [](OpOperand &opOperand) { return &opOperand; });
     }
     // Right now all the cases we see have one output. This can be relaxed once
     // we see multiple output ops.


### PR DESCRIPTION
Applied llvm-use-vector-utils clang-tidy check.