### PR TITLE
[Common] Update CombineSourceLayoutTransform pass to fold broadcast

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -553,6 +554,34 @@ bool isSupportedSingleInputRelayoutOpForSource(Operation *op) {
   return linalgOp && linalg::isaBroadcastOpInterface(linalgOp).has_value();
 }
 
+/// Returns true if `user` is a supported relayout op that uses `result` as a
+/// valid source for extending the relayout chain.
+///
+/// We use different logic for DPS vs non-DPS ops so neither case needs to
+/// consider operand numbers:
+/// - DPS ops (e.g. linalg broadcast): Iterate getDpsInputOperands(). Only
+///   consider uses as an *input* operand.
+/// - Non-DPS ops (expand_shape, collapse_shape, transpose, etc.): Caller
+///   iterates result.getUsers(), so we know user consumes result. These ops
+///   have a single input.
+static bool isRelayoutChainExtension(Operation *user, Value result) {
+  if (!isSupportedSingleInputRelayoutOpForSource(user)) {
+    return false;
+  }
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(user);
+  if (dpsOp) {
+    for (OpOperand *input : dpsOp.getDpsInputOperands()) {
+      if (input->get() == result) {
+        return true;
+      }
+    }
+    return false;
+  }
+  // Non-DPS: caller iterates result.getUsers(), so user consumes result.
+  // Single-input relayout ops have only one place for it.
+  return true;
+}
+
 /// Collects all relayout ops in the chain starting from `relayoutOp`
 /// (inclusive). The chain extends through result->user edges where the user is
 /// a supported relayout op.
@@ -563,8 +592,7 @@ static void collectRelayoutChain(Operation *relayoutOp,
   }
   Value result = relayoutOp->getResult(0);
   for (Operation *user : result.getUsers()) {
-    if (isSupportedSingleInputRelayoutOpForSource(user) &&
-        user->getOperand(0) == result) {
+    if (isRelayoutChainExtension(user, result)) {
       collectRelayoutChain(user, chain);
     }
   }
@@ -586,16 +614,14 @@ static bool isComplexRelayoutChain(Operation *relayoutOp) {
   if (chain.size() < 2) {
     return false;
   }
-  bool hasReshape = llvm::any_of(chain, [](Operation *op) {
-    return isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(op);
-  });
+  bool hasReshape = llvm::any_of(
+      chain, llvm::IsaPred<tensor::ExpandShapeOp, tensor::CollapseShapeOp>);
   // Need at least one op that is not reshape and not extract_slice (e.g. copy,
   // transpose, broadcast, pad).
-  bool hasOtherNonExtractSlice = llvm::any_of(chain, [](Operation *op) {
-    return !isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
-                tensor::ExtractSliceOp>(op);
-  });
-  return hasReshape && hasOtherNonExtractSlice;
+  bool allReshapeOrExtractSlice = llvm::all_of(
+      chain, llvm::IsaPred<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
+                           tensor::ExtractSliceOp>);
+  return hasReshape && !allReshapeOrExtractSlice;
 }
 
 /// Collects direct relayout op users of `loadResult` that start complex
@@ -606,8 +632,7 @@ getComplexChainRelayoutUsers(Value loadResult,
                              bool combineNonComplexChains = false) {
   SmallPtrSet<Operation *, 4> complexUsers;
   for (Operation *user : loadResult.getUsers()) {
-    if (isSupportedSingleInputRelayoutOpForSource(user) &&
-        user->getOperand(0) == loadResult &&
+    if (isRelayoutChainExtension(user, loadResult) &&
         (combineNonComplexChains || isComplexRelayoutChain(user))) {
       complexUsers.insert(user);
     }
@@ -1177,8 +1202,7 @@ struct FoldConsumerRelayoutIntoMapLoadPattern
     Operation *consumerOp = nullptr;
     Value mapLoadResult = mapLoadOp.getResult(0);
     for (Operation *user : mapLoadOp->getUsers()) {
-      if (isSupportedSingleInputRelayoutOpForSource(user) &&
-          user->getOperand(0) == mapLoadResult) {
+      if (isRelayoutChainExtension(user, mapLoadResult)) {
         consumerOp = user;
         break;
       }

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
@@ -539,9 +540,46 @@ static MapStoreOp insertIdentityMapStore(RewriterBase &rewriter,
 }
 
 bool isSupportedSingleInputRelayoutOp(Operation *op) {
-  return isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
-             tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
-             linalg::TransposeOp>(op);
+  if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
+          tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
+          linalg::TransposeOp>(op)) {
+    return true;
+  }
+  auto genericOp = dyn_cast<linalg::GenericOp>(op);
+  return genericOp && linalg::isaBroadcastOpInterface(genericOp).has_value();
+}
+
+/// Returns true if the relayout op starts a "complex" chain.
+/// A "complex" chain is :-
+/// - a chain of relayout ops with length >= 2,
+/// - or a chain of length 1 with one of the supported linalg relayout ops.
+static bool isComplexRelayoutChain(Operation *relayoutOp) {
+  assert(isSupportedSingleInputRelayoutOp(relayoutOp) &&
+         "expected a supported relayout op");
+  Value result = relayoutOp->getResult(0);
+  bool hasRelayoutUser = llvm::any_of(result.getUsers(), [](Operation *user) {
+    return isSupportedSingleInputRelayoutOp(user);
+  });
+  // Chain length >= 2 -> complex.
+  if (hasRelayoutUser) {
+    return true;
+  }
+  // Chain length 1: complex only if the op is a linalg op.
+  return isa<linalg::LinalgOp>(relayoutOp);
+}
+
+/// Collects direct relayout op users of `loadResult` that start a complex
+/// relayout chain.
+static SmallPtrSet<Operation *, 4>
+getComplexChainRelayoutUsers(Value loadResult) {
+  SmallPtrSet<Operation *, 4> complexUsers;
+  for (Operation *user : loadResult.getUsers()) {
+    if (isSupportedSingleInputRelayoutOp(user) &&
+        user->getOperand(0) == loadResult && isComplexRelayoutChain(user)) {
+      complexUsers.insert(user);
+    }
+  }
+  return complexUsers;
 }
 
 // This is only desirable in the dispatch scope but not in the workgroup scope.
@@ -996,6 +1034,30 @@ foldExtractSliceIntoMapLoad(RewriterBase &rewriter,
                                      indexTransformBuilder);
 }
 
+/// Fold a consumer broadcast `linalg.generic` into a producer `map_load`.
+static FailureOr<MapLoadOp> foldBroadcastGenericIntoMapLoad(
+    RewriterBase &rewriter, linalg::GenericOp genericOp, MapLoadOp mapLoadOp) {
+  assert(genericOp.getDpsInputs()[0] == mapLoadOp.getResult(0) &&
+         "expected map_load to be the producer of genericOp input");
+  if (!linalg::isaBroadcastOpInterface(genericOp).has_value()) {
+    return rewriter.notifyMatchFailure(genericOp,
+                                       "generic op is not a broadcast");
+  }
+
+  AffineMap inputMap = genericOp.getIndexingMapsArray()[0];
+  return foldConsumerIntoMapLoadImpl(
+      rewriter, genericOp, mapLoadOp,
+      [inputMap](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
+        SmallVector<Value> sourceIndices;
+        sourceIndices.reserve(inputMap.getNumResults());
+        for (AffineExpr expr : inputMap.getResults()) {
+          unsigned pos = cast<AffineDimExpr>(expr).getPosition();
+          sourceIndices.push_back(indices[pos]);
+        }
+        return sourceIndices;
+      });
+}
+
 /// Fold a consumer `padOp` into a producer `mapLoadOp`.
 /// Index transformation: source_idx = new_idx - low_pad
 /// Fill value is set to the pad value.
@@ -1063,6 +1125,9 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
       .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
         return foldPadIntoMapLoad(rewriter, padOp, mapLoadOp);
       })
+      .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
+        return foldBroadcastGenericIntoMapLoad(rewriter, genericOp, mapLoadOp);
+      })
       .Default([](Operation *) { return failure(); });
 }
 
@@ -1091,12 +1156,18 @@ struct FoldConsumerRelayoutIntoMapLoadPattern
   }
 };
 
