### PR TITLE
[CI] Move linux_x64_clang_debug to postsubmit

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -120,6 +120,7 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
         "windows_x64_msvc",
         "test_torch",
+        "linux_x64_clang_debug",
     ]
 )
 
@@ -131,7 +132,6 @@ DEFAULT_SCHEDULE_ONLY_JOBS = frozenset(
         "macos_x64_clang",
         "linux_arm64_clang",
         "linux_x64_clang_byollvm",
-        "linux_x64_clang_debug",
         "linux_x64_clang_tsan",
         "linux_x64_gcc",
     ]

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -118,9 +118,9 @@ CONTROL_JOB_REGEXES = frozenset(
 # They may also run on presubmit only under certain conditions.
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
+        "linux_x64_clang_debug",
         "windows_x64_msvc",
         "test_torch",
-        "linux_x64_clang_debug",
     ]
 )
 


### PR DESCRIPTION
Following discussion on [discord](https://discord.com/channels/689900678990135345/689957613152239638/1469438836508463369) on making the debug build post-submit