### PR TITLE
[VectorDistribute] add support padding integer attention masks 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_online_attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_online_attention.mlir
@@ -93,6 +93,53 @@ func.func @online_attention_tile_then_pad(%query: tensor<192x1024x64xf32>, %key:
 #mapK = affine_map<(batch, m, k1, k2, n) -> (batch, k2, k1)>
 #mapV = affine_map<(batch, m, k1, k2, n) -> (batch, k2, n)>
 #mapS = affine_map<(batch, m, k1, k2, n) -> ()>
+#mapM = affine_map<(batch, m, k1, k2, n) -> (batch, m, k2)>
+#mapO = affine_map<(batch, m, k1, k2, n) -> (batch, m, n)>
+#mapR = affine_map<(batch, m, k1, k2, n) -> (batch, m)>
+
+//                                                        batch, m, k1, k2, n
+#lowering_config = #iree_gpu.lowering_config<{reduction = [   0, 0,  0, 32, 0]}>
+
+// CHECK-LABEL: func.func @online_attention_tile_then_pad_bool_mask
+func.func @online_attention_tile_then_pad_bool_mask(%query: tensor<192x1024x64xf32>, %key: tensor<192x?x64xf32>, %value: tensor<192x?x64xf32>, %mask: tensor<192x1024x?xi1>) -> tensor<192x1024x64xf32> {
+  %scale = arith.constant 1.0 : f32
+
+  %output_empty = tensor.empty() : tensor<192x1024x64xf32>
+  %row_red_empty = tensor.empty() : tensor<192x1024xf32>
+
+  %sum_ident = arith.constant 0.000000e+00 : f32
+  %max_ident = arith.constant -3.40282347E+38 : f32
+
+  %output_fill = linalg.fill ins(%sum_ident : f32) outs(%output_empty : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+  %acc_fill = linalg.fill ins(%max_ident : f32) outs(%row_red_empty : tensor<192x1024xf32>) -> tensor<192x1024xf32>
+  %sum_fill = linalg.fill ins(%sum_ident : f32) outs(%row_red_empty : tensor<192x1024xf32>) -> tensor<192x1024xf32>
+
+  //         CHECK: arith.constant false
+  // CHECK-COUNT-3: tensor.pad
+  //         CHECK: iree_linalg_ext.online_attention
+  //    CHECK-SAME:   : tensor<192x1024x64xf32>, tensor<192x32x64xf32>, tensor<192x32x64xf32>, f32, tensor<192x1024x32xi1>)
+  %out:3 = iree_linalg_ext.online_attention
+        {
+          indexing_maps = [#mapQ, #mapK, #mapV, #mapS, #mapM, #mapO, #mapR, #mapR],
+          lowering_config = #lowering_config
+        }
+        ins(%query, %key, %value, %scale, %mask : tensor<192x1024x64xf32>, tensor<192x?x64xf32>, tensor<192x?x64xf32>, f32, tensor<192x1024x?xi1>)
+        outs(%output_fill, %acc_fill, %sum_fill : tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>)
+        {
+          ^bb0(%score: f32):
+            iree_linalg_ext.yield %score: f32
+        }
+        -> tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>
+
+  return %out#0 : tensor<192x1024x64xf32>
+}
+
+// -----
+
+#mapQ = affine_map<(batch, m, k1, k2, n) -> (batch, m, k1)>
+#mapK = affine_map<(batch, m, k1, k2, n) -> (batch, k2, k1)>
+#mapV = affine_map<(batch, m, k1, k2, n) -> (batch, k2, n)>
+#mapS = affine_map<(batch, m, k1, k2, n) -> ()>
 #mapM = affine_map<(batch, m, k1, k2, n) -> (batch, m)>
 #mapO = affine_map<(batch, m, k1, k2, n) -> (batch, m, n)>
 #mapR = affine_map<(batch, m, k1, k2, n) -> (batch, m)>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_online_attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_online_attention.mlir
@@ -140,6 +140,53 @@ func.func @online_attention_tile_then_pad_bool_mask(%query: tensor<192x1024x64xf
 #mapK = affine_map<(batch, m, k1, k2, n) -> (batch, k2, k1)>
 #mapV = affine_map<(batch, m, k1, k2, n) -> (batch, k2, n)>
 #mapS = affine_map<(batch, m, k1, k2, n) -> ()>
+#mapM = affine_map<(batch, m, k1, k2, n) -> (batch, m, k2)>
+#mapO = affine_map<(batch, m, k1, k2, n) -> (batch, m, n)>
+#mapR = affine_map<(batch, m, k1, k2, n) -> (batch, m)>
+
+//                                                        batch, m, k1, k2, n
+#lowering_config = #iree_gpu.lowering_config<{reduction = [   0, 0,  0, 32, 0]}>
+
+// CHECK-LABEL: func.func @online_attention_tile_then_pad_i8_mask
+func.func @online_attention_tile_then_pad_i8_mask(%query: tensor<192x1024x64xf32>, %key: tensor<192x?x64xf32>, %value: tensor<192x?x64xf32>, %mask: tensor<192x1024x?xi8>) -> tensor<192x1024x64xf32> {
+  %scale = arith.constant 1.0 : f32
+
+  %output_empty = tensor.empty() : tensor<192x1024x64xf32>
+  %row_red_empty = tensor.empty() : tensor<192x1024xf32>
+
+  %sum_ident = arith.constant 0.000000e+00 : f32
+  %max_ident = arith.constant -3.40282347E+38 : f32
+
+  %output_fill = linalg.fill ins(%sum_ident : f32) outs(%output_empty : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+  %acc_fill = linalg.fill ins(%max_ident : f32) outs(%row_red_empty : tensor<192x1024xf32>) -> tensor<192x1024xf32>
+  %sum_fill = linalg.fill ins(%sum_ident : f32) outs(%row_red_empty : tensor<192x1024xf32>) -> tensor<192x1024xf32>
+
+  //         CHECK: arith.constant 0 : i8
+  // CHECK-COUNT-3: tensor.pad
+  //         CHECK: iree_linalg_ext.online_attention
+  //    CHECK-SAME:   : tensor<192x1024x64xf32>, tensor<192x32x64xf32>, tensor<192x32x64xf32>, f32, tensor<192x1024x32xi8>)
+  %out:3 = iree_linalg_ext.online_attention
+        {
+          indexing_maps = [#mapQ, #mapK, #mapV, #mapS, #mapM, #mapO, #mapR, #mapR],
+          lowering_config = #lowering_config
+        }
+        ins(%query, %key, %value, %scale, %mask : tensor<192x1024x64xf32>, tensor<192x?x64xf32>, tensor<192x?x64xf32>, f32, tensor<192x1024x?xi8>)
+        outs(%output_fill, %acc_fill, %sum_fill : tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>)
+        {
+          ^bb0(%score: f32):
+            iree_linalg_ext.yield %score: f32
+        }
+        -> tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>
+
+  return %out#0 : tensor<192x1024x64xf32>
+}
+
+// -----
+
+#mapQ = affine_map<(batch, m, k1, k2, n) -> (batch, m, k1)>
+#mapK = affine_map<(batch, m, k1, k2, n) -> (batch, k2, k1)>
+#mapV = affine_map<(batch, m, k1, k2, n) -> (batch, k2, n)>
+#mapS = affine_map<(batch, m, k1, k2, n) -> ()>
 #mapM = affine_map<(batch, m, k1, k2, n) -> (batch, m)>
 #mapO = affine_map<(batch, m, k1, k2, n) -> (batch, m, n)>
 #mapR = affine_map<(batch, m, k1, k2, n) -> (batch, m)>

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -285,6 +285,9 @@ struct OnlineAttentionOpInterface final
                                        paddedOp.getValueMap());
     if (paddedOp.getMask()) {
       Type maskElementType = getElementTypeOrSelf(paddedOp.getMask().getType());
+      // The attention mask can be either float or integer. For float masks,
+      // we use maximumf whose identity is -INF.
+      // For integer masks we use addi with identity value 0/false.
       arith::AtomicRMWKind maskNeutralKind =
           isa<FloatType>(maskElementType) ? arith::AtomicRMWKind::maximumf
                                           : arith::AtomicRMWKind::addi;

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -284,8 +284,12 @@ struct OnlineAttentionOpInterface final
                                        arith::AtomicRMWKind::addf, bounds,
                                        paddedOp.getValueMap());
     if (paddedOp.getMask()) {
+      Type maskElementType = getElementTypeOrSelf(paddedOp.getMask().getType());
+      arith::AtomicRMWKind maskNeutralKind =
+          isa<FloatType>(maskElementType) ? arith::AtomicRMWKind::maximumf
+                                          : arith::AtomicRMWKind::addi;
       selectNeutralElementForReducedDims(builder, paddedOp.getMaskMutable()[0],
-                                         arith::AtomicRMWKind::maximumf, bounds,
+                                         maskNeutralKind, bounds,
                                          *paddedOp.getMaskMap());
     }
     return result->replacements;


### PR DESCRIPTION
Currently compiling attention with  an integer/bool mask crashes. This fix addresses this by selecting the neutral element based on the type of the mask. 