### PR TITLE
Infer dynamic loop bounds from IntegerRangeAnalysis for GPU tile-and-fuse

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -107,9 +107,8 @@ func.func @scaled_matmul_with_dynamic_red_dim(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_with_dynamic_red_dim
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-//   CHECK-NOT:     mma_kind
 
 // -----
 
@@ -142,12 +141,12 @@ func.func @scaled_matmul_with_dynamic_batch(
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 //  CHECK-SAME:     reduction = [0, 0, 0, 1, 1]
-//  CHECK-SAME:     subgroup = [0, 4, 4, 0, 0]
-//  CHECK-SAME:     workgroup = [1, 128, 256, 0, 0]
+//  CHECK-SAME:     subgroup = [2, 2, 8, 0, 0]
+//  CHECK-SAME:     workgroup = [2, 128, 256, 0, 0]
 
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-SAME: Remark=26112
+// CHECK-REMARKS-SAME: Remark=34816
 
 // -----
 
@@ -185,7 +184,7 @@ func.func @small_scaled_matmul(
 
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-SAME: Remark=2176
+// CHECK-REMARKS: Remark=2176
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
@@ -88,9 +88,9 @@ func.func @matmul_4096_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !TC = tensor<?x32xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x32xf32>>
 //      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64>
+// CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64
 func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index) {
-  // CHECK:       #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 4], thread = [1, 1, 0], workgroup = [1, 64, 0]}>
+  // CHECK:       #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, padding = [64, 32, 32], promote_operands = [0, 1], reduction = [0, 0, 8], subgroup = [2, 1, 0], workgroup = [64, 32, 0]}>
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [%arg4, 32], strides = [1, 1] : !TC -> !DTC{%arg4}
   return
@@ -98,16 +98,16 @@ func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %ar
 
 // -----
 
-//      CHECK:         #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
-// CHECK-SAME:         workgroup_size = [1024, 1, 1] subgroup_size = 64,
-// CHECK-SAME:         {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
+//      CHECK:         #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK-SAME:         workgroup_size = [256, 1, 1] subgroup_size = 64,
+// CHECK-SAME:         {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 !TA = tensor<?x4096xf32>
 !TB = tensor<4096x4096xf32>
 !TC = tensor<?x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x4096xf32>>
 func.func @matmul_DYN_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index) {
-//      CHECK:         #iree_gpu.lowering_config<{lane_basis =  {{\[}}[1, 1, 64], [0, 1, 2]],
-// CHECK-SAME:         partial_reduction = [0, 0, 4096], subgroup_basis =  {{\[}}[1, 1, 16], [0, 1, 2]], thread = [0, 0, 4], workgroup = [1, 1, 0]}
+//      CHECK:         #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK-SAME:         padding = [128, 128, 16], promote_operands = [0, 1], reduction = [0, 0, 4], subgroup = [4, 4, 0], workgroup = [128, 128, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [%arg4, 4096], strides = [1, 1] : !TC -> !DTC{%arg4}
   return
@@ -115,8 +115,8 @@ func.func @matmul_DYN_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC,
 
 // -----
 
-// CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
-// CHECK:    #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 4], thread = [1, 4, 0], workgroup = [1, 256, 0]}
+// CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK:    #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, padding = [64, 128, 32], promote_operands = [0, 1], reduction = [0, 0, 8], subgroup = [2, 4, 0], workgroup = [64, 128, 0]}
 !TA = tensor<?x32xf32>
 !TB = tensor<32x4096xf32>
 !TC = tensor<?x4096xf32>
@@ -129,8 +129,8 @@ func.func @matmul_DYN_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %
 
 // -----
 
-// CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
-// CHECK:    #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 1], thread = [1, 4, 0], workgroup = [1, 256, 0]}
+// CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+// CHECK:    #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, padding = [32, 32, 4], promote_operands = [0, 1], reduction = [0, 0, 1], subgroup = [1, 2, 0], workgroup = [32, 32, 0]}
 !TA = tensor<?x1xf32>
 !TB = tensor<1x4096xf32>
 !TC = tensor<?x4096xf32>
@@ -153,9 +153,9 @@ func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %a
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x32xf32>>
 
 //      CHECK:    #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:    workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+// CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 func.func @matmul_32_32_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
-   // CHECK:     #iree_gpu.lowering_config<{reduction = [0, 0, 1], thread = [1, 8, 0], workgroup = [64, 128, 1]}
+   // CHECK:     #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, padding = [32, 32, 64], promote_operands = [0, 1], reduction = [0, 0, 16], subgroup = [1, 1, 0], workgroup = [32, 32, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !TC -> !DTC
   return
@@ -168,9 +168,9 @@ func.func @matmul_32_32_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
 //      CHECK:         #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:         workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+// CHECK-SAME:         workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
-   // CHECK:      #iree_gpu.lowering_config<{reduction = [0, 0, 1], thread = [1, 8, 0], workgroup = [64, 128, 1]}
+   // CHECK:      #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, padding = [128, 128, 16], promote_operands = [0, 1], reduction = [0, 0, 4], subgroup = [4, 4, 0], workgroup = [128, 128, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !TC -> !DTC
   return
@@ -182,8 +182,8 @@ func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC)
 // Dynamic all
 // ============================================================================
 
-//     CHECK:      LLVMGPUVectorDistribute
-// CHECK-SAME:     workgroup_size = [1024, 1, 1] subgroup_size = 64,
+//     CHECK:      LLVMGPUTileAndFuse
+// CHECK-SAME:     workgroup_size = [256, 1, 1] subgroup_size = 64,
 
 
 !TA = tensor<?x?xf32>
@@ -192,9 +192,9 @@ func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC)
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32>>
 func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index, %arg5 : index, %arg6 : index) {
 
-  //      CHECK:     {lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
-  // CHECK-SAME:     partial_reduction = [0, 0, 4096], subgroup_basis = {{\[}}[1, 1, 16], [0, 1, 2]],
-  // CHECK-SAME:     thread = [0, 0, 4], workgroup = [1, 1, 0]}
+  //      CHECK:     {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+  // CHECK-SAME:     padding = [128, 128, 16], promote_operands = [0, 1], reduction = [0, 0, 4],
+  // CHECK-SAME:     subgroup = [4, 4, 0], workgroup = [128, 128, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [%arg4, %arg5], strides = [1, 1] : !TC -> !DTC{%arg4, %arg5}
   return


### PR DESCRIPTION
Added function to determine bounds of dynamic dims in GEMMs using InterRangeAnalysis in Tile & Fuse Pipeline.