### PR TITLE
Fix iree-link Python package distribution

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -166,6 +166,7 @@ declare_mlir_python_sources(IREECompilerAPIPythonTools
     tools/import_onnx/importer_externalization_overrides.py
     tools/ir_tool/__main__.py
     tools/scripts/iree_compile/__main__.py
+    tools/scripts/iree_link/__main__.py
     tools/scripts/iree_opt/__main__.py
 )
 

--- a/compiler/bindings/python/iree/compiler/_package_test.py
+++ b/compiler/bindings/python/iree/compiler/_package_test.py
@@ -36,6 +36,7 @@ print("IREE version:", v.VERSION)
 
 check_tool("iree-compile", ["--help"], "IREE compilation driver")
 check_tool("iree-ir-tool", ["--help"], "IREE IR Tool")
+check_tool("iree-link", ["--help"], "IREE module linker")
 check_tool("iree-opt", ["--help"], "IREE modular optimizer driver")
 
 # ONNX dependent.


### PR DESCRIPTION
## Summary

The `iree-link` console script wrapper module was not included in the Python package manifest, causing:
```
ModuleNotFoundError: No module named 'iree.compiler.tools.scripts.iree_link'
```

This fixes an oversight from #22419 by:
- Adding `tools/scripts/iree_link/__main__.py` to the CMake SOURCES list
- Adding `iree-link` to `_package_test.py` so this is caught by CI going forward

## Test plan

- [ ] CI runs `_package_test.py` which now verifies `iree-link --help` works

🤖 Generated with [Claude Code](https://claude.ai/code)

Signed-off-by: Stella Laurenzo <stellaraccident@gmail.com>