### PR TITLE
[DispatchCreation] Update split reduction heuristics for GEMM

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
@@ -14,7 +14,7 @@ util.func public @split_matmul(%arg0: tensor<32x40960xf32>, %arg1: tensor<40960x
 }
 
 // CHECK-LABEL: @split_matmul
-//       CHECK: iree_linalg_ext.split_reduction = [320 : index]
+//       CHECK: iree_linalg_ext.split_reduction = [160 : index]
 
 // -----
 
@@ -78,7 +78,7 @@ util.func public @split_multi_dims_gemm_3(%arg0: tensor<16x96x48x32xf32>, %arg1:
 }
 
 // CHECK-LABEL: @split_multi_dims_gemm_3
-//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 12 : index, 48 : index]
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 6 : index, 48 : index]
 
 // -----
 
@@ -103,17 +103,17 @@ util.func public @no_split_dynamic_matmul(%arg0: tensor<?x40960xf32>, %arg1: ten
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-util.func public @no_split_matmul_large_mn(%arg0: tensor<4096x150000xf32>, %arg1: tensor<150000x2048xf32>, %arg2: tensor<4096x2048xf32>) -> tensor<4096x2048xf32> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4096x150000xf32>, tensor<150000x2048xf32>) outs(%arg2 : tensor<4096x2048xf32>) {
+util.func public @no_split_matmul_small_ratio(%arg0: tensor<3840x21760xf32>, %arg1: tensor<21760x3840xf32>, %arg2: tensor<3840x3840xf32>) -> tensor<3840x3840xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<3840x21760xf32>, tensor<21760x3840xf32>) outs(%arg2 : tensor<3840x3840xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %1 = arith.mulf %in, %in_0 : f32
     %2 = arith.addf %1, %out : f32
     linalg.yield %2 : f32
-  } -> tensor<4096x2048xf32>
-  util.return %0 : tensor<4096x2048xf32>
+  } -> tensor<3840x3840xf32>
+  util.return %0 : tensor<3840x3840xf32>
 }
 
-// CHECK-LABEL: @no_split_matmul_large_mn
+// CHECK-LABEL: @no_split_matmul_small_ratio
 //   CHECK-NOT: iree_linalg_ext.split_reduction
 
 // -----

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
@@ -14,7 +14,7 @@ util.func public @split_matmul(%arg0: tensor<32x40960xf32>, %arg1: tensor<40960x
 }
 
 // CHECK-LABEL: @split_matmul
-//       CHECK: iree_linalg_ext.split_reduction = [160 : index]
+//       CHECK: iree_linalg_ext.split_reduction = [320 : index]
 
 // -----
 
@@ -78,7 +78,7 @@ util.func public @split_multi_dims_gemm_3(%arg0: tensor<16x96x48x32xf32>, %arg1:
 }
 
 // CHECK-LABEL: @split_multi_dims_gemm_3
-//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 6 : index, 48 : index]
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 12 : index, 48 : index]
 
 // -----
 
@@ -103,17 +103,17 @@ util.func public @no_split_dynamic_matmul(%arg0: tensor<?x40960xf32>, %arg1: ten
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-util.func public @no_split_matmul_small_ratio(%arg0: tensor<3840x21760xf32>, %arg1: tensor<21760x3840xf32>, %arg2: tensor<3840x3840xf32>) -> tensor<3840x3840xf32> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<3840x21760xf32>, tensor<21760x3840xf32>) outs(%arg2 : tensor<3840x3840xf32>) {
+util.func public @no_split_matmul_large_mn(%arg0: tensor<4096x150000xf32>, %arg1: tensor<150000x2268xf32>, %arg2: tensor<4096x2268xf32>) -> tensor<4096x2268xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4096x150000xf32>, tensor<150000x2268xf32>) outs(%arg2 : tensor<4096x2268xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %1 = arith.mulf %in, %in_0 : f32
     %2 = arith.addf %1, %out : f32
     linalg.yield %2 : f32
-  } -> tensor<3840x3840xf32>
-  util.return %0 : tensor<3840x3840xf32>
+  } -> tensor<4096x2268xf32>
+  util.return %0 : tensor<4096x2268xf32>
 }
 
-// CHECK-LABEL: @no_split_matmul_small_ratio
+// CHECK-LABEL: @no_split_matmul_large_mn
 //   CHECK-NOT: iree_linalg_ext.split_reduction
 
 // -----


### PR DESCRIPTION
There are two types of GEMM with large reduction dimensions need split reduction which are convolution-like shapes (y=1, x=1) and standard GEMM shapes. The current split heuristics were mostly derived from convolutions with x=1, y=1, which typically have relatively small m/n sizes and an extremely large k size. However, for GEMM the shape characteristics are different. The goal of this PR is to update the heuristics to improve the performance for GEMM shapes while keeping the performance for convolution-like shapes unchanged. The new decision parameters were derived from extensive experiments on Mi355.

With the new heuristics, the performance for convolution-like shapes (include all Prod and Proxy lists, also added new customer shapes) is as below:

```
Total tests: 381

Baseline total:     62729.17 us
New total:  61222.39 us
Overall speedup:    1.02x
Overall improvement: +2.40%

Tests improved:  67/381 (17.6%)
Tests neutral:   303/381 (79.5%)
Tests regressed: 11/381 (2.9%)
```

And for large-k GEMM shapes:

```
Total tests: 38

Baseline total:     127169.12 us
New total:  97637.32 us
Overall speedup:    1.30x
Overall improvement: +23.22%

Tests improved:  17/38 (44.7%)
Tests neutral:   18/38 (47.4%)
Tests regressed: 3/38 (7.9%)
```

