### PR TITLE
Simplify type switch cases. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -298,17 +298,17 @@ blockDynamicDimensions(RewriterBase &rewriter,
                        const TensorDynamicDimAnalysis &dynamicDimAnalysis,
                        Operation *operation) {
   return TypeSwitch<Operation *, LogicalResult>(operation)
-      .Case<IREE::LinalgExt::AttentionOp>([&](auto attentionOp) {
+      .Case([&](IREE::LinalgExt::AttentionOp attentionOp) {
         return blockDynamicDimensions(rewriter, dynamicDimAnalysis,
                                       attentionOp);
       })
-      .Case<linalg::LinalgOp>([&](auto linalgOp) {
+      .Case([&](linalg::LinalgOp linalgOp) {
         if (clEnableBlockedMatmuls) {
           return blockDynamicDimensions(rewriter, dynamicDimAnalysis, linalgOp);
         }
         return success();
       })
-      .Default([&](Operation *op) { return success(); });
+      .Default(success());
 }
 
 void BlockDynamicDimensionsPass::runOnOperation() {

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -487,24 +487,24 @@ FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
                                            Operation *op,
                                            MapScatterOp mapScatterOp) {
   return llvm::TypeSwitch<Operation *, FailureOr<MapScatterOp>>(op)
-      .Case<linalg::CopyOp>([&](linalg::CopyOp copyOp) {
+      .Case([&](linalg::CopyOp copyOp) {
         return foldIdentityLikeOpIntoMapScatter(rewriter, copyOp, mapScatterOp);
       })
-      .Case<linalg::TransposeOp>([&](linalg::TransposeOp transposeOp) {
+      .Case([&](linalg::TransposeOp transposeOp) {
         return foldTransposeIntoMapScatter(rewriter, transposeOp, mapScatterOp);
       })
-      .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expandOp) {
+      .Case([&](tensor::ExpandShapeOp expandOp) {
         return foldExpandShapeIntoMapScatter(rewriter, expandOp, mapScatterOp);
       })
-      .Case<tensor::CollapseShapeOp>([&](tensor::CollapseShapeOp collapseOp) {
+      .Case([&](tensor::CollapseShapeOp collapseOp) {
         return foldCollapseShapeIntoMapScatter(rewriter, collapseOp,
                                                mapScatterOp);
       })
-      .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp extractSliceOp) {
+      .Case([&](tensor::ExtractSliceOp extractSliceOp) {
         return foldExtractSliceIntoMapScatter(rewriter, extractSliceOp,
                                               mapScatterOp);
       })
-      .Default([](Operation *) { return failure(); });
+      .Default(failure());
 }
 
 // Insert identity map_scatter op after the root and replace all uses.

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -171,11 +171,11 @@ static LogicalResult replaceDestinationBuffer(OpResult resultValue,
                                               Value destinationValue) {
   Operation *op = resultValue.getOwner();
   return TypeSwitch<Operation *, LogicalResult>(op)
-      .Case<DestinationStyleOpInterface>([&](auto op) {
+      .Case([&](DestinationStyleOpInterface op) {
         op.setDpsInitOperand(resultValue.getResultNumber(), destinationValue);
         return success();
       })
-      .Case<tensor::EmptyOp>([&](auto emptyOp) {
+      .Case([&](tensor::EmptyOp emptyOp) {
         emptyOp.replaceAllUsesWith(destinationValue);
         return success();
       })
@@ -229,11 +229,10 @@ modifyResultToUseStoreBuffer(OpBuilder &b, OpResult resultValue,
     Operation *op = it->getOwner();
     resultBuffer =
         TypeSwitch<Operation *, Value>(op)
-            .Case<DestinationStyleOpInterface>(
-                [&](auto) { return resultBuffer; })
+            .Case([&](DestinationStyleOpInterface) { return resultBuffer; })
             .Case<scf::IfOp, scf::ForOp, tensor::InsertSliceOp,
                   vector::TransferWriteOp>([&](auto) { return resultBuffer; })
-            .Case<tensor::InsertSliceOp>([&](auto insertSliceOp) -> Value {
+            .Case([&](tensor::InsertSliceOp insertSliceOp) -> Value {
               if (it->get() == insertSliceOp.getDest()) {
                 return resultBuffer;
               }
@@ -243,7 +242,7 @@ modifyResultToUseStoreBuffer(OpBuilder &b, OpResult resultValue,
                 [&](auto reshapeOp) {
                   return getReverseOfReshapeOp(b, reshapeOp, resultBuffer);
                 })
-            .Case<tensor::CastOp>([&](tensor::CastOp castOp) {
+            .Case([&](tensor::CastOp castOp) {
               return getReverseOfCastOp(b, castOp, resultBuffer);
             })
             .Default([&](Operation *) { return nullptr; });

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -119,7 +119,7 @@ struct BubbleResourceCastPattern
     Location loc = castOp.getLoc();
     bool swapped =
         TypeSwitch<Operation *, bool>(producer)
-            .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp extract) {
+            .Case([&](tensor::ExtractSliceOp extract) {
               if (!extract->hasOneUse()) {
                 return false;
               }
@@ -131,7 +131,7 @@ struct BubbleResourceCastPattern
               extract.getSourceMutable().assign(newCast);
               return true;
             })
-            .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expand) {
+            .Case([&](tensor::ExpandShapeOp expand) {
               if (!expand->hasOneUse()) {
                 return false;
               }
@@ -142,19 +142,18 @@ struct BubbleResourceCastPattern
               expand.getSrcMutable().assign(newCast);
               return true;
             })
-            .Case<tensor::CollapseShapeOp>(
-                [&](tensor::CollapseShapeOp collapse) {
-                  if (!collapse->hasOneUse()) {
-                    return false;
-                  }
+            .Case([&](tensor::CollapseShapeOp collapse) {
+              if (!collapse->hasOneUse()) {
+                return false;
+              }
 
-                  rewriter.setInsertionPoint(collapse);
-                  auto newCast = IREE::GPU::BufferResourceCastOp::create(
-                      rewriter, loc, collapse.getSrcType(), collapse.getSrc());
-                  collapse.getSrcMutable().assign(newCast);
-                  return true;
-                })
-            .Case<tensor::PadOp>([&](tensor::PadOp pad) {
+              rewriter.setInsertionPoint(collapse);
+              auto newCast = IREE::GPU::BufferResourceCastOp::create(
+                  rewriter, loc, collapse.getSrcType(), collapse.getSrc());
+              collapse.getSrcMutable().assign(newCast);
+              return true;
+            })
+            .Case([&](tensor::PadOp pad) {
               if (!pad->hasOneUse()) {
                 return false;
               }
@@ -165,7 +164,7 @@ struct BubbleResourceCastPattern
               pad.getSourceMutable().assign(newCast);
               return true;
             })
-            .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
+            .Case([&](linalg::LinalgOp linalgOp) {
               // Skip gather-like linalg ops.
               if (linalgOp.hasIndexSemantics() || !linalgOp->hasOneUse()) {
                 return false;
@@ -180,7 +179,7 @@ struct BubbleResourceCastPattern
               }
               return true;
             })
-            .Case<tensor::EmptyOp>([&](tensor::EmptyOp empty) {
+            .Case([&](tensor::EmptyOp empty) {
               // Drop all casts of empties.
               return true;
             })

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -807,7 +807,7 @@ private:
               .Case([&](IREE::LinalgExt::GatherOp gatherOp) {
                 return tileAtSubgroupLevel(rewriter, gatherOp);
               })
-              .Default([](Operation *) { return failure(); });
+              .Default(failure());
 
       if (failed(tilingResult)) {
         continue;

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -78,7 +78,7 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
   std::optional<SmallVector<int64_t>> vectorSizes;
   SmallVector<bool> scalableFlags;
   TypeSwitch<Operation *, void>(op)
-      .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
+      .Case([&](linalg::LinalgOp linalgOp) {
         std::optional<VectorizationTileSizes> result =
             inferSizesFromIR(linalgOp, /*opResult=*/std::nullopt);
         if (result) {
@@ -92,7 +92,7 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
           vectorSizes = result->vectorSizes;
         }
       })
-      .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
+      .Case([&](tensor::PadOp padOp) {
         auto ty = padOp.getResultType();
         // TODO(hanchung): Infer the vector sizes for pad op after
         // maskedVectorize method allows dynamic result shapes.
@@ -101,7 +101,7 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
         }
         vectorSizes = SmallVector<int64_t>(ty.getShape());
       })
-      .Case<IREE::LinalgExt::GatherOp>([&](IREE::LinalgExt::GatherOp gatherOp) {
+      .Case([&](IREE::LinalgExt::GatherOp gatherOp) {
         std::optional<VectorizationTileSizes> result =
             inferSizesFromIR(gatherOp.getOutput());
         if (result) {

--- a/compiler/src/iree/compiler/Codegen/Common/InstrumentMemoryAccesses.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/InstrumentMemoryAccesses.cpp
@@ -38,7 +38,7 @@ struct InstrumentMemoryAccessesPass
     auto workgroupKey = instrumentOp.getWorkgroupKey();
     getOperation()->walk([&](Operation *op) {
       TypeSwitch<Operation *>(op)
-          .Case<memref::LoadOp>([&](auto loadOp) {
+          .Case([&](memref::LoadOp loadOp) {
             OpBuilder builder(loadOp);
             builder.setInsertionPointAfter(loadOp);
             auto instrumentOp = IREE::HAL::InstrumentMemoryLoadOp::create(
@@ -48,7 +48,7 @@ struct InstrumentMemoryAccessesPass
             loadOp.getResult().replaceAllUsesExcept(instrumentOp.getResult(),
                                                     instrumentOp);
           })
-          .Case<memref::StoreOp>([&](auto storeOp) {
+          .Case([&](memref::StoreOp storeOp) {
             OpBuilder builder(storeOp);
             auto instrumentOp = IREE::HAL::InstrumentMemoryStoreOp::create(
                 builder, storeOp.getLoc(), storeOp.getValueToStore().getType(),
@@ -56,7 +56,7 @@ struct InstrumentMemoryAccessesPass
                 storeOp.getMemRef(), storeOp.getIndices());
             storeOp.getValueMutable().assign(instrumentOp.getResult());
           })
-          .Case<vector::LoadOp>([&](auto loadOp) {
+          .Case([&](vector::LoadOp loadOp) {
             OpBuilder builder(loadOp);
             builder.setInsertionPointAfter(loadOp);
             auto instrumentOp = IREE::HAL::InstrumentMemoryLoadOp::create(
@@ -66,7 +66,7 @@ struct InstrumentMemoryAccessesPass
             loadOp.getResult().replaceAllUsesExcept(instrumentOp.getResult(),
                                                     instrumentOp);
           })
-          .Case<vector::StoreOp>([&](auto storeOp) {
+          .Case([&](vector::StoreOp storeOp) {
             OpBuilder builder(storeOp);
             auto instrumentOp = IREE::HAL::InstrumentMemoryStoreOp::create(
                 builder, storeOp.getLoc(), storeOp.getVectorType(), buffer,

--- a/compiler/src/iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.cpp
@@ -179,7 +179,7 @@ static void updateTensorDimInfo(
           [&](auto op) {
             updateTensorDimInfo(op, solver, divisibilityInfo, rangeInfo);
           })
-      .Case<DestinationStyleOpInterface>([&](auto op) {
+      .Case([&](DestinationStyleOpInterface op) {
         updateTensorDimInfo(op, solver, divisibilityInfo, rangeInfo);
       });
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -246,19 +246,17 @@ static LogicalResult lowerWorkgroupCount(
   }
 
   return TypeSwitch<Operation *, LogicalResult>(countOps[0])
-      .Case<IREE::TensorExt::DispatchWorkgroupCountFromSliceOp>(
-          [&](auto countOp) {
-            return lowerWorkgroupCountFromSliceOp(rewriter, countOp,
-                                                  entryPointFn, workgroupCount,
-                                                  maxWorkgroupParallelDims);
-          })
-      .Case<IREE::TensorExt::DispatchWorkgroupCountFromDagRootOp>(
-          [&](auto countOp) {
-            return lowerDispatchWorkgroupCountForDagRootOp(
-                rewriter, countOp, tileSizes, staticLoopRanges, interchange,
-                partitionedLoops, maxWorkgroupParallelDims);
-          })
-      .Default([&](Operation *) { return success(); });
+      .Case([&](IREE::TensorExt::DispatchWorkgroupCountFromSliceOp countOp) {
+        return lowerWorkgroupCountFromSliceOp(rewriter, countOp, entryPointFn,
+                                              workgroupCount,
+                                              maxWorkgroupParallelDims);
+      })
+      .Case([&](IREE::TensorExt::DispatchWorkgroupCountFromDagRootOp countOp) {
+        return lowerDispatchWorkgroupCountForDagRootOp(
+            rewriter, countOp, tileSizes, staticLoopRanges, interchange,
+            partitionedLoops, maxWorkgroupParallelDims);
+      })
+      .Default(success());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
@@ -244,7 +244,7 @@ static SmallVector<int64_t> inferResultWorkgroupTileMultiples(OpResult result) {
   // Propagate the operand multiples through the given operation to compute
   // the multiples for the desired result.
   return llvm::TypeSwitch<Operation *, SmallVector<int64_t>>(op)
-      .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expandOp) {
+      .Case([&](tensor::ExpandShapeOp expandOp) {
         SmallVector<int64_t> srcMultiples = getOperandMultiples()[0];
         LDBG() << "Inferring workgroup tile size multiples for "
                << expandOp->getName() << " result.\n";
@@ -256,21 +256,21 @@ static SmallVector<int64_t> inferResultWorkgroupTileMultiples(OpResult result) {
                << llvm::interleaved_array(resultMultiples);
         return resultMultiples;
       })
-      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
+      .Case([&](linalg::PackOp packOp) {
         SmallVector<int64_t> srcMultiples = getOperandMultiples()[0];
         return inferWorkgroupTileMultiplesFromPackUnPack(
                    packOp, /*initialPackedMultiples=*/std::nullopt,
                    /*initialUnPackedMultiples=*/srcMultiples)
             .second;
       })
-      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unPackOp) {
+      .Case([&](linalg::UnPackOp unPackOp) {
         SmallVector<int64_t> srcMultiples = getOperandMultiples()[0];
         return inferWorkgroupTileMultiplesFromPackUnPack(
                    unPackOp, /*initialPackedMultiples=*/srcMultiples,
                    /*initialUnPackedMultiples=*/std::nullopt)
             .second;
       })
-      .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
+      .Case([&](linalg::LinalgOp linalgOp) {
         SmallVector<SmallVector<int64_t>> operandMultiples =
             getOperandMultiples();
         LDBG()
@@ -315,7 +315,7 @@ static SmallVector<int64_t> inferUseWorkgroupTileMultiples(OpOperand *use) {
   // Propagate the operand multiples through the given operation to compute
   // the multiples for the desired result.
   return llvm::TypeSwitch<Operation *, SmallVector<int64_t>>(op)
-      .Case<tensor::CollapseShapeOp>([&](tensor::CollapseShapeOp collapseOp) {
+      .Case([&](tensor::CollapseShapeOp collapseOp) {
         SmallVector<int64_t> destMultiples = getResultMultiples()[0];
         LDBG() << "Inferring workgroup tile size multiples for "
                << collapseOp->getName() << "source.\n";
@@ -327,14 +327,14 @@ static SmallVector<int64_t> inferUseWorkgroupTileMultiples(OpOperand *use) {
                << llvm::interleaved_array(srcMultiples);
         return srcMultiples;
       })
-      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
+      .Case([&](linalg::PackOp packOp) {
         SmallVector<int64_t> destMultiples = getResultMultiples()[0];
         return inferWorkgroupTileMultiplesFromPackUnPack(
                    packOp, /*initialPackedMultiples=*/destMultiples,
                    /*initialUnPackedMultiples=*/std::nullopt)
             .first;
       })
-      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unpackOp) {
+      .Case([&](linalg::UnPackOp unpackOp) {
         SmallVector<int64_t> destMultiples = getResultMultiples()[0];
         return inferWorkgroupTileMultiplesFromPackUnPack(
                    unpackOp, /*initialPackedMultiples=*/std::nullopt,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -92,7 +92,7 @@ static void addOperands(Operation *op, SetVector<Value> &operandSet) {
     return;
   }
   TypeSwitch<Operation *, void>(op)
-      .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
+      .Case([&](linalg::LinalgOp linalgOp) {
         SmallVector<Value> inputOperands = linalgOp.getDpsInputs();
         operandSet.insert(inputOperands.begin(), inputOperands.end());
       })
@@ -711,7 +711,7 @@ transform_dialect::IREEApplyLoopIndependentCodeMotionOp::applyToOne(
           .Case<affine::AffineForOp, scf::ForOp>([&](auto loop) {
             return loop.promoteIfSingleIteration(rewriter);
           })
-          .Default([](Operation *) { return success(); });
+          .Default(success());
     });
   });
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
@@ -84,7 +84,7 @@ static LogicalResult getCallOpType(MLIRContext *context,
         callOperandTypes.push_back(scalarType);
         return success();
       })
-      .Case<MemRefType>([&](MemRefType memrefType) {
+      .Case([&](MemRefType memrefType) {
         // Base ptr.
         callOperandTypes.push_back(MemRefType::get(
             ArrayRef<int64_t>{}, memrefType.getElementType(),
@@ -97,12 +97,12 @@ static LogicalResult getCallOpType(MLIRContext *context,
                                 indexType);
         return success();
       })
-      .Case<NullPointerType>([&](NullPointerType nullPointerType) {
+      .Case([&](NullPointerType nullPointerType) {
         callOperandTypes.push_back(nullPointerType);
         callOperandTypes.push_back(IndexType::get(context));
         return success();
       })
-      .Default([&](Type t) { return failure(); });
+      .Default(failure());
 }
 
 /// Map `operand` of a `ukernel.generic` operation to the operand(s) of
@@ -116,7 +116,7 @@ static LogicalResult lowerToCallOperands(Location loc, RewriterBase &rewriter,
         callOperands.push_back(operand);
         return success();
       })
-      .Case<MemRefType>([&](MemRefType memrefType) {
+      .Case([&](MemRefType memrefType) {
         auto extractStridedMetadataOp =
             memref::ExtractStridedMetadataOp::create(rewriter, loc, operand);
         // Base ptr.
@@ -130,13 +130,13 @@ static LogicalResult lowerToCallOperands(Location loc, RewriterBase &rewriter,
         }
         return success();
       })
-      .Case<NullPointerType>([&](NullPointerType /*unused*/) {
+      .Case([&](NullPointerType /*unused*/) {
         callOperands.push_back(operand);
         callOperands.push_back(
             arith::ConstantIndexOp::create(rewriter, loc, 0));
         return success();
       })
-      .Default([](Type) { return failure(); });
+      .Default(failure());
 }
 
 static FailureOr<func::CallOp>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -129,40 +129,38 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
 
 static std::optional<ComputeBitwidths> getComputeBitwidthForType(Type type) {
   return llvm::TypeSwitch<Type, std::optional<ComputeBitwidths>>(type)
-      .Case<FloatType>(
-          [](FloatType floatType) -> std::optional<ComputeBitwidths> {
-            switch (floatType.getIntOrFloatBitWidth()) {
-            case 64:
-              return ComputeBitwidths::FP64;
-            case 32:
-              return ComputeBitwidths::FP32;
-            case 16:
-              return ComputeBitwidths::FP16;
-            case 8:
-              return ComputeBitwidths::FP8;
-            case 6:
-              return ComputeBitwidths::FP6;
-            case 4:
-              return ComputeBitwidths::FP4;
-            default:
-              return std::nullopt;
-            }
-          })
-      .Case<IntegerType>(
-          [](IntegerType intType) -> std::optional<ComputeBitwidths> {
-            switch (intType.getWidth()) {
-            case 64:
-              return ComputeBitwidths::Int64;
-            case 32:
-              return ComputeBitwidths::Int32;
-            case 16:
-              return ComputeBitwidths::Int16;
-            case 8:
-              return ComputeBitwidths::Int8;
-            default:
-              return std::nullopt;
-            }
-          })
+      .Case([](FloatType floatType) -> std::optional<ComputeBitwidths> {
+        switch (floatType.getIntOrFloatBitWidth()) {
+        case 64:
+          return ComputeBitwidths::FP64;
+        case 32:
+          return ComputeBitwidths::FP32;
+        case 16:
+          return ComputeBitwidths::FP16;
+        case 8:
+          return ComputeBitwidths::FP8;
+        case 6:
+          return ComputeBitwidths::FP6;
+        case 4:
+          return ComputeBitwidths::FP4;
+        default:
+          return std::nullopt;
+        }
+      })
+      .Case([](IntegerType intType) -> std::optional<ComputeBitwidths> {
+        switch (intType.getWidth()) {
+        case 64:
+          return ComputeBitwidths::Int64;
+        case 32:
+          return ComputeBitwidths::Int32;
+        case 16:
+          return ComputeBitwidths::Int16;
+        case 8:
+          return ComputeBitwidths::Int8;
+        default:
+          return std::nullopt;
+        }
+      })
       .Default(std::optional<ComputeBitwidths>());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/ConvertSRefToMemRef.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/ConvertSRefToMemRef.cpp
@@ -388,7 +388,7 @@ ChangeStatus StridedLayoutValueElement::updateBlockArgument(
               }
               return true;
             })
-            .Default([&](Operation *) { return false; });
+            .Default(false);
   }
   if (!didUpdate) {
     solver.getExplorer().walkIncomingBranchOperands(
@@ -797,7 +797,7 @@ struct ConvertWriteSliceOp final : OpConversionPattern<PCF::WriteSliceOp> {
               writeOp, writeOp.getSource(), destSlice, offsets, inBounds);
           return success();
         })
-        .Default([](Type) { return failure(); });
+        .Default(failure());
   }
 };
 
@@ -840,7 +840,7 @@ struct ConvertReadSliceOp final : OpConversionPattern<PCF::ReadSliceOp> {
               readOp, vector, sourceSlice, offsets, zeroPadding, inBounds);
           return success();
         })
-        .Default([](Type) { return failure(); });
+        .Default(failure());
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -525,13 +525,13 @@ struct PackUnPackOpInterface
                           const BufferizationOptions &options,
                           bufferization::BufferizationState &state) const {
     return TypeSwitch<Operation *, LogicalResult>(op)
-        .template Case<linalg::PackOp>([&](auto pack) {
+        .Case([&](linalg::PackOp pack) {
           return bufferizePackOp(rewriter, pack, options, state);
         })
-        .template Case<linalg::UnPackOp>([&](auto unpack) {
+        .Case([&](linalg::UnPackOp unpack) {
           return bufferizeUnPackOp(rewriter, unpack, options, state);
         })
-        .Default([](auto) { return failure(); });
+        .Default(failure());
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1156,7 +1156,7 @@ private:
       // - For all other (unknown) operations, assume an identity mapping for
       // any value whose rank matches the operation’s loop count.
       TypeSwitch<Operation *>(op)
-          .Case<IndexingMapOpInterface>([&](auto op) {
+          .Case([&](IndexingMapOpInterface op) {
             propagateOnIndexingMapOp(op, indicesEquivalence,
                                      valueToGlobalDimMaps);
           })
@@ -3172,7 +3172,7 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
   // These operations have their own logic of lowering config.
   auto result =
       TypeSwitch<Operation *, LogicalResult>(op)
-          .Case<IREE::LinalgExt::CustomOp>([&](auto op) {
+          .Case([&](IREE::LinalgExt::CustomOp op) {
             return setDefaultCustomOpLoweringConfig(entryPointFn, op,
                                                     initCPULaunchConfig);
           })
@@ -3184,7 +3184,7 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
                 IREE::LinalgExt::WinogradInputTransformOp,
                 IREE::LinalgExt::WinogradOutputTransformOp>(
               [&](auto op) { return setWinogradRootConfig(entryPointFn, op); })
-          .Default([&](Operation *op) { return failure(); });
+          .Default(failure());
   if (succeeded(result)) {
     return result;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -34,14 +34,12 @@ void collectLoopsToPeel(Operation *op,
     return;
   }
 
-  int maxNumLoopsToPeel = TypeSwitch<Operation *, int>(op)
-                              .Case<linalg::LinalgOp>([](auto linalgOp) {
-                                return linalgOp.getNumLoops();
-                              })
-                              .Case<linalg::PackOp>([](auto packOp) {
-                                return packOp.getSourceRank();
-                              })
-                              .Default([](auto) { return 0; });
+  int maxNumLoopsToPeel =
+      TypeSwitch<Operation *, int>(op)
+          .Case(
+              [](linalg::LinalgOp linalgOp) { return linalgOp.getNumLoops(); })
+          .Case([](linalg::PackOp packOp) { return packOp.getSourceRank(); })
+          .Default([](auto) { return 0; });
   for (int i = 0; i < maxNumLoopsToPeel; ++i) {
     op = op->getParentOfType<scf::ForOp>();
     auto loop = cast_or_null<scf::ForOp>(op);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -184,7 +184,7 @@ static LogicalResult verifyConvTileAndDecomposeExpertConfig(
             owSize = shapeAfterTiling[2];
             return success();
           })
-          .Case<linalg::Conv2DNchwFchwOp>([&](auto) {
+          .Case([&](linalg::Conv2DNchwFchwOp) {
             // shape: N, OC, OH, OW, (IC), KH, KW
             khSize = shapeAfterTiling[5];
             kwSize = shapeAfterTiling[6];
@@ -200,7 +200,7 @@ static LogicalResult verifyConvTileAndDecomposeExpertConfig(
             owSize = shapeAfterTiling[3];
             return success();
           })
-          .Default([&](auto) { return failure(); });
+          .Default(failure());
   if (failed(isSizeExtracted)) {
     return op->emitOpError("unsupported conv types");
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2344,11 +2344,11 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
     }
   }
   return TypeSwitch<Operation *, LogicalResult>(computeOp)
-      .Case<IREE::LinalgExt::FftOp>([&](auto fftOp) {
+      .Case([&](IREE::LinalgExt::FftOp fftOp) {
         LDBG() << "FFT Config";
         return setFftConfig(target, entryPointFn, fftOp);
       })
-      .Case<IREE::LinalgExt::SortOp>([&](auto sortOp) {
+      .Case([&](IREE::LinalgExt::SortOp sortOp) {
         LDBG() << "Sort Config";
         return IREE::GPU::setSortConfig(target, entryPointFn, sortOp);
       })
@@ -2358,12 +2358,12 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
         LDBG() << "Winograd Config";
         return setWinogradOpConfig(target, entryPointFn, winogradOp);
       })
-      .Case<IREE::LinalgExt::CustomOp>([&](auto customOp) {
+      .Case([&](IREE::LinalgExt::CustomOp customOp) {
         LDBG() << "CustomOp Config";
         return setDefaultCustomOpLoweringConfig(entryPointFn, customOp,
                                                 initGPULaunchConfig);
       })
-      .Case<IREE::LinalgExt::ScatterOp>([&](auto scatterOp) {
+      .Case([&](IREE::LinalgExt::ScatterOp scatterOp) {
         LDBG() << "ScatterOp Config";
         if (failed(IREE::GPU::setScatterLoweringConfig(target, entryPointFn,
                                                        scatterOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -792,7 +792,7 @@ struct LLVMGPUConfigureTensorLayoutsPass final
                 return setGPULoweringConfigLayout(config, candidate,
                                                   workgroupSize, rewriter);
               })
-              .Default([](Attribute) -> LogicalResult { return failure(); });
+              .Default(failure());
 
       if (failed(result)) {
         return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -686,7 +686,7 @@ struct PropagateHintThroughDelinearize final
           }
           return success();
         })
-        .Default([](auto) { return failure(); });
+        .Default(failure());
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1130,7 +1130,7 @@ static Value getBase(Value v) {
               v = op.getSource();
               return true;
             })
-            .Case<memref::TransposeOp>([&](auto op) {
+            .Case([&](memref::TransposeOp op) {
               v = op.getIn();
               return true;
             })
@@ -1138,7 +1138,7 @@ static Value getBase(Value v) {
               v = op.getSrc();
               return true;
             })
-            .Default([](Operation *) { return false; });
+            .Default(false);
     if (!shouldContinue) {
       break;
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1751,7 +1751,7 @@ static LogicalResult setSPIRVOpConfig(IREE::GPU::TargetAttr target,
         return op->emitOpError(
             "named matmul not supported, expected to be generalized first");
       })
-      .Case<linalg::ConvolutionOpInterface>([target](auto op) {
+      .Case([target](linalg::ConvolutionOpInterface op) {
         // Use the result type in case of larger bitwidth for accumulators.
         auto type = cast<ShapedType>(op->getResult(0).getType());
         const int bitwidth = type.getElementTypeBitWidth();
@@ -1768,7 +1768,7 @@ static LogicalResult setSPIRVOpConfig(IREE::GPU::TargetAttr target,
         // If unsuccessful, try to tile and distribute/vectorize.
         return setDefaultOpConfig(target, op);
       })
-      .Case<linalg::GenericOp>([&](linalg::GenericOp op) {
+      .Case([&](linalg::GenericOp op) {
         LLVM_DEBUG(llvm::dbgs() << "configuring for generic op\n");
         if (succeeded(detail::setTilingAndMatmulOpConfig(op, target))) {
           return success();
@@ -1792,13 +1792,13 @@ static LogicalResult setSPIRVOpConfig(IREE::GPU::TargetAttr target,
         LLVM_DEBUG(llvm::dbgs() << "failed to set config of generic");
         return failure();
       })
-      .Case<IREE::LinalgExt::FftOp>([target](IREE::LinalgExt::FftOp op) {
+      .Case([target](IREE::LinalgExt::FftOp op) {
         return setFftOpConfig(target, op);
       })
       .Case<IREE::LinalgExt::WinogradInputTransformOp,
             IREE::LinalgExt::WinogradOutputTransformOp>(
           [&](auto op) { return setWinogradOpConfig(target, op); })
-      .Default([](Operation *) { return failure(); });
+      .Default(failure());
 };
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -273,7 +273,7 @@ private:
 MemRefUsageAnalysis::MemRefUsageAnalysis(mlir::Operation *op) {
   op->walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
-        .Case<mlir::FunctionOpInterface>([this](auto funcOp) {
+        .Case([this](mlir::FunctionOpInterface funcOp) {
           for (Value arg : funcOp.getArguments()) {
             analyzeMemRefValue(arg);
           }

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
@@ -89,11 +89,12 @@ static LogicalResult
 setVMVXRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op) {
   auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
-        .Case<IREE::LinalgExt::FftOp>(
-            [&](auto op) { return setRootConfig(entryPointFn, op); })
-        .Case<TilingInterface>(
-            [&](auto op) { return setRootConfig(entryPointFn, op); })
-        .Default([&](Operation *op) { return success(); });
+        .Case([&](IREE::LinalgExt::FftOp op) {
+          return setRootConfig(entryPointFn, op);
+        })
+        .Case(
+            [&](TilingInterface op) { return setRootConfig(entryPointFn, op); })
+        .Default(success());
   };
   return setRootConfigFn(op);
 }

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -121,7 +121,7 @@ static bool isParameterized(const SymbolTable &moduleSymbols,
             .Case([=](IREE::Flow::TensorConstantOp accessor) {
               return isAttrParameterized(accessor.getValueAttr());
             })
-            .Default([=](auto) { return false; });
+            .Default(false);
     if (parameterized) {
       return WalkResult::interrupt();
     }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -633,10 +633,10 @@ IdentityResolverAttr::getUnifiedEncoding(ArrayRef<Attribute> encodings) const {
 Type IdentityResolverAttr::convertType(Type type) const {
   using IREE::TensorExt::DispatchTensorType;
   return TypeSwitch<Type, Type>(type)
-      .Case<RankedTensorType>([&](auto rankedTensorType) {
+      .Case([&](RankedTensorType rankedTensorType) {
         return rankedTensorType.dropEncoding();
       })
-      .Case<DispatchTensorType>([&](auto dispatchTensorType) {
+      .Case([&](DispatchTensorType dispatchTensorType) {
         auto boundType =
             dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
         if (!boundType || !boundType.getEncoding()) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -974,10 +974,12 @@ refineTensorAccess(Value value, IREE::TensorExt::DispatchTensorType type) {
     bool hasWrites = false;
     for (OpOperand &uses : value.getUses()) {
       TypeSwitch<Operation *>(uses.getOwner())
-          .Case<IREE::TensorExt::DispatchTensorLoadOp>(
-              [&](auto loadOp) { hasReads = true; })
-          .Case<IREE::TensorExt::DispatchTensorStoreOp>(
-              [&](auto storeOp) { hasWrites = true; })
+          .Case([&](IREE::TensorExt::DispatchTensorLoadOp loadOp) {
+            hasReads = true;
+          })
+          .Case([&](IREE::TensorExt::DispatchTensorStoreOp storeOp) {
+            hasWrites = true;
+          })
           .Default([&](auto op) {
             // Treat unknown ops conservatively as read/write.
             hasReads = true;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -395,7 +395,7 @@ static std::string summarizeDispatchRegion(Region &region) {
     TypeSwitch<Operation *>(op)
         .Case<IREE::LinalgExt::AttentionOp, IREE::LinalgExt::OnlineAttentionOp>(
             [&](auto op) { updateIfBetter(kMaxCost, op); })
-        .Case<linalg::LinalgOp>([&](auto op) {
+        .Case([&](linalg::LinalgOp op) {
           int64_t estimatedCost = estimateLinalgOpCost(op);
           updateIfBetter(estimatedCost, op);
         })
@@ -441,13 +441,12 @@ static std::string summarizeDispatchRegion(Region &region) {
             bestSummary =
                 opName + "_" + loopRangesToString(op.getStaticLoopRanges());
           })
-      .Case<linalg::LinalgOp>(
-          [&](auto op) { bestSummary = summarizeLinalgOp(op); })
+      .Case([&](linalg::LinalgOp op) { bestSummary = summarizeLinalgOp(op); })
       .Case<linalg::PackOp, linalg::UnPackOp>([&](auto op) {
         auto opName = getOpNameWithoutDialectName(op);
         bestSummary = opName + "_" + operandTypeToString(op.getSource());
       })
-      .Case<IREE::Encoding::SetEncodingOp>([&](auto op) {
+      .Case([&](IREE::Encoding::SetEncodingOp op) {
         auto opName = getOpNameWithoutDialectName(op);
         auto encoding = cast<IREE::Encoding::EncodingAttr>(
             op.getResultType().getEncoding());
@@ -457,7 +456,7 @@ static std::string summarizeDispatchRegion(Region &region) {
         bestSummary = opName + "_" + index + "_" + loopRangesToString(shape);
         ;
       })
-      .Case<IREE::Encoding::UnsetEncodingOp>([&](auto op) {
+      .Case([&](IREE::Encoding::UnsetEncodingOp op) {
         auto opName = getOpNameWithoutDialectName(op);
         auto encoding = cast<IREE::Encoding::EncodingAttr>(
             op.getSourceType().getEncoding());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
@@ -25,9 +25,8 @@ namespace mlir::iree_compiler::IREE::Flow {
 
 static std::string inferTraceKey(Operation *op) {
   return TypeSwitch<Operation *, std::string>(op)
-      .Case<IREE::Flow::DispatchOp>(
-          [&](auto op) { return op.getEntryPointName(); })
-      .Case<IREE::Util::CallOp>([&](auto op) { return op.getCallee().str(); })
+      .Case([&](IREE::Flow::DispatchOp op) { return op.getEntryPointName(); })
+      .Case([&](IREE::Util::CallOp op) { return op.getCallee().str(); })
       .Default([](auto *op) { return op->getName().getStringRef().str(); });
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchExterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchExterns.cpp
@@ -141,7 +141,7 @@ struct OutlineDispatchExternsPass
       SmallVector<Operation *> deadOps;
       auto outlineOps = [&](Operation *op) {
         return TypeSwitch<Operation *, WalkResult>(op)
-            .Case<IREE::HAL::DispatchExternOp>([&](auto dispatchExternOp) {
+            .Case([&](IREE::HAL::DispatchExternOp dispatchExternOp) {
               if (failed(outlineDispatchExternOp("extern_dispatch",
                                                  dispatchExternOp,
                                                  moduleSymbolTable))) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -180,18 +180,16 @@ struct OutlineDispatchRegionsPass
       SmallVector<Operation *> deadOps;
       auto outlineOps = [&](Operation *op) {
         return TypeSwitch<Operation *, WalkResult>(op)
-            .Case<IREE::Flow::DispatchWorkgroupsOp>(
-                [&](auto dispatchWorkgroupsOp) {
-                  if (failed(outlineDispatchWorkgroupsOp(
-                          (namePrefix + "_dispatch_" +
-                           llvm::Twine(deadOps.size()))
-                              .str(),
-                          dispatchWorkgroupsOp))) {
-                    return WalkResult::interrupt();
-                  }
-                  deadOps.push_back(op);
-                  return WalkResult::advance();
-                })
+            .Case([&](IREE::Flow::DispatchWorkgroupsOp dispatchWorkgroupsOp) {
+              if (failed(outlineDispatchWorkgroupsOp(
+                      (namePrefix + "_dispatch_" + llvm::Twine(deadOps.size()))
+                          .str(),
+                      dispatchWorkgroupsOp))) {
+                return WalkResult::interrupt();
+              }
+              deadOps.push_back(op);
+              return WalkResult::advance();
+            })
             .Default(WalkResult::advance());
       };
       if (funcOp.walk(outlineOps).wasInterrupted()) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -96,10 +96,10 @@ SmallVector<Range> getLoopRanges(Operation *op, Location loc,
             tensor::InsertSliceOp>([&](auto op) {
         return getLoopRangesFromValue(op.getSource(), loc, builder);
       })
-      .Case<TilingInterface>([&](TilingInterface op) {
+      .Case([&](TilingInterface op) {
         return getLoopRangesImpl(op, loc, builder);
       })
-      .Case<ReifyRankedShapedTypeOpInterface>([&](auto shapedOp) {
+      .Case([&](ReifyRankedShapedTypeOpInterface shapedOp) {
         return getLoopRangesImpl(shapedOp, loc, builder);
       })
       .Default([](Operation *op) -> SmallVector<Range> {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ReplicateGlobalsPerAffinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ReplicateGlobalsPerAffinity.cpp
@@ -120,14 +120,14 @@ Value ValuePerAffinityHelper::getOrCreateValueForAffinity(
   }
 
   return TypeSwitch<Operation *, Value>(opOperand->get().getDefiningOp())
-      .Case<IREE::Util::GlobalLoadOpInterface>([&](auto loadOp) {
+      .Case([&](IREE::Util::GlobalLoadOpInterface loadOp) {
         return getOrCreateGlobalLoadForAffinity(loadOp, affinityAttr);
       })
-      .Case<IREE::Stream::AffinityOpInterface>([&](auto affinityOp) {
+      .Case([&](IREE::Stream::AffinityOpInterface affinityOp) {
         return getOrCreateAffinityOpForAffinity(
             affinityOp, cast<OpResult>(opOperand->get()), affinityAttr);
       })
-      .Case<IREE::Flow::TensorReshapeOp>([&](auto reshapeOp) {
+      .Case([&](IREE::Flow::TensorReshapeOp reshapeOp) {
         builder.setInsertionPoint(reshapeOp);
         Value source = getOrCreateValueForAffinity(
             &reshapeOp.getSourceMutable(), affinityAttr);
@@ -430,14 +430,14 @@ void ReplicateGlobalsPerAffinityPass::runOnOperation() {
     LDBG() << "processing op: " << *currentOp;
     worklist.erase(worklist.begin());
     TypeSwitch<Operation *>(currentOp)
-        .Case<IREE::Util::GlobalOpInterface>([&](auto globalOp) {
+        .Case([&](IREE::Util::GlobalOpInterface globalOp) {
           const Explorer::GlobalInfo *globalInfo =
               explorer.getGlobalInfo(globalOp);
           for (auto loadOp : globalInfo->getLoads()) {
             worklist.insert(loadOp);
           }
         })
-        .Case<IREE::Util::GlobalLoadOpInterface>([&](auto loadOp) {
+        .Case([&](IREE::Util::GlobalLoadOpInterface loadOp) {
           explorer.walkTransitiveUses(
               loadOp.getLoadedGlobalValue(), [&](OpOperand &operand) {
                 if (isa<IREE::Util::InitializerOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/Attributes/DeviceTargetPVS.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/Attributes/DeviceTargetPVS.cpp
@@ -43,7 +43,7 @@ void DeviceTargetGlobalPVS::initializeOperation(IREE::Util::GlobalOp globalOp,
   std::function<bool(Attribute)> unionAttr;
   unionAttr = [&](Attribute attr) -> bool {
     return TypeSwitch<Attribute, bool>(attr)
-        .Case<IREE::HAL::DeviceTargetAttr>([&](auto targetAttr) {
+        .Case([&](IREE::HAL::DeviceTargetAttr targetAttr) {
           LLVM_DEBUG({
             llvm::dbgs() << "DeviceTargetGlobalPVS: unioning with target: ";
             attr.print(llvm::dbgs());
@@ -52,7 +52,7 @@ void DeviceTargetGlobalPVS::initializeOperation(IREE::Util::GlobalOp globalOp,
           unionAssumed(targetAttr);
           return true;
         })
-        .Case<IREE::HAL::DeviceFallbackAttr>([&](auto fallbackAttr) {
+        .Case([&](IREE::HAL::DeviceFallbackAttr fallbackAttr) {
           LLVM_DEBUG({
             llvm::dbgs() << "DeviceTargetGlobalPVS: unioning with fallback: ";
             attr.print(llvm::dbgs());
@@ -78,7 +78,7 @@ void DeviceTargetGlobalPVS::initializeOperation(IREE::Util::GlobalOp globalOp,
           unionAssumed(fallbackPVS.getState());
           return true;
         })
-        .Case<IREE::HAL::DeviceSelectAttr>([&](auto selectAttr) {
+        .Case([&](IREE::HAL::DeviceSelectAttr selectAttr) {
           LLVM_DEBUG({
             llvm::dbgs() << "DeviceTargetGlobalPVS: unioning with selected "
                             "child devices: ";

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
@@ -198,14 +198,15 @@ BindingLayoutAnalysis::BindingLayoutAnalysis(Operation *rootOp,
   };
   rootOp->walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
-        .Case<IREE::Stream::ExecutableExportOp>(
-            [&](auto exportOp) { (void)getExportInfo(exportOp); })
-        .Case<IREE::HAL::ExecutableExportOp>([&](auto exportOp) {
+        .Case([&](IREE::Stream::ExecutableExportOp exportOp) {
+          (void)getExportInfo(exportOp);
+        })
+        .Case([&](IREE::HAL::ExecutableExportOp exportOp) {
           auto &exportInfo = getExportInfo(exportOp);
           exportInfo.pipelineLayout =
               assumeExportLayout(exportOp.getLayoutAttr());
         })
-        .Case<IREE::Stream::CmdDispatchOp>([&](auto dispatchOp) {
+        .Case([&](IREE::Stream::CmdDispatchOp dispatchOp) {
           dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPointAttr) {
             auto exportOp =
                 symbolTable.lookupNearestSymbolFrom(dispatchOp, entryPointAttr);
@@ -219,7 +220,7 @@ BindingLayoutAnalysis::BindingLayoutAnalysis(Operation *rootOp,
   // Derive the layouts for each export op.
   for (auto &it : exportInfos) {
     TypeSwitch<Operation *>(it.first)
-        .Case<IREE::Stream::ExecutableExportOp>([&](auto exportOp) {
+        .Case([&](IREE::Stream::ExecutableExportOp exportOp) {
           it.second->pipelineLayout =
               deriveStreamExportLayout(exportOp, it.second->dispatchOps);
         })

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
@@ -169,7 +169,7 @@ void DeviceAnalysis::gatherDeviceTargets(
   do {
     auto attr = worklist.pop_back_val();
     if (!TypeSwitch<Attribute, bool>(attr)
-             .Case<SymbolRefAttr>([&](auto symRefAttr) {
+             .Case([&](SymbolRefAttr symRefAttr) {
                auto globalOp =
                    explorer.getSymbolTables()
                        .lookupNearestSymbolFrom<IREE::Util::GlobalOpInterface>(
@@ -183,20 +183,20 @@ void DeviceAnalysis::gatherDeviceTargets(
                  return false;
                }
              })
-             .Case<IREE::HAL::DeviceTargetAttr>([&](auto targetAttr) {
+             .Case([&](IREE::HAL::DeviceTargetAttr targetAttr) {
                resultSet.insert(targetAttr);
                return true;
              })
-             .Case<IREE::HAL::DeviceFallbackAttr>([&](auto fallbackAttr) {
+             .Case([&](IREE::HAL::DeviceFallbackAttr fallbackAttr) {
                worklist.insert(fallbackAttr.getName());
                return true;
              })
-             .Case<IREE::HAL::DeviceSelectAttr>([&](auto selectAttr) {
+             .Case([&](IREE::HAL::DeviceSelectAttr selectAttr) {
                worklist.insert(selectAttr.getDevices().begin(),
                                selectAttr.getDevices().end());
                return true;
              })
-             .Default([](auto attr) { return false; })) {
+             .Default(false)) {
       // No initial value means fall back to defaults. We do that by
       // inserting all knowable targets.
       gatherLegacyDeviceTargetAttrs(fromOp, resultSet);

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -1250,7 +1250,7 @@ static Operation *matchSingleTransferOp(IREE::Stream::CmdExecuteOp executeOp) {
                      }
                    })
                // Dispatch/collective/etc fail the search.
-               .Default([&](auto otherOp) { return false; })) {
+               .Default(false)) {
         return nullptr;
       }
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -339,14 +339,14 @@ getDeviceFallbackGlobals(IREE::Util::GlobalOpInterface deviceGlobal,
       return true; // ignore uninitialized devices
     }
     return TypeSwitch<Attribute, bool>(attr)
-        .Case<IREE::HAL::DeviceOrdinalAttr>([](auto attr) { return true; })
-        .Case<IREE::HAL::DeviceTargetAttr>([](auto attr) { return true; })
-        .Case<IREE::HAL::DeviceFallbackAttr>([&](auto fallbackAttr) {
+        .Case([](IREE::HAL::DeviceOrdinalAttr attr) { return true; })
+        .Case([](IREE::HAL::DeviceTargetAttr attr) { return true; })
+        .Case([&](IREE::HAL::DeviceFallbackAttr fallbackAttr) {
           resultSet.insert(symbolTable.lookup<IREE::Util::GlobalOpInterface>(
               fallbackAttr.getName().getValue()));
           return true;
         })
-        .Default([](auto attr) { return false; });
+        .Default(false);
   };
   auto initialValue = deviceGlobal.getGlobalInitialValue();
   if (auto selectAttr =

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
@@ -77,11 +77,11 @@ verifyDeviceTargetAttr(Operation *deviceOp,
 static LogicalResult verifyAttr(Operation *deviceOp, Attribute attr,
                                 const TargetRegistry &targetRegistry) {
   return TypeSwitch<Attribute, LogicalResult>(attr)
-      .Case<IREE::HAL::DeviceTargetAttr>([&](auto deviceTargetAttr) {
+      .Case([&](IREE::HAL::DeviceTargetAttr deviceTargetAttr) {
         return verifyDeviceTargetAttr(deviceOp, deviceTargetAttr,
                                       targetRegistry);
       })
-      .Case<IREE::HAL::DeviceSelectAttr>([&](auto deviceSelectAttr) {
+      .Case([&](IREE::HAL::DeviceSelectAttr deviceSelectAttr) {
         for (auto attr : deviceSelectAttr.getDevices().getValue()) {
           if (failed(verifyAttr(deviceOp, attr, targetRegistry))) {
             return failure();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1771,11 +1771,11 @@ ShapedType PackOp::getPackedType(ShapedType sourceType,
       sourceType.getShape(), innerTileSizes, innerDimsPos, outerDimsPerm);
 
   return TypeSwitch<ShapedType, ShapedType>(sourceType)
-      .Case<RankedTensorType>([&](auto shapedType) {
+      .Case([&](RankedTensorType shapedType) {
         return RankedTensorType::get(resultTypeShape,
                                      shapedType.getElementType());
       })
-      .Case<MemRefType>([&](auto shapedType) {
+      .Case([&](MemRefType shapedType) {
         return MemRefType::get(resultTypeShape, shapedType.getElementType());
       })
       .Default([&](Type t) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -74,10 +74,10 @@ Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
     return arith::ConstantIndexOp::create(builder, loc, type.getDimSize(dim));
   }
   return TypeSwitch<Type, Value>(v.getType())
-      .Case<RankedTensorType>([&](RankedTensorType t) -> Value {
+      .Case([&](RankedTensorType t) -> Value {
         return builder.createOrFold<tensor::DimOp>(loc, v, dim);
       })
-      .Case<MemRefType>([&](MemRefType t) -> Value {
+      .Case([&](MemRefType t) -> Value {
         return builder.createOrFold<memref::DimOp>(loc, v, dim);
       });
 }
@@ -111,11 +111,11 @@ Operation *getSlice(OpBuilder &b, Location loc, Value src,
                     ArrayRef<OpFoldResult> sizes,
                     ArrayRef<OpFoldResult> strides) {
   return TypeSwitch<Type, Operation *>(src.getType())
-      .Case<RankedTensorType>([&](RankedTensorType t) -> Operation * {
+      .Case([&](RankedTensorType t) -> Operation * {
         return tensor::ExtractSliceOp::create(b, loc, src, offsets, sizes,
                                               strides);
       })
-      .Case<MemRefType>([&](MemRefType type) -> Operation * {
+      .Case([&](MemRefType type) -> Operation * {
         return memref::SubViewOp::create(b, loc, src, offsets, sizes, strides);
       })
       .Default([&](Type t) -> Operation * {
@@ -126,11 +126,11 @@ Operation *getSlice(OpBuilder &b, Location loc, Value src,
 
 Value castValue(OpBuilder &b, Location loc, Value src, ShapedType type) {
   return TypeSwitch<Type, Value>(src.getType())
-      .Case<RankedTensorType>([&](RankedTensorType t) -> Value {
+      .Case([&](RankedTensorType t) -> Value {
         assert(isa<RankedTensorType>(type) && "expected compatible type");
         return tensor::CastOp::create(b, loc, type, src)->getResult(0);
       })
-      .Case<MemRefType>([&](MemRefType type) -> Value {
+      .Case([&](MemRefType type) -> Value {
         assert(isa<MemRefType>(type) && "expected compatible type");
         return memref::CastOp::create(b, loc, type, src)->getResult(0);
       })

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -759,7 +759,7 @@ ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
                 newState.unionAssumed(sourceAffinityAttr);
               }
             })
-            .Case<IREE::Util::GlobalLoadOpInterface>([&](auto loadOp) {
+            .Case([&](IREE::Util::GlobalLoadOpInterface loadOp) {
               auto *globalInfo = solver.getExplorer().queryGlobalInfoFrom(
                   loadOp.getGlobalName(), loadOp);
               auto &globalPVS = solver.getElementFor<GlobalAffinityPVS>(
@@ -779,7 +779,7 @@ ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
                 newState ^= globalPVS.getState();
               }
             })
-            .Case<mlir::arith::SelectOp>([&](auto op) {
+            .Case([&](mlir::arith::SelectOp op) {
               auto &truePVS = solver.getElementFor<ValueProducerAffinityPVS>(
                   *this, Position::forValue(op.getTrueValue()),
                   DFX::Resolution::REQUIRED);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -1176,17 +1176,17 @@ struct ConvertExecutableOp
       // and rely only the patterns.
       moduleOp.walk([&](Operation *op) {
         TypeSwitch<Operation *>(op)
-            .Case<IREE::Flow::DispatchWorkgroupIDOp>([&](auto op) {
+            .Case([&](IREE::Flow::DispatchWorkgroupIDOp op) {
               replaceDispatchWorkgroupInfoOp<
                   IREE::Flow::DispatchWorkgroupIDOp,
                   IREE::Stream::DispatchWorkgroupIDOp>(op, rewriter);
             })
-            .Case<IREE::Flow::DispatchWorkgroupCountOp>([&](auto op) {
+            .Case([&](IREE::Flow::DispatchWorkgroupCountOp op) {
               replaceDispatchWorkgroupInfoOp<
                   IREE::Flow::DispatchWorkgroupCountOp,
                   IREE::Stream::DispatchWorkgroupCountOp>(op, rewriter);
             })
-            .Case<IREE::Flow::DispatchWorkgroupSizeOp>([&](auto op) {
+            .Case([&](IREE::Flow::DispatchWorkgroupSizeOp op) {
               replaceDispatchWorkgroupInfoOp<
                   IREE::Flow::DispatchWorkgroupSizeOp,
                   IREE::Stream::DispatchWorkgroupSizeOp>(op, rewriter);

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -3922,7 +3922,7 @@ static bool isSourceImmediatelyResolved(Value resource) {
   return TypeSwitch<Operation *, bool>(definingOp)
       .Case<IREE::Stream::ResourceAllocOp, IREE::Stream::TensorImportOp>(
           [](auto op) { return true; })
-      .Default([](auto op) { return false; });
+      .Default(false);
 }
 
 // Elides barriers that source their operands from immediate operations.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AutomaticReferenceCounting.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AutomaticReferenceCounting.cpp
@@ -974,15 +974,15 @@ static bool analyzeRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 
   // Dispatch to pattern-specific handlers using TypeSwitch.
   return llvm::TypeSwitch<Operation *, bool>(op)
-      .Case<scf::ForOp>([&](scf::ForOp forOp) {
+      .Case([&](scf::ForOp forOp) {
         return analyzeForLoop(forOp, asmState, lastUseSet, coverage,
                               indeterminateResources, handledResources);
       })
-      .Case<scf::IfOp>([&](scf::IfOp ifOp) {
+      .Case([&](scf::IfOp ifOp) {
         return analyzeIfOp(ifOp, asmState, lastUseSet, coverage,
                            indeterminateResources, handledResources);
       })
-      .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+      .Case([&](scf::WhileOp whileOp) {
         return analyzeWhileOp(whileOp, asmState, lastUseSet, coverage,
                               indeterminateResources, handledResources);
       })

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
@@ -1035,7 +1035,7 @@ static bool trySinkAwaitIntoBranch(IREE::Stream::TimepointAwaitOp awaitOp,
     }
   };
   return TypeSwitch<Operation *, bool>(controlFlowOp)
-      .Case<scf::IfOp>([&](auto ifOp) {
+      .Case([&](scf::IfOp ifOp) {
         // scf.if has mutually exclusive branches - sink into all that need it.
         LLVM_DEBUG({
           llvm::dbgs() << "[ElideTimepoints] sinking await into scf.if ";
@@ -1063,7 +1063,7 @@ static bool trySinkAwaitIntoBranch(IREE::Stream::TimepointAwaitOp awaitOp,
         }
         return true;
       })
-      .Case<scf::IndexSwitchOp>([&](auto switchOp) {
+      .Case([&](scf::IndexSwitchOp switchOp) {
         // scf.index_switch has mutually exclusive case regions - sink into all
         // that need it.
         LLVM_DEBUG({
@@ -1101,7 +1101,7 @@ static bool trySinkAwaitIntoBranch(IREE::Stream::TimepointAwaitOp awaitOp,
         }
         return true;
       })
-      .Default([](auto) { return false; });
+      .Default(false);
 }
 
 // Hoists await past control flow when the value only used after.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -286,7 +286,7 @@ static bool emplaceAllocationsInRegion(Region &region) {
       if (op.hasTrait<OpTrait::IREE::Stream::AsyncPhaseOp>()) {
         didChange = TypeSwitch<Operation *, bool>(&op)
                         // TODO(#11249): support in-place collective ops.
-                        .Case<IREE::Stream::AsyncDispatchOp>([&](auto op) {
+                        .Case([&](IREE::Stream::AsyncDispatchOp op) {
                           return tryEmplaceDispatchOp(op, indexSet);
                         })
                         .Default(false) ||

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
@@ -361,12 +361,12 @@ struct MaterializeBuiltinsPass
     auto walkResult = getOperation()->walk(
         [&](IREE::Stream::StreamableOpInterface streamableOp) {
           return TypeSwitch<Operation *, WalkResult>(streamableOp)
-              .Case<IREE::Stream::AsyncSplatOp>([&](auto splatOp) {
+              .Case([&](IREE::Stream::AsyncSplatOp splatOp) {
                 return succeeded(processSplatOp(splatOp, requiredModules))
                            ? WalkResult::advance()
                            : WalkResult::interrupt();
               })
-              .Case<IREE::Stream::AsyncFillOp>([&](auto fillOp) {
+              .Case([&](IREE::Stream::AsyncFillOp fillOp) {
                 return succeeded(processFillOp(fillOp, requiredModules))
                            ? WalkResult::advance()
                            : WalkResult::interrupt();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/UnifyEncodingForGlobals.cpp
@@ -656,16 +656,16 @@ static void applyTensorEncodingUpdates(TensorEncodingUpdates &updates) {
     const OperandEncodingUpdates &opUpdates = operandUpdates;
     IRRewriter rewriter(op->getContext());
     TypeSwitch<Operation *>(op)
-        .Case<TensorDispatchOp>([&](auto dispatchOp) {
+        .Case([&](TensorDispatchOp dispatchOp) {
           updateTensorDispatchOp(dispatchOp, opUpdates, rewriter);
         })
-        .Case<TensorCloneOp>([&](auto cloneOp) {
+        .Case([&](TensorCloneOp cloneOp) {
           updateTensorCloneOp(cloneOp, opUpdates, rewriter);
         })
-        .Case<TensorEncodeOp>([&](auto encodeOp) {
+        .Case([&](TensorEncodeOp encodeOp) {
           updateTensorEncodeOp(encodeOp, opUpdates, rewriter);
         })
-        .Case<TensorUpdateOp>([&](auto updateOp) {
+        .Case([&](TensorUpdateOp updateOp) {
           updateTensorUpdateOp(updateOp, opUpdates, rewriter);
         })
         .Case<TensorSizeOfOp, TensorEmptyOp, TensorConstantOp, TensorSplatOp,
@@ -720,7 +720,7 @@ static void collectUpdatesForStreamTensorOps(Explorer &explorer,
       // The fixup will be applied directly to these ops, so updates are not
       // needed for their users.
       TypeSwitch<Operation *>(user)
-          .Case<TensorDispatchOp>([&](auto dispatchOp) {
+          .Case([&](TensorDispatchOp dispatchOp) {
             // The operand number is the index in the full operand list
             // (including workload). We need the index in getMixedOperands() for
             // encoding lookup.

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4314,11 +4314,11 @@ private:
         std::optional<std::pair<StringRef, StringRef>> vmNames =
             TypeSwitch<Type, std::optional<std::pair<StringRef, StringRef>>>(
                 objectType)
-                .Case<IREE::VM::ListType>([&](auto t) {
+                .Case([&](IREE::VM::ListType t) {
                   return std::make_pair(StringRef("iree_vm_list_t"),
                                         StringRef("iree_vm_list_deref"));
                 })
-                .template Case<IREE::VM::BufferType>([&](auto t) {
+                .Case([&](IREE::VM::BufferType t) {
                   return std::make_pair(StringRef("iree_vm_buffer_t"),
                                         StringRef("iree_vm_buffer_deref"));
                 })
@@ -4640,11 +4640,11 @@ class ListGetOpConversion : public EmitCConversionPattern<OpTy> {
         TypeSwitch<Operation *, std::pair<std::optional<StringRef>,
                                           std::optional<StringRef>>>(
             getOp.getOperation())
-            .Case<IREE::VM::ListGetI32Op>([&](auto op) {
+            .Case([&](IREE::VM::ListGetI32Op op) {
               return std::make_pair(StringRef("IREE_VM_VALUE_TYPE_I32"),
                                     StringRef("iree_vm_value_get_i32"));
             })
-            .template Case<IREE::VM::ListGetI64Op>([&](auto op) {
+            .Case([&](IREE::VM::ListGetI64Op op) {
               return std::make_pair(StringRef("IREE_VM_VALUE_TYPE_I64"),
                                     StringRef("iree_vm_value_get_i64"));
             })
@@ -4868,10 +4868,12 @@ class ListSetOpConversion : public EmitCConversionPattern<OpTy> {
 
     std::optional<StringRef> valueConstructor =
         TypeSwitch<Operation *, std::optional<StringRef>>(setOp.getOperation())
-            .Case<IREE::VM::ListSetI32Op>(
-                [&](auto op) { return StringRef("iree_vm_value_make_i32"); })
-            .template Case<IREE::VM::ListSetI64Op>(
-                [&](auto op) { return StringRef("iree_vm_value_make_i64"); })
+            .Case([&](IREE::VM::ListSetI32Op op) {
+              return StringRef("iree_vm_value_make_i32");
+            })
+            .Case([&](IREE::VM::ListSetI64Op op) {
+              return StringRef("iree_vm_value_make_i64");
+            })
             .Default([](Operation *) { return std::nullopt; });
 
     if (!valueConstructor.has_value()) {

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ConvertToYieldableCalls.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ConvertToYieldableCalls.cpp
@@ -36,13 +36,13 @@ public:
     SmallVector<IREE::VM::CallVariadicOp> variadicCallsToConvert;
     moduleOp.walk([&](Operation *op) {
       llvm::TypeSwitch<Operation *>(op)
-          .Case<IREE::VM::CallOp>([&](auto callOp) {
+          .Case([&](IREE::VM::CallOp callOp) {
             Operation *calleeOp = symbolTable.lookup(callOp.getCallee());
             if (isCalleeYieldable(calleeOp)) {
               callsToConvert.push_back(callOp);
             }
           })
-          .Case<IREE::VM::CallVariadicOp>([&](auto callVariadicOp) {
+          .Case([&](IREE::VM::CallVariadicOp callVariadicOp) {
             Operation *calleeOp =
                 symbolTable.lookup(callVariadicOp.getCallee());
             if (isCalleeYieldable(calleeOp)) {

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -400,7 +400,7 @@ foldUnitDimsOnGlobal(IRRewriter &rewriter, IREE::Util::GlobalOpInterface global,
             return IREE::Util::UninitializedAttr::get(rewriter.getContext(),
                                                       newGlobalType);
           })
-          .Case<IREE::Stream::NamedParameterAttr>(
+          .Case(
               // TODO: Remove this case once frontends have caught up, we should
               // not have stream.parameter.named at this level.
               [&](IREE::Stream::NamedParameterAttr attr) {
@@ -408,12 +408,11 @@ foldUnitDimsOnGlobal(IRRewriter &rewriter, IREE::Util::GlobalOpInterface global,
                     rewriter.getContext(), newGlobalType, attr.getScope(),
                     attr.getKey(), attr.getConfig());
               })
-          .Case<IREE::Flow::NamedParameterAttr>(
-              [&](IREE::Flow::NamedParameterAttr attr) {
-                return IREE::Flow::NamedParameterAttr::get(
-                    rewriter.getContext(), newGlobalType, attr.getScope(),
-                    attr.getKey(), attr.getConfig());
-              })
+          .Case([&](IREE::Flow::NamedParameterAttr attr) {
+            return IREE::Flow::NamedParameterAttr::get(
+                rewriter.getContext(), newGlobalType, attr.getScope(),
+                attr.getKey(), attr.getConfig());
+          })
           .Default([&](Attribute) { return nullptr; });
   if (!newInitialValue) {
     return success();

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -502,15 +502,15 @@ isFusableWithConsumer(OpOperand &fusedOperand, const FusionTracker &tracker,
 
   if (isPackLikeOp(consumer)) {
     return TypeSwitch<Operation *, bool>(producer)
-        .Case<tensor::PadOp>([&](auto padOp) { return true; })
-        .Case<linalg::LinalgOp>([&](auto linalgOp) {
+        .Case([&](tensor::PadOp padOp) { return true; })
+        .Case([&](linalg::LinalgOp linalgOp) {
           AffineMap producerIndexingMap = linalgOp.getIndexingMapMatchingResult(
               cast<OpResult>(fusedOperand.get()));
           // Make sure the producer op has an identity result indexing map. As
           // CPU backend currently can't handle transpose between fused ops.
           return producerIndexingMap.isIdentity();
         })
-        .Default([](Operation *) { return false; });
+        .Default(false);
   }
 
   // By default, padding should be fused with producers. It is hard to square
@@ -712,8 +712,8 @@ static bool isFusableWithProducer(OpOperand &operand,
 
   if (isPackLikeOp(consumer)) {
     return TypeSwitch<Operation *, bool>(producer)
-        .Case<tensor::PadOp>([&](auto padOp) { return true; })
-        .Case<linalg::LinalgOp>([&](auto linalgOp) {
+        .Case([&](tensor::PadOp padOp) { return true; })
+        .Case([&](linalg::LinalgOp linalgOp) {
           if (auto packOp = dyn_cast<linalg::PackOp>(consumer)) {
             // TODO(#12746): fusion of pack with dynamic inner tile size
             // causes an error in backend. Disable for now.
@@ -727,7 +727,7 @@ static bool isFusableWithProducer(OpOperand &operand,
           // CPU backend currently can't handle transpose between fused ops.
           return producerIndexingMap.isIdentity();
         })
-        .Default([](Operation *) { return false; });
+        .Default(false);
   }
 
   if (!isa<IREE::LinalgExt::LinalgFusionOpInterface>(consumer) ||

--- a/compiler/src/iree/compiler/DispatchCreation/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SplitReduction.cpp
@@ -94,17 +94,17 @@ struct SplitReductionPass final
     IRRewriter rewriter(context);
     funcOp->walk([&](Operation *op) {
       TypeSwitch<Operation *>(op)
-          .Case<linalg::MatmulOp>([&](auto matmulOp) {
+          .Case([&](linalg::MatmulOp matmulOp) {
             if (splitMatmulReductionRatio > 1) {
               matmulCandidates.push_back(matmulOp);
             }
           })
-          .Case<IREE::LinalgExt::TopkOp>([&](auto topkOp) {
+          .Case([&](IREE::LinalgExt::TopkOp topkOp) {
             if (!topkSplitReductionRatio.empty()) {
               topkCandidates.push_back(topkOp);
             }
           })
-          .Case<linalg::GenericOp>([&](auto genericOp) {
+          .Case([&](linalg::GenericOp genericOp) {
             if (splitArgmaxTileSize > 1 &&
                 IREE::LinalgExt::isArgmaxOp(genericOp)) {
               // Due to isArgmaxOp, we support exactly one reduction dimension.

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -133,7 +133,7 @@ struct EncodingAttrPropagationInterface final
           EncodingAttrPropagationInterface, IREE::Encoding::EncodingAttr> {
   bool isPropagableDown(Attribute attr, OpOperand *target) const {
     return TypeSwitch<Operation *, bool>(target->getOwner())
-        .Case<linalg::GenericOp>([&](auto genericOp) {
+        .Case([&](linalg::GenericOp genericOp) {
           // Only support parallel generic ops.
           if (genericOp.getNumReductionLoops() != 0) {
             return false;
@@ -152,7 +152,7 @@ struct EncodingAttrPropagationInterface final
           }
           return true;
         })
-        .Default([&](auto) { return false; });
+        .Default(false);
   }
 
   FailureOr<IREE::Encoding::PropagationEncoding>
@@ -161,7 +161,7 @@ struct EncodingAttrPropagationInterface final
     return TypeSwitch<Operation *,
                       FailureOr<IREE::Encoding::PropagationEncoding>>(
                target->getOwner())
-        .Case<linalg::GenericOp>([&](auto genericOp) {
+        .Case([&](linalg::GenericOp genericOp) {
           IREE::Encoding::PropagationEncoding propEncoding;
           propEncoding.operandEncodings.reserve(genericOp->getNumOperands());
           // Append the target and respective operand's indexing maps to the
@@ -200,7 +200,7 @@ struct EncodingAttrPropagationInterface final
           }
           return propEncoding;
         })
-        .Default([&](auto) { return failure(); });
+        .Default(failure());
   }
 };
 
@@ -210,14 +210,14 @@ struct LayoutAttrPropagationInterface final
   bool isPropagableUp(Attribute attr, OpResult target) const {
     auto layoutAttr = cast<IREE::Encoding::LayoutAttr>(attr);
     return TypeSwitch<Operation *, bool>(target.getOwner())
-        .Case<tensor::CastOp>([&](auto castOp) {
+        .Case([&](tensor::CastOp castOp) {
           // CastOp is propagable if it is casting between compatible shapes,
           // because the dimensions need to be consistent with the
           // user_indexing_maps carried by the encoding. The tensor.cast op
           // verifier already guarantees that the shapes are compatible.
           return layoutAttr.isSerialized();
         })
-        .Default([&](auto) { return false; });
+        .Default(false);
   }
 
   FailureOr<IREE::Encoding::PropagationEncoding>
@@ -226,13 +226,13 @@ struct LayoutAttrPropagationInterface final
     return TypeSwitch<Operation *,
                       FailureOr<IREE::Encoding::PropagationEncoding>>(
                target.getOwner())
-        .Case<tensor::CastOp>([&](tensor::CastOp) {
+        .Case([&](tensor::CastOp) {
           IREE::Encoding::PropagationEncoding propEncoding;
           propEncoding.resultEncodings.push_back(encoding);
           propEncoding.operandEncodings.push_back(encoding);
           return propEncoding;
         })
-        .Default([&](auto) { return failure(); });
+        .Default(failure());
   }
 };
 

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -86,10 +86,10 @@ static LogicalResult hoistLoopInvariants(LoopLikeOpInterface loopOp,
   FailureOr<LoopLikeOpInterface> wrappedLoop =
       TypeSwitch<Operation *, FailureOr<LoopLikeOpInterface>>(
           loopOp.getOperation())
-          .Case<scf::WhileOp>([&](scf::WhileOp op) {
+          .Case([&](scf::WhileOp op) {
             return scf::wrapWhileLoopInZeroTripCheck(op, rewriter);
           })
-          .Default([&](Operation *op) { return failure(); });
+          .Default(failure());
   if (failed(wrappedLoop)) {
     return failure();
   }


### PR DESCRIPTION
Applied llvm-type-switch-case-types clang-tidy check. Also simplified trivial `.Default` lambdas returning `failure()`, `success()`, or `false` to direct values by hand.