-// Insert identity map_load op after the root and replace uses.
-static MapLoadOp insertIdentityMapLoad(RewriterBase &rewriter, OpResult root) {
+// Insert identity map_load op after the root and replace only uses whose
+// owner is in `complexChainUsers` (i.e. uses that are part of a complex
+// relayout chain). Other uses keep using the load/root directly.
+static MapLoadOp
+insertIdentityMapLoad(RewriterBase &rewriter, OpResult root,
+                      const SmallPtrSetImpl<Operation *> &complexChainUsers) {
   Location loc = root.getLoc();
   SetVector<OpOperand *> originalUses;
   for (OpOperand &use : root.getUses()) {
-    originalUses.insert(&use);
+    if (complexChainUsers.contains(use.getOwner())) {
+      originalUses.insert(&use);
+    }
   }
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointAfterValue(root);
@@ -1122,12 +1193,11 @@ struct InsertMapLoadOpPattern
 
   LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {
-    // Check if the load has at least one relayout op user.
-    bool hasRelayoutUser =
-        llvm::any_of(loadOp->getUsers(), [](Operation *user) {
-          return isSupportedSingleInputRelayoutOp(user);
-        });
-    if (!hasRelayoutUser) {
+    Value loadResult = loadOp.getResult();
+    SmallPtrSet<Operation *, 4> complexChainUsers =
+        getComplexChainRelayoutUsers(loadResult);
+    // Only introduce map_load when there is at least one complex chain.
+    if (complexChainUsers.empty()) {
       return failure();
     }
     // Check that the load doesn't already have a map_load user (avoid
@@ -1138,7 +1208,8 @@ struct InsertMapLoadOpPattern
     if (hasMapLoadUser) {
       return failure();
     }
-    (void)insertIdentityMapLoad(rewriter, loadOp->getResult(0));
+    (void)insertIdentityMapLoad(rewriter, cast<OpResult>(loadResult),
+                                complexChainUsers);
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -571,10 +571,13 @@ static void collectRelayoutChain(Operation *relayoutOp,
 }
 
 /// Returns true if the relayout op starts a "complex" chain.
-/// A "complex" chain is one that is difficult for bufferization to handle:
-/// - chain length >= 2,
-/// - contains at least one reshape op (expand_shape or collapse_shape),
-/// - and contains at least one op that is not extract_slice.
+/// A "complex" chain is one that is difficult for bufferization to handle. The
+/// conditions are:
+/// - The chain length must be >= 2.
+/// - The chain must contain at least one reshape op (expand_shape or
+/// collapse_shape).
+/// - The chain must contain at least one op that is not extract_slice or a
+/// reshape op.
 static bool isComplexRelayoutChain(Operation *relayoutOp) {
   assert(isSupportedSingleInputRelayoutOpForSource(relayoutOp) &&
          "expected a supported relayout op");
@@ -595,14 +598,17 @@ static bool isComplexRelayoutChain(Operation *relayoutOp) {
   return hasReshape && hasOtherNonExtractSlice;
 }
 
-/// Collects direct relayout op users of `loadResult` that start a complex
-/// relayout chain.
+/// Collects direct relayout op users of `loadResult` that start complex
+/// relayout chains. When `combineNonComplexChains` is true it includes all
+/// relayout op users regardless of complexity.
 static SmallPtrSet<Operation *, 4>
-getComplexChainRelayoutUsers(Value loadResult) {
+getComplexChainRelayoutUsers(Value loadResult,
+                             bool combineNonComplexChains = false) {
   SmallPtrSet<Operation *, 4> complexUsers;
   for (Operation *user : loadResult.getUsers()) {
     if (isSupportedSingleInputRelayoutOpForSource(user) &&
-        user->getOperand(0) == loadResult && isComplexRelayoutChain(user)) {
+        user->getOperand(0) == loadResult &&
+        (combineNonComplexChains || isComplexRelayoutChain(user))) {
       complexUsers.insert(user);
     }
   }
@@ -1220,13 +1226,15 @@ insertIdentityMapLoad(RewriterBase &rewriter, OpResult root,
 /// relayout ops into it iteratively.
 struct InsertMapLoadOpPattern
     : public OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  InsertMapLoadOpPattern(MLIRContext *context, bool combineNonComplexChains)
+      : OpRewritePattern(context),
+        combineNonComplexChains(combineNonComplexChains) {}
 
   LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {
     Value loadResult = loadOp.getResult();
     SmallPtrSet<Operation *, 4> complexChainUsers =
-        getComplexChainRelayoutUsers(loadResult);
+        getComplexChainRelayoutUsers(loadResult, combineNonComplexChains);
     // Only introduce map_load when there is at least one complex chain.
     if (complexChainUsers.empty()) {
       return failure();
@@ -1243,6 +1251,9 @@ struct InsertMapLoadOpPattern
                                 complexChainUsers);
     return success();
   }
+
+private:
+  bool combineNonComplexChains;
 };
 
 namespace {
@@ -1264,7 +1275,7 @@ struct CombineSourceLayoutTransformationPass final
     // Insert identity map_load ops after load_from_buffer ops and fold
     // consumer relayout ops into them.
     RewritePatternSet patterns(context);
-    patterns.add<InsertMapLoadOpPattern>(context);
+    patterns.add<InsertMapLoadOpPattern>(context, testCombineNonComplexChains);
     patterns.add<FoldConsumerRelayoutIntoMapLoadPattern>(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -539,33 +539,60 @@ static MapStoreOp insertIdentityMapStore(RewriterBase &rewriter,
   return mapStoreOp;
 }
 
-bool isSupportedSingleInputRelayoutOp(Operation *op) {
-  if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
-          tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
-          linalg::TransposeOp>(op)) {
+bool isSupportedSingleInputRelayoutOpForResult(Operation *op) {
+  return isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
+             tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
+             linalg::TransposeOp>(op);
+}
+
+bool isSupportedSingleInputRelayoutOpForSource(Operation *op) {
+  if (isSupportedSingleInputRelayoutOpForResult(op)) {
     return true;
   }
-  auto genericOp = dyn_cast<linalg::GenericOp>(op);
-  return genericOp && linalg::isaBroadcastOpInterface(genericOp).has_value();
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  return linalgOp && linalg::isaBroadcastOpInterface(linalgOp).has_value();
+}
+
+/// Collects all relayout ops in the chain starting from `relayoutOp`
+/// (inclusive). The chain extends through result->user edges where the user is
+/// a supported relayout op.
+static void collectRelayoutChain(Operation *relayoutOp,
+                                 SmallPtrSetImpl<Operation *> &chain) {
+  if (!chain.insert(relayoutOp).second) {
+    return;
+  }
+  Value result = relayoutOp->getResult(0);
+  for (Operation *user : result.getUsers()) {
+    if (isSupportedSingleInputRelayoutOpForSource(user) &&
+        user->getOperand(0) == result) {
+      collectRelayoutChain(user, chain);
+    }
+  }
 }
 
 /// Returns true if the relayout op starts a "complex" chain.
-/// A "complex" chain is :-
-/// - a chain of relayout ops with length >= 2,
-/// - or a chain of length 1 with one of the supported linalg relayout ops.
+/// A "complex" chain is one that is difficult for bufferization to handle:
+/// - chain length >= 2,
+/// - contains at least one reshape op (expand_shape or collapse_shape),
+/// - and contains at least one op that is not extract_slice.
 static bool isComplexRelayoutChain(Operation *relayoutOp) {
-  assert(isSupportedSingleInputRelayoutOp(relayoutOp) &&
+  assert(isSupportedSingleInputRelayoutOpForSource(relayoutOp) &&
          "expected a supported relayout op");
-  Value result = relayoutOp->getResult(0);
-  bool hasRelayoutUser = llvm::any_of(result.getUsers(), [](Operation *user) {
-    return isSupportedSingleInputRelayoutOp(user);
-  });
-  // Chain length >= 2 -> complex.
-  if (hasRelayoutUser) {
-    return true;
+  SmallPtrSet<Operation *, 4> chain;
+  collectRelayoutChain(relayoutOp, chain);
+  if (chain.size() < 2) {
+    return false;
   }
-  // Chain length 1: complex only if the op is a linalg op.
-  return isa<linalg::LinalgOp>(relayoutOp);
+  bool hasReshape = llvm::any_of(chain, [](Operation *op) {
+    return isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(op);
+  });
+  // Need at least one op that is not reshape and not extract_slice (e.g. copy,
+  // transpose, broadcast, pad).
+  bool hasOtherNonExtractSlice = llvm::any_of(chain, [](Operation *op) {
+    return !isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
+                tensor::ExtractSliceOp>(op);
+  });
+  return hasReshape && hasOtherNonExtractSlice;
 }
 
 /// Collects direct relayout op users of `loadResult` that start a complex
@@ -574,7 +601,7 @@ static SmallPtrSet<Operation *, 4>
 getComplexChainRelayoutUsers(Value loadResult) {
   SmallPtrSet<Operation *, 4> complexUsers;
   for (Operation *user : loadResult.getUsers()) {
-    if (isSupportedSingleInputRelayoutOp(user) &&
+    if (isSupportedSingleInputRelayoutOpForSource(user) &&
         user->getOperand(0) == loadResult && isComplexRelayoutChain(user)) {
       complexUsers.insert(user);
     }
@@ -593,11 +620,11 @@ shouldDoReshapesByExpansion(IREE::Codegen::RelayoutCombinationScope scope) {
 
 /// Insert identity map_store ops after the given operation if it is a valid
 /// leaf op of a relayout op chain. A relayout op chain is a sequence of
-/// relayout ops (defined by `isSupportedSingleInputRelayoutOp`) for which the
-/// only users of the ops in the chain are relayout ops, except for the leaves
-/// of the chain. The leaves are simply relayout ops that have non relayout op
-/// users. The `controlFn` is a callback on the leaf OpResult that provides
-/// control over whether or not to insert a map_store op.
+/// relayout ops (defined by `isSupportedSingleInputRelayoutOpForResult`) for
+/// which the only users of the ops in the chain are relayout ops, except for
+/// the leaves of the chain. The leaves are simply relayout ops that have non
+/// relayout op users. The `controlFn` is a callback on the leaf OpResult that
+/// provides control over whether or not to insert a map_store op.
 struct InsertMapStoreOpPattern : public RewritePattern {
   InsertMapStoreOpPattern(MLIRContext *context,
                           CombineRelayoutOpsControlFnRef controlFn = nullptr,
@@ -607,12 +634,13 @@ struct InsertMapStoreOpPattern : public RewritePattern {
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    if (!isSupportedSingleInputRelayoutOp(op)) {
+    if (!isSupportedSingleInputRelayoutOpForResult(op)) {
       return failure();
     }
     // Relayout ops with only relayout op users are not leaves.
     auto isDimOrSupportedRelayoutOp = [](Operation *op) {
-      return isSupportedSingleInputRelayoutOp(op) || isa<tensor::DimOp>(op);
+      return isSupportedSingleInputRelayoutOpForResult(op) ||
+             isa<tensor::DimOp>(op);
     };
     if (llvm::all_of(op->getUsers(), isDimOrSupportedRelayoutOp)) {
       return failure();
@@ -797,7 +825,7 @@ getCombineRelayoutOpsControlFn(IREE::Codegen::RelayoutCombinationScope scope) {
       // it, so don't introduce map_store.
       llvm::SetVector<Operation *> slice;
       BackwardSliceOptions options;
-      options.filter = isSupportedSingleInputRelayoutOp;
+      options.filter = isSupportedSingleInputRelayoutOpForResult;
       options.inclusive = true;
       LogicalResult result =
           getBackwardSlice(parallelInsertOp.getSource(), &slice, options);
@@ -1034,19 +1062,20 @@ foldExtractSliceIntoMapLoad(RewriterBase &rewriter,
                                      indexTransformBuilder);
 }
 
-/// Fold a consumer broadcast `linalg.generic` into a producer `map_load`.
-static FailureOr<MapLoadOp> foldBroadcastGenericIntoMapLoad(
-    RewriterBase &rewriter, linalg::GenericOp genericOp, MapLoadOp mapLoadOp) {
-  assert(genericOp.getDpsInputs()[0] == mapLoadOp.getResult(0) &&
-         "expected map_load to be the producer of genericOp input");
-  if (!linalg::isaBroadcastOpInterface(genericOp).has_value()) {
-    return rewriter.notifyMatchFailure(genericOp,
-                                       "generic op is not a broadcast");
+/// Fold a consumer broadcast op (named or generic) into a producer `map_load`.
+static FailureOr<MapLoadOp>
+foldBroadcastIntoMapLoad(RewriterBase &rewriter, linalg::LinalgOp broadcastOp,
+                         MapLoadOp mapLoadOp) {
+  if (!linalg::isaBroadcastOpInterface(broadcastOp).has_value()) {
+    return rewriter.notifyMatchFailure(broadcastOp.getOperation(),
+                                       "op is not a broadcast");
   }
+  assert(broadcastOp.getDpsInputs()[0] == mapLoadOp.getResult(0) &&
+         "expected map_load to be the producer of broadcast input");
 
-  AffineMap inputMap = genericOp.getIndexingMapsArray()[0];
+  AffineMap inputMap = broadcastOp.getIndexingMapsArray()[0];
   return foldConsumerIntoMapLoadImpl(
-      rewriter, genericOp, mapLoadOp,
+      rewriter, broadcastOp.getOperation(), mapLoadOp,
       [inputMap](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
         SmallVector<Value> sourceIndices;
         sourceIndices.reserve(inputMap.getNumResults());
@@ -1125,8 +1154,8 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
       .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
         return foldPadIntoMapLoad(rewriter, padOp, mapLoadOp);
       })
-      .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
-        return foldBroadcastGenericIntoMapLoad(rewriter, genericOp, mapLoadOp);
+      .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
+        return foldBroadcastIntoMapLoad(rewriter, linalgOp, mapLoadOp);
       })
       .Default([](Operation *) { return failure(); });
 }
@@ -1138,10 +1167,12 @@ struct FoldConsumerRelayoutIntoMapLoadPattern
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapLoadOp mapLoadOp,
                                 PatternRewriter &rewriter) const override {
-    // Find a consumer relayout op.
+    // Find a consumer relayout op (one that uses map_load result as its input).
     Operation *consumerOp = nullptr;
+    Value mapLoadResult = mapLoadOp.getResult(0);
     for (Operation *user : mapLoadOp->getUsers()) {
-      if (isSupportedSingleInputRelayoutOp(user)) {
+      if (isSupportedSingleInputRelayoutOpForSource(user) &&
+          user->getOperand(0) == mapLoadResult) {
         consumerOp = user;
         break;
       }

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -60,7 +60,6 @@ bool isSupportedSingleInputRelayoutOpForResult(Operation *op);
 
 /// Returns true if the `op` type has a folding pattern into
 /// iree_linalg_ext.map_load (used by CombineSourceLayoutTransformationPass).
-/// Includes broadcast GenericOp in addition to the ops supported for Result.
 bool isSupportedSingleInputRelayoutOpForSource(Operation *op);
 
 /// Fold the `op` into the `mapLoadOp` and return the resulting map_load,

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -55,8 +55,13 @@ CombineRelayoutOpsControlFn
 getCombineRelayoutOpsControlFn(IREE::Codegen::RelayoutCombinationScope scope);
 
 /// Returns true if the `op` type has a folding pattern into
-/// iree_linalg_ext.map_store or iree_linalg_ext.map_load.
-bool isSupportedSingleInputRelayoutOp(Operation *op);
+/// iree_linalg_ext.map_store (used by CombineResultLayoutTransformationPass).
+bool isSupportedSingleInputRelayoutOpForResult(Operation *op);
+
+/// Returns true if the `op` type has a folding pattern into
+/// iree_linalg_ext.map_load (used by CombineSourceLayoutTransformationPass).
+/// Includes broadcast GenericOp in addition to the ops supported for Result.
+bool isSupportedSingleInputRelayoutOpForSource(Operation *op);
 
 /// Fold the `op` into the `mapLoadOp` and return the resulting map_load,
 /// or failure if the transformation is not supported. The `op` should be a

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
@@ -83,7 +83,7 @@ static bool gpuRelayoutCombinationControlFn(OpResult leaf) {
   }
   llvm::SetVector<Operation *> slice;
   BackwardSliceOptions options;
-  options.filter = isSupportedSingleInputRelayoutOp;
+  options.filter = isSupportedSingleInputRelayoutOpForResult;
   options.inclusive = true;
   LogicalResult result = getBackwardSlice(leaf, &slice, options);
   if (failed(result)) {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -230,6 +230,11 @@ def CombineSourceLayoutTransformationPass :
     tensor.collapse_shape, tensor.expand_shape, tensor.extract_slice,
     tensor.pad, etc.) into a single iree_linalg_ext.map_load operation.
   }];
+  let options = [
+    Option<"testCombineNonComplexChains", "test-combine-non-complex-chains",
+           "bool", /*default=*/"false",
+           "For lit-testing: combine all relayout chains, not just complex ones. Not for general usage.">,
+  ];
   let dependentDialects = [
     "affine::AffineDialect",
     "arith::ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -128,7 +128,8 @@ struct FoldRelayoutOpIntoMapStorePattern
       return failure();
     }
     // Folding tensor.pad is handled by a separate pattern.
-    if (!isSupportedSingleInputRelayoutOp(op) || isa<tensor::PadOp>(op)) {
+    if (!isSupportedSingleInputRelayoutOpForResult(op) ||
+        isa<tensor::PadOp>(op)) {
       return failure();
     }
     if (failed(foldIntoMapStore(rewriter, op, mapStoreOp))) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -16,8 +16,14 @@ func.func @transpose(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @transpose
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
 //   FOLD-NOT:   linalg.transpose
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX2]], %[[IDX0]], %[[IDX1]], {{.*}} : index, index, index, f32
+//       FOLD:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
 
 // -----
 
@@ -33,8 +39,15 @@ func.func @expand_shape(%buffer : memref<8x16xf32>) -> tensor<2x4x16xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @expand_shape
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<2x4x16xf32>
 //   FOLD-NOT:   tensor.expand_shape
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       FOLD:     %[[LINEARIZE:.+]] = affine.linearize_index disjoint [%[[IDX0]], %[[IDX1]]] by (2, 4) : index
+//       FOLD:     iree_linalg_ext.yield %[[LINEARIZE]], %[[IDX2]], {{.*}} : index, index, f32
+//       FOLD:   } : tensor<8x16xf32> into tensor<2x4x16xf32> -> tensor<2x4x16xf32>
 
 // -----
 
@@ -50,8 +63,15 @@ func.func @collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @collapse_shape
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<8x16xf32>
 //   FOLD-NOT:   tensor.collapse_shape
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       FOLD:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX0]] into (2, 4) : index, index
+//       FOLD:     iree_linalg_ext.yield %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[IDX1]], {{.*}} : index, index, index, f32
+//       FOLD:   } : tensor<2x4x16xf32> into tensor<8x16xf32> -> tensor<8x16xf32>
 
 // -----
 
@@ -107,8 +127,16 @@ func.func @extract_slice(%buffer : memref<64xf32>) -> tensor<16xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @extract_slice
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-DAG:   %[[C8:.+]] = arith.constant 8 : index
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<16xf32>
 //   FOLD-NOT:   tensor.extract_slice
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index):
+//       FOLD:     %[[NEW_IDX:.+]] = arith.addi %[[IDX0]], %[[C8]] overflow<nsw> : index
+//       FOLD:     iree_linalg_ext.yield %[[NEW_IDX]], {{.*}} : index, f32
+//       FOLD:   } : tensor<64xf32> into tensor<16xf32> -> tensor<16xf32>
 
 // -----
 
@@ -128,9 +156,15 @@ func.func @copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @copy_transpose
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<16x4xf32>
 //   FOLD-NOT:   linalg.copy
 //   FOLD-NOT:   linalg.transpose
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]], {{.*}} : index, index, f32
+//       FOLD:   } : tensor<4x16xf32> into tensor<16x4xf32> -> tensor<16x4xf32>
 
 // -----
 
@@ -150,8 +184,15 @@ func.func @pad_zero_low(%buffer : memref<1x50x64xf32>) -> tensor<1x64x64xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @pad_zero_low
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-DAG:   %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<1x64x64xf32>
 //   FOLD-NOT:   tensor.pad
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX0]], %[[IDX1]], %[[IDX2]], %[[CST]] : index, index, index, f32
+//       FOLD:   } : tensor<1x50x64xf32> into tensor<1x64x64xf32> -> tensor<1x64x64xf32>
 
 // -----
 
@@ -171,8 +212,19 @@ func.func @pad_non_zero_low(%buffer : memref<8x16xf32>) -> tensor<10x20xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @pad_non_zero_low
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   FOLD-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   FOLD-DAG:   %[[CST:.+]] = arith.constant 1.000000e+00 : f32
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<10x20xf32>
 //   FOLD-NOT:   tensor.pad
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       FOLD:     %[[NEW_IDX0:.+]] = arith.subi %[[IDX0]], %[[C1]] overflow<nsw> : index
+//       FOLD:     %[[NEW_IDX1:.+]] = arith.subi %[[IDX1]], %[[C2]] overflow<nsw> : index
+//       FOLD:     iree_linalg_ext.yield %[[NEW_IDX0]], %[[NEW_IDX1]], %[[CST]] : index, index, f32
+//       FOLD:   } : tensor<8x16xf32> into tensor<10x20xf32> -> tensor<10x20xf32>
 
 // -----
 
@@ -203,9 +255,19 @@ func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<2x
 //       CHECK:   tensor.pad
 //       CHECK:     tensor.yield %[[CST1]] : f32
 // FOLD-LABEL: @nested_pads_different_values
+//  FOLD-SAME:   %[[BUFFER:.+]]:
 // With test-combine-non-complex-chains, first pad folds; second pad still remains.
-//       FOLD:   iree_linalg_ext.map_load
-//       FOLD:   tensor.pad
+//   FOLD-DAG:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<2x5x20xf32>
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       FOLD:     {{.*}} = affine.linearize_index disjoint [%[[IDX0]], %[[IDX1]]] by (2, 5) : index
+//       FOLD:     {{.*}} = arith.subi {{.*}} overflow<nsw> : index
+//       FOLD:     iree_linalg_ext.yield {{.*}}, %[[CST0]] : index, index, f32
+//       FOLD:   } : tensor<8x16xf32> into tensor<2x5x20xf32> -> tensor<2x5x20xf32>
+//       FOLD:   tensor.pad %[[MAP_LOAD]]
 
 // -----
 
@@ -231,8 +293,14 @@ func.func @broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @broadcast_generic
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<2x3x4x5xf32>
 //   FOLD-NOT:   linalg.generic
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX0]], %[[IDX1]], {{.*}} : index, index, f32
+//       FOLD:   } : tensor<2x3xf32> into tensor<2x3x4x5xf32> -> tensor<2x3x4x5xf32>
 
 // -----
 
@@ -249,8 +317,14 @@ func.func @broadcast_named(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
 //   CHECK-NOT:   iree_linalg_ext.map_load
 // FOLD-LABEL: @broadcast_named
 //  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<2x3x4x5xf32>
 //   FOLD-NOT:   linalg.broadcast
-//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX0]], %[[IDX1]], {{.*}} : index, index, f32
+//       FOLD:   } : tensor<2x3xf32> into tensor<2x3x4x5xf32> -> tensor<2x3x4x5xf32>
 
 // -----
 
@@ -274,7 +348,14 @@ func.func @complex_relayout_chain(%buffer : memref<8x16xf32>) -> tensor<16x8xf32
 //       CHECK:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]], {{.*}} : index, index, f32
 //       CHECK:   } : tensor<8x16xf32> into tensor<16x8xf32> -> tensor<16x8xf32>
 // FOLD-LABEL: @complex_relayout_chain
-//       FOLD:   iree_linalg_ext.map_load
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<16x8xf32>
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]], {{.*}} : index, index, f32
+//       FOLD:   } : tensor<8x16xf32> into tensor<16x8xf32> -> tensor<16x8xf32>
 
 // -----
 
@@ -299,7 +380,15 @@ func.func @complex_chain_reshape_and_transpose(%buffer : memref<4x8xf32>) -> ten
 //       CHECK:     iree_linalg_ext.yield %[[LINEAR]], %[[IDX0]], %0 : index, index, f32
 //       CHECK:   } : tensor<4x8xf32> into tensor<8x2x2xf32> -> tensor<8x2x2xf32>
 // FOLD-LABEL: @complex_chain_reshape_and_transpose
-//       FOLD:   iree_linalg_ext.map_load
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<8x2x2xf32>
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       FOLD:     %[[LINEAR:.+]] = affine.linearize_index disjoint [%[[IDX1]], %[[IDX2]]] by (2, 2) : index
+//       FOLD:     iree_linalg_ext.yield %[[LINEAR]], %[[IDX0]], {{.*}} : index, index, f32
+//       FOLD:   } : tensor<4x8xf32> into tensor<8x2x2xf32> -> tensor<8x2x2xf32>
 
 // -----
 
@@ -345,5 +434,15 @@ func.func @fold_broadcast_pad_expand_shape(%buffer : memref<2x64xf32>, %batch : 
 //       CHECK:   } : tensor<2x64xf32> into tensor<1x4x16x4x2x16xf32> -> tensor<1x4x16x4x2x16xf32>
 //       CHECK:   linalg.copy ins({{.*}}) outs(%[[MAP_LOAD]]
 // FOLD-LABEL: @fold_broadcast_pad_expand_shape
-//       FOLD:   iree_linalg_ext.map_load
+//  FOLD-SAME:   %[[BUFFER:.+]]: memref<2x64xf32>, %[[BATCH:.+]]: index
+//   FOLD-DAG:   %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<1x4x16x4x2x16xf32>
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index, %[[IDX4:.+]]: index, %[[IDX5:.+]]: index):
+//       FOLD:     {{.*}} = affine.linearize_index disjoint [%[[IDX1]], %[[IDX2]], %[[IDX3]], %[[IDX4]], %[[IDX5]]] by (4, 16, 4, 2, 16) : index
+//       FOLD:     {{.*}}:3 = affine.delinearize_index {{.*}} into (64, 4, 32) : index, index, index
+//       FOLD:     iree_linalg_ext.yield %[[BATCH]], {{.*}}, %[[CST]] : index, index, f32
+//       FOLD:   } : tensor<2x64xf32> into tensor<1x4x16x4x2x16xf32> -> tensor<1x4x16x4x2x16xf32>
 //       FOLD:   linalg.copy

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -12,7 +12,7 @@ func.func @fold_transpose(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
 //       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
 //   CHECK-NOT:   linalg.transpose
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
+//       CHECK:   iree_linalg_ext.map_load
 //  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
 //  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
 // For perm=[1,2,0], inverse_perm=[2,0,1]: output[i,j,k] = input[k,i,j], so yield [idx2,idx0,idx1].
@@ -28,16 +28,9 @@ func.func @fold_expand_shape(%buffer : memref<8x16xf32>) -> tensor<2x4x16xf32> {
 }
 // CHECK-LABEL: @fold_expand_shape
 //  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<2x4x16xf32>
-//   CHECK-NOT:   tensor.expand_shape
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
-//       CHECK:     %[[LINEARIZE:.+]] = affine.linearize_index
-//  CHECK-SAME:       [%[[IDX0]], %[[IDX1]]] by (2, 4)
-//       CHECK:     iree_linalg_ext.yield %[[LINEARIZE]], %[[IDX2]],
-//       CHECK:   } : tensor<8x16xf32> into tensor<2x4x16xf32> -> tensor<2x4x16xf32>
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.expand_shape
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
@@ -48,15 +41,9 @@ func.func @fold_collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32>
 }
 // CHECK-LABEL: @fold_collapse_shape
 //  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<8x16xf32>
-//   CHECK-NOT:   tensor.collapse_shape
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
-//       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX0]] into (2, 4)
-//       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[IDX1]],
-//       CHECK:   } : tensor<2x4x16xf32> into tensor<8x16xf32> -> tensor<8x16xf32>
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.collapse_shape
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
@@ -93,16 +80,9 @@ func.func @fold_extract_slice(%buffer : memref<64xf32>) -> tensor<16xf32> {
 }
 // CHECK-LABEL: @fold_extract_slice
 //  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//   CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
 //       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<16xf32>
-//   CHECK-NOT:   tensor.extract_slice
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index):
-//       CHECK:     %[[NEW_IDX:.+]] = arith.addi %[[IDX0]], %[[C8]] overflow<nsw>
-//       CHECK:     iree_linalg_ext.yield %[[NEW_IDX]],
-//       CHECK:   } : tensor<64xf32> into tensor<16xf32> -> tensor<16xf32>
+//       CHECK:   tensor.extract_slice %[[SOURCE]][8] [16] [1]
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
@@ -122,7 +102,7 @@ func.func @fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
 //       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<16x4xf32>
 //   CHECK-NOT:   linalg.copy
 //   CHECK-NOT:   linalg.transpose
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
+//       CHECK:   iree_linalg_ext.map_load
 //  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
 //  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
 //       CHECK:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]],
@@ -130,7 +110,6 @@ func.func @fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
 
 // -----
 
-// Low padding is [0, 0, 0], so indices are passed through unchanged due to subi with 0.
 func.func @fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf32>) -> tensor<1x64x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %source = iree_codegen.load_from_buffer %buffer : memref<1x50x64xf32> -> tensor<1x50x64xf32>
@@ -142,15 +121,9 @@ func.func @fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf32>)
 }
 // CHECK-LABEL: @fold_pad_with_zero_low_padding_offsets
 //  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//   CHECK-DAG:   %[[CST:.+]] = arith.constant 0.000000e+00 : f32
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<1x64x64xf32>
-//   CHECK-NOT:   tensor.pad
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
-//       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[IDX1]], %[[IDX2]], %[[CST]] :
-//       CHECK:   } : tensor<1x50x64xf32> into tensor<1x64x64xf32> -> tensor<1x64x64xf32>
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.pad
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
@@ -165,19 +138,9 @@ func.func @fold_pad_with_non_zero_low_padding_offsets(%buffer : memref<8x16xf32>
 }
 // CHECK-LABEL: @fold_pad_with_non_zero_low_padding_offsets
 //  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//   CHECK-DAG:   %[[CST:.+]] = arith.constant 1.000000e+00 : f32
-//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<10x20xf32>
-//   CHECK-NOT:   tensor.pad
-//       CHECK:   %[[MAP_GATHER:.+]] = iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
-//       CHECK:     %[[NEW_IDX0:.+]] = arith.subi %[[IDX0]], %[[C1]] overflow<nsw> : index
-//       CHECK:     %[[NEW_IDX1:.+]] = arith.subi %[[IDX1]], %[[C2]] overflow<nsw> : index
-//       CHECK:     iree_linalg_ext.yield %[[NEW_IDX0]], %[[NEW_IDX1]], %[[CST]] :
-//       CHECK:   } : tensor<8x16xf32> into tensor<10x20xf32> -> tensor<10x20xf32>
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.pad
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
@@ -208,3 +171,54 @@ func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<14
 // Second pad is NOT folded because the map_load already has a padding value.
 //       CHECK:   tensor.pad
 //       CHECK:     tensor.yield %[[CST1]] : f32
+
+// -----
+
+func.func @fold_broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<2x3xf32> -> tensor<2x3xf32>
+  %init = tensor.empty() : tensor<2x3x4x5xf32>
+  %broadcast = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  } ins(%source : tensor<2x3xf32>) outs(%init : tensor<2x3x4x5xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<2x3x4x5xf32>
+  return %broadcast : tensor<2x3x4x5xf32>
+}
+// CHECK-LABEL: @fold_broadcast_generic
+//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<2x3x4x5xf32>
+//   CHECK-NOT:   linalg.generic
+//       CHECK:   iree_linalg_ext.map_load
+//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
+// Broadcast: output (d0,d1,d2,d3) reads from source at (d0,d1)
+//       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[IDX1]],
+//       CHECK:   } : tensor<2x3xf32> into tensor<2x3x4x5xf32> -> tensor<2x3x4x5xf32>
+
+// -----
+
+func.func @complex_relayout_chain(%buffer : memref<8x16xf32>) -> tensor<16x8xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
+  %expanded = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
+  %collapsed = tensor.collapse_shape %expanded [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
+  %init = tensor.empty() : tensor<16x8xf32>
+  %transposed = linalg.transpose ins(%collapsed : tensor<8x16xf32>) outs(%init : tensor<16x8xf32>) permutation = [1, 0]
+  return %transposed : tensor<16x8xf32>
+}
+// CHECK-LABEL: @complex_relayout_chain
+//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.empty() : tensor<16x8xf32>
+//   CHECK-NOT:   tensor.expand_shape
+//   CHECK-NOT:   tensor.collapse_shape
+//   CHECK-NOT:   linalg.transpose
+//       CHECK:   iree_linalg_ext.map_load {{.*}} into {{.*}} {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//  CHECK-NEXT:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]], {{.*}} : index, index, f32
+//       CHECK:   } : tensor<8x16xf32> into tensor<16x8xf32> -> tensor<16x8xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -1,46 +1,40 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-combine-source-layout-transformation,canonicalize,cse))" \
 // RUN:   -split-input-file %s | FileCheck %s
 
-func.func @fold_transpose(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
+func.func @no_fold_transpose(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x4x16xf32> -> tensor<2x4x16xf32>
   %init = tensor.empty() : tensor<4x16x2xf32>
   %transposed = linalg.transpose ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]
   return %transposed : tensor<4x16x2xf32>
 }
-// CHECK-LABEL: @fold_transpose
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
-//   CHECK-NOT:   linalg.transpose
-//       CHECK:   iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
-// For perm=[1,2,0], inverse_perm=[2,0,1]: output[i,j,k] = input[k,i,j], so yield [idx2,idx0,idx1].
-//       CHECK:     iree_linalg_ext.yield %[[IDX2]], %[[IDX0]], %[[IDX1]],
-//       CHECK:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
+// CHECK-LABEL: @no_fold_transpose
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.transpose
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @fold_expand_shape(%buffer : memref<8x16xf32>) -> tensor<2x4x16xf32> {
+func.func @no_fold_expand_shape(%buffer : memref<8x16xf32>) -> tensor<2x4x16xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
   %expand = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
   return %expand : tensor<2x4x16xf32>
 }
-// CHECK-LABEL: @fold_expand_shape
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+// CHECK-LABEL: @no_fold_expand_shape
+//  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.expand_shape
 //   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @fold_collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32> {
+func.func @no_fold_collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x4x16xf32> -> tensor<2x4x16xf32>
   %collapse = tensor.collapse_shape %source [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
   return %collapse : tensor<8x16xf32>
 }
-// CHECK-LABEL: @fold_collapse_shape
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+// CHECK-LABEL: @no_fold_collapse_shape
+//  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.collapse_shape
 //   CHECK-NOT:   iree_linalg_ext.map_load
@@ -78,17 +72,15 @@ func.func @fold_extract_slice(%buffer : memref<64xf32>) -> tensor<16xf32> {
   %slice = tensor.extract_slice %source[8] [16] [1] : tensor<64xf32> to tensor<16xf32>
   return %slice : tensor<16xf32>
 }
-// CHECK-LABEL: @fold_extract_slice
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+// CHECK-LABEL: @no_fold_extract_slice
+//  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.extract_slice %[[SOURCE]][8] [16] [1]
 //   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-// Test folding copy into map_load. The copy is chained with a transpose
-// so the resulting map_load is not an identity.
-func.func @fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
+func.func @no_fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<4x16xf32> -> tensor<4x16xf32>
   %init = tensor.empty() : tensor<4x16xf32>
   %copied = linalg.copy ins(%source : tensor<4x16xf32>) outs(%init : tensor<4x16xf32>) -> tensor<4x16xf32>
@@ -96,21 +88,16 @@ func.func @fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
   %transposed = linalg.transpose ins(%copied : tensor<4x16xf32>) outs(%init2 : tensor<16x4xf32>) permutation = [1, 0]
   return %transposed : tensor<16x4xf32>
 }
-// CHECK-LABEL: @fold_copy_transpose
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<16x4xf32>
-//   CHECK-NOT:   linalg.copy
-//   CHECK-NOT:   linalg.transpose
-//       CHECK:   iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
-//       CHECK:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]],
-//       CHECK:   } : tensor<4x16xf32> into tensor<16x4xf32> -> tensor<16x4xf32>
+// CHECK-LABEL: @no_fold_copy_transpose
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.copy
+//       CHECK:   linalg.transpose
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf32>) -> tensor<1x64x64xf32> {
+func.func @no_fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf32>) -> tensor<1x64x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %source = iree_codegen.load_from_buffer %buffer : memref<1x50x64xf32> -> tensor<1x50x64xf32>
   %padded = tensor.pad %source low[0, 0, 0] high[0, 14, 0] {
@@ -119,15 +106,15 @@ func.func @fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf32>)
   } : tensor<1x50x64xf32> to tensor<1x64x64xf32>
   return %padded : tensor<1x64x64xf32>
 }
-// CHECK-LABEL: @fold_pad_with_zero_low_padding_offsets
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+// CHECK-LABEL: @no_fold_pad_with_zero_low_padding_offsets
+//  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.pad
 //   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @fold_pad_with_non_zero_low_padding_offsets(%buffer : memref<8x16xf32>) -> tensor<10x20xf32> {
+func.func @no_fold_pad_with_non_zero_low_padding_offsets(%buffer : memref<8x16xf32>) -> tensor<10x20xf32> {
   %cst = arith.constant 1.000000e+00 : f32
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
   %padded = tensor.pad %source low[1, 2] high[1, 2] {
@@ -136,19 +123,17 @@ func.func @fold_pad_with_non_zero_low_padding_offsets(%buffer : memref<8x16xf32>
   } : tensor<8x16xf32> to tensor<10x20xf32>
   return %padded : tensor<10x20xf32>
 }
-// CHECK-LABEL: @fold_pad_with_non_zero_low_padding_offsets
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+// CHECK-LABEL: @no_fold_pad_with_non_zero_low_padding_offsets
+//  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.pad
 //   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-// Test that nested pads with different padding values are NOT both folded.
-// The first pad gets folded, but the second pad remains because the map_load
-// already has a non-poison padding value. Folding both would incorrectly
-// overwrite the first padding value.
-func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<14x24xf32> {
+// Chain with pad -> reshape -> pad. Reshape makes it complex, so first pad is folded
+// into map_load. Second pad is NOT folded because map_load already has a padding value.
+func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<2x7x24xf32> {
   %cst0 = arith.constant 0.000000e+00 : f32
   %cst1 = arith.constant 1.000000e+00 : f32
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
@@ -156,11 +141,12 @@ func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<14
   ^bb0(%arg0: index, %arg1: index):
     tensor.yield %cst0 : f32
   } : tensor<8x16xf32> to tensor<10x20xf32>
-  %pad1 = tensor.pad %pad0 low[2, 2] high[2, 2] {
-  ^bb0(%arg0: index, %arg1: index):
+  %expanded = tensor.expand_shape %pad0 [[0, 1], [2]] output_shape [2, 5, 20] : tensor<10x20xf32> into tensor<2x5x20xf32>
+  %pad1 = tensor.pad %expanded low[0, 1, 2] high[0, 1, 2] {
+  ^bb0(%arg0: index, %arg1: index, %arg2: index):
     tensor.yield %cst1 : f32
-  } : tensor<10x20xf32> to tensor<14x24xf32>
-  return %pad1 : tensor<14x24xf32>
+  } : tensor<2x5x20xf32> to tensor<2x7x24xf32>
+  return %pad1 : tensor<2x7x24xf32>
 }
 // CHECK-LABEL: @nested_pads_different_values
 //       CHECK:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
@@ -174,7 +160,7 @@ func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<14
 
 // -----
 
-func.func @fold_broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
+func.func @no_fold_broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x3xf32> -> tensor<2x3xf32>
   %init = tensor.empty() : tensor<2x3x4x5xf32>
   %broadcast = linalg.generic {
@@ -189,20 +175,31 @@ func.func @fold_broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf
   } -> tensor<2x3x4x5xf32>
   return %broadcast : tensor<2x3x4x5xf32>
 }
-// CHECK-LABEL: @fold_broadcast_generic
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   %[[DEST:.+]] = tensor.empty() : tensor<2x3x4x5xf32>
-//   CHECK-NOT:   linalg.generic
-//       CHECK:   iree_linalg_ext.map_load
-//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
-// Broadcast: output (d0,d1,d2,d3) reads from source at (d0,d1)
-//       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[IDX1]],
-//       CHECK:   } : tensor<2x3xf32> into tensor<2x3x4x5xf32> -> tensor<2x3x4x5xf32>
+// CHECK-LABEL: @no_fold_broadcast_generic
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.generic
+//   CHECK-NOT:   iree_linalg_ext.map_load
 
 // -----
 
+func.func @no_fold_broadcast_named(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<2x3xf32> -> tensor<2x3xf32>
+  %init = tensor.empty() : tensor<2x3x4x5xf32>
+  %broadcast = linalg.broadcast ins(%source : tensor<2x3xf32>) outs(%init : tensor<2x3x4x5xf32>) dimensions = [2, 3]
+  return %broadcast : tensor<2x3x4x5xf32>
+}
+// CHECK-LABEL: @no_fold_broadcast_named
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.broadcast
+//   CHECK-NOT:   iree_linalg_ext.map_load
+
+// -----
+
+// Due to applyPatternsGreedily collapse(expand(x)) gets folded to x, so we end up
+// with load->transpose before our patterns see the chain. And since single transpose
+// is not complex - so no map_load op is inserted.
 func.func @complex_relayout_chain(%buffer : memref<8x16xf32>) -> tensor<16x8xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
   %expanded = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
@@ -212,13 +209,74 @@ func.func @complex_relayout_chain(%buffer : memref<8x16xf32>) -> tensor<16x8xf32
   return %transposed : tensor<16x8xf32>
 }
 // CHECK-LABEL: @complex_relayout_chain
-//  CHECK-SAME:   %[[BUFFER:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.transpose ins(%[[LOAD]]
+//   CHECK-NOT:   iree_linalg_ext.map_load
+
+// -----
+
+// Chain with reshape (expand_shape) + non-extract_slice (transpose) - complex chain,
+// so map_load is introduced and the chain is folded.
+func.func @complex_chain_reshape_and_transpose(%buffer : memref<4x8xf32>) -> tensor<8x2x2xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<4x8xf32> -> tensor<4x8xf32>
+  %expanded = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 2, 8] : tensor<4x8xf32> into tensor<2x2x8xf32>
+  %init = tensor.empty() : tensor<8x2x2xf32>
+  %transposed = linalg.transpose ins(%expanded : tensor<2x2x8xf32>) outs(%init : tensor<8x2x2xf32>) permutation = [2, 0, 1]
+  return %transposed : tensor<8x2x2xf32>
+}
+// CHECK-LABEL: @complex_chain_reshape_and_transpose
+//  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   tensor.empty() : tensor<16x8xf32>
+//       CHECK:   tensor.empty() : tensor<8x2x2xf32>
 //   CHECK-NOT:   tensor.expand_shape
