### PR TITLE
[LinalgExt] Cleanup TD definitions to avoid variadic everywhere

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -283,8 +283,9 @@ struct ScatterOpConversion final
     }
 
     auto scatterOp = IREE::LinalgExt::ScatterOp::create(
-        rewriter, op.getLoc(), originalType, ValueRange{updates, indices},
-        ValueRange{original}, scatterDimMap, op.getUniqueIndices());
+        rewriter, op.getLoc(), originalType,
+        /*updates=*/updates, /*indices=*/indices, /*original=*/original,
+        scatterDimMap, op.getUniqueIndices());
 
     rewriter.inlineRegionBefore(op.getUpdateComputation(),
                                 scatterOp.getRegion(),
@@ -568,7 +569,8 @@ struct ScanOpConversion final
     }
 
     auto scanOp = IREE::LinalgExt::ScanOp::create(
-        rewriter, op.getLoc(), outputTys, inputs, outputs,
+        rewriter, op.getLoc(), outputTys,
+        /*input=*/input0, /*output=*/outputs[0], /*accumulator=*/outputs[1],
         rewriter.getI64IntegerAttr(reduceAxis), rewriter.getBoolAttr(1));
 
     rewriter.inlineRegionBefore(op.getRegion(), scanOp.getRegion(),
@@ -654,8 +656,8 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
       newResultTypes.push_back(op->getResultTypes()[i]);
     }
     auto topkOp = rewriter.replaceOpWithNewOp<IREE::LinalgExt::TopkOp>(
-        op, newResultTypes, ValueRange{operand},
-        ValueRange{negInfTensor, posInfTensor}, kDim);
+        op, newResultTypes, /*values=*/operand, /*indices=*/Value(),
+        /*output_values=*/negInfTensor, /*output_indices=*/posInfTensor, kDim);
 
     // Define the region of TopK with a GT comparison
     SmallVector<Type> types(2, valueElementType);

--- a/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
@@ -136,9 +136,9 @@ public:
 
     // Create the LinalgExt scatter operation.
     auto scatter = IREE::LinalgExt::ScatterOp::create(
-        builder, TypeRange{values.getType()}, ValueRange{updates, indices},
-        ValueRange{values}, builder.getDenseI64ArrayAttr({0, 1}),
-        builder.getBoolAttr(true));
+        builder, TypeRange{values.getType()},
+        /*updates=*/updates, /*indices=*/indices, /*original=*/values,
+        builder.getDenseI64ArrayAttr({0, 1}), builder.getBoolAttr(true));
 
     llvm::SmallVector<Type> args(2, valuesTy.getElementType());
     Block *scatterBody =

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -91,8 +91,8 @@ struct ScatterOpConversion
     Value indicesVal = op.indices();
     auto scatterOp = IREE::LinalgExt::ScatterOp::create(
         rewriter, op.getLoc(), op->getResultTypes(),
-        ValueRange{updateVal, indicesVal}, op.getOutputs(), dimMap,
-        op.getUniqueIndices());
+        /*updates=*/updateVal, /*indices=*/indicesVal,
+        /*original=*/op.getOutputs()[0], dimMap, op.getUniqueIndices());
     rewriter.inlineRegionBefore(op.getRegion(), scatterOp.getRegion(),
                                 scatterOp.getRegion().begin());
     rewriter.replaceOp(op, scatterOp->getResults());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -200,7 +200,7 @@ tileToThreadLevel(OpTy op, PatternRewriter &rewriter,
   }
 
   // Get the rank of the operation.
-  auto outputType = cast<RankedTensorType>(op.getOutputs()[0].getType());
+  auto outputType = cast<RankedTensorType>(op.getDpsInits()[0].getType());
   int64_t rank = outputType.getRank();
 
   // threadNumThreads contains only the innermost dimension's num threads.
@@ -453,8 +453,7 @@ struct ConvertGatherToCoalescedDMA
     }
 
     // Validate that innermost dimension is large enough for coalesced DMA.
-    auto outputType =
-        cast<RankedTensorType>(gatherOp.getOutputs()[0].getType());
+    auto outputType = cast<RankedTensorType>(gatherOp.getOutput().getType());
     int64_t rank = outputType.getRank();
     int64_t innermostDim = outputType.getShape()[rank - 1];
     if (ShapedType::isDynamic(innermostDim)) {
@@ -696,7 +695,7 @@ private:
     }
 
     // Get the output type to determine rank and shape.
