### PR TITLE
[LDS] Clean up comments, add tests, and refactor DMA alignment checking.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -684,7 +684,7 @@ struct ConvertGatherToCoalescedDMA
       return failure();
     }
 
-    auto subgroupSize = getDMAAlignedSubgroupSize(
+    std::optional<int64_t> subgroupSize = getDMAAlignedSubgroupSize(
         funcOp, outputType.getElementType(), innermostDim);
     if (!subgroupSize) {
       return failure();
@@ -945,7 +945,10 @@ private:
     int64_t rank = outputType.getRank();
     ArrayRef<int64_t> shape = outputType.getShape();
 
-    // Check DMA alignment using the shared utility.
+    // Skip coalesced DMA if the available elements are not aligned to the
+    // minimum transfer size. The minimum transfer size is subgroupSize *
+    // minElementsPerLane, where minElementsPerLane is determined by the
+    // smallest DMA size and element type.
     int64_t innermostDim = shape[rank - 1];
     if (ShapedType::isDynamic(innermostDim)) {
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -413,9 +413,10 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     if (tensor::PadOp pad = traceToTensorPad(input)) {
       // Verify pad constraints: low padding must be all zeros, pad value must
       // be 0.
-      // TODO(#23365): Support non-zero pad values (e.g., -inf, 1) by emitting
-      // a select on the loaded values from LDS to replace OOB zeros with the
-      // desired padding element.
+      // TODO: Support non-zero pad values (e.g., -inf for softmax, 1 for
+      // identity). Currently, OOB reads return 0 via hardware clamping. For
+      // non-zero padding, we'd need to emit a post-DMA select on the LDS
+      // values to replace zeros with the desired pad element.
       bool validPad = true;
       for (OpFoldResult low : pad.getMixedLowPad()) {
         if (!isConstantIntValue(low, 0)) {
@@ -671,19 +672,11 @@ struct ConvertGatherToCoalescedDMA
       return failure();
     }
 
-    // Get the function containing this operation.
     auto funcOp = gatherOp->getParentOfType<FunctionOpInterface>();
     if (!funcOp) {
       return failure();
     }
 
-    // Get subgroup size from translation_info.
-    std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
-    if (!subgroupSize) {
-      return failure();
-    }
-
-    // Validate that innermost dimension is large enough for coalesced DMA.
     auto outputType = cast<RankedTensorType>(gatherOp.getOutput().getType());
     int64_t rank = outputType.getRank();
     int64_t innermostDim = outputType.getShape()[rank - 1];
@@ -691,32 +684,9 @@ struct ConvertGatherToCoalescedDMA
       return failure();
     }
 
-    Type elementType = outputType.getElementType();
-    int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
-    IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-    if (!target || !targetSupportsGlobalLoadDMA(target)) {
-      return failure();
-    }
-
-    ArrayRef<int64_t> dmaSizes;
-    if (DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes()) {
-      dmaSizes = dmaSizesAttr.asArrayRef();
-    }
-
-    int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-    for (int64_t dmaSize : dmaSizes) {
-      if (dmaSize % elementBits != 0) {
-        continue;
-      }
-      int64_t elementsPerLane = dmaSize / elementBits;
-      int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-      minElementsPerTransfer =
-          std::min(minElementsPerTransfer, elementsPerTransfer);
-    }
-
-    if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
-        innermostDim % minElementsPerTransfer != 0) {
+    auto subgroupSize = getDMAAlignedSubgroupSize(
+        funcOp, outputType.getElementType(), innermostDim);
+    if (!subgroupSize) {
       return failure();
     }
 
@@ -975,61 +945,26 @@ private:
     int64_t rank = outputType.getRank();
     ArrayRef<int64_t> shape = outputType.getShape();
 
-    // Skip coalesced DMA if the innermost dimension is smaller than the minimum
-    // transfer size. The minimum transfer size is subgroupSize *
-    // minElementsPerLane, where minElementsPerLane is determined by the
-    // smallest DMA size and element type.
+    // Check DMA alignment using the shared utility.
     int64_t innermostDim = shape[rank - 1];
     if (ShapedType::isDynamic(innermostDim)) {
       return failure();
     }
 
-    // Get the element type bit width.
-    Type elementType = outputType.getElementType();
-    int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
-    // Get DMA sizes from target to compute minimum transfer size.
-    IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-    if (!target) {
-      return failure();
-    }
-
-    ArrayRef<int64_t> dmaSizes;
-    if (DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes()) {
-      dmaSizes = dmaSizesAttr.asArrayRef();
-    }
-
-    // Find minimum elements per transfer across all DMA sizes.
-    // We need innermostDim >= subgroupSize * minElementsPerLane.
-    int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-    for (int64_t dmaSize : dmaSizes) {
-      if (dmaSize % elementBits != 0) {
-        continue;
-      }
-      int64_t elementsPerLane = dmaSize / elementBits;
-      int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-      minElementsPerTransfer =
-          std::min(minElementsPerTransfer, elementsPerTransfer);
-    }
-
     // Determine how many elements are available for coalesced access.
     // For CopyOp with tensor.empty() output, we can linearize all dimensions.
-    // Otherwise, we can only use the innermost dimension.
     int64_t availableElements = innermostDim;
     if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
       Value output = copyOp.getOutputs()[0];
       if (output.getDefiningOp<tensor::EmptyOp>()) {
-        // Can linearize all dimensions - compute total static elements.
         if (llvm::none_of(shape, ShapedType::isDynamic)) {
           availableElements = ShapedType::getNumElements(shape);
         }
       }
     }
 
-    // If no valid DMA size found or available elements are not aligned to
-    // transfer size, skip.
-    if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
-        availableElements % minElementsPerTransfer != 0) {
+    if (!getDMAAlignedSubgroupSize(funcOp, outputType.getElementType(),
+                                   availableElements)) {
       return failure();
     }
 
@@ -1052,7 +987,7 @@ private:
     int64_t numTiledDims = 0;
 
     if (isPadFusion) {
-      // TODO(#23365): Tile to subgroups for pad fusion by propagating source
+      // TODO: Tile to subgroups for pad fusion by propagating source
       // offsets through tiling. Currently, after subgroup tiling each warp's
       // DMA gets the full pre-pad source but a sub-tiled init, and the DMA
       // lowering has no way to offset into the source. This requires adding

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1307,3 +1307,66 @@ func.func @no_lower_oob_without_fat_raw_buffer(
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return
 }
+
+// -----
+
+// Test: OOB clamping with dynamic source inner dimension.
+// Source is <4x?xf32> (dynamic innermost), dest is <4x256xf32>.
+// in_bounds = [true, false]: inner dim may be OOB.
+// The OOB check uses memref.dim (not arith.constant) to get the dynamic
+// source inner dimension size.
+// With subgroup_size=64, 128-bit DMA (4 f32/lane): 64*4=256 elements/transfer.
+// 4 outer rows × 1 transfer/row = 4 gather_to_lds ops.
+
+#executable_target_rocm_hsaco_fb_dyn = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_64_dyn = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @gather_dma_dynamic_inner_dim_oob
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<4x256xf32, #gpu.address_space<workgroup>>
+func.func @gather_dma_dynamic_inner_dim_oob(
+    %source: memref<4x?xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<4x256xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_dyn,
+    translation_info = #translation_64_dyn} {
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (64)
+  scf.forall (%arg6) in (64) {
+    // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
+    // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
+    //
+    // Transfer 1: linearOffset = 0
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
+    // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 256)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 256)
+    //
+    // Bounds check: memref.dim for dynamic source inner dim (not arith.constant).
+    // CHECK: %[[FALSE:.+]] = arith.constant false
+    // CHECK: %[[DIM:.+]] = memref.dim %[[SRC]], %{{.+}}
+    // CHECK: %[[CMP:.+]] = arith.cmpi uge, %[[SRC_DELIN0]]#1, %[[DIM]] : index
+    // CHECK: %[[OOB:.+]] = arith.ori %[[FALSE]], %[[CMP]] : i1
+    // Replace outermost index with 4 (source dim 0 size) to force hardware OOB.
+    // CHECK: %[[C4_OOB:.+]] = arith.constant 4 : index
+    // CHECK: %[[FIXED_IDX:.+]] = arith.select %[[OOB]], %[[C4_OOB]], %[[SRC_DELIN0]]#0 : index
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[FIXED_IDX]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
+    //
+    // Remaining 3 transfers.
+    // CHECK-COUNT-3: amdgpu.gather_to_lds {{.+}} : vector<4xf32>
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [true, false] :
+      memref<4x?xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<4x256xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -253,12 +253,13 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     ParallelCombiningOpInterface and must live inside an op implementing
     `InParallelOpInterface`, such as `scf.forall.in_parallel`.
 
-    ## Lowering Paths
+    ## Lowering
 
-    Two lowering strategies are supported:
-    1. Lowers to `amdgpu.gather_to_lds` operations when lowering
-       requirements are met.
-    2. Default lowering using `vector.gather` operations.
+    Lowers to `amdgpu.gather_to_lds` operations via the
+    `AMDGPULowerCoalescedDMAToGatherLDS` pass. The pass requires:
+    - Source memref with `fat_raw_buffer` address space (for OOB clamping)
+    - Contiguous trailing dimensions in the destination memref
+    - Element sizes compatible with target `dma_sizes`
 
     ## Operands and Results
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -253,13 +253,12 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     ParallelCombiningOpInterface and must live inside an op implementing
     `InParallelOpInterface`, such as `scf.forall.in_parallel`.
 
-    ## Lowering
+    ## Lowering Paths
 
-    Lowers to `amdgpu.gather_to_lds` operations via the
-    `AMDGPULowerCoalescedDMAToGatherLDS` pass. The pass requires:
-    - Source memref with `fat_raw_buffer` address space (for OOB clamping)
-    - Contiguous trailing dimensions in the destination memref
-    - Element sizes compatible with target `dma_sizes`
+    Two lowering strategies are supported:
+    1. Lowers to `amdgpu.gather_to_lds` operations when lowering
+       requirements are met.
+    2. Default lowering using `vector.gather` operations.
 
     ## Operands and Results
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pipeline_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pipeline_coalesced_dma.mlir
@@ -424,13 +424,14 @@ hal.executable public @coalesced_dma_oob_clamping {
         %dest = memref.alloc() : memref<4x256xf32, #gpu.address_space<workgroup>>
         // CHECK: scf.forall (%[[LANE_ID:.+]]) in (64)
         scf.forall (%arg6) in (64) {
-          // 4 outer rows, 1 transfer per row.
-          // Verify OOB clamping pattern for the first transfer:
+          // 4 outer rows, 1 transfer per row (256 elements / 64 lanes / 4
+          // elements per lane = 1). For each transfer, OOB clamping on dim 1:
           //   memref.dim → arith.cmpi uge → arith.select → gather_to_lds
-          // CHECK: memref.dim
-          // CHECK: arith.cmpi uge
-          // CHECK: arith.select
-          // CHECK: amdgpu.gather_to_lds
+          // CHECK: %[[DIM:.+]] = memref.dim %{{.+}}, %{{.+}}
+          // CHECK: %[[CMP:.+]] = arith.cmpi uge, %{{.+}}, %[[DIM]]
+          // CHECK: %[[OOB:.+]] = arith.ori %{{.+}}, %[[CMP]]
+          // CHECK: %[[SEL:.+]] = arith.select %[[OOB]], %{{.+}}, %{{.+}}
+          // CHECK: amdgpu.gather_to_lds %{{.+}}[%[[SEL]], %{{.+}}]
           // Remaining 3 transfers also produce gather_to_lds ops.
           // CHECK-COUNT-3: amdgpu.gather_to_lds
           // CHECK-NOT: iree_gpu.coalesced_gather_dma

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pipeline_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pipeline_coalesced_dma.mlir
@@ -371,3 +371,145 @@ hal.executable public @coalesced_dma_multi_transfer_128bit {
     }
   }
 }
+
+// -----
+
+// Test: OOB clamping for in_bounds attribute.
+// When in_bounds = [true, false], the innermost dimension may be OOB.
+// The pass should emit bounds checking on non-outermost OOB dims and
+// select an out-of-range outermost index to force hardware zero return.
+//
+// Source: 4x?xf32 (dynamic innermost, may be smaller than dest)
+// Dest: 4x256xf32 (static, LDS)
+// With numLinearDims=1, linearSize=256, 64 threads, 128-bit DMA:
+//   - 4 elements/lane, 256 elements/transfer -> 1 transfer per outer row
+//   - 4 outer rows -> 4 gather_to_lds ops total
+// For each op, OOB clamping on dim 1 should generate:
+//   - memref.dim to get dynamic source size
+//   - arith.cmpi uge (compare source index >= dim size)
+//   - arith.select (replace outermost index with OOB value)
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx942", features = "", wgp = <
+    compute = fp64|fp32|fp16|int64|int32|int16|int8,
+    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
+    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: hal.executable public @coalesced_dma_oob_clamping
+hal.executable public @coalesced_dma_oob_clamping {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @lower_coalesced_dma_oob ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // CHECK-LABEL: func.func @lower_coalesced_dma_oob
+      func.func @lower_coalesced_dma_oob(%arg0: memref<4x?xf32, #amdgpu.address_space<fat_raw_buffer>>)
+        attributes {
+          hal.executable.target = #executable_target_rocm_hsaco_fb,
+          translation_info = #translation} {
+        %dest = memref.alloc() : memref<4x256xf32, #gpu.address_space<workgroup>>
+        // CHECK: scf.forall (%[[LANE_ID:.+]]) in (64)
+        scf.forall (%arg6) in (64) {
+          // 4 outer rows, 1 transfer per row.
+          // Verify OOB clamping pattern for the first transfer:
+          //   memref.dim → arith.cmpi uge → arith.select → gather_to_lds
+          // CHECK: memref.dim
+          // CHECK: arith.cmpi uge
+          // CHECK: arith.select
+          // CHECK: amdgpu.gather_to_lds
+          // Remaining 3 transfers also produce gather_to_lds ops.
+          // CHECK-COUNT-3: amdgpu.gather_to_lds
+          // CHECK-NOT: iree_gpu.coalesced_gather_dma
+          iree_gpu.coalesced_gather_dma %arg0 into %dest lane(%arg6)
+            in_bounds [true, false] :
+            memref<4x?xf32, #amdgpu.address_space<fat_raw_buffer>>,
+            memref<4x256xf32, #gpu.address_space<workgroup>>, index
+        } {mapping = [#gpu.thread<linear_dim_0>]}
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// Test: Mixed DMA transfer sizes (128-bit + 32-bit).
+// With 5x64 f32 elements and 64 threads (linearized path):
+//   - Total elements = 320
+//   - 128-bit DMA: 4 elements/lane, 256 elements/transfer -> 1 transfer
+//   - Remaining: 64 elements
+//   - 32-bit DMA: 1 element/lane, 64 elements/transfer -> 1 transfer
+//   - Total: 1 x vector<4xf32> + 1 x vector<1xf32>
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx942", features = "", wgp = <
+    compute = fp64|fp32|fp16|int64|int32|int16|int8,
+    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
+    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: hal.executable public @coalesced_dma_mixed_sizes
+hal.executable public @coalesced_dma_mixed_sizes {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @lower_coalesced_dma_mixed ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // CHECK-LABEL: func.func @lower_coalesced_dma_mixed
+      func.func @lower_coalesced_dma_mixed()
+        attributes {
+          hal.executable.target = #executable_target_rocm_hsaco_fb,
+          translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<5x64xf32, #hal.descriptor_type<storage_buffer>>
+        %assumed = memref.assume_alignment %0, 64 : memref<5x64xf32, #hal.descriptor_type<storage_buffer>>
+        %source = amdgpu.fat_raw_buffer_cast %assumed resetOffset : memref<5x64xf32, #hal.descriptor_type<storage_buffer>> to memref<5x64xf32, #amdgpu.address_space<fat_raw_buffer>>
+        %dest = memref.alloc() : memref<5x64xf32, #gpu.address_space<workgroup>>
+        // CHECK: scf.forall (%[[LANE_ID:.+]]) in (64)
+        scf.forall (%arg6) in (64) {
+          // Mixed DMA sizes: 128-bit (vector<4xf32>) + 32-bit (vector<1xf32>)
+          // 128-bit segment: lane offset = lane_id * 4
+          // CHECK: %[[C4:.+]] = arith.constant 4 : index
+          // CHECK: arith.muli %[[LANE_ID]], %[[C4]]
+          // 32-bit segment: lane offset = lane_id * 1
+          // CHECK: %[[C1:.+]] = arith.constant 1 : index
+          // CHECK: arith.muli %[[LANE_ID]], %[[C1]]
+          // CHECK: amdgpu.gather_to_lds {{.*}} : vector<4xf32>
+          // CHECK: amdgpu.gather_to_lds {{.*}} : vector<1xf32>
+          // CHECK-NOT: amdgpu.gather_to_lds
+          iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
+            memref<5x64xf32, #amdgpu.address_space<fat_raw_buffer>>,
+            memref<5x64xf32, #gpu.address_space<workgroup>>, index
+        } {mapping = [#gpu.thread<linear_dim_0>]}
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Remove stale TODO(#23365) PR references; keep TODOs for remaining limitations.
* Update CoalescedGatherDMAOp description: remove non-existent vector.gather lowering path, document actual pass requirements.
* Add lit test for OOB clamping logic (in_bounds with dynamic source dims).
* Add lit test for mixed DMA transfer sizes (128-bit + 32-bit segments).
* Refactor ConvertGatherToCoalescedDMA and tileAtSubgroupLevel to reuse getDMAAlignedSubgroupSize(), removing ~50 lines of duplicated code.