### PR TITLE
[Codegen][GPU] Add LDS alias scope metadata for LoadToLDS operations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -110,6 +110,7 @@ iree_compiler_cc_library(
         "LLVMGPUVectorLowering.cpp",
         "LLVMGPUVectorToGPU.cpp",
         "Passes.cpp",
+        "ROCDLAddLDSAliasScopes.cpp",
         "ROCDLAnnotateKernelForTranslation.cpp",
         "ROCDLBufferInstructionsOptimization.cpp",
         "ROCDLConfigureBufferInstructions.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -89,6 +89,7 @@ iree_cc_library(
     "LLVMGPUVectorLowering.cpp"
     "LLVMGPUVectorToGPU.cpp"
     "Passes.cpp"
+    "ROCDLAddLDSAliasScopes.cpp"
     "ROCDLAnnotateKernelForTranslation.cpp"
     "ROCDLBufferInstructionsOptimization.cpp"
     "ROCDLConfigureBufferInstructions.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h"
@@ -375,6 +376,18 @@ struct ConvertToROCDLPass final
     }
 
     LDBG() << "After converting to rocdl\n" << m;
+
+    // Add alias scope metadata to LoadToLDS operations for better s_waitcnt
+    // generation in pipelined loops with multi-buffered LDS.
+    {
+      PassManager nestedPM(&getContext());
+      nestedPM.addPass(createROCDLAddLDSAliasScopesPass());
+      if (failed(runPipeline(nestedPM, m))) {
+        return signalPassFailure();
+      }
+    }
+
+    LDBG() << "After adding alias scopes to LoadToLDS\n" << m;
 
     // 16 is the maximum relevant alignment for all AMD GPUs. Unceremoniously
     // set it to 16 as all of our allocations almost always have much greater

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAddLDSAliasScopes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAddLDSAliasScopes.cpp
@@ -1,0 +1,113 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
+#include "llvm/Support/DebugLog.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+
+#define DEBUG_TYPE "iree-rocdl-add-lds-alias-scopes"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_ROCDLADDLDSALIASSCOPESPASS
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h.inc"
+
+namespace {
+
+/// Trace an LDS pointer back through GEP and extractvalue operations to find
+/// the root value representing the underlying LDS allocation. After
+/// AMDGPU-to-ROCDL conversion, memref descriptors are lowered to LLVM structs,
+/// and LDS pointers are obtained via extractvalue (to get the base pointer from
+/// the descriptor) followed by GEP (to compute offsets). This function walks
+/// backwards through that chain so that pointers derived from the same
+/// allocation map to the same root value.
+static Value traceToLDSBase(Value ldsPtr) {
+  Value current = ldsPtr;
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    if (auto gepOp = current.getDefiningOp<LLVM::GEPOp>()) {
+      current = gepOp.getBase();
+      changed = true;
+    } else if (auto extractOp = current.getDefiningOp<LLVM::ExtractValueOp>()) {
+      current = extractOp.getContainer();
+      changed = true;
+    }
+  }
+  return current;
+}
+
+/// Adds alias scope metadata to ROCDL::LoadToLDSOp operations.
+///
+/// This pass enables the LLVM backend to distinguish between different LDS
+/// buffers used in multi-buffered pipelining. Without alias scopes, the
+/// backend conservatively inserts s_waitcnt vmcnt(0) before every LDS access
+/// that might alias with a prior LoadToLDS operation.
+///
+/// With alias scopes, the backend understands that:
+/// - LoadToLDS ops to buffer 0 don't alias with ops to buffer 1
+/// - ds_read from buffer 0 doesn't conflict with LoadToLDS to buffer 1
+///
+/// This allows the backend to eliminate redundant vmcnt(0) instructions,
+/// enabling better overlap between global loads and LDS reads.
+struct ROCDLAddLDSAliasScopesPass final
+    : impl::ROCDLAddLDSAliasScopesPassBase<ROCDLAddLDSAliasScopesPass> {
+
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    MLIRContext *ctx = m.getContext();
+
+    // Create a single alias scope domain for LDS DMA operations.
+    auto domainAttr = LLVM::AliasScopeDomainAttr::get(
+        ctx, StringAttr::get(ctx, "lds_dma_domain"));
+
+    DenseMap<Value, LLVM::AliasScopeAttr> baseToScope;
+    SmallVector<LLVM::AliasScopeAttr> allScopes;
+    // First pass: create unique alias scopes for each distinct LDS allocation.
+    m.walk([&](ROCDL::LoadToLDSOp loadOp) {
+      Value base = traceToLDSBase(loadOp.getLdsPtr());
+      if (!baseToScope.contains(base)) {
+        std::string scopeName =
+            "lds_buffer_" + std::to_string(baseToScope.size());
+        auto scopeAttr = LLVM::AliasScopeAttr::get(
+            domainAttr, StringAttr::get(ctx, scopeName));
+        baseToScope[base] = scopeAttr;
+        allScopes.push_back(scopeAttr);
+      }
+    });
+
+    // Only add metadata when there are multiple distinct LDS buffers.
+    // With a single buffer, alias scopes provide no disambiguation benefit.
+    if (allScopes.size() <= 1) {
+      return;
+    }
+
+    LDBG() << "Adding alias scopes to " << allScopes.size()
+           << " distinct LDS buffers";
+
+    // Second pass: attach alias_scopes and noalias_scopes to each LoadToLDSOp.
+    m.walk([&](ROCDL::LoadToLDSOp loadOp) {
+      Value base = traceToLDSBase(loadOp.getLdsPtr());
+      LLVM::AliasScopeAttr scopeAttr = baseToScope.lookup(base);
+
+      loadOp.setAliasScopesAttr(ArrayAttr::get(ctx, {scopeAttr}));
+      SmallVector<Attribute> noaliasScopes;
+      for (LLVM::AliasScopeAttr otherScope : allScopes) {
+        if (otherScope != scopeAttr) {
+          noaliasScopes.push_back(otherScope);
+        }
+      }
+      loadOp.setNoaliasScopesAttr(ArrayAttr::get(ctx, noaliasScopes));
+
+      LDBG() << "Added alias scope to LoadToLDSOp: " << loadOp;
+    });
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -13,6 +13,26 @@ include "mlir/Pass/PassBase.td"
 // ROCDL Passes (keep alphabetical)
 //===----------------------------------------------------------------------===//
 
+def ROCDLAddLDSAliasScopesPass : Pass<
+    "iree-rocdl-add-lds-alias-scopes", "ModuleOp"> {
+  let summary = "Add alias scope metadata to ROCDL LoadToLDS operations";
+  let description = [{
+    Attaches LLVM alias scope metadata to ROCDL::LoadToLDSOp operations so the
+    LLVM backend can distinguish between different LDS buffers used in
+    multi-buffered pipelining.
+
+    Without alias scopes, SIInsertWaitcnts conservatively inserts
+    s_waitcnt vmcnt(0) before every LDS read that might alias with a prior
+    LoadToLDS. With alias scopes, the backend knows that LoadToLDS ops to
+    different buffers don't alias, eliminating redundant vmcnt(0) and enabling
+    overlap between global-to-LDS loads and LDS reads.
+  }];
+  let dependentDialects = [
+    "LLVM::LLVMDialect",
+    "ROCDL::ROCDLDialect"
+  ];
+}
+
 def ROCDLAnnotateKernelForTranslationPass : Pass<
     "iree-rocdl-annotate-kernel-for-translation", "LLVM::LLVMFuncOp"> {
   let summary = "Set function attributes before translating to LLVM IR";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -56,6 +56,7 @@ iree_lit_test_suite(
             "reduction_pipeline_rocm.mlir",
             "reduction_pipeline_softmax_rocm.mlir",
             "reuse_shared_memory_allocs.mlir",
+            "rocdl_add_lds_alias_scopes.mlir",
             "rocdl_load_to_transpose_load.mlir",
             "rocdl_pipeline_test.mlir",
             "sort_pipeline_test.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_lit_test_suite(
     "reduction_pipeline_rocm.mlir"
     "reduction_pipeline_softmax_rocm.mlir"
     "reuse_shared_memory_allocs.mlir"
+    "rocdl_add_lds_alias_scopes.mlir"
     "rocdl_load_to_transpose_load.mlir"
     "rocdl_pipeline_test.mlir"
     "sort_pipeline_test.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_add_lds_alias_scopes.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_add_lds_alias_scopes.mlir
@@ -1,0 +1,135 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-rocdl-add-lds-alias-scopes)' %s | FileCheck %s
+
+// CHECK-LABEL: llvm.func @single_lds_buffer
+// CHECK: rocdl.load.to.lds
+// CHECK-NOT: alias_scopes
+// CHECK: rocdl.load.to.lds
+// CHECK-NOT: alias_scopes
+llvm.func @single_lds_buffer(
+    %global : !llvm.ptr<1>,
+    %desc : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>) {
+  %base = llvm.extractvalue %desc[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %c0 = llvm.mlir.constant(0 : i64) : i64
+  %c64 = llvm.mlir.constant(64 : i64) : i64
+  %ptr0 = llvm.getelementptr %base[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %ptr1 = llvm.getelementptr %base[%c64] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  rocdl.load.to.lds %global, %ptr0, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr1, 4, 0, 0 : <1>
+  llvm.return
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @two_lds_buffers
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[SCOPE_A:.*]]], noalias_scopes = [#[[SCOPE_B:.*]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[SCOPE_B]]], noalias_scopes = [#[[SCOPE_A]]]}
+llvm.func @two_lds_buffers(
+    %global : !llvm.ptr<1>,
+    %desc_A : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_B : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>) {
+  %base_A = llvm.extractvalue %desc_A[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %base_B = llvm.extractvalue %desc_B[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %c0 = llvm.mlir.constant(0 : i64) : i64
+  %ptr_A = llvm.getelementptr %base_A[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %ptr_B = llvm.getelementptr %base_B[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  rocdl.load.to.lds %global, %ptr_A, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr_B, 4, 0, 0 : <1>
+  llvm.return
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @three_lds_buffers
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[S0:.*]]], noalias_scopes = [#[[S1:.*]], #[[S2:.*]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[S1]]], noalias_scopes = [#[[S0]], #[[S2]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[S2]]], noalias_scopes = [#[[S0]], #[[S1]]]}
+llvm.func @three_lds_buffers(
+    %global : !llvm.ptr<1>,
+    %desc_A : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_B : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_C : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>) {
+  %base_A = llvm.extractvalue %desc_A[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %base_B = llvm.extractvalue %desc_B[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %base_C = llvm.extractvalue %desc_C[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %c0 = llvm.mlir.constant(0 : i64) : i64
+  %ptr_A = llvm.getelementptr %base_A[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %ptr_B = llvm.getelementptr %base_B[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %ptr_C = llvm.getelementptr %base_C[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  rocdl.load.to.lds %global, %ptr_A, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr_B, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr_C, 4, 0, 0 : <1>
+  llvm.return
+}
+
+// -----
+
+// Nested GEP chains (GEP -> GEP -> extractvalue): simulates multi-buffered
+// subviews where the slot offset and element offset produce two levels of GEP.
+// Two different base structs should produce two distinct scopes.
+// CHECK-LABEL: llvm.func @nested_gep_two_bases
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[N0:.*]]], noalias_scopes = [#[[N1:.*]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[N1]]], noalias_scopes = [#[[N0]]]}
+llvm.func @nested_gep_two_bases(
+    %global : !llvm.ptr<1>,
+    %desc_A : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_B : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>) {
+  %base_A = llvm.extractvalue %desc_A[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %base_B = llvm.extractvalue %desc_B[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %slot_offset = llvm.mlir.constant(4096 : i64) : i64
+  %elem_offset = llvm.mlir.constant(42 : i64) : i64
+
+  %a_slot = llvm.getelementptr %base_A[%slot_offset] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %a_elem = llvm.getelementptr %a_slot[%elem_offset] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+
+  %b_slot = llvm.getelementptr %base_B[%slot_offset] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %b_elem = llvm.getelementptr %b_slot[%elem_offset] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  rocdl.load.to.lds %global, %a_elem, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %b_elem, 4, 0, 0 : <1>
+  llvm.return
+}
+
+// -----
+
+// Multi-buffered scenario: four loads targeting two slot-offset pairs from two
+// different base allocations. Each slot produces a distinct descriptor after
+// memref-to-LLVM lowering, so we expect 4 distinct scopes.
+// CHECK-LABEL: llvm.func @multi_buffered_four_scopes
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[MA:.*]]], noalias_scopes = [#[[MB:.*]], #[[MC:.*]], #[[MD:.*]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[MB]]], noalias_scopes = [#[[MA]], #[[MC]], #[[MD]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[MC]]], noalias_scopes = [#[[MA]], #[[MB]], #[[MD]]]}
+// CHECK: rocdl.load.to.lds {{.*}} {alias_scopes = [#[[MD]]], noalias_scopes = [#[[MA]], #[[MB]], #[[MC]]]}
+llvm.func @multi_buffered_four_scopes(
+    %global : !llvm.ptr<1>,
+    %desc_A0 : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_B0 : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_A1 : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>,
+    %desc_B1 : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>) {
+  %c0 = llvm.mlir.constant(0 : i64) : i64
+
+  %base_A0 = llvm.extractvalue %desc_A0[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %ptr_A0 = llvm.getelementptr %base_A0[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %base_B0 = llvm.extractvalue %desc_B0[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %ptr_B0 = llvm.getelementptr %base_B0[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+
+  %base_A1 = llvm.extractvalue %desc_A1[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %ptr_A1 = llvm.getelementptr %base_A1[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  %base_B1 = llvm.extractvalue %desc_B1[1]
+    : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+  %ptr_B1 = llvm.getelementptr %base_B1[%c0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f32
+  rocdl.load.to.lds %global, %ptr_A0, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr_B0, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr_A1, 4, 0, 0 : <1>
+  rocdl.load.to.lds %global, %ptr_B1, 4, 0, 0 : <1>
+  llvm.return
+}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/iree-org/iree/pull/23400. I find that the backend will conservatively insert vmcnt(0) that kills the multi-buffering async load performance. Cursor did the investigation and help me understand that we need to attach alias scopes so that the backend can differentiate from multiple buffers that they are not alias to each other so no conservative vmcnt(0) added.

Detailed Context: In pipelined loops with multi-buffered LDS, the LLVM backend's SIInsertWaitcnts pass conservatively inserts s_waitcnt vmcnt(0) before ds_read when it can't prove that in-flight buffer_load_lds operations target a different LDS region. With alias scopes, the backend knows that LoadToLDS ops to different buffers don't alias, eliminating one redundant vmcnt(0) per loop iteration.

The pass traces each LoadToLDS LDS pointer back through GEP and extractvalue chains to find the root allocation, creates a unique scope per distinct root, and annotates each op with alias_scopes (self) and noalias_scopes (all others).

In end to end multi-buffered pipeline test, this pass can provide enough hint for backend to skip overly conservative vmcnt(0).