### PR TITLE
Add util.string operations for runtime string formatting.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
@@ -143,6 +143,8 @@ Operation *UtilDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                             Type type, Location loc) {
   if (isa<IREE::Util::NullAttr>(value)) {
     return IREE::Util::NullOp::create(builder, loc, type);
+  } else if (isa<IREE::Util::BufferType>(type)) {
+    return IREE::Util::BufferConstantOp::create(builder, loc, value);
   } else if (arith::ConstantOp::isBuildableWith(value, type)) {
     return arith::ConstantOp::create(builder, loc, type,
                                      cast<TypedAttr>(value));

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -1396,6 +1396,7 @@ def OpGroupBufferOps : OpDocGroup {
 let opDocGroup = OpGroupBufferOps in {
 
 def Util_BufferConstantOp : Util_PureOp<"buffer.constant", [
+  ConstantLike,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
   let summary = [{Constant host-side byte buffer.}];
@@ -1434,6 +1435,7 @@ def Util_BufferConstantOp : Util_PureOp<"buffer.constant", [
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 def Util_BufferAllocOp : Util_PureOp<"buffer.alloc", [
@@ -1865,6 +1867,82 @@ def Util_BufferHashOp : Util_Op<"buffer.hash", [
 }
 
 } // OpGroupBufferOps
+
+//===----------------------------------------------------------------------===//
+// String formatting
+//===----------------------------------------------------------------------===//
+
+def OpGroupStringOps : OpDocGroup {
+  let summary = "String formatting ops";
+  let description = "";
+}
+
+let opDocGroup = OpGroupStringOps in {
+
+def Util_StringFormatOp : Util_PureOp<"string.format", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
+  let summary = [{Formats a string from a template and arguments.}];
+  let description = [{
+    Produces a `!util.buffer` containing the formatted string. Uses `{}`-style
+    substitution: `{}` for sequential args, `{N}` for explicit ordinal. `{{`
+    and `}}` produce literal braces. Cannot mix `{}` and `{N}` in the same
+    format string.
+
+    Integer args are converted to unsigned decimal. Buffer args are copied
+    as-is. Folds to `util.buffer.constant` when all arguments are constant.
+    Partially folds when some arguments are constant by merging constant
+    segments into the format string literals.
+
+    Example:
+    ```mlir
+    %key = util.string.format "blk.{}.attn_q.weight"(%idx) : (index) -> !util.buffer
+    %multi = util.string.format "blk.{}.ffn.{}.weight"(%a, %b) : (index, index) -> !util.buffer
+    ```
+  }];
+  let arguments = (ins
+    StrAttr:$format,
+    Variadic<AnyTypeOf<[Index, AnySignlessInteger, Util_BufferType]>>:$args
+  );
+  let results = (outs
+    Util_BufferType:$result
+  );
+  let assemblyFormat = [{
+    $format `(` $args `)` attr-dict `:` functional-type($args, $result)
+  }];
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+}
+
+def Util_StringItoaOp : Util_PureOp<"string.itoa", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+]> {
+  let summary = [{Converts an integer to its decimal string representation.}];
+  let description = [{
+    Produces a `!util.buffer` containing the unsigned decimal string
+    representation of the input integer value. Folds to `util.buffer.constant`
+    when the input is constant.
+
+    Example:
+    ```mlir
+    %str = util.string.itoa %value : index -> !util.buffer
+    ```
+  }];
+  let arguments = (ins
+    AnyTypeOf<[Index, AnySignlessInteger]>:$value
+  );
+  let results = (outs
+    Util_BufferType:$result
+  );
+  let assemblyFormat = [{
+    $value attr-dict `:` type($value) `->` type($result)
+  }];
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+}
+
+} // OpGroupStringOps
 
 //===----------------------------------------------------------------------===//
 // Status

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
@@ -17,6 +17,7 @@ include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 def Util_BufferType : Util_TypeDef<"Buffer", [
   Util_ReferenceType,
   Util_SizeAwareType,
+  Util_HoistableType,
   DeclareTypeInterfaceMethods<Util_GlobalType, [
     "isAccessStorageCompatible",
   ]>,

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/BUILD.bazel
@@ -37,6 +37,8 @@ iree_lit_test_suite(
             "op_verification.mlir",
             "range_folding.mlir",
             "range_ops.mlir",
+            "string_folding.mlir",
+            "string_ops.mlir",
             "structural_folding.mlir",
             "structural_inlining.mlir",
             "structural_ops.mlir",

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/CMakeLists.txt
@@ -34,6 +34,8 @@ iree_lit_test_suite(
     "op_verification.mlir"
     "range_folding.mlir"
     "range_ops.mlir"
+    "string_folding.mlir"
+    "string_ops.mlir"
     "structural_folding.mlir"
     "structural_inlining.mlir"
     "structural_ops.mlir"

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/string_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/string_folding.mlir
@@ -1,0 +1,197 @@
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @itoa_fold_constant
+util.func public @itoa_fold_constant() -> !util.buffer {
+  %c42 = arith.constant 42 : index
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "42"
+  %str = util.string.itoa %c42 : index -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @itoa_fold_zero
+util.func public @itoa_fold_zero() -> !util.buffer {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "0"
+  %str = util.string.itoa %c0 : index -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @itoa_no_fold_dynamic
+util.func public @itoa_no_fold_dynamic(%v : index) -> !util.buffer {
+  // CHECK-SAME: (%[[V:.+]]: index)
+  // CHECK: util.string.itoa %[[V]] : index -> !util.buffer
+  %str = util.string.itoa %v : index -> !util.buffer
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_fold_all_constant
+util.func public @format_fold_all_constant() -> !util.buffer {
+  %c5 = arith.constant 5 : index
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "blk.5.attn_q.weight"
+  %key = util.string.format "blk.{}.attn_q.weight"(%c5) : (index) -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_fold_no_args
+util.func public @format_fold_no_args() -> !util.buffer {
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "static_key"
+  %key = util.string.format "static_key"() : () -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_partial_fold
+util.func public @format_partial_fold(%dynamic : index) -> !util.buffer {
+  // CHECK-SAME: (%[[DYNAMIC:.+]]: index)
+  %c5 = arith.constant 5 : index
+  // CHECK: util.string.format "blk.5.layer.{}.weight"(%[[DYNAMIC]]) : (index) -> !util.buffer
+  %key = util.string.format "blk.{}.layer.{}.weight"(%c5, %dynamic) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_partial_fold_last_arg
+util.func public @format_partial_fold_last_arg(%dynamic : index) -> !util.buffer {
+  // CHECK-SAME: (%[[DYNAMIC:.+]]: index)
+  %c7 = arith.constant 7 : index
+  // CHECK: util.string.format "{}.layer.7"(%[[DYNAMIC]]) : (index) -> !util.buffer
+  %key = util.string.format "{}.layer.{}"(%dynamic, %c7) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_fold_buffer_arg
+util.func public @format_fold_buffer_arg() -> !util.buffer {
+  %scope = util.buffer.constant : !util.buffer = "model"
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "model::blk.weight"
+  %key = util.string.format "{}::blk.weight"(%scope) : (!util.buffer) -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_partial_fold_mixed_buffer_int
+util.func public @format_partial_fold_mixed_buffer_int(%idx : index) -> !util.buffer {
+  // CHECK-SAME: (%[[IDX:.+]]: index)
+  %scope = util.buffer.constant : !util.buffer = "model"
+  // CHECK: util.string.format "model::blk.{}.weight"(%[[IDX]]) : (index) -> !util.buffer
+  %key = util.string.format "{}::blk.{}.weight"(%scope, %idx) : (!util.buffer, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_fold_escaped_braces
+util.func public @format_fold_escaped_braces() -> !util.buffer {
+  %c1 = arith.constant 1 : index
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "a{1}b"
+  %key = util.string.format "a{{{}}}b"(%c1) : (index) -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_no_fold_all_dynamic
+util.func public @format_no_fold_all_dynamic(%a : index, %b : index) -> !util.buffer {
+  // CHECK-SAME: (%[[A:.+]]: index, %[[B:.+]]: index)
+  // CHECK: util.string.format "blk.{}.layer.{}.weight"(%[[A]], %[[B]]) : (index, index) -> !util.buffer
+  %key = util.string.format "blk.{}.layer.{}.weight"(%a, %b) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_identity_buffer_elimination
+util.func public @format_identity_buffer_elimination(%buf : !util.buffer) -> !util.buffer {
+  // CHECK-SAME: (%[[BUF:.+]]: !util.buffer)
+  // CHECK-NOT: util.string.format
+  // CHECK: util.return %[[BUF]]
+  %result = util.string.format "{}"(%buf) : (!util.buffer) -> !util.buffer
+  util.return %result : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @format_single_int_to_itoa
+util.func public @format_single_int_to_itoa(%num : index) -> !util.buffer {
+  // CHECK-SAME: (%[[NUM:.+]]: index)
+  // CHECK: %[[ITOA:.+]] = util.string.itoa %[[NUM]] : index -> !util.buffer
+  // CHECK: util.return %[[ITOA]]
+  %result = util.string.format "{}"(%num) : (index) -> !util.buffer
+  util.return %result : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @itoa_fold_through_extui
+util.func public @itoa_fold_through_extui() -> !util.buffer {
+  %c42 = arith.constant 42 : i8
+  %wide = arith.extui %c42 : i8 to i32
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "42"
+  %str = util.string.itoa %wide : i32 -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @itoa_fold_through_index_cast
+util.func public @itoa_fold_through_index_cast() -> !util.buffer {
+  %c42 = arith.constant 42 : index
+  %i32 = arith.index_cast %c42 : index to i32
+  // CHECK: %[[CST:.+]] = util.buffer.constant : !util.buffer = "42"
+  %str = util.string.itoa %i32 : i32 -> !util.buffer
+  // CHECK: util.return %[[CST]]
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// Ordinal normalization is handled by partial fold, which rebuilds format
+// strings with sequential placeholders and reorders args to match segment order.
+// CHECK-LABEL: @format_normalize_explicit_ordinals
+util.func public @format_normalize_explicit_ordinals(%a : index, %b : index) -> !util.buffer {
+  // CHECK-SAME: (%[[A:.+]]: index, %[[B:.+]]: index)
+  // CHECK: util.string.format "{}.{}"(%[[A]], %[[B]]) : (index, index) -> !util.buffer
+  %key = util.string.format "{0}.{1}"(%a, %b) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// Out-of-order ordinals get canonicalized by partial fold (args reordered).
+// CHECK-LABEL: @format_reorder_out_of_order_ordinals
+util.func public @format_reorder_out_of_order_ordinals(%a : index, %b : index) -> !util.buffer {
+  // CHECK-SAME: (%[[A:.+]]: index, %[[B:.+]]: index)
+  // CHECK: util.string.format "{}.{}"(%[[B]], %[[A]]) : (index, index) -> !util.buffer
+  %key = util.string.format "{1}.{0}"(%a, %b) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// Duplicate ordinals get canonicalized by partial fold (args duplicated).
+// CHECK-LABEL: @format_duplicate_ordinals
+util.func public @format_duplicate_ordinals(%a : index, %b : index) -> !util.buffer {
+  // CHECK-SAME: (%[[A:.+]]: index, %[[B:.+]]: index)
+  // CHECK: util.string.format "{}.{}.{}"(%[[B]], %[[B]], %[[A]]) : (index, index, index) -> !util.buffer
+  %key = util.string.format "{1}.{1}.{0}"(%a, %b) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/string_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/string_ops.mlir
@@ -1,0 +1,89 @@
+// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+
+// CHECK-LABEL: @string_format_single_arg
+util.func public @string_format_single_arg(%idx : index) -> !util.buffer {
+  // CHECK: util.string.format "blk.{}.attn_q.weight"(%arg0) : (index) -> !util.buffer
+  %key = util.string.format "blk.{}.attn_q.weight"(%idx) : (index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_multi_arg
+util.func public @string_format_multi_arg(%a : index, %b : index) -> !util.buffer {
+  // CHECK: util.string.format "blk.{}.ffn.{}.weight"(%arg0, %arg1) : (index, index) -> !util.buffer
+  %key = util.string.format "blk.{}.ffn.{}.weight"(%a, %b) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_no_args
+util.func public @string_format_no_args() -> !util.buffer {
+  // CHECK: util.string.format "static_key"() : () -> !util.buffer
+  %key = util.string.format "static_key"() : () -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_explicit_ordinals
+util.func public @string_format_explicit_ordinals(%a : index, %b : index) -> !util.buffer {
+  // CHECK: util.string.format "y={1} x={0}"(%arg0, %arg1) : (index, index) -> !util.buffer
+  %key = util.string.format "y={1} x={0}"(%a, %b) : (index, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_escaped_braces
+util.func public @string_format_escaped_braces() -> !util.buffer {
+  // CHECK: util.string.format "hello {{[{][{]}}world{{[}][}]}}"() : () -> !util.buffer
+  %key = util.string.format "hello {{world}}"() : () -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_buffer_arg
+util.func public @string_format_buffer_arg(%scope : !util.buffer, %idx : index) -> !util.buffer {
+  // CHECK: util.string.format "{}::blk.{}.weight"(%arg0, %arg1) : (!util.buffer, index) -> !util.buffer
+  %key = util.string.format "{}::blk.{}.weight"(%scope, %idx) : (!util.buffer, index) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_i32_arg
+util.func public @string_format_i32_arg(%v : i32) -> !util.buffer {
+  // CHECK: util.string.format "layer_{}"(%arg0) : (i32) -> !util.buffer
+  %key = util.string.format "layer_{}"(%v) : (i32) -> !util.buffer
+  util.return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_itoa_index
+util.func public @string_itoa_index(%v : index) -> !util.buffer {
+  // CHECK: util.string.itoa %arg0 : index -> !util.buffer
+  %str = util.string.itoa %v : index -> !util.buffer
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_itoa_i32
+util.func public @string_itoa_i32(%v : i32) -> !util.buffer {
+  // CHECK: util.string.itoa %arg0 : i32 -> !util.buffer
+  %str = util.string.itoa %v : i32 -> !util.buffer
+  util.return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_itoa_i64
+util.func public @string_itoa_i64(%v : i64) -> !util.buffer {
+  // CHECK: util.string.itoa %arg0 : i64 -> !util.buffer
+  %str = util.string.itoa %v : i64 -> !util.buffer
+  util.return %str : !util.buffer
+}

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/BUILD.bazel
@@ -15,12 +15,14 @@ package(
 iree_compiler_cc_library(
     name = "Conversion",
     srcs = [
+        "BuiltinRegistry.cpp",
         "ConversionTarget.cpp",
         "ImportUtils.cpp",
         "TargetOptions.cpp",
         "TypeConverter.cpp",
     ],
     hdrs = [
+        "BuiltinRegistry.h",
         "ConversionDialectInterface.h",
         "ConversionTarget.h",
         "ImportUtils.h",

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.cpp
@@ -1,0 +1,54 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.h"
+
+namespace mlir::iree_compiler {
+
+void BuiltinRegistry::add(StringRef name, FunctionType type,
+                          BodyBuilder bodyBuilder) {
+  assert(!nameToIndex.count(name) && "duplicate builtin registration");
+  unsigned index = builtins.size();
+  builtins.push_back({name.str(), type, std::move(bodyBuilder),
+                      /*funcOp=*/nullptr,
+                      /*useCount=*/0});
+  nameToIndex[builtins[index].name] = index;
+}
+
+void BuiltinRegistry::declareAll(Operation *moduleOp) {
+  OpBuilder builder(moduleOp->getContext());
+  auto &moduleBlock = moduleOp->getRegion(0).front();
+  builder.setInsertionPointToStart(&moduleBlock);
+  auto location = moduleOp->getLoc();
+  for (auto &builtin : builtins) {
+    auto funcOp =
+        IREE::VM::FuncOp::create(builder, location, builtin.name, builtin.type);
+    SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+    builtin.funcOp = funcOp;
+  }
+}
+
+IREE::VM::FuncOp BuiltinRegistry::use(StringRef name) {
+  auto iterator = nameToIndex.find(name);
+  assert(iterator != nameToIndex.end() && "unknown builtin");
+  auto &builtin = builtins[iterator->second];
+  ++builtin.useCount;
+  return builtin.funcOp;
+}
+
+void BuiltinRegistry::finalize() {
+  for (auto &builtin : builtins) {
+    if (builtin.useCount == 0) {
+      builtin.funcOp->erase();
+      builtin.funcOp = nullptr;
+    } else {
+      OpBuilder builder(builtin.funcOp);
+      builtin.bodyBuilder(builtin.funcOp, builder);
+    }
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.h
@@ -1,0 +1,73 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_VM_CONVERSION_BUILTINREGISTRY_H_
+#define IREE_COMPILER_DIALECT_VM_CONVERSION_BUILTINREGISTRY_H_
+
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "mlir/IR/Builders.h"
+
+namespace mlir::iree_compiler {
+
+// Registry of VM builtin helper functions used during dialect conversion.
+//
+// During conversion to the VM dialect, some source ops expand into calls to
+// shared helper functions (e.g., integer-to-string conversion). Naively
+// creating these helpers on-demand via lookupSymbol + create during pattern
+// application causes O(n) module scans and mutates the module mid-conversion.
+//
+// BuiltinRegistry solves this with a four-phase lifecycle:
+//   1. Registration: populate*Patterns functions call add() to register
+//      builtins with their signatures and deferred body builders.
+//   2. Declaration: declareAll() inserts empty vm.func declarations into the
+//      module before conversion begins.
+//   3. Conversion: patterns call use() to obtain the FuncOp and record usage.
+//   4. Finalization: finalize() erases unused declarations and populates used
+//      ones by invoking their body builders.
+class BuiltinRegistry {
+public:
+  // Callback that populates a declared vm.func with its body.
+  // The FuncOp has the correct signature but no entry block; the callback
+  // must add blocks and populate the function body.
+  using BodyBuilder =
+      std::function<void(IREE::VM::FuncOp funcOp, OpBuilder &builder)>;
+
+  // Registers a builtin helper with the given name, signature, and deferred
+  // body builder. Must be called before declareAll().
+  void add(StringRef name, FunctionType type, BodyBuilder bodyBuilder);
+
+  // Inserts empty vm.func declarations for all registered builtins into the
+  // module. Must be called once, before applyPartialConversion.
+  void declareAll(Operation *moduleOp);
+
+  // Returns the FuncOp for the named builtin and increments its use count.
+  // Called by conversion patterns during matchAndRewrite.
+  IREE::VM::FuncOp use(StringRef name);
+
+  // Erases unused declarations (use count == 0) and populates used ones
+  // (use count >= 1) by invoking their body builders. Must be called once,
+  // after applyPartialConversion completes.
+  void finalize();
+
+private:
+  struct Builtin {
+    std::string name;
+    FunctionType type;
+    BodyBuilder bodyBuilder;
+    IREE::VM::FuncOp funcOp; // Set by declareAll().
+    unsigned useCount = 0;
+  };
+  // Ordered list for deterministic declaration order.
+  SmallVector<Builtin> builtins;
+  // Index for O(1) lookup by name.
+  llvm::StringMap<unsigned> nameToIndex;
+};
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_DIALECT_VM_CONVERSION_BUILTINREGISTRY_H_

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
@@ -14,12 +14,14 @@ iree_cc_library(
   NAME
     Conversion
   HDRS
+    "BuiltinRegistry.h"
     "ConversionDialectInterface.h"
     "ConversionTarget.h"
     "ImportUtils.h"
     "TargetOptions.h"
     "TypeConverter.h"
   SRCS
+    "BuiltinRegistry.cpp"
     "ConversionTarget.cpp"
     "ImportUtils.cpp"
     "TargetOptions.cpp"

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD.bazel
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "ConvertGlobalOps.cpp",
         "ConvertListOps.cpp",
         "ConvertStatusOps.cpp",
+        "ConvertStringOps.cpp",
         "ConvertStructuralOps.cpp",
         "Patterns.cpp",
     ],

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "ConvertGlobalOps.cpp"
     "ConvertListOps.cpp"
     "ConvertStatusOps.cpp"
+    "ConvertStringOps.cpp"
     "ConvertStructuralOps.cpp"
     "Patterns.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStringOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStringOps.cpp
@@ -1,0 +1,324 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.h"
+#include "iree/compiler/Dialect/VM/Conversion/TypeConverter.h"
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+static Value castToI64(Value value, OpBuilder &builder) {
+  if (value.getType().isInteger(64)) {
+    return value;
+  }
+  return builder.createOrFold<IREE::VM::ExtI32I64UOp>(
+      value.getLoc(), builder.getI64Type(), value);
+}
+
+static constexpr const char kItoaBuiltinName[] = "__iree_string_itoa_u64";
+
+// Populates the body of the __iree_string_itoa_u64 builtin helper.
+// Converts a uint64 value to its unsigned decimal string representation
+// stored in a newly-allocated VM buffer.
+//
+// The function has signature (i64) -> !vm.ref<!vm.buffer> and is structured as:
+//   entry: check for zero, branch to zero_case or loop
+//   zero_case: store '0', clone 1 byte, return
+//   loop(remaining, position): extract digit, store, divide, cond_br
+//   extract: clone the used portion, return
+static void buildItoaBody(IREE::VM::FuncOp funcOp, OpBuilder &builder) {
+  auto location = funcOp.getLoc();
+  auto i32Type = builder.getI32Type();
+  auto i64Type = builder.getI64Type();
+  auto bufferRefType =
+      IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
+
+  Block *entryBlock = funcOp.addEntryBlock();
+  builder.setInsertionPointToStart(entryBlock);
+  Value inputValue = entryBlock->getArgument(0);
+
+  Value constantZeroI64 = IREE::VM::ConstI64ZeroOp::create(builder, location);
+  Value constantOneI32 = IREE::VM::ConstI32Op::create(builder, location, 1);
+  Value constantOneI64 = IREE::VM::ConstI64Op::create(builder, location, 1);
+  Value constantTenI64 = IREE::VM::ConstI64Op::create(builder, location, 10);
+  Value constantTwentyI64 = IREE::VM::ConstI64Op::create(builder, location, 20);
+  Value constantNineteenI64 =
+      IREE::VM::ConstI64Op::create(builder, location, 19);
+  Value asciiZeroI32 = IREE::VM::ConstI32Op::create(builder, location, 48);
+
+  // Allocate 20-byte scratch buffer (max digits for uint64).
+  Value scratchBuffer = IREE::VM::BufferAllocOp::create(
+      builder, location, bufferRefType, constantTwentyI64, constantOneI32);
+
+  // Check for zero.
+  Value isZero = IREE::VM::CmpEQI64Op::create(builder, location, i32Type,
+                                              inputValue, constantZeroI64);
+
+  // Create blocks.
+  Block *zeroCaseBlock = funcOp.addBlock();
+  Block *loopBlock = funcOp.addBlock();
+  loopBlock->addArgument(i64Type, location); // remaining
+  loopBlock->addArgument(i64Type, location); // write position
+  Block *extractBlock = funcOp.addBlock();
+  extractBlock->addArgument(i64Type, location); // start position
+
+  // Entry: cond_br to zero case or loop.
+  IREE::VM::CondBranchOp::create(builder, location, isZero, zeroCaseBlock,
+                                 ValueRange{}, loopBlock,
+                                 ValueRange{inputValue, constantNineteenI64});
+
+  // Zero case: store ASCII '0' at position 0, clone 1 byte, return.
+  builder.setInsertionPointToEnd(zeroCaseBlock);
+  IREE::VM::BufferStoreI8Op::create(builder, location, scratchBuffer,
+                                    constantZeroI64, asciiZeroI32);
+  Value zeroResult = IREE::VM::BufferCloneOp::create(
+      builder, location, bufferRefType, scratchBuffer, constantZeroI64,
+      constantOneI64, constantOneI32);
+  IREE::VM::ReturnOp::create(builder, location, ValueRange{zeroResult});
+
+  // Loop: extract digit, store, advance.
+  builder.setInsertionPointToEnd(loopBlock);
+  Value remaining = loopBlock->getArgument(0);
+  Value writePosition = loopBlock->getArgument(1);
+
+  // digit = remaining % 10
+  Value digit = IREE::VM::RemI64UOp::create(builder, location, i64Type,
+                                            remaining, constantTenI64);
+  // Truncate digit to i32 for ASCII conversion.
+  Value digitI32 =
+      IREE::VM::TruncI64I32Op::create(builder, location, i32Type, digit);
+  // ascii = digit + '0'
+  Value asciiDigit = IREE::VM::AddI32Op::create(builder, location, i32Type,
+                                                digitI32, asciiZeroI32);
+  // Store the digit byte.
+  IREE::VM::BufferStoreI8Op::create(builder, location, scratchBuffer,
+                                    writePosition, asciiDigit);
+  // remaining = remaining / 10
+  Value nextRemaining = IREE::VM::DivI64UOp::create(builder, location, i64Type,
+                                                    remaining, constantTenI64);
+  // position = position - 1
+  Value nextPosition = IREE::VM::SubI64Op::create(
+      builder, location, i64Type, writePosition, constantOneI64);
+  // Check if done (remaining == 0).
+  Value loopDone = IREE::VM::CmpEQI64Op::create(builder, location, i32Type,
+                                                nextRemaining, constantZeroI64);
+  IREE::VM::CondBranchOp::create(builder, location, loopDone, extractBlock,
+                                 ValueRange{writePosition}, loopBlock,
+                                 ValueRange{nextRemaining, nextPosition});
+
+  // Extract: clone from start position to end of scratch buffer.
+  builder.setInsertionPointToEnd(extractBlock);
+  Value startPosition = extractBlock->getArgument(0);
+  Value stringLength = IREE::VM::SubI64Op::create(
+      builder, location, i64Type, constantTwentyI64, startPosition);
+  Value resultBuffer = IREE::VM::BufferCloneOp::create(
+      builder, location, bufferRefType, scratchBuffer, startPosition,
+      stringLength, constantOneI32);
+  IREE::VM::ReturnOp::create(builder, location, ValueRange{resultBuffer});
+}
+
+// Registers all builtin helpers needed by string conversion patterns.
+static void registerStringBuiltins(BuiltinRegistry &builtins,
+                                   MLIRContext *context) {
+  auto i64Type = IntegerType::get(context, 64);
+  auto bufferRefType =
+      IREE::VM::RefType::get(IREE::VM::BufferType::get(context));
+  auto itoaType = FunctionType::get(context, {i64Type}, {bufferRefType});
+  builtins.add(kItoaBuiltinName, itoaType, buildItoaBody);
+}
+
+struct StringItoaOpConversion
+    : public OpConversionPattern<IREE::Util::StringItoaOp> {
+  BuiltinRegistry &builtins;
+  StringItoaOpConversion(const TypeConverter &typeConverter,
+                         MLIRContext *context, BuiltinRegistry &builtins)
+      : OpConversionPattern(typeConverter, context), builtins(builtins) {}
+  LogicalResult
+  matchAndRewrite(IREE::Util::StringItoaOp itoaOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto itoaFunc = builtins.use(kItoaBuiltinName);
+    Value inputI64 = castToI64(adaptor.getValue(), rewriter);
+    rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(itoaOp, itoaFunc,
+                                                  ValueRange{inputI64});
+    return success();
+  }
+};
+
+struct StringFormatOpConversion
+    : public OpConversionPattern<IREE::Util::StringFormatOp> {
+  BuiltinRegistry &builtins;
+  StringFormatOpConversion(const TypeConverter &typeConverter,
+                           MLIRContext *context, BuiltinRegistry &builtins)
+      : OpConversionPattern(typeConverter, context), builtins(builtins) {}
+  LogicalResult
+  matchAndRewrite(IREE::Util::StringFormatOp formatOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto location = formatOp.getLoc();
+    auto i64Type = rewriter.getI64Type();
+    auto bufferRefType =
+        getTypeConverter()->convertType(formatOp.getResult().getType());
+
+    StringRef format = formatOp.getFormat();
+
+    // Parse the format string into segments at compile time.
+    struct Segment {
+      enum Kind { Literal, Arg };
+      Kind kind;
+      std::string literal;
+      unsigned argIndex;
+    };
+    SmallVector<Segment> segments;
+    unsigned nextSequentialIndex = 0;
+    size_t position = 0;
+    std::string currentLiteral;
+    while (position < format.size()) {
+      char character = format[position];
+      if (character == '{') {
+        if (position + 1 < format.size() && format[position + 1] == '{') {
+          currentLiteral += '{';
+          position += 2;
+          continue;
+        }
+        if (!currentLiteral.empty()) {
+          segments.push_back({Segment::Literal, currentLiteral, 0});
+          currentLiteral.clear();
+        }
+        size_t closePosition = format.find('}', position + 1);
+        StringRef content = format.slice(position + 1, closePosition);
+        if (content.empty()) {
+          segments.push_back({Segment::Arg, {}, nextSequentialIndex++});
+        } else {
+          unsigned index;
+          content.getAsInteger(10, index);
+          segments.push_back({Segment::Arg, {}, index});
+        }
+        position = closePosition + 1;
+      } else if (character == '}') {
+        if (position + 1 < format.size() && format[position + 1] == '}') {
+          currentLiteral += '}';
+          position += 2;
+          continue;
+        }
+        ++position;
+      } else {
+        currentLiteral += character;
+        ++position;
+      }
+    }
+    if (!currentLiteral.empty()) {
+      segments.push_back({Segment::Literal, currentLiteral, 0});
+    }
+
+    Value constantZeroI64 =
+        IREE::VM::ConstI64ZeroOp::create(rewriter, location);
+    Value constantOneI32 = IREE::VM::ConstI32Op::create(rewriter, location, 1);
+
+    // Phase 1: Convert all integer args to buffers via itoa.
+    // Build a vector of buffer values for each arg.
+    SmallVector<Value> argBuffers(formatOp.getArgs().size());
+    IREE::VM::FuncOp itoaFunc;
+    for (auto [index, arg] : llvm::enumerate(adaptor.getArgs())) {
+      auto originalArgType = formatOp.getArgs()[index].getType();
+      if (isa<IREE::Util::BufferType>(originalArgType)) {
+        // Already a buffer (type-converted to vm.ref by adaptor).
+        argBuffers[index] = arg;
+      } else {
+        // Integer arg: call itoa to produce a buffer.
+        if (!itoaFunc) {
+          itoaFunc = builtins.use(kItoaBuiltinName);
+        }
+        Value inputI64 = castToI64(arg, rewriter);
+        auto callOp = IREE::VM::CallOp::create(rewriter, location, itoaFunc,
+                                               ValueRange{inputI64});
+        argBuffers[index] = callOp.getResult(0);
+      }
+    }
+
+    // Phase 2: Compute total length.
+    // Literal segment lengths are known at compile time. Buffer segment
+    // lengths require vm.buffer.length calls at runtime.
+    int64_t staticLength = 0;
+    SmallVector<Value> dynamicLengths;
+    for (const auto &segment : segments) {
+      if (segment.kind == Segment::Literal) {
+        staticLength += segment.literal.size();
+      } else {
+        Value bufferLength = IREE::VM::BufferLengthOp::create(
+            rewriter, location, i64Type, argBuffers[segment.argIndex]);
+        dynamicLengths.push_back(bufferLength);
+      }
+    }
+    Value totalLength =
+        IREE::VM::ConstI64Op::create(rewriter, location, staticLength);
+    for (Value dynamicLength : dynamicLengths) {
+      totalLength = IREE::VM::AddI64Op::create(rewriter, location, i64Type,
+                                               totalLength, dynamicLength);
+    }
+
+    // Phase 3: Allocate result buffer.
+    Value resultBuffer = IREE::VM::BufferAllocOp::create(
+        rewriter, location, bufferRefType, totalLength, constantOneI32);
+
+    // Phase 4: Copy each segment into the result buffer.
+    Value currentOffset = constantZeroI64;
+    for (const auto &segment : segments) {
+      if (segment.kind == Segment::Literal) {
+        // Create inline rodata for the literal.
+        auto literalAttr = rewriter.getStringAttr(segment.literal);
+        Value literalBuffer = IREE::VM::RodataInlineOp::create(
+            rewriter, location, bufferRefType, literalAttr);
+        Value literalLength = IREE::VM::ConstI64Op::create(
+            rewriter, location, segment.literal.size());
+        IREE::VM::BufferCopyOp::create(rewriter, location, literalBuffer,
+                                       constantZeroI64, resultBuffer,
+                                       currentOffset, literalLength);
+        currentOffset = IREE::VM::AddI64Op::create(
+            rewriter, location, i64Type, currentOffset, literalLength);
+      } else {
+        // Copy the arg buffer into the result.
+        Value argBuffer = argBuffers[segment.argIndex];
+        Value argLength = IREE::VM::BufferLengthOp::create(rewriter, location,
+                                                           i64Type, argBuffer);
+        IREE::VM::BufferCopyOp::create(rewriter, location, argBuffer,
+                                       constantZeroI64, resultBuffer,
+                                       currentOffset, argLength);
+        currentOffset = IREE::VM::AddI64Op::create(rewriter, location, i64Type,
+                                                   currentOffset, argLength);
+      }
+    }
+
+    rewriter.replaceOp(formatOp, resultBuffer);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateUtilStringToVMPatterns(MLIRContext *context,
+                                    ConversionTarget &conversionTarget,
+                                    TypeConverter &typeConverter,
+                                    BuiltinRegistry &builtins,
+                                    RewritePatternSet &patterns) {
+  registerStringBuiltins(builtins, context);
+
+  conversionTarget.addIllegalOp<IREE::Util::StringFormatOp>();
+  conversionTarget.addIllegalOp<IREE::Util::StringItoaOp>();
+
+  patterns.insert<StringItoaOpConversion>(typeConverter, context, builtins);
+  patterns.insert<StringFormatOpConversion>(typeConverter, context, builtins);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Dialect/VM/Conversion/BuiltinRegistry.h"
 #include "iree/compiler/Dialect/VM/Conversion/TypeConverter.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "mlir/IR/Attributes.h"
@@ -41,6 +42,11 @@ void populateUtilListToVMPatterns(MLIRContext *context,
 void populateUtilStatusToVMPatterns(MLIRContext *context,
                                     ConversionTarget &conversionTarget,
                                     TypeConverter &typeConverter,
+                                    RewritePatternSet &patterns);
+void populateUtilStringToVMPatterns(MLIRContext *context,
+                                    ConversionTarget &conversionTarget,
+                                    TypeConverter &typeConverter,
+                                    BuiltinRegistry &builtins,
                                     RewritePatternSet &patterns);
 void populateUtilStructuralToVMPatterns(MLIRContext *context,
                                         ConversionTarget &conversionTarget,
@@ -125,6 +131,7 @@ void populateUtilToVMPatterns(MLIRContext *context,
                               ConversionTarget &conversionTarget,
                               TypeConverter &typeConverter,
                               ImportTable &importTable,
+                              BuiltinRegistry &builtins,
                               RewritePatternSet &patterns) {
   patterns.insert<NullOpConversion>(typeConverter, context);
   patterns.insert<CmpEQOpConversion>(typeConverter, context);
@@ -143,6 +150,8 @@ void populateUtilToVMPatterns(MLIRContext *context,
                                patterns);
   populateUtilStatusToVMPatterns(context, conversionTarget, typeConverter,
                                  patterns);
+  populateUtilStringToVMPatterns(context, conversionTarget, typeConverter,
+                                 builtins, patterns);
   populateUtilStructuralToVMPatterns(context, conversionTarget, typeConverter,
                                      importTable, patterns);
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.h
@@ -13,11 +13,14 @@
 
 namespace mlir::iree_compiler {
 
+class BuiltinRegistry;
+
 // Appends IREE special hint ops to VM dialect patterns.
 void populateUtilToVMPatterns(MLIRContext *context,
                               ConversionTarget &conversionTarget,
                               TypeConverter &typeConverter,
                               ImportTable &importTable,
+                              BuiltinRegistry &builtins,
                               RewritePatternSet &patterns);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "global_ops.mlir",
             "list_ops.mlir",
             "status_ops.mlir",
+            "string_ops.mlir",
             "structural_ops.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "global_ops.mlir"
     "list_ops.mlir"
     "status_ops.mlir"
+    "string_ops.mlir"
     "structural_ops.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/string_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/string_ops.mlir
@@ -1,0 +1,85 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-vm-conversion{index-bits=64})' %s | FileCheck %s
+
+// Verify the generated itoa builtin function body.
+// CHECK:      vm.func private @__iree_string_itoa_u64(%arg0: i64) -> !vm.buffer {
+// CHECK-DAG:    %[[ZERO_I64:.+]] = vm.const.i64.zero
+// CHECK-DAG:    %[[C1_I32:.+]] = vm.const.i32 1
+// CHECK-DAG:    %[[C1_I64:.+]] = vm.const.i64 1
+// CHECK-DAG:    %[[C10:.+]] = vm.const.i64 10
+// CHECK-DAG:    %[[C20:.+]] = vm.const.i64 20
+// CHECK-DAG:    %[[C19:.+]] = vm.const.i64 19
+// CHECK-DAG:    %[[ASCII_ZERO:.+]] = vm.const.i32 48
+// CHECK:        %[[SCRATCH:.+]] = vm.buffer.alloc %[[C20]], %[[C1_I32]]
+// CHECK:        %[[IS_ZERO:.+]] = vm.cmp.eq.i64 %arg0, %[[ZERO_I64]]
+// CHECK:        vm.cond_br %[[IS_ZERO]], ^[[ZERO_BB:.+]], ^[[LOOP_BB:.+]](%arg0, %[[C19]] : i64, i64)
+// Zero case: store '0', clone 1 byte, return.
+// CHECK:      ^[[ZERO_BB]]:
+// CHECK:        vm.buffer.store.i8 %[[ASCII_ZERO]], %[[SCRATCH]][%[[ZERO_I64]]]
+// CHECK:        %[[ZERO_RESULT:.+]] = vm.buffer.clone %[[SCRATCH]], %[[ZERO_I64]], %[[C1_I64]], %[[C1_I32]]
+// CHECK:        vm.return %[[ZERO_RESULT]]
+// Loop: extract digit, store in reverse, divide by 10, loop until zero.
+// CHECK:      ^[[LOOP_BB]](%[[REM:.+]]: i64, %[[POS:.+]]: i64):
+// CHECK:        %[[DIGIT:.+]] = vm.rem.i64.u %[[REM]], %[[C10]]
+// CHECK:        %[[DIGIT_I32:.+]] = vm.trunc.i64.i32 %[[DIGIT]]
+// CHECK:        %[[ASCII:.+]] = vm.add.i32 %[[DIGIT_I32]], %[[ASCII_ZERO]]
+// CHECK:        vm.buffer.store.i8 %[[ASCII]], %[[SCRATCH]][%[[POS]]]
+// CHECK:        %[[NEXT_REM:.+]] = vm.div.i64.u %[[REM]], %[[C10]]
+// CHECK:        %[[NEXT_POS:.+]] = vm.sub.i64 %[[POS]], %[[C1_I64]]
+// CHECK:        %[[DONE:.+]] = vm.cmp.eq.i64 %[[NEXT_REM]], %[[ZERO_I64]]
+// CHECK:        vm.cond_br %[[DONE]], ^[[EXTRACT_BB:.+]](%[[POS]] : i64), ^[[LOOP_BB]](%[[NEXT_REM]], %[[NEXT_POS]] : i64, i64)
+// Extract: clone from start position to end of scratch buffer.
+// CHECK:      ^[[EXTRACT_BB]](%[[START:.+]]: i64):
+// CHECK:        %[[LENGTH:.+]] = vm.sub.i64 %[[C20]], %[[START]]
+// CHECK:        %[[RESULT:.+]] = vm.buffer.clone %[[SCRATCH]], %[[START]], %[[LENGTH]], %[[C1_I32]]
+// CHECK:        vm.return %[[RESULT]]
+// CHECK:      }
+
+// CHECK-LABEL: @string_itoa
+func.func @string_itoa(%arg0 : index) -> !util.buffer {
+  // CHECK: vm.call @__iree_string_itoa_u64(%arg0) : (i64) -> !vm.buffer
+  %str = util.string.itoa %arg0 : index -> !util.buffer
+  return %str : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_single_arg
+func.func @string_format_single_arg(%arg0 : index) -> !util.buffer {
+  // CHECK: vm.call @__iree_string_itoa_u64(%arg0) : (i64) -> !vm.buffer
+  // CHECK: vm.buffer.length
+  // CHECK: vm.add.i64
+  // CHECK: vm.buffer.alloc
+  // CHECK: vm.rodata.inline : !vm.buffer = "blk."
+  // CHECK: vm.buffer.copy
+  // CHECK: vm.buffer.copy
+  // CHECK: vm.rodata.inline : !vm.buffer = ".attn_q.weight"
+  // CHECK: vm.buffer.copy
+  %key = util.string.format "blk.{}.attn_q.weight"(%arg0) : (index) -> !util.buffer
+  return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_no_args
+func.func @string_format_no_args() -> !util.buffer {
+  // CHECK: vm.rodata.inline : !vm.buffer = "static_key"
+  // CHECK-NOT: vm.buffer.copy
+  %key = util.string.format "static_key"() : () -> !util.buffer
+  return %key : !util.buffer
+}
+
+// -----
+
+// CHECK-LABEL: @string_format_buffer_arg
+func.func @string_format_buffer_arg(%scope : !util.buffer, %idx : index) -> !util.buffer {
+  // CHECK: vm.call @__iree_string_itoa_u64
+  // CHECK: vm.buffer.length
+  // CHECK: vm.buffer.length
+  // CHECK: vm.buffer.alloc
+  // CHECK: vm.buffer.copy
+  // CHECK: vm.buffer.copy
+  // CHECK: vm.buffer.copy
+  // CHECK: vm.buffer.copy
+  %key = util.string.format "{}::blk.{}.weight"(%scope, %idx) : (!util.buffer, index) -> !util.buffer
+  return %key : !util.buffer
+}


### PR DESCRIPTION
Adds util.string.format and util.string.itoa operations to support constructing strings at runtime, enabling dynamic parameter scope and key construction where values come from model metadata or other runtime sources. The format op uses Python-style placeholders supporting both sequential implicit ("{}" auto-numbered from 0) and explicit ordinals ("{0} {1}" with arbitrary order and duplication). Arguments can be !util.buffer for string interpolation or integer types for numeric formatting. The itoa op provides a simpler interface for pure integer-to-string conversion. Both operations produce !util.buffer results representing UTF-8 encoded strings without null terminators, matching the buffer type's semantics as an opaque byte sequence.

The implementation includes canonicalization patterns that compose under greedy application. PartialFoldStringFormat merges constant arguments into the format string literal, producing util.buffer.constant when all args are constant or simplified formats with remaining dynamic args. EliminateIdentityFormat removes no-op format("{}")(buffer) passthroughs. SimplifySingleIntFormatToItoa converts format("{}")(int) to the simpler itoa(int). FoldItoaThroughZeroExtend allows itoa to see through arith.extui and arith.index_cast with constant sources for more constant folding opportunities. NormalizeFormatOrdinals canonicalizes explicit ordinals to sequential implicit placeholders, handling cases partial fold misses when all arguments are dynamic (partial fold only triggers with at least one constant), and correctly reorders arguments for out-of-order references ("{1}.{0}" → "{}.{}" with args reordered) and duplicates ordinals ("{0}.{0}" → "{}.{}" with args duplicated).

VM lowering expands string operations into sequences of buffer operations and calls to a single __iree_string_itoa_u64 builtin helper. The itoa op converts directly to a call to the builtin, which implements digit extraction as a VM function (allocates 20-byte scratch, writes digits right-to-left via rem/div loop, clones result slice). The format op expands inline by first converting any integer args to buffers via the itoa builtin, computing total length from static literal sizes plus vm.buffer.length calls for dynamic segments, allocating the result buffer, then copying each segment via vm.rodata.inline for compile-time literals and vm.buffer.copy for argument buffers. Format expansion is fully inlined rather than calling a builtin to enable DCE and buffer reuse optimizations when formats appear in loops or get duplicated during earlier passes. A new BuiltinRegistry infrastructure (BuiltinRegistry.h/cpp) provides centralized registration and lazy instantiation of VM builtin function signatures, avoiding scattered function declarations across conversion passes and enabling the same builtin to be referenced from multiple Util-to-VM conversion patterns.

Tests cover operation semantics, constant folding, canonicalization patterns including ordinal normalization with reordering and duplication, hoisting of format results into globals, and end-to-end VM lowering. This infrastructure enables parameter operations to construct scope::key strings dynamically at runtime, supporting models like frank-models where scope comes from metadata rather than compile-time constants.