### PR TITLE
[GPU] Add iree_gpu.global_subgroup_barrier op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -343,4 +343,23 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// GlobalSubgroupBarrierOp
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_GlobalSubgroupBarrierOp : Op<IREEGPU_Dialect,
+    "global_subgroup_barrier", []> {
+  let summary = "Synchronization-only barrier across all subgroups.";
+  let description = [{
+    All subgroups in the workgroup must reach any instance of this op before
+    any can proceed past it. Unlike `gpu.barrier`, this op has no memory
+    fence semantics - memory operations can be freely reordered with respect
+    to it. Fences are handled separately.
+  }];
+
+  let arguments = (ins);
+  let results = (outs);
+  let assemblyFormat = "attr-dict";
+}
+
 #endif // IREE_CODEGEN_DIALECT_IREEGPUOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -355,6 +355,10 @@ def IREEGPU_GlobalSubgroupBarrierOp : Op<IREEGPU_Dialect,
     any can proceed past it. Unlike `gpu.barrier`, this op has no memory
     fence semantics - memory operations can be freely reordered with respect
     to it. Fences are handled separately.
+
+    This operation operates on a single, global workgroup-wide barrier object
+    that can implement such dynamic join and must not be used if such a barrier
+    isn't available.
   }];
 
   let arguments = (ins);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -45,9 +45,9 @@ namespace {
 
 // Lower iree_gpu.global_subgroup_barrier to just the hardware barrier
 // instruction, with NO memory fences. Fences are handled separately.
-struct LowerGlobalSubgroupBarrier
-    : public OpRewritePattern<IREE::GPU::GlobalSubgroupBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct LowerGlobalSubgroupBarrier final
+    : OpRewritePattern<IREE::GPU::GlobalSubgroupBarrierOp> {
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::GPU::GlobalSubgroupBarrierOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
@@ -41,6 +42,24 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
 
 namespace {
+
+// Lower iree_gpu.global_subgroup_barrier to just the hardware barrier
+// instruction, with NO memory fences. Fences are handled separately.
+struct LowerGlobalSubgroupBarrier
+    : public OpRewritePattern<IREE::GPU::GlobalSubgroupBarrierOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::GPU::GlobalSubgroupBarrierOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<NVVM::Barrier0Op>(op);
+    return success();
+  }
+};
+
+static void
+populateLowerGlobalSubgroupBarrierPatterns(RewritePatternSet &patterns) {
+  patterns.add<LowerGlobalSubgroupBarrier>(patterns.getContext());
+}
 
 /// A pass that replaces all occurrences of GPU device operations with their
 /// corresponding NVVM equivalent.
@@ -97,6 +116,7 @@ struct ConvertToNVVMPass final
           patterns, VectorTransferToSCFOptions().enableFullUnroll());
       populateDropSharedMemoryDeallocOpPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
+      populateLowerGlobalSubgroupBarrierPatterns(patterns);
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);
       vector::populateVectorBroadcastLoweringPatterns(patterns);
       vector::populateVectorContractLoweringPatterns(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -35,6 +35,7 @@ iree_lit_test_suite(
             "conv_pipeline_test_cuda.mlir",
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",
+            "convert_to_rocdl_gfx1200.mlir",
             "convert_to_rocdl_gfx950.mlir",
             "create_async_groups.mlir",
             "create_tile_sizes.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -35,7 +35,7 @@ iree_lit_test_suite(
             "conv_pipeline_test_cuda.mlir",
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",
-            "convert_to_rocdl_gfx1200.mlir",
+            "convert_to_rocdl_gfx1201.mlir",
             "convert_to_rocdl_gfx950.mlir",
             "create_async_groups.mlir",
             "create_tile_sizes.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "conv_pipeline_test_cuda.mlir"
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"
+    "convert_to_rocdl_gfx1200.mlir"
     "convert_to_rocdl_gfx950.mlir"
     "create_async_groups.mlir"
     "create_tile_sizes.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -30,7 +30,7 @@ iree_lit_test_suite(
     "conv_pipeline_test_cuda.mlir"
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"
-    "convert_to_rocdl_gfx1200.mlir"
+    "convert_to_rocdl_gfx1201.mlir"
     "convert_to_rocdl_gfx950.mlir"
     "create_async_groups.mlir"
     "create_tile_sizes.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -452,3 +452,23 @@ hal.executable private @interface_wg_size {
 // CHECK-LABEL: llvm.func @interface_wg_size
 //       CHECK:   %[[WGDIMX:.+]] = nvvm.read.ptx.sreg.ntid.x
 //       CHECK:   %[[WGDIMY:.+]] = nvvm.read.ptx.sreg.ntid.y
+
+// -----
+
+#pipeline_layout_barrier = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable @barrier_test {
+  hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
+    hal.executable.export public @global_subgroup_barrier layout(#pipeline_layout_barrier)
+    builtin.module {
+      func.func @global_subgroup_barrier() {
+        iree_gpu.global_subgroup_barrier
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @global_subgroup_barrier
+//       CHECK:   nvvm.barrier0

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -330,3 +330,15 @@ builtin.module {
 //   CHECK-DAG: llvm.getelementptr %[[A0]][0, 0, 0, 0]
 //   CHECK-DAG: %[[A:.+]] = llvm.mlir.addressof @__shared_memory__
 //   CHECK-DAG: llvm.getelementptr %[[A]][0, 0, 0, 0]
+
+// -----
+
+builtin.module {
+  func.func @global_subgroup_barrier() {
+    iree_gpu.global_subgroup_barrier
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @global_subgroup_barrier
+//       CHECK:   llvm.inline_asm has_side_effects asm_dialect = att ";;;WARNING: BREAKS DEBUG WATCHES{{.*}}s_barrier"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx1200.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx1200.mlir
@@ -1,0 +1,12 @@
+// RUN: iree-opt --iree-gpu-test-target=gfx1200 --iree-convert-to-rocdl %s | FileCheck %s
+
+module {
+  func.func @global_subgroup_barrier() {
+    iree_gpu.global_subgroup_barrier
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @global_subgroup_barrier
+//       CHECK:   rocdl.s.barrier.signal id = -1
+//       CHECK:   rocdl.s.barrier.wait id = -1

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx1201.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx1201.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-gpu-test-target=gfx1200 --iree-convert-to-rocdl %s | FileCheck %s
+// RUN: iree-opt --iree-gpu-test-target=gfx1201 --iree-convert-to-rocdl %s | FileCheck %s
 
 module {
   func.func @global_subgroup_barrier() {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
 
 // Test permlane lowering on gfx950.
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -29,3 +29,15 @@ module {
 // CHECK-PERMLANE-LABEL: llvm.func @test_permlane_16_32_lowering
 // CHECK-PERMLANE: rocdl.permlane32.swap
 // CHECK-PERMLANE: rocdl.permlane16.swap
+
+// -----
+
+module {
+  func.func @global_subgroup_barrier() {
+    iree_gpu.global_subgroup_barrier
+    return
+  }
+}
+
+// CHECK-PERMLANE-LABEL: llvm.func @global_subgroup_barrier
+//       CHECK-PERMLANE:   rocdl.s.barrier


### PR DESCRIPTION
Add a synchronization-only barrier op that has no memory fence semantics. The key distinction between this and `gpu.barrier` is that it's semantically global. That is, a subgroup is let through a barrier once all subgroups have reached *any* instance of the barrier, not just a specific one. Note that this is a dramatically more restrictive condition for optimizing the barriers themselves and should only be preferred in situations where it is expressly required. This op also does not fence memory and expects that to be handled separately.