### PR TITLE
[LDS] Add pre-check to ensure all copies are DMA-convertible before converting any

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -97,6 +97,47 @@ static bool tracesToTensorEmpty(Value value) {
   return initValue.getDefiningOp<tensor::EmptyOp>() != nullptr;
 }
 
+/// Check DMA alignment for available elements against target DMA sizes.
+/// Returns subgroup size if aligned, std::nullopt otherwise.
+static std::optional<int64_t> checkDMAAlignment(FunctionOpInterface funcOp,
+                                                Type elementType,
+                                                int64_t availableElements) {
+  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+  if (!subgroupSize) {
+    return std::nullopt;
+  }
+
+  int64_t elementBits = elementType.getIntOrFloatBitWidth();
+
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+  if (!target) {
+    return std::nullopt;
+  }
+
+  ArrayRef<int64_t> dmaSizes;
+  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+    dmaSizes = dmaSizesAttr.asArrayRef();
+  }
+
+  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
+  for (int64_t dmaSize : dmaSizes) {
+    if (dmaSize % elementBits != 0) {
+      continue;
+    }
+    int64_t elementsPerLane = dmaSize / elementBits;
+    int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
+    minElementsPerTransfer =
+        std::min(minElementsPerTransfer, elementsPerTransfer);
+  }
+
+  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
+      availableElements % minElementsPerTransfer != 0) {
+    return std::nullopt;
+  }
+
+  return subgroupSize;
+}
+
 /// Helper to compute thread number of threads based on translation_info.
 /// Uses the subgroup_size from translation_info for thread-level tiling.
 static SmallVector<OpFoldResult>
@@ -108,52 +149,15 @@ computeThreadNumThreadsImpl(OpBuilder &builder, Operation *op,
     return {};
   }
 
-  // Get the function containing this operation.
   auto funcOp = op->getParentOfType<FunctionOpInterface>();
   if (!funcOp) {
     return {};
   }
 
-  // Get subgroup size from translation_info.
-  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
-  if (!subgroupSize) {
-    return {};
-  }
-
-  // Skip coalesced DMA if the innermost dimension is smaller than the minimum
-  // transfer size. The minimum transfer size is subgroupSize *
-  // minElementsPerLane.
   int64_t rank = outputType.getRank();
   int64_t innermostDim = outputType.getShape()[rank - 1];
   if (ShapedType::isDynamic(innermostDim)) {
     return {};
-  }
-
-  // Get element type bit width.
-  Type elementType = outputType.getElementType();
-  int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
-  // Get DMA sizes from target to compute minimum transfer size.
-  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-  if (!target) {
-    return {};
-  }
-
-  ArrayRef<int64_t> dmaSizes;
-  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
-    dmaSizes = dmaSizesAttr.asArrayRef();
-  }
-
-  // Find minimum elements per transfer across all DMA sizes.
-  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-  for (int64_t dmaSize : dmaSizes) {
-    if (dmaSize % elementBits != 0) {
-      continue;
-    }
-    int64_t elementsPerLane = dmaSize / elementBits;
-    int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-    minElementsPerTransfer =
-        std::min(minElementsPerTransfer, elementsPerTransfer);
   }
 
   // Determine how many elements are available for coalesced access.
@@ -168,13 +172,45 @@ computeThreadNumThreadsImpl(OpBuilder &builder, Operation *op,
     }
   }
 
-  // If no valid DMA size found or elements not aligned to transfer size, skip.
-  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
-      availableElements % minElementsPerTransfer != 0) {
+  auto subgroupSize =
+      checkDMAAlignment(funcOp, outputType.getElementType(), availableElements);
+  if (!subgroupSize) {
     return {};
   }
 
   return {builder.getIndexAttr(*subgroupSize)};
+}
+
+/// Check if a linalg.copy is viable for DMA conversion based on alignment and
+/// size constraints. This does NOT modify the IR.
+static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
+  auto funcOp = copyOp->getParentOfType<FunctionOpInterface>();
+  if (!funcOp) {
+    return false;
+  }
+
+  auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
+  int64_t rank = outputType.getRank();
+  ArrayRef<int64_t> shape = outputType.getShape();
+  int64_t innermostDim = shape[rank - 1];
+  if (ShapedType::isDynamic(innermostDim)) {
+    return false;
+  }
+
+  // The pre-check runs before tiling, so the output is directly a
+  // tensor.empty() (not yet inside forall block args). A simple defining op
+  // check suffices here, unlike tracesToTensorEmpty used post-tiling.
+  int64_t availableElements = innermostDim;
+  Value output = copyOp.getOutputs()[0];
+  if (output.getDefiningOp<tensor::EmptyOp>()) {
+    if (llvm::none_of(shape, ShapedType::isDynamic)) {
+      availableElements = ShapedType::getNumElements(shape);
+    }
+  }
+
+  return checkDMAAlignment(funcOp, outputType.getElementType(),
+                           availableElements)
+      .has_value();
 }
 
 /// Check if the given forall op has warp mapping.