-    auto outputType = cast<RankedTensorType>(op.getOutputs()[0].getType());
+    auto outputType = cast<RankedTensorType>(op.getDpsInits()[0].getType());
     int64_t rank = outputType.getRank();
     ArrayRef<int64_t> shape = outputType.getShape();
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -153,12 +153,6 @@ verifyGatherScatter(OpTy op, int64_t sliceRank, ShapedType originalType,
                     StringRef updateName) {
   static_assert(llvm::is_one_of<OpTy, GatherOp, ScatterOp>::value,
                 "applies to only gather or scatter operations");
-  if (op.getInputs().size() != 2) {
-    return op.emitOpError("expected two input operands");
-  }
-  if (op.getOutputs().size() != 1) {
-    return op.emitOpError("expected one output operand");
-  }
 
   auto indicesType = op.getIndicesType();
   if (indicesType.getRank() < 1 ||
@@ -1085,18 +1079,8 @@ LogicalResult FftOp::verify() {
   if (length & (length - 1)) {
     return op->emitOpError("only powers of 2 are handled currently");
   }
-  if (!getNumDpsInputs() || !isScalar(getDpsInputOperand(0))) {
+  if (!isScalar(getDpsInputOperand(0))) {
     return op->emitOpError("expected to carry `stage` input");
-  }
-  if (getNumDpsInputs() != 1) {
-    if (getNumDpsInputs() != 3 || isScalar(getDpsInputOperand(1)) ||
-        isScalar(getDpsInputOperand(2))) {
-      return op->emitOpError("expected to carry real and imag coeff inputs");
-    }
-  }
-  if (getNumDpsInits() != 2) {
-    return op->emitOpError(
-        "expected outputs to be real and imag tensor/memref");
   }
   return success();
 }
@@ -1108,21 +1092,17 @@ FftOp::reifyResultShapes(OpBuilder &b,
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
+MutableOperandRange FftOp::getDpsInitsMutable() {
+  return MutableOperandRange(*this, /*numInputs=*/hasCoeff() ? 3 : 1,
+                             /*numInits=*/2);
+}
+
 //===----------------------------------------------------------------------===//
 // ScanOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult ScanOp::verify() {
   Operation *op = getOperation();
-  if (getNumDpsInputs() != 1) {
-    return op->emitOpError("expected one input operands");
-  }
-  if (getNumDpsInits() != 2) {
-    return op->emitOpError("expected two output operands");
-  }
-  if (!isa<ShapedType>(getInput().getType())) {
-    return op->emitOpError("expected first input element type to be shaped");
-  }
   auto accumulatorType = cast<ShapedType>(getAccumulator().getType());
   auto inputType = cast<ShapedType>(getInput().getType());
   auto outputType = cast<ShapedType>(getOutput().getType());
@@ -1181,31 +1161,29 @@ ScanOp::reifyResultShapes(OpBuilder &b,
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
+MutableOperandRange ScanOp::getDpsInitsMutable() {
+  return MutableOperandRange(*this, /*numInputs=*/1, /*numInits=*/2);
+}
+
 //===----------------------------------------------------------------------===//
 // TopkOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult TopkOp::verify() {
   Operation *op = getOperation();
-  if (getNumDpsInputs() != 1 && getNumDpsInputs() != 2) {
-    return op->emitOpError("expected one or two input operands");
-  }
-  if (getNumDpsInits() != 2) {
-    return op->emitOpError("expected two output operands");
-  }
   if (getDimension() >= getInputRank()) {
     return op->emitOpError("dimension exceeds rank");
   }
   // Ensure input/output element types match
   auto inputValuesType = cast<ShapedType>(getValues().getType());
-  auto outputValuesType = cast<ShapedType>(outputValues().getType());
+  auto outputValuesType = cast<ShapedType>(getOutputValues().getType());
   if (inputValuesType.getElementType() != outputValuesType.getElementType()) {
     return op->emitOpError("expected input/output value types to be identical");
   }
   // Indices must be int if provided
-  auto outputIndicesType = cast<ShapedType>(outputIndices().getType());
-  if (auto inputIndices = getIndices()) {
-    auto inputIndicesType = cast<ShapedType>(inputIndices->getType());
+  auto outputIndicesType = cast<ShapedType>(getOutputIndices().getType());
+  if (Value inputIndices = getIndices()) {
+    auto inputIndicesType = cast<ShapedType>(inputIndices.getType());
     if (!inputIndicesType.getElementType().isInteger(32) ||
         !outputIndicesType.getElementType().isInteger(32)) {
       return op->emitOpError("expected input/output indices types to be int32");
@@ -1216,15 +1194,15 @@ LogicalResult TopkOp::verify() {
   if (inputValuesType.getRank() != outputValuesType.getRank()) {
     return op->emitOpError("expected input/output to have the same rank");
   }
-  if (auto inputIndices = getIndices()) {
-    auto inputIndicesType = cast<ShapedType>(inputIndices->getType());
+  if (Value inputIndices = getIndices()) {
+    auto inputIndicesType = cast<ShapedType>(inputIndices.getType());
     if (inputIndicesType.getRank() != outputIndicesType.getRank()) {
       return op->emitOpError("expected input/output to have the same rank");
     }
   }
   // Input indicies and values must have the same shape.
-  if (auto inputIndices = getIndices()) {
-    auto inputIndicesType = cast<ShapedType>(inputIndices->getType());
+  if (Value inputIndices = getIndices()) {
+    auto inputIndicesType = cast<ShapedType>(inputIndices.getType());
     if (failed(verifyCompatibleShape(inputValuesType, inputIndicesType))) {
       return op->emitOpError("input indices/values shape must match");
     }
@@ -1271,6 +1249,11 @@ TopkOp::reifyResultShapes(OpBuilder &b,
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
+MutableOperandRange TopkOp::getDpsInitsMutable() {
+  return MutableOperandRange(*this, /*numInputs=*/getIndices() ? 2 : 1,
+                             /*numInits=*/2);
+}
+
 //===----------------------------------------------------------------------===//
 // ArgCompareOp
 //===----------------------------------------------------------------------===//
@@ -1278,27 +1261,11 @@ TopkOp::reifyResultShapes(OpBuilder &b,
 LogicalResult ArgCompareOp::verify() {
   Operation *op = getOperation();
 
-  // The operation supports two modes based on the number of inputs:
-  // - Implicit-index mode (1 input): Computes indices from iteration variables.
-  // - Explicit-index mode (2 inputs): Uses pre-existing (value, index) pairs.
-  unsigned numInputs = llvm::size(getInputs());
-  if (numInputs != 1 && numInputs != 2) {
-    return op->emitOpError("expected 1 or 2 input operands, but got ")
-           << numInputs;
-  }
-
   ShapedType inputValueType = getInputType();
   Type inputValueElemType = inputValueType.getElementType();
 
-  unsigned numOutputs = getNumDpsInits();
-  if (numOutputs != 2) {
-    return op->emitOpError(
-               "expected two output operands (value and index), but got ")
-           << numOutputs;
-  }
-
-  auto outputValueType = getOutputValueType();
-  auto outputIndexType = getOutputIndexType();
+  ShapedType outputValueType = getOutputValueType();
+  ShapedType outputIndexType = getOutputIndexType();
   Type outputIndexElemType = getOutputIndexElementType();
 
   if (hasExplicitIndexInput()) {
@@ -1459,6 +1426,11 @@ IREE::LinalgExt::ArgCompareOp::getIndexingMapsForResults() {
 
 SmallVector<int64_t> IREE::LinalgExt::ArgCompareOp::getStaticLoopRanges() {
   return llvm::to_vector(getInputType().getShape());
+}
+
+MutableOperandRange ArgCompareOp::getDpsInitsMutable() {
+  return MutableOperandRange(*this, /*numInputs=*/getInputIndex() ? 2 : 1,
+                             /*numInits=*/2);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1795,6 +1767,8 @@ PackOp::reifyResultShapes(OpBuilder &builder,
       .reifyResultShapes(builder, reifiedReturnShapes);
 }
 
+MutableOperandRange PackOp::getDpsInitsMutable() { return getOutputMutable(); }
+
 //===----------------------------------------------------------------------===//
 // UnPackOp
 //===----------------------------------------------------------------------===//
@@ -1845,18 +1819,16 @@ LogicalResult UnPackOp::verify() {
   return success();
 }
 
+MutableOperandRange UnPackOp::getDpsInitsMutable() {
+  return getOutputMutable();
+}
+
 //===----------------------------------------------------------------------===//
 // WinogradInputTransformOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult WinogradInputTransformOp::verify() {
   Operation *op = getOperation();
-  if (getNumDpsInputs() != 1) {
-    return op->emitOpError("expected one input operand");
-  }
-  if (getNumDpsInits() != 1) {
-    return op->emitOpError("expected one output operand");
-  }
   auto inputType = getInputType();
   auto outputType = getOutputType();
   if (outputType.getElementType() != inputType.getElementType()) {
@@ -1949,12 +1921,6 @@ LogicalResult WinogradInputTransformOp::reifyResultShapes(
 
 LogicalResult WinogradFilterTransformOp::verify() {
   Operation *op = getOperation();
-  if (getNumDpsInputs() != 1) {
-    return op->emitOpError("expected one input operand");
-  }
-  if (getNumDpsInits() != 1) {
-    return op->emitOpError("expected one output operand");
-  }
   auto inputType = getInputType();
   auto outputType = getOutputType();
   if (outputType.getElementType() != inputType.getElementType()) {
@@ -2042,12 +2008,6 @@ LogicalResult WinogradFilterTransformOp::reifyResultShapes(
 
 LogicalResult WinogradOutputTransformOp::verify() {
   Operation *op = getOperation();
-  if (getNumDpsInputs() != 1) {
-    return op->emitOpError("expected one input operand");
-  }
-  if (getNumDpsInits() != 1) {
-    return op->emitOpError("expected one output operand");
-  }
   auto inputType = getInputType();
   auto outputType = getOutputType();
   unsigned inputRank = inputType.getRank();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -45,8 +45,7 @@ def OpGroupNonStructuredOps : OpDocGroup {
 let opDocGroup = OpGroupNonStructuredOps in {
 
 def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
-    [AttrSizedOperandSegments,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<LinalgFusionInterface,
       ["getIndexingMapsForResults", "getIndexingMapsForOperands",
        "getStaticLoopRanges"]>,
@@ -99,8 +98,9 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
       https://www.tensorflow.org/api_docs/python/tf/tensor_scatter_nd_update
   }];
   let arguments = (ins
-      Variadic<AnyRankedTensorOrMemRef>:$inputs,
-      Variadic<AnyRankedTensorOrMemRef>:$outputs,
+      AnyRankedTensorOrMemRef:$updates,
+      AnyRankedTensorOrMemRef:$indices,
+      AnyRankedTensorOrMemRef:$original,
       DenseI64ArrayAttr:$dimension_map,
       DefaultValuedAttr<BoolAttr, "true">:$unique_indices
   );
@@ -109,37 +109,21 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   let assemblyFormat = [{
     attr-dict `dimension_map` `=` $dimension_map
               `unique_indices` `(` $unique_indices `)`
-    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $updates `,` $indices `:` type($updates) `,` type($indices) `)`
+    `outs` `(` $original `:` type($original) `)`
     $region (`->` type($results)^)?
   }];
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    static constexpr unsigned kUpdatesOpNum = 0;
-    static constexpr unsigned kIndicesOpNum = 1;
-    static constexpr unsigned kOriginalOpNum = 2;
-
     int64_t getIndexDepth() {
       return getDimensionMap().size();
-    }
-
-    Value getUpdates() {
-      return getDpsInputOperand(0)->get();
     }
 
     ShapedType getUpdateType() {
       return cast<ShapedType>(getUpdates().getType());
     }
 
-    Value getIndices() {
-      return getDpsInputOperand(1)->get();
-    }
-
     ShapedType getIndicesType() {
       return cast<ShapedType>(getIndices().getType());
-    }
-
-    Value getOriginal() {
-      return getDpsInitOperand(0)->get();
     }
 
     ShapedType getOriginalType() {
@@ -147,7 +131,7 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     }
 
     /// Utility to get the rank of the portion of `indices` that
-    /// represents the batch dimensions
+    /// represents the batch dimensions.
     int64_t getBatchRank() {
       return getUpdateType().getRank() - getUpdateSliceRank();
     }
@@ -171,14 +155,13 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
+      return getOriginalMutable();
     }
   }];
 }
 
 def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
-    [AttrSizedOperandSegments,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<LinalgFusionInterface,
       ["getIndexingMapsForResults", "getIndexingMapsForOperands",
        "getStaticLoopRanges"]>,
@@ -206,23 +189,20 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
     semantics.
   }];
   let arguments = (ins
-      Variadic<AnyRankedTensorOrMemRef>:$inputs,
-      Variadic<AnyRankedTensorOrMemRef>:$outputs,
+      AnyRankedTensorOrMemRef:$source,
+      AnyRankedTensorOrMemRef:$indices,
+      AnyRankedTensorOrMemRef:$output,
       DenseI64ArrayAttr:$dimension_map
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
     attr-dict `dimension_map` `=` $dimension_map
-    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $source `,` $indices `:` type($source) `,` type($indices) `)`
+    `outs` `(` $output `:` type($output) `)`
     (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    static constexpr unsigned kSourceOpNum = 0;
-    static constexpr unsigned kIndicesOpNum = 1;
-    static constexpr unsigned kResultOpNum = 2;
-
     /// Utility to get the number of indices used to index into `source`.
     int64_t getIndexDepth() {
       return getDimensionMap().size();
@@ -239,24 +219,12 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
       return getOutputType().getRank() - getOutputSliceRank();
     }
 
-    Value getSource(){
-      return getOperand(kSourceOpNum);
-    }
-
     ShapedType getSourceType(){
       return cast<ShapedType>(getSource().getType());
     }
 
-    Value getIndices(){
-      return getOperand(kIndicesOpNum);
-    }
-
     ShapedType getIndicesType(){
       return cast<ShapedType>(getIndices().getType());
-    }
-
-    Value getOutput(){
-      return getOperand(kResultOpNum);
     }
 
     ShapedType getOutputType(){
@@ -265,7 +233,7 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
 
     /// For DPS interface.
     MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
+      return getOutputMutable();
     }
   }];
 
@@ -557,32 +525,25 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
     context, they will be the second and third inputs.
   }];
 
-  let arguments = (ins Variadic<AnyType>:$inputs,
-                       Variadic<AnyShaped>:$outputs
+  let arguments = (ins AnyType:$stage,
+                       Optional<AnyShaped>:$real_coeff,
+                       Optional<AnyShaped>:$imag_coeff,
+                       AnyShaped:$real,
+                       AnyShaped:$imag
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
-    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `outs` `(` $outputs `:` type($outputs) `)`
+    attr-dict
+    `ins` `(` $stage (`,` $real_coeff^ `,` $imag_coeff)? `:` type($stage) (`,` type($real_coeff)^ `,` type($imag_coeff))? `)`
+    `outs` `(` $real `,` $imag `:` type($real) `,` type($imag) `)`
     (`:` type($results)^)?
   }];
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getStage() { return getInputs()[0]; }
-    Value getReal() { return getOutputs()[0]; }
-    Value getImag() { return getOutputs()[1]; }
-    bool hasCoeff() { return getNumDpsInputs() > 1; }
+    bool hasCoeff() { return static_cast<bool>(getRealCoeff()); }
     void generateScalarImplWithoutCoeffBuf(
         OpBuilder & b, Location loc, ArrayRef<Value> operands, Value wholeSize);
     void generateScalarImplWithCoeffBuf(OpBuilder & b, Location loc,
                                         ArrayRef<Value> operands);
-    Value getRealCoeff() {
-      if (!hasCoeff()) return Value();
-      return getInputs()[1];
-    }
-    Value getImagCoeff() {
-      if (!hasCoeff()) return Value();
-      return getInputs()[2];
-    }
     ShapedType getOperandType() {
       return cast<ShapedType>(getReal().getType());
     }
@@ -598,15 +559,12 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
-    MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
-    }
+    MutableOperandRange getDpsInitsMutable();
   }];
 }
 
 def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
-    [AttrSizedOperandSegments,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["generateScalarImplementation",
        "getIterationDomain",
@@ -618,8 +576,9 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
     Computes the inclusive/exclusive scan along a given dimension.
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$input,
+                       AnyShaped:$output,
+                       AnyShaped:$accumulator,
                        I64Attr:$dimension,
                        BoolAttr:$inclusive
   );
@@ -631,21 +590,12 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
     attr-dict
     `dimension` `(` $dimension `)`
     `inclusive` `(` $inclusive `)`
-    `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `,` $accumulator `:` type($output) `,` type($accumulator) `)`
     $region (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getInput() {
-      return getDpsInputOperand(0)->get();
-    }
-    Value getAccumulator() {
-      return getDpsInitOperand(1)->get();
-    }
-    Value getOutput() {
-      return getDpsInitOperand(0)->get();
-    }
     ShapedType getOperandType() {
       return cast<ShapedType>(getInput().getType());
     }
@@ -655,14 +605,11 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
-    MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
-    }
+    MutableOperandRange getDpsInitsMutable();
   }];
 }
 
 def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
-  AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
   DeclareOpInterfaceMethods<LinalgExtInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
@@ -692,8 +639,10 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
    Note: when the two values are equal, the first occurence is always selected.
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$values,
+                       Optional<AnyShaped>:$indices,
+                       AnyShaped:$output_values,
+                       AnyShaped:$output_indices,
                        I64Attr:$dimension
   );
 
@@ -702,28 +651,12 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
   let assemblyFormat = [{
     attr-dict
     `dimension` `(` $dimension `)`
-    `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $values (`,` $indices^)? `:` type($values) (`,` type($indices)^)? `)`
+    `outs` `(` $output_values `,` $output_indices `:` type($output_values) `,` type($output_indices) `)`
     $region (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getValues() {
-      return getDpsInputOperand(0)->get();
-    }
-    std::optional<Value> getIndices() {
-      if (getNumDpsInputs() < 2) {
-        return {};
-      } else {
-        return getDpsInputOperand(1)->get();
-      }
-    }
-    Value outputValues() {
-      return getDpsInitOperand(0)->get();
-    }
-    Value outputIndices() {
-      return getDpsInitOperand(1)->get();
-    }
     ShapedType getInputType() {
       return cast<ShapedType>(getValues().getType());
     }
@@ -733,9 +666,7 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
-    MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
-    }
+    MutableOperandRange getDpsInitsMutable();
   }];
 }
 
@@ -837,8 +768,10 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
   }];
 
   let arguments = (ins
-    Variadic<AnyShaped>:$inputs,
-    Variadic<AnyShaped>:$outputs,
+    AnyShaped:$input_value,
+    Optional<AnyShaped>:$input_index,
+    AnyShaped:$output_value,
+    AnyShaped:$output_index,
     Optional<Index>:$index_base,
     I64Attr:$dimension
   );
@@ -850,37 +783,17 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
   let assemblyFormat = [{
     attr-dict
     `dimension` `(` $dimension `)`
-    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $input_value (`,` $input_index^)? `:` type($input_value) (`,` type($input_index)^)? `)`
+    `outs` `(` $output_value `,` $output_index `:` type($output_value) `,` type($output_index) `)`
     (`index_base` `(` $index_base^ `:` type($index_base) `)`)?
     $region (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getInputValue() {
-      return getDpsInputOperand(0)->get();
-    }
-
     // Returns true when the operation is in explicit-index mode, which occurs
     // when a second input operand provides pre-computed indices.
     bool hasExplicitIndexInput() {
-      return getInputs().size() == 2;
-    }
-
-    // Returns the index input operand, or nullptr if not in explicit-index mode.
-    Value getInputIndex() {
-      if (!hasExplicitIndexInput()){
-        return nullptr;
-      }
-      return getDpsInputOperand(1)->get();
-    }
-
-    Value outputValue() {
-      return getDpsInitOperand(0)->get();
-    }
-
-    Value outputIndex() {
-      return getDpsInitOperand(1)->get();
+      return static_cast<bool>(getInputIndex());
     }
 
     ShapedType getInputType() {
@@ -888,11 +801,11 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     }
 
     ShapedType getOutputValueType() {
-      return cast<ShapedType>(outputValue().getType());
+      return cast<ShapedType>(getOutputValue().getType());
     }
 
     ShapedType getOutputIndexType() {
-      return cast<ShapedType>(outputIndex().getType());
+      return cast<ShapedType>(getOutputIndex().getType());
     }
 
     // Returns the ShapedType of the index input, or nullptr if not in
@@ -922,9 +835,7 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     }
 
     // For DPS interface.
-    MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
-    }
+    MutableOperandRange getDpsInitsMutable();
 
     SmallVector<AffineMap> getIndexingMapsArray();
   }];
@@ -1631,8 +1542,8 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-    Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$input,
+    AnyShaped:$output,
     DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$outer_dims_perm,
     DenseI64ArrayAttr:$inner_dims_pos,
     Variadic<Index>:$inner_tiles,
@@ -1642,13 +1553,13 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
     attr-dict
-    $inputs
+    $input
     (`padding_value` `(` $padding_value^ `:` type($padding_value) `)`)?
     (`outer_dims_perm` `=` $outer_dims_perm^)?
     `inner_dims_pos` `=` $inner_dims_pos
     `inner_tiles` `=`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles)
-    `into` $outputs `:` `(` type($inputs) type($outputs) `)`
+    `into` $output `:` `(` type($input) type($output) `)`
      (`->` type($results)^)?
   }];
 
@@ -1661,16 +1572,6 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
   ];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-
-    // Return the output operand.
-    Value getOutput() {
-      return getDpsInitOperand(0)->get();
-    }
-
-    // Return the input operand.
-    Value getInput() {
-      return getDpsInputOperand(0)->get();
-    }
 
     // Return the output rank.
     int64_t getOutputRank() {
@@ -1733,14 +1634,11 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
-    MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
-    }
+    MutableOperandRange getDpsInitsMutable();
   }];
 }
 
 def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
-  AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
   DeclareOpInterfaceMethods<LinalgExtInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
@@ -1778,8 +1676,8 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
     ```
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-    Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$input,
+    AnyShaped:$output,
     DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$outer_dims_perm,
     DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$inner_dims_pos,
     Variadic<Index>:$inner_tiles,
@@ -1788,12 +1686,12 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
     attr-dict
-    $inputs
+    $input
     (`outer_dims_perm` `=` $outer_dims_perm^)?
     `inner_dims_pos` `=` $inner_dims_pos
     `inner_tiles` `=`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles)
-    `into` $outputs `:` `(` type($inputs) type($outputs) `)`
+    `into` $output `:` `(` type($input) type($output) `)`
      (`->` type($results)^)?
   }];
 
@@ -1805,16 +1703,6 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
   ];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-
-    // Return the output operand.
-    Value getOutput() {
-      return getDpsInitOperand(0)->get();
-    }
-
-    // Return the input operand.
-    Value getInput() {
-      return getDpsInputOperand(0)->get();
-    }
 
     // Return the output rank.
     int64_t getOutputRank() {
@@ -1855,9 +1743,7 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
-    MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
-    }
+    MutableOperandRange getDpsInitsMutable();
   }];
 }
 
@@ -1875,8 +1761,7 @@ def OpGroupWinogradOps : OpDocGroup {
 let opDocGroup = OpGroupWinogradOps in {
 
 def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_transform",
-    [AttrSizedOperandSegments,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",
        "getLoopIteratorTypes",
@@ -1896,8 +1781,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     of this operator is first collapsed and then fed to a batch matmul op.
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$input,
+                       AnyShaped:$output,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
                        DenseI64ArrayAttr:$image_dimensions
@@ -1910,18 +1795,12 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `image_dimensions` `(` $image_dimensions `)`
-    `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
     (`->` type($result)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getInput() {
-      return getDpsInputOperand(0)->get();
-    }
-    Value getOutput() {
-      return getDpsInitOperand(0)->get();
-    }
     Value getOriginalOperand() {
       return getInput();
     }
@@ -1975,14 +1854,13 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
+      return getOutputMutable();
     }
   }];
 }
 
 def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_transform",
