### PR TITLE
[Codegen] Move tuner attr flag to codegen options

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
@@ -98,6 +98,7 @@ iree_compiler_cc_library(
         ":UKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
+        "//compiler/src/iree/compiler/Codegen/Utils:CodegenOptions",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_cc_library(
     MLIRViewLikeInterface
     iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Interfaces::UKernelOpInterface
+    iree::compiler::Codegen::Utils::CodegenOptions
     iree::compiler::Dialect::Util::IR
     iree::compiler::Utils
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
+#include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -39,6 +40,8 @@ static ArrayAttr getIndexArrayAttr(MLIRContext *context,
         return IntegerAttr::get(IndexType::get(context), APInt(64, value));
       }));
 }
+
+bool shouldSetTunerAttributes() { return CodegenOptions::setTunerAttributes; }
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -12,7 +12,6 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/SCF/IR/DeviceMappingInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -28,11 +27,8 @@ using TileSizesListTypeRef = ArrayRef<SmallVector<int64_t>>;
 /// Typedef for scalable tile flags at different levels of tiling.
 using ScalableTileFlagsListType = SmallVector<SmallVector<bool>>;
 using ScalableTileFlagsListTypeRef = ArrayRef<SmallVector<bool>>;
-/// Flag to add attributes for tuner.
-inline llvm::cl::opt<bool>
-    clSetTunerAttr("iree-config-add-tuner-attributes",
-                   llvm::cl::desc("Adds attribute for tuner."),
-                   llvm::cl::init(false));
+/// Returns whether tuner attributes should be set on root ops.
+bool shouldSetTunerAttributes();
 } // namespace mlir::iree_compiler
 
 // clang-format off
@@ -71,7 +67,7 @@ getWorkgroupSize(mlir::FunctionOpInterface funcOp);
 /// Returns the subgroup size specified on the `exportOp`.
 std::optional<int64_t> getSubgroupSize(mlir::FunctionOpInterface funcOp);
 
-/// Sets and overwites the translate executable info for the given entry point.
+/// Sets and overwrites the translate executable info for the given entry point.
 /// Returns success() at the end. It is convenient when a caller need to
 /// propagate the state.
 LogicalResult
@@ -146,7 +142,7 @@ inline LogicalResult setOpConfigAndEntryPointFnTranslation(
     mlir::FunctionOpInterface entryPointFn, Operation *op,
     IREE::Codegen::LoweringConfigAttrInterface config,
     IREE::Codegen::TranslationInfoAttr translationInfo) {
-  if (clSetTunerAttr) {
+  if (shouldSetTunerAttributes()) {
     setRootOpInfo(op);
   }
   if (config) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -22,6 +22,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
@@ -785,7 +785,7 @@ LogicalResult setReductionConfig(IREE::GPU::TargetAttr target,
       context, CodeGenPipeline::LLVMGPUVectorDistribute, SymbolRefAttr(),
       {workgroupSize, 1, 1}, subgroupSize, pipelineConfig);
 
-  if (clSetTunerAttr) {
+  if (shouldSetTunerAttributes()) {
     setRootOpInfo(op);
   }
   return setTranslationInfo(entryPoint, translationInfo);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_root_op_attribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_root_op_attribute.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-config-add-tuner-attributes --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-codegen-add-tuner-attributes --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
 
 func.func @matmul(%lhs: tensor<4x4xf32>, %rhs: tensor<4x4xf32>) -> tensor<4x4xf32> {
   %c0 = arith.constant 0.0 : f32

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -12,6 +12,7 @@ IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 namespace mlir::iree_compiler {
 
 std::string CodegenOptions::tuningSpecPath = "";
+bool CodegenOptions::setTunerAttributes = false;
 
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category("IREE Codegen Options");
@@ -21,6 +22,10 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc("Path to a module containing a tuning spec (transform "
                      "dialect library). Accepts MLIR text (.mlir) and "
                      "bytecode (.mlirbc) formats."));
+
+  binder.opt<bool>("iree-config-add-tuner-attributes", setTunerAttributes,
+                   llvm::cl::cat(category),
+                   llvm::cl::desc("Adds attribute for tuner."));
 }
 
 void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -23,9 +23,16 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
                      "dialect library). Accepts MLIR text (.mlir) and "
                      "bytecode (.mlirbc) formats."));
 
-  binder.opt<bool>("iree-config-add-tuner-attributes", setTunerAttributes,
+  binder.opt<bool>("iree-codegen-add-tuner-attributes", setTunerAttributes,
                    llvm::cl::cat(category),
                    llvm::cl::desc("Adds attribute for tuner."));
+
+  // Deprecated alias for the old spelling.
+  binder.opt<bool>(
+      "iree-config-add-tuner-attributes", setTunerAttributes,
+      Deprecated("use --iree-codegen-add-tuner-attributes instead"),
+      llvm::cl::Hidden, llvm::cl::desc("Adds attribute for tuner."),
+      llvm::cl::cat(category));
 }
 
 void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -22,6 +22,9 @@ struct CodegenOptions {
   // Path to a module containing a tuning spec.
   static std::string tuningSpecPath;
 
+  // Whether to add attributes for the tuner on root ops.
+  static bool setTunerAttributes;
+
   void bindOptions(OptionsBinder &binder);
 };
 

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -201,7 +201,7 @@ thread count. For a given input graph, the knobs associated with a particular
 dispatch can be seen by adding the following flags when compiling.
 
 * `--iree-hal-dump-executable-benchmarks-to=<directory>`
-* `--iree-config-add-tuner-attributes`
+* `--iree-codegen-add-tuner-attributes`
 
 These will dump standalone hal.executable benchmarks for each dispatch. Within
 these benchmark files we can find an attribute associated to the root op of the


### PR DESCRIPTION
Do not rely on an inline variable for flags. This follows how we handle other flags shared across GPU and CPU
pipelines.

Rename the flag but add alias with the old spelling. The new flag name is `--iree-codegen-add-tuner-attributes`.

Assisted-by: claude

Issue: https://github.com/iree-org/iree/issues/23535