### PR TITLE
[VectorDistribute] Remove special convolution handling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -813,6 +813,9 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
+  // Convert convolutions to matmuls by tiling filter dimensions.
+  funcPassManager.addPass(createGPUTileAndConvertConvToMatmulPass());
+
   // Set anchors at tensor level for vector distribution later and hoist out
   // loop invariant anchors.
   funcPassManager.addPass(createDecomposeHorizontallyFusedGemmsPass());


### PR DESCRIPTION
Add a pass to tile convolutions to matmuls so we never encounter a conv op in vector distribute during layout configuration. This is effectively an NFC, as this was what the unit dim folding was accomplishing.