@@ -597,6 +633,41 @@ struct GPUConvertToCoalescedDMAPass final
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
+
+    // Pre-check: decide whether all linalg.copy ops should be DMA-converted.
+    // Only activate when at least one copy already has use_global_load_dma
+    // (indicating DMA intent from upstream config, e.g. --iree-llvmgpu-use-
+    // direct-load). Collect all promoted copies (use_global_load_dma or
+    // derived_thread_config). If ALL are DMA-convertible, upgrade them all to
+    // use_global_load_dma. If ANY fails, downgrade them all to
+    // derived_thread_config.
+    // Note: GatherOps are excluded — they come from input IR (not from
+    // GPUPromoteMatmulOperands) and are handled independently by
+    // ConvertGatherToCoalescedDMA.
+    SmallVector<linalg::CopyOp> promotedCopies;
+    bool hasDMAIntent = false;
+    funcOp->walk([&](linalg::CopyOp copyOp) {
+      if (getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp)) {
+        hasDMAIntent = true;
+        promotedCopies.push_back(copyOp);
+      } else if (getLoweringConfig<IREE::GPU::DerivedThreadConfigAttr>(
+                     copyOp)) {
+        promotedCopies.push_back(copyOp);
+      }
+    });
+
+    if (hasDMAIntent) {
+      bool allConvertible = llvm::all_of(promotedCopies, isCopyDMAConvertible);
+      for (linalg::CopyOp copyOp : promotedCopies) {
+        if (allConvertible) {
+          setLoweringConfig(copyOp,
+                            IREE::GPU::UseGlobalLoadDMAAttr::get(context));
+        } else {
+          setLoweringConfig(copyOp,
+                            IREE::GPU::DerivedThreadConfigAttr::get(context));
+        }
+      }
+    }
 
     // Preprocessing: apply subgroup-level tiling.
     if (failed(applySubgroupTiling(funcOp))) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -451,3 +451,159 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
 
   return %result : tensor<64x128xf32>
 }