-//   CHECK-NOT:   tensor.collapse_shape
 //   CHECK-NOT:   linalg.transpose
 //       CHECK:   iree_linalg_ext.map_load {{.*}} into {{.*}} {
-//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
-//  CHECK-NEXT:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]], {{.*}} : index, index, f32
-//       CHECK:   } : tensor<8x16xf32> into tensor<16x8xf32> -> tensor<16x8xf32>
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       CHECK:     %[[LINEAR:.+]] = affine.linearize_index disjoint [%[[IDX1]], %[[IDX2]]] by (2, 2) : index
+//       CHECK:     iree_linalg_ext.yield %[[LINEAR]], %[[IDX0]], %0 : index, index, f32
+//       CHECK:   } : tensor<4x8xf32> into tensor<8x2x2xf32> -> tensor<8x2x2xf32>
+
+// -----
+
+// Chain broadcast -> pad -> expand_shape folds into map_load, but copy doesn't
+// because it uses expand_shape's result (later map_load) as outs (operand 1).
+func.func @fold_broadcast_pad_expand_shape(%buffer : memref<2x64xf32>, %batch : index) -> tensor<1x4x16x4x2x16xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %source = iree_codegen.load_from_buffer %buffer : memref<2x64xf32> -> tensor<2x64xf32>
+  %extracted = tensor.extract_slice %source[%batch, 0] [1, 64] [1, 1] : tensor<2x64xf32> to tensor<1x64xf32>
+  %init = tensor.empty() : tensor<1x64x4x28xf32>
+  %broadcast = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  } ins(%extracted : tensor<1x64xf32>) outs(%init : tensor<1x64x4x28xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<1x64x4x28xf32>
+  %padded = tensor.pad %broadcast low[0, 0, 0, 0] high[0, 0, 0, 4] {
+  ^bb0(%arg0: index, %arg1: index, %arg2: index, %arg3: index):
+    tensor.yield %cst : f32
+  } : tensor<1x64x4x28xf32> to tensor<1x64x4x32xf32>
+  %expanded = tensor.expand_shape %padded [[0], [1, 2], [3], [4, 5]] output_shape [1, 4, 16, 4, 2, 16] : tensor<1x64x4x32xf32> into tensor<1x4x16x4x2x16xf32>
+  %copy_dest = tensor.empty() : tensor<1x4x16x4x2x16xf32>
+  %result = linalg.copy ins(%copy_dest : tensor<1x4x16x4x2x16xf32>) outs(%expanded : tensor<1x4x16x4x2x16xf32>) -> tensor<1x4x16x4x2x16xf32>
+  return %result : tensor<1x4x16x4x2x16xf32>
+}
+// CHECK-LABEL: @fold_broadcast_pad_expand_shape
+//  CHECK-SAME:   %[[BUFFER:.+]]: memref<2x64xf32>, %[[BATCH:.+]]: index
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.empty() : tensor<1x4x16x4x2x16xf32>
+//   CHECK-NOT:   tensor.extract_slice
+//   CHECK-NOT:   linalg.generic
+//   CHECK-NOT:   tensor.pad
+//   CHECK-NOT:   tensor.expand_shape
+//       CHECK:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load {{.*}} into {{.*}} {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index, %[[IDX4:.+]]: index, %[[IDX5:.+]]: index):
+//       CHECK:     {{.*}} = affine.linearize_index disjoint [%[[IDX1]], %[[IDX2]], %[[IDX3]], %[[IDX4]], %[[IDX5]]] by (4, 16, 4, 2, 16) : index
+//       CHECK:     {{.*}} = affine.delinearize_index {{.*}} into (64, 4, 32) : index, index, index
+//       CHECK:     iree_linalg_ext.yield %[[BATCH]], {{.*}}, {{.*}} : index, index, f32
+//       CHECK:   } : tensor<2x64xf32> into tensor<1x4x16x4x2x16xf32> -> tensor<1x4x16x4x2x16xf32>
+//       CHECK:   linalg.copy ins({{.*}}) outs(%[[MAP_LOAD]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -1,43 +1,57 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-combine-source-layout-transformation,canonicalize,cse))" \
 // RUN:   -split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-combine-source-layout-transformation{test-combine-non-complex-chains=true},canonicalize,cse))" \
