### PR TITLE
Use new vector.multi_reduction populate methods

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -229,7 +229,11 @@ struct VectorReductionToGPUPass final
     // TODO: Remove once MultiDimReduce is supported by distribute patterns.
     {
       RewritePatternSet patterns(ctx);
-      vector::populateVectorMultiReductionLoweringPatterns(
+      vector::populateVectorMultiReductionReorderAndExpandPatterns(
+          patterns, vector::VectorMultiReductionLowering::InnerReduction);
+      vector::populateVectorMultiReductionFlatteningPatterns(
+          patterns, vector::VectorMultiReductionLowering::InnerReduction);
+      vector::populateVectorMultiReductionUnrollingPatterns(
           patterns, vector::VectorMultiReductionLowering::InnerReduction);
       // Add clean up patterns after lowering of multidimreduce lowering.
       patterns.add<InsertToBroadcast>(ctx);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -90,7 +90,11 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     vector::populateScalarVectorTransferLoweringPatterns(
         patterns, /*benefit=*/1, /*allowMultipleUses=*/true);
     vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
-    vector::populateVectorMultiReductionLoweringPatterns(
+    vector::populateVectorMultiReductionReorderAndExpandPatterns(
+        patterns, vectorMultiReductionLowering);
+    vector::populateVectorMultiReductionFlatteningPatterns(
+        patterns, vectorMultiReductionLowering);
+    vector::populateVectorMultiReductionUnrollingPatterns(
         patterns, vectorMultiReductionLowering);
     populateVectorTransferFullPartialPatterns(patterns, vectorTransformOptions);
     (void)applyPatternsGreedily(funcOp, std::move(patterns));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -605,7 +605,13 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorGatherLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);
-      vector::populateVectorMultiReductionLoweringPatterns(
+      vector::populateVectorMultiReductionReorderAndExpandPatterns(
+          contractLoweringPatterns,
+          vector::VectorMultiReductionLowering::InnerReduction);
+      vector::populateVectorMultiReductionFlatteningPatterns(
+          contractLoweringPatterns,
+          vector::VectorMultiReductionLowering::InnerReduction);
+      vector::populateVectorMultiReductionUnrollingPatterns(
           contractLoweringPatterns,
           vector::VectorMultiReductionLowering::InnerReduction);
       contractLoweringPatterns.add<UnrollElementwiseOps>(funcOp->getContext());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -499,7 +499,11 @@ static void populateMultiReductionLoweringPatterns(Operation *target,
                                                    PatternBenefit benefit) {
   assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
 
-  vector::populateVectorMultiReductionLoweringPatterns(
+  vector::populateVectorMultiReductionReorderAndExpandPatterns(
+      patterns, vector::VectorMultiReductionLowering::InnerReduction, benefit);
+  vector::populateVectorMultiReductionFlatteningPatterns(
+      patterns, vector::VectorMultiReductionLowering::InnerReduction, benefit);
+  vector::populateVectorMultiReductionUnrollingPatterns(
       patterns, vector::VectorMultiReductionLowering::InnerReduction, benefit);
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
@@ -80,7 +80,11 @@ public:
       vector::populateVectorBroadcastLoweringPatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
           patterns, options.vectorContractLowering);
-      vector::populateVectorMultiReductionLoweringPatterns(
+      vector::populateVectorMultiReductionReorderAndExpandPatterns(
+          patterns, vector::VectorMultiReductionLowering::InnerParallel);
+      vector::populateVectorMultiReductionFlatteningPatterns(
+          patterns, vector::VectorMultiReductionLowering::InnerParallel);
+      vector::populateVectorMultiReductionUnrollingPatterns(
           patterns, vector::VectorMultiReductionLowering::InnerParallel);
       vector::populateVectorTransposeLoweringPatterns(
           patterns, options.vectorTransposeLowering);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -391,7 +391,11 @@ public:
         return WalkResult::advance();
       });
       RewritePatternSet patterns(context);
-      vector::populateVectorMultiReductionLoweringPatterns(
+      vector::populateVectorMultiReductionReorderAndExpandPatterns(
+          patterns, vector::VectorMultiReductionLowering::InnerParallel);
+      vector::populateVectorMultiReductionFlatteningPatterns(
+          patterns, vector::VectorMultiReductionLowering::InnerParallel);
+      vector::populateVectorMultiReductionUnrollingPatterns(
           patterns, vector::VectorMultiReductionLowering::InnerParallel);
       if (failed(applyOpPatternsGreedily(reductionOps, std::move(patterns)))) {
         funcOp.emitOpError("vector lowering failed");


### PR DESCRIPTION
`populateVectorMultiReductionLoweringPatterns` is being deprecated upstream. See https://github.com/llvm/llvm-project/pull/180750 for reference. This populate method has been replaced for three populate methods with a finer level of granularity.

* `populateVectorMultiReductionReorderAndExpandPatterns`
* `populateVectorMultiReductionFlatteningPatterns`
* `populateVectorMultiReductionUnrollingPatterns`