### PR TITLE
[PCF] Fix bufferization bugs for generic and loop ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/ExternalInterfaces/BufferizationExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/ExternalInterfaces/BufferizationExternalModels.cpp
@@ -104,9 +104,8 @@ struct GenericOpInterface
     for (int64_t i = 0, e = genericOp->getNumResults(); i < e; ++i) {
       OpOperand *tiedInit = genericOp.getTiedInit(i);
       if (tiedInit) {
-        int64_t initIdx =
-            llvm::count(genericOp.getIsTied().take_front(i), true);
-        replacements.push_back(newInits[initIdx]);
+        replacements.push_back(
+            newGenericOp->getOperand(tiedInit->getOperandNumber()));
       } else {
         replacements.push_back(newGenericOp->getResult(i));
       }
@@ -218,8 +217,8 @@ struct LoopOpInterface
     for (int64_t i = 0, e = loopOp->getNumResults(); i < e; ++i) {
       OpOperand *tiedInit = loopOp.getTiedInit(i);
       if (tiedInit) {
-        int64_t initIdx = llvm::count(loopOp.getIsTied().take_front(i), true);
-        replacements.push_back(newInits[initIdx]);
+        replacements.push_back(
+            newLoopOp->getOperand(tiedInit->getOperandNumber()));
       } else {
         replacements.push_back(newLoopOp->getResult(i));
       }

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/ExternalInterfaces/BufferizationExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/ExternalInterfaces/BufferizationExternalModels.cpp
@@ -90,9 +90,28 @@ struct GenericOpInterface
         rewriter, loc, newResultTypes, genericOp.getScope(), newInits,
         genericOp.getDynamicSizes(), genericOp.getIsTied(),
         genericOp.getNumIterators(), genericOp.getSyncOnReturn());
+    // The builder doesn't set num_leading_args (it defaults to 0), but we
+    // need to preserve it from the original op since the execute region's
+    // block arguments include leading args from the initialize region.
+    newGenericOp.setNumLeadingArgs(genericOp.getNumLeadingArgs());
     newGenericOp.getRegion().takeBody(genericOp.getRegion());
     newGenericOp.getInitializer().takeBody(genericOp.getInitializer());
-    replaceOpWithBufferizedValues(rewriter, op, newGenericOp.getResults());
+
+    // For results with tied inits, use the init buffer directly so
+    // bufferization knows the result aliases the init (avoids extraneous
+    // copies). Self-allocated results use the new op's result.
+    SmallVector<Value> replacements;
+    for (int64_t i = 0, e = genericOp->getNumResults(); i < e; ++i) {
+      OpOperand *tiedInit = genericOp.getTiedInit(i);
+      if (tiedInit) {
+        int64_t initIdx =
+            llvm::count(genericOp.getIsTied().take_front(i), true);
+        replacements.push_back(newInits[initIdx]);
+      } else {
+        replacements.push_back(newGenericOp->getResult(i));
+      }
+    }
+    replaceOpWithBufferizedValues(rewriter, op, replacements);
     return success();
   }
 
@@ -191,7 +210,21 @@ struct LoopOpInterface
         newInits, loopOp.getDynamicSizes(), loopOp.getIsTied(),
         loopOp.getSyncOnReturn());
     newLoopOp.getRegion().takeBody(loopOp.getRegion());
-    replaceOpWithBufferizedValues(rewriter, op, newLoopOp.getResults());
+
+    // For results with tied inits, use the init buffer directly so
+    // bufferization knows the result aliases the init (avoids extraneous
+    // copies). Self-allocated results use the new op's result.
+    SmallVector<Value> replacements;
+    for (int64_t i = 0, e = loopOp->getNumResults(); i < e; ++i) {
+      OpOperand *tiedInit = loopOp.getTiedInit(i);
+      if (tiedInit) {
+        int64_t initIdx = llvm::count(loopOp.getIsTied().take_front(i), true);
+        replacements.push_back(newInits[initIdx]);
+      } else {
+        replacements.push_back(newLoopOp->getResult(i));
+      }
+    }
+    replaceOpWithBufferizedValues(rewriter, op, replacements);
     return success();
   }
 
