### PR TITLE
[GPU][Codegen] Implement virtual sparse mfma (VSMFMA)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1212,6 +1212,11 @@ getMNKShape(VirtualMMAIntrinsic type) {
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16:
     return {32, 32, 16};
+  // Sparse trick VSMFMAs for skinny GEMMs: semantically 8x16xK.
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16:
+    return {8, 16, 32};
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8:
+    return {8, 16, 64};
   }
   assert(false && "unhandled virtual mma layout type.");
   return {};
@@ -1222,6 +1227,8 @@ getABCElementTypes(MLIRContext *context, VirtualMMAIntrinsic type) {
   Type f8E4M3FNUZ = Float8E4M3FNUZType::get(context);
   Type f16 = Float16Type::get(context);
   Type f32 = Float32Type::get(context);
+  Type i8 = IntegerType::get(context, 8);
+  Type i32 = IntegerType::get(context, 32);
 
   switch (type) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
@@ -1234,6 +1241,12 @@ getABCElementTypes(MLIRContext *context, VirtualMMAIntrinsic type) {
     return {f16, f16, f32};
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16:
     return {f16, f16, f32};
+  // Sparse trick VSMFMAs for skinny GEMMs: semantically 8x16xK.
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16:
+    return {f16, f16, f32};
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8: {
+    return {i8, i8, i32};
+  }
   }
   assert(false && "unhandled virtual mma layout type.");
   return {};
@@ -1283,7 +1296,9 @@ int64_t VirtualMMAAttr::getSubgroupSize() const {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
-  case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16: {
+  case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16:
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16:
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8: {
     return 64;
   }
   }
@@ -1322,6 +1337,52 @@ LogicalResult VirtualMMAAttr::populateOperandOffsetsSizesStrides(
   return success();
 }
 
+// Returns true on odd lanes and false on even lanes.
+static Value createLaneParityPredicate(OpBuilder &builder, Location loc) {
+  Value laneId = gpu::LaneIdOp::create(builder, loc, /*upper_bound=*/nullptr);
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value lowBit = arith::AndIOp::create(builder, loc, laneId, one);
+  return arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ne, lowBit,
+                               zero);
+}
+
+// Rearranges a dense LHS operand into sparse-trick ordering based on lane
+// parity.
+static Value selectSparseLHS(OpBuilder &builder, Location loc, Value denseLhs,
+                             Value isOddLane, ArrayRef<int64_t> evenLaneIndices,
+                             ArrayRef<int64_t> oddLaneIndices) {
+  Value evenLaneSparseLhs = vector::ShuffleOp::create(
+      builder, loc, denseLhs, denseLhs, evenLaneIndices);
+  Value oddLaneSparseLhs = vector::ShuffleOp::create(builder, loc, denseLhs,
+                                                     denseLhs, oddLaneIndices);
+  return arith::SelectOp::create(builder, loc, isOddLane, oddLaneSparseLhs,
+                                 evenLaneSparseLhs);
+}
+
+// Creates a constant sparse index vector for SMFMAC operations.
+//
+// The sparse index encodes which 2 positions out of each group of 4
+// K-elements are selected for 2:4 structured sparsity. Each 4-bit
+// field within selectorBits selects positions for one K-group:
+//   0x4 (0100b) -> positions {0,1};  0xE (1110b) -> positions {2,3}.
+//
+// For 16-bit source data (f16/bf16): vector<4xi8>, 2 groups per i8.
+// For 8-bit source data (i8): vector<2xi16>, 4 groups per i16.
+//
+// Only the first element carries active selector bits; remaining
+// elements are padding zeros.
+static Value createConstSparseIndex(OpBuilder &builder, Location loc,
+                                    VectorType sparseIndexVectorType,
+                                    int64_t selectorBits) {
+  Type elemTy = sparseIndexVectorType.getElementType();
+  Value zero = arith::ConstantOp::create(
+      builder, loc, builder.getZeroAttr(sparseIndexVectorType));
+  Value selector = arith::ConstantOp::create(
+      builder, loc, builder.getIntegerAttr(elemTy, selectorBits));
+  return vector::InsertOp::create(builder, loc, selector, zero, 0);
+}
+
 int64_t VirtualMMAAttr::getIntrinsicsK() const {
   switch (getIntrinsic()) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
@@ -1329,12 +1390,137 @@ int64_t VirtualMMAAttr::getIntrinsicsK() const {
     return 2;
   }
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
-  case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ: {
+  case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16:
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8: {
     return 1;
   }
   }
   assert(false && "unhandled virtual mma layout type.");
   return 0;
+}
+
+// Expand collapsed ACC [c0, c1] -> [c0, 0, c1, 0].
+static Value expandAccumulator(OpBuilder &builder, Location loc, Value acc) {
+  auto accType = cast<VectorType>(acc.getType());
+  Value zero =
+      arith::ConstantOp::create(builder, loc, builder.getZeroAttr(accType));
+
+  return vector::ShuffleOp::create(builder, loc, acc, zero,
+                                   ArrayRef<int64_t>{0, 2, 1, 3});
+}
+
+// Collapse expanded ACC [d0, d1, d2, d3] -> [d0+d1, d2+d3].
+static Value collapseAccumulator(OpBuilder &builder, Location loc, Value acc) {
+  auto accType = cast<VectorType>(acc.getType());
+  Type elementType = accType.getElementType();
+
+  Value evens = vector::ShuffleOp::create(builder, loc, acc, acc,
+                                          ArrayRef<int64_t>{0, 2});
+  Value odds = vector::ShuffleOp::create(builder, loc, acc, acc,
+                                         ArrayRef<int64_t>{1, 3});
+
+  if (isa<FloatType>(elementType)) {
+    return arith::AddFOp::create(builder, loc, evens, odds);
+  }
+  return arith::AddIOp::create(builder, loc, evens, odds);
+}
+
+// Struct with consolidated info necessary for sparse trick invocation as a
+// VSMFMA.
+struct VSMFMAConfig {
+  int64_t m, n, k;
+  VectorType sparseIndexVectorType;
+  int64_t evenSparseIndex;
+  int64_t oddSparseIndex;
+  ArrayRef<int64_t> evenLaneLhsIndices;
+  ArrayRef<int64_t> oddLaneLhsIndices;
+};
+
+// Virtual Sparse MFMA (VSMFMA) ops represent invocations of the sparse trick
+// targeting skinny GEMMs (M=8).
+//
+// === The sparse trick ===
+//
+// Sparse MFMA (V_SMFMAC) instructions perform MMA on an imbalanced pair of
+// operands: a 4:2 structured-sparse matrix A and a dense matrix B. The
+// instruction also takes a sparsity index that encodes which 2 of every 4
+// elements along K are non-zero within the sparse matrix A. The trick exploits
+// this by pairing even/odd lanes to jointly describe a full dense row. For
+// example, with i8 (K=64, 16 elements per thread along K):
+//
+//   Logical row 0 (16 elements along K):
+//   K0 K1 K2 K3 | K4 K5 K6 K7 | K8 K9 K10 K11 | K12 K13 K14 K15
+//
+//   Lane 0 (even, sparse index 0x4444 -> positions {0,1} per group of 4):
+//   K0 K1  _  _ | K4 K5  _  _ | K8  K9   _   _  | K12 K13  _   _
+//
+//   Lane 1 (odd,  sparse index 0xEEEE -> positions {2,3} per group of 4):
+//    _  _ K2 K3 |  _  _ K6 K7 |  _   _  K10 K11 |  _   _  K14 K15
+//
+// The lane-pairing layout maps each of the 8 logical M-rows to a pair of
+// adjacent physical rows (row 2i and 2i+1 for logical row i). Within each pair,
+// the even lane supplies positions {0,1} from each K-group of 4 and the odd
+// lane supplies positions {2,3}. The hardware interprets each physical row as
+// having 2:4 structured sparsity and computes a partial dot product over only
+// its non-zero elements. Summing the two physical rows' results reconstructs
+// the full dense dot product for the logical row. This yields a semantic M=8
+// matmul from a physical 16×16 instruction.
+//
+// === Operand packing ===
+//
+// The LHS operand arrives as a dense vector of K-elements for one M-row
+// (e.g. vector<8xf16> for f16, vector<16xi8> for i8). selectSparseLHS picks
+// the appropriate half based on lane parity:
+//   even lanes: {0,1, 4,5, ...}   (first 2 of each group of 4)
+//   odd  lanes: {2,3, 6,7, ...}   (last 2 of each group of 4)
+//
+// createConstSparseIndex builds the matching sparsity index vector that tells
+// the hardware which K-positions each lane's compressed elements correspond to
+// (0x44/0x4444 for even, 0xEE/0xEEEE for odd).
+//
+// === Accumulator expand/collapse ===
+//
+// Because the sparse trick maps two hardware rows to one logical row, adjacent
+// register pairs in the output hold partial sums for the same dense row.
+// Collapsing sums each pair (v0+v1, v2+v3) produce the 2-element semantic
+// result: one complete value per logical row.
+//
+// The layout and distribution infrastructure operate on the collapsed vector
+// (e.g vector<2xf32>). buildVSMFMAOp handles the translation: it expands
+// a collapsed accumulator into the 4-element physical form before the smfmac,
+// then collapses the result back afterward.
+static LogicalResult buildVSMFMAOp(OpBuilder &builder, Location loc,
+                                   const VSMFMAConfig &config,
+                                   ValueRange inputs, Value acc,
+                                   SmallVectorImpl<Value> &results) {
+  Value smfmacAcc = expandAccumulator(builder, loc, acc);
+  auto expandedAccType = cast<VectorType>(smfmacAcc.getType());
+
+  // Find lane ID parity.
+  Value isOddLane = createLaneParityPredicate(builder, loc);
+
+  // Select indices owned by thread depending on lane ID parity.
+  Value sparseLhs =
+      selectSparseLHS(builder, loc, inputs[0], isOddLane,
+                      config.evenLaneLhsIndices, config.oddLaneLhsIndices);
+
+  // Select sparse index to pass in to smfmac depending on lane ID parity.
+  Value sparseIndex = arith::SelectOp::create(
+      builder, loc, isOddLane,
+      createConstSparseIndex(builder, loc, config.sparseIndexVectorType,
+                             config.oddSparseIndex),
+      createConstSparseIndex(builder, loc, config.sparseIndexVectorType,
+                             config.evenSparseIndex));
+
+  Value smfmacResult = amdgpu::SparseMFMAOp::create(
+      builder, loc, expandedAccType, config.m, config.n, config.k, sparseLhs,
+      inputs[1], smfmacAcc, sparseIndex,
+      /*cbsz=*/0, /*abid=*/0);
+
+  Value result = collapseAccumulator(builder, loc, smfmacResult);
+  results.push_back(result);
+  return success();
 }
 
 // Generates amdgpu.mfma/wmma operation on the given inputs for this attribute
@@ -1393,6 +1579,38 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
     results.push_back(acc);
     return success();
   }
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16: {
+    if (getColMajor()) {
+      return failure();
+    }
+    static constexpr int64_t kEvenIndices[] = {0, 1, 4, 5};
+    static constexpr int64_t kOddIndices[] = {2, 3, 6, 7};
+    VSMFMAConfig config{/*m=*/16,
+                        /*n=*/16,
+                        /*k=*/32,
+                        VectorType::get({4}, builder.getIntegerType(8)),
+                        /*evenSparseIndex=*/0x44,
+                        /*oddSparseIndex=*/0xEE,
+                        kEvenIndices,
+                        kOddIndices};
+    return buildVSMFMAOp(builder, loc, config, inputs, outputs[0], results);
+  }
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8: {
+    if (getColMajor()) {
+      return failure();
+    }
+    static constexpr int64_t kEvenIndices[] = {0, 1, 4, 5, 8, 9, 12, 13};
+    static constexpr int64_t kOddIndices[] = {2, 3, 6, 7, 10, 11, 14, 15};
+    VSMFMAConfig config{/*m=*/16,
+                        /*n=*/16,
+                        /*k=*/64,
+                        VectorType::get({2}, builder.getIntegerType(16)),
+                        /*evenSparseIndex=*/0x4444,
+                        /*oddSparseIndex=*/0xEEEE,
+                        kEvenIndices,
+                        kOddIndices};
+    return buildVSMFMAOp(builder, loc, config, inputs, outputs[0], results);
+  }
   }
   return failure();
 }
