### PR TITLE
[DispatchCreation] Fix producer fusion with nested region uses

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -761,28 +761,26 @@ static bool isFusableWithProducer(OpOperand &operand,
 static bool hasUsesBetweenProducerAndRoot(Operation *producer, Operation *root,
                                           const FusionGroup &fusionGroup,
                                           const DominanceInfo &dominanceInfo) {
-  for (Value result : producer->getResults()) {
-    for (OpOperand &use : result.getUses()) {
-      Operation *user = use.getOwner();
-      // Walk up to the parent in the same block as the producer/root.
-      while (user->getBlock() != root->getBlock()) {
-        user = user->getParentOp();
-        if (!user) {
-          break;
-        }
-      }
+  for (OpOperand &use : producer->getUses()) {
+    Operation *user = use.getOwner();
+    // Walk up to the parent in the same block as the producer/root.
+    while (user->getBlock() != root->getBlock()) {
+      user = user->getParentOp();
       if (!user) {
-        continue;
+        break;
       }
-      // If the user is in the fusion group, it will be moved too.
-      if (fusionGroup.contains(user) || user == producer) {
-        continue;
-      }
-      // If the user does not come after the root, then moving the producer
-      // into the dispatch at root's position would break dominance.
-      if (!dominanceInfo.properlyDominates(root, user)) {
-        return true;
-      }
+    }
+    if (!user) {
+      continue;
+    }
+    // If the user is in the fusion group, it will be moved too.
+    if (fusionGroup.contains(user)) {
+      continue;
+    }
+    // If the user does not come after the root, then moving the producer
+    // into the dispatch at root's position would break dominance.
+    if (!dominanceInfo.properlyDominates(root, user)) {
+      return true;
     }
   }
   return false;

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -754,6 +754,40 @@ static bool isFusableWithProducer(OpOperand &operand,
   return true;
 }
 
+/// Check if moving the producer into the dispatch at the root's position would
+/// break any existing uses. Returns true if there are uses between the producer
+/// and the root that are not in the fusion group, which would cause a dominance
+/// violation.
+static bool hasUsesBetweenProducerAndRoot(Operation *producer, Operation *root,
+                                          const FusionGroup &fusionGroup,
+                                          const DominanceInfo &dominanceInfo) {
+  for (Value result : producer->getResults()) {
+    for (OpOperand &use : result.getUses()) {
+      Operation *user = use.getOwner();
+      // Walk up to the parent in the same block as the producer/root.
+      while (user->getBlock() != root->getBlock()) {
+        user = user->getParentOp();
+        if (!user) {
+          break;
+        }
+      }
+      if (!user) {
+        continue;
+      }
+      // If the user is in the fusion group, it will be moved too.
+      if (fusionGroup.contains(user) || user == producer) {
+        continue;
+      }
+      // If the user does not come after the root, then moving the producer
+      // into the dispatch at root's position would break dominance.
+      if (!dominanceInfo.properlyDominates(root, user)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 /// Starting from the `root` op, traverse the operand use-def chain
 /// in reverse to fuse with producers.
 static void
@@ -779,6 +813,11 @@ fuseRootsWithProducers(MLIRContext *context, Operation *root,
       }
 
       if (!isFusableWithProducer(operand, tracker, options, fuseWithTruncate)) {
+        continue;
+      }
+
+      if (hasUsesBetweenProducerAndRoot(producer, root, fusionGroup,
+                                        dominanceInfo)) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -764,17 +764,11 @@ static bool hasUsesBetweenProducerAndRoot(Operation *producer, Operation *root,
   for (OpOperand &use : producer->getUses()) {
     Operation *user = use.getOwner();
     // Walk up to the parent in the same block as the producer/root.
-    while (user->getBlock() != root->getBlock()) {
+    while (user && user->getBlock() != root->getBlock()) {
       user = user->getParentOp();
-      if (!user) {
-        break;
-      }
-    }
-    if (!user) {
-      continue;
     }
     // If the user is in the fusion group, it will be moved too.
-    if (fusionGroup.contains(user)) {
+    if (!user || fusionGroup.contains(user)) {
       continue;
     }
     // If the user does not come after the root, then moving the producer


### PR DESCRIPTION
In `fuseRootsWithProducers`, the pass only checked same-block uses via `getFusableUses`, missing uses from above where a producer's result is captured in nested regions. This caused dominance violations when the producer was fused into a later dispatch, breaking intervening ops that used it.

The fix walks up from each use to the parent op in the same block as root and verifies the root dominates it, blocking fusion if not.

Fixes: https://github.com/iree-org/iree/issues/23339

Co-authored-by: GitHub Copilot <noreply@github.com>