-    [AttrSizedOperandSegments,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",
        "getLoopIteratorTypes",
@@ -2002,8 +1880,8 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     and then fed to a batch matmul op.
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$input,
+                       AnyShaped:$output,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
                        DenseI64ArrayAttr:$kernel_dimensions
@@ -2016,18 +1894,12 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `kernel_dimensions` `(` $kernel_dimensions `)`
-    `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
     (`->` type($result)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getInput() {
-      return getDpsInputOperand(0)->get();
-    }
-    Value getOutput() {
-      return getDpsInitOperand(0)->get();
-    }
     ShapedType getInputType() {
       return cast<ShapedType>(getInput().getType());
     }
@@ -2086,14 +1958,13 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
+      return getOutputMutable();
     }
   }];
 }
 
 def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_transform",
-    [AttrSizedOperandSegments,
-     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",
        "getLoopIteratorTypes",
@@ -2117,8 +1988,8 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     only the non-padded part of the output.
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
+  let arguments = (ins AnyShaped:$input,
+                       AnyShaped:$output,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
                        DenseI64ArrayAttr:$image_dimensions
@@ -2131,18 +2002,12 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `image_dimensions` `(` $image_dimensions `)`
-    `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
     (`->` type($result)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getInput() {
-      return getDpsInputOperand(0)->get();
-    }
-    Value getOutput() {
-      return getDpsInitOperand(0)->get();
-    }
     ShapedType getInputType() {
       return cast<ShapedType>(getInput().getType());
     }
@@ -2196,7 +2061,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {
-      return getOutputsMutable();
+      return getOutputMutable();
     }
   }];
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -598,44 +598,6 @@ func.func @map_scatter_0D(
 
 // -----
 
-func.func @arg_compare_invalid_too_many_inputs(
-    %input_val: tensor<2x10xf32>,
-    %input_idx: tensor<2x10xi32>,
-    %input_extra: tensor<2x10xf32>,
-    %out_val: tensor<2xf32>,
-    %out_idx: tensor<2xi32>
-) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{expected 1 or 2 input operands, but got 3}}
-  %0:2 = iree_linalg_ext.arg_compare
-    dimension(1)
-    ins(%input_val, %input_idx, %input_extra : tensor<2x10xf32>, tensor<2x10xi32>, tensor<2x10xf32>)
-    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
-  } -> tensor<2xf32>, tensor<2xi32>
-  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
-}
-
-// -----
-
-func.func @arg_compare_invalid_missing_output(
-    %input_val: tensor<2x10xf32>,
-    %out_val: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{expected two output operands (value and index), but got 1}}
-  %0:2 = iree_linalg_ext.arg_compare
-    dimension(1)
-    ins(%input_val : tensor<2x10xf32>)
-    outs(%out_val : tensor<2xf32>) {
-    ^bb0(%a: f32, %b: f32):
-      %cmp = arith.cmpf ogt, %a, %b : f32
-      iree_linalg_ext.yield %cmp : i1
-  } -> tensor<2xf32>, tensor<2xi32>
-  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
-}
-
-// -----
-
 func.func @arg_compare_invalid_dim(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
@@ -935,21 +897,6 @@ func.func @arg_compare_invalid_explicit_index_with_base(
       iree_linalg_ext.yield %cmp : i1
   } -> tensor<2xf32>, tensor<2xi32>
   return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
-}
-
-// -----
-
-func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
-  // expected-error@+1 {{expected one or two input operands}}
-  %0:2 = iree_linalg_ext.topk
-        dimension(1)
-        ins(%input_indices, %input_indices, %input_indices : tensor<2x10xi32>, tensor<2x10xi32>, tensor<2x10xi32>)
-        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):
-          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
-          iree_linalg_ext.yield %0 : i1
-        } -> tensor<2x3xf32>, tensor<2x3xi32>
-  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -209,8 +209,8 @@ public:
         isNchwFchw ? fchwKernelDims : hwcfKernelDims;
     Value winogradFilter =
         IREE::LinalgExt::WinogradFilterTransformOp::create(
-            rewriter, loc, kernelInit.getType(), ValueRange{kernel},
-            ValueRange{kernelInit}, outputTileSize, kernelSize, kernelDims)
+            rewriter, loc, kernelInit.getType(), /*input=*/kernel,
+            /*output=*/kernelInit, outputTileSize, kernelSize, kernelDims)
             .getResults()[0];
 
     // Add collapse shape
