### PR TITLE
Fix DenseMap iterator invalidation in OptionsBinder::topLevelOpt

### DIFF
--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -182,8 +182,11 @@ public:
     auto &optionInfos = getOptionsStorage();
     auto dummyIt = optionInfos.find(kDummyRootFlag);
     if (dummyIt != optionInfos.end()) {
-      optionInfos[name] = std::move(dummyIt->second);
+      // Erase before inserting: operator[] may grow the map and invalidate
+      // dummyIt.
+      auto value = std::move(dummyIt->second);
       optionInfos.erase(dummyIt);
+      optionInfos[name] = std::move(value);
     }
     getRootFlag() = name;
 


### PR DESCRIPTION
## Summary

- Fix crash on startup of all IREE compiler tools (`iree-compile`, `iree-opt`, etc.) caused by DenseMap iterator invalidation in `OptionsBinder::topLevelOpt`
- `optionInfos[name]` may grow the map when inserting a new key, invalidating the `dummyIt` iterator used on the next line to erase
- Erase before inserting to avoid using a stale iterator

Fixes #23411.

## Test plan

- `iree-opt --version` no longer crashes (was 100% repro before fix)