### PR TITLE
[PCF] Add producer fusion into pcf.generic/loop ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/BUILD.bazel
@@ -39,6 +39,7 @@ iree_compiler_cc_library(
         "ConvertSRefToMemRef.cpp",
         "FuseConsumers.cpp",
         "FusePCFWrites.cpp",
+        "FuseProducers.cpp",
         "LowerStructuralPCF.cpp",
         "Passes.cpp",
         "ResolveTokens.cpp",

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     "ConvertSRefToMemRef.cpp"
     "FuseConsumers.cpp"
     "FusePCFWrites.cpp"
+    "FuseProducers.cpp"
     "LowerStructuralPCF.cpp"
     "Passes.cpp"
     "ResolveTokens.cpp"

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseProducers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseProducers.cpp
@@ -1,0 +1,239 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/TilingInterface.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-pcf-fuse-producers"
+
+namespace mlir::iree_compiler::IREE::PCF {
+
+#define GEN_PASS_DEF_FUSEPRODUCERSPASS
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h.inc"
+
+namespace {
+
+struct FuseProducersPass final
+    : impl::FuseProducersPassBase<FuseProducersPass> {
+  void runOnOperation() override;
+};
+
+struct FuseProducerIntoGenericOp
+    : public OpRewritePattern<IREE::PCF::GenericOp> {
+  using Base::Base;
+  LogicalResult matchAndRewrite(IREE::PCF::GenericOp genericOp,
+                                PatternRewriter &rewriter) const override {
+    ProducerFusionParams params;
+    if (failed(matchTilableProducer(rewriter, genericOp, params))) {
+      return failure();
+    }
+    fuseTilableProducer(rewriter, genericOp, params);
+    return success();
+  }
+};
+
+struct FuseProducerIntoLoopOp : public OpRewritePattern<IREE::PCF::LoopOp> {
+  using Base::Base;
+  LogicalResult matchAndRewrite(IREE::PCF::LoopOp loopOp,
+                                PatternRewriter &rewriter) const override {
+    ProducerFusionParams params;
+    if (failed(matchTilableProducer(rewriter, loopOp, params))) {
+      return failure();
+    }
+    fuseTilableProducer(rewriter, loopOp, params);
+    return success();
+  }
+};
+
+void FuseProducersPass::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  patterns.add<FuseProducerIntoGenericOp, FuseProducerIntoLoopOp>(
+      &getContext());
+  populatePCFDropUnusedResultPatterns(patterns);
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+//===---------------------------------------------------------------------===//
+// Producer fusion impls
+//===---------------------------------------------------------------------===//
+
+/// For a given result of a scoped op, find all pcf.read_slice ops on the
+/// corresponding sref region argument that read the init value.
+template <typename OpTy>
+static LogicalResult
+lookupConsumerSlices(OpResult result,
+                     SmallVectorImpl<PCF::ReadSliceOp> &slices) {
+  OpTy owner = cast<OpTy>(result.getOwner());
+  Value tiedArg = owner.getRegionRefArgs()[result.getResultNumber()];
+
+  // Collect all read_slice ops on this sref arg. Write_slice users are
+  // allowed but not tracked. Any other user type prevents fusion.
+  SmallVector<PCF::ReadSliceOp> reads;
+  for (Operation *user : tiedArg.getUsers()) {
+    if (isa<PCF::WriteSliceOp>(user)) {
+      continue;
+    }
+    auto readOp = dyn_cast<PCF::ReadSliceOp>(user);
+    if (!readOp || !readOp.hasUnitStride()) {
+      return failure();
+    }
+    reads.push_back(readOp);
+  }
+
+  // With SyncOnReturn semantics, the only case where a read does not see the
+  // init value is when there are overlapping reads and writes, which is
+  // explicitly undefined behavior. We may therefore optimize as though all
+  // reads see the init value.
+  auto srefType = cast<PCF::ShapedRefType>(tiedArg.getType());
+  if (!srefType.isReturnOnlySync()) {
+    return failure();
+  }
+
+  slices.append(reads.begin(), reads.end());
+  return success();
+}
+
+template <typename OpTy>
+static LogicalResult matchTilableProducerImpl(RewriterBase &rewriter,
+                                              OpTy scopedOp,
+                                              ProducerFusionParams &params) {
+  for (int64_t i = 0, e = scopedOp->getNumResults(); i < e; ++i) {
+    OpOperand *tiedInit = scopedOp.getTiedInit(i);
+    if (!tiedInit) {
+      continue;
+    }
+
+    Value initValue = tiedInit->get();
+    Operation *defOp = initValue.getDefiningOp();
+    if (!defOp) {
+      continue;
+    }
+    auto producer = dyn_cast<TilingInterface>(defOp);
+    if (!producer) {
+      continue;
+    }
+
+    // Must be DPS with single result.
+    auto dpsProducer = dyn_cast<DestinationStyleOpInterface>(defOp);
+    if (!dpsProducer || defOp->getNumResults() != 1) {
+      continue;
+    }
+
+    // Verify dominance of producer's operands.
+    DominanceInfo dominanceInfo(scopedOp->getParentOp());
+    bool allDominate = llvm::all_of(defOp->getOperands(), [&](Value v) {
+      return dominanceInfo.dominates(v, scopedOp);
+    });
+    if (!allDominate) {
+      continue;
+    }
+
+    // Find read_slice ops on the corresponding sref arg.
+    SmallVector<PCF::ReadSliceOp> readSlices;
+    if (failed(
+            lookupConsumerSlices<OpTy>(scopedOp->getOpResult(i), readSlices))) {
+      continue;
+    }
+
+    if (readSlices.empty()) {
+      continue;
+    }
+
+    params.resultIndex = i;
+    params.producer = defOp;
+    params.readSlices = std::move(readSlices);
+    return success();
+  }
+  return rewriter.notifyMatchFailure(scopedOp, "no fusable producer found");
+}
+
+template <typename OpTy>
+static void fuseTilableProducerImpl(RewriterBase &rewriter, OpTy scopedOp,
+                                    const ProducerFusionParams &params) {
+  auto producer = cast<TilingInterface>(params.producer);
+
+  // Step 1: Replace the init with the producer's DPS init.
+  auto dpsProducer = cast<DestinationStyleOpInterface>(params.producer);
+  Value producerDPSInit = dpsProducer.getDpsInits()[0];
+
+  OpOperand *tiedInit = scopedOp.getTiedInit(params.resultIndex);
+  rewriter.modifyOpInPlace(scopedOp,
+                           [&]() { tiedInit->assign(producerDPSInit); });
+
+  // Step 2: At each read_slice, generate tiled producer.
+  for (PCF::ReadSliceOp readSlice : params.readSlices) {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(readSlice);
+    Location loc = readSlice.getLoc();
+
+    SmallVector<OpFoldResult> offsets = readSlice.getMixedOffsets();
+    SmallVector<OpFoldResult> sizes = readSlice.getMixedSizes();
+
+    FailureOr<TilingResult> tiledResult = producer.generateResultTileValue(
+        rewriter, /*resultNumber=*/0, offsets, sizes);
+    assert(succeeded(tiledResult) && "unexpected tiling failure");
+
+    Value replacement = tiledResult->tiledValues[0];
+
+    // generateResultTileValue produces a tensor. If the read_slice returns a
+    // vector, extract it with vector.transfer_read.
+    if (auto vectorType = dyn_cast<VectorType>(readSlice.getType())) {
+      auto tensorType = cast<RankedTensorType>(replacement.getType());
+      Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+      SmallVector<Value> indices(tensorType.getRank(), zero);
+      SmallVector<bool> inBounds(tensorType.getRank(), true);
+      replacement = vector::TransferReadOp::create(
+          rewriter, loc, vectorType, replacement, indices,
+          /*padding=*/std::nullopt, inBounds);
+    }
+
+    rewriter.replaceOp(readSlice, replacement);
+  }
+
+  // Step 3: Erase the original producer if it has no other uses.
+  if (params.producer->use_empty()) {
+    rewriter.eraseOp(params.producer);
+  }
+}
+
+} // namespace
+
+//===---------------------------------------------------------------------===//
+// Public API Specializations
+//===---------------------------------------------------------------------===//
+
+LogicalResult matchTilableProducer(RewriterBase &rewriter,
+                                   PCF::GenericOp genericOp,
+                                   ProducerFusionParams &params) {
+  return matchTilableProducerImpl(rewriter, genericOp, params);
+}
+
+LogicalResult matchTilableProducer(RewriterBase &rewriter, PCF::LoopOp loopOp,
+                                   ProducerFusionParams &params) {
+  return matchTilableProducerImpl(rewriter, loopOp, params);
+}
+
+void fuseTilableProducer(RewriterBase &rewriter, PCF::GenericOp genericOp,
+                         const ProducerFusionParams &params) {
+  return fuseTilableProducerImpl(rewriter, genericOp, params);
+}
+
+void fuseTilableProducer(RewriterBase &rewriter, PCF::LoopOp loopOp,
+                         const ProducerFusionParams &params) {
+  return fuseTilableProducerImpl(rewriter, loopOp, params);
+}
+
+} // namespace mlir::iree_compiler::IREE::PCF

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.td
@@ -58,6 +58,30 @@ def FuseConsumersPass : Pass<"iree-pcf-fuse-consumers", ""> {
                            "::mlir::iree_compiler::IREE::PCF::PCFDialect"];
 }
 
