### PR TITLE
[VectorExt] Refactor transfer_gather to use unified indexing_maps

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1268,11 +1268,10 @@ func.func @paged_transfer_gather(%indices: vector<16xindex>,
   %c0 = arith.constant 0 : index
 
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0, %c0]
-  [None, %indices: vector<16xindex>, None], %cst0 { indexed_maps = [
-                                             affine_map<(d0, d1, d2) -> (d1)>],
-    permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>,
-    in_bounds = [true, true] }
-  : memref<4096x512x8xf16>, vector<16x8xf16>
+  [%indices : vector<16xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>]
+  } : memref<4096x512x8xf16>, vector<16x8xf16>
 
   %l_out = iree_vector_ext.to_layout %out to layout(#layout) : vector<16x8xf16>
 
@@ -1320,13 +1319,11 @@ func.func @paged_transfer_gather_multi_index(%indices: vector<16xindex>,
   %c0 = arith.constant 0 : index
 
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0, %c0]
-  [None, %indices: vector<16xindex>, %indices2: vector<8x16xindex>], %cst0
-                                           { indexed_maps = [
-                                             affine_map<(d0, d1, d2) -> (d1)>,
-                                             affine_map<(d0, d1, d2) -> (d2, d1)>],
-    permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>,
-    in_bounds = [true, true] }
-  : memref<4096x512x8xf16>, vector<16x8xf16>
+  [%indices, %indices2 : vector<16xindex>, vector<8x16xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0, s1] -> (0, s0, s1)>,
+                     affine_map<(d0, d1)[s0, s1] -> (d0)>,
+                     affine_map<(d0, d1)[s0, s1] -> (d1, d0)>]
+  } : memref<4096x512x8xf16>, vector<16x8xf16>
 
   %l_out = iree_vector_ext.to_layout %out to layout(#layout) : vector<16x8xf16>
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3109,8 +3109,10 @@ func.func @cache_swizzle_resource_cast(%stride: index) {
 func.func @transfer_gather(%source : tensor<?x64xf16>, %indices: vector<8xindex>) -> vector<8x64xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f16
-  %out = iree_vector_ext.transfer_gather %source[%c0, %c0][%indices: vector<8xindex>, None], %cst {
-    indexed_maps = [affine_map<(d0, d1) -> (d0)>]
+  %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
+  [%indices : vector<8xindex>], %cst {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>]
   } : tensor<?x64xf16>, vector<8x64xf16>
   return %out : vector<8x64xf16>
 }
@@ -3119,7 +3121,7 @@ func.func @transfer_gather(%source : tensor<?x64xf16>, %indices: vector<8xindex>
 // CHECK-SAME: %[[SOURCE:.+]]: tensor<?x64xf16>, %[[INDICES:.+]]: vector<8xindex>
 // CHECK: %[[C0:.+]] = arith.constant 0 : index
 // CHECK: %[[BUFFER:.+]] = bufferization.to_buffer %[[SOURCE]]
-// CHECK: iree_vector_ext.transfer_gather %[[BUFFER]][%[[C0]], %[[C0]]][%[[INDICES]]: vector<8xindex>, None]
+// CHECK: iree_vector_ext.transfer_gather %[[BUFFER]][%[[C0]], %[[C0]]] [%[[INDICES]] : vector<8xindex>]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -702,11 +702,11 @@ func.func @paged_transfer_gather(%indices: vector<16xindex>,
   // expected-remark @above {{element_tile = [1]}}
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0, %c0]
   // expected-remark @above {{element_tile = [1, 8]}}
-  [None, %indices1: vector<16xindex>, None], %cst0, %mask { indexed_maps = [
-                                             affine_map<(d0, d1, d2) -> (d1)>],
-    permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>,
-    in_bounds = [true, true] }
-  : memref<4096x512x8xf16>, vector<16x8xf16>
+  [%indices1 : vector<16xindex>], %cst0, %mask {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>,
+                     affine_map<(d0, d1)[s0] -> (d0, d1)>]
+  } : memref<4096x512x8xf16>, vector<16x8xf16>, vector<16x8xi1>
   %l_out = iree_vector_ext.to_layout %out to layout(#layout) : vector<16x8xf16>
 
   return %l_out : vector<16x8xf16>

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -201,6 +201,25 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
       if (!getMask()) return std::nullopt;
       return getIndexingMapsArray().back();
     }
