### PR TITLE
Integrate llvm/llvm-project@3b2233a

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp
@@ -627,7 +627,8 @@ static void fuseTilableConsumerImpl(RewriterBase &rewriter, OpTy producerOp,
                           newResultDests);
     }
   } else {
-    fuseIntoWriteSlices(rewriter, target, params.operands, params.slices,
+    SmallVector<PCF::WriteSliceOp> slices(params.slices);
+    fuseIntoWriteSlices(rewriter, target, params.operands, slices,
                         newResultDests);
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp
@@ -510,7 +510,7 @@ addResults(RewriterBase &rewriter, PCF::GenericOp genericOp,
 template <typename OpTy>
 static void fuseTilableConsumerImpl(RewriterBase &rewriter, OpTy producerOp,
                                     TilingInterface target,
-                                    const ConsumerFusionParams &params) {
+                                    ConsumerFusionParams &params) {
   assert(!params.results.empty() && "unexpected empty number of results");
 
   Location loc = target.getLoc();
@@ -627,8 +627,7 @@ static void fuseTilableConsumerImpl(RewriterBase &rewriter, OpTy producerOp,
                           newResultDests);
     }
   } else {
-    SmallVector<PCF::WriteSliceOp> slices(params.slices);
-    fuseIntoWriteSlices(rewriter, target, params.operands, slices,
+    fuseIntoWriteSlices(rewriter, target, params.operands, params.slices,
                         newResultDests);
   }
 
@@ -894,14 +893,12 @@ LogicalResult matchTilableConsumer(RewriterBase &rewriter,
 }
 
 void fuseTilableConsumer(RewriterBase &rewriter, PCF::GenericOp producerOp,
-                         TilingInterface target,
-                         const ConsumerFusionParams &params) {
+                         TilingInterface target, ConsumerFusionParams &params) {
   return fuseTilableConsumerImpl(rewriter, producerOp, target, params);
 }
 
 void fuseTilableConsumer(RewriterBase &rewriter, PCF::LoopOp producerOp,
-                         TilingInterface target,
-                         const ConsumerFusionParams &params) {
+                         TilingInterface target, ConsumerFusionParams &params) {
   return fuseTilableConsumerImpl(rewriter, producerOp, target, params);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h
@@ -90,11 +90,9 @@ LogicalResult matchTilableConsumer(RewriterBase &rewriter, PCF::LoopOp loopOp,
                                    ConsumerFusionParams &params);
 
 void fuseTilableConsumer(RewriterBase &rewriter, PCF::GenericOp genericOp,
-                         TilingInterface target,
-                         const ConsumerFusionParams &params);
+                         TilingInterface target, ConsumerFusionParams &params);
 void fuseTilableConsumer(RewriterBase &rewriter, PCF::LoopOp loopOp,
-                         TilingInterface target,
-                         const ConsumerFusionParams &params);
+                         TilingInterface target, ConsumerFusionParams &params);
 
 // Pattern set for dropping unused results from scoped ops. Due to memory
 // effects this requires cascading operation erasure and is unsuitable for


### PR DESCRIPTION
Carrying reverts:

- https://github.com/llvm/llvm-project/commit/c6964b1b4dcda0f19f91cef186314f4cc2e0feb8 (breaks i1 tensor handling, see https://github.com/iree-org/iree/issues/23463) (looked into by @rkayaith)
- https://github.com/llvm/llvm-project/commit/34eb59dd4bb26cab248cc3a29b57b8dbe8d46849 (depends on https://github.com/llvm/llvm-project/commit/c6964b1b4dcda0f19f91cef186314f4cc2e0feb8)
- https://github.com/llvm/llvm-project/commit/75eecd27eb432ef8085c2f7733d067de80afa894 (removes LLVMSupport from Python bindings CMake, breaks iree-dialects build, see https://github.com/iree-org/iree/issues/23476) (looked into by @RattataKing)

Dropped reverts:
https://github.com/llvm/llvm-project/commit/a1d7cda1d7ca4983e02727f589952b02626d2dc8

Other points of interest:
https://github.com/llvm/llvm-project/commit/1de1a76dc9042ffc8026217cf0b105f0b86c16fb disallows implicit `const SmallVector` -> `MutableArrayRef`. [Affects PCF](https://github.com/iree-org/iree/blob/a852a42734d182a7049433822c72607a06dca8fd/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseConsumers.cpp#L630) when we pass `params.slices`(coming from coming from `const ConsumerFusionParams &params`) into `fuseIntoWriteSlices`; fix by dropping extraneous const qualifier 