### PR TITLE
[docs] Fix reference warnings and update metal-hal-driver.md

### DIFF
--- a/docs/website/docs/developers/debugging/llvm.md
+++ b/docs/website/docs/developers/debugging/llvm.md
@@ -41,7 +41,7 @@ in manually recreating the LLVM compilation so that you no longer have to
 route any changes through IREE.
 
 For more details and other related flags, see
-[the documentation on dumping intermediate files](../general/developer-tips/#dumping-executable-files).
+[the documentation on dumping intermediate files](../general/developer-tips.md#dumping-executable-files).
 
 !!! tip
 

--- a/docs/website/docs/developers/design-docs/metal-hal-driver.md
+++ b/docs/website/docs/developers/design-docs/metal-hal-driver.md
@@ -205,10 +205,6 @@ preprared GPU executables for a particular device. At the moment the Metal
 HAL driver does not peforming any caching on GPU programs; it simply reads the
 program from the FlatBuffer and hands it over to Metal driver.
 
-### Descriptor set / pipeline layout
-
-See [Resource descriptors](#resource-descriptors) for more details.
-
 ## Compute Pipeline
 
 ### Shader/kernel compilation

--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -198,7 +198,7 @@ and is not supported by Bazel rules.
 
 ### Code Coverage
 
-Use the [IREE_ENABLE_RUNTIME_COVERAGE](../../building/cmake-options/#iree_enable_runtime_coverage)
+Use the [IREE_ENABLE_RUNTIME_COVERAGE](../building/cmake-options.md#iree_enable_runtime_coverage)
 CMake option to enable code coverage instrumentation and add synthetic targets
 for managing profiling state. Tests run with coverage enabled with automatically
 write profiles to the build directory and then the


### PR DESCRIPTION
The resource binding implementation is already documented in "Command buffer dispatch" section which describes the MTLArgumentEncoder flow.