### PR TITLE
Integrate llvm/llvm-project@c6cb8f3

### DIFF
--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -301,6 +301,12 @@ function(iree_llvm_add_external_project name location)
     endif()
   endif()
 
+  # Disable PCH for external projects (llvm/llvm-project@b82c7fc65229).
+  # External projects live in a separate binary dir from LLVM, so CMake cannot
+  # resolve the LLVMSupport PCH path for targets that try to reuse it.
+  # Function scope ensures this doesn't affect LLVM/MLIR's own PCH.
+  set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
+
   add_subdirectory(${location} "llvm-external-projects/${name}" EXCLUDE_FROM_ALL)
 endfunction()
 


### PR DESCRIPTION
Other points of interest:

- https://github.com/llvm/llvm-project/commit/b82c7fc65229 adds PCH infrastructure to LLVM with LLVMSupport PCH reuse. External projects (e.g., StableHLO) live in a separate binary dir from LLVM, so CMake cannot resolve the LLVMSupport PCH path for targets that try to reuse it. Fix by disabling PCH in the scope of iree_llvm_add_external_project(); LLVM/MLIR's own PCH is unaffected.