+// RUN:   -split-input-file %s | FileCheck %s --check-prefix=FOLD
 
-func.func @no_fold_transpose(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
+func.func @transpose(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x4x16xf32> -> tensor<2x4x16xf32>
   %init = tensor.empty() : tensor<4x16x2xf32>
   %transposed = linalg.transpose ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]
   return %transposed : tensor<4x16x2xf32>
 }
-// CHECK-LABEL: @no_fold_transpose
+// CHECK-LABEL: @transpose
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   linalg.transpose
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @transpose
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   linalg.transpose
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @no_fold_expand_shape(%buffer : memref<8x16xf32>) -> tensor<2x4x16xf32> {
+func.func @expand_shape(%buffer : memref<8x16xf32>) -> tensor<2x4x16xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
   %expand = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
   return %expand : tensor<2x4x16xf32>
 }
-// CHECK-LABEL: @no_fold_expand_shape
+// CHECK-LABEL: @expand_shape
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.expand_shape
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @expand_shape
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   tensor.expand_shape
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @no_fold_collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32> {
+func.func @collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x4x16xf32> -> tensor<2x4x16xf32>
   %collapse = tensor.collapse_shape %source [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
   return %collapse : tensor<8x16xf32>
 }
-// CHECK-LABEL: @no_fold_collapse_shape
+// CHECK-LABEL: @collapse_shape
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.collapse_shape
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @collapse_shape
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   tensor.collapse_shape
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
@@ -49,8 +63,15 @@ func.func @no_fold_rank0_collapse_shape(%buffer : memref<1x1x1xf32>) -> tensor<f
   return %collapse : tensor<f32>
 }
 // CHECK-LABEL: @no_fold_rank0_collapse_shape
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.collapse_shape
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @no_fold_rank0_collapse_shape
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   tensor.collapse_shape
+//   FOLD-NOT:   iree_linalg_ext.map_load
 
 // -----
 