@@ -1402,7 +1620,9 @@ int64_t VirtualMMAAttr::getBlockSize() const {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
-  case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16: {
+  case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16:
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16:
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8: {
     return 1;
   }
   }
@@ -1467,6 +1687,30 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(VirtualMMAIntrinsic intrinsic,
     case kMMAOperandAcc:
       return {/*outer=*/{4, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
               /*element=*/{4, 1}};
+    }
+  case VirtualMMAIntrinsic::VSMFMA_F32_16x16x32_F16:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
+      return {/*outer=*/{1, 1}, /*thread=*/{8, 4}, /*tstrides=*/{2, 16},
+              /*element=*/{1, 8}};
+    case kMMAOperandRhs:
+      return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
+              /*element=*/{8, 1}};
+    case kMMAOperandAcc:
+      return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
+              /*element=*/{2, 1}};
+    }
+  case VirtualMMAIntrinsic::VSMFMA_I32_16x16x64_I8:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
+      return {/*outer=*/{1, 1}, /*thread=*/{8, 4}, /*tstrides=*/{2, 16},
+              /*element=*/{1, 16}};
+    case kMMAOperandRhs:
+      return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
+              /*element=*/{16, 1}};
+    case kMMAOperandAcc:
+      return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
+              /*element=*/{2, 1}};
     }
   }
   assert(false && "unhandled virtual mma layout type.");

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -373,6 +373,8 @@ def VMFMA_F32_16x16x32_F16  : I32EnumAttrCase<"VMFMA_F32_16x16x32_F16", 0>;
 def VMFMA_F32_32x32x16_F16  : I32EnumAttrCase<"VMFMA_F32_32x32x16_F16", 1>;
 def VMFMA_F32_16x16x32_F8E4M3FNUZ  : I32EnumAttrCase<"VMFMA_F32_16x16x32_F8E4M3FNUZ", 2>;
 def VMFMA_F32_32x32x16_F8E4M3FNUZ  : I32EnumAttrCase<"VMFMA_F32_32x32x16_F8E4M3FNUZ", 3>;
