### PR TITLE
[Codegen][GPU] Rework GPUVerifyDistribution to use PreOrder walk with skip

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -115,6 +115,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",
+        "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Interfaces:TensorMaskingOpInterface",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -149,6 +149,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::Codegen::Utils
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
+    iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Interfaces::TensorMaskingOpInterface

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVerifyDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVerifyDistribution.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/Visitors.h"
@@ -20,10 +21,13 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-/// Pass to verify that writes only happen in distributed contexts. Code in
-/// shared contexts are executed uniformly across all threads after resolution
-/// of distributed contexts (i.e. scf.forall), thus operations with write
-/// memory effects are inherently
+/// Pass to verify that writes only happen in distributed contexts.
+///
+/// The approach is to walk the function in pre-order, skipping into regions
+/// that are known to be distributed (thread/lane-mapped scf.forall,
+/// lane-scoped pcf.generic/pcf.loop). Any write memory effect encountered
+/// outside these skipped regions is an error, since it would execute uniformly
+/// across all threads.
 struct GPUVerifyDistributionPass final
     : impl::GPUVerifyDistributionPassBase<GPUVerifyDistributionPass> {
 
@@ -44,26 +48,62 @@ struct GPUVerifyDistributionPass final
     auto privateAddressSpace = gpu::AddressSpaceAttr::get(
         &getContext(), gpu::GPUDialect::getPrivateAddressSpace());
 
-    WalkResult res = funcOp.walk([&](Operation *op) {
-      if (auto forallOp = dyn_cast<scf::ForallOp>(op)) {
-        std::optional<ArrayAttr> mapping = forallOp.getMapping();
-        if (!mapping || mapping.value().empty()) {
-          forallOp->emitOpError("requires a mapping attribute.");
-          return WalkResult::interrupt();
-        }
+    WalkResult res =
+        funcOp->walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+          // PCF generic/loop ops: check the scope attribute to determine
+          // if this is a lane-distributed context (skip) or subgroup-level
+          // context (advance into body to verify nested writes).
+          auto checkPCFScope = [](Attribute scope) -> WalkResult {
+            if (isa<IREE::GPU::LaneScopeAttr>(scope)) {
+              return WalkResult::skip();
+            }
+            // Subgroup scope and other scopes are not fully distributed
+            // to threads — continue walking into their bodies.
+            return WalkResult::advance();
+          };
+          if (auto genericOp = dyn_cast<IREE::PCF::GenericOp>(op)) {
+            return checkPCFScope(genericOp.getScope());
+          }
+          if (auto loopOp = dyn_cast<IREE::PCF::LoopOp>(op)) {
+            return checkPCFScope(loopOp.getScope());
+          }
 
-        if (isa<IREE::GPU::LaneIdAttr>(*mapping.value().begin()) &&
-            !operationHasParentForallOfMappingType<
-                mlir::gpu::GPUWarpMappingAttr>(forallOp)) {
-          forallOp->emitOpError("lane distributed scf.forall must have a "
-                                "parent subgroup distributed loop.");
-          return WalkResult::interrupt();
-        }
-        return WalkResult::advance();
-      }
-      if (auto memoryEffectOp = dyn_cast<MemoryEffectOpInterface>(op)) {
-        if (!operationHasParentForallOfMappingType<
-                mlir::gpu::GPUThreadMappingAttr, IREE::GPU::LaneIdAttr>(op)) {
+          if (auto forallOp = dyn_cast<scf::ForallOp>(op)) {
+            std::optional<ArrayAttr> mapping = forallOp.getMapping();
+            if (!mapping || mapping.value().empty()) {
+              forallOp->emitOpError("requires a mapping attribute.");
+              return WalkResult::interrupt();
+            }
+
+            Attribute firstMapping = *mapping.value().begin();
+
+            // Lane-mapped foralls must have a subgroup-distributed parent.
+            if (isa<IREE::GPU::LaneIdAttr>(firstMapping) &&
+                !operationHasParentForallOfMappingType<
+                    mlir::gpu::GPUWarpMappingAttr>(forallOp)) {
+              forallOp->emitOpError("lane distributed scf.forall must have a "
+                                    "parent subgroup distributed loop.");
+              return WalkResult::interrupt();
+            }
+
+            // Thread-mapped and lane-mapped foralls are distributed contexts.
+            // Skip their bodies — writes inside are fine.
+            if (isa<mlir::gpu::GPUThreadMappingAttr, IREE::GPU::LaneIdAttr>(
+                    firstMapping)) {
+              return WalkResult::skip();
+            }
+
+            // Other mappings (e.g. warp mapping) — continue walking into
+            // their bodies since they aren't fully distributed to threads.
+            return WalkResult::advance();
+          }
+
+          // Any write memory effect in undistributed context is an error.
+          auto memoryEffectOp = dyn_cast<MemoryEffectOpInterface>(op);
+          if (!memoryEffectOp) {
+            return WalkResult::advance();
+          }
+
           for (Value operand : memoryEffectOp->getOperands()) {
             auto type = dyn_cast<MemRefType>(operand.getType());
             if (!type || !memoryEffectOp.getEffectOnValue<MemoryEffects::Write>(
@@ -83,14 +123,13 @@ struct GPUVerifyDistributionPass final
             }
 
             op->emitOpError(
-                "write affecting operations on shared resources are restricted "
-                "to lane or thread distributed contexts.");
+                "write affecting operations on shared resources are "
+                "restricted to lane or thread distributed contexts.");
             return WalkResult::interrupt();
           }
-        }
-      }
-      return WalkResult::advance();
-    });
+
+          return WalkResult::advance();
+        });
 
     if (res.wasInterrupted()) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_verify_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_verify_distribution.mlir