+
+    /// Invert the source indexing map to get a permutation map suitable for
+    /// vector.transfer_read. The source map is
+    /// (vector_dims)[symbols] -> (source_dims). This returns
+    /// (source_dims) -> (vector_dims), where non-dim results (gathered
+    /// symbols, broadcast constants) become constant 0.
+    AffineMap getPermutationMap() {
+      AffineMap sourceMap = getSourceIndexingMap();
+      MLIRContext *ctx = getContext();
+      SmallVector<AffineExpr> exprs(sourceMap.getNumDims(),
+                                    getAffineConstantExpr(0, ctx));
+      for (auto [i, expr] : llvm::enumerate(sourceMap.getResults())) {
+        if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
+          exprs[dimExpr.getPosition()] = getAffineDimExpr(i, ctx);
+        }
+      }
+      return AffineMap::get(sourceMap.getNumResults(), /*symbolCount=*/0,
+                            exprs, ctx);
+    }
   }];
 
   let assemblyFormat = "$base `[` $offsets `]` (`[` $index_vecs^ `:` type($index_vecs) `]`)? `,` $padding (`,` $mask^)? attr-dict `:` type($base) `,` type($vector) (`,` type($mask)^)?";

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -117,128 +117,95 @@ def IREEVectorExt_ToSIMTOp : IREEVectorExt_PureOp<"to_simt",
 }
 
 def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
-    DeclareOpInterfaceMethods<VectorTransferOpInterface>,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<ConditionallySpeculatable>,
     DeclareOpInterfaceMethods<MaskableOpInterface>,
-    AttrSizedOperandSegments
+    AttrSizedOperandSegments,
+    TypesMatchWith<"padding type must match source element type",
+                   "base", "padding", "getElementTypeOrSelf($_self)">
   ]> {
   let arguments = (ins AnyShaped:$base,
-                       Variadic<Index>:$indices,
-                       Variadic<VectorOfAnyRankOf<[Index]>>:$index_vecs,
-                       BoolArrayAttr:$indexed,
-                       AffineMapArrayAttr:$indexed_maps,
-                       AffineMapAttr:$permutation_map,
+                       Variadic<Index>:$offsets,
+                       Variadic<AnyTypeOf<[Index, VectorOfAnyRankOf<[Index]>]>>:$index_vecs,
+                       AffineMapArrayAttr:$indexing_maps,
                        AnyType:$padding,
-                       Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
-                       BoolArrayAttr:$in_bounds);
+                       Optional<VectorOfAnyRankOf<[I1]>>:$mask);
   let results = (outs AnyVectorOfAnyRank:$vector);
 
