### PR TITLE
[VectorDistribute] Reify shape to enable folding

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Dialect/Vector/Utils/VectorUtils.h"
 #include "mlir/IR/Builders.h"
-#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler::IREE::VectorExt {


### PR DESCRIPTION
During vectorization of `to_layout`, use shape reification if possible. 

`to_layout` is vectorized to a pair of masked `transfer_read` and `transfer_write`. If padding is required, the vectorization of `linalg.generic` will also use masked `transfer_read/write`. On the operands, the resulting chain is already successfully folded before this change.

By using shape reification, the same mask SSA value will be used for the entire `transfer_write -> transfer_read -> transfer_write` chain on the result of `linalg.generic`, enabling the same folding to take place and avoiding insertion of `memref.copy` during bufferization.

This is part of https://github.com/iree-org/iree/issues/23415.

Assisted-by: Claude Code