+def VSMFMA_F32_16x16x32_F16  : I32EnumAttrCase<"VSMFMA_F32_16x16x32_F16", 4>;
+def VSMFMA_I32_16x16x64_I8   : I32EnumAttrCase<"VSMFMA_I32_16x16x64_I8", 5>;
 
 def IREEGPU_VirtualMMAIntrinsic : IREEGPU_I32EnumAttr<"VirtualMMAIntrinsic",
     "Descriptor for different Virtual MMA intrinsics", [
@@ -380,6 +382,8 @@ def IREEGPU_VirtualMMAIntrinsic : IREEGPU_I32EnumAttr<"VirtualMMAIntrinsic",
       VMFMA_F32_32x32x16_F16,
       VMFMA_F32_16x16x32_F8E4M3FNUZ,
       VMFMA_F32_32x32x16_F8E4M3FNUZ,
+      VSMFMA_F32_16x16x32_F16,
+      VSMFMA_I32_16x16x64_I8,
     ]>;
 
 // Enum for scaled mma intrinsic, loosely matching the MMAIntrinsic enum above

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -37,6 +37,24 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16, col_major = true>
 
 module {
+  func.func @test_vsmfma_f16_16x16x32() attributes {
+      mma_types = #iree_gpu.virtual_mma_layout<VSMFMA_F32_16x16x32_F16>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_vsmfma_f16_16x16x32
+//  CHECK-SAME:   mma_types = #iree_gpu.virtual_mma_layout<VSMFMA_F32_16x16x32_F16>
+
+module {
+  func.func @test_vsmfma_i8_16x16x64() attributes {
+      mma_types = #iree_gpu.virtual_mma_layout<VSMFMA_I32_16x16x64_I8>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_vsmfma_i8_16x16x64
+//  CHECK-SAME:   mma_types = #iree_gpu.virtual_mma_layout<VSMFMA_I32_16x16x64_I8>
+
+module {
   func.func @test_WMMAR3_f16_16x16x16_f32() attributes {
       mma_types = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>} {
     return


### PR DESCRIPTION
This PR introduces virtual sparse MFMAs (VSMFMA), which implement the sparse trick for skinny GEMM (M=8) workloads originally described in the hugging face article [Creating custom kernels for the AMD MI300](https://huggingface.co/blog/mi300kernels). Specifically, this patch implements `VSMFMA_F32_16x16x32_F16` and `VSMFMA_I32_16x16x64_I8`. Plumbing `VSMFMA` through MMA selection and support for other variants will be follow-up PRs.

Sparse MFMA (V_SMFMAC) instructions perform MMA on an imbalanced pair of operands: a 4:2 structured-sparse matrix A and a dense matrix B. The instruction also takes a sparsity index that encodes which 2 of every 4 elements along K are non-zero within the sparse matrix A. The trick exploits this by pairing even/odd lanes to jointly describe a full dense row. For example, with `i8` (`K=64`, 16 elements per thread along K):

```
Logical row 0 (16 elements along K):
K0 K1 K2 K3 | K4 K5 K6 K7 | K8 K9 K10 K11 | K12 K13 K14 K15

Lane 0 (even, sparse index 0x4444 -> selects positions {0,1} per group of 4):
K0 K1  _  _ | K4 K5  _  _ | K8  K9   _   _  | K12 K13  _   _

Lane 1 (odd,  sparse index 0xEEEE -> selects positions {2,3} per group of 4):
_  _ K2 K3 |  _  _ K6 K7 |  _   _  K10 K11 |  _   _  K14 K15

```

The lane-pairing layout maps each of the 8 logical M-rows to a pair of adjacent physical rows (`row 2i` and `2i+1` for logical row `i`). Within each pair, the even lane supplies positions
  `{0,1}` from each K-group of 4 and the odd lane supplies positions `{2,3}`. The hardware interprets each physical row as having 2:4 structured sparsity and computes a partial dot product over only its non-zero elements. Summing the two physical rows' results reconstructs the full dense dot product for the logical row. This yields a semantic `M=8` matmul from a physical `16×16` instruction.

The benefit over the current approach of padding M=8 to M=16 for dense MFMA is that sparse MFMA processes twice the K-depth of the equivalent dense MFMA in the same number of cycles. The overhead of packing the sparse A operand and collapsing the accumulator partials is outweighed by the throughput gain. In HIP microbenchmarks on gfx942, the sparse trick achieves ~1.5–2x throughput improvement over padding to M=16 for M=8 skinny GEMMs.

For more context: #22863
HIP implementation: https://github.com/nod-ai/hip-matmul/pull/17

Assisted by: Claude