### PR TITLE
Initial plumbing for inner_tiled on CPU with data-tiled MMA attribute.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/BUILD.bazel
@@ -16,6 +16,7 @@ package(
 exports_files([
     "IREECPUAttrs.td",
     "IREECPUDialect.td",
+    "IREECPUEnums.td",
 ])
 
 iree_td_library(
@@ -25,6 +26,7 @@ iree_td_library(
         [
             "IREECPUAttrs.td",
             "IREECPUDialect.td",
+            "IREECPUEnums.td",
         ],
         include = ["*.td"],
     ),
@@ -43,6 +45,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "IREECPUDialect.h",
+        "IREECPUEnums.h",
         "IREECPUTypes.h",
     ],
     textual_hdrs = [
@@ -50,10 +53,13 @@ iree_compiler_cc_library(
         "IREECPUAttrs.h.inc",
         "IREECPUDialect.cpp.inc",
         "IREECPUDialect.h.inc",
+        "IREECPUEnums.cpp.inc",
+        "IREECPUEnums.h.inc",
     ],
     deps = [
         ":IREECPUAttrs",
         ":IREECPUDialectGen",
+        ":IREECPUEnums",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
@@ -82,6 +88,29 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "IREECPUDialect.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "IREECPUEnums",
+    tbl_outs = [
+        (
+            [
+                "--gen-enum-decls",
+                "--dialect=iree_cpu",
+            ],
+            "IREECPUEnums.h.inc",
+        ),
+        (
+            [
+                "--gen-enum-defs",
+                "--dialect=iree_cpu",
+            ],
+            "IREECPUEnums.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "IREECPUEnums.td",
     deps = [":td_files"],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/BUILD.bazel
@@ -68,6 +68,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgInterfaces",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/CMakeLists.txt
@@ -15,18 +15,22 @@ iree_cc_library(
     IREECPUDialect
   HDRS
     "IREECPUDialect.h"
+    "IREECPUEnums.h"
     "IREECPUTypes.h"
   TEXTUAL_HDRS
     "IREECPUAttrs.cpp.inc"
     "IREECPUAttrs.h.inc"
     "IREECPUDialect.cpp.inc"
     "IREECPUDialect.h.inc"
+    "IREECPUEnums.cpp.inc"
+    "IREECPUEnums.h.inc"
   SRCS
     "IREECPUAttrs.cpp"
     "IREECPUDialect.cpp"
   DEPS
     ::IREECPUAttrs
     ::IREECPUDialectGen
+    ::IREECPUEnums
     LLVMSupport
     MLIRAffineDialect
     MLIRIR
@@ -48,6 +52,16 @@ iree_tablegen_library(
   OUTS
     --gen-dialect-decls IREECPUDialect.h.inc
     --gen-dialect-defs IREECPUDialect.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    IREECPUEnums
+  TD_FILE
+    "IREECPUEnums.td"
+  OUTS
+    --gen-enum-decls --dialect=iree_cpu IREECPUEnums.h.inc
+    --gen-enum-defs --dialect=iree_cpu IREECPUEnums.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
     MLIRAffineDialect
     MLIRIR
     MLIRLinalgDialect
+    MLIRLinalgInterfacesIncGenLib
     MLIRParser
     MLIRSupport
     MLIRTensorDialect

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -298,7 +298,7 @@ struct CPUOpaqueMmaLayout {
   Type cType;
 };
 
-}  // namespace
+} // namespace
 
 static std::tuple<int64_t, int64_t, int64_t>
 getMNKShapeFromIntrinsic(MMAIntrinsic intrinsic) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -287,6 +287,8 @@ SmallVector<bool> LoweringConfigAttr::getVectorScalableFlags() const {
 // CPU MMA intrinsic layout (MxNxK shape and element types)
 //===----------------------------------------------------------------------===//
 
+namespace {
+
 struct CPUOpaqueMmaLayout {
   int64_t mSize = 0;
   int64_t nSize = 0;
@@ -295,6 +297,8 @@ struct CPUOpaqueMmaLayout {
   Type bType;
   Type cType;
 };
+
+}  // namespace
 
 static std::tuple<int64_t, int64_t, int64_t>
 getMNKShapeFromIntrinsic(MMAIntrinsic intrinsic) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -8,8 +8,92 @@
 #define IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUATTRS
 
 include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.td"
+include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td"
 include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+//===----------------------------------------------------------------------===//
+// MMA intrinsic
+//===----------------------------------------------------------------------===//
+
+def IREECPU_MMAIntrinsicAttr
+    : EnumAttr<IREECPU_Dialect, IREECPU_MMAIntrinsic, "mma_intrinsic">;
+
+//===----------------------------------------------------------------------===//
+// InnerTiledSemantics (for use with iree_codegen.inner_tiled)
+//===----------------------------------------------------------------------===//
+
+def IREECPU_InnerTiledSemanticsAttr
+    : AttrDef<
+          IREECPU_Dialect, "InnerTiledSemantics",
+          [DeclareAttrInterfaceMethods<
+              IREECodegen_InnerTiledSemanticsAttrInterface, ["getTileTypes",
+                                                             "getOpaque"]>]> {
+  let mnemonic = "mma_semantics";
+  let cppNamespace = "::mlir::iree_compiler::IREE::CPU";
+
+  let description = [{
+    Attribute describing aspects of inner-tiled MMA semantics that are
+    orthogonal to the data_tiled_mma_layout kind. On CPU, tiles are always
+    undistributed (no thread distribution) and always expanded (opaque = false),
+    so there is currently no parameter here, making this temporarily a unit
+    attribute, but this could evolve in the future to look more like
+    IREEGPU_InnerTiledSemanticsAttr.
+  }];
+
+  let parameters = (ins);
+
+  let assemblyFormat = "`<` `>`";
+}
+
+//===----------------------------------------------------------------------===//
+// DataTiled MMA Attributes
+//===----------------------------------------------------------------------===//
+//
+// CPU analogue of IREEGPU_DataTiledMMAAttr, for use with
+// iree_codegen.inner_tiled. Like the GPU case, this wraps an intrinsic-enum and
+// some intrinsics_{m,n,k} unrolling factor. Unlike the GPU case, there is no
+// thread-distribution, no concept of subgroups and no interleaving of
+// intrinsics' layout.
+//
+// Some GPU-specific methods in IREECodegen_InnerTileDescAttrInterface are left
+// here but are unused.
+//
+
+def IREECPU_DataTiledMMAAttr
+    : AttrDef<
+          IREECPU_Dialect, "DataTiledMMA",
+          [DeclareAttrInterfaceMethods<
+              IREECodegen_InnerTileDescAttrInterface,
+              ["getExpectedNumInputs", "getExpectedNumOutputs",
+               "verifyIndexingMaps", "getUndistributedTileTypes",
+               "getDistributedTileTypes", "getUndistributedTileDimExpansion",
+               "populateOperandOffsetsSizesStrides",
+               "getDistributionMappingKind", "getDistributionWorkerCount",
+               "buildUnderlyingOperations",
+]>]> {
+  let mnemonic = "data_tiled_mma_layout";
+  let cppNamespace = "::mlir::iree_compiler::IREE::CPU";
+
+  let description = [{
+    CPU data-tiled MMA layout.
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let parameters =
+      (ins EnumParameter<IREECPU_MMAIntrinsic>:$intrinsic,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Intrinsic count along the M dimension.">:$intrinsics_m,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Intrinsic count along the N dimension.">:$intrinsics_n,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Intrinsic count along the K dimension.">:$intrinsics_k);
+}
 
 //===----------------------------------------------------------------------===//
 // CPU Specific Lowering Config Attributes

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -77,7 +77,14 @@ def IREECPU_DataTiledMMAAttr
   let cppNamespace = "::mlir::iree_compiler::IREE::CPU";
 
   let description = [{
-    CPU data-tiled MMA layout.
+    CPU analogue of IREEGPU_DataTiledMMAAttr, for use with
+    iree_codegen.inner_tiled. Like the GPU case, this wraps an intrinsic-enum and
+    some intrinsics_{m,n,k} unrolling factor. Unlike the GPU case, there is no
+    thread-distribution, no concept of subgroups and no interleaving of
+    intrinsics' layout.
+
+    Some GPU-specific methods in IREECodegen_InnerTileDescAttrInterface are left
+    here but are unused.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.h
@@ -1,0 +1,16 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUENUMS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUENUMS_H_
+
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
+
+// clang-format off
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.h.inc"
+// clang-format on
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUENUMS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.h
@@ -1,4 +1,4 @@
-// Copyright 2024 The IREE Authors
+// Copyright 2026 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -1,0 +1,132 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUENUMS
+#define IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUENUMS
+
+include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.td"
+include "mlir/IR/EnumAttr.td"
+
+//===----------------------------------------------------------------------===//
+// MMA intrinsic
+//===----------------------------------------------------------------------===//
+
+class IREECPU_I32EnumAttr<string name, string summary,
+                          list<I32EnumAttrCase> cases>
+    : I32EnumAttr<name, summary, cases> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::CPU";
+  let genSpecializedAttr = 0;
+}
+
+// Enum values for CPU MMA (matrix-multiply-accumulate) intrinsics.
+//
+// The may be "virtual" intrinsics not directly corresponding to a LLVM
+// intrinsic. Here are a few possible scenarios where that happens:
+//   * The target may lack an intrinsic for some narrow LHS/RHS type like i8,
+//     requiring upcasting i8 to i16 and using i16 intrinsics. In that case, the
+//     enum here represents a i8 matmul but the lowering creates the cast and
+//     i16 matmul combination.
+//   * The target may have an intrinsic consuming only a segment of one of its
+//     register operands. This is typical on Arm with
+//     multiply-accumulate-by-element instructions. Here, we may choose between
+//     two approaches:
+//     - Either reflect the actual intrinsic 1:1, consuming a fractional
+//     register.
+//       The advantage is greater flexibility, and only needing one enum value.
+//       The downside is reliance on compiler optimization to produce the
+//       expected code in the typical case where several such intrinsics
+//       collectively use the whole register.
+//     - Or have enum values representing a group of such intrinsics,
+//     collectively
+//       using whole registers. The advantage is ensuring that the generated
+//       code is what is expected. The downside is needing several enum values
+//       with different tile sizes.
+//
+// Note that even a scalar multiply-accumulate is technically a matmul
+// with MxNxK shape 1x1x1. Vector element-wise multiply-accumulate with vector
+// size N is seen here as a matrix multiply-accumulate with MxNxK shape 1xNx1.
+// It could be equivalently seen as shape Nx1x1, so we have to pick a convention
+// here, breaking the M-N symmetry: we choose to spread the vector dimension
+// along the N matrix dimension. The MMA attribute types that wrap this enum
+// shall combine it with a boolean "transpose" parameter flipping that, which
+// will typically be used for narrow matmuls with a small N-dimension size.
+//
+// Symbolic names are of the form
+//
+//    MMA_ARCH_MxNxK_ACC_LHS_RHS_FLAVOR
+//
+// Where:
+//    * ARCH denotes the architecture and ISA extension, e.g. X86_AVX512BF16.
+//    * MxNxK denotes the matmul shape performed by this intrinsic.
+//    * ACC_LHS_RHS denote the element types. The _RHS is omitted when unneeded.
+//    * FLAVOR distinguishes intrinsics otherwise agreeing, and/or hints at how
+//      the intrinsic is meant to be lowered in case it's not just a direct
+//      lowering to the target LLVM intrinsic. For example, for i8 matmul on
+//      targets only providing instructions for i32 matmuls, or for f16 matmuls
+//      on targets only providing instructions for f32 matmuls, we may need to
+//      lower to a cast followed by a matmul on the wider type. This would be
+//      indicated by a _CAST_I16 or _CAST_F32 suffix.
+//
+// Values are 0xABCD where:
+// * A denotes the architecture:
+//   - 0 is reserved for the None-value.
+//   - 1 is x86.
+//   - 2 is Arm.
+//   - 3 is RISC-V.
+// * B denotes the instruction family / ISA extension set.
+//   - For x86:
+//     - 1 is SSE.
+//     - 2 is AVX/AVX2.
+//     - 3 is AVX-512.
+//   - For Arm:
+//     - 1 is NEON.
+//     - 2 is SVE/SVE2.
+//     - 3 is SME/SME2.
+// * C denotes the element type of the A-matrix (LHS):
+//   * 0 = float64 (IEEE754 half precision).
+//   * 1 = float32 (IEEE754 half precision).
+//   * 2 = float16 (IEEE754 half precision).
+//   * 3 = bfloat16 ("Brain" float format, i.e. high half of float32).
+//   * 4 = 8-bit float (incl. f8E5M2, f8E4M3FN, etc).
+//   * A = 16-bit integer (any signedness).
+//   * C = 8-bit integer (any signedness).
+// * D enumerates intrinsics that share the same 0xABC* bits.
+//
+def IREECPU_MMA_None : I32EnumAttrCase<"None", 0>;
+def MMA_X86_AVX512_1x8x1_F64_F64
+    : I32EnumAttrCase<"MMA_X86_AVX512_1x8x1_F64_F64", 0x1300>;
+def MMA_X86_AVX512_1x16x1_F32_F32
+    : I32EnumAttrCase<"MMA_X86_AVX512_1x16x1_F32_F32", 0x1310>;
+def MMA_X86_AVX512_1x16x1_F32_F16_CASTF32
+    : I32EnumAttrCase<"MMA_X86_AVX512_1x16x1_F32_F16_CASTF32", 0x1320>;
+def MMA_X86_AVX512FP16_1x32x1_F16_F16
+    : I32EnumAttrCase<"MMA_X86_AVX512FP16_1x32x1_F16_F16", 0x1321>;
+def MMA_X86_AVX512BF16_1x16x2_F32_BF16
+    : I32EnumAttrCase<"MMA_X86_AVX512BF16_1x16x2_F32_BF16", 0x1330>;
+def MMA_X86_AVX512_1x16x2_I32_I16
+    : I32EnumAttrCase<"MMA_X86_AVX512_1x16x2_I32_I16", 0x13A0>;
+def MMA_X86_AVX512VNNI_1x16x2_I32_I16
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I16", 0x13A1>;
+def MMA_X86_AVX512_1x16x2_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_X86_AVX512_1x16x2_I32_I8_CASTI16", 0x13C0>;
+def MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16", 0x13C1>;
+
+def IREECPU_MMAIntrinsic
+    : IREECPU_I32EnumAttr<
+          "MMAIntrinsic", "Descriptor for different MMA intrinsics",
+          [IREECPU_MMA_None,
+
+           // X86 AVX-512
+           MMA_X86_AVX512_1x8x1_F64_F64, MMA_X86_AVX512_1x16x1_F32_F32,
+           MMA_X86_AVX512_1x16x1_F32_F16_CASTF32,
+           MMA_X86_AVX512FP16_1x32x1_F16_F16,
+           MMA_X86_AVX512BF16_1x16x2_F32_BF16, MMA_X86_AVX512_1x16x2_I32_I16,
+           MMA_X86_AVX512VNNI_1x16x2_I32_I16,
+           MMA_X86_AVX512_1x16x2_I32_I8_CASTI16,
+           MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16]>;
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -1,4 +1,4 @@
-// Copyright 2024 The IREE Authors
+// Copyright 2026 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_DIALECT_CPU_IREECPUTYPES_H_
 
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         # keep sorted
         [
             "invalid.mlir",
+            "iree_cpu_inner_tiled_ops.mlir",
             "roundtrip.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "invalid.mlir"
+    "iree_cpu_inner_tiled_ops.mlir"
     "roundtrip.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -1,0 +1,204 @@
+// RUN: iree-opt %s -split-input-file | FileCheck %s
+//
+// Test that iree_codegen.inner_tiled accepts kind = #iree_cpu.data_tiled_mma_layout<...>
+// with semantics = #iree_cpu.mma_semantics<...>, exercising different
+// IREECPU_MMAIntrinsic enum values and power-of-two intrinsics_{m,n,k} in 1..8.
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+
+// MMA_X86_AVX512_1x8x1_F64_F64, intrinsics 1x1x1
+func.func @cpu_avx512_1x8x1_f64(
+    %lhs: vector<1x1x1xf64>, %rhs: vector<1x1x8xf64>, %acc: vector<1x1x8xf64>)
+    -> vector<1x1x8xf64> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x8x1_F64_F64>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xf64>, vector<1x1x8xf64> into vector<1x1x8xf64>
+  return %0 : vector<1x1x8xf64>
+}
+// CHECK-LABEL: func @cpu_avx512_1x8x1_f64
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x8x1_F64_F64>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512_1x16x1_F32_F32, intrinsics 2x1x1
+func.func @cpu_avx512_1x16x1_f32(
+    %lhs: vector<2x1x2x1xf32>, %rhs: vector<1x1x1x16xf32>, %acc: vector<2x1x2x16xf32>)
+    -> vector<2x1x2x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<2x1x2x1xf32>, vector<1x1x1x16xf32> into vector<2x1x2x16xf32>
+  return %0 : vector<2x1x2x16xf32>
+}
+// CHECK-LABEL: func @cpu_avx512_1x16x1_f32
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 2>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512_1x16x1_F32_F16_CASTF32, intrinsics 1x2x1 -> M=1,N=2,K=1
+func.func @cpu_avx512_1x16x1_f16_castf32(
+    %lhs: vector<1x1x1xf16>, %rhs: vector<1x2x32xf16>, %acc: vector<1x2x32xf32>)
+    -> vector<1x2x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F16_CASTF32, intrinsics_n = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xf16>, vector<1x2x32xf16> into vector<1x2x32xf32>
+  return %0 : vector<1x2x32xf32>
+}
+// CHECK-LABEL: func @cpu_avx512_1x16x1_f16_castf32
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F16_CASTF32, intrinsics_n = 2>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics 1x1x2
+func.func @cpu_avx512fp16_1x32x1_f16(
+    %lhs: vector<1x2x1x2xf16>, %rhs: vector<2x1x2x32xf16>, %acc: vector<1x1x1x32xf16>)
+    -> vector<1x1x1x32xf16> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics_k = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x2x1x2xf16>, vector<2x1x2x32xf16> into vector<1x1x1x32xf16>
+  return %0 : vector<1x1x1x32xf16>
+}
+// CHECK-LABEL: func @cpu_avx512fp16_1x32x1_f16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics_k = 2>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics 2x2x1
+func.func @cpu_avx512bf16_1x16x2_bf16(
+    %lhs: vector<2x1x2x2xbf16>, %rhs: vector<1x2x2x32xbf16>, %acc: vector<2x2x2x32xf32>)
+    -> vector<2x2x2x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 2, intrinsics_n = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<2x1x2x2xbf16>, vector<1x2x2x32xbf16> into vector<2x2x2x32xf32>
+  return %0 : vector<2x2x2x32xf32>
+}
+// CHECK-LABEL: func @cpu_avx512bf16_1x16x2_bf16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 2, intrinsics_n = 2>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512_1x16x2_I32_I16, intrinsics 1x4x1
+func.func @cpu_avx512_1x16x2_i32_i16(
+    %lhs: vector<1x1x1x2xi16>, %rhs: vector<1x4x2x64xi16>, %acc: vector<1x4x1x64xi32>)
+    -> vector<1x4x1x64xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I16, intrinsics_n = 4>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1x2xi16>, vector<1x4x2x64xi16> into vector<1x4x1x64xi32>
+  return %0 : vector<1x4x1x64xi32>
+}
+// CHECK-LABEL: func @cpu_avx512_1x16x2_i32_i16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I16, intrinsics_n = 4>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics 2x1x2
+func.func @cpu_avx512vnni_1x16x2_i32_i16(
+    %lhs: vector<2x2x2x4xi16>, %rhs: vector<2x1x4x16xi16>, %acc: vector<2x1x2x16xi32>)
+    -> vector<2x1x2x16xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics_m = 2, intrinsics_k = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<2x2x2x4xi16>, vector<2x1x4x16xi16> into vector<2x1x2x16xi32>
+  return %0 : vector<2x1x2x16xi32>
+}
+// CHECK-LABEL: func @cpu_avx512vnni_1x16x2_i32_i16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics_m = 2, intrinsics_k = 2>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics 1x1x4
+func.func @cpu_avx512_1x16x2_i32_i8(
+    %lhs: vector<1x4x1x8xi8>, %rhs: vector<4x1x8x16xi8>, %acc: vector<1x1x1x16xi32>)
+    -> vector<1x1x1x16xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics_k = 4>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x4x1x8xi8>, vector<4x1x8x16xi8> into vector<1x1x1x16xi32>
+  return %0 : vector<1x1x1x16xi32>
+}
+// CHECK-LABEL: func @cpu_avx512_1x16x2_i32_i8
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics_k = 4>
+
+// -----
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics 4x1x2
+func.func @cpu_avx512vnni_1x16x2_i32_i8(
+    %lhs: vector<4x2x4x4xi8>, %rhs: vector<2x1x4x16xi8>, %acc: vector<4x1x4x16xi32>)
+    -> vector<4x1x4x16xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics_m = 4, intrinsics_k = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<4x2x4x4xi8>, vector<2x1x4x16xi8> into vector<4x1x4x16xi32>
+  return %0 : vector<4x1x4x16xi32>
+}
+// CHECK-LABEL: func @cpu_avx512vnni_1x16x2_i32_i8
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics_m = 4, intrinsics_k = 2>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -28,6 +28,7 @@ func.func @cpu_avx512_1x8x1_f64(
 //  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -50,6 +51,7 @@ func.func @cpu_avx512_1x16x1_f32(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 2>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -72,6 +74,7 @@ func.func @cpu_avx512_1x16x1_f16_castf32(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F16_CASTF32, intrinsics_n = 2>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -94,6 +97,7 @@ func.func @cpu_avx512fp16_1x32x1_f16(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics_k = 2>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -116,6 +120,7 @@ func.func @cpu_avx512bf16_1x16x2_bf16(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 2, intrinsics_n = 2>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -138,6 +143,7 @@ func.func @cpu_avx512_1x16x2_i32_i16(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I16, intrinsics_n = 4>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -160,6 +166,7 @@ func.func @cpu_avx512vnni_1x16x2_i32_i16(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics_m = 2, intrinsics_k = 2>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,
@@ -182,6 +189,7 @@ func.func @cpu_avx512_1x16x2_i32_i8(
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics_k = 4>
 
 // -----
+
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
   affine_map<(i, j, k) -> (k, j)>,


### PR DESCRIPTION
This is just the initial round of plumbing to get to the point where one can at least build and validate a `inner_tiled` op on CPU, meaning with a `kind` parameter that is a CPU-specific data-tiled MMA layout attr with an intrinsic enum that designates a SIMD intrinsic.

Most of this was written by AI.