-  let summary = [{Gathers a supervector from memory into an SSA vector value.}];
+  let summary = [{Gathers a supervector from a shaped source into an SSA vector value.}];
 
   let description = [{
-    The iree_vector_ext.transfer_gather operation provides a structured
-    abstraction for gathers, by preserving the iteration space mapping between
-    the result vector and the memory dimensions being indexed.
+    The `transfer_gather` operation reads elements from a shaped source (memref
+    or tensor) into a vector, where each source dimension can be independently
+    contiguous, gathered, or broadcast.
 
-    The operation is a generalization of `vector.transfer_read` op, where the
-    slice from which the read is performed is not guranteed to be contiguous,
-    and instead how the slice is gathered is defined explicitly in the
-    operation.
-
-    The operation can be thought of as:
-      1. A contiguous slice gathered from the base as described by the operation
-      2. A `vector.transfer_read` on the contiguous slice
-
-    The operation defines `permutation_map`, `padding`, `mask`, `in_bounds` in
-    the same way as `vector.transfer_read` defines, but on the inferred
-    contiguous slice.
-
-    The other parameters of the operation define how the contiguous slice is
-    gathered from the source. `indices` define a base to offset the source by.
-    `indexed` defines for each dimension if the dimension is gathered or
-    contiguous.
-
-    The `indices` contains a base to offset the source by. The `indexed` array
-    defines if a dimension is gathered or not. For example, for the following
-    gather:
+    Semantically, for each position in the result vector:
 
     ```
-    slice[i, j, k] = base[i + i_offset][j][indices[i][j][k]]
+    result[d0, d1, ...] = base[offsets[0] + f0(d, s), offsets[1] + f1(d, s), ...]
     ```
 
-    The operation would represent this as:
+    where each `fi` is the i-th result of the source indexing map evaluated at
+    the vector position `d = (d0, d1, ...)` and gathered index values
+    `s = (s0, s1, ...)`.
+
+    The `indexing_maps` attribute describes all indexing. Every map has
+    `numDims = result vector rank` and `numSymbols = number of index vecs`:
+
+    - Map 0 (source map): `(vector_dims)[symbols] -> (source_dims)`.
+      A dim expr means the source dimension is contiguous (iterated in
+      lockstep with the vector dimension). A symbol expr means the source
+      dimension is gathered (looked up via the corresponding index vector).
+      A constant 0 means the source dimension is broadcast (always reads
+      at the base offset).
+    - Maps 1..N (index vec maps): `(vector_dims)[symbols] -> (index_vec_dims)`.
+      Describes how each index vector is indexed from the vector iteration
+      space. Only dim exprs are allowed.
+    - Optional last map (mask map): present only when a mask operand is
+      provided. Only dim exprs are allowed.
+
+    Example — embedding lookup: reading rows from a 3D source where the row
+    index is gathered from an index vector, while the column is contiguous:
 
     ```
-    indices = %i_offset, 0, 0
-    indexed = [False, False, True]
+    // result[i, j] = base[0, indices[i], j]
+    %result = iree_vector_ext.transfer_gather %base[%c0, %c0, %c0]
+      [%indices : vector<16xindex>], %pad {
+        indexing_maps = [
+          affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
+          affine_map<(d0, d1)[s0] -> (d0)>
+        ]
+      } : memref<4096x512x8xf16>, vector<16x8xf16>
     ```
-
-    For every dimension that is gathered, the operation defines how it is
-    gathered. For each gathered dimension, the operation expects a vector of
-    indices in `index_vecs` to act as a source of indices for that dimension
-    and an AffineMap in `index_maps` describing how this source of indices is
-    indexed. For example, for the following gather:
-
-    ```
-    slice[i, j, k] = base[i][indices0[i] + offset][indices1[j, k]]
-    ```
-
-    The indexing would be described by:
-
-    ```
-    indices      = 0, %offset, 0
-    indexed      = [False, True, True]
-    index_vecs   = %index_vec1, %index_vec2
-    index_maps = [
-      affine_map<(i, j, k) -> (i),
-      affine_map<(i, j, k) -> (j, k)
-    ]
-    ```
-
-    With these additional parameters, the operation can define a supervector
-    read from a non-contiguous slice. For example:
-
-    ```
-    base: memref<8192x8x16xf32>
-    indices0 : vector<2xindex>
-    indices1 : vector<4x8xindex>
-
-    slice[i, j, k] = base[indices0[k]][j][indices1[i, j]]
-    vector = read(slice) : memref<8192x8x16xf32> -> vector<16x8x2xf32>
-    ```
-
-    Can be represented by:
-
-    ```
-    %vector = vector.transfer_gather %base[0, 0, 0](%indices0, %indices1) {
-      gather_dims = [0, 2],
-      index_maps = [
-        affine_map<(i, j, k) -> (k)>,
-        affine_map<(i, j, k) -> (i, j)>
-      ],
-      in_bounds = [true, true, true],
-      permutation_map = affine_map<(i, j, k) -> (k, j, i)>
-    } : memref<8192x8x16xf32> -> vector<16x8x2xf32>
-    ```
-
-    The crucial structure of the operation relies on the index_vec and
-    the result vector's indexing being defined based on the dimensions of the
-    memory. This mapping can be exploited to simplify gathered dimensions
-    to contiguous dimensions.
   }];
 
   let extraClassDeclaration = [{
     // MaskableOpInterface methods.
     bool supportsPassthru() { return true; }
 
-    SmallVector<AffineMap> getIndexedMapsArray() {
-      return llvm::to_vector(getIndexedMaps().getAsValueRange<AffineMapAttr>());
+    SmallVector<AffineMap> getIndexingMapsArray() {
+      return llvm::to_vector(getIndexingMaps().getAsValueRange<AffineMapAttr>());
+    }
+
+    AffineMap getSourceIndexingMap() {
+      return getIndexingMapsArray().front();
+    }
+
+    SmallVector<AffineMap> getIndexVecIndexingMaps() {
+      auto maps = getIndexingMapsArray();
+      return SmallVector<AffineMap>(
+          maps.begin() + 1, maps.begin() + 1 + getIndexVecs().size());
+    }
+
+    std::optional<AffineMap> getMaskIndexingMap() {
+      if (!getMask()) return std::nullopt;
+      return getIndexingMapsArray().back();
     }
   }];
 
+  let assemblyFormat = "$base `[` $offsets `]` (`[` $index_vecs^ `:` type($index_vecs) `]`)? `,` $padding (`,` $mask^)? attr-dict `:` type($base) `,` type($vector) (`,` type($mask)^)?";
+
   let hasCanonicalizer = 1;
-  let hasCustomAssemblyFormat = 1;
   let hasFolder = 1;
   let hasVerifier = 1;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/canonicalize.mlir
@@ -58,17 +58,19 @@ func.func @transfer_gather_fold_broadcast(%indices: vector<64xindex>,
   %broadcasted = vector.broadcast %indices : vector<64xindex> to vector<32x64xindex>
 
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
-  [None, %broadcasted: vector<32x64xindex>], %cst0
-  { indexed_maps = [affine_map<(d0, d1) -> (d1, d0)>]}
-  : tensor<4096x64xf16>, vector<64x32xf16>
+  [%broadcasted : vector<32x64xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (d0, s0)>,
+                     affine_map<(d0, d1)[s0] -> (d1, d0)>]
+  } : tensor<4096x64xf16>, vector<64x32xf16>
 
   return %out : vector<64x32xf16>
 }
 
