### PR TITLE
[Codegen] Add FusePCFStoresPass for store fusion into PCF ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -112,6 +112,7 @@ iree_compiler_cc_library(
         "FoldTensorSubsetIntoVectorTransferOps.cpp",
         "ForOpCanonicalizationPass.cpp",
         "ForallToFor.cpp",
+        "FusePCFStores.cpp",
         "FuseTensorPadWithConsumer.cpp",
         "GenericVectorization.cpp",
         "HoistStaticallyBoundAllocations.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -105,6 +105,7 @@ iree_cc_library(
     "FoldTensorSubsetIntoVectorTransferOps.cpp"
     "ForOpCanonicalizationPass.cpp"
     "ForallToFor.cpp"
+    "FusePCFStores.cpp"
     "FuseTensorPadWithConsumer.cpp"
     "GenericVectorization.cpp"
     "HoistStaticallyBoundAllocations.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/FusePCFStores.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FusePCFStores.cpp
@@ -1,0 +1,260 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFTypes.h"
+#include "iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/ViewLikeInterfaceUtils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_FUSEPCFSTORESPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+/// Helper function to get all PCF::WriteSliceOps from a PCF::GenericOp or
+/// PCF::LoopOp that write to a specific result.
+template <typename PCFOpTy>
+static FailureOr<SmallVector<IREE::PCF::WriteSliceOp>>
+getProducerSlices(PCFOpTy pcfOp, OpResult result) {
+  static_assert(std::is_same_v<PCFOpTy, IREE::PCF::GenericOp> ||
+                    std::is_same_v<PCFOpTy, IREE::PCF::LoopOp>,
+                "PCFOpTy must be PCF::GenericOp or PCF::LoopOp");
+  BlockArgument tiedArg = pcfOp.getRegionRefArgs()[result.getResultNumber()];
+
+  // The fusion is only valid if the sref type is return only sync scope.
+  auto srefType = dyn_cast<IREE::PCF::ShapedRefType>(tiedArg.getType());
+  if (!srefType || !srefType.isReturnOnlySync()) {
+    return failure();
+  }
+
+  // Collect all WriteSliceOps that use this argument. Skip ReadSliceOps but
+  // fail if there are any other users.
+  SmallVector<IREE::PCF::WriteSliceOp> writeSlices;
+  for (Operation *user : tiedArg.getUsers()) {
+    if (isa<IREE::PCF::ReadSliceOp>(user)) {
+      continue;
+    }
+    auto writeSlice = dyn_cast<IREE::PCF::WriteSliceOp>(user);
+    if (!writeSlice) {
+      return failure();
+    }
+    writeSlices.push_back(writeSlice);
+  }
+
+  return writeSlices;
+}
+
+struct FuseStoreToBuffer
+    : public OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
+  using OpRewritePattern<IREE::Codegen::StoreToBufferOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    Value tensor = storeOp.getTensor();
+
+    Operation *definingOp = tensor.getDefiningOp();
+    auto producerLoop = dyn_cast_if_present<IREE::PCF::LoopOp>(definingOp);
+    auto producerGeneric =
+        dyn_cast_if_present<IREE::PCF::GenericOp>(definingOp);
+    if (!producerLoop && !producerGeneric) {
+      return failure();
+    }
+
+    // Make sure that the buffer operand of the store dominates the producer
+    // loop.
+    DominanceInfo domInfo(definingOp);
+    Value buffer = storeOp.getBuffer();
+    if (!domInfo.dominates(buffer, definingOp)) {
+      return failure();
+    }
+
+    // Get the write_slice ops that produce the result written by the store.
+    OpResult result = cast<OpResult>(tensor);
+    FailureOr<SmallVector<IREE::PCF::WriteSliceOp>> maybeSlices = failure();
+    if (producerLoop) {
+      maybeSlices = getProducerSlices(producerLoop, result);
+    } else {
+      assert(producerGeneric && "unexpected undefined generic");
+      maybeSlices = getProducerSlices(producerGeneric, result);
+    }
+    if (failed(maybeSlices)) {
+      return failure();
+    }
+
+    SmallVector<IREE::PCF::WriteSliceOp> writeSlices = *maybeSlices;
+
+    // For each WriteSliceOp, write its source to the store op's buffer.
+    for (IREE::PCF::WriteSliceOp writeSlice : writeSlices) {
+      rewriter.setInsertionPoint(writeSlice);
+
+      // Create subview for the destination.
+      Value destSlice = memref::SubViewOp::create(
+          rewriter, writeSlice.getLoc(), buffer, writeSlice.getMixedOffsets(),
+          writeSlice.getMixedSizes(), writeSlice.getMixedStrides());
+
+      // Handle different source types. Create but don't replace the write_slice
+      // ops. We rely on unused result cleanup patterns to drop them when
+      // possible.
+      Type sourceType = writeSlice.getSourceType();
+      if (isa<RankedTensorType>(sourceType)) {
+        IREE::Codegen::StoreToBufferOp::create(
+            rewriter, storeOp.getLoc(), writeSlice.getSource(), destSlice);
+      } else if (isa<MemRefType>(sourceType)) {
+        memref::CopyOp::create(rewriter, storeOp.getLoc(),
+                               writeSlice.getSource(), destSlice);
+      } else if (auto vectorType = dyn_cast<VectorType>(sourceType)) {
+        SmallVector<bool> inBounds(vectorType.getRank(), true);
+        for (auto [inBound, vecSize, storeSize] :
+             llvm::zip_equal(inBounds, vectorType.getShape(),
+                             writeSlice.getStaticSizes())) {
+          inBound = vecSize == storeSize;
+        }
+        SmallVector<Value> offsets(
+            vectorType.getRank(),
+            arith::ConstantIndexOp::create(rewriter, writeSlice.getLoc(), 0));
+        vector::TransferWriteOp::create(rewriter, storeOp.getLoc(),
+                                        writeSlice.getSource(), destSlice,
+                                        offsets, inBounds);
+      } else {
+        llvm_unreachable("Invalid write_slice operand type");
+      }
+    }
+
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+struct FuseDispatchTensorStore
+    : public OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
+  using OpRewritePattern<
+      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    // Unimplemented: non-unit stride.
+    if (!storeOp.hasUnitStride()) {
+      return failure();
+    }
+    Value value = storeOp.getValue();
+    Value target = storeOp.getTarget();
+
+    Operation *definingOp = value.getDefiningOp();
+    auto producerLoop = dyn_cast_if_present<IREE::PCF::LoopOp>(definingOp);
+    auto producerGeneric =
+        dyn_cast_if_present<IREE::PCF::GenericOp>(definingOp);
+    if (!producerLoop && !producerGeneric) {
+      return failure();
+    }
+
+    DominanceInfo domInfo(definingOp);
+    if (!domInfo.dominates(target, definingOp)) {
+      return failure();
+    }
+
+    // Get the write_slice ops that produce the result written by the store.
+    OpResult result = cast<OpResult>(value);
+    FailureOr<SmallVector<IREE::PCF::WriteSliceOp>> maybeSlices = failure();
+    if (producerLoop) {
+      maybeSlices = getProducerSlices(producerLoop, result);
+    } else {
+      assert(producerGeneric && "unexpected undefined generic");
+      maybeSlices = getProducerSlices(producerGeneric, result);
+    }
+    if (failed(maybeSlices)) {
+      return failure();
+    }
+
+    SmallVector<IREE::PCF::WriteSliceOp> writeSlices = *maybeSlices;
+
+    // Check that all source operands are tensors as that's the only type
+    // that can be written to the special dispatch type. Also non-unit stride
+    // is currently unsupported.
+    if (!llvm::all_of(writeSlices, [](IREE::PCF::WriteSliceOp writeSlice) {
+          return isa<RankedTensorType>(writeSlice.getSourceType()) &&
+                 writeSlice.hasUnitStride();
+        })) {
+      return failure();
+    }
+
+    // For each WriteSliceOp, create a new DispatchTensorStoreOp of just the
+    // written slice.
+    AffineExpr d0, d1;
+    bindSymbols(rewriter.getContext(), d0, d1);
+    AffineExpr add = d0 + d1;
+    for (IREE::PCF::WriteSliceOp writeSlice : writeSlices) {
+      rewriter.setInsertionPoint(writeSlice);
+
+      // Add the offsets of the WriteSliceOp to the offsets of the store.
+      SmallVector<OpFoldResult> newOffsets;
+      SmallVector<OpFoldResult> writeOffsets = writeSlice.getMixedOffsets();
+      SmallVector<OpFoldResult> storeOffsets = storeOp.getMixedOffsets();
+
+      for (auto [writeOffset, storeOffset] :
+           llvm::zip_equal(writeOffsets, storeOffsets)) {
+        newOffsets.push_back(affine::makeComposedFoldedAffineApply(
+            rewriter, writeSlice.getLoc(), add, {writeOffset, storeOffset}));
+      }
+
+      // Get the source to store. If the write_slice source is a rank-reducing
+      // insert_slice into tensor.empty, use the insert_slice source directly.
+      Value sourceToStore = writeSlice.getSource();
+      SmallVector<OpFoldResult> sizesToStore = writeSlice.getMixedSizes();
+      if (auto insertOp =
+              sourceToStore.getDefiningOp<tensor::InsertSliceOp>()) {
+        if (insertOp.getDest().getDefiningOp<tensor::EmptyOp>()) {
+          RankedTensorType insertSourceType = insertOp.getSourceType();
+          RankedTensorType insertResultType = insertOp.getResultType();
+          if (isRankReducedType(insertResultType, insertSourceType) ==
+              SliceVerificationResult::Success) {
+            sourceToStore = insertOp.getSource();
+            sizesToStore = insertOp.getMixedSizes();
+          }
+        }
+      }
+
+      // Use the sizes of the source tensor.
+      IREE::TensorExt::DispatchTensorStoreOp::create(
+          rewriter, storeOp.getLoc(), sourceToStore, target,
+          storeOp.getTargetDims(), newOffsets, sizesToStore,
+          storeOp.getMixedStrides());
+    }
+
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+struct FusePCFStoresPass final
+    : impl::FusePCFStoresPassBase<FusePCFStoresPass> {
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<FuseStoreToBuffer, FuseDispatchTensorStore>(context);
+    IREE::PCF::populatePCFDropUnusedResultPatterns(patterns);
+    if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -618,6 +618,28 @@ def FuseTensorPadWithConsumerPass :
   let summary = "Fuse tensor.pad op into its consumer op's tiled loop nest";
 }
 
+def FusePCFStoresPass
+    : Pass<"iree-codegen-fuse-pcf-stores", ""> {
+  let summary = "Fuse store operations into PCF parallel ops";
+  let description = [{
+    Fuses `iree_codegen.store_to_buffer` and `iree_tensor_ext.dispatch_tensor_store`
+    operations with their producer `pcf.loop` or `pcf.generic` ops. The pattern
+    converts `pcf.write_slice` operations inside the PCF region to direct buffer
+    writes or dispatch tensor stores.
+
+    This eliminates unnecessary tensor materializations by writing directly to
+    the final destination buffer inside the parallel loop body.
+  }];
+  let dependentDialects = [
+    "iree_compiler::IREE::PCF::PCFDialect",
+    "iree_compiler::IREE::Codegen::IREECodegenDialect",
+    "iree_compiler::IREE::TensorExt::IREETensorExtDialect",
+    "memref::MemRefDialect",
+    "vector::VectorDialect",
+    "affine::AffineDialect"
+  ];
+}
+
 def GenericVectorizationPass :
     InterfacePass<"iree-codegen-generic-vectorization", "mlir::FunctionOpInterface"> {
   let summary = "Pass to perform vectorization on tensor/linalg ops.";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -63,6 +63,7 @@ iree_lit_test_suite(
             "fold_tensor_extract_op.mlir",
             "forall_to_for.mlir",
             "forop_canonicalization.mlir",
+            "fuse_pcf_stores.mlir",
             "generic_vectorization.mlir",
             "hoist_statically_bound_allocations.mlir",
             "hoist_unrolled_vector_extract_insert_slice.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -58,6 +58,7 @@ iree_lit_test_suite(
     "fold_tensor_extract_op.mlir"
     "forall_to_for.mlir"
     "forop_canonicalization.mlir"
+    "fuse_pcf_stores.mlir"
     "generic_vectorization.mlir"
     "hoist_statically_bound_allocations.mlir"
     "hoist_unrolled_vector_extract_insert_slice.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/fuse_pcf_stores.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fuse_pcf_stores.mlir
@@ -1,0 +1,509 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(iree-codegen-fuse-pcf-stores)" --split-input-file | FileCheck %s
+
+// Test fusing store_to_buffer with pcf.loop producing tensor result.
+// After fusion, the loop no longer produces a result (ref arg dropped).
+func.func @fuse_store_to_buffer_tensor(%init: tensor<32x64xf32>, %dest: memref<32x64xf32>, %n: index) {
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_codegen.store_to_buffer %result, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @fuse_store_to_buffer_tensor(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: memref<32x64xf32>
+//  CHECK-SAME:   %[[N:[A-Za-z0-9_]+]]: index
+
+//       CHECK:   pcf.loop scope(#pcf.sequential) count(%[[N]])
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     %[[SUBVIEW:.+]] = memref.subview %[[DEST]][%[[I]], 0] [8, 8] [1, 1]
+//       CHECK:     iree_codegen.store_to_buffer %[[TILE]], %[[SUBVIEW]]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_codegen.store_to_buffer
+//       CHECK:   return
+
+// -----
+
+// Test fusing store_to_buffer with vector source in write_slice.
+// The vector constant may be hoisted outside the loop.
+func.func @fuse_store_to_buffer_vector(%init: tensor<32x64xf32>, %dest: memref<32x64xf32>, %n: index) {
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant dense<0.0> : vector<8x8xf32>
+    pcf.write_slice %c0 into %ref[%i, 0] [8, 8] [1, 1] : vector<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_codegen.store_to_buffer %result, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @fuse_store_to_buffer_vector(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: memref<32x64xf32>
+//  CHECK-SAME:   %[[N:[A-Za-z0-9_]+]]: index
+
+//   CHECK-DAG:   %[[VEC:.+]] = arith.constant dense<0.000000e+00> : vector<8x8xf32>
+//       CHECK:   pcf.loop scope(#pcf.sequential) count(%[[N]])
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+//       CHECK:     %[[SUBVIEW:.+]] = memref.subview %[[DEST]][%[[I]], 0] [8, 8] [1, 1]
+//       CHECK:     vector.transfer_write %[[VEC]], %[[SUBVIEW]]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_codegen.store_to_buffer
+//       CHECK:   return
+
+// -----
+
+// Test fusing with pcf.generic instead of pcf.loop.
+func.func @fuse_store_to_buffer_generic(%init: tensor<32x64xf32>, %dest: memref<32x64xf32>) {
+  %result = pcf.generic scope(#pcf.sequential)
+    execute(%ref = %init)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%id0, %id1] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_codegen.store_to_buffer %result, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @fuse_store_to_buffer_generic(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: memref<32x64xf32>
+
+//       CHECK:   pcf.generic scope(#pcf.sequential)
+//       CHECK:     execute[
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     %[[SUBVIEW:.+]] = memref.subview %[[DEST]]
+//       CHECK:     iree_codegen.store_to_buffer %[[TILE]], %[[SUBVIEW]]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_codegen.store_to_buffer
+//       CHECK:   return
+
+// -----
+
+// Test with memref source in write_slice - should use memref.copy.
+func.func @fuse_store_to_buffer_memref_source(%init: tensor<32x64xf32>, %dest: memref<32x64xf32>, %src: memref<8x8xf32>, %n: index) {
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    pcf.write_slice %src into %ref[%i, 0] [8, 8] [1, 1] : memref<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_codegen.store_to_buffer %result, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @fuse_store_to_buffer_memref_source(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: memref<32x64xf32>
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9_]+]]: memref<8x8xf32>
+//  CHECK-SAME:   %[[N:[A-Za-z0-9_]+]]: index
+
+//       CHECK:   pcf.loop scope(#pcf.sequential) count(%[[N]])
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+//       CHECK:     %[[SUBVIEW:.+]] = memref.subview %[[DEST]][%[[I]], 0] [8, 8] [1, 1]
+//       CHECK:     memref.copy %[[SRC]], %[[SUBVIEW]]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_codegen.store_to_buffer
+//       CHECK:   return
+
+// -----
+
+// Negative test: non return-only-sync scope should not fuse.
+func.func @no_fuse_non_return_only_sync(%init: tensor<32x64xf32>, %dest: memref<32x64xf32>, %n: index) {
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, #pcf.sequential>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, #pcf.sequential>
+    pcf.return
+  }
+  iree_codegen.store_to_buffer %result, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @no_fuse_non_return_only_sync(
+//       CHECK:   %[[RESULT:.+]] = pcf.loop
+//       CHECK:   iree_codegen.store_to_buffer %[[RESULT]]
+//       CHECK:   return
+
+// -----
+
+// Negative test: buffer does not dominate the producer loop.
+func.func @no_fuse_buffer_not_dominating(%init: tensor<32x64xf32>, %n: index) {
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  // Buffer is allocated after the loop, so it cannot dominate.
+  %alloc = memref.alloc() : memref<32x64xf32>
+  iree_codegen.store_to_buffer %result, %alloc : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @no_fuse_buffer_not_dominating(
+//       CHECK:   %[[RESULT:.+]] = pcf.loop
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc
+//       CHECK:   iree_codegen.store_to_buffer %[[RESULT]], %[[ALLOC]]
+//       CHECK:   return
+
+// -----
+
+// Negative test: tensor not from pcf.loop or pcf.generic.
+func.func @no_fuse_tensor_not_from_pcf(%tensor: tensor<32x64xf32>, %dest: memref<32x64xf32>) {
+  iree_codegen.store_to_buffer %tensor, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @no_fuse_tensor_not_from_pcf(
+//       CHECK:   iree_codegen.store_to_buffer
+//       CHECK:   return
+
+// -----
+
+// Test fusing with multiple write_slices in the same loop body.
+func.func @fuse_store_to_buffer_multiple_writes(%init: tensor<32x64xf32>, %dest: memref<32x64xf32>, %n: index) {
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile1 = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile1 into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    %c1 = arith.constant 1.0 : f32
+    %tile2 = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c1 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile2 into %ref[%i, 8] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_codegen.store_to_buffer %result, %dest : tensor<32x64xf32> into memref<32x64xf32>
+  return
+}
+
+// CHECK-LABEL: @fuse_store_to_buffer_multiple_writes(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9_]+]]: memref<32x64xf32>
+//  CHECK-SAME:   %[[N:[A-Za-z0-9_]+]]: index
+
+//       CHECK:   pcf.loop scope(#pcf.sequential) count(%[[N]])
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+//       CHECK:     tensor.generate
+//       CHECK:     memref.subview %[[DEST]][%[[I]], 0] [8, 8] [1, 1]
+//       CHECK:     iree_codegen.store_to_buffer
+//       CHECK:     tensor.generate
+//       CHECK:     memref.subview %[[DEST]][%[[I]], 8] [8, 8] [1, 1]
+//       CHECK:     iree_codegen.store_to_buffer
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_codegen.store_to_buffer
+//       CHECK:   return
+
+// -----
+
+// =============================================================================
+// FuseDispatchTensorStore pattern tests
+// =============================================================================
+
+// Test fusing dispatch_tensor_store with pcf.loop producing tensor result.
+// After fusion, the loop no longer produces a result and stores directly to
+// the dispatch tensor binding.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @fuse_dispatch_tensor_store_basic(%init: tensor<32x64xf32>, %n: index) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_tensor_ext.dispatch.tensor.store %result, %binding, offsets = [0, 0], sizes = [32, 64], strides = [1, 1]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  return
+}
+
+// CHECK-LABEL: @fuse_dispatch_tensor_store_basic(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[N:[A-Za-z0-9_]+]]: index
+
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   pcf.loop scope(#pcf.sequential) count(%[[N]])
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[TILE]], %[[BINDING]]
+//  CHECK-SAME:       offsets = [%[[I]], 0], sizes = [8, 8], strides = [1, 1]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_tensor_ext.dispatch.tensor.store
+//       CHECK:   return
+
+// -----
+
+// Test that offsets from write_slice are added to dispatch_tensor_store offsets.
+// The original store has offsets [4, 8], and write_slice has offsets [%i, 0].
+// The fused store should have offsets [%i + 4, 8].
+
+#pipeline_layout2 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @fuse_dispatch_tensor_store_offset_composition(%init: tensor<32x64xf32>, %n: index) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout2) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x128xf32>>
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  // Store at offset [4, 8] into a larger tensor.
+  iree_tensor_ext.dispatch.tensor.store %result, %binding, offsets = [4, 8], sizes = [32, 64], strides = [1, 1]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x128xf32>>
+  return
+}
+
+// CHECK-LABEL: @fuse_dispatch_tensor_store_offset_composition(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[N:[A-Za-z0-9_]+]]: index
+
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   pcf.loop scope(#pcf.sequential) count(%[[N]])
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     %[[OFFSET:.+]] = affine.apply
+//  CHECK-SAME:       %[[I]]
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[TILE]], %[[BINDING]]
+//  CHECK-SAME:       offsets = [%[[OFFSET]], 8], sizes = [8, 8], strides = [1, 1]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_tensor_ext.dispatch.tensor.store
+//       CHECK:   return
+
+// -----
+
+// Test fusing dispatch_tensor_store with pcf.generic.
+
+#pipeline_layout3 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @fuse_dispatch_tensor_store_generic(%init: tensor<32x64xf32>) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout3) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  %result = pcf.generic scope(#pcf.sequential)
+    execute(%ref = %init)[%id0: index, %id1: index, %n0: index, %n1: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%id0, %id1] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_tensor_ext.dispatch.tensor.store %result, %binding, offsets = [0, 0], sizes = [32, 64], strides = [1, 1]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  return
+}
+
+// CHECK-LABEL: @fuse_dispatch_tensor_store_generic(
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9_]+]]: tensor<32x64xf32>
+
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   pcf.generic scope(#pcf.sequential)
+//       CHECK:     execute[%[[ID0:[A-Za-z0-9_]+]]: index, %[[ID1:[A-Za-z0-9_]+]]: index
+//       CHECK:     %[[TILE:.+]] = tensor.generate
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[TILE]], %[[BINDING]]
+//  CHECK-SAME:       offsets = [%[[ID0]], %[[ID1]]], sizes = [8, 8], strides = [1, 1]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_tensor_ext.dispatch.tensor.store
+//       CHECK:   return
+
+// -----
+
+// Test rank-reducing insert_slice optimization: when write_slice source is a
+// rank-reducing insert_slice into tensor.empty, we use the insert_slice source
+// directly instead of the padded tensor.
+
+#pipeline_layout_rank_reduce = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @fuse_dispatch_tensor_store_rank_reducing_insert(%init: tensor<32x64xf32>, %n: index) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout_rank_reduce) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    // Create a 1D vector (rank 1)
+    %vec = arith.constant dense<0.0> : tensor<8xf32>
+    // Create a 2D empty tensor (rank 2)
+    %empty = tensor.empty() : tensor<8x1xf32>
+    // Rank-reducing insert: 1D tensor<8xf32> into 2D tensor<8x1xf32>
+    %padded = tensor.insert_slice %vec into %empty[0, 0] [8, 1] [1, 1]
+        : tensor<8xf32> into tensor<8x1xf32>
+    // Write the padded 2D tensor
+    pcf.write_slice %padded into %ref[%i, 0] [8, 1] [1, 1]
+        : tensor<8x1xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_tensor_ext.dispatch.tensor.store %result, %binding, offsets = [0, 0], sizes = [32, 64], strides = [1, 1]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  return
+}
+
+// CHECK-LABEL: @fuse_dispatch_tensor_store_rank_reducing_insert(
+// The constant gets hoisted outside the loop:
+//   CHECK-DAG:   %[[VEC:.+]] = arith.constant dense<0.000000e+00> : tensor<8xf32>
+//   CHECK-DAG:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   pcf.loop
+//       CHECK:     execute[%[[I:[A-Za-z0-9_]+]]: index] {
+// The optimization should use the 1D tensor directly, not the 2D padded version:
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[VEC]], %[[BINDING]]
+//  CHECK-SAME:       sizes = [8, 1]
+//       CHECK:     pcf.return
+//   CHECK-NOT:   iree_tensor_ext.dispatch.tensor.store
+//       CHECK:   return
+
+// -----
+
+// Negative test: non-unit stride in dispatch_tensor_store should not fuse.
+
+#pipeline_layout4 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @no_fuse_dispatch_tensor_store_non_unit_stride(%init: tensor<32x64xf32>, %n: index) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout4) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x128xf32>>
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<8x8xf32>
+    pcf.write_slice %tile into %ref[%i, 0] [8, 8] [1, 1] : tensor<8x8xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  // Non-unit stride - should not fuse.
+  iree_tensor_ext.dispatch.tensor.store %result, %binding, offsets = [0, 0], sizes = [32, 64], strides = [2, 2]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x128xf32>>
+  return
+}
+
+// CHECK-LABEL: @no_fuse_dispatch_tensor_store_non_unit_stride(
+//       CHECK:   %[[RESULT:.+]] = pcf.loop
+//       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[RESULT]]
+//  CHECK-SAME:     strides = [2, 2]
+//       CHECK:   return
+
+// -----
+
+// Negative test: tensor not from pcf.loop or pcf.generic should not fuse.
+
+#pipeline_layout5 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @no_fuse_dispatch_tensor_store_non_pcf_source(%tensor: tensor<32x64xf32>) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout5) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  iree_tensor_ext.dispatch.tensor.store %tensor, %binding, offsets = [0, 0], sizes = [32, 64], strides = [1, 1]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  return
+}
+
+// CHECK-LABEL: @no_fuse_dispatch_tensor_store_non_pcf_source(
+//       CHECK:   iree_tensor_ext.dispatch.tensor.store
+//       CHECK:   return
+
+// -----
+
+// Negative test: non-unit stride in write_slice should not fuse.
+
+#pipeline_layout6 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @no_fuse_dispatch_tensor_store_write_slice_non_unit_stride(%init: tensor<32x64xf32>, %n: index) {
+  %binding = hal.interface.binding.subspan layout(#pipeline_layout6) binding(0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  %result = pcf.loop scope(#pcf.sequential) count(%n)
+    execute(%ref = %init)[%i: index]
+         : (!pcf.sref<32x64xf32, sync(#pcf.sequential)>)
+        -> (tensor<32x64xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    %tile = tensor.generate {
+    ^bb0(%ii: index, %jj: index):
+      tensor.yield %c0 : f32
+    } : tensor<4x4xf32>
+    // Non-unit stride in write_slice - should not fuse.
+    pcf.write_slice %tile into %ref[%i, 0] [4, 4] [2, 2]
+        : tensor<4x4xf32> into !pcf.sref<32x64xf32, sync(#pcf.sequential)>
+    pcf.return
+  }
+  iree_tensor_ext.dispatch.tensor.store %result, %binding, offsets = [0, 0], sizes = [32, 64], strides = [1, 1]
+      : tensor<32x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x64xf32>>
+  return
+}
+
+// CHECK-LABEL: @no_fuse_dispatch_tensor_store_write_slice_non_unit_stride(
+//       CHECK:   %[[RESULT:.+]] = pcf.loop
+//       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[RESULT]]
+//       CHECK:   return


### PR DESCRIPTION
Introduces two patterns for fusing store-like operations into producing pcf.loop/generic ops:

`FuseStoreToBuffer`: Fuses iree_codegen.store_to_buffer with pcf.loop/ pcf.generic by converting pcf.write_slice to direct memref writes (subview + store/copy/transfer_write depending on source type).

`FuseDispatchTensorStore`: Fuses iree_tensor_ext.dispatch_tensor_store with PCF parallel ops by creating per-slice stores with composed offsets. Includes optimization for rank-reducing insert_slice into tensor.empty.

The intent is for this pass to run close to late stage fusion and before bufferization, eliminating all result tied values on pcf ops and removing the need for global allocations. In practice these patterns must succeed for code generation to succeed.