@@ -27,3 +27,103 @@ func.func @lane_forall_no_warp_parent() attributes {translation_info = #translat
   } {mapping = [#iree_gpu.lane_id<0>]}
   return
 }
+
+// -----
+
+// Writes inside thread-mapped foralls should pass verification.
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+func.func @thread_forall_write_ok(%buf: memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes {translation_info = #translation} {
+  scf.forall (%tid) in (64) {
+    %cst = arith.constant 0.0 : f32
+    memref.store %cst, %buf[%tid] : memref<64xf32, #gpu.address_space<workgroup>>
+  } {mapping = [#gpu.thread<x>]}
+  return
+}
+
+// -----
+
+// Writes outside any distributed context should fail.
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+func.func @undistributed_write(%buf: memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes {translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f32
+  // expected-error @+1 {{write affecting operations on shared resources are restricted to lane or thread distributed contexts}}
+  memref.store %cst, %buf[%c0] : memref<64xf32, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// Writes inside pcf.generic should pass verification.
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+func.func @pcf_generic_write_ok(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
+    attributes {translation_info = #translation} {
+  pcf.generic scope(#iree_gpu.subgroup_scope)
+    execute[%sg_id: index, %num_sg: index] {
+    pcf.generic scope(#iree_gpu.lane_scope)
+      execute[%lane_id: index, %sg_size: index] {
+      %cst = arith.constant 0.0 : f16
+      memref.store %cst, %buf[%lane_id] : memref<256xf16, #gpu.address_space<workgroup>>
+      pcf.return
+    }
+    pcf.return
+  }
+  return
+}
+
+// -----
+
+// Writes inside lane-scoped pcf.loop should pass verification.
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+func.func @pcf_loop_lane_scope_write_ok(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
+    attributes {translation_info = #translation} {
+  %c4 = arith.constant 4 : index
+  pcf.loop scope(#iree_gpu.lane_scope) count(%c4)
+    execute[%iv: index] {
+    %cst = arith.constant 0.0 : f16
+    memref.store %cst, %buf[%iv] : memref<256xf16, #gpu.address_space<workgroup>>
+    pcf.return
+  }
+  return
+}
+
+// -----
+
+// Writes inside subgroup-scoped pcf.generic (without lane nesting) should fail.
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+func.func @pcf_subgroup_scope_write_fail(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
+    attributes {translation_info = #translation} {
+  pcf.generic scope(#iree_gpu.subgroup_scope)
+    execute[%sg_id: index, %num_sg: index] {
+    %cst = arith.constant 0.0 : f16
+    // expected-error @+1 {{write affecting operations on shared resources are restricted to lane or thread distributed contexts}}
+    memref.store %cst, %buf[%sg_id] : memref<256xf16, #gpu.address_space<workgroup>>
+    pcf.return
+  }
+  return
+}
+
+// -----
+
+// Write outside pcf.generic (but pcf.generic exists elsewhere) should fail.
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+func.func @write_outside_pcf_generic(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
+    attributes {translation_info = #translation} {
+  pcf.generic scope(#iree_gpu.subgroup_scope)
+    execute[%sg_id: index, %num_sg: index] {
+    pcf.return
+  }
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-error @+1 {{write affecting operations on shared resources are restricted to lane or thread distributed contexts}}
+  memref.store %cst, %buf[%c0] : memref<256xf16, #gpu.address_space<workgroup>>
+  return
+}


### PR DESCRIPTION
Rework the pass to walk in pre-order and skip into distributed regions (thread/lane-mapped scf.forall, pcf.generic, pcf.loop) rather than checking parent ops for every write. This is simpler, more efficient, and correctly handles PCF ops.

Add test cases for thread-mapped forall writes, undistributed writes, pcf.generic writes, pcf.loop writes, and writes outside pcf.generic regions.