-// CHECK: #[[$MAP:.*]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-DAG: #[[$SMAP:.*]] = affine_map<(d0, d1)[s0] -> (d0, s0)>
+// CHECK-DAG: #[[$IVMAP:.*]] = affine_map<(d0, d1)[s0] -> (d0)>
 // CHECK-LABEL: @transfer_gather_fold_broadcast
 // CHECK: transfer_gather
-// CHECK-SAME: indexed_maps = [#[[$MAP]]]
+// CHECK-SAME: indexing_maps = [#[[$SMAP]], #[[$IVMAP]]]
 
 // -----
 
@@ -82,17 +84,19 @@ func.func @transfer_gather_fold_transpose(%indices: vector<64x32xindex>,
   %transposed = vector.transpose %indices, [1, 0] : vector<64x32xindex> to vector<32x64xindex>
 
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
-  [None, %transposed: vector<32x64xindex>], %cst0
-  {indexed_maps = [affine_map<(d0, d1) -> (d1, d0)>]}
-  : tensor<4096x64xf16>, vector<64x32xf16>
+  [%transposed : vector<32x64xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (d0, s0)>,
+                     affine_map<(d0, d1)[s0] -> (d1, d0)>]
+  } : tensor<4096x64xf16>, vector<64x32xf16>
 
   return %out : vector<64x32xf16>
 }
 
