### PR TITLE
[Codegen][PCF] Add PCF lowering passes to backend pipelines

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -98,6 +98,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
         "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -157,6 +157,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::PCF::Transforms
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "hal_interface_workgroup_info.mlir",
             "illegal_configuration.mlir",
             "lowering_strategy_from_tuning_spec.mlir",
+            "pcf_lowering.mlir",
             "peel.mlir",
             "pipeline_arm_sme_streaming_mode_tests.mlir",
             "pipeline_disable_distribution_tests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "hal_interface_workgroup_info.mlir"
     "illegal_configuration.mlir"
     "lowering_strategy_from_tuning_spec.mlir"
+    "pcf_lowering.mlir"
     "peel.mlir"
     "pipeline_arm_sme_streaming_mode_tests.mlir"
     "pipeline_disable_distribution_tests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pcf_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pcf_lowering.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(func.func(iree-pcf-resolve-tokens, iree-pcf-convert-sref-to-memref, iree-pcf-lower-structural-pcf))" --split-input-file | FileCheck %s
+
+func.func @pcf_workgroup_loop(%arg0: memref<64xf32>) {
+  %c64 = arith.constant 64 : index
+  pcf.loop scope(#iree_codegen.workgroup_scope) count(%c64)
+    execute[%iv: index] {
+    %c0 = arith.constant 0.0 : f32
+    memref.store %c0, %arg0[%iv] : memref<64xf32>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_workgroup_loop
+//       CHECK:   hal.interface.workgroup.id
+//       CHECK:   hal.interface.workgroup.count
+//       CHECK:   scf.for

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -138,6 +138,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:ConfigUtils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",
+        "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -181,6 +181,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::ConfigUtils
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
+    iree::compiler::Codegen::Dialect::PCF::Transforms
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -50,6 +50,7 @@ iree_lit_test_suite(
             "llvmgpu_bufferize.mlir",
             "nvvm_pipeline_test.mlir",
             "pack_shared_memory_alloc.mlir",
+            "pcf_lowering.mlir",
             "pipeline_coalesced_dma.mlir",
             "prefetch_shared_memory.mlir",
             "reduction_pipeline_cuda.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_lit_test_suite(
     "llvmgpu_bufferize.mlir"
     "nvvm_pipeline_test.mlir"
     "pack_shared_memory_alloc.mlir"
+    "pcf_lowering.mlir"
     "pipeline_coalesced_dma.mlir"
     "prefetch_shared_memory.mlir"
     "reduction_pipeline_cuda.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pcf_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pcf_lowering.mlir
@@ -1,0 +1,75 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(func.func(iree-pcf-resolve-tokens, iree-pcf-convert-sref-to-memref, iree-pcf-lower-structural-pcf))" --split-input-file | FileCheck %s
+
+func.func @pcf_workgroup_loop(%arg0: memref<64xf32>) {
+  %c64 = arith.constant 64 : index
+  pcf.loop scope(#iree_codegen.workgroup_scope) count(%c64)
+    execute[%iv: index] {
+    %c0 = arith.constant 0.0 : f32
+    memref.store %c0, %arg0[%iv] : memref<64xf32>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_workgroup_loop
+// Verify workgroup IDs are materialized.
+//       CHECK:   hal.interface.workgroup.id
+//       CHECK:   hal.interface.workgroup.count
+
+// -----
+
+func.func @pcf_subgroup_generic() {
+  pcf.generic scope(#iree_gpu.subgroup_scope)
+    execute[%id: index, %n: index] {
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_subgroup_generic
+// Verify subgroup IDs are materialized.
+//       CHECK:   gpu.subgroup_id
+//       CHECK:   gpu.num_subgroups
+
+// -----
+
+func.func @pcf_lane_generic() {
+  pcf.generic scope(#iree_gpu.lane_scope)
+    execute[%id: index, %n: index] {
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_lane_generic
+// Verify lane IDs are materialized.
+//       CHECK:   gpu.lane_id
+//       CHECK:   gpu.subgroup_size
+
+// -----
+
+// Test nested workgroup -> subgroup -> lane pattern.
+func.func @pcf_nested_gpu_scopes(%arg0: memref<64xf32>) {
+  %c64 = arith.constant 64 : index
+  pcf.loop scope(#iree_codegen.workgroup_scope) count(%c64)
+    execute[%wg_id: index] {
+    pcf.generic scope(#iree_gpu.subgroup_scope)
+      execute[%sg_id: index, %sg_n: index] {
+      pcf.generic scope(#iree_gpu.lane_scope)
+        execute[%lane_id: index, %lane_n: index] {
+        %c0 = arith.constant 0.0 : f32
+        memref.store %c0, %arg0[%lane_id] : memref<64xf32>
+        pcf.return
+      }
+      pcf.return
+    }
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_nested_gpu_scopes
+// Verify workgroup, subgroup, and lane IDs are materialized.
+//       CHECK:   hal.interface.workgroup.id
+//       CHECK:   gpu.subgroup_id
+//       CHECK:   gpu.lane_id

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -96,6 +96,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common/GPU:GPUHeuristics",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -142,6 +142,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
+    iree::compiler::Codegen::Dialect::PCF::Transforms
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -54,6 +54,7 @@ iree_lit_test_suite(
             "lowering_scalar_dispatch.mlir",
             "map_memref_storage_class.mlir",
             "materialize_executable_conditions.mlir",
+            "pcf_lowering.mlir",
             "physical_storage_buffer_addresses.mlir",
             "pipeline_matmul_cooperative_ops.mlir",
             "pipeline_matmul_promotion.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_lit_test_suite(
     "lowering_scalar_dispatch.mlir"
     "map_memref_storage_class.mlir"
     "materialize_executable_conditions.mlir"
+    "pcf_lowering.mlir"
     "physical_storage_buffer_addresses.mlir"
     "pipeline_matmul_cooperative_ops.mlir"
     "pipeline_matmul_promotion.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pcf_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pcf_lowering.mlir
@@ -1,0 +1,75 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(func.func(iree-pcf-resolve-tokens, iree-pcf-convert-sref-to-memref, iree-pcf-lower-structural-pcf))" --split-input-file | FileCheck %s
+
+func.func @pcf_workgroup_loop(%arg0: memref<64xf32>) {
+  %c64 = arith.constant 64 : index
+  pcf.loop scope(#iree_codegen.workgroup_scope) count(%c64)
+    execute[%iv: index] {
+    %c0 = arith.constant 0.0 : f32
+    memref.store %c0, %arg0[%iv] : memref<64xf32>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_workgroup_loop
+// Verify workgroup IDs are materialized.
+//       CHECK:   hal.interface.workgroup.id
+//       CHECK:   hal.interface.workgroup.count
+
+// -----
+
+func.func @pcf_subgroup_generic() {
+  pcf.generic scope(#iree_gpu.subgroup_scope)
+    execute[%id: index, %n: index] {
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_subgroup_generic
+// Verify subgroup IDs are materialized.
+//       CHECK:   gpu.subgroup_id
+//       CHECK:   gpu.num_subgroups
+
+// -----
+
+func.func @pcf_lane_generic() {
+  pcf.generic scope(#iree_gpu.lane_scope)
+    execute[%id: index, %n: index] {
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_lane_generic
+// Verify lane IDs are materialized.
+//       CHECK:   gpu.lane_id
+//       CHECK:   gpu.subgroup_size
+
+// -----
+
+// Test nested workgroup -> subgroup -> lane pattern.
+func.func @pcf_nested_gpu_scopes(%arg0: memref<64xf32>) {
+  %c64 = arith.constant 64 : index
+  pcf.loop scope(#iree_codegen.workgroup_scope) count(%c64)
+    execute[%wg_id: index] {
+    pcf.generic scope(#iree_gpu.subgroup_scope)
+      execute[%sg_id: index, %sg_n: index] {
+      pcf.generic scope(#iree_gpu.lane_scope)
+        execute[%lane_id: index, %lane_n: index] {
+        %c0 = arith.constant 0.0 : f32
+        memref.store %c0, %arg0[%lane_id] : memref<64xf32>
+        pcf.return
+      }
+      pcf.return
+    }
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_nested_gpu_scopes
+// Verify workgroup, subgroup, and lane IDs are materialized.
+//       CHECK:   hal.interface.workgroup.id
+//       CHECK:   gpu.subgroup_id
+//       CHECK:   gpu.lane_id

--- a/compiler/src/iree/compiler/Codegen/VMVX/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/VMVX/BUILD.bazel
@@ -71,6 +71,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
         "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",

--- a/compiler/src/iree/compiler/Codegen/VMVX/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/VMVX/CMakeLists.txt
@@ -76,6 +76,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common::CPU::CommonCPUPasses
     iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::PCF::Transforms
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::HAL::IR

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "assign_constant_ordinals.mlir",
             "link_executables.mlir",
             "lower_linalg_microkernels.mlir",
+            "pcf_lowering.mlir",
             "pipeline.mlir",
             "select_lowering_strategy.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "assign_constant_ordinals.mlir"
     "link_executables.mlir"
     "lower_linalg_microkernels.mlir"
+    "pcf_lowering.mlir"
     "pipeline.mlir"
     "select_lowering_strategy.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pcf_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pcf_lowering.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(func.func(iree-pcf-resolve-tokens, iree-pcf-convert-sref-to-memref, iree-pcf-lower-structural-pcf))" --split-input-file | FileCheck %s
+
+func.func @pcf_workgroup_loop(%arg0: memref<64xf32>) {
+  %c64 = arith.constant 64 : index
+  pcf.loop scope(#iree_codegen.workgroup_scope) count(%c64)
+    execute[%iv: index] {
+    %c0 = arith.constant 0.0 : f32
+    memref.store %c0, %arg0[%iv] : memref<64xf32>
+    pcf.return
+  }
+  return
+}
+
+// CHECK-LABEL: @pcf_workgroup_loop
+//       CHECK:   hal.interface.workgroup.id
+//       CHECK:   hal.interface.workgroup.count
+//       CHECK:   scf.for


### PR DESCRIPTION
Add the three PCF lowering passes (ResolveTokens, ConvertSRefToMemRef, LowerStructuralPCF) to each backend pipeline at the beginning of the late stage lowering pipelines (lower to llvm/spirv).

Also adds smoketest files to verify PCF ops lower correctly for each backend. This required exposing the lower-to-llvm/spirv pipelines as actual callable pass pipelines for testing. We should aim to expand the testing coverage of these pipelines to make them more first class.