### PR TITLE
Misc cleanup and base runtime utilities.

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -100,6 +100,9 @@ build:generic_clang --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
 # Treat warnings as errors...
 build:generic_clang --copt=-Werror --host_copt=-Werror
+# ...except for unused command-line arguments, which fire spuriously during
+# LTO backend compilation when Bazel passes linkopts to the compiler.
+build:generic_clang --copt=-Wno-error=unused-command-line-argument
 # ...and silence them outside of the workspace.
 build:generic_clang --per_file_copt=external/.*@-w
 # ...and silence them on host builds. There is no host_per_file_copt and

--- a/build_tools/bin/iree-bazel-fuzz
+++ b/build_tools/bin/iree-bazel-fuzz
@@ -60,7 +60,7 @@ EXAMPLES
     iree-bazel-fuzz -d //path/to:target
 
     # Overnight fuzzing: all fuzz targets under a path (Ctrl+C to stop)
-    iree-bazel-fuzz //runtime/src/iree/tokenizer2/... -- -jobs=128
+    iree-bazel-fuzz //runtime/src/iree/tokenizer/... -- -jobs=128
 
     # Time-limited multi-target fuzzing
     iree-bazel-fuzz //runtime/... -- -jobs=64 -max_total_time=3600

--- a/build_tools/bin/iree-bazel-test
+++ b/build_tools/bin/iree-bazel-test
@@ -46,7 +46,7 @@ EXAMPLES
     iree-bazel-test //runtime/src/iree/base:status_test
 
     # Test multiple targets at once
-    iree-bazel-test //runtime/src/iree/tokenizer2/... //tools/test:iree-tokenize.txt
+    iree-bazel-test //runtime/src/iree/tokenizer/... //tools/test:iree-tokenize.txt
 
     # Test all tools
     iree-bazel-test //tools/...

--- a/runtime/src/iree/base/attributes.h
+++ b/runtime/src/iree/base/attributes.h
@@ -158,6 +158,29 @@
 #endif  // IREE_HAVE_ATTRIBUTE(cold)
 
 //===----------------------------------------------------------------------===//
+// Portable explicit prefetch hints
+//===----------------------------------------------------------------------===//
+
+#if IREE_HAVE_BUILTIN(__builtin_prefetch) || defined(__GNUC__)
+#define IREE_BUILTIN_PREFETCH_RO(ptr, hint) \
+  __builtin_prefetch((ptr), /*rw=*/0, hint)
+#define IREE_BUILTIN_PREFETCH_RW(ptr, hint) \
+  __builtin_prefetch((ptr), /*rw=*/1, hint)
+#else
+#define IREE_BUILTIN_PREFETCH_RO(ptr, hint)
+#define IREE_BUILTIN_PREFETCH_RW(ptr, hint)
+#endif  // IREE_HAVE_BUILTIN(__builtin_prefetch)
+
+// This is how the 0--3 locality hint is interpreted by both Clang and GCC on
+// both arm64 and x86-64.
+enum {
+  IREE_BUILTIN_PREFETCH_LOCALITY_NONE = 0,  // No locality. Data accessed once.
+  IREE_BUILTIN_PREFETCH_LOCALITY_L3 = 1,    // Some locality. Try to keep in L3.
+  IREE_BUILTIN_PREFETCH_LOCALITY_L2 = 2,    // More locality. Try to keep in L2.
+  IREE_BUILTIN_PREFETCH_LOCALITY_L1 = 3,    // Most locality. Try to keep in L1.
+};
+
+//===----------------------------------------------------------------------===//
 // IREE_LIKELY / IREE_UNLIKELY
 //===----------------------------------------------------------------------===//
 

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -274,6 +274,16 @@ iree_runtime_cc_library(
     ],
 )
 
