### PR TITLE
[hip] Clear sticky error after hipErrorPeerAccessAlreadyEnabled

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -47,6 +47,7 @@ IREE_HAL_HIP_OPTIONAL_PFN_DECL(hipGetDeviceProperties, hipDeviceProp_tR0000*,
 // const char* instead of hipError_t so it uses a different macro.
 IREE_HAL_HIP_REQUIRED_PFN_STR_DECL(hipGetErrorName, hipError_t)
 IREE_HAL_HIP_REQUIRED_PFN_STR_DECL(hipGetErrorString, hipError_t)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGetLastError)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGraphAddEmptyNode, hipGraphNode_t*,
                                hipGraph_t, const hipGraphNode_t*, size_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGraphAddEventRecordNode, hipGraphNode_t*,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -453,7 +453,9 @@ static iree_status_t iree_hal_hip_device_enable_peering(
 
     hip_error = symbols->hipDeviceEnablePeerAccess(j, 0);
     if (hip_error == hipErrorPeerAccessAlreadyEnabled) {
-      // Already peered. That's okay.
+      // Already peered. That's okay. Clear the sticky error so it doesn't
+      // affect subsequent HIP calls.
+      symbols->hipGetLastError();
       continue;
     } else if (hip_error != hipSuccess) {
       // Unhandled error, propagate it.


### PR DESCRIPTION
On ROCm 7.0+, `hipGetLastError` was changed to match CUDA's sticky error semantics — errors now persist until explicitly cleared with `hipGetLastError()`, rather than being reset by subsequent successful API calls. This means any HIP call that returns a non-success error code (even an expected one) will leave a sticky error that can break later operations in the same thread.

One case where this surfaces is `hipDeviceEnablePeerAccess`: when PyTorch enables peer access before IREE initializes, IREE's redundant call returns `hipErrorPeerAccessAlreadyEnabled`. Previously this was harmless, but with sticky errors it breaks subsequent PyTorch operations.

This adds a `hipGetLastError()` call to clear the expected error, mirroring [PyTorch's pattern](https://github.com/pytorch/pytorch/blob/6bde79ce1e64adc412412ed8e6e58e5f0a641d54/c10/cuda/CUDACachingAllocator.cpp#L4408-L4411).

Fixes iree-org/iree-turbine#1265

### `hipGetLastError` behavior change history

1. [`ROCm/clr@3dc47bc`](https://github.com/ROCm/clr/commit/3dc47bc8392a6edb1d1a9a4b328b88c844f6f014) (Sep 2021) — first attempt to match CUDA sticky error semantics
2. [`ROCm/clr@ce0995e`](https://github.com/ROCm/clr/commit/ce0995e799139e48e64c51f49a37e82351686fa8) (Oct 2021) — reverted
3. [`ROCm/clr@5f477900`](https://github.com/ROCm/clr/commit/5f477900a3cfe7f8f54879aae65fce696c1697ab) (Aug 2024) — re-introduced, env var gated
4. [`ROCm/clr@582dc7dd`](https://github.com/ROCm/clr/commit/582dc7dd6dbbfc8dda346b4228620196d138b679) (Nov 2024) — reverted again
5. [`ROCm/clr@e3b87544`](https://github.com/ROCm/clr/commit/e3b87544482f43760e0bf1c49e628039199c4bdf) (Nov 2024) — re-added behind `DEBUG_HIP_7_PREVIEW` env var
6. [`ROCm/clr@664bf232`](https://github.com/ROCm/clr/commit/664bf232dd9e4b6d9ef68a89f26fc65941dd3a86) (May 2025) — removed env var, made default