### PR TITLE
[LinalgExt][NFC] Drop redundant function argument comments.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -283,8 +283,7 @@ struct ScatterOpConversion final
     }
 
     auto scatterOp = IREE::LinalgExt::ScatterOp::create(
-        rewriter, op.getLoc(), originalType,
-        /*updates=*/updates, /*indices=*/indices, /*original=*/original,
+        rewriter, op.getLoc(), originalType, updates, indices, original,
         scatterDimMap, op.getUniqueIndices());
 
     rewriter.inlineRegionBefore(op.getUpdateComputation(),

--- a/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
@@ -136,9 +136,9 @@ public:
 
     // Create the LinalgExt scatter operation.
     auto scatter = IREE::LinalgExt::ScatterOp::create(
-        builder, TypeRange{values.getType()},
-        /*updates=*/updates, /*indices=*/indices, /*original=*/values,
-        builder.getDenseI64ArrayAttr({0, 1}), builder.getBoolAttr(true));
+        builder, TypeRange{values.getType()}, updates, indices,
+        /*original=*/values, builder.getDenseI64ArrayAttr({0, 1}),
+        builder.getBoolAttr(true));
 
     llvm::SmallVector<Type> args(2, valuesTy.getElementType());
     Block *scatterBody =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -260,7 +260,7 @@ public:
         isNchwFchw ? nchwImageDims : nhwcImageDims;
     Value winogradInput =
         IREE::LinalgExt::WinogradInputTransformOp::create(
-            rewriter, loc, inputTfInit.getType(), /*input=*/input,
+            rewriter, loc, inputTfInit.getType(), input,
             /*output=*/inputTfInit, outputTileSize, kernelSize, imageDims)
             .getResults()[0];
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -823,9 +823,9 @@ struct DropScatterUnitDims final : public OpRewritePattern<ScatterOp> {
     }
 
     auto newScatter = ScatterOp::create(
-        rewriter, scatterOp.getLoc(), TypeRange{original.getType()},
-        /*updates=*/updates, /*indices=*/indices, /*original=*/original,
-        scatterOp.getDimensionMap(), scatterOp.getUniqueIndices());
+        rewriter, scatterOp.getLoc(), TypeRange{original.getType()}, updates,
+        indices, original, scatterOp.getDimensionMap(),
+        scatterOp.getUniqueIndices());
     rewriter.inlineRegionBefore(scatterOp.getRegion(), newScatter.getRegion(),
                                 newScatter.getRegion().begin());
     rewriter.replaceOp(scatterOp,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -183,12 +183,9 @@ computeParallelTopk(Location loc, RewriterBase &rewriter,
 
   // Parallel topk
   auto parallelTopkOp = iree_compiler::IREE::LinalgExt::TopkOp::create(
-      rewriter, loc,
-      /*resultTypes=*/parallelTopkResultTypes,
-      /*values=*/parallelTopkIns[0],
+      rewriter, loc, parallelTopkResultTypes, parallelTopkIns[0],
       /*indices=*/parallelTopkIns.size() > 1 ? parallelTopkIns[1] : Value(),
-      /*output_values=*/parallelTopkOuts[0],
-      /*output_indices=*/parallelTopkOuts[1], kDimParallel);
+      parallelTopkOuts[0], parallelTopkOuts[1], kDimParallel);
   rewriter.cloneRegionBefore(topkOp.getRegion(), parallelTopkOp.getRegion(),
                              parallelTopkOp.getRegion().end());
 
@@ -262,11 +259,9 @@ TopkOp computeReductionTopk(Location loc, RewriterBase &rewriter, TopkOp topkOp,
 
   // Combined final topk
   auto reductionTopkOp = iree_compiler::IREE::LinalgExt::TopkOp::create(
-      rewriter, loc,
-      /*resultTypes=*/topkOp->getResultTypes(),
-      /*values=*/valuesCollapsed, /*indices=*/indicesCollapsed,
-      /*output_values=*/topkOp.getOutputValues(),
-      /*output_indices=*/topkOp.getOutputIndices(), kDimOrig);
+      rewriter, loc, topkOp->getResultTypes(), valuesCollapsed,
+      indicesCollapsed, topkOp.getOutputValues(), topkOp.getOutputIndices(),
+      kDimOrig);
   rewriter.cloneRegionBefore(topkOp.getRegion(), reductionTopkOp.getRegion(),
                              reductionTopkOp.getRegion().end());
   return reductionTopkOp;


### PR DESCRIPTION
The comments were introduced by https://github.com/iree-org/iree/commit/dad36f999934096bc44817ecaa1d06333a1db71f and the revision removes redundant comments.