### PR TITLE
[LLVMGPU] Fix barrier handling when pipelining with non-transfer_read ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:MemRefUtils",
         "@llvm-project//mlir:NVGPUDialect",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
     MLIRMathDialect
     MLIRMemRefDialect
     MLIRMemRefTransforms
+    MLIRMemRefUtils
     MLIRNVGPUDialect
     MLIRSCFDialect
     MLIRSCFTransforms


### PR DESCRIPTION
Software pipelining removes barriers from the pipelined loop, and then adds them back based on the loads/stores in the schedule, but it performs specific matching for vector.transfer_read ops. When we use other operations, like amdgpu.transpose_load, instead of vector.transfer_read, this causes barriers to be removed from the IR, causing data race possibilities, and in some cases performance issues.

This PR fixes the issue by using the MemoryEffectsOpInterface instead of explicit transfer_read matching.

Fixes https://github.com/iree-org/iree/issues/23421