### PR TITLE
[Codegen] Propagate padding to producers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -141,9 +141,9 @@ void GPUApplyPaddingLevelPass::runOnOperation() {
   llvm::SmallDenseSet<TilingInterface> targetOps =
       getTiledOps(funcOp, tilingLevel);
 
+  MaskListener maskListener;
+  IRRewriter rewriter(funcOp, &maskListener);
   for (TilingInterface op : targetOps) {
-    MaskListener maskListener;
-    IRRewriter rewriter(funcOp, &maskListener);
     // If some op does not get padded, that is fine for now.
     (void)applyPaddingLevel(rewriter, op, tilingLevel);
     // Propagate padding up by padding producers if possible.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -148,8 +148,7 @@ void GPUApplyPaddingLevelPass::runOnOperation() {
     (void)applyPaddingLevel(rewriter, op, tilingLevel);
     // Propagate padding up by padding producers if possible.
     while (!maskListener.pads.empty()) {
-      tensor::PadOp padOp = maskListener.pads.back();
-      maskListener.pads.pop_back();
+      tensor::PadOp padOp = maskListener.pads.pop_back_val();
 
       auto resultVal = dyn_cast<OpResult>(padOp.getSource());
       if (!resultVal) {

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -174,6 +174,47 @@ static void selectNeutralElementForReducedDims(OpBuilder &b, OpOperand &operand,
   operand.set(genericOp.getResult(0));
 }
 
+FailureOr<Value> maskProducerTilingInterfaceOpImpl(
+    Operation *op, OpBuilder &b, AffineMap iterDomainToSizeMap,
+    unsigned resultNumber, ArrayRef<OpFoldResult> sizes) {
+  auto tilingInterfaceOp = cast<TilingInterface>(op);
+  // Determine the new padded iteration domain size.
+  SmallVector<Range> iterDomain = tilingInterfaceOp.getIterationDomain(b);
+  SmallVector<OpFoldResult> paddedDomainSizes =
+      llvm::map_to_vector(iterDomain, [&](Range r) { return r.size; });
+  for (auto [expr, paddedSize] :
+       llvm::zip_equal(iterDomainToSizeMap.getResults(), sizes)) {
+    auto dimExpr = dyn_cast<AffineDimExpr>(expr);
+    if (!dimExpr) {
+      op->emitError("only dim expressions supported in iterDomainToSizeMap");
+      return failure();
+    }
+    unsigned dimPos = dimExpr.getPosition();
+    paddedDomainSizes[dimPos] = paddedSize;
+  }
+  // Use poison for padded values, i.e., values outside the original iteration
+  // domain.
+  auto poison = ub::PoisonAttr::get(b.getContext());
+  SmallVector<Attribute> padValues(op->getNumOperands(), poison);
+  // Dispatch to the interfase-based implementation for actually masking the
+  // operation.
+  linalg::PadTilingInterfaceOptions options =
+      linalg::PadTilingInterfaceOptions()
+          .setPaddingSizes(paddedDomainSizes)
+          .setPaddingValues(padValues)
+          .setPadToMultipleOf(false);
+  FailureOr<linalg::PadTilingInterfaceResult> result =
+      linalg::rewriteAsPaddedOp(b, tilingInterfaceOp, options);
+  if (failed(result)) {
+    op->emitError("failed to pad op");
+    return failure();
+  }
+  // We use the results of the paddedOp directly, because they have the size
+  // we're interested in and not the replacements values that are "unpadded" to
+  // the original size.
+  return result->paddedOp->getResults()[resultNumber];
+}
+
 struct LinalgGenericOpInterface final
     : TensorMaskingOpInterface::ExternalModel<LinalgGenericOpInterface,
                                               linalg::GenericOp> {
@@ -195,6 +236,16 @@ struct LinalgGenericOpInterface final
     return result->replacements;
   }
 
+  FailureOr<Value> maskAsProducer(Operation *op, OpBuilder &builder,
+                                  unsigned resultNumber,
+                                  ArrayRef<OpFoldResult> padSizes) const {
+    auto genericOp = cast<linalg::GenericOp>(op);
+    AffineMap resultMap = genericOp.getMatchingIndexingMap(
+        genericOp.getDpsInitOperand(resultNumber));
+    return maskProducerTilingInterfaceOpImpl(op, builder, resultMap,
+                                             resultNumber, padSizes);
+  }
+
 private:
   /// Mask the poison inputs for reductions by selecting the neutral element on
   /// the masked out-of-bounds iterations.
@@ -202,6 +253,7 @@ private:
   maskReductionsInGenericBody(OpBuilder &builder, linalg::GenericOp oldLinalgOp,
                               linalg::GenericOp paddedLinalgOp) const {
     Location loc = paddedLinalgOp.getLoc();
+    OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(paddedLinalgOp.getBody());
     SmallVector<OpFoldResult> oldBounds =
         getBoundsToGuard(builder, oldLinalgOp, paddedLinalgOp);
@@ -289,6 +341,16 @@ struct OnlineAttentionOpInterface final
                                          *paddedOp.getMaskMap());
     }
     return result->replacements;
+  }
+
+  FailureOr<Value> maskAsProducer(Operation *op, OpBuilder &builder,
+                                  unsigned resultNumber,
+                                  ArrayRef<OpFoldResult> padSizes) const {
+    auto onlineAttentionOp = cast<IREE::LinalgExt::OnlineAttentionOp>(op);
+    AffineMap resultMap = onlineAttentionOp.getMatchingIndexingMap(
+        onlineAttentionOp.getDpsInitOperand(resultNumber));
+    return maskProducerTilingInterfaceOpImpl(op, builder, resultMap,
+                                             resultNumber, padSizes);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -181,7 +181,7 @@ FailureOr<Value> maskProducerTilingInterfaceOpImpl(
   // Determine the new padded iteration domain size.
   SmallVector<Range> iterDomain = tilingInterfaceOp.getIterationDomain(b);
   SmallVector<OpFoldResult> paddedDomainSizes =
-      llvm::map_to_vector(iterDomain, [&](Range r) { return r.size; });
+      llvm::map_to_vector(iterDomain, [](Range r) { return r.size; });
   for (auto [expr, paddedSize] :
        llvm::zip_equal(iterDomainToSizeMap.getResults(), sizes)) {
     auto dimExpr = dyn_cast<AffineDimExpr>(expr);

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.td
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.td
@@ -23,6 +23,19 @@ def TensorMaskingOpInterface : OpInterface<"TensorMaskingOpInterface"> {
         "OpBuilder &":$builder,
         "ArrayRef<OpFoldResult>":$padMultiples)
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Mask this operation as a producer of an input to another masked
+        operation. Returns the replacement for the result with resultNumber
+        padded to the given padSizes.
+      }],
+      /*retTy=*/"FailureOr<Value>",
+      /*methodName=*/"maskAsProducer",
+      /*args=*/(ins
+        "OpBuilder &":$builder,
+        "unsigned":$resultNumber,
+        "ArrayRef<OpFoldResult>":$padSizes)
+    >,
   ];
 }
 


### PR DESCRIPTION
When padding an operation based on its lowering config, propagate the padding to producers of input values if the producers also implement the `TensorMaskingOpInterface` and do not have their own lowering configuration.

Padding the producers is done through a new method on the `TensorMaskingOpInterface`.

This is part of https://github.com/iree-org/iree/issues/23415.