-// CHECK: #[[$MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG: #[[$SMAP:.*]] = affine_map<(d0, d1)[s0] -> (d0, s0)>
+// CHECK-DAG: #[[$IVMAP:.*]] = affine_map<(d0, d1)[s0] -> (d0, d1)>
 // CHECK-LABEL: @transfer_gather_fold_transpose
 // CHECK: transfer_gather
-// CHECK-SAME: indexed_maps = [#[[$MAP]]]
+// CHECK-SAME: indexing_maps = [#[[$SMAP]], #[[$IVMAP]]]
 
 // -----
 
@@ -106,9 +110,11 @@ func.func @transfer_gather_fold_step(%indices: vector<64x32xindex>,
   %step = vector.step : vector<64xindex>
 
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
-  [%step : vector<64xindex>, %indices: vector<64x32xindex>], %cst0
-  {indexed_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)> ]}
-  : tensor<4096x64xf16>, vector<64x32xf16>
+  [%step, %indices : vector<64xindex>, vector<64x32xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0, s1] -> (s0, s1)>,
+                     affine_map<(d0, d1)[s0, s1] -> (d0)>,
+                     affine_map<(d0, d1)[s0, s1] -> (d0, d1)>]
+  } : tensor<4096x64xf16>, vector<64x32xf16>
 
   return %out : vector<64x32xf16>
 }
@@ -116,7 +122,7 @@ func.func @transfer_gather_fold_step(%indices: vector<64x32xindex>,
 // CHECK-LABEL: @transfer_gather_fold_step
 // CHECK-SAME: %[[ARG1:.*]]: vector<64x32xindex>
 // CHECK: transfer_gather
-// CHECK-SAME: [None, %[[ARG1]]
+// CHECK-SAME: [%[[ARG1]] : vector<64x32xindex>]
 
 // -----
 
@@ -129,9 +135,11 @@ func.func @transfer_gather_fold_single_element(%scalar: vector<1xindex>,
   %c0 = arith.constant 0 : index
 
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
-  [%scalar : vector<1xindex>, %indices: vector<64x1xindex>], %cst0
-  {indexed_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)> ]}
-  : tensor<4096x64xf16>, vector<64x1xf16>
+  [%scalar, %indices : vector<1xindex>, vector<64x1xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0, s1] -> (s0, s1)>,
+                     affine_map<(d0, d1)[s0, s1] -> (d1)>,
+                     affine_map<(d0, d1)[s0, s1] -> (d0, d1)>]
+  } : tensor<4096x64xf16>, vector<64x1xf16>
 
   return %out : vector<64x1xf16>
 }
