### PR TITLE
[docs] Fix invalid flag names and typos

### DIFF
--- a/docs/website/docs/developers/building/emscripten.md
+++ b/docs/website/docs/developers/building/emscripten.md
@@ -52,7 +52,7 @@ $ cmake --build ../iree-build-host/ --target install
 
 ```shell
 $ emcmake cmake -G Ninja -B ../iree-build-emscripten/ \
-  -DCMake_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=Release \
   -DIREE_HOST_BIN_DIR=$(realpath ../iree-build-host/install/bin) \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_COMPILER=OFF \

--- a/docs/website/docs/developers/update-sdxl-golden-outputs.md
+++ b/docs/website/docs/developers/update-sdxl-golden-outputs.md
@@ -66,7 +66,6 @@ iree-build/tools/iree-compile \
   --iree-vm-target-truncate-unsupported-floats \
   --iree-llvmgpu-enable-prefetch=true \
   --iree-opt-data-tiling=false \
-  --iree-codegen-gpu-native-math-precision=true \
   --iree-codegen-llvmgpu-use-vector-distribution \
   --iree-rocm-waves-per-eu=2 \
   --iree-execution-model=async-external \

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -115,7 +115,7 @@ print(list(loaded_model.signatures.keys()))
     ["Missing serving signature in SavedModel"](#missing-serving-signature-in-savedmodel).
 
 Then you can import the model with `iree-import-tf`. You can read the options
-supported via `iree-import-tf -help`. Using
+supported via `iree-import-tf --help`. Using
 [MobileNet v2](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
 as an example and assuming the serving signature is `predict`:
 


### PR DESCRIPTION
I'm testing a new multi-model review tool, it reported some outdated docs:

- Remove nonexistent `--iree-codegen-gpu-native-math-precision` flag from SDXL golden outputs guide (found by GPT-5.3)
- Fix `CMake_BUILD_TYPE` -> `CMAKE_BUILD_TYPE` case typo in Emscripten build docs (found by GPT-5.3)
- Fix `iree-import-tf -help` -> `--help` in TensorFlow guide; the tool uses Python argparse which requires `-h` or `--help` (found by GPT-5.3)

Findings from Gemini Flash confirmed issues 1. and 3. independently.