### PR TITLE
[Tests] Use llvm-cpu backend for transients_test.mlir

### DIFF
--- a/tests/e2e/regression/transients_test.mlir
+++ b/tests/e2e/regression/transients_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=rocm --iree-rocm-target=mi300x --iree-opt-level=O3 --compile-to=stream %s | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=llvm-cpu --iree-opt-level=O3 --compile-to=stream %s | FileCheck %s
 
 // No transient allocations created.
 util.func @test_no_transients(%arg0 : tensor<128x256xf32>, %arg1 : tensor<256x512xf32>,


### PR DESCRIPTION
- Switch `transients_test.mlir` from `rocm` backend to `llvm-cpu`
- Fixes scheduled CI failures on ARM64, macOS, and BYOLLVM builds