### PR TITLE
[Async] Split CTS sync tests into parallel binaries and eliminate timing deps

### DIFF
--- a/runtime/src/iree/async/cts/sync/BUILD.bazel
+++ b/runtime/src/iree/async/cts/sync/BUILD.bazel
@@ -174,22 +174,25 @@ iree_runtime_cc_library(
 )
 
 #===------------------------------------------------------------------------===#
-# Convenience targets
+# Test groups
 #===------------------------------------------------------------------------===#
 
-# All sync tests (link with backend library and main.cc for test binary).
+# Notification, cancellation, and signal tests.
 iree_runtime_cc_library(
-    name = "all_tests",
+    name = "notification_tests",
     testonly = True,
     deps = [
         ":cancellation_test",
         ":notification_test",
-        ":relay_test",
-        ":semaphore_async_test",
-        ":semaphore_linked_test",
-        ":semaphore_sync_test",
         ":signal_test",
-    ] + select({
+    ],
+)
+
+# Platform-specific tests: fences, platform primitive relays.
+iree_runtime_cc_library(
+    name = "platform_tests",
+    testonly = True,
+    deps = select({
         "//build_tools/bazel:iree_is_windows": [
             ":relay_windows_test",
         ],
@@ -202,6 +205,26 @@ iree_runtime_cc_library(
             ":relay_posix_test",
         ],
     }),
+)
+
+# Relay tests: portable notification-to-notification relay dataflow.
+iree_runtime_cc_library(
+    name = "relay_tests",
+    testonly = True,
+    deps = [
+        ":relay_test",
+    ],
+)
+
+# Semaphore tests: timeline semantics, async operations, chained wait/signal.
+iree_runtime_cc_library(
+    name = "semaphore_tests",
+    testonly = True,
+    deps = [
+        ":semaphore_async_test",
+        ":semaphore_linked_test",
+        ":semaphore_sync_test",
+    ],
 )
 
 #===------------------------------------------------------------------------===#

--- a/runtime/src/iree/async/cts/sync/CMakeLists.txt
+++ b/runtime/src/iree/async/cts/sync/CMakeLists.txt
@@ -160,28 +160,52 @@ iree_cc_library(
   PUBLIC
 )
 
-set(_all_tests_platform_deps "")
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  list(APPEND _all_tests_platform_deps ::relay_windows_test)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  list(APPEND _all_tests_platform_deps ::fence_posix_test)
-  list(APPEND _all_tests_platform_deps ::relay_posix_test)
-else()
-  list(APPEND _all_tests_platform_deps ::fence_posix_test)
-  list(APPEND _all_tests_platform_deps ::relay_posix_test)
-endif()
 iree_cc_library(
   NAME
-    all_tests
+    notification_tests
   DEPS
     ::cancellation_test
     ::notification_test
+    ::signal_test
+  TESTONLY
+  PUBLIC
+)
+
+set(_platform_tests_platform_deps "")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  list(APPEND _platform_tests_platform_deps ::relay_windows_test)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND _platform_tests_platform_deps ::fence_posix_test)
+  list(APPEND _platform_tests_platform_deps ::relay_posix_test)
+else()
+  list(APPEND _platform_tests_platform_deps ::fence_posix_test)
+  list(APPEND _platform_tests_platform_deps ::relay_posix_test)
+endif()
+iree_cc_library(
+  NAME
+    platform_tests
+  DEPS
+    ${_platform_tests_platform_deps}
+  TESTONLY
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    relay_tests
+  DEPS
     ::relay_test
+  TESTONLY
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    semaphore_tests
+  DEPS
     ::semaphore_async_test
     ::semaphore_linked_test
     ::semaphore_sync_test
-    ::signal_test
-    ${_all_tests_platform_deps}
   TESTONLY
   PUBLIC
 )

--- a/runtime/src/iree/async/platform/io_uring/cts/BUILD.bazel
+++ b/runtime/src/iree/async/platform/io_uring/cts/BUILD.bazel
@@ -110,12 +110,48 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
-    name = "sync_tests",
+    name = "sync_notification_tests",
     srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":backends",
-        "//runtime/src/iree/async/cts/sync:all_tests",
+        "//runtime/src/iree/async/cts/sync:notification_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_platform_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:platform_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_relay_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:relay_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_semaphore_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:semaphore_tests",
         "//runtime/src/iree/async/cts/util:registry",
         "//runtime/src/iree/testing:gtest",
     ],

