### PR TITLE
Integrate llvm/llvm-project@fbed673f5238f219e43af0f88802d5422a77218b

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -726,7 +726,6 @@ public:
         }
         llvm::TargetOptions opt;
         opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-        opt.NoInfsFPMath = false;
         opt.NoNaNsFPMath = true;
         // Be extra cautious while this is less tested, and prevent unknown
         // fallbacks from global isel.


### PR DESCRIPTION
Integrate up to llvm/llvm-project@fbed673f5238f219e43af0f88802d5422a77218b

Fixes:
- Fix references to `NoInfsFPMath` target option, which was removed in llvm/llvm-project@5c5677d7b80e086c2fb2620511a213a5128b5e00
- Update test after `NoSideEffects` was added to `gpu.subgroup_reduce` in llvm/llvm-project@368d7ea12c0b


Reverts:
- llvm/llvm-project@3e1e86ef1fb8973f90cde376d5ad2d79ec7f52d9 (see #23401)