### PR TITLE
[CI] Update IREE test suite

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
+          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
           path: iree-test-suites
       - name: Install ONNX ops test suite requirements
         run: |
@@ -199,7 +199,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
+          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
           path: iree-test-suites
       - name: Install ONNX models test suite requirements
         run: |

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
+          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
           path: iree-test-suites
           lfs: false
 
@@ -190,7 +190,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
+          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
           path: iree-test-suites
           lfs: false
 

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -33,27 +33,36 @@ jobs:
           - name: cpu_task
             markers: "cpu"
             config-file: torch_ops_cpu_llvm_sync.json
-            runs-on: ubuntu-24.04
+            cache-dir: /home/nod/iree_tests_cache
+            runs-on:
+              - self-hosted # Must come first.
+              - persistent-cache
+              - Linux
+              - X64
+              - threadripper
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]
+            cache-dir: /home/nod/iree_tests_cache
           - name: amdgpu_hip_gfx1201_O3
             config-file: torch_ops_gpu_hip_gfx1201_O3.json
             runs-on: [Linux, X64, gfx1201]
+            cache-dir: /home/nod/iree_tests_cache
           - name: amdgpu_vulkan_O3
             config-file: torch_ops_gpu_vulkan_O3.json
             # TODO(#22579): Remove `shark10-ci` label. There are vulkan driver issues on other runners.
             runs-on: [Linux, X64, rdna3, shark10-ci]
+            cache-dir: /home/nod/iree_tests_cache
           - name: amdgpu_rocm_mi300_gfx942_O3
             config-file: torch_ops_gpu_hip_gfx942_O3.json
             runs-on: linux-mi325-1gpu-ossci-iree-org
+            cache-dir: /shark-cache/data/iree-regression-cache
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       LOG_FILE_PATH: /tmp/test_torch_ops_${{ matrix.name }}_logs.json
       VENV_DIR: ${{ github.workspace }}/venv
       GH_TOKEN: ${{ github.token }}
       CONFIG_FILE_PATH: tests/external/iree-test-suites/torch_ops/${{ matrix.config-file }}
-      CACHE_DIR: /home/nod/iree_tests_cache
     steps:
       - name: Checking out IREE repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,7 +107,7 @@ jobs:
               --durations=20 \
               --report-log=${LOG_FILE_PATH} \
               --config-files=${CONFIG_FILE_PATH} \
-              --artifact-directory=${CACHE_DIR}/torch_ops/artifacts
+              --artifact-directory=${{ matrix.cache-dir }}/torch_ops/artifacts
 
   tests:
     name: "torch_models tests :: ${{ matrix.name }}"
@@ -113,7 +122,7 @@ jobs:
             cache-dir: /home/nod/iree_tests_cache
             summary-file: torch_models_cpu_task_summary.json
             runs-on:
-              - self-hosted # must come first
+              - self-hosted # Must come first.
               - persistent-cache
               - Linux
               - X64

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -53,6 +53,7 @@ jobs:
       VENV_DIR: ${{ github.workspace }}/venv
       GH_TOKEN: ${{ github.token }}
       CONFIG_FILE_PATH: tests/external/iree-test-suites/torch_ops/${{ matrix.config-file }}
+      CACHE_DIR: /home/nod/iree_tests_cache
     steps:
       - name: Checking out IREE repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -77,7 +78,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
+          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
           path: iree-test-suites
           lfs: false
       - name: Install Torch ops test suite requirements
@@ -96,7 +97,8 @@ jobs:
               --timeout=30 \
               --durations=20 \
               --report-log=${LOG_FILE_PATH} \
-              --config-files=${CONFIG_FILE_PATH}
+              --config-files=${CONFIG_FILE_PATH} \
+              --artifact-directory=${CACHE_DIR}/torch_ops/artifacts
 
   tests:
     name: "torch_models tests :: ${{ matrix.name }}"
@@ -146,7 +148,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 12c82056ac64e32c4a9599611364e5ce534e3a5d
+          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
           path: iree-test-suites
           # Don't need lfs for torch models yet.
           lfs: false


### PR DESCRIPTION
* Cache torch_ops expected output (useful to prevent timeouts)
* Move torch_ops targeting CPU to self-hosted runners

[Diff](https://github.com/iree-org/iree-test-suites/compare/12c82056ac64e32c4a9599611364e5ce534e3a5d..3182e7a131551362e5e5eb20bbb18bfa6e7eb89c)