### PR TITLE
Move Convert1X1FilterConv2DToMatmul pass from GlobalOptimization to Preprocessing

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -50,7 +50,6 @@ iree_compiler_cc_library(
     name = "GlobalOptimization",
     srcs = [
         "CleanupNumericNarrowing.cpp",
-        "Convert1X1FilterConv2DToMatmul.cpp",
         "ConvertStridedContractionToContraction.cpp",
         "DataLayoutPropagation.cpp",
         "DecomposeConcat.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -41,7 +41,6 @@ iree_cc_library(
     "Utils.h"
   SRCS
     "CleanupNumericNarrowing.cpp"
-    "Convert1X1FilterConv2DToMatmul.cpp"
     "ConvertStridedContractionToContraction.cpp"
     "DataLayoutPropagation.cpp"
     "DecomposeConcat.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -14,11 +14,6 @@ def CleanupNumericNarrowingPass :
   let summary = "Cleans up any numeric narrowing ops inserted by iree-global-opt-infer-numeric-narrowing.";
 }
 
-def Convert1X1FilterConv2DToMatmulPass:
-    Pass<"iree-global-opt-convert-1x1-filter-conv2d-to-matmul", ""> {
-  let summary = "Convert linalg convolution ops with 1x1 kernels into linalg matrix multiplication ops.";
-}
-
 def ConvertStridedContractionToContractionPass:
     Pass<"iree-global-opt-convert-strided-contraction-to-contraction", ""> {
   let summary = "Factors out an extract_slice from contraction-like ops with strided inputs.";

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -18,7 +18,6 @@ iree_lit_test_suite(
         # keep sorted
         [
             "cleanup_numeric_narrowing.mlir",
-            "conv1x1_to_matmul.mlir",
             "data_layout_propagation.mlir",
             "demote_contraction_inputs_to_bf16.mlir",
             "detach_elementwise_from_named_ops.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -15,7 +15,6 @@ iree_lit_test_suite(
     lit
   SRCS
     "cleanup_numeric_narrowing.mlir"
-    "conv1x1_to_matmul.mlir"
     "data_layout_propagation.mlir"
     "demote_contraction_inputs_to_bf16.mlir"
     "detach_elementwise_from_named_ops.mlir"

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
     srcs = [
         "ApplyPDLPatterns.cpp",
         "AttrBasedPipelinePass.cpp",
+        "Convert1X1FilterConv2DToMatmul.cpp",
         "ConvertConv2DToImg2Col.cpp",
         "ConvertConvFilterToChannelsLast.cpp",
         "ConvertConvToChannelsLast.cpp",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
   SRCS
     "ApplyPDLPatterns.cpp"
     "AttrBasedPipelinePass.cpp"
+    "Convert1X1FilterConv2DToMatmul.cpp"
     "ConvertConv2DToImg2Col.cpp"
     "ConvertConvFilterToChannelsLast.cpp"
     "ConvertConvToChannelsLast.cpp"

--- a/compiler/src/iree/compiler/Preprocessing/Common/Convert1X1FilterConv2DToMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Convert1X1FilterConv2DToMatmul.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/GlobalOptimization/Passes.h"
+#include "iree/compiler/Preprocessing/Common/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/IR/AffineExpr.h"
@@ -12,10 +12,10 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-namespace mlir::iree_compiler::GlobalOptimization {
+namespace mlir::iree_compiler::Preprocessing {
 
 #define GEN_PASS_DEF_CONVERT1X1FILTERCONV2DTOMATMULPASS
-#include "iree/compiler/GlobalOptimization/Passes.h.inc"
+#include "iree/compiler/Preprocessing/Common/Passes.h.inc"
 
 namespace {
 
@@ -97,4 +97,4 @@ struct Convert1X1FilterConv2DToMatmulPass
   }
 };
 } // namespace
-} // namespace mlir::iree_compiler::GlobalOptimization
+} // namespace mlir::iree_compiler::Preprocessing

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -40,6 +40,14 @@ def AttrBasedPipelinePass : Pass<"iree-preprocessing-attr-based-pipeline", ""> {
   ];
 }
 
+def Convert1X1FilterConv2DToMatmulPass:
+    Pass<"iree-preprocessing-convert-1x1-filter-conv2d-to-matmul", ""> {
+  let summary = "Convert linalg convolution ops with 1x1 kernels into linalg matrix multiplication ops.";
+  let dependentDialects = [
+    "mlir::linalg::LinalgDialect",
+  ];
+}
+
 def ConvertConv2DToImg2ColPass :
     Pass<"iree-preprocessing-convert-conv2d-to-img2col", ""> {
   let summary = "Convert linalg convolution ops to matmul img2col based implementation";

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         # keep sorted
         [
             "attr_based_pipeline.mlir",
+            "conv1x1_to_matmul.mlir",
             "conv2d_to_img2col.mlir",
             "conv_filter_to_channels_last.mlir",
             "conv_to_channels_last.mlir",

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "attr_based_pipeline.mlir"
+    "conv1x1_to_matmul.mlir"
     "conv2d_to_img2col.mlir"
     "conv_filter_to_channels_last.mlir"
     "conv_to_channels_last.mlir"

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv1x1_to_matmul.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv1x1_to_matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --mlir-print-local-scope -iree-global-opt-convert-1x1-filter-conv2d-to-matmul %s | FileCheck %s
+// RUN: iree-opt --split-input-file --mlir-print-local-scope -iree-preprocessing-convert-1x1-filter-conv2d-to-matmul %s | FileCheck %s
 
 util.func public @nhwc_conv_2d(%input: tensor<1x4x5x2xf32>, %filter: tensor<1x1x2x7xf32>) -> tensor<1x4x5x7xf32> {
     %0 = tensor.empty() : tensor<1x4x5x7xf32>

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -121,7 +121,7 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
       .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
       .addPass(mlir::createSimplifyDepthwiseConvPass)
       .addPass(createConvertConvToChannelsLastPass)
-      .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
+      .addPass(createConvert1X1FilterConv2DToMatmulPass)
       .addPass(createConvertConvFilterToChannelsLastPass);
   passManager.addPass(DispatchCreation::createFoldUnitExtentDimsPass());
   passManager.addPass(createCanonicalizerPass());


### PR DESCRIPTION
This PR relocates the `Convert1X1FilterConv2DToMatmulPass` from `GlobalOptimization` to `Preprocessing/Common`, as this pass is only used within the preprocessing pipeline (iree-preprocessing-transpose-convolution-pipeline).