### PR TITLE
[DispatchCreation] Set split reduction sizes for batch first conv layouts

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -112,14 +112,13 @@ getOuterReductionSizes(PartialReductionOpInterface op,
   return tileSizes;
 }
 
-/// Determines split reduction sizes for weight backward convolutions.
-/// These convolutions have a special CHWN or CNHW layout, where the filter
-/// sizes (corresponding to output image sizes in forward convolutions) are
-/// typically large, while the output spatial dimensions are small. This makes
-/// the split reduction strategy particularly effective.
+/// Determines split reduction sizes for convolutions. Analyzes the convolution
+/// structure to find reduction dimensions that can be split to improve
+/// parallelism. Splitting can be applied across multiple reduction dimensions,
+/// with tile sizes varying according to the output (parallel dimension) sizes.
 static std::optional<SmallVector<int64_t>>
-getWeightBackwardReductionSizes(PartialReductionOpInterface op,
-                                int64_t splitReductionTargetSize) {
+getConvolutionReductionSizes(PartialReductionOpInterface op,
+                             int64_t splitReductionTargetSize) {
   // First check if the input op is a convolution with static shapes.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
   if (!linalgOp || !linalg::isaConvolutionOpInterface(linalgOp)) {
@@ -193,17 +192,6 @@ getWeightBackwardReductionSizes(PartialReductionOpInterface op,
     return std::nullopt;
   }
 
-  // Only apply to weight backward convolutions with CHWN or CNHW layout.
-  if (batchPos.front() == 0) {
-    LDBG() << "skipping op; not apply to batch first layout";
-    return std::nullopt;
-  }
-
-  if (!inputChannelPos.empty() && inputChannelPos.front() > filterPos.back()) {
-    LDBG() << "skipping op; not apply to channel last layout";
-    return std::nullopt;
-  }
-
   std::optional<SmallVector<int64_t>> maybeSizes =
       getReductionDimSizes(op.getOperation());
   if (!maybeSizes) {
@@ -228,16 +216,17 @@ getWeightBackwardReductionSizes(PartialReductionOpInterface op,
   int64_t depthSize = getSizeAt(outputShape, depthPos);
 
   // The constants below are determined based on empirical data.
-  const int64_t largeParallelSize = 512;
+  const int64_t largeParallelSize = 640000;
   const int64_t largeReductionSize = 8192;
   const int64_t ratioThreshold = 64;
 
-  // When the batch and output channel sizes are large, the workload tends
-  // to distributed across many workgroups, making split reduction little to
-  // no effect.
-  if (outputChannelSize >= largeParallelSize &&
-      batchSize >= largeParallelSize) {
-    LDBG() << "skipping op; large output channel or batch size";
+  // When the parallel dimension sizes are large, the workload tends to
+  // distributed across many workgroups, making split reduction little to no
+  // effect.
+  bool isBatchFirstLayout = batchPos.front() == 0;
+  int64_t mainDistributedSize = isBatchFirstLayout ? imageSize : batchSize;
+  if (outputChannelSize * mainDistributedSize >= largeParallelSize) {
+    LDBG() << "skipping op; large parallel dimension sizes";
     return std::nullopt;
   }
 
@@ -256,6 +245,8 @@ getWeightBackwardReductionSizes(PartialReductionOpInterface op,
   // workgroups, thereby reducing the need for extensive splitting along the
   // reduction dimensions.
   int64_t outputSize = outputChannelSize * batchSize * imageSize * depthSize;
+  int64_t startTileSize =
+      isBatchFirstLayout ? tileSizes.back() : tileSizes.front();
   int64_t limitParallelLoops;
   if (outputSize < 32 * 32) {
     limitParallelLoops = 2048;
@@ -266,12 +257,16 @@ getWeightBackwardReductionSizes(PartialReductionOpInterface op,
   } else if (outputSize < 512 * 512) {
     limitParallelLoops = 16;
   } else {
-    limitParallelLoops = std::min<int64_t>(16, tileSizes[0]);
+    limitParallelLoops = std::min<int64_t>(8, startTileSize);
   }
 
-  // Based on the limitParallelLoops, assign tile size from the outermost
-  // dimension to the innermost.
-  for (int64_t i = 0; i < tileSizes.size(); i++) {
+  // Based on the limitParallelLoops, assign tile size. For batch-first layout,
+  // go from the innermost dimension to the outermost; otherwise, go from the
+  // outermost to the innermost.
+  int64_t start = isBatchFirstLayout ? tileSizes.size() - 1 : 0;
+  int64_t end = isBatchFirstLayout ? -1 : tileSizes.size();
+  int64_t step = isBatchFirstLayout ? -1 : 1;
+  for (int64_t i = start; i != end; i += step) {
     int64_t lowerBound = llvm::divideCeil(tileSizes[i], limitParallelLoops);
     std::optional<int64_t> maybeTileSize =
         findSmallestFactorWithLowerBound(tileSizes[i], lowerBound);
@@ -478,8 +473,8 @@ struct SetSplitReductionSizesPass final
         return;
       }
 
-      // --- Case 2: Generic weight backward convolution ---
-      if (auto tileSizes = getWeightBackwardReductionSizes(
+      // --- Case 2: Generic convolution ---
+      if (auto tileSizes = getConvolutionReductionSizes(
               tilingOp, splitReductionTargetSize)) {
         IREE::LinalgExt::setSplitReductionAttribute(tilingOp, *tileSizes);
         return;

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
@@ -59,25 +59,48 @@ util.func public @conv_2d_cnhw_cfhw_large(%arg0: tensor<16x16x227x227xf32>, %arg
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @no_split_conv_2d_nhwc_fhwc(%arg0: tensor<16x227x227x16xf32>, %arg1: tensor<64x3x3x16xf32>, %arg2: tensor<16x225x225x64xf32>) -> tensor<16x225x225x64xf32> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x227x227x16xf32>, tensor<64x3x3x16xf32>) outs(%arg2 : tensor<16x225x225x64xf32>) {
-  ^bb0(%in: f32, %in_0: f32, %out: f32):
-    %3 = arith.mulf %in, %in_0 : f32
+util.func public @conv_2d_nhwc_fhwc(%arg0: tensor<32x15x15x2376xf16>, %arg1: tensor<256x3x3x2376xf16>, %arg2: tensor<32x13x13x256xf32>) -> tensor<32x13x13x256xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<32x15x15x2376xf16>, tensor<256x3x3x2376xf16>) outs(%arg2 : tensor<32x13x13x256xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
     %4 = arith.addf %out, %3 : f32
     linalg.yield %4 : f32
-  } -> tensor<16x225x225x64xf32>
-  util.return %0 : tensor<16x225x225x64xf32>
+  } -> tensor<32x13x13x256xf32>
+  util.return %0 : tensor<32x13x13x256xf32>
 }
 
-// CHECK-LABEL: @no_split_conv_2d_nhwc_fhwc
+// CHECK-LABEL: @conv_2d_nhwc_fhwc
+//       CHECK: iree_linalg_ext.split_reduction = [3 : index, 3 : index, 297 : index]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @no_split_nhwc_fhwc_large_output(%arg0: tensor<32x52x52x2376xf16>, %arg1: tensor<256x3x3x2376xf16>, %arg2: tensor<32x50x50x256xf32>) -> tensor<32x50x50x256xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<32x52x52x2376xf16>, tensor<256x3x3x2376xf16>) outs(%arg2 : tensor<32x50x50x256xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<32x50x50x256xf32>
+  util.return %0 : tensor<32x50x50x256xf32>
+}
+
+// CHECK-LABEL: @no_split_nhwc_fhwc_large_output
 //   CHECK-NOT: iree_linalg_ext.split_reduction
+
 
 // -----
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @no_split_large_N_F_sizes(%arg0: tensor<16x98x50x1024xf32>, %arg1: tensor<16x96x48x1024xf32>, %arg2: tensor<1024x3x3x1024xf32>) -> tensor<1024x3x3x1024xf32> {
+util.func public @no_split_chwn_chwf_large_N_F_sizes(%arg0: tensor<16x98x50x1024xf32>, %arg1: tensor<16x96x48x1024xf32>, %arg2: tensor<1024x3x3x1024xf32>) -> tensor<1024x3x3x1024xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x98x50x1024xf32>, tensor<16x96x48x1024xf32>) outs(%arg2 : tensor<1024x3x3x1024xf32>) {
   ^bb0(%in: f32, %in_3: f32, %out: f32):
     %12 = arith.mulf %in, %in_3 : f32
@@ -87,7 +110,7 @@ util.func public @no_split_large_N_F_sizes(%arg0: tensor<16x98x50x1024xf32>, %ar
   util.return %0 : tensor<1024x3x3x1024xf32>
 }
 
-// CHECK-LABEL:  @no_split_large_N_F_sizes
+// CHECK-LABEL:  @no_split_chwn_chwf_large_N_F_sizes
 //   CHECK-NOT:  iree_linalg_ext.split_reduction
 
 // -----
@@ -95,7 +118,7 @@ util.func public @no_split_large_N_F_sizes(%arg0: tensor<16x98x50x1024xf32>, %ar
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @no_split_small_H_W_sizes(%arg0: tensor<16x26x18x96xf32>, %arg1: tensor<16x24x16x96xf32>, %arg2: tensor<96x3x3x96xf32>) -> tensor<96x3x3x96xf32> {
+util.func public @no_split_chwn_chwf_small_H_W_sizes(%arg0: tensor<16x26x18x96xf32>, %arg1: tensor<16x24x16x96xf32>, %arg2: tensor<96x3x3x96xf32>) -> tensor<96x3x3x96xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x18x96xf32>, tensor<16x24x16x96xf32>) outs(%arg2 : tensor<96x3x3x96xf32>) {
   ^bb0(%in: f32, %in_3: f32, %out: f32):
     %12 = arith.mulf %in, %in_3 : f32
@@ -105,5 +128,5 @@ util.func public @no_split_small_H_W_sizes(%arg0: tensor<16x26x18x96xf32>, %arg1
   util.return %0 : tensor<96x3x3x96xf32>
 }
 
-// CHECK-LABEL:  @no_split_small_H_W_sizes
+// CHECK-LABEL:  @no_split_chwn_chwf_small_H_W_sizes
 //   CHECK-NOT:  iree_linalg_ext.split_reduction


### PR DESCRIPTION
This PR generalizes the convolution split reduction heuristic beyond weight backward convolutions to any convolution with large reduction dimensions relative to small output sizes, where splitting the reduction improves parallelism most effectively.

Some benchmark results (NHWC convolutions on MI355):

| # | Shape | Speedup | Baseline (μs) | Split Reduction (μs) | Saved (μs) |
| --- | --- | --- | --- | --- | --- |
| 1 | convfp16 -n 32 -c 256 -H 7 -W 7 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 2 -t 1 | 5.05x | 1024.1 | 202.7 | 821.4 |
| 2 | convfp16 -n 32 -c 256 -H 13 -W 13 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 2 -t 1 | 3.12x | 1137.6 | 364.9 | 772.7 |