@@ -62,25 +83,36 @@ func.func @no_fold_rank0_expand_shape(%buffer : memref<f32>) -> tensor<1x1x1xf32
   return %expand : tensor<1x1x1xf32>
 }
 // CHECK-LABEL: @no_fold_rank0_expand_shape
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.expand_shape
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @no_fold_rank0_expand_shape
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   tensor.expand_shape
+//   FOLD-NOT:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @fold_extract_slice(%buffer : memref<64xf32>) -> tensor<16xf32> {
+func.func @extract_slice(%buffer : memref<64xf32>) -> tensor<16xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<64xf32> -> tensor<64xf32>
   %slice = tensor.extract_slice %source[8] [16] [1] : tensor<64xf32> to tensor<16xf32>
   return %slice : tensor<16xf32>
 }
-// CHECK-LABEL: @no_fold_extract_slice
+// CHECK-LABEL: @extract_slice
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.extract_slice %[[SOURCE]][8] [16] [1]
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @extract_slice
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   tensor.extract_slice
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @no_fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
+func.func @copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<4x16xf32> -> tensor<4x16xf32>
   %init = tensor.empty() : tensor<4x16xf32>
   %copied = linalg.copy ins(%source : tensor<4x16xf32>) outs(%init : tensor<4x16xf32>) -> tensor<4x16xf32>
