### PR TITLE
[CI] Update IREE test_suite

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: c3b48ed923548e74b85329e201c12fe69cb1df2f
+          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
           path: iree-test-suites
       - name: Install ONNX ops test suite requirements
         run: |
@@ -199,7 +199,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: c3b48ed923548e74b85329e201c12fe69cb1df2f
+          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
           path: iree-test-suites
       - name: Install ONNX models test suite requirements
         run: |

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: c3b48ed923548e74b85329e201c12fe69cb1df2f
+          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
           path: iree-test-suites
           lfs: false
 
@@ -190,7 +190,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: c3b48ed923548e74b85329e201c12fe69cb1df2f
+          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
           path: iree-test-suites
           lfs: false
 

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: c3b48ed923548e74b85329e201c12fe69cb1df2f
+          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
           path: iree-test-suites
           lfs: false
       - name: Install Torch ops test suite requirements
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: c3b48ed923548e74b85329e201c12fe69cb1df2f
+          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
           path: iree-test-suites
           # Don't need lfs for torch models yet.
           lfs: false

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Install Torch ops test suite requirements
         run: |
           source ${VENV_DIR}/bin/activate
+          pip install -e iree-test-suites
           python -m pip install -r iree-test-suites/torch_ops/requirements.txt
       - name: Run Torch ops test suite
         env:
@@ -156,6 +157,7 @@ jobs:
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
           source ${VENV_DIR}/bin/activate
+          pip install -e ${{ github.workspace}}/iree-test-suites
           pip install -r ${{ github.workspace }}/iree-test-suites/torch_models/requirements.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* torch_ops expected output is now fetched from azure
* increased tolerance for convolution tests in torch_ops
* moves pytest_iree to top level in iree-test-suite

Diff: https://github.com/iree-org/iree-test-suites/compare/c3b48ed923548e74b85329e201c12fe69cb1df2f...12c82056ac64e32c4a9599611364e5ce534e3a5d