--- a/runtime/src/iree/async/platform/io_uring/cts/CMakeLists.txt
+++ b/runtime/src/iree/async/platform/io_uring/cts/CMakeLists.txt
@@ -113,12 +113,54 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 iree_cc_test(
   NAME
-    sync_tests
+    sync_notification_tests
   SRCS
     "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
   DEPS
     ::backends
-    iree::async::cts::sync::all_tests
+    iree::async::cts::sync::notification_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+iree_cc_test(
+  NAME
+    sync_platform_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::platform_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+iree_cc_test(
+  NAME
+    sync_relay_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::relay_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+iree_cc_test(
+  NAME
+    sync_semaphore_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::semaphore_tests
     iree::async::cts::util::registry
     iree::testing::gtest
 )

--- a/runtime/src/iree/async/platform/iocp/cts/BUILD.bazel
+++ b/runtime/src/iree/async/platform/iocp/cts/BUILD.bazel
@@ -110,12 +110,48 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
-    name = "sync_tests",
+    name = "sync_notification_tests",
     srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":backends",
-        "//runtime/src/iree/async/cts/sync:all_tests",
+        "//runtime/src/iree/async/cts/sync:notification_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_platform_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:platform_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_relay_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:relay_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_semaphore_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:semaphore_tests",
         "//runtime/src/iree/async/cts/util:registry",
         "//runtime/src/iree/testing:gtest",
     ],

--- a/runtime/src/iree/async/platform/iocp/cts/CMakeLists.txt
+++ b/runtime/src/iree/async/platform/iocp/cts/CMakeLists.txt
@@ -113,12 +113,54 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 iree_cc_test(
   NAME
-    sync_tests
+    sync_notification_tests
   SRCS
     "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
   DEPS
     ::backends
-    iree::async::cts::sync::all_tests
+    iree::async::cts::sync::notification_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+iree_cc_test(
+  NAME
+    sync_platform_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::platform_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+iree_cc_test(
+  NAME
+    sync_relay_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::relay_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+iree_cc_test(
+  NAME
+    sync_semaphore_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::semaphore_tests
     iree::async::cts::util::registry
     iree::testing::gtest
 )

--- a/runtime/src/iree/async/platform/posix/cts/BUILD.bazel
+++ b/runtime/src/iree/async/platform/posix/cts/BUILD.bazel
@@ -116,12 +116,48 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
-    name = "sync_tests",
+    name = "sync_notification_tests",
     srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
     target_compatible_with = _POSIX_ONLY,
     deps = [
         ":backends",
-        "//runtime/src/iree/async/cts/sync:all_tests",
+        "//runtime/src/iree/async/cts/sync:notification_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_platform_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = _POSIX_ONLY,
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:platform_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_relay_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = _POSIX_ONLY,
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:relay_tests",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "sync_semaphore_tests",
+    srcs = ["//runtime/src/iree/async/cts/util:test_main.cc"],
+    target_compatible_with = _POSIX_ONLY,
+    deps = [
+        ":backends",
+        "//runtime/src/iree/async/cts/sync:semaphore_tests",
         "//runtime/src/iree/async/cts/util:registry",
         "//runtime/src/iree/testing:gtest",
     ],

--- a/runtime/src/iree/async/platform/posix/cts/CMakeLists.txt
+++ b/runtime/src/iree/async/platform/posix/cts/CMakeLists.txt
@@ -113,12 +113,54 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 iree_cc_test(
   NAME
-    sync_tests
+    sync_notification_tests
   SRCS
     "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
   DEPS
     ::backends
-    iree::async::cts::sync::all_tests
+    iree::async::cts::sync::notification_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+iree_cc_test(
+  NAME
+    sync_platform_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::platform_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+iree_cc_test(
+  NAME
+    sync_relay_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::relay_tests
+    iree::async::cts::util::registry
+    iree::testing::gtest
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+iree_cc_test(
+  NAME
+    sync_semaphore_tests
+  SRCS
+    "${PROJECT_SOURCE_DIR}/runtime/src/iree/async/cts/util/test_main.cc"
+  DEPS
+    ::backends
+    iree::async::cts::sync::semaphore_tests
     iree::async::cts::util::registry
     iree::testing::gtest
 )


### PR DESCRIPTION
Split the monolithic sync_tests binary (which ran all sync CTS tests serially per backend) into four parallel test targets:
  - sync_notification_tests (cancellation, notification, signal)
  - sync_platform_tests (platform-specific fences, primitive relays)
  - sync_relay_tests (portable notification-to-notification relays)
  - sync_semaphore_tests (timeline semantics, async ops, linked chains)

This reduces the io_uring CTS critical path from ~13s to ~1.3s by allowing Bazel/CTest to schedule the four binaries concurrently and eliminating all timing-based synchronization from the relay tests.

The original relay tests used waiter threads with 20ms settle waits and polling loops with 100ms timeouts — timing dependencies that are fragile on slow CI runners and accounted for ~4s of the old 13s critical path.

The new approach uses two verification strategies:

For most relay tests: verify relay side effects via epoch queries on the sink notification. DrainPending processes relay CQEs synchronously with immediate-timeout polls; after it returns, the epoch reflects whether the relay fired. No threads, no polling loops, no timing.

For TSAN cross-thread coverage: a dedicated NotificationRelayWakesCrossThread test uses an iree_notification_t gate with an epoch-checking predicate. The baseline epoch is captured before spawning the waiter thread, avoiding the three-actor race inherent in iree_async_notification_wait (which captures its baseline epoch internally at function entry — if the relay fires first, the waiter sees the already-incremented epoch as baseline and blocks until timeout). The gate's prepare/commit/cancel protocol makes this race-free across all thread interleavings.

The same gate pattern fixes the PrimitiveToNotification test in relay_posix_test.cc, which had the same race bug. All other POSIX and Windows relay tests now use the simpler DrainPending + synchronous check pattern, removing WaitPrimitiveReadable and WaitEventSignaled helpers.

Tested: ASAN 400/400 runs (4 targets x 100), TSAN clean, Windows IOCP, macOS kqueue.