@@ -265,17 +298,19 @@ struct WriteSliceOpInterface
 struct ReadSliceOpInterface
     : BufferizableOpInterface::ExternalModel<ReadSliceOpInterface,
                                              PCF::ReadSliceOp> {
-  static MemRefType
-  getMaximallyDynamicBufferType(MLIRContext *context,
-                                PCF::ShapedRefType sourceType) {
-    // Create result type with maximally dynamic layout and no memory space.
-    // Layout and memory space aren't known until resolving sref types, after
-    // which we will propagate both to this operation's users.
-    SmallVector<int64_t> strides(sourceType.getRank(), ShapedType::kDynamic);
+  /// Build a memref type for the slice result using the read_slice's sizes.
+  /// The result shape comes from the slice sizes, not the full source shape.
+  /// Layout and memory space are maximally dynamic (unknown until resolving
+  /// sref types, after which both are propagated to this operation's users).
+  static MemRefType getSliceBufferType(MLIRContext *context,
+                                       PCF::ReadSliceOp readOp) {
+    auto resultTensorType = cast<RankedTensorType>(readOp.getResultType());
+    int64_t rank = resultTensorType.getRank();
+    SmallVector<int64_t> strides(rank, ShapedType::kDynamic);
     auto layout =
         StridedLayoutAttr::get(context, ShapedType::kDynamic, strides);
-    return MemRefType::get(sourceType.getShape(), sourceType.getElementType(),
-                           layout,
+    return MemRefType::get(resultTensorType.getShape(),
+                           resultTensorType.getElementType(), layout,
                            /*memorySpace=*/nullptr);
   }
   FailureOr<BaseMemRefType>
@@ -283,8 +318,7 @@ struct ReadSliceOpInterface
                 const BufferizationState &state,
                 SmallVector<Value> &invocationStack) const {
     auto readOp = cast<PCF::ReadSliceOp>(op);
-    return getMaximallyDynamicBufferType(op->getContext(),
-                                         readOp.getSourceType());
+    return getSliceBufferType(op->getContext(), readOp);
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
@@ -298,8 +332,8 @@ struct ReadSliceOpInterface
     }
 
     // Create result type with maximally dynamic layout and no memory space.
-    auto resultType =
-        getMaximallyDynamicBufferType(op->getContext(), readOp.getSourceType());
+    // Uses the slice sizes, not the full source shape.
+    MemRefType resultType = getSliceBufferType(op->getContext(), readOp);
 
     // GetMemrefOp lets us get a memref out of a read_slice. Accesses to srefs
     // are allowed to ignore accesses to this memref.

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/ExternalInterfaces/test/bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/ExternalInterfaces/test/bufferize.mlir
@@ -198,3 +198,85 @@ util.func private @read_tensor(%src: !pcf.sref<?x?xi32, #pcf.test_scope>, %s0: i
 //  CHECK-NEXT:   %[[MEMREF:.+]] = pcf.get_memref %[[SRC]][0, 1] [%[[S0]], %[[S1]]] [1, 1] : !pcf.sref<?x?xi32, #pcf.test_scope> to memref<?x?xi32, strided<[?, ?], offset: ?>>
 //  CHECK-NEXT:   %[[RESULT:.+]] = bufferization.to_tensor %[[MEMREF]] : memref<?x?xi32, strided<[?, ?], offset: ?>> to tensor<?x?xi32>
 //  CHECK-NEXT:   util.return %[[RESULT]] : tensor<?x?xi32>
+
+// -----
+
+// Verify that read_slice uses the slice result shape (4x8), not the source
+// sref shape (16x16), when building the memref type.
+util.func private @read_slice_shape(%src: !pcf.sref<16x16xi32, #pcf.test_scope>) -> tensor<4x8xi32> {
+  %result = pcf.read_slice %src[0, 0] [4, 8] [1, 1] : !pcf.sref<16x16xi32, #pcf.test_scope> to tensor<4x8xi32>
+  util.return %result : tensor<4x8xi32>
+}
+
+// CHECK-LABEL: @read_slice_shape
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: !pcf.sref<16x16xi32, #pcf.test_scope>
+//  CHECK-NEXT:   %[[MEMREF:.+]] = pcf.get_memref %[[SRC]][0, 0] [4, 8] [1, 1] : !pcf.sref<16x16xi32, #pcf.test_scope> to memref<4x8xi32, strided<[?, ?], offset: ?>>
+//  CHECK-NEXT:   %[[RESULT:.+]] = bufferization.to_tensor %[[MEMREF]] : memref<4x8xi32, strided<[?, ?], offset: ?>> to tensor<4x8xi32>
+//  CHECK-NEXT:   util.return %[[RESULT]] : tensor<4x8xi32>
+
+// -----
+
+// Verify that bufferizing a generic with an initializer preserves the
+// num_leading_args property. Without this, the initializer's yielded values
+// would be lost when the op is rebuilt during bufferization.
+util.func private @bufferize_generic_with_initializer(%d0: index, %d1: index) {
+  %0 = bufferization.alloc_tensor(%d0, %d1) : tensor<?x?xf32>
+  %1 = pcf.generic scope(#pcf.test_scope) initialize {
+      %c42 = arith.constant 42 : index
+      pcf.yield %c42 : index
+    } -> (%leading: index)
+    execute(%ref = %0)[%id: index, %n: index]
+         : (!pcf.sref<?x?xf32, #pcf.test_scope>)
+        -> (tensor<?x?xf32>) {
+    util.optimization_barrier %leading : index
+    pcf.return
+  }
+  util.return
+}
+
+// CHECK-LABEL: @bufferize_generic_with_initializer(
+//  CHECK-SAME:   %[[D0:[A-Za-z0-9]+]]: index
+//  CHECK-SAME:   %[[D1:[A-Za-z0-9]+]]: index
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc(%[[D0]], %[[D1]]) {alignment = 64 : i64} : memref<?x?xf32>
+//       CHECK:   pcf.generic scope(#pcf.test_scope) initialize {
+//  CHECK-NEXT:       %[[C42:.+]] = arith.constant 42
+//  CHECK-NEXT:       pcf.yield %[[C42]]
+//  CHECK-NEXT:     } -> (%[[LEADING:.+]]: index)
+//  CHECK-NEXT:     execute(%{{.*}} = %[[ALLOC]])[%{{.*}}: index, %{{.*}}: index]
+//  CHECK-NEXT:          : (!pcf.sref<?x?xf32, #pcf.test_scope>)
+//  CHECK-NEXT:         -> (memref<?x?xf32>) {
+//       CHECK:       util.optimization_barrier %[[LEADING]]
+//       CHECK:       pcf.return
+//  CHECK-NEXT:     }
+
+// -----
+
+// Verify that tied results use the init buffer directly (not the new op's
+// result) while untied results use the new op's result. This ensures
+// bufferization knows tied results alias their inits.
+util.func private @bufferize_loop_tied_result_users(%d0: index, %n: index) -> (tensor<4xi32>, tensor<?xi32>) {
+  %init = bufferization.alloc_tensor() : tensor<4xi32>
+  %0:2 = pcf.loop scope(#pcf.test_scope) count(%n)
+    execute(%ref = %init, %ref_1)[%id: index]
+         : (!pcf.sref<4xi32, #pcf.test_scope>, !pcf.sref<?xi32, #pcf.test_scope>)
+        -> (tensor<4xi32>, tensor<?xi32>{%d0}) {
+    pcf.return
+  }
+  util.return %0#0, %0#1 : tensor<4xi32>, tensor<?xi32>
+}
+
+// CHECK-LABEL: @bufferize_loop_tied_result_users(
+//  CHECK-SAME:   %[[D0:[A-Za-z0-9]+]]: index
+//  CHECK-SAME:   %[[N:[A-Za-z0-9]+]]: index
+//       CHECK:   %[[INIT:.+]] = memref.alloc() {alignment = 64 : i64} : memref<4xi32>
+//       CHECK:   %[[LOOP:.+]]:2 = pcf.loop scope(#pcf.test_scope) count(%[[N]])
+//  CHECK-NEXT:     execute(%{{.*}} = %[[INIT]], %{{.*}})[%{{.*}}: index]
+//  CHECK-NEXT:          : (!pcf.sref<4xi32, #pcf.test_scope>,
+//  CHECK-SAME:             !pcf.sref<?xi32, #pcf.test_scope>)
+//  CHECK-NEXT:         -> (memref<4xi32>, memref<?xi32>{%[[D0]]}) {
+//       CHECK:       pcf.return
+//  CHECK-NEXT:     }
+// Tied result: replaced by init buffer directly, not the loop result.
+//   CHECK-DAG:   bufferization.to_tensor %[[INIT]]
+// Untied result: replaced by the loop op's result.
+//   CHECK-DAG:   bufferization.to_tensor %[[LOOP]]#1


### PR DESCRIPTION
Three independent bug fixes:

1. Preserve num_leading_args when bufferizing pcf.generic. The builder defaults to 0, but the execute region's block arguments include leading args from the initialize region.

2. Fix pcf.read_slice bufferization to use the result tensor shape (the slice sizes) instead of the full source sref shape when computing the memref type. This fixes memref.copy shape mismatches.

3. Use init buffers directly for tied results in pcf.generic and pcf.loop bufferization. This lets the bufferization framework know the result aliases the init, eliminating extraneous memref.copy operations.