### PR TITLE
[Util] Integrate `DenseIntElementsAttr` switch to unpacked i1 data

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -371,7 +371,6 @@ static LogicalResult serializeGenericElementData(Location loc,
     case 1:
       // NOTE: i1 is treated as i8 in a lot of places in MLIR/IREE and will need
       // a larger cleanup to serialize as a sub-byte value like the others.
-      return serializeRawData(loc, attr, os);
     case 8:
       return serializeRawData(loc, attr, os);
     case 16:
@@ -436,13 +435,9 @@ static LogicalResult serializeGenericResourceElementData(
     unsigned bitWidth = integerType.getIntOrFloatBitWidth();
     switch (bitWidth) {
     case 1:
-      return serializeResourceRawData(loc, resourceElementsAttr, os);
     case 8:
-      return serializeResourceRawData(loc, resourceElementsAttr, os);
     case 16:
-      return serializeResourceRawData(loc, resourceElementsAttr, os);
     case 32:
-      return serializeResourceRawData(loc, resourceElementsAttr, os);
     case 64:
       return serializeResourceRawData(loc, resourceElementsAttr, os);
     default:


### PR DESCRIPTION
As of LLVM commit llvm/llvm-project@c6964b1b4dcd, DenseElementsAttr no longer bit-packs i1
values. Each i1 element is stored as a full byte (0x00 or 0x01), matching
the behavior of DenseResourceElementsAttr.

This drops our revert and removes the now-unnecessary `serializeBitIntegerValuesAsBytes`
function which previously unpacked bit-packed i1 values.]

closes https://github.com/iree-org/iree/issues/23463