@@ -139,20 +147,20 @@ func.func @transfer_gather_fold_single_element(%scalar: vector<1xindex>,
 // CHECK-LABEL: @transfer_gather_fold_single_element
 // CHECK-SAME: %{{.*}}: vector<1xindex>, %[[ARG1:.*]]: vector<64x1xindex>
 // CHECK: transfer_gather
-// CHECK-SAME: [None, %[[ARG1]]
+// CHECK-SAME: [%[[ARG1]] : vector<64x1xindex>]
 
 // -----
 
-func.func @transfer_gather_fold_contiguous_load(%scalar: vector<64x1xindex>,
-  %indices: vector<64x1xindex>,
+func.func @transfer_gather_fold_contiguous_load(
   %source: tensor<4096x64xf16>)
   -> vector<64x1xf16> {
 
   %cst0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
 
-  %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
-  [None, None], %cst0 {indexed_maps = []} : tensor<4096x64xf16>, vector<64x1xf16>
+  %out = iree_vector_ext.transfer_gather %source[%c0, %c0], %cst0 {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>]
+  } : tensor<4096x64xf16>, vector<64x1xf16>
 
   return %out : vector<64x1xf16>
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -48,36 +48,37 @@ func.func @invalid_to_simt_vector_element_type(%simt : vector<64xf32>) -> vector
 
 // -----
 
-func.func @indexing_map_mismatch(%indices: vector<128xindex>,
+func.func @wrong_num_indexing_maps(%indices: vector<128xindex>,
   %source: tensor<128xf16>)
   -> vector<128xf16> {
 
   %cst0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
 
-  // expected-error @+1 {{op requires number of results for corressponding indexing map to match the rank of index vector at dim: 0}}
+  // expected-error @+1 {{'iree_vector_ext.transfer_gather' op expected 2 indexing maps, got: 1}}
   %out = iree_vector_ext.transfer_gather %source[%c0]
-  [%indices: vector<128xindex>], %cst0
-  { indexed_maps = [affine_map<(d0, d1) -> (d0, d1)>]}
-  : tensor<128xf16>, vector<128xf16>
+  [%indices : vector<128xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0)[s0] -> (s0)>]
+  } : tensor<128xf16>, vector<128xf16>
 
   return %out : vector<128xf16>
 }
 
 // -----
 
-func.func @indexing_map_invalid_index_vector_shape(%indices: vector<128x64xindex>,
+func.func @index_vec_shape_mismatch(%indices: vector<128x64xindex>,
   %source: tensor<128x64xf16>)
   -> vector<128x64xf16> {
 
   %cst0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
 
-  // expected-error @+1 {{'iree_vector_ext.transfer_gather' op Invalid index vector shape at dim: 0, expected: 64, 128, got: 128, 64}}
+  // expected-error @+1 {{'iree_vector_ext.transfer_gather' op Mismatched vector shape for index vec at position 0. Expected: [64, 128], got: [128, 64]}}
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
-  [None, %indices: vector<128x64xindex>], %cst0
-  { indexed_maps = [affine_map<(d0, d1) -> (d1, d0)>]}
-  : tensor<128x64xf16>, vector<128x64xf16>
+  [%indices : vector<128x64xindex>], %cst0 {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (d0, s0)>,
+                     affine_map<(d0, d1)[s0] -> (d1, d0)>]
+  } : tensor<128x64xf16>, vector<128x64xf16>
 
   return %out : vector<128x64xf16>
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -199,6 +199,31 @@ func.func @transfer_gather(%indices: vector<128xindex>,
 
 // -----
 
+func.func @transfer_gather_scalar_index(%idx: index,
+  %source: tensor<4096x64xf16>)
+  -> vector<64xf16> {
+  %cst0 = arith.constant 0.0 : f16
+  %c0 = arith.constant 0 : index
+
+  %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
+  [%idx : index], %cst0 {
+    indexing_maps = [affine_map<(d0)[s0] -> (s0, d0)>,
+                     affine_map<(d0)[s0] -> ()>]
+  } : tensor<4096x64xf16>, vector<64xf16>
+
+  return %out : vector<64xf16>
+}
+
+// CHECK-DAG: #[[$SMAP_S0D0:.+]] = affine_map<(d0)[s0] -> (s0, d0)>
+// CHECK-DAG: #[[$IVMAP_SCALAR:.+]] = affine_map<(d0)[s0] -> ()>
+// CHECK-LABEL: func.func @transfer_gather_scalar_index
+// CHECK-SAME:    %[[IDX:.+]]: index, %[[SOURCE:.+]]: tensor<4096x64xf16>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[PAD:.+]] = arith.constant 0.000000e+00 : f16
+// CHECK:       iree_vector_ext.transfer_gather %[[SOURCE]][%[[C0]], %[[C0]]] [%[[IDX]] : index], %[[PAD]] {indexing_maps = [#[[$SMAP_S0D0]], #[[$IVMAP_SCALAR]]]} : tensor<4096x64xf16>, vector<64xf16>
+
+// -----
+
 // CHECK-LABEL: func @arg_compare_implicit_index
 func.func @arg_compare_implicit_index(%input: vector<4x128xf32>,
                                       %out_val: vector<4xf32>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BufferizationInterfaces.cpp
@@ -51,7 +51,7 @@ struct TransferGatherOpInterface
                           const BufferizationOptions &options,
                           BufferizationState &state) const {
     auto gatherOp = cast<IREE::VectorExt::TransferGatherOp>(op);
-    assert(isa<TensorType>(gatherOp.getShapedType()) &&
+    assert(isa<TensorType>(gatherOp.getBase().getType()) &&
            "only tensor types expected");
     FailureOr<Value> buffer =
         getBuffer(rewriter, gatherOp.getBase(), options, state);
@@ -59,10 +59,10 @@ struct TransferGatherOpInterface
       return failure();
     }
     replaceOpWithNewBufferizedOp<IREE::VectorExt::TransferGatherOp>(
-        rewriter, gatherOp, gatherOp.getVectorType(), *buffer,
-        gatherOp.getIndices(), gatherOp.getIndexVecs(), gatherOp.getIndexed(),
-        gatherOp.getIndexedMaps(), gatherOp.getPermutationMap(),
-        gatherOp.getPadding(), gatherOp.getMask(), gatherOp.getInBoundsAttr());
+        rewriter, gatherOp, cast<VectorType>(gatherOp.getVector().getType()),
+        *buffer, gatherOp.getOffsets(), gatherOp.getIndexVecs(),
+        gatherOp.getIndexingMapsAttr(), gatherOp.getPadding(),
+        gatherOp.getMask());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
@@ -96,7 +96,7 @@ func.func @linalg_ext_gather(%source : tensor<1024x128xi32>, %indices : tensor<1
 //  CHECK-SAME:     : tensor<10xi32>, vector<10xi32>
 //       CHECK:   %[[CAST:.+]] = arith.index_cast %[[READ]]
 //       CHECK:   %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
-//  CHECK-SAME:     [%[[C0]], %[[C0]]][%[[CAST]]: vector<10xindex>, None], %[[PAD]]
+//  CHECK-SAME:     [%[[C0]], %[[C0]]] [%[[CAST]] : vector<10xindex>]
 
 // -----
 
@@ -148,7 +148,7 @@ func.func @linalg_ext_gather_unit_dim(%source : tensor<1024x128xi32>, %indices :
 //  CHECK-SAME:     : tensor<10x1xi32>, vector<10xi32>
 //       CHECK:   %[[CAST:.+]] = arith.index_cast %[[READ]]
 //       CHECK:   %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
-//  CHECK-SAME:     [%[[C0]], %[[C0]]][%[[CAST]]: vector<10xindex>, None]
+//  CHECK-SAME:     [%[[C0]], %[[C0]]] [%[[CAST]] : vector<10xindex>]
 
 // -----
 


### PR DESCRIPTION
Refactors transfer_gather to use a single `indexing_maps` attribute that encodes source, index vector, and mask mappings in a unified AffineMap array. This replaces the previous separate indexed/permutation_map attributes with a more expressive representation.

Example — embedding lookup: reading rows from a 3D source where the row
index is gathered from an index vector, while the column is contiguous:

```mlir
// result[i, j] = base[0, indices[i], j]
%result = iree_vector_ext.transfer_gather %base[%c0, %c0, %c0]
  [%indices : vector<16xindex>], %pad {
    indexing_maps = [
      affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
      affine_map<(d0, d1)[s0] -> (d0)>
    ]
  } : memref<4096x512x8xf16>, vector<16x8xf16>
```

The main problem with the previous representation was it required the indexing maps to be iterated over the memory space. This doesn't work at all for "ragged tensors", where you are doing something like:

```mlir
// result[i, j] = base[0, indices[i], j]
%result = iree_vector_ext.transfer_gather %base[%c0]
  [%indices : vector<16x8xindex>], %pad {
    indexing_maps = [
      affine_map<(d0, d1)[s0] -> (s0)>,
      affine_map<(d0, d1)[s0] -> (d0, d1)>
    ]
  } : memref<?xf16>, vector<16x8xf16>
```

As we move to handle more complex gathers, we need this form of transfer_gather representation. Note that this form of transfer_gather is more expressive than the previous form, and should handle everything the previous form did.

This form also enables us to directly vectorize a tensor.extract inside a linalg.generic to a transfer_gather, rather than vector.gather.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>