### PR TITLE
[GPU][LDS] Fix promote_operands/promotion_types size mismatch

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -963,6 +963,11 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // If needed then add C operand which would be operand 2 or 4 for unscaled
     // and scaled GEMM respectively.
     promotionList.push_back(promotionList.size());
+    // Use default config attribute for the C promotion.
+    if (!promotionArray.empty()) {
+      promotionArray.push_back(
+          IREE::GPU::DerivedThreadConfigAttr::get(context));
+    }
   }
   ArrayRef<Attribute> promotionTypes = useDirectLoad
                                            ? ArrayRef<Attribute>(promotionArray)


### PR DESCRIPTION
Otherwise, enabling LDS DMA on fused matmul+elementwise ops, where matmul C operand is promoted, triggers an assertion at

https://github.com/iree-org/iree/blob/c23abe741b847f1db2ba742b22b0485cc19bc633/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp#L110-L111

because operands has 3 entries (A, B and C) but promotion_types only has 2.