### PR TITLE
[PCF] Add pcf.barrier

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.td
@@ -735,6 +735,25 @@ def PCF_GetMemrefOp : PCF_Op<"get_memref", [
 // Misc
 //===----------------------------------------------------------------------===//
 
+def BarrierOp : PCF_Op<"barrier", []> {
+  let summary = [{Global barrier synchronizing all workers at the given scope.}];
+  let description = [{
+    Creates a global barrier that synchronizes all workers at the specified
+    scope. All workers must reach *any* instance of the barrier before any can
+    proceed past it. This is not a named or numbered barrier -- all barriers
+    at a given scope are considered the same synchronization point.
+
+    This means that two workers may reach different `pcf.barrier` ops in the
+    program (e.g., on different sides of a conditional branch) and still
+    satisfy each other's synchronization requirements, as long as they share
+    the same scope.
+  }];
+
+  let arguments = (ins PCF_ScopeAttrInterface:$scope);
+  let results = (outs);
+  let assemblyFormat = [{`(` $scope `)` attr-dict}];
+}
+
 def PCF_YieldOp : PCF_Op<"yield", [ParentOneOf<["IREE::PCF::GenericOp"]>, Pure,
                                    ReturnLike, Terminator,
 ]> {


### PR DESCRIPTION
Adds a new pcf.barrier op that synchronizes all workers at a given scope. Semantically this is a global barrier. Once all workers have reached any barrier of this kind, all are allowed through. Importantly this means multiple instruction streams can synchronize against one another. This op also does not do any memory fencing.