+
+// -----
+
+// Test: Two copies both with use_global_load_dma and both DMA-convertible.
+// Both should be converted to coalesced DMA.
+
+#gpu_target_pair = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_pair = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pair}>
+#translation_pair = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @copy_pair_both_convertible
+func.func @copy_pair_both_convertible(
+    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
+    %src1: tensor<32x256xf32>, %init1: tensor<32x256xf32>)
+    -> (tensor<64x128xf32>, tensor<32x256xf32>)
+  attributes {hal.executable.target = #exec_target_pair, translation_info = #translation_pair} {
+  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%src0 : tensor<64x128xf32>)
+    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
+  %r1 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%src1 : tensor<32x256xf32>)
+    outs(%init1 : tensor<32x256xf32>) -> tensor<32x256xf32>
+
+  // Both copies should be converted since both are DMA-convertible.
+  // CHECK: iree_gpu.coalesced_gather_dma
+  // CHECK: iree_gpu.coalesced_gather_dma
+  // CHECK-NOT: linalg.copy
+
+  return %r0, %r1 : tensor<64x128xf32>, tensor<32x256xf32>
+}
+
+// -----
+
+// Negative test: Two copies with use_global_load_dma, but one has misaligned
+// innermost dimension. Neither should be converted.
+
+#gpu_target_pair_one_bad = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_pair_one_bad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pair_one_bad}>
+#translation_pair_one_bad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @copy_pair_one_unconvertible
+func.func @copy_pair_one_unconvertible(
+    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
+    %src1: tensor<64x32xf32>, %init1: tensor<64x32xf32>)
+    -> (tensor<64x128xf32>, tensor<64x32xf32>)
+  attributes {hal.executable.target = #exec_target_pair_one_bad, translation_info = #translation_pair_one_bad} {
+  // First copy is DMA-convertible (128 % 64 == 0), but second is not (32 % 64 != 0).
+  // Since not ALL copies are convertible, neither should be converted.
+  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%src0 : tensor<64x128xf32>)
+    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
+  %r1 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%src1 : tensor<64x32xf32>)
+    outs(%init1 : tensor<64x32xf32>) -> tensor<64x32xf32>
+
+  // CHECK-NOT: iree_gpu.coalesced_gather_dma
+  // CHECK: linalg.copy
+  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
+  // CHECK: linalg.copy
+  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
+
+  return %r0, %r1 : tensor<64x128xf32>, tensor<64x32xf32>
+}
+
+// -----
+
+// Test: Mixed attributes (1 use_global_load_dma + 1 derived_thread_config),
+// both DMA-convertible. Both should be upgraded and converted to DMA.
+
+#gpu_target_mixed_ok = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_mixed_ok = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_mixed_ok}>
+#translation_mixed_ok = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @copy_mixed_attrs_both_convertible
+func.func @copy_mixed_attrs_both_convertible(
+    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
+    %src1: tensor<32x256xf32>, %init1: tensor<32x256xf32>)
+    -> (tensor<64x128xf32>, tensor<32x256xf32>)
+  attributes {hal.executable.target = #exec_target_mixed_ok, translation_info = #translation_mixed_ok} {
+  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%src0 : tensor<64x128xf32>)
+    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
+  // This copy has derived_thread_config but IS DMA-convertible.
+  // The pass should upgrade it to use_global_load_dma and convert both.
+  %r1 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
+    ins(%src1 : tensor<32x256xf32>)
+    outs(%init1 : tensor<32x256xf32>) -> tensor<32x256xf32>
+
+  // Both copies should be converted since both are DMA-convertible.
+  // CHECK: iree_gpu.coalesced_gather_dma
+  // CHECK: iree_gpu.coalesced_gather_dma
+  // CHECK-NOT: linalg.copy
+
+  return %r0, %r1 : tensor<64x128xf32>, tensor<32x256xf32>
+}
+
+// -----
+
+// Negative test: Mixed attributes (1 use_global_load_dma + 1 derived_thread_config),
+// but the derived_thread_config copy is NOT DMA-convertible. Neither should be
+// converted.
+
+#gpu_target_mixed_bad = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_mixed_bad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_mixed_bad}>
+#translation_mixed_bad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @copy_mixed_attrs_one_unconvertible
+func.func @copy_mixed_attrs_one_unconvertible(
+    %src0: tensor<64x128xf32>, %init0: tensor<64x128xf32>,
+    %src1: tensor<64x32xf32>, %init1: tensor<64x32xf32>)
+    -> (tensor<64x128xf32>, tensor<64x32xf32>)
+  attributes {hal.executable.target = #exec_target_mixed_bad, translation_info = #translation_mixed_bad} {
+  // First copy is DMA-convertible, but second is not (32 % 64 != 0).
+  %r0 = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%src0 : tensor<64x128xf32>)
+    outs(%init0 : tensor<64x128xf32>) -> tensor<64x128xf32>
+  %r1 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
+    ins(%src1 : tensor<64x32xf32>)
+    outs(%init1 : tensor<64x32xf32>) -> tensor<64x32xf32>
+
+  // CHECK-NOT: iree_gpu.coalesced_gather_dma
+  // CHECK: linalg.copy
+  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
+  // CHECK: linalg.copy
+  // CHECK-SAME: lowering_config = #iree_gpu.derived_thread_config
+
+  return %r0, %r1 : tensor<64x128xf32>, tensor<64x32xf32>
+}


### PR DESCRIPTION
This patch ensures we either use DMA for all promoted operands or none. This is to ensure we can have async buffer pipelines.

* Add isCopyDMAConvertible() to check DMA viability without modifying IR.
* In GPUConvertToCoalescedDMAPass, collect all linalg.copy ops with use_global_load_dma or derived_thread_config. If ALL are DMA-convertible, upgrade them all to use_global_load_dma. If ANY fails, downgrade them all to derived_thread_config.
* Add new lit tests for paired copy conversion and mixed attribute scenarios.