### PR TITLE
[PCF] Add MemoryEffectsOpInterface to WriteSliceOp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/erase_dead_alloc_and_stores.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/erase_dead_alloc_and_stores.mlir
@@ -1,20 +1,33 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-erase-dead-alloc-and-stores))" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-erase-dead-alloc-and-stores))" --split-input-file %s | FileCheck %s
 
-module {
-  func.func @dead_alloc() {
-    %0 = memref.alloc() : memref<8x64xf32, 3>
-    %1 = memref.subview %0[0, 0] [8, 4] [1, 1] : memref<8x64xf32, 3> to
-      memref<8x4xf32, affine_map<(d0, d1) -> (d0 * 64 + d1)>, 3>
-    %c0 = arith.constant 0 : index
-    %cst_0 = arith.constant dense<0.000000e+00> : vector<1x4xf32>
-    vector.transfer_write %cst_0, %1[%c0, %c0] {in_bounds = [true, true]} :
-      vector<1x4xf32>, memref<8x4xf32, affine_map<(d0, d1) -> (d0 * 64 + d1)>, 3>
-    return
-  }
+func.func @dead_alloc() {
+  %0 = memref.alloc() : memref<8x64xf32, 3>
+  %1 = memref.subview %0[0, 0] [8, 4] [1, 1] : memref<8x64xf32, 3> to
+    memref<8x4xf32, affine_map<(d0, d1) -> (d0 * 64 + d1)>, 3>
+  %c0 = arith.constant 0 : index
+  %cst_0 = arith.constant dense<0.000000e+00> : vector<1x4xf32>
+  vector.transfer_write %cst_0, %1[%c0, %c0] {in_bounds = [true, true]} :
+    vector<1x4xf32>, memref<8x4xf32, affine_map<(d0, d1) -> (d0 * 64 + d1)>, 3>
+  return
 }
 
 // CHECK-LABEL:   func.func @dead_alloc
 //   CHECK-NOT:     memref.alloc
 //   CHECK-NOT:     memref.subview
 //   CHECK-NOT:     vector.transfer_write
+//       CHECK:     return
+
+// -----
+
+func.func @write_slice_preserves_alloc(
+    %dest: !pcf.sref<8x4xf32, #pcf.test_scope>) {
+  %alloc = memref.alloc() : memref<8x4xf32>
+  pcf.write_slice %alloc into %dest[0, 0] [8, 4] [1, 1]
+      : memref<8x4xf32> into !pcf.sref<8x4xf32, #pcf.test_scope>
+  return
+}
+
+// CHECK-LABEL:   func.func @write_slice_preserves_alloc
+//       CHECK:     %[[ALLOC:.+]] = memref.alloc() : memref<8x4xf32>
+//       CHECK:     pcf.write_slice %[[ALLOC]] into %{{.+}}[0, 0] [8, 4] [1, 1]
 //       CHECK:     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.cpp
@@ -919,6 +919,19 @@ LogicalResult WriteSliceOp::fold(FoldAdaptor adaptor,
   return success();
 }
 
+void WriteSliceOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (isa<MemRefType>(getSourceType())) {
+    // Source memrefs are read from.
+    effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
+                         SideEffects::DefaultResource::get());
+  }
+  // The dest operand is written to.
+  effects.emplace_back(MemoryEffects::Write::get(), &getDestMutable(),
+                       SideEffects::DefaultResource::get());
+}
+
 OpFoldResult ReadSliceOp::fold(FoldAdaptor adaptor) {
   SmallVector<OpFoldResult> mixedOffsets = getMixedOffsets();
   SmallVector<OpFoldResult> mixedStrides = getMixedStrides();

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.td
@@ -460,6 +460,7 @@ let opDocGroup = OpGroupWriteOps in {
   def PCF_WriteSliceOp
       : PCF_Op<"write_slice", [AttrSizedOperandSegments,
                                OffsetSizeAndStrideOpInterface,
+                               DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
                                AllRanksMatch<["source", "dest"]>,
                                AllElementTypesMatch<["source", "dest"]>,
   ]> {


### PR DESCRIPTION
Without declared memory effects, WriteSliceOp (which has no results) appears side-effect-free to OptimizeVectorTransferPass. This causes eraseDeadAllocAndStores to eliminate writes as dead code.

Declare Read on the source operand and Write on the dest (pcf.sref).