@@ -259,9 +259,9 @@ public:
     const std::array<int64_t, 2> imageDims =
         isNchwFchw ? nchwImageDims : nhwcImageDims;
     Value winogradInput =
-        IREE::LinalgExt::WinogradInputTransformOp ::create(
-            rewriter, loc, inputTfInit.getType(), ValueRange{input},
-            ValueRange{inputTfInit}, outputTileSize, kernelSize, imageDims)
+        IREE::LinalgExt::WinogradInputTransformOp::create(
+            rewriter, loc, inputTfInit.getType(), /*input=*/input,
+            /*output=*/inputTfInit, outputTileSize, kernelSize, imageDims)
             .getResults()[0];
 
     // Add collapse shape
@@ -317,7 +317,7 @@ public:
     Value paddedOutput =
         IREE::LinalgExt::WinogradOutputTransformOp::create(
             rewriter, loc, outputTfInit.getType(),
-            ValueRange{expandedBmmResult}, ValueRange{outputTfInit},
+            /*input=*/expandedBmmResult, /*output=*/outputTfInit,
             outputTileSize, kernelSize, imageDims)
             .getResults()[0];
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -69,14 +69,14 @@ struct FoldWinogradOpUnitDims : public OpRewritePattern<TransformOp> {
     }
 
     auto newInput = tensor::createCanonicalRankReducingExtractSliceOp(
-        rewriter, loc, transformOp.getInputs()[0], newInputType);
+        rewriter, loc, transformOp.getInput(), newInputType);
     auto newInit = tensor::createCanonicalRankReducingExtractSliceOp(
-        rewriter, loc, transformOp.getOutputs()[0], newOutputType);
+        rewriter, loc, transformOp.getOutput(), newOutputType);
     auto rankReducedTransform = clone(rewriter, transformOp, newOutputType,
                                       ValueRange{newInput, newInit});
     auto insertSliceOp = tensor::createCanonicalRankReducingInsertSliceOp(
         rewriter, loc, rankReducedTransform->getResult(0),
-        transformOp.getOutputs()[0]);
+        transformOp.getOutput());
     rewriter.replaceOp(transformOp, insertSliceOp);
 
     return success();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -557,7 +557,7 @@ struct DropScatterUnitIndexDepth final : public OpRewritePattern<ScatterOp> {
         rewriter, scatterOp.getLoc(), scatterOp.getIndices(), reassoc);
 
     rewriter.modifyOpInPlace(scatterOp, [&]() {
-      scatterOp.setOperand(ScatterOp::kIndicesOpNum, collapseOp.getResult());
+      scatterOp.getIndicesMutable().set(collapseOp.getResult());
     });
     return success();
   }
