### PR TITLE
Enable TensorDynamicDimAnalysis to propagate through `iree_codegen.load_from_buffer`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.cpp
@@ -139,8 +139,6 @@ static void updateTensorDimInfo(
     return;
   }
 
-  MemRefType bufferType = loadFromBufferOp.getBuffer().getType();
-
   std::optional<ValueRange> maybeBufferDynamicDims =
       IREE::Util::findDynamicDims(loadFromBufferOp.getBuffer());
   if (!maybeBufferDynamicDims.has_value()) {
@@ -150,6 +148,7 @@ static void updateTensorDimInfo(
 
   Value result = loadFromBufferOp.getResult();
   uint64_t dynamicDimIndex = 0;
+  MemRefType bufferType = loadFromBufferOp.getBuffer().getType();
   for (auto [dimIndex, dimSize] : llvm::enumerate(bufferType.getShape())) {
     if (ShapedType::isStatic(dimSize)) {
       continue;

--- a/compiler/src/iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
 #define DEBUG_TYPE "iree-codegen-dynamic-dim-analysis"
@@ -138,7 +139,7 @@ static void updateTensorDimInfo(
     return;
   }
 
-  auto bufferType = cast<MemRefType>(loadFromBufferOp.getBuffer().getType());
+  MemRefType bufferType = loadFromBufferOp.getBuffer().getType();
 
   std::optional<ValueRange> maybeBufferDynamicDims =
       IREE::Util::findDynamicDims(loadFromBufferOp.getBuffer());

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -103,6 +103,12 @@ func.func @block_attention_dims() {
 
 // -----
 
+#pipeline_layout = #hal.pipeline.layout<constants = 4, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+    #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 func.func @block_attention_dims_load_from_buffer() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 8.837890e-02 : f16

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -101,6 +101,93 @@ func.func @block_attention_dims() {
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[GENERIC]], %[[OUTPUT_BINDING]]
 
+func.func @block_attention_dims_load_from_buffer() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 8.837890e-02 : f16
+  %m_in = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %k2_in = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %0:2 = util.assume.int
+      %m_in<umin = 16, umax = 4080, udiv = 16>,
+      %k2_in<umin = 16, umax = 4080, udiv = 32>
+    : index, index
+  %m = iree_tensor_ext.dispatch.workload.ordinal %0#0, 0 : index
+  %k2 = iree_tensor_ext.dispatch.workload.ordinal %0#1, 1 : index
+  %q_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>>{%m}
+  %key_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>>{%k2}
+  %value_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>>{%k2}
+  %mask_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+      : memref<4x32x?x?xf16, #hal.descriptor_type<storage_buffer>>{%m, %k2}
+  %output_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) flags(Indirect)
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>>{%m}
+  %q = iree_codegen.load_from_buffer %q_in
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>> -> tensor<4x?x32x128xf16>
+  %key = iree_codegen.load_from_buffer %key_in
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>> -> tensor<4x?x32x128xf16>
+  %value = iree_codegen.load_from_buffer %value_in
+      : memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>> -> tensor<4x?x32x128xf16>
+  %mask = iree_codegen.load_from_buffer %mask_in
+      : memref<4x32x?x?xf16, #hal.descriptor_type<storage_buffer>> -> tensor<4x32x?x?xf16>
+  %1 = tensor.empty(%m) : tensor<4x?x32x128xf16>
+  %2 = tensor.empty(%m) : tensor<4x32x?x128xf16>
+  %attn = iree_linalg_ext.attention {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]}
+      ins(%q, %key, %value, %cst, %mask : tensor<4x?x32x128xf16>, tensor<4x?x32x128xf16>, tensor<4x?x32x128xf16>, f16, tensor<4x32x?x?xf16>)
+      outs(%2 : tensor<4x32x?x128xf16>) {
+    ^bb0(%b0 : f16) :
+      iree_linalg_ext.yield %b0 : f16
+  }-> tensor<4x32x?x128xf16>
+  %result = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%attn : tensor<4x32x?x128xf16>) outs(%1 : tensor<4x?x32x128xf16>) {
+  ^bb0(%in: f16, %out: f16):
+    linalg.yield %in : f16
+  } -> tensor<4x?x32x128xf16>
+  iree_codegen.store_to_buffer %result, %output_in
+      : tensor<4x?x32x128xf16> into memref<4x?x32x128xf16, #hal.descriptor_type<storage_buffer>>
+  return
+}
+// CHECK-LABEL: func @block_attention_dims_load_from_buffer()
+//   CHECK-DAG:   %[[M:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 0 : index
+//   CHECK-DAG:   %[[K2:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 1 : index
+//       CHECK:   %[[Q_BUF:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
+//       CHECK:   %[[K_BUF:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
+//       CHECK:   %[[V_BUF:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
+//       CHECK:   %[[MASK_BUF:.+]] = hal.interface.binding.subspan {{.+}} binding(3)
+//       CHECK:   %[[OUT_BUF:.+]] = hal.interface.binding.subspan {{.+}} binding(4)
+//
+//   CHECK-DAG:   %[[M_DYNAMIC:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 16)>()[%[[M]]]
+//   CHECK-DAG:   %[[K2_DYNAMIC:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 32)>()[%[[K2]]]
+//
+//   CHECK-DAG:   %[[OUT_EXPAND:.+]] = memref.expand_shape %[[OUT_BUF]] {{\[}}[0], [1, 2], [3], [4]] output_shape [4, %[[M_DYNAMIC]], 16, 32, 128]
+//   CHECK-DAG:   %[[Q_EXPAND:.+]] = memref.expand_shape %[[Q_BUF]] {{\[}}[0], [1, 2], [3], [4]] output_shape [4, %[[M_DYNAMIC]], 16, 32, 128]
+//   CHECK-DAG:   %[[K_EXPAND:.+]] = memref.expand_shape %[[K_BUF]] {{\[}}[0], [1, 2], [3], [4]] output_shape [4, %[[K2_DYNAMIC]], 32, 32, 128]
+//   CHECK-DAG:   %[[V_EXPAND:.+]] = memref.expand_shape %[[V_BUF]] {{\[}}[0], [1, 2], [3], [4]] output_shape [4, %[[K2_DYNAMIC]], 32, 32, 128]
+//   CHECK-DAG:   %[[MASK_EXPAND1:.+]] = memref.expand_shape %[[MASK_BUF]] {{\[}}[0], [1], [2, 3], [4]] output_shape [4, 32, %[[M_DYNAMIC]], 16, %{{.+}}]
+//   CHECK-DAG:   %[[MASK_EXPAND2:.+]] = memref.expand_shape %[[MASK_EXPAND1]] {{\[}}[0], [1], [2], [3], [4, 5]] output_shape [4, 32, %[[M_DYNAMIC]], 16, %[[K2_DYNAMIC]], 32]
+//
+//   CHECK-DAG:   %[[Q:.+]] = iree_codegen.load_from_buffer %[[Q_EXPAND]] : memref<4x?x16x32x128xf16
+//   CHECK-DAG:   %[[KEY:.+]] = iree_codegen.load_from_buffer %[[K_EXPAND]] : memref<4x?x32x32x128xf16
+//   CHECK-DAG:   %[[VALUE:.+]] = iree_codegen.load_from_buffer %[[V_EXPAND]] : memref<4x?x32x32x128xf16
+//   CHECK-DAG:   %[[MASK:.+]] = iree_codegen.load_from_buffer %[[MASK_EXPAND2]] : memref<4x32x?x16x?x32xf16
+//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%[[M_DYNAMIC]]) : tensor<4x32x?x16x128xf16>
+//
+//       CHECK:   %[[ATTN:.+]] = iree_linalg_ext.attention
+//  CHECK-SAME:       ins(%[[Q]], %[[KEY]], %[[VALUE]], %{{.+}}, %[[MASK]]
+//  CHECK-SAME:       outs(%[[INIT]] : tensor<4x32x?x16x128xf16>)
+//       CHECK:   %[[OUT:.+]] = linalg.generic
+//       CHECK:   iree_codegen.store_to_buffer %[[OUT]], %[[OUT_EXPAND]] :
+//  CHECK-SAME:       tensor<4x?x16x32x128xf16> into memref<4x?x16x32x128xf16
+
 // -----
 
 func.func @basic_blocking_test(%arg0 : index, %lhs : tensor<?x2048xf32>, %rhs : tensor<2048x4096xf32>) -> tensor<?x4096xf32> {

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -101,6 +101,8 @@ func.func @block_attention_dims() {
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[GENERIC]], %[[OUTPUT_BINDING]]
 
+// -----
+
 func.func @block_attention_dims_load_from_buffer() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 8.837890e-02 : f16


### PR DESCRIPTION
Extended `TensorDynamicDimAnalysis` to propagate information through `iree_codegen.load_from_buffer` ops by reading the dynamic dimensions from the source memref. 

Without this change the block-dynamic-dims pass was only able to block the dynamic dimension of Q for IR that looks similar to the test that is included here. The reason for this is that Q could be read from the `empty` op of the result,  however the other dims are not exposed via the result of the attention op.  