### PR TITLE
[NFC][Codegen] Update InnerTiledDescAttrInterface to not use void methods when unnecessary

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -117,26 +117,20 @@ def IREECodegen_InnerTileDescAttrInterface :
         ```
         where `tA`, `tB`, and `tC` are the element types of matrices A, B, and C,
         respectively.
-
-        The returned values are placed into the `result` vector, which will have
-        its existing contents overwritten if there is any.
       }],
-      /*retType=*/"void",
+      /*retType=*/"::llvm::SmallVector<::mlir::VectorType, 4>",
       /*methodName=*/"getUndistributedTileTypes",
-      /*args=*/(ins "::llvm::SmallVectorImpl<::mlir::VectorType>&":$result)
+      /*args=*/(ins)
     >,
     InterfaceMethod<
       /*desc=*/[{
         For each operand, return the vector type of the inner tile after the operation
         is distributed to threads. Vectors of this type will be stored into or
         loaded from registers by individual threads.
-
-        The returned values are placed into the `result` vector, which will have
-        its existing contents overwritten if there is any.
       }],
-      /*retType=*/"void",
+      /*retType=*/"::llvm::SmallVector<::mlir::VectorType, 4>",
       /*methodName=*/"getDistributedTileTypes",
-      /*args=*/(ins "::llvm::SmallVectorImpl<::mlir::VectorType>&":$result)
+      /*args=*/(ins)
     >,
     InterfaceMethod<
       /*desc=*/[{
@@ -279,8 +273,8 @@ def IREECodegen_InnerTileDescAttrInterface :
     /// operand into `results`.
     void getUndistributedOperandSize(::llvm::SmallVectorImpl<int64_t>& result) const {
       result.clear();
-      ::llvm::SmallVector<::mlir::VectorType> undistributedTypes;
-      $_attr.getUndistributedTileTypes(undistributedTypes);
+      ::llvm::SmallVector<::mlir::VectorType> undistributedTypes =
+          $_attr.getUndistributedTileTypes();
       ::llvm::append_range(result, ::llvm::map_range(undistributedTypes,
         [](auto vt) { return vt.getNumElements(); }));
     }
@@ -288,8 +282,8 @@ def IREECodegen_InnerTileDescAttrInterface :
     /// Return the element element type of each operand into `results`.
     void getElementTypes(::llvm::SmallVectorImpl<::mlir::Type>& result) const {
       result.clear();
-      ::llvm::SmallVector<::mlir::VectorType> undistributedTypes;
-      $_attr.getUndistributedTileTypes(undistributedTypes);
+      ::llvm::SmallVector<::mlir::VectorType> undistributedTypes =
+          $_attr.getUndistributedTileTypes();
       ::llvm::append_range(result, ::llvm::map_range(undistributedTypes,
         [](auto vt) { return vt.getElementType(); }));
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -339,16 +339,12 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
     // are defined in IREEGPUInterfaces.cpp.
     //========================================================================//
 
-    void $cppClass::getUndistributedTileTypes(
-        SmallVectorImpl<VectorType>& result) const {
-      return cast<DataTiledMMAInterfaceAttr>(*this)
-          .getUndistributedTileTypes(result);
+    SmallVector<VectorType, 4> $cppClass::getUndistributedTileTypes() const {
+      return cast<DataTiledMMAInterfaceAttr>(*this).getUndistributedTileTypes();
     }
 
-    void $cppClass::getDistributedTileTypes(
-        SmallVectorImpl<VectorType>& result) const {
-      return cast<DataTiledMMAInterfaceAttr>(*this)
-          .getDistributedTileTypes(result);
+    SmallVector<VectorType, 4> $cppClass::getDistributedTileTypes() const {
+      return cast<DataTiledMMAInterfaceAttr>(*this).getDistributedTileTypes();
     }
 
     std::optional<::mlir::SmallVector<int64_t, 2>>
@@ -653,8 +649,8 @@ def IREEGPU_ScaledMMAAttr :
     /// has shape `<K, KB, N>`, and `C` has shape `<M, N>`.
     ::std::tuple<int64_t, int64_t, int64_t, int64_t>
     getScaledMNKShape() const {
-      ::llvm::SmallVector<::mlir::VectorType> preThreadTypes;
-      getUndistributedTileTypes(preThreadTypes);
+      ::llvm::SmallVector<::mlir::VectorType> preThreadTypes =
+          getUndistributedTileTypes();
       ::llvm::ArrayRef<int64_t> accShape = preThreadTypes[4].getShape();
       ::llvm::ArrayRef<int64_t> lhsShape = preThreadTypes[0].getShape();
       return {accShape[0], accShape[1], lhsShape[1], lhsShape[2]};

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -44,10 +44,10 @@ getSwizzledDistributionShape(const TileSwizzle &swizzle) {
   return shape;
 }
 
-void DataTiledMMAInterfaceAttr::getUndistributedTileTypes(
-    SmallVectorImpl<VectorType> &result) {
-  SmallVector<Type> elementTypes;
-  getElementTypes(elementTypes);
+SmallVector<VectorType, 4>
+DataTiledMMAInterfaceAttr::getUndistributedTileTypes() {
+  SmallVector<VectorType, 4> result;
+  SmallVector<Type> elementTypes = getElementTypes();
   for (auto [i, elementType] : llvm::enumerate(elementTypes)) {
     TileSwizzle swizzle = getTileSwizzle(i);
     SmallVector<int64_t> shape;
@@ -59,12 +59,13 @@ void DataTiledMMAInterfaceAttr::getUndistributedTileTypes(
     applyPermutationToVector(shape, swizzle.permutation);
     result.push_back(VectorType::get(shape, elementType));
   }
+  return result;
 }
 
-void DataTiledMMAInterfaceAttr::getDistributedTileTypes(
-    SmallVectorImpl<VectorType> &result) {
-  SmallVector<Type> elementTypes;
-  getElementTypes(elementTypes);
+SmallVector<VectorType, 4>
+DataTiledMMAInterfaceAttr::getDistributedTileTypes() {
+  SmallVector<VectorType, 4> result;
+  SmallVector<Type> elementTypes = getElementTypes();
   auto getShape = [=](unsigned operandIndex) {
     return sliceSwizzledShape(
         getTileSwizzle(operandIndex), [](TileSwizzle::Dim d) {
@@ -74,6 +75,7 @@ void DataTiledMMAInterfaceAttr::getDistributedTileTypes(
   for (auto [i, elementType] : llvm::enumerate(elementTypes)) {
     result.push_back(VectorType::get(getShape(i), elementType));
   }
+  return result;
 }
 
 std::optional<::mlir::SmallVector<int64_t, 2>>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -46,8 +46,8 @@ def IREEGPU_MmaInterfaceAttr
     /// `<K, N>`, and `C` has shape `<M, N>`.
     ::std::tuple<int64_t, int64_t, int64_t>
     getMNKShape() const {
-      ::llvm::SmallVector<::mlir::VectorType> preThreadTypes;
-      $_attr.getUndistributedTileTypes(preThreadTypes);
+      ::llvm::SmallVector<::mlir::VectorType> preThreadTypes =
+          $_attr.getUndistributedTileTypes();
       ::llvm::ArrayRef<int64_t> accShape = preThreadTypes[2].getShape();
       ::llvm::ArrayRef<int64_t> lhsShape = preThreadTypes[0].getShape();
       return {accShape[0], accShape[1], lhsShape[1]};
@@ -72,8 +72,8 @@ def IREEGPU_MmaInterfaceAttr
     /// storing such shaped vectors in the registers.
     ::std::tuple<::mlir::VectorType, ::mlir::VectorType, ::mlir::VectorType>
     getABCVectorTypes() const {
-      ::llvm::SmallVector<::mlir::VectorType> threadTypes;
-      $_attr.getDistributedTileTypes(threadTypes);
+      ::llvm::SmallVector<::mlir::VectorType> threadTypes =
+          $_attr.getDistributedTileTypes();
       return {threadTypes[0], threadTypes[1], threadTypes[2]};
     }
   }];
@@ -153,9 +153,9 @@ def IREEGPU_DataTiledMMAInterfaceAttr
         Returns the element types of the data tiled operation corresponding to
         the DataTiledMMAInterfaceAttr.
       }],
-      /*retType=*/"void",
+      /*retType=*/"::llvm::SmallVector<::mlir::Type, 8>",
       /*methodName=*/"getElementTypes",
-      /*args=*/(ins "SmallVectorImpl<Type>&":$result)
+      /*args=*/(ins)
     >,
     InterfaceMethod<
       /*desc=*/[{
@@ -183,9 +183,9 @@ def IREEGPU_DataTiledMMAInterfaceAttr
     // implementation among DataTiledMMAInterfaceAttr.
     //========================================================================//
 
-    void getUndistributedTileTypes(SmallVectorImpl<VectorType>& result);
+    SmallVector<VectorType, 4> getUndistributedTileTypes();
 
-    void getDistributedTileTypes(SmallVectorImpl<VectorType>& result);
+    SmallVector<VectorType, 4> getDistributedTileTypes();
 
     std::optional<::mlir::SmallVector<int64_t, 2>>
     getUndistributedTileDimExpansion(int64_t operandIndex, int64_t logicalDim);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
@@ -143,8 +143,8 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
       newPermutations = llvm::to_vector(*permutationsAttr);
     }
 
-    SmallVector<VectorType> unexpandedLogicalTypes;
-    tiledOp.getKind().getUndistributedTileTypes(unexpandedLogicalTypes);
+    SmallVector<VectorType> unexpandedLogicalTypes =
+        tiledOp.getKind().getUndistributedTileTypes();
     for (int64_t opIndex : llvm::seq(firstOperand, lastOperand)) {
       Value operand = newOperands[opIndex];
       std::optional<ArrayRef<int64_t>> permutation;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -1123,8 +1123,8 @@ struct LowerInnerTiledPattern
     }
 
     SmallVector<Value> operands = tiledOp.getOperands();
-    SmallVector<VectorType> regTypes;
-    tiledOp.getKind().getDistributedTileTypes(regTypes);
+    SmallVector<VectorType> regTypes =
+        tiledOp.getKind().getDistributedTileTypes();
 
     for (auto [operand, regType] : llvm::zip_equal(operands, regTypes)) {
       if (operand.getType() != regType) {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -166,8 +166,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
     if (!intrinsicScaledMma) {
       return {};
     }
-    SmallVector<VectorType> vectorTypes;
-    intrinsicScaledMma.getDistributedTileTypes(vectorTypes);
+    SmallVector<VectorType> vectorTypes =
+        intrinsicScaledMma.getDistributedTileTypes();
     // For scaled_matmul, the size of the LHS scales and RHS scales are added
     // to the total LHS and RHS sizes, because we use these sizes to select the
     // unrolling factors for M, N, and K, which affect both the input and the

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -765,8 +765,8 @@ static FailureOr<int64_t>
 getKSize(IREE::Codegen::InnerTileDescAttrInterface intrinsic) {
   int64_t kSize = 1;
   int64_t lhsOperandIndex = 0;
-  SmallVector<VectorType> undistributedTypes;
-  intrinsic.getUndistributedTileTypes(undistributedTypes);
+  SmallVector<VectorType> undistributedTypes =
+      intrinsic.getUndistributedTileTypes();
   ArrayRef<int64_t> shape = undistributedTypes[lhsOperandIndex].getShape();
   SmallVector<utils::IteratorType> lhsIteratorTypes =
       intrinsic.getOperandIteratorTypes()[lhsOperandIndex];


### PR DESCRIPTION
Within the `InnerTileDescAttrInterface` we have some interface methods which have return values, and others which are void and update output parameters. For interface methods like `populateOperandOffsetsSizesStrides` this makes sense because it has multiple outputs and this is a valid alternative to making a struct to house three `SmallVector`s. However, for interface methods updating only a single argument (`getUndistributedTileTypes`) this does not make sense and is inconsistent with the other interface methods with return values (`getUndistributedTileDimExpansion`).