@@ -757,8 +757,8 @@ struct DropGatherUnitDims final : public OpRewritePattern<GatherOp> {
 
     auto newGather = GatherOp::create(
         rewriter, gatherOp.getLoc(), TypeRange{reducedOutput.getType()},
-        ValueRange{reducedSource, reducedIndices}, ValueRange{reducedOutput},
-        gatherOp.getDimensionMap());
+        /*source=*/reducedSource, /*indices=*/reducedIndices,
+        /*output=*/reducedOutput, gatherOp.getDimensionMap());
     rewriter.replaceOp(gatherOp,
                        rankExpandValue(rewriter, loc, gatherOp.getOutput(),
                                        newGather.getResult(0), options));
@@ -824,7 +824,7 @@ struct DropScatterUnitDims final : public OpRewritePattern<ScatterOp> {
 
     auto newScatter = ScatterOp::create(
         rewriter, scatterOp.getLoc(), TypeRange{original.getType()},
-        ValueRange{updates, indices}, ValueRange{original},
+        /*updates=*/updates, /*indices=*/indices, /*original=*/original,
         scatterOp.getDimensionMap(), scatterOp.getUniqueIndices());
     rewriter.inlineRegionBefore(scatterOp.getRegion(), newScatter.getRegion(),
                                 newScatter.getRegion().begin());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/RewriteFft.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/RewriteFft.cpp
@@ -180,7 +180,10 @@ static SmallVector<Value> generateFFT(ImplicitLocOpBuilder &b,
     inputs.append(getCoeffConstants(b, direction, s));
     results =
         FftOp::create(b, TypeRange{results[0].getType(), results[1].getType()},
-                      inputs, results)
+                      /*stage=*/inputs[0],
+                      /*real_coeff=*/inputs.size() > 1 ? inputs[1] : Value(),
+                      /*imag_coeff=*/inputs.size() > 2 ? inputs[2] : Value(),
+                      /*real=*/results[0], /*imag=*/results[1])
             .getResults();
   }
 


### PR DESCRIPTION
For some reason the tablegen for this dialect stuck out like a sore thumb where many of the operands to the ops in this dialect were using an array of ExtraClassDeclarations to provide the getters/setters for operands instead of using the declarative formats like every other dialect.

Also drops the verifier checks for operand counts since it's enforced by the tablegen and a few invalid tests because they fail as parser errors now and aren't as important to test.

Fixes https://github.com/iree-org/iree/issues/17511