+iree_runtime_cc_test(
+    name = "memory_test",
+    srcs = ["memory_test.cc"],
+    deps = [
+        ":memory",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 iree_runtime_cc_library(
     name = "path",
     srcs = ["path.c"],

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -144,6 +144,25 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "csprng",
+    srcs = ["csprng.c"],
+    hdrs = ["csprng.h"],
+    deps = [
+        "//runtime/src/iree/base",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "csprng_test",
+    srcs = ["csprng_test.cc"],
+    deps = [
+        ":csprng",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "dynamic_library",
     srcs = [
         "dynamic_library_posix.c",

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -295,6 +295,17 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    memory_test
+  SRCS
+    "memory_test.cc"
+  DEPS
+    ::memory
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 iree_cc_library(
   NAME
     path

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -143,6 +143,29 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    csprng
+  HDRS
+    "csprng.h"
+  SRCS
+    "csprng.c"
+  DEPS
+    iree::base
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    csprng_test
+  SRCS
+    "csprng_test.cc"
+  DEPS
+    ::csprng
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
     dynamic_library
   HDRS
     "dynamic_library.h"

--- a/runtime/src/iree/base/internal/csprng.c
+++ b/runtime/src/iree/base/internal/csprng.c
@@ -1,0 +1,101 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/csprng.h"
+
+//===----------------------------------------------------------------------===//
+// Platform CSPRNG implementations
+//===----------------------------------------------------------------------===//
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+#include <bcrypt.h>
+#pragma comment(lib, "bcrypt.lib")
+
+IREE_API_EXPORT iree_status_t iree_csprng_fill(iree_byte_span_t buffer) {
+  if (buffer.data_length == 0) return iree_ok_status();
+  NTSTATUS status =
+      BCryptGenRandom(NULL, buffer.data, (ULONG)buffer.data_length,
+                      BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+  if (!BCRYPT_SUCCESS(status)) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "BCryptGenRandom failed: 0x%08lX", status);
+  }
+  return iree_ok_status();
+}
+
+#elif defined(IREE_PLATFORM_APPLE) || defined(IREE_PLATFORM_BSD)
+
+#include <stdlib.h>
+
+IREE_API_EXPORT iree_status_t iree_csprng_fill(iree_byte_span_t buffer) {
+  if (buffer.data_length == 0) return iree_ok_status();
+  arc4random_buf(buffer.data, buffer.data_length);
+  return iree_ok_status();
+}
+
+#elif defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_ANDROID)
+
+#include <errno.h>
+#include <sys/random.h>
+
+IREE_API_EXPORT iree_status_t iree_csprng_fill(iree_byte_span_t buffer) {
+  if (buffer.data_length == 0) return iree_ok_status();
+  iree_host_size_t total_read = 0;
+  while (total_read < buffer.data_length) {
+    ssize_t bytes_read =
+        getrandom(buffer.data + total_read, buffer.data_length - total_read, 0);
+    if (bytes_read < 0) {
+      if (errno == EINTR) continue;
+      return iree_make_status(iree_status_code_from_errno(errno),
+                              "getrandom failed");
+    }
+    total_read += (iree_host_size_t)bytes_read;
+  }
+  return iree_ok_status();
+}
+
+#elif defined(IREE_PLATFORM_EMSCRIPTEN)
+
+#include <emscripten.h>
+
+IREE_API_EXPORT iree_status_t iree_csprng_fill(iree_byte_span_t buffer) {
+  if (buffer.data_length == 0) return iree_ok_status();
+  // crypto.getRandomValues has a max size of 65536 bytes.
+  // For larger requests, chunk the calls.
+  iree_host_size_t offset = 0;
+  while (offset < buffer.data_length) {
+    iree_host_size_t chunk_size = buffer.data_length - offset;
+    if (chunk_size > 65536) chunk_size = 65536;
+
+    // Use JavaScript's crypto.getRandomValues via Emscripten.
+    // Returns 0 on success, 1 on failure.
+    int result = EM_ASM_INT(
+        {
+          try {
+            var buf = new Uint8Array(Module.HEAPU8.buffer, $0, $1);
+            crypto.getRandomValues(buf);
+            return 0;
+          } catch (e) {
+            return 1;
+          }
+        },
+        buffer.data + offset, chunk_size);
+
+    if (result != 0) {
+      return iree_make_status(IREE_STATUS_INTERNAL,
+                              "crypto.getRandomValues failed");
+    }
+    offset += chunk_size;
+  }
+  return iree_ok_status();
+}
+
+#else
+
+#error "CSPRNG not implemented for this platform"
+
+#endif  // IREE_PLATFORM_*

--- a/runtime/src/iree/base/internal/csprng.h
+++ b/runtime/src/iree/base/internal/csprng.h
@@ -1,0 +1,50 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_INTERNAL_CSPRNG_H_
+#define IREE_BASE_INTERNAL_CSPRNG_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Cryptographically Secure Pseudo-Random Number Generator (CSPRNG)
+//===----------------------------------------------------------------------===//
+//
+// Platform-abstracted access to the operating system's cryptographic random
+// number generator. Use for security-sensitive purposes:
+//   - Cryptographic key generation
+//   - Nonces and IVs
+//   - Session tokens
+//   - Any randomness where predictability would be a security vulnerability
+//
+// For non-security purposes (shuffling, load balancing, jitter), prefer
+// iree/base/internal/prng.h which is faster but NOT cryptographically secure.
+//
+// Platform implementations:
+//   Windows:       BCryptGenRandom (system preferred RNG)
+//   macOS/BSD:     arc4random_buf
+//   Linux/Android: getrandom() syscall (requires kernel 3.17+)
+//   Emscripten:    crypto.getRandomValues
+
+// Fills |buffer| with cryptographically random data.
+//
+// This function blocks until all requested bytes are available. On modern
+// systems this completes immediately; blocking only occurs during early boot
+// before the entropy pool is initialized (extremely rare in practice).
+//
+// Returns IREE_STATUS_INTERNAL on platform RNG failure (should not happen
+// on correctly configured systems).
+IREE_API_EXPORT iree_status_t iree_csprng_fill(iree_byte_span_t buffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_INTERNAL_CSPRNG_H_

--- a/runtime/src/iree/base/internal/csprng_test.cc
+++ b/runtime/src/iree/base/internal/csprng_test.cc
@@ -1,0 +1,68 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/csprng.h"
+
+#include <cstring>
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+TEST(CSPRNG, FillSmallBuffer) {
+  uint8_t buffer[32];
+  memset(buffer, 0, sizeof(buffer));
+
+  IREE_ASSERT_OK(iree_csprng_fill(iree_make_byte_span(buffer, sizeof(buffer))));
+
+  // Check that at least some bytes are non-zero (extremely high probability).
+  // A correctly functioning CSPRNG should produce non-zero bytes.
+  int non_zero_count = 0;
+  for (size_t i = 0; i < sizeof(buffer); ++i) {
+    if (buffer[i] != 0) ++non_zero_count;
+  }
+  EXPECT_GT(non_zero_count, 0)
+      << "CSPRNG returned all zeros, which is extremely unlikely";
+}
+
+TEST(CSPRNG, FillLargeBuffer) {
+  // Test with buffer > 65536 bytes to exercise chunking on Emscripten.
+  constexpr size_t kSize = 128 * 1024;
+  auto buffer = std::make_unique<uint8_t[]>(kSize);
+  memset(buffer.get(), 0, kSize);
+
+  IREE_ASSERT_OK(iree_csprng_fill(iree_make_byte_span(buffer.get(), kSize)));
+
+  // Check that at least some bytes are non-zero.
+  int non_zero_count = 0;
+  for (size_t i = 0; i < kSize; ++i) {
+    if (buffer[i] != 0) ++non_zero_count;
+  }
+  EXPECT_GT(non_zero_count, 0)
+      << "CSPRNG returned all zeros, which is extremely unlikely";
+}
+
+TEST(CSPRNG, FillZeroLengthBuffer) {
+  // Zero-length buffer should succeed without error.
+  IREE_EXPECT_OK(iree_csprng_fill(iree_make_byte_span(nullptr, 0)));
+}
+
+TEST(CSPRNG, MultipleCallsProduceDifferentData) {
+  uint8_t buffer1[64];
+  uint8_t buffer2[64];
+
+  IREE_ASSERT_OK(
+      iree_csprng_fill(iree_make_byte_span(buffer1, sizeof(buffer1))));
+  IREE_ASSERT_OK(
+      iree_csprng_fill(iree_make_byte_span(buffer2, sizeof(buffer2))));
+
+  // Two consecutive calls should produce different data with high probability.
+  EXPECT_NE(0, memcmp(buffer1, buffer2, sizeof(buffer1)))
+      << "Two consecutive CSPRNG fills produced identical data";
+}
+
+}  // namespace

--- a/runtime/src/iree/base/internal/dynamic_library.h
+++ b/runtime/src/iree/base/internal/dynamic_library.h
@@ -62,6 +62,12 @@ void iree_dynamic_library_release(iree_dynamic_library_t* library);
 iree_status_t iree_dynamic_library_lookup_symbol(
     iree_dynamic_library_t* library, const char* symbol_name, void** out_fn);
 
+// Tries to lookup a symbol from the dynamic library exports without creating
+// a status. Returns NULL if the symbol is not found. Use
+// iree_dynamic_library_lookup_symbol if error details are needed.
+void* iree_dynamic_library_try_lookup_symbol(iree_dynamic_library_t* library,
+                                             const char* symbol_name);
+
 // Loads a debug database (PDB/DWARF/etc) from the given path providing debug
 // symbols for this library and attaches it to the symbol store (if active).
 iree_status_t iree_dynamic_library_attach_symbols_from_file(

--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -321,6 +321,13 @@ iree_status_t iree_dynamic_library_lookup_symbol(
   return iree_ok_status();
 }
 
+void* iree_dynamic_library_try_lookup_symbol(iree_dynamic_library_t* library,
+                                             const char* symbol_name) {
+  IREE_ASSERT_ARGUMENT(library);
+  IREE_ASSERT_ARGUMENT(symbol_name);
+  return dlsym(library->handle, symbol_name);
+}
+
 iree_status_t iree_dynamic_library_attach_symbols_from_file(
     iree_dynamic_library_t* library, const char* file_path) {
   return iree_ok_status();

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -333,6 +333,13 @@ iree_status_t iree_dynamic_library_lookup_symbol(
   return iree_ok_status();
 }
 
+void* iree_dynamic_library_try_lookup_symbol(iree_dynamic_library_t* library,
+                                             const char* symbol_name) {
+  IREE_ASSERT_ARGUMENT(library);
+  IREE_ASSERT_ARGUMENT(symbol_name);
+  return (void*)GetProcAddress(library->module, symbol_name);
+}
+
 iree_status_t iree_dynamic_library_append_symbol_path_to_builder(
     void* symbol, iree_string_builder_t* builder) {
   HMODULE hm = NULL;

--- a/runtime/src/iree/base/internal/json.h
+++ b/runtime/src/iree/base/internal/json.h
@@ -304,6 +304,23 @@ iree_status_t iree_json_parse_double(iree_string_view_t value, double* out);
 // Returns error for any other value including "null".
 iree_status_t iree_json_parse_bool(iree_string_view_t value, bool* out);
 
+// Looks up a required boolean field.
+// Returns error if the key is not found, the value is "null", or the value is
+// not a valid boolean ("true" or "false").
+iree_status_t iree_json_lookup_bool(iree_string_view_t object_value,
+                                    iree_string_view_t key, bool* out);
+
+// Looks up a required string field, unescapes it, and writes to |buffer|.
+// Returns error if the key is not found, the value is "null", or the buffer is
+// too small for the unescaped content.
+//
+// |buffer| provides the output storage (data and capacity via size).
+// |out_length| receives the actual length written (not NUL-terminated).
+iree_status_t iree_json_lookup_string(iree_string_view_t object_value,
+                                      iree_string_view_t key,
+                                      iree_mutable_string_view_t buffer,
+                                      iree_host_size_t* out_length);
+
 // Looks up an optional boolean field with a default value.
 // Returns |default_value| if the key is not found or the value is "null".
 // Returns error if the value is present but not a valid boolean.
@@ -318,19 +335,17 @@ iree_status_t iree_json_try_lookup_int64(iree_string_view_t object_value,
                                          iree_string_view_t key,
                                          int64_t default_value, int64_t* out);
 
-// Looks up an optional string field, unescapes it, and writes to buffer.
+// Looks up an optional string field, unescapes it, and writes to |buffer|.
 // Returns |default_value| copied to buffer if key is not found or value is
 // "null". Returns error if value is present but not a string, or if the buffer
 // is too small for the unescaped content.
 //
-// |out_buffer| receives the unescaped UTF-8 string (not NUL-terminated).
-// |buffer_capacity| is the size of the output buffer in bytes.
-// |out_length| receives the actual length written.
+// |buffer| provides the output storage (data and capacity via size).
+// |out_length| receives the actual length written (not NUL-terminated).
 iree_status_t iree_json_try_lookup_string(iree_string_view_t object_value,
                                           iree_string_view_t key,
                                           iree_string_view_t default_value,
-                                          char* out_buffer,
-                                          iree_host_size_t buffer_capacity,
+                                          iree_mutable_string_view_t buffer,
                                           iree_host_size_t* out_length);
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/memory_test.cc
+++ b/runtime/src/iree/base/internal/memory_test.cc
@@ -1,0 +1,69 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/memory.h"
+
+#include <cstring>
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+TEST(SecureMemory, WipeZerosMemory) {
+  uint8_t buffer[256];
+  memset(buffer, 0xFF, sizeof(buffer));
+
+  iree_memory_wipe(buffer, sizeof(buffer));
+
+  // Verify all bytes are zero.
+  for (size_t i = 0; i < sizeof(buffer); ++i) {
+    EXPECT_EQ(0, buffer[i]) << "Byte at index " << i << " not wiped";
+  }
+}
+
+TEST(SecureMemory, WipeEmptyBuffer) {
+  // Zero-length wipe should not crash.
+  iree_memory_wipe(nullptr, 0);
+}
+
+TEST(SecureMemory, LockAndUnlock) {
+  constexpr size_t kSize = 4096;
+  auto buffer = std::make_unique<uint8_t[]>(kSize);
+
+  // Lock may fail if the process lacks privileges or exceeds RLIMIT_MEMLOCK.
+  // This is not fatal - we test the API contract but allow failure.
+  iree_status_t status = iree_memory_lock(buffer.get(), kSize);
+  if (iree_status_is_ok(status)) {
+    // If lock succeeded, unlock should work.
+    iree_memory_unlock(buffer.get(), kSize);
+  } else {
+    // Lock failed (e.g., insufficient privileges). This is acceptable.
+    iree_status_ignore(status);
+  }
+}
+
+TEST(SecureMemory, LockEmptyBuffer) {
+  // Zero-length lock should succeed as a no-op.
+  IREE_EXPECT_OK(iree_memory_lock(nullptr, 0));
+  iree_memory_unlock(nullptr, 0);
+}
+
+TEST(SecureMemory, ProtectSensitive) {
+  constexpr size_t kSize = 4096;
+  auto buffer = std::make_unique<uint8_t[]>(kSize);
+
+  // This is best-effort and may be a no-op on some platforms.
+  // Just verify it doesn't crash.
+  iree_memory_protect_sensitive(buffer.get(), kSize);
+}
+
+TEST(SecureMemory, ProtectSensitiveEmptyBuffer) {
+  // Zero-length protect should not crash.
+  iree_memory_protect_sensitive(nullptr, 0);
+}
+
+}  // namespace

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -52,6 +52,37 @@ static inline iree_string_view_t iree_make_cstring_view(const char* str) {
   return v;
 }
 
+// A mutable string view into a non-NUL-terminated char buffer.
+// Unlike iree_string_view_t, the data pointer is non-const for writing.
+// Useful for output buffers where we track capacity and written length.
+typedef struct iree_mutable_string_view_t {
+  char* data;
+  iree_host_size_t size;
+} iree_mutable_string_view_t;
+
+// Returns an empty mutable string view.
+static inline iree_mutable_string_view_t iree_mutable_string_view_empty(void) {
+  iree_mutable_string_view_t v = {NULL, 0};
+  return v;
+}
+
+// Returns true if the given mutable string view is empty.
+#define iree_mutable_string_view_is_empty(sv) \
+  (((sv).data == NULL) || ((sv).size == 0))
+
+static inline iree_mutable_string_view_t iree_make_mutable_string_view(
+    char* str, iree_host_size_t str_length) {
+  iree_mutable_string_view_t v = {str, str_length};
+  return v;
+}
+
+// Converts a mutable string view to a const string view.
+static inline iree_string_view_t iree_make_const_string_view(
+    iree_mutable_string_view_t mutable_view) {
+  iree_string_view_t v = {mutable_view.data, mutable_view.size};
+  return v;
+}
+
 // A pair of strings.
 typedef struct iree_string_pair_t {
   union {

--- a/runtime/src/iree/base/testing/dynamic_library_test.cc
+++ b/runtime/src/iree/base/testing/dynamic_library_test.cc
@@ -134,5 +134,33 @@ TEST_F(DynamicLibraryTest, GetSymbolFailure) {
   iree_dynamic_library_release(library);
 }
 
+TEST_F(DynamicLibraryTest, TryLookupSymbolSuccess) {
+  iree_dynamic_library_t* library = NULL;
+  IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
+      library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
+      iree_allocator_system(), &library));
+
+  void* symbol = iree_dynamic_library_try_lookup_symbol(library, "times_two");
+  EXPECT_NE(nullptr, symbol);
+
+  // Verify the symbol works.
+  auto fn_ptr = reinterpret_cast<int (*)(int)>(symbol);
+  EXPECT_EQ(246, fn_ptr(123));
+
+  iree_dynamic_library_release(library);
+}
+
+TEST_F(DynamicLibraryTest, TryLookupSymbolNotFound) {
+  iree_dynamic_library_t* library = NULL;
+  IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
+      library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
+      iree_allocator_system(), &library));
+
+  void* symbol = iree_dynamic_library_try_lookup_symbol(library, "unknown");
+  EXPECT_EQ(nullptr, symbol);
+
+  iree_dynamic_library_release(library);
+}
+
 }  // namespace
 }  // namespace iree

--- a/runtime/src/iree/base/tracing.h
+++ b/runtime/src/iree/base/tracing.h
@@ -258,6 +258,10 @@ enum {
 #define IREE_RETURN_AND_END_ZONE_IF_ERROR(zone_id, ...) \
   IREE_RETURN_IF_ERROR(__VA_ARGS__)
 
+// Ends the current zone and returns unconditionally.
+// Sugar for IREE_TRACE_ZONE_END + return for non-conditional error returns.
+#define IREE_RETURN_AND_END_ZONE(zone_id, ...) return (__VA_ARGS__)
+
 // Sets the dynamic color of the zone to an XXBBGGRR value.
 #define IREE_TRACE_ZONE_SET_COLOR(zone_id, color_xrgb)
 

--- a/runtime/src/iree/base/tracing/console.h
+++ b/runtime/src/iree/base/tracing/console.h
@@ -182,6 +182,10 @@ void iree_tracing_memory_free(const char* name, size_t name_length, void* ptr);
 #define IREE_RETURN_AND_END_ZONE_IF_ERROR(zone_id, ...) \
   IREE_RETURN_AND_EVAL_IF_ERROR(IREE_TRACE_ZONE_END(zone_id), __VA_ARGS__)
 
+#define IREE_RETURN_AND_END_ZONE(zone_id, ...) \
+  IREE_TRACE_ZONE_END(zone_id);                \
+  return (__VA_ARGS__)
+
 // TODO(benvanik): move zone color to BEGIN macro so that we can print the line
 // with it initially.
 #define IREE_TRACE_ZONE_SET_COLOR(zone_id, color_xbgr)

--- a/runtime/src/iree/base/tracing/tracy.h
+++ b/runtime/src/iree/base/tracing/tracy.h
@@ -243,6 +243,10 @@ void* iree_tracing_obscure_ptr(void* ptr);
 #define IREE_RETURN_AND_END_ZONE_IF_ERROR(zone_id, ...) \
   IREE_RETURN_AND_EVAL_IF_ERROR(IREE_TRACE_ZONE_END(zone_id), __VA_ARGS__)
 
+#define IREE_RETURN_AND_END_ZONE(zone_id, ...) \
+  IREE_TRACE_ZONE_END(zone_id);                \
+  return (__VA_ARGS__)
+
 #define IREE_TRACE_ZONE_SET_COLOR(zone_id, color_xbgr) \
   ___tracy_emit_zone_color(iree_tracing_make_zone_ctx(zone_id), color_xbgr)
 

--- a/runtime/src/iree/hal/buffer_heap.c
+++ b/runtime/src/iree/hal/buffer_heap.c
@@ -130,7 +130,7 @@ iree_status_t iree_hal_heap_buffer_create(
       memcmp(&data_allocator, &host_allocator, sizeof(data_allocator)) == 0;
 
   iree_hal_heap_buffer_t* buffer = NULL;
-  iree_byte_span_t data = iree_make_byte_span(NULL, 0);
+  iree_byte_span_t data = iree_byte_span_empty();
   iree_status_t status =
       same_allocator
           ? iree_hal_heap_buffer_allocate_slab(allocation_size, host_allocator,

--- a/runtime/src/iree/hal/local/elf/elf_module_test_main.c
+++ b/runtime/src/iree/hal/local/elf/elf_module_test_main.c
@@ -15,7 +15,7 @@
 
 static iree_status_t query_arch_test_file_data(
     iree_const_byte_span_t* out_file_data) {
-  *out_file_data = iree_make_const_byte_span(NULL, 0);
+  *out_file_data = iree_const_byte_span_empty();
 
   iree_string_view_t pattern = iree_string_view_empty();
 #if defined(IREE_ARCH_ARM_32)

--- a/runtime/src/iree/hal/local/executable_library_benchmark.c
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.c
@@ -168,7 +168,7 @@ static iree_status_t iree_hal_executable_library_run(
       iree_hal_local_executable_cast(executable);
 
   // Allocate workgroup-local memory that each invocation can use.
-  iree_byte_span_t local_memory = iree_make_byte_span(NULL, 0);
+  iree_byte_span_t local_memory = iree_byte_span_empty();
   iree_host_size_t local_memory_size =
       local_executable->dispatch_attrs
           ? local_executable->dispatch_attrs[FLAG_export_ordinal]

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -101,8 +101,8 @@ static iree_status_t iree_hal_system_executable_load(
     iree_hal_system_executable_t* executable,
     iree_const_byte_span_t executable_data, iree_allocator_t host_allocator) {
   // Check to see if the library has a footer indicating embedded debug data.
-  iree_const_byte_span_t library_data = iree_make_const_byte_span(NULL, 0);
-  iree_const_byte_span_t debug_data = iree_make_const_byte_span(NULL, 0);
+  iree_const_byte_span_t library_data = iree_const_byte_span_empty();
+  iree_const_byte_span_t debug_data = iree_const_byte_span_empty();
   const iree_hal_system_executable_footer_t* footer =
       iree_hal_system_executable_try_query_footer(executable_data);
   if (footer) {

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -534,7 +534,7 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
   memset(&call, 0, sizeof(call));
   call.function = entry_fn;
   call.arguments = iree_make_byte_span(&call_args, sizeof(call_args));
-  call.results = iree_make_byte_span(NULL, 0);
+  call.results = iree_byte_span_empty();
   status = entry_fn.module->begin_call(entry_fn.module->self, stack, call);
 
   // Clean up the stack if needed, such as when the call fails.

--- a/runtime/src/iree/tokenizer/huggingface/bpe_json.c
+++ b/runtime/src/iree/tokenizer/huggingface/bpe_json.c
@@ -467,15 +467,16 @@ iree_status_t iree_tokenizer_from_bpe_json(iree_string_view_t json,
     iree_string_view_t model;
     status = iree_tokenizer_json_extract_model(json, &model);
     if (iree_status_is_ok(status)) {
-      char suffix_buffer[16];  // Must match bpe.c state storage.
+      char suffix_storage[16];  // Must match bpe.c state storage.
       iree_host_size_t suffix_length = 0;
       // Empty default means no suffix if key is missing or null.
       status = iree_json_try_lookup_string(
           model, IREE_SV("end_of_word_suffix"), iree_string_view_empty(),
-          suffix_buffer, sizeof(suffix_buffer), &suffix_length);
+          iree_make_mutable_string_view(suffix_storage, sizeof(suffix_storage)),
+          &suffix_length);
       if (iree_status_is_ok(status) && suffix_length > 0) {
         status = iree_tokenizer_bpe_set_end_of_word_suffix(
-            tokenizer, iree_make_string_view(suffix_buffer, suffix_length));
+            tokenizer, iree_make_string_view(suffix_storage, suffix_length));
       }
     }
   }

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -417,7 +417,7 @@ IREE_API_EXPORT iree_status_t iree_vm_begin_invoke(
 
   // Allocate argument storage on the native stack. It only needs to survive the
   // begin call as it's consumed by the invokee.
-  iree_byte_span_t arguments = iree_make_byte_span(NULL, 0);
+  iree_byte_span_t arguments = iree_byte_span_empty();
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_vm_function_call_compute_cconv_fragment_size(
@@ -442,7 +442,7 @@ IREE_API_EXPORT iree_status_t iree_vm_begin_invoke(
   // storage. This reduces the overall available stack space but not by much,
   // and if the stack needs to dynamically grow the inlined storage will still
   // be available.
-  iree_byte_span_t results = iree_make_byte_span(NULL, 0);
+  iree_byte_span_t results = iree_byte_span_empty();
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_vm_function_call_compute_cconv_fragment_size(
               cconv_results, /*segment_size_list=*/NULL, &results.data_length));


### PR DESCRIPTION
New utilities in `runtime/src/iree/base/` for security-sensitive operations, JSON parsing, and struct layout.

### New utilities

**Cryptographic and secure memory operations**:
- `iree_csprng_fill` - cryptographically secure RNG using platform APIs (BCryptGenRandom, arc4random_buf, getrandom, crypto.getRandomValues)
- `iree_memory_lock/unlock` - lock pages in RAM to prevent swapping
- `iree_memory_protect_sensitive` - exclude regions from core dumps (Linux MADV_DONTDUMP)
- `iree_memory_wipe` - secure zeroing guaranteed not to be optimized away (SecureZeroMemory, explicit_bzero, volatile fallback)

**JSON parsing helpers**:
- `iree_json_lookup_bool/string` - required field lookup with null checks
- `iree_json_try_lookup_string` - optional fields with defaults
- `iree_mutable_string_view_t` - output buffer type for writing
- Better error messages (include key names in failures)

**Struct layout calculation**:
- 2D array support in `IREE_STRUCT_LAYOUT` via `IREE_STRUCT_ARRAY_FIELD`
- Overflow checking on both dimensions

**Miscellaneous**:
- `IREE_RETURN_AND_END_ZONE` macro for unconditional returns with tracing
- `IREE_BUILTIN_PREFETCH_RO/RW` macros with locality hints
- `iree_host_size_next_power_of_two` / `iree_device_size_next_power_of_two` with overflow saturation
- `iree_dynamic_library_try_lookup_symbol` for non-throwing symbol lookup
- `iree_containerof` macro
- Cleanup pass using `iree_const_byte_span_empty()`

### Testing

Added comprehensive tests for CSPRNG (including large buffer chunking on Emscripten), secure memory operations
(lock/unlock/wipe/protect), and dynamic library symbol lookup. All tests pass under ASAN.

### Implementation notes

- CSPRNG chunks buffers >65536 bytes on Emscripten (crypto.getRandomValues limit)
- Memory lock failures are non-fatal (insufficient privileges / RLIMIT_MEMLOCK)
- Secure wipe uses platform-specific APIs where available, volatile loop fallback elsewhere
- Next-power-of-two saturates to max value on overflow instead of wrapping to 0
