### PR TITLE
[VectorExt] Add vectorization support for iree_linalg_ext.arg_compare

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -208,25 +208,25 @@ void GenericVectorizationPass::runOnOperation() {
 
     // Try to vectorize to transfer_gather, if possible.
     llvm::TypeSwitch<Operation *>(op)
-        .Case<linalg::GenericOp>([&](auto genericOp) {
+        .Case([&](linalg::GenericOp genericOp) {
           if (vectorizeToTransferGather) {
             (void)IREE::VectorExt::vectorizeGatherLikeGenericToTransferGather(
                 rewriter, genericOp, vectorSizes, scalableVecDims,
                 /*vectorizeNDExtract=*/true);
-          } else {
-            FailureOr<linalg::VectorizationResult> result =
-                linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
-                                  /*vectorizeNDExtract=*/true);
-            if (succeeded(result)) {
-              rewriter.replaceOp(op, result->replacements);
-            }
+            return;
+          }
+          FailureOr<linalg::VectorizationResult> result =
+              linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
+                                /*vectorizeNDExtract=*/true);
+          if (succeeded(result)) {
+            rewriter.replaceOp(op, result->replacements);
           }
         })
-        .Case<IREE::LinalgExt::GatherOp>([&](auto gatherOp) {
+        .Case([&](IREE::LinalgExt::GatherOp gatherOp) {
           (void)IREE::VectorExt::vectorizeLinalgExtGatherToTransferGather(
               rewriter, gatherOp, vectorSizes);
         })
-        .Case<IREE::LinalgExt::ArgCompareOp>([&](auto argCompareOp) {
+        .Case([&](IREE::LinalgExt::ArgCompareOp argCompareOp) {
           (void)IREE::VectorExt::vectorizeLinalgExtArgCompare(
               rewriter, argCompareOp, vectorSizes);
         })

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -886,8 +886,8 @@ func.func @ukernel_unpack_infer_vector_sizes(%lhs: tensor<1x8x16x1xf32>, %rhs: t
 // -----
 
 func.func @arg_compare_implicit_index(%input: tensor<4x128xf32>,
-                                       %out_val: tensor<4xf32>,
-                                       %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
+                                      %out_val: tensor<4xf32>,
+                                      %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
   %result:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<4x128xf32>)
@@ -925,9 +925,9 @@ func.func @arg_compare_implicit_index(%input: tensor<4x128xf32>,
 // -----
 
 func.func @arg_compare_explicit_index(%partial_vals: tensor<4x32xf32>,
-                                       %partial_idxs: tensor<4x32xi32>,
-                                       %out_val: tensor<4xf32>,
-                                       %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
+                                      %partial_idxs: tensor<4x32xi32>,
+                                      %out_val: tensor<4xf32>,
+                                      %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
   %result:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%partial_vals, %partial_idxs : tensor<4x32xf32>, tensor<4x32xi32>)
@@ -968,8 +968,8 @@ func.func @arg_compare_explicit_index(%partial_vals: tensor<4x32xf32>,
 // -----
 
 func.func @arg_compare_with_index_base(%input: tensor<4x128xf32>,
-                                        %out_val: tensor<4xf32>,
-                                        %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
+                                       %out_val: tensor<4xf32>,
+                                       %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
   %base = arith.constant 64 : index
   %result:2 = iree_linalg_ext.arg_compare
     dimension(1)

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -882,3 +882,123 @@ func.func @ukernel_unpack_infer_vector_sizes(%lhs: tensor<1x8x16x1xf32>, %rhs: t
 // CHECK-MASK:         %[[READ:.*]] = vector.transfer_read %[[UKERNEL]]{{.*}} : tensor<1x1x16x16xf32>, vector<1x1x16x16xf32>
 // CHECK-MASK:         %[[CAST:.*]] = vector.shape_cast %[[READ]] : vector<1x1x16x16xf32> to vector<16x16xf32>
 // CHECK-MASK:         vector.transfer_write %[[CAST]]{{.*}} : vector<16x16xf32>, tensor<16x16xf32>
+
+// -----
+
+func.func @arg_compare_implicit_index(%input: tensor<4x128xf32>,
+                                       %out_val: tensor<4xf32>,
+                                       %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
+  %result:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input : tensor<4x128xf32>)
+    outs(%out_val, %out_idx : tensor<4xf32>, tensor<4xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4xf32>, tensor<4xi32>
+  return %result#0, %result#1 : tensor<4xf32>, tensor<4xi32>
+}
+// CHECK-LABEL: func.func @arg_compare_implicit_index
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUT_VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUT_IDX:[a-zA-Z0-9]+]]
+// CHECK:         %[[INPUT_VEC:.+]] = vector.transfer_read %[[INPUT]]
+// CHECK-SAME:      tensor<4x128xf32>, vector<4x128xf32>
+// CHECK:         %[[OUT_VAL_VEC:.+]] = vector.transfer_read %[[OUT_VAL]]
+// CHECK-SAME:      tensor<4xf32>, vector<4xf32>
+// CHECK:         %[[OUT_IDX_VEC:.+]] = vector.transfer_read %[[OUT_IDX]]
+// CHECK-SAME:      tensor<4xi32>, vector<4xi32>
+// CHECK:         %[[RESULT_VAL:.+]], %[[RESULT_IDX:.+]] = iree_vector_ext.arg_compare
+// CHECK-SAME:      dimension(1)
+// CHECK-SAME:      ins(%[[INPUT_VEC]] : vector<4x128xf32>)
+// CHECK-SAME:      inits(%[[OUT_VAL_VEC]], %[[OUT_IDX_VEC]] : vector<4xf32>, vector<4xi32>)
+// CHECK:         ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:           %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:           iree_vector_ext.yield %[[CMP]] : i1
+// CHECK:         -> vector<4xf32>, vector<4xi32>
+// CHECK:         %[[WRITE_VAL:.+]] = vector.transfer_write %[[RESULT_VAL]], %[[OUT_VAL]]
+// CHECK-SAME:      vector<4xf32>, tensor<4xf32>
+// CHECK:         %[[WRITE_IDX:.+]] = vector.transfer_write %[[RESULT_IDX]], %[[OUT_IDX]]
+// CHECK-SAME:      vector<4xi32>, tensor<4xi32>
+// CHECK:         return %[[WRITE_VAL]], %[[WRITE_IDX]]
+
+// -----
+
+func.func @arg_compare_explicit_index(%partial_vals: tensor<4x32xf32>,
+                                       %partial_idxs: tensor<4x32xi32>,
+                                       %out_val: tensor<4xf32>,
+                                       %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
+  %result:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%partial_vals, %partial_idxs : tensor<4x32xf32>, tensor<4x32xi32>)
+    outs(%out_val, %out_idx : tensor<4xf32>, tensor<4xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4xf32>, tensor<4xi32>
+  return %result#0, %result#1 : tensor<4xf32>, tensor<4xi32>
+}
+// CHECK-LABEL: func.func @arg_compare_explicit_index
+// CHECK-SAME:    %[[PARTIAL_VALS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[PARTIAL_IDXS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUT_VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUT_IDX:[a-zA-Z0-9]+]]
+// CHECK:         %[[VALS_VEC:.+]] = vector.transfer_read %[[PARTIAL_VALS]]
+// CHECK-SAME:      tensor<4x32xf32>, vector<4x32xf32>
+// CHECK:         %[[IDXS_VEC:.+]] = vector.transfer_read %[[PARTIAL_IDXS]]
+// CHECK-SAME:      tensor<4x32xi32>, vector<4x32xi32>
+// CHECK:         %[[OUT_VAL_VEC:.+]] = vector.transfer_read %[[OUT_VAL]]
+// CHECK-SAME:      tensor<4xf32>, vector<4xf32>
+// CHECK:         %[[OUT_IDX_VEC:.+]] = vector.transfer_read %[[OUT_IDX]]
+// CHECK-SAME:      tensor<4xi32>, vector<4xi32>
+// CHECK:         %[[RESULT_VAL:.+]], %[[RESULT_IDX:.+]] = iree_vector_ext.arg_compare
+// CHECK-SAME:      dimension(1)
+// CHECK-SAME:      ins(%[[VALS_VEC]], %[[IDXS_VEC]] : vector<4x32xf32>, vector<4x32xi32>)
+// CHECK-SAME:      inits(%[[OUT_VAL_VEC]], %[[OUT_IDX_VEC]] : vector<4xf32>, vector<4xi32>)
+// CHECK:         ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:           %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:           iree_vector_ext.yield %[[CMP]] : i1
+// CHECK:         -> vector<4xf32>, vector<4xi32>
+// CHECK:         %[[WRITE_VAL:.+]] = vector.transfer_write %[[RESULT_VAL]], %[[OUT_VAL]]
+// CHECK-SAME:      vector<4xf32>, tensor<4xf32>
+// CHECK:         %[[WRITE_IDX:.+]] = vector.transfer_write %[[RESULT_IDX]], %[[OUT_IDX]]
+// CHECK-SAME:      vector<4xi32>, tensor<4xi32>
+// CHECK:         return %[[WRITE_VAL]], %[[WRITE_IDX]]
+
+// -----
+
+func.func @arg_compare_with_index_base(%input: tensor<4x128xf32>,
+                                        %out_val: tensor<4xf32>,
+                                        %out_idx: tensor<4xi32>) -> (tensor<4xf32>, tensor<4xi32>) {
+  %base = arith.constant 64 : index
+  %result:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input : tensor<4x128xf32>)
+    outs(%out_val, %out_idx : tensor<4xf32>, tensor<4xi32>)
+    index_base(%base : index) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4xf32>, tensor<4xi32>
+  return %result#0, %result#1 : tensor<4xf32>, tensor<4xi32>
+}
+// CHECK-LABEL: func.func @arg_compare_with_index_base
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUT_VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUT_IDX:[a-zA-Z0-9]+]]
+// CHECK:         %[[BASE:.+]] = arith.constant 64 : index
+// CHECK:         %[[INPUT_VEC:.+]] = vector.transfer_read %[[INPUT]]
+// CHECK:         %[[OUT_VAL_VEC:.+]] = vector.transfer_read %[[OUT_VAL]]
+// CHECK:         %[[OUT_IDX_VEC:.+]] = vector.transfer_read %[[OUT_IDX]]
+// CHECK:         %[[RESULT_VAL:.+]], %[[RESULT_IDX:.+]] = iree_vector_ext.arg_compare
+// CHECK-SAME:      dimension(1)
+// CHECK-SAME:      ins(%[[INPUT_VEC]] : vector<4x128xf32>)
+// CHECK-SAME:      inits(%[[OUT_VAL_VEC]], %[[OUT_IDX_VEC]] : vector<4xf32>, vector<4xi32>)
+// CHECK-SAME:      index_base(%[[BASE]] : index)
+// CHECK:         ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:           %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:           iree_vector_ext.yield %[[CMP]] : i1
+// CHECK:         -> vector<4xf32>, vector<4xi32>
+// CHECK:         %[[WRITE_VAL:.+]] = vector.transfer_write %[[RESULT_VAL]], %[[OUT_VAL]]
+// CHECK:         %[[WRITE_IDX:.+]] = vector.transfer_write %[[RESULT_IDX]], %[[OUT_IDX]]
+// CHECK:         return %[[WRITE_VAL]], %[[WRITE_IDX]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
@@ -36,6 +36,40 @@ vectorizeLinalgExtGatherToTransferGather(RewriterBase &rewriter,
                                          IREE::LinalgExt::GatherOp gatherOp,
                                          ArrayRef<int64_t> vectorSizes = {});
 
+/// Vectorizes iree_linalg_ext.arg_compare to iree_vector_ext.arg_compare.
+///
+/// This transformation wraps the tensor operation with vector.transfer_read
+/// and vector.transfer_write operations, creating a vectorized version.
+///
+/// %result:2 = iree_linalg_ext.arg_compare
+///   dimension(1)
+///   ins(%input : tensor<4x128xf32>)
+///   outs(%out_val, %out_idx : tensor<4xf32>, tensor<4xi32>) {
+/// ^bb0(%a: f32, %b: f32):
+///   %cmp = arith.cmpf ogt, %a, %b : f32
+///   iree_linalg_ext.yield %cmp : i1
+/// }
+///
+///  vectorizes to:
+///
+/// %input_vec = vector.transfer_read %input
+/// %out_val_vec = vector.transfer_read %out_val
+/// %out_idx_vec = vector.transfer_read %out_idx
+/// %result_vec:2 = iree_vector_ext.arg_compare
+///   dimension(1)
+///   ins(%input_vec : vector<4x128xf32>)
+///   inits(%out_val_vec, %out_idx_vec : vector<4xf32>, vector<4xi32>) {
+/// ^bb0(%a: f32, %b: f32):
+///   %cmp = arith.cmpf ogt, %a, %b : f32
+///   iree_vector_ext.yield %cmp : i1
+/// }
+/// %write_val = vector.transfer_write %result_vec#0, %out_val
+/// %write_idx = vector.transfer_write %result_vec#1, %out_idx
+LogicalResult
+vectorizeLinalgExtArgCompare(RewriterBase &rewriter,
+                             IREE::LinalgExt::ArgCompareOp argCompareOp,
+                             ArrayRef<int64_t> vectorSizes = {});
+
 void populateVectorTransferGatherLoweringPatterns(RewritePatternSet &patterns);
 
 void populateVectorMaskLoweringPatterns(RewritePatternSet &patterns);

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -581,6 +581,146 @@ vectorizeLinalgExtGatherToTransferGather(RewriterBase &rewriter,
   return success();
 }
 
+/// Vectorizes iree_linalg_ext.arg_compare to iree_vector_ext.arg_compare.
+///
+/// This function performs a straightforward transformation: it wraps the
+/// iree_linalg_ext.arg_compare operation with vector.transfer_read/write
+/// operations to create a vector version, and creates an equivalent
+/// iree_vector_ext.arg_compare operation in between.
+///
+/// Example transformation (implicit-index mode):
+///
+/// %result:2 = iree_linalg_ext.arg_compare
+///   dimension(1)
+///   ins(%input : tensor<4x128xf32>)
+///   outs(%out_val, %out_idx : tensor<4xf32>, tensor<4xi32>) {
+/// ^bb0(%a: f32, %b: f32):
+///   %cmp = arith.cmpf ogt, %a, %b : f32
+///   iree_linalg_ext.yield %cmp : i1
+/// } -> tensor<4xf32>, tensor<4xi32>
+///
+/// Vectorizes to:
+///
+/// %input_vec = vector.transfer_read %input[%c0, %c0]
+///   : tensor<4x128xf32>, vector<4x128xf32>
+/// %out_val_vec = vector.transfer_read %out_val[%c0]
+///   : tensor<4xf32>, vector<4xf32>
+/// %out_idx_vec = vector.transfer_read %out_idx[%c0]
+///   : tensor<4xi32>, vector<4xi32>
+/// %result_vec:2 = iree_vector_ext.arg_compare
+///   dimension(1)
+///   ins(%input_vec : vector<4x128xf32>)
+///   inits(%out_val_vec, %out_idx_vec : vector<4xf32>, vector<4xi32>) {
+/// ^bb0(%a: f32, %b: f32):
+///   %cmp = arith.cmpf ogt, %a, %b : f32
+///   iree_vector_ext.yield %cmp : i1
+/// } -> vector<4xf32>, vector<4xi32>
+/// %write_val = vector.transfer_write %result_vec#0, %out_val[%c0]
+///   : vector<4xf32>, tensor<4xf32>
+/// %write_idx = vector.transfer_write %result_vec#1, %out_idx[%c0]
+///   : vector<4xi32>, tensor<4xi32>
+LogicalResult
+vectorizeLinalgExtArgCompare(RewriterBase &rewriter,
+                             IREE::LinalgExt::ArgCompareOp argCompareOp,
+                             ArrayRef<int64_t> vectorSizes) {
+  auto loc = argCompareOp.getLoc();
+  RewriterBase::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(argCompareOp);
+
+  ShapedType outValTy = argCompareOp.getOutputValueType();
+  ShapedType outIdxTy = argCompareOp.getOutputIndexType();
+
+  if (vectorSizes.empty()) {
+    vectorSizes = outValTy.getShape();
+  }
+
+  // Only static shapes are supported. Dynamic shapes would require masking.
+  if (!outValTy.hasStaticShape()) {
+    return failure();
+  }
+
+  Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+
+  // Vectorize the DPS input operands (input_value and optional input_index).
+  // We explicitly access these by name to avoid accidentally including
+  // index_base.
+  SmallVector<Value> inputVecs;
+  auto vectorizeInput = [&](Value input) {
+    auto inputTy = cast<ShapedType>(input.getType());
+    SmallVector<Value> readIndices(inputTy.getRank(), zero);
+    auto inputVecTy =
+        VectorType::get(inputTy.getShape(), inputTy.getElementType());
+    // TODO(Bangtian): Add masking/padding support for partial tiles.
+    // Currently passes std::nullopt, assuming vector size matches tensor shape.
+    auto readOp = vector::TransferReadOp::create(
+        rewriter, loc, inputVecTy, input, readIndices, std::nullopt);
+    inputVecs.push_back(readOp);
+  };
+
+  vectorizeInput(argCompareOp.getInputValue());
+  if (Value inputIndex = argCompareOp.getInputIndex()) {
+    vectorizeInput(inputIndex);
+  }
+
+  SmallVector<Value> initVecs;
+  for (Value init : argCompareOp.getDpsInits()) {
+    auto initTy = cast<ShapedType>(init.getType());
+    SmallVector<Value> readIndices(initTy.getRank(), zero);
+    auto initVecTy =
+        VectorType::get(initTy.getShape(), initTy.getElementType());
+    auto readOp = vector::TransferReadOp::create(rewriter, loc, initVecTy, init,
+                                                 readIndices, std::nullopt);
+    initVecs.push_back(readOp);
+  }
+
+  auto outValVecTy = VectorType::get(vectorSizes, outValTy.getElementType());
+  auto outIdxVecTy = VectorType::get(vectorSizes, outIdxTy.getElementType());
+
+  Region &srcRegion = argCompareOp.getRegion();
+
+  // Create the vector arg_compare operation using the builder that takes
+  // individual operands (this properly handles AttrSizedOperandSegments).
+  Value inputIndex = (inputVecs.size() > 1) ? inputVecs[1] : Value();
+  Value indexBase = argCompareOp.getIndexBase();
+
+  auto vectorArgCompareOp = IREE::VectorExt::ArgCompareOp::create(
+      rewriter, loc, TypeRange{outValVecTy, outIdxVecTy},
+      /*input_value=*/inputVecs[0],
+      /*input_index=*/inputIndex,
+      /*init_value=*/initVecs[0],
+      /*init_index=*/initVecs[1],
+      /*index_base=*/indexBase,
+      /*dimension=*/argCompareOp.getDimension());
+
+  // Clone the comparator region from LinalgExt op to VectorExt op.
+  // Clear the auto-created empty block first (from
+  // SingleBlockImplicitTerminator).
+  Region &dstRegion = vectorArgCompareOp.getRegion();
+  dstRegion.getBlocks().clear();
+  rewriter.cloneRegionBefore(srcRegion, dstRegion, dstRegion.begin());
+
+  // Replace LinalgExt::YieldOp with VectorExt::YieldOp.
+  Block &block = dstRegion.front();
+  auto oldYield = cast<IREE::LinalgExt::YieldOp>(block.getTerminator());
+  OpBuilder builder(oldYield);
+  IREE::VectorExt::YieldOp::create(builder, oldYield.getLoc(),
+                                   oldYield.getOperands());
+  oldYield.erase();
+
+  SmallVector<Value> results;
+  for (auto [idx, result] : llvm::enumerate(vectorArgCompareOp.getResults())) {
+    Value output = argCompareOp.getDpsInits()[idx];
+    auto outputTy = cast<ShapedType>(output.getType());
+    SmallVector<Value> writeIndices(outputTy.getRank(), zero);
+    auto writeOp = vector::TransferWriteOp::create(rewriter, loc, result,
+                                                   output, writeIndices);
+    results.push_back(writeOp.getResult());
+  }
+
+  rewriter.replaceOp(argCompareOp, results);
+  return success();
+}
+
 /// Lowers vector.mask %mask { iree_vector_ext.transfer_gather }
 ///  into
 /// iree_vector_ext.transfer_gather %mask

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -661,16 +661,10 @@ vectorizeLinalgExtArgCompare(RewriterBase &rewriter,
       /*index_base=*/indexBase,
       /*dimension=*/argCompareOp.getDimension());
 
-  // Clone comparator region. Clear auto-created block from
-  // SingleBlockImplicitTerminator (not tracked by rewriter), then recreate and
-  // populate using rewriter.
-  Region &dstRegion = vectorArgCompareOp.getRegion();
   Block *srcBlock = &srcRegion.front();
-
-  // Block auto-created by SingleBlockImplicitTerminator isn't rewriter-tracked.
-  dstRegion.getBlocks().clear();
-
-  // Create a new block with arguments using the rewriter.
+  Region &dstRegion = vectorArgCompareOp.getRegion();
+  rewriter.modifyOpInPlace(vectorArgCompareOp,
+                           [&]() { dstRegion.getBlocks().clear(); });
   SmallVector<Location> argLocs(srcBlock->getNumArguments(), loc);
   Block *dstBlock = rewriter.createBlock(&dstRegion, dstRegion.end(),
                                          srcBlock->getArgumentTypes(), argLocs);

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -590,18 +590,18 @@ vectorizeLinalgExtArgCompare(RewriterBase &rewriter,
   rewriter.setInsertionPoint(argCompareOp);
 
   auto inputValTy = cast<ShapedType>(argCompareOp.getInputValue().getType());
-  ShapedType outValTy = argCompareOp.getOutputValueType();
-  ShapedType outIdxTy = argCompareOp.getOutputIndexType();
-
-  if (vectorSizes.empty()) {
-    vectorSizes = outValTy.getShape();
-  }
-
   // Only static shapes are supported. Dynamic shapes would require masking.
   // Check input shape (includes reduction dimension) to catch dynamic reduction
   // dimensions that wouldn't appear in the static output shape.
   if (!inputValTy.hasStaticShape()) {
     return failure();
+  }
+
+  ShapedType outValTy = argCompareOp.getOutputValueType();
+  ShapedType outIdxTy = argCompareOp.getOutputIndexType();
+
+  if (vectorSizes.empty()) {
+    vectorSizes = outValTy.getShape();
   }
 
   // Ensure full tiles - partial tiles would require masking support.
@@ -667,7 +667,8 @@ vectorizeLinalgExtArgCompare(RewriterBase &rewriter,
   Region &dstRegion = vectorArgCompareOp.getRegion();
   Block *srcBlock = &srcRegion.front();
 
-  dstRegion.getBlocks().clear(); // Clear untracked auto-created block.
+  // Block auto-created by SingleBlockImplicitTerminator isn't rewriter-tracked.
+  dstRegion.getBlocks().clear();
 
   // Create a new block with arguments using the rewriter.
   SmallVector<Location> argLocs(srcBlock->getNumArguments(), loc);
@@ -690,7 +691,7 @@ vectorizeLinalgExtArgCompare(RewriterBase &rewriter,
     }
     // Replace LinalgExt::YieldOp with VectorExt::YieldOp.
     SmallVector<Value> mappedOperands;
-    for (const auto &operand : yieldOp.getOperands()) {
+    for (Value operand : yieldOp.getOperands()) {
       mappedOperands.push_back(mapper.lookup(operand));
     }
     IREE::VectorExt::YieldOp::create(rewriter, yieldOp.getLoc(),


### PR DESCRIPTION
Previously, the`iree_vector_ext.arg_compare` operation was added by #23386. 
This PR is about vectorizing `iree_linalg_ext.arg_compare` to `iree_vector_ext.arg_compare`.

Refer to Issue #23005 and [discord discussion](https://discord.com/channels/689900678990135345/1461079481803608158) for more context.  

Assisted-by:  [Claude Code](https://claude.ai/code)