### PR TITLE
Reapply "[Codegen][Common] Allow generic conv ops to decompose to lower dim ops (#23294)" (#23383)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
@@ -1,4 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
+// Test the same patterns on generic convolution ops by first generalizing the
+// named ops. This ensures decomposition works on both named and generic convs.
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(linalg-generalize-named-ops,iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0, 0, 0, 0], [1, 1, 1, 4, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
 module {


### PR DESCRIPTION
https://github.com/iree-org/iree/pull/23294 was reverted by https://github.com/iree-org/iree/pull/23383 to resolve https://github.com/iree-org/iree/issues/23382

But now with https://github.com/llvm/llvm-project/pull/179883 merged we can reapply https://github.com/iree-org/iree/pull/23294

Refer to [this thread](https://github.com/iree-org/iree/issues/23382#issuecomment-3853181957) for more detail.