+def FuseProducersPass : Pass<"iree-pcf-fuse-producers", ""> {
+  let summary = "Fuses DPS producers into pcf.generic/loop ops through tied init args.";
+  let description = [{
+    Pass for fusing producer operations into `pcf.generic` and `pcf.loop` ops.
+
+    The input is IR containing PCF parallel ops whose tied init values are
+    produced by operations implementing `TilingInterface` and
+    `DestinationStyleOpInterface` (e.g. `linalg.fill`).
+
+    The pass matches each tied init that is the single result of a DPS producer.
+    For each `pcf.read_slice` on the corresponding sref argument, it generates a
+    tiled version of the producer via `generateResultTileValue` and replaces the
+    read with the tiled result. The scoped op's init is updated to the producer's
+    DPS init, and the original producer is erased if unused.
+
+    The underlying fusion patterns are exposed via `matchTilableProducer()` and
+    `fuseTilableProducer()` for use in custom pipelines.
+  }];
+  let dependentDialects = ["::mlir::arith::ArithDialect",
+                           "::mlir::affine::AffineDialect",
+                           "::mlir::vector::VectorDialect",
+                           "::mlir::iree_compiler::IREE::PCF::PCFDialect"];
+}
+
 def FusePCFWritesPass : Pass<"iree-pcf-fuse-pcf-writes", ""> {
   let summary = "Consolidates pcf.write_slice ops in loop bodies";
   let description = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
@@ -110,9 +110,9 @@ struct ProducerFusionParams {
 // through its tied init argument. The producer must:
 //   1. Implement TilingInterface and DestinationStyleOpInterface.
 //   2. Have a single result.
-//   3. Have all operands dominating the scoped op.
-//   4. Feed into a tied init of the scoped op whose corresponding sref arg
-//      has only read_slice and write_slice users.
+//   3. Have all operands dominating the generic/loop op.
+//   4. Feed into a tied init of the generic/loop op whose corresponding sref
+//      arg has only read_slice and write_slice users.
 //
 // On success, |params| is populated with the result index, producer op, and
 // list of read_slice ops to replace with tiled producer computations.
@@ -122,7 +122,7 @@ LogicalResult matchTilableProducer(RewriterBase &rewriter,
 LogicalResult matchTilableProducer(RewriterBase &rewriter, PCF::LoopOp loopOp,
                                    ProducerFusionParams &params);
 
-// Fuses the matched producer into the scoped op by:
+// Fuses the matched producer into the pcf.generic/loop op by:
 //   1. Replacing the tied init with the producer's DPS init.
 //   2. Generating tiled producer computations at each read_slice site via
 //      TilingInterface::generateResultTileValue.

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
@@ -96,6 +96,42 @@ void fuseTilableConsumer(RewriterBase &rewriter, PCF::LoopOp loopOp,
                          TilingInterface target,
                          const ConsumerFusionParams &params);
 
+struct ProducerFusionParams {
+  // Which result index of the scoped op has a fusable producer init.
+  unsigned resultIndex;
+  // The producer op to fuse (implements TilingInterface + DPS). Stored as
+  // Operation* to avoid requiring the full TilingInterface definition here.
+  Operation *producer;
+  // Read sites on the corresponding sref arg that consume the init value.
+  SmallVector<PCF::ReadSliceOp> readSlices;
+};
+
+// Helpers to match a DPS producer as fusable into a pcf.generic/loop op
+// through its tied init argument. The producer must:
+//   1. Implement TilingInterface and DestinationStyleOpInterface.
+//   2. Have a single result.
+//   3. Have all operands dominating the scoped op.
+//   4. Feed into a tied init of the scoped op whose corresponding sref arg
+//      has only read_slice and write_slice users.
+//
+// On success, |params| is populated with the result index, producer op, and
+// list of read_slice ops to replace with tiled producer computations.
+LogicalResult matchTilableProducer(RewriterBase &rewriter,
+                                   PCF::GenericOp genericOp,
+                                   ProducerFusionParams &params);
+LogicalResult matchTilableProducer(RewriterBase &rewriter, PCF::LoopOp loopOp,
+                                   ProducerFusionParams &params);
+
+// Fuses the matched producer into the scoped op by:
+//   1. Replacing the tied init with the producer's DPS init.
+//   2. Generating tiled producer computations at each read_slice site via
+//      TilingInterface::generateResultTileValue.
+//   3. Erasing the original producer if it has no remaining uses.
+void fuseTilableProducer(RewriterBase &rewriter, PCF::GenericOp genericOp,
+                         const ProducerFusionParams &params);
+void fuseTilableProducer(RewriterBase &rewriter, PCF::LoopOp loopOp,
+                         const ProducerFusionParams &params);
+
 // Pattern set for dropping unused results from scoped ops. Due to memory
 // effects this requires cascading operation erasure and is unsuitable for
 // a canonicalization pattern.

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "convert_sref_to_memref.mlir",
             "fuse_consumers.mlir",
             "fuse_pcf_writes.mlir",
+            "fuse_producers.mlir",
             "lower_structural_pcf.mlir",
             "resolve_tokens.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "convert_sref_to_memref.mlir"
     "fuse_consumers.mlir"
     "fuse_pcf_writes.mlir"
+    "fuse_producers.mlir"
     "lower_structural_pcf.mlir"
     "resolve_tokens.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/fuse_producers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/test/fuse_producers.mlir
@@ -1,0 +1,275 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(iree-pcf-fuse-producers)" --split-input-file | FileCheck %s
+
+// Positive Tests:
+//* - linalg.fill producer into pcf.generic
+//* - linalg.fill producer into pcf.loop
+//* - linalg.transpose producer into pcf.generic
+//* - Producer with multiple read sites
+//* - Producer erased when no other uses
+//* - Producer kept when other uses exist
+//* - Fusion skips first init (no producer) and fuses second init
+//* - Producer fusion with vector read_slice
+
+// Basic: fuse a linalg.fill producer into a pcf.generic's init.
+func.func @fuse_fill_into_generic(%arg0: tensor<8x16xf32>, %dest: tensor<8x16xf32>) -> tensor<8x16xf32> {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<8x16xf32>) -> tensor<8x16xf32>
+  %0 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %fill)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>) {
+    %slice = pcf.read_slice %ref[%id0, %id1] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %result = linalg.exp ins(%slice : tensor<4x8xf32>) outs(%slice : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %result into %ref[%id0, %id1] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0 : tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @fuse_fill_into_generic
+//  CHECK-SAME:   %[[ARG0:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+
+//       CHECK:  %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-NOT:  linalg.fill
+//       CHECK:  %[[GENERIC:.+]] = pcf.generic scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF:.+]] = %[[DEST]])[%[[ID0:[A-Za-z0-9_]+]]: index, %[[ID1:[A-Za-z0-9_]+]]: index
+//       CHECK:    %[[EXTRACT:.+]] = tensor.extract_slice %[[DEST]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    %[[TILED_FILL:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[EXTRACT]] : tensor<4x8xf32>)
+//       CHECK:    %[[EXP:.+]] = linalg.exp ins(%[[TILED_FILL]]{{.*}} outs(%[[TILED_FILL]]
+//       CHECK:    pcf.write_slice %[[EXP]] into %[[REF]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    pcf.return
+//       CHECK:  return %[[GENERIC]]
+
+// -----
+
+// Basic: fuse a linalg.fill producer into a pcf.loop's init.
+func.func @fuse_fill_into_loop(%dest: tensor<8x16xf32>, %n0: index, %n1: index) -> tensor<8x16xf32> {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<8x16xf32>) -> tensor<8x16xf32>
+  %0 = pcf.loop scope(#pcf.test_scope) count(%n0, %n1)
+    execute(%ref = %fill)[%id0: index, %id1: index]
+            : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+           -> (tensor<8x16xf32>) {
+    %slice = pcf.read_slice %ref[%id0, %id1] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %result = linalg.exp ins(%slice : tensor<4x8xf32>) outs(%slice : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %result into %ref[%id0, %id1] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0 : tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @fuse_fill_into_loop
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+
+//       CHECK:  %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-NOT:  linalg.fill
+//       CHECK:  %[[LOOP:.+]] = pcf.loop scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF:.+]] = %[[DEST]])[%[[ID0:[A-Za-z0-9_]+]]: index, %[[ID1:[A-Za-z0-9_]+]]: index
+//       CHECK:    %[[EXTRACT:.+]] = tensor.extract_slice %[[DEST]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    %[[TILED_FILL:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[EXTRACT]] : tensor<4x8xf32>)
+//       CHECK:    %[[EXP:.+]] = linalg.exp ins(%[[TILED_FILL]]{{.*}} outs(%[[TILED_FILL]]
+//       CHECK:    pcf.write_slice %[[EXP]] into %[[REF]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    pcf.return
+//       CHECK:  return %[[LOOP]]
+
+// -----
+
+// Fuse a linalg.transpose producer. Verifies that the tiled transpose extracts
+// from the input with permuted offsets and sizes.
+func.func @fuse_transpose_into_generic(%input: tensor<16x8xf32>, %dest: tensor<8x16xf32>) -> tensor<8x16xf32> {
+  %empty = tensor.empty() : tensor<8x16xf32>
+  %transpose = linalg.transpose ins(%input : tensor<16x8xf32>) outs(%empty : tensor<8x16xf32>) permutation = [1, 0]
+  %0 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %transpose)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>) {
+    %slice = pcf.read_slice %ref[%id0, %id1] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %result = linalg.exp ins(%slice : tensor<4x8xf32>) outs(%slice : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %result into %ref[%id0, %id1] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0 : tensor<8x16xf32>
+}
+
+// The transpose has permutation [1,0], so a result tile at [id0, id1] of size
+// [4, 8] maps to an input tile at [id1, id0] of size [8, 4].
+//
+// CHECK-LABEL: @fuse_transpose_into_generic
+//  CHECK-SAME:   %[[INPUT:[A-Za-z0-9_]+]]: tensor<16x8xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+
+//       CHECK:  %[[EMPTY:.+]] = tensor.empty() : tensor<8x16xf32>
+//   CHECK-NOT:  linalg.transpose
+//       CHECK:  %[[GENERIC:.+]] = pcf.generic scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF:.+]] = %[[EMPTY]])[%[[ID0:[A-Za-z0-9_]+]]: index, %[[ID1:[A-Za-z0-9_]+]]: index
+//       CHECK:    %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[INPUT]][%[[ID1]], %[[ID0]]] [8, 4] [1, 1] : tensor<16x8xf32> to tensor<8x4xf32>
+//       CHECK:    %[[OUT_SLICE:.+]] = tensor.extract_slice %[[EMPTY]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1] : tensor<8x16xf32> to tensor<4x8xf32>
+//       CHECK:    %[[TRANSPOSED:.+]] = linalg.transpose ins(%[[INPUT_SLICE]] : tensor<8x4xf32>) outs(%[[OUT_SLICE]] : tensor<4x8xf32>) permutation = [1, 0]
+//       CHECK:    %[[EXP:.+]] = linalg.exp ins(%[[TRANSPOSED]]{{.*}} outs(%[[TRANSPOSED]]
+//       CHECK:    pcf.write_slice %[[EXP]] into %[[REF]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    pcf.return
+//       CHECK:  return %[[GENERIC]]
+
+// -----
+
+// Multiple read_slice sites for the same init value.
+func.func @fuse_fill_multiple_reads(%dest: tensor<8x16xf32>) -> tensor<8x16xf32> {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<8x16xf32>) -> tensor<8x16xf32>
+  %0 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %fill)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>) {
+    %slice0 = pcf.read_slice %ref[%id0, 0] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %result0 = linalg.exp ins(%slice0 : tensor<4x8xf32>) outs(%slice0 : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %result0 into %ref[%id0, 0] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    %slice1 = pcf.read_slice %ref[%id0, 8] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %result1 = linalg.exp ins(%slice1 : tensor<4x8xf32>) outs(%slice1 : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %result1 into %ref[%id0, 8] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0 : tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @fuse_fill_multiple_reads
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+
+//       CHECK:  %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-NOT:  linalg.fill
+//       CHECK:  %[[GENERIC:.+]] = pcf.generic scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF:.+]] = %[[DEST]])[%[[ID0:[A-Za-z0-9_]+]]: index
+//       CHECK:    %[[EXT0:.+]] = tensor.extract_slice %[[DEST]][%[[ID0]], 0] [4, 8] [1, 1]
+//       CHECK:    %[[FILL0:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[EXT0]]
+//       CHECK:    %[[EXP0:.+]] = linalg.exp ins(%[[FILL0]]
+//       CHECK:    pcf.write_slice %[[EXP0]] into %[[REF]][%[[ID0]], 0] [4, 8] [1, 1]
+//       CHECK:    %[[EXT1:.+]] = tensor.extract_slice %[[DEST]][%[[ID0]], 8] [4, 8] [1, 1]
+//       CHECK:    %[[FILL1:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[EXT1]]
+//       CHECK:    %[[EXP1:.+]] = linalg.exp ins(%[[FILL1]]
+//       CHECK:    pcf.write_slice %[[EXP1]] into %[[REF]][%[[ID0]], 8] [4, 8] [1, 1]
+//       CHECK:    pcf.return
+//       CHECK:  return %[[GENERIC]]
+
+// -----
+
+// Producer kept when it has other uses.
+func.func @keep_producer_with_other_uses(%dest: tensor<8x16xf32>) -> (tensor<8x16xf32>, tensor<8x16xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<8x16xf32>) -> tensor<8x16xf32>
+  %0 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %fill)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>) {
+    %slice = pcf.read_slice %ref[%id0, %id1] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %result = linalg.exp ins(%slice : tensor<4x8xf32>) outs(%slice : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %result into %ref[%id0, %id1] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0, %fill : tensor<8x16xf32>, tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @keep_producer_with_other_uses
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+
+//       CHECK:  %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//       CHECK:  %[[FILL:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[DEST]]
+//       CHECK:  %[[GENERIC:.+]] = pcf.generic scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF:.+]] = %[[DEST]])[%[[ID0:[A-Za-z0-9_]+]]: index, %[[ID1:[A-Za-z0-9_]+]]: index
+//       CHECK:    %[[EXT:.+]] = tensor.extract_slice %[[DEST]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    %[[TILED_FILL:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[EXT]]
+//       CHECK:    pcf.return
+//       CHECK:  return %[[GENERIC]], %[[FILL]]
+
+// -----
+
+// First init has no producer (block arg), second init has a fill producer.
+// Verify that the second init is fused while the first is left unchanged.
+func.func @fuse_second_init_only(%arg0: tensor<8x16xf32>, %dest: tensor<4x8xf32>) -> (tensor<8x16xf32>, tensor<4x8xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<4x8xf32>) -> tensor<4x8xf32>
+  %0:2 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref0 = %arg0, %ref1 = %fill)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>, !pcf.sref<4x8xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>, tensor<4x8xf32>) {
+    %slice0 = pcf.read_slice %ref0[%id0, %id1] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %slice1 = pcf.read_slice %ref1[0, 0] [4, 8] [1, 1] : !pcf.sref<4x8xf32, sync(#pcf.test_scope)> to tensor<4x8xf32>
+    %add = linalg.add ins(%slice0, %slice1 : tensor<4x8xf32>, tensor<4x8xf32>) outs(%slice1 : tensor<4x8xf32>) -> tensor<4x8xf32>
+    pcf.write_slice %add into %ref0[%id0, %id1] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0#0, %0#1 : tensor<8x16xf32>, tensor<4x8xf32>
+}
+
+// CHECK-LABEL: @fuse_second_init_only
+//  CHECK-SAME:   %[[ARG0:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<4x8xf32>
+
+//       CHECK:  %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-NOT:  linalg.fill
+//       CHECK:  %[[GENERIC:.+]]:2 = pcf.generic scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF0:.+]] = %[[ARG0]], %[[REF1:.+]] = %[[DEST]])
+//       CHECK:    pcf.read_slice %[[REF0]][%{{.+}}, %{{.+}}] [4, 8] [1, 1]
+//       CHECK:    %[[TILED_FILL:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[DEST]] : tensor<4x8xf32>)
+//       CHECK:    linalg.add
+//       CHECK:    pcf.write_slice
+//       CHECK:    pcf.return
+
+// -----
+
+// Producer fusion with vector read_slice. The tiled producer result (tensor) is
+// converted to a vector via vector.transfer_read.
+func.func @fuse_fill_vector_read(%dest: tensor<8x16xf32>) -> tensor<8x16xf32> {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<8x16xf32>) -> tensor<8x16xf32>
+  %0 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %fill)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>) {
+    %vec = pcf.read_slice %ref[%id0, %id1] [4, 8] [1, 1] : !pcf.sref<8x16xf32, sync(#pcf.test_scope)> to vector<4x8xf32>
+    pcf.write_slice %vec into %ref[%id0, %id1] [4, 8] [1, 1] : vector<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0 : tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @fuse_fill_vector_read
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: tensor<8x16xf32>
+
+//       CHECK:  %[[POISON:.+]] = ub.poison : f32
+//       CHECK:  %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:  %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-NOT:  linalg.fill
+//       CHECK:  %[[GENERIC:.+]] = pcf.generic scope(#pcf.test_scope)
+//  CHECK-NEXT:    execute(%[[REF:.+]] = %[[DEST]])[%[[ID0:[A-Za-z0-9_]+]]: index, %[[ID1:[A-Za-z0-9_]+]]: index
+//       CHECK:    %[[EXT:.+]] = tensor.extract_slice %[[DEST]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    %[[TILED_FILL:.+]] = linalg.fill ins(%[[CST]]{{.*}} outs(%[[EXT]]
+//       CHECK:    %[[VEC:.+]] = vector.transfer_read %[[TILED_FILL]][%[[C0]], %[[C0]]], %[[POISON]] {in_bounds = [true, true]}
+//       CHECK:    pcf.write_slice %[[VEC]] into %[[REF]][%[[ID0]], %[[ID1]]] [4, 8] [1, 1]
+//       CHECK:    pcf.return
+//       CHECK:  return %[[GENERIC]]
+
+// -----
+
+// Negative Tests:
+//  - No read_slice on the sref
+
+// Negative: no read_slice on the sref (only writes).
+func.func @no_fuse_no_reads(%dest: tensor<8x16xf32>) -> tensor<8x16xf32> {
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%dest : tensor<8x16xf32>) -> tensor<8x16xf32>
+  %0 = pcf.generic scope(#pcf.test_scope)
+    execute(%ref = %fill)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<8x16xf32, sync(#pcf.test_scope)>)
+        -> (tensor<8x16xf32>) {
+    %cst2 = arith.constant dense<1.0> : tensor<4x8xf32>
+    pcf.write_slice %cst2 into %ref[%id0, %id1] [4, 8] [1, 1] : tensor<4x8xf32> into !pcf.sref<8x16xf32, sync(#pcf.test_scope)>
+    pcf.return
+  }
+  return %0 : tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @no_fuse_no_reads
+//       CHECK:  %[[FILL:.+]] = linalg.fill
+//       CHECK:  %[[GENERIC:.+]] = pcf.generic
+//  CHECK-NEXT:    execute(%{{.+}} = %[[FILL]])
+//       CHECK:  return %[[GENERIC]]


### PR DESCRIPTION
Add FuseProducersPass (iree-pcf-fuse-producers) that fuses DPS producers into pcf.generic and pcf.loop ops through their tied init arguments.

For each tied init that is the single result of a TilingInterface + DestinationStyleOpInterface producer (e.g. linalg.fill, linalg.transpose), the pass:
1. Replaces the scoped op's init with the producer's DPS init
2. At each pcf.read_slice on the corresponding sref, generates a tiled version of the producer via generateResultTileValue
3. For vector-typed read_slices, converts the tiled tensor result to a vector via vector.transfer_read
4. Erases the original producer if it has no remaining uses

The pass requires SyncOnReturn semantics on the sref, under which overlapping reads and writes are undefined behavior, allowing all reads to assume as though they see the init value.