@@ -88,16 +120,21 @@ func.func @no_fold_copy_transpose(%buffer : memref<4x16xf32>) -> tensor<16x4xf32
   %transposed = linalg.transpose ins(%copied : tensor<4x16xf32>) outs(%init2 : tensor<16x4xf32>) permutation = [1, 0]
   return %transposed : tensor<16x4xf32>
 }
-// CHECK-LABEL: @no_fold_copy_transpose
+// CHECK-LABEL: @copy_transpose
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   linalg.copy
 //       CHECK:   linalg.transpose
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @copy_transpose
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   linalg.copy
+//   FOLD-NOT:   linalg.transpose
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @no_fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf32>) -> tensor<1x64x64xf32> {
+func.func @pad_zero_low(%buffer : memref<1x50x64xf32>) -> tensor<1x64x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %source = iree_codegen.load_from_buffer %buffer : memref<1x50x64xf32> -> tensor<1x50x64xf32>
   %padded = tensor.pad %source low[0, 0, 0] high[0, 14, 0] {
@@ -106,15 +143,19 @@ func.func @no_fold_pad_with_zero_low_padding_offsets(%buffer : memref<1x50x64xf3
   } : tensor<1x50x64xf32> to tensor<1x64x64xf32>
   return %padded : tensor<1x64x64xf32>
 }
-// CHECK-LABEL: @no_fold_pad_with_zero_low_padding_offsets
+// CHECK-LABEL: @pad_zero_low
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.pad
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @pad_zero_low
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   tensor.pad
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @no_fold_pad_with_non_zero_low_padding_offsets(%buffer : memref<8x16xf32>) -> tensor<10x20xf32> {
+func.func @pad_non_zero_low(%buffer : memref<8x16xf32>) -> tensor<10x20xf32> {
   %cst = arith.constant 1.000000e+00 : f32
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
   %padded = tensor.pad %source low[1, 2] high[1, 2] {
@@ -123,11 +164,15 @@ func.func @no_fold_pad_with_non_zero_low_padding_offsets(%buffer : memref<8x16xf
   } : tensor<8x16xf32> to tensor<10x20xf32>
   return %padded : tensor<10x20xf32>
 }
-// CHECK-LABEL: @no_fold_pad_with_non_zero_low_padding_offsets
+// CHECK-LABEL: @pad_non_zero_low
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.pad
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @pad_non_zero_low
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   tensor.pad
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
@@ -157,10 +202,14 @@ func.func @nested_pads_different_values(%buffer : memref<8x16xf32>) -> tensor<2x
 // Second pad is NOT folded because the map_load already has a padding value.
 //       CHECK:   tensor.pad
 //       CHECK:     tensor.yield %[[CST1]] : f32
+// FOLD-LABEL: @nested_pads_different_values
+// With test-combine-non-complex-chains, first pad folds; second pad still remains.
+//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   tensor.pad
 
 // -----
 
-func.func @no_fold_broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
+func.func @broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x3xf32> -> tensor<2x3xf32>
   %init = tensor.empty() : tensor<2x3x4x5xf32>
   %broadcast = linalg.generic {
@@ -175,44 +224,57 @@ func.func @no_fold_broadcast_generic(%buffer : memref<2x3xf32>) -> tensor<2x3x4x
   } -> tensor<2x3x4x5xf32>
   return %broadcast : tensor<2x3x4x5xf32>
 }
-// CHECK-LABEL: @no_fold_broadcast_generic
+// CHECK-LABEL: @broadcast_generic
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   linalg.generic
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @broadcast_generic
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   linalg.generic
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-func.func @no_fold_broadcast_named(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
+func.func @broadcast_named(%buffer : memref<2x3xf32>) -> tensor<2x3x4x5xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<2x3xf32> -> tensor<2x3xf32>
   %init = tensor.empty() : tensor<2x3x4x5xf32>
   %broadcast = linalg.broadcast ins(%source : tensor<2x3xf32>) outs(%init : tensor<2x3x4x5xf32>) dimensions = [2, 3]
   return %broadcast : tensor<2x3x4x5xf32>
 }
-// CHECK-LABEL: @no_fold_broadcast_named
+// CHECK-LABEL: @broadcast_named
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   linalg.broadcast
 //   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @broadcast_named
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//   FOLD-NOT:   linalg.broadcast
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
-// Due to applyPatternsGreedily collapse(expand(x)) gets folded to x, so we end up
-// with load->transpose before our patterns see the chain. And since single transpose
-// is not complex - so no map_load op is inserted.
 func.func @complex_relayout_chain(%buffer : memref<8x16xf32>) -> tensor<16x8xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<8x16xf32> -> tensor<8x16xf32>
   %expanded = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
-  %collapsed = tensor.collapse_shape %expanded [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
-  %init = tensor.empty() : tensor<16x8xf32>
-  %transposed = linalg.transpose ins(%collapsed : tensor<8x16xf32>) outs(%init : tensor<16x8xf32>) permutation = [1, 0]
-  return %transposed : tensor<16x8xf32>
+  %init_t = tensor.empty() : tensor<16x2x4xf32>
+  %transposed = linalg.transpose ins(%expanded : tensor<2x4x16xf32>) outs(%init_t : tensor<16x2x4xf32>) permutation = [2, 0, 1]
+  %collapsed = tensor.collapse_shape %transposed [[0], [1, 2]] : tensor<16x2x4xf32> into tensor<16x8xf32>
+  return %collapsed : tensor<16x8xf32>
 }
 // CHECK-LABEL: @complex_relayout_chain
 //  CHECK-SAME:   %[[BUFFER:.+]]:
-//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//       CHECK:   linalg.transpose ins(%[[LOAD]]
-//   CHECK-NOT:   iree_linalg_ext.map_load
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.empty() : tensor<16x8xf32>
+//   CHECK-NOT:   tensor.expand_shape
+//   CHECK-NOT:   linalg.transpose
+//   CHECK-NOT:   tensor.collapse_shape
+//       CHECK:   iree_linalg_ext.map_load {{.*}} into {{.*}} {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       CHECK:     iree_linalg_ext.yield %[[IDX1]], %[[IDX0]], {{.*}} : index, index, f32
+//       CHECK:   } : tensor<8x16xf32> into tensor<16x8xf32> -> tensor<16x8xf32>
+// FOLD-LABEL: @complex_relayout_chain
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
@@ -236,6 +298,8 @@ func.func @complex_chain_reshape_and_transpose(%buffer : memref<4x8xf32>) -> ten
 //       CHECK:     %[[LINEAR:.+]] = affine.linearize_index disjoint [%[[IDX1]], %[[IDX2]]] by (2, 2) : index
 //       CHECK:     iree_linalg_ext.yield %[[LINEAR]], %[[IDX0]], %0 : index, index, f32
 //       CHECK:   } : tensor<4x8xf32> into tensor<8x2x2xf32> -> tensor<8x2x2xf32>
+// FOLD-LABEL: @complex_chain_reshape_and_transpose
+//       FOLD:   iree_linalg_ext.map_load
 
 // -----
 
@@ -280,3 +344,6 @@ func.func @fold_broadcast_pad_expand_shape(%buffer : memref<2x64xf32>, %batch : 
 //       CHECK:     iree_linalg_ext.yield %[[BATCH]], {{.*}}, {{.*}} : index, index, f32
 //       CHECK:   } : tensor<2x64xf32> into tensor<1x4x16x4x2x16xf32> -> tensor<1x4x16x4x2x16xf32>
 //       CHECK:   linalg.copy ins({{.*}}) outs(%[[MAP_LOAD]]
+// FOLD-LABEL: @fold_broadcast_pad_expand_shape
+//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   linalg.copy


### PR DESCRIPTION
This commit makes following updates :-
1. Folds named/generic broadcast op into MapLoadOp.
2. Inserts identity MapLoadOp only for "complex" relayout => chains length ≥ 2, has reshape (expand/collapse), and has non-extract_slice op (transpose, pad, copy, broadcast). 
3. Avoids map_load for simple chains (e.g. single extract_slice) to prevent large memref.alloca and stack size issues.
4. Adds pass flag/option `test-combine-non-complex-chains` for lit-testing each op in isolation.