### PR TITLE
[LDS] Add fallback for CoalescedGatherDMA lowering.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -162,7 +162,7 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 ///   - dstDimOffset: position without lane offset (uniform across subgroup)
 ///   - indices[dim]: index memref mapping dest positions to source positions
 static std::pair<SmallVector<Value>, SmallVector<Value>>
-generateGatherIndices(PatternRewriter &rewriter, Location loc,
+generateGatherIndices(OpBuilder &rewriter, Location loc,
                       ValueRange srcDimOffsets, ValueRange dstDimOffsets,
                       OperandRange indices) {
   SmallVector<Value> srcIndices;
@@ -197,7 +197,8 @@ struct LowerCoalescedGatherDMAPattern final
 
   LowerCoalescedGatherDMAPattern(MLIRContext *context,
                                  ArrayRef<int64_t> targetDmaSizes)
-      : OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp>(context),
+      : OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp>(context,
+                                                          /*benefit=*/2),
         targetDmaSizes(targetDmaSizes) {}
 
   LogicalResult matchAndRewrite(IREE::GPU::CoalescedGatherDMAOp dmaOp,
@@ -476,6 +477,253 @@ private:
   ArrayRef<int64_t> targetDmaSizes;
 };
 
+/// Fallback pattern that lowers CoalescedGatherDMAOp to
+/// vector.transfer_read/vector.transfer_write when the fast path
+/// (gather_to_lds) fails due to DMA size alignment issues.
+/// Each lane transfers one element per iteration across the subgroup.
+struct LowerCoalescedGatherDMAFallbackPattern final
+    : public OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp> {
+  using Base::Base;
+
+  LowerCoalescedGatherDMAFallbackPattern(MLIRContext *context)
+      : OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp>(context,
+                                                          /*benefit=*/1) {}
+
+  LogicalResult matchAndRewrite(IREE::GPU::CoalescedGatherDMAOp dmaOp,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  void emitFallbackTransfers(OpBuilder &builder, Location loc, Value source,
+                             Value dest, ArrayRef<int64_t> destShape,
+                             int64_t numLinearDims, Type elementType,
+                             OperandRange indices, int64_t subgroupSize,
+                             Value laneId,
+                             std::optional<ArrayAttr> inBoundsAttr) const;
+};
+
+LogicalResult LowerCoalescedGatherDMAFallbackPattern::matchAndRewrite(
+    IREE::GPU::CoalescedGatherDMAOp dmaOp, PatternRewriter &rewriter) const {
+  LDBG() << "Fallback: Processing CoalescedGatherDMAOp: " << dmaOp;
+
+  auto forallOp = dmaOp->getParentOfType<scf::ForallOp>();
+  if (!forallOp) {
+    return rewriter.notifyMatchFailure(
+        dmaOp, "coalesced_gather_dma not inside scf.forall");
+  }
+
+  if (failed(verifyThreadMapping(forallOp))) {
+    return rewriter.notifyMatchFailure(
+        dmaOp, "forall does not have proper thread mapping");
+  }
+
+  if (failed(verifyMemoryLayoutContiguous(dmaOp, rewriter))) {
+    return failure();
+  }
+
+  Value source = dmaOp.getSource();
+  Value dest = dmaOp.getInit();
+  auto sourceType = cast<MemRefType>(source.getType());
+  auto destType = cast<MemRefType>(dest.getType());
+  Type elementType = sourceType.getElementType();
+  ArrayRef<int64_t> destShape = destType.getShape();
+
+  std::optional<int64_t> subgroupSize =
+      getSubgroupSize(dmaOp->getParentOfType<FunctionOpInterface>());
+  if (!subgroupSize.has_value()) {
+    return rewriter.notifyMatchFailure(dmaOp,
+                                       "unable to determine subgroup size");
+  }
+
+  // Compute linearized dimensions (same as fast path).
+  int64_t destRank = destShape.size();
+  int64_t numLinearDims = destType.getNumContiguousTrailingDims();
+  numLinearDims = std::max<int64_t>(numLinearDims, 1);
+
+  for (int64_t i = destRank - numLinearDims; i < destRank; ++i) {
+    if (ShapedType::isDynamic(destShape[i])) {
+      return rewriter.notifyMatchFailure(
+          dmaOp, "dynamic dimension in linearized portion");
+    }
+  }
+
+  // OOB padding requires fat_raw_buffer.
+  if (std::optional<ArrayAttr> inBounds = dmaOp.getInBounds()) {
+    if (!hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+      for (Attribute attr : *inBounds) {
+        if (!cast<BoolAttr>(attr).getValue()) {
+          return rewriter.notifyMatchFailure(
+              dmaOp, "in_bounds with OOB dimensions requires "
+                     "fat_raw_buffer address space on source");
+        }
+      }
+    }
+  }
+
+  rewriter.setInsertionPoint(dmaOp);
+  TypedValue<IndexType> laneId = dmaOp.getLane();
+  Location loc = dmaOp.getLoc();
+
+  emitFallbackTransfers(rewriter, loc, source, dest, destShape, numLinearDims,
+                        elementType, dmaOp.getIndices(), *subgroupSize, laneId,
+                        dmaOp.getInBounds());
+
+  rewriter.eraseOp(dmaOp);
+  return success();
+}
+
+void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
+    OpBuilder &builder, Location loc, Value source, Value dest,
+    ArrayRef<int64_t> destShape, int64_t numLinearDims, Type elementType,
+    OperandRange indices, int64_t subgroupSize, Value laneId,
+    std::optional<ArrayAttr> inBoundsAttr) const {
+  int64_t destRank = destShape.size();
+  int64_t numOuterDims = destRank - numLinearDims;
+
+  // Compute linearized size.
+  int64_t linearSize = 1;
+  for (int64_t i = numOuterDims; i < destRank; ++i) {
+    linearSize *= destShape[i];
+  }
+
+  // Element distribution across lanes.
+  int64_t numFullIterations = linearSize / subgroupSize;
+  int64_t remainder = linearSize % subgroupSize;
+  int64_t numIterations = numFullIterations + (remainder > 0 ? 1 : 0);
+
+  LDBG() << "Fallback: linearSize=" << linearSize
+         << " subgroupSize=" << subgroupSize
+         << " numFullIter=" << numFullIterations << " remainder=" << remainder;
+
+  // Build delinearization basis for linear portion.
+  SmallVector<int64_t> linearBasis;
+  for (int64_t i = numOuterDims; i < destRank; ++i) {
+    linearBasis.push_back(destShape[i]);
+  }
+  SmallVector<OpFoldResult> basis =
+      getAsIndexOpFoldResult(builder.getContext(), linearBasis);
+
+  // Build tile sizes for outer dimension iteration.
+  SmallVector<int64_t> tileSizes(destRank, 1);
+  for (int64_t i = numOuterDims; i < destRank; ++i) {
+    tileSizes[i] = destShape[i];
+  }
+
+  // Padding value and vector type for transfers.
+  Value padVal =
+      arith::ConstantOp::create(builder, loc, builder.getZeroAttr(elementType));
+  VectorType vecType = VectorType::get({1}, elementType);
+
+  // Lambda to emit a single element transfer at the given linear offset.
+  auto emitSingleTransfer = [&](OpBuilder &b, Location loc,
+                                SmallVector<Value> &outerDimOffsets,
+                                Value linearOffset) {
+    // Delinearize linear offset to multi-dim indices.
+    // Both source and destination use the same delinearized position,
+    // but generateGatherIndices handles the gather indirection for source.
+    auto delinearize = affine::AffineDelinearizeIndexOp::create(
+        b, loc, linearOffset, basis, /*hasOuterBound=*/true);
+
+    SmallVector<Value> srcDimOffsets(outerDimOffsets);
+    llvm::append_range(srcDimOffsets, delinearize.getResults());
+    SmallVector<Value> dstDimOffsets(outerDimOffsets);
+    llvm::append_range(dstDimOffsets, delinearize.getResults());
+
+    auto [srcIndices, dstIndices] =
+        generateGatherIndices(b, loc, srcDimOffsets, dstDimOffsets, indices);
+
+    // OOB handling: replicate the fast path's outermost-index-replacement
+    // trick for non-outermost dimensions.
+    auto sourceType = cast<MemRefType>(source.getType());
+    if (inBoundsAttr && hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+      ArrayRef<int64_t> sourceShape = sourceType.getShape();
+      Value anyNonOutermostOOB =
+          arith::ConstantOp::create(b, loc, b.getBoolAttr(false));
+
+      for (int64_t dim = 1; dim < sourceType.getRank(); ++dim) {
+        if (dim >= static_cast<int64_t>(inBoundsAttr->size())) {
+          break;
+        }
+        bool dimInBounds = cast<BoolAttr>((*inBoundsAttr)[dim]).getValue();
+        if (dimInBounds) {
+          continue;
+        }
+
+        Value dimSize;
+        if (ShapedType::isDynamic(sourceShape[dim])) {
+          dimSize = memref::DimOp::create(b, loc, source, dim);
+        } else {
+          dimSize = arith::ConstantIndexOp::create(b, loc, sourceShape[dim]);
+        }
+
+        Value isOOB = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::uge,
+                                            srcIndices[dim], dimSize);
+        anyNonOutermostOOB =
+            arith::OrIOp::create(b, loc, anyNonOutermostOOB, isOOB);
+      }
+
+      Value oobOuterIdx;
+      if (ShapedType::isDynamic(sourceShape[0])) {
+        oobOuterIdx = memref::DimOp::create(b, loc, source, 0);
+      } else {
+        oobOuterIdx = arith::ConstantIndexOp::create(b, loc, sourceShape[0]);
+      }
+      srcIndices[0] = arith::SelectOp::create(b, loc, anyNonOutermostOOB,
+                                              oobOuterIdx, srcIndices[0]);
+    }
+
+    // Determine in_bounds for vector.transfer_read.
+    // For vector<1xelemType>, there is 1 vector dim mapped to innermost
+    // memref dim. Set in_bounds based on original DMA's in_bounds for
+    // the innermost dimension.
+    SmallVector<bool> readInBounds = {true};
+    if (inBoundsAttr && inBoundsAttr->size() > 0) {
+      bool innermostInBounds =
+          cast<BoolAttr>((*inBoundsAttr)[inBoundsAttr->size() - 1]).getValue();
+      readInBounds[0] = innermostInBounds;
+    }
+
+    Value vec = vector::TransferReadOp::create(
+        b, loc, vecType, source, srcIndices, padVal, readInBounds);
+    vector::TransferWriteOp::create(b, loc, vec, dest, dstIndices,
+                                    SmallVector<bool>{true});
+  };
+
+  // Emit transfers for each outer position and each iteration.
+  for (const SmallVector<int64_t> &outerOffsets :
+       StaticTileOffsetRange(destShape, tileSizes)) {
+
+    SmallVector<Value> outerDimOffsets;
+    for (int64_t i = 0; i < numOuterDims; ++i) {
+      outerDimOffsets.push_back(
+          arith::ConstantIndexOp::create(builder, loc, outerOffsets[i]));
+    }
+
+    for (int64_t iter = 0; iter < numIterations; ++iter) {
+      Value linearBase =
+          arith::ConstantIndexOp::create(builder, loc, iter * subgroupSize);
+      Value linearOffset =
+          arith::AddIOp::create(builder, loc, linearBase, laneId);
+
+      if (iter >= numFullIterations) {
+        // Remainder: guard with scf.if(linearOffset < linearSize).
+        Value linearSizeVal =
+            arith::ConstantIndexOp::create(builder, loc, linearSize);
+        Value inRange =
+            arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ult,
+                                  linearOffset, linearSizeVal);
+        scf::IfOp::create(builder, loc, inRange,
+                          [&](OpBuilder &thenBuilder, Location thenLoc) {
+                            emitSingleTransfer(thenBuilder, thenLoc,
+                                               outerDimOffsets, linearOffset);
+                            scf::YieldOp::create(thenBuilder, thenLoc);
+                          });
+      } else {
+        emitSingleTransfer(builder, loc, outerDimOffsets, linearOffset);
+      }
+    }
+  }
+}
+
 namespace {
 struct AMDGPULowerCoalescedDMAToGatherLDSPass final
     : impl::AMDGPULowerCoalescedDMAToGatherLDSPassBase<
@@ -500,6 +748,7 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.add<LowerCoalescedGatherDMAPattern>(context, dmaSizes);
+    patterns.add<LowerCoalescedGatherDMAFallbackPattern>(context);
 
     walkAndApplyPatterns(funcOp, std::move(patterns));
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -485,10 +485,6 @@ struct LowerCoalescedGatherDMAFallbackPattern final
     : public OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp> {
   using Base::Base;
 
-  LowerCoalescedGatherDMAFallbackPattern(MLIRContext *context)
-      : OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp>(context,
-                                                          /*benefit=*/1) {}
-
   LogicalResult matchAndRewrite(IREE::GPU::CoalescedGatherDMAOp dmaOp,
                                 PatternRewriter &rewriter) const override;
 
@@ -595,10 +591,8 @@ void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
          << " numFullIter=" << numFullIterations << " remainder=" << remainder;
 
   // Build delinearization basis for linear portion.
-  SmallVector<int64_t> linearBasis;
-  for (int64_t i = numOuterDims; i < destRank; ++i) {
-    linearBasis.push_back(destShape[i]);
-  }
+  SmallVector<int64_t> linearBasis =
+      llvm::to_vector(destShape.drop_front(numOuterDims));
   SmallVector<OpFoldResult> basis =
       getAsIndexOpFoldResult(builder.getContext(), linearBasis);
 
@@ -676,7 +670,7 @@ void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
     // memref dim. Set in_bounds based on original DMA's in_bounds for
     // the innermost dimension.
     SmallVector<bool> readInBounds = {true};
-    if (inBoundsAttr && inBoundsAttr->size() > 0) {
+    if (inBoundsAttr && !inBoundsAttr->empty()) {
       bool innermostInBounds =
           cast<BoolAttr>((*inBoundsAttr)[inBoundsAttr->size() - 1]).getValue();
       readInBounds[0] = innermostInBounds;
@@ -692,11 +686,11 @@ void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
   for (const SmallVector<int64_t> &outerOffsets :
        StaticTileOffsetRange(destShape, tileSizes)) {
 
-    SmallVector<Value> outerDimOffsets;
-    for (int64_t i = 0; i < numOuterDims; ++i) {
-      outerDimOffsets.push_back(
-          arith::ConstantIndexOp::create(builder, loc, outerOffsets[i]));
-    }
+    SmallVector<Value> outerDimOffsets = llvm::map_to_vector(
+        llvm::ArrayRef(outerOffsets).take_front(numOuterDims),
+        [&](int64_t offset) -> Value {
+          return arith::ConstantIndexOp::create(builder, loc, offset);
+        });
 
     for (int64_t iter = 0; iter < numIterations; ++iter) {
       Value linearBase =
@@ -752,9 +746,7 @@ struct AMDGPULowerCoalescedDMAToGatherLDSPass final
 
     walkAndApplyPatterns(funcOp, std::move(patterns));
 
-    // Verify all CoalescedGatherDMAOps were lowered. Currently, we require all
-    // ops to be successfully lowered. In the future, a fallback lowering path
-    // (e.g., using global_load) could handle ops that don't match the pattern.
+    // Verify all CoalescedGatherDMAOps were lowered.
     WalkResult result = funcOp.walk([&](IREE::GPU::CoalescedGatherDMAOp op) {
       op.emitOpError(
           "failed to lower to gather_to_lds; possible causes: source "

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -83,12 +83,13 @@ def GPUConvertToCoalescedDMAPass :
 
 def AMDGPULowerCoalescedDMAToGatherLDSPass :
     InterfacePass<"iree-codegen-amdgpu-lower-coalesced-dma-to-gather-lds", "mlir::FunctionOpInterface"> {
-  let summary = "Lower coalesced DMA operations to amdgpu.gather_to_lds.";
+  let summary = "Lower coalesced DMA operations to amdgpu.gather_to_lds with vector fallback.";
   let dependentDialects = [
     "::mlir::affine::AffineDialect",
     "::mlir::gpu::GPUDialect",
     "::mlir::scf::SCFDialect",
     "::mlir::amdgpu::AMDGPUDialect",
+    "::mlir::vector::VectorDialect",
     "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1324,9 +1324,9 @@ func.func @fallback_1d_basic(
     // CHECK: %[[C48:.+]] = arith.constant 48 : index
     // CHECK: %[[CMP:.+]] = arith.cmpi ult, %[[LIN1]], %[[C48]]
     // CHECK: scf.if %[[CMP]]
-    // CHECK:   affine.delinearize_index %[[LIN1]] into (48)
-    // CHECK:   vector.transfer_read {{.+}} {in_bounds = [true]} : memref<48xf32, {{.+}}>, vector<1xf32>
-    // CHECK:   vector.transfer_write
+    // CHECK:   %[[DELIN1:.+]] = affine.delinearize_index %[[LIN1]] into (48)
+    // CHECK:   %[[VEC1:.+]] = vector.transfer_read %[[SRC]][%[[DELIN1]]], %[[PAD]] {in_bounds = [true]} : memref<48xf32, {{.+}}>, vector<1xf32>
+    // CHECK:   vector.transfer_write %[[VEC1]], %[[DST]][%[[DELIN1]]] {in_bounds = [true]} : vector<1xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
       memref<48xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1371,11 +1371,13 @@ func.func @fallback_2d_basic(
     // CHECK: vector.transfer_write %{{.+}}, %[[DST]][%[[DELIN0]]#0, %[[DELIN0]]#1] {in_bounds = [true]} : vector<1xf32>
     //
     // Remainder iteration: guarded
-    // CHECK: arith.cmpi ult
-    // CHECK: scf.if
-    // CHECK:   affine.delinearize_index {{.+}} into (3, 16)
-    // CHECK:   vector.transfer_read
-    // CHECK:   vector.transfer_write
+    // CHECK: %[[LIN1:.+]] = arith.addi %{{.+}}, %[[LANE_ID]]
+    // CHECK: %[[C48:.+]] = arith.constant 48 : index
+    // CHECK: %[[CMP:.+]] = arith.cmpi ult, %[[LIN1]], %[[C48]]
+    // CHECK: scf.if %[[CMP]]
+    // CHECK:   %[[DELIN1:.+]]:2 = affine.delinearize_index %[[LIN1]] into (3, 16)
+    // CHECK:   %[[VEC1:.+]] = vector.transfer_read %[[SRC]][%[[DELIN1]]#0, %[[DELIN1]]#1], %{{.+}} {in_bounds = [true]} : memref<3x16xf32, {{.+}}>, vector<1xf32>
+    // CHECK:   vector.transfer_write %[[VEC1]], %[[DST]][%[[DELIN1]]#0, %[[DELIN1]]#1] {in_bounds = [true]} : vector<1xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
       memref<3x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1472,13 +1474,78 @@ func.func @fallback_non_outermost_oob(
     // Replace outermost index with sourceShape[0]=4 if OOB
     // CHECK: %[[C4:.+]] = arith.constant 4 : index
     // CHECK: %[[SRC_IDX:.+]] = arith.select %[[ANY_OOB]], %[[C4]], %[[DELIN]]#0
-    // Transfer with in_bounds=[false] for innermost dim
-    // CHECK: vector.transfer_read %[[SRC]][%[[SRC_IDX]], %[[DELIN]]#1], %{{.+}} : memref<4x12xf32, {{.+}}>, vector<1xf32>
-    // CHECK: vector.transfer_write %{{.+}}, %[[DST]][%[[DELIN]]#0, %[[DELIN]]#1] {in_bounds = [true]} : vector<1xf32>
+    // Transfer without in_bounds (default [false]) for OOB innermost dim.
+    // Note: when in_bounds=[false], MLIR omits the attribute in the output.
+    // CHECK: %[[READ:.+]] = vector.transfer_read %[[SRC]][%[[SRC_IDX]], %[[DELIN]]#1]
+    // CHECK-SAME: : memref<4x12xf32, {{.+}}>, vector<1xf32>
+    // CHECK-NOT: in_bounds
+    // Dest write is always in_bounds.
+    // CHECK: vector.transfer_write %[[READ]], %[[DST]][%[[DELIN]]#0, %[[DELIN]]#1] {in_bounds = [true]}
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [true, false] :
       memref<4x12xf32, #amdgpu.address_space<fat_raw_buffer>>,
       memref<4x16xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
+// Test: Fallback with outer dimensions. Dest has non-contiguous dim 0
+// (stride 64 but dim 1 size=8, so 8 != 64). numLinearDims=1 (only dim 1),
+// numOuterDims=1 (dim 0). The outer dimension (dim 0) is iterated via
+// StaticTileOffsetRange, generating separate transfers for each row.
+//   - linearSize = 8, subgroupSize = 32
+//   - 0 full iterations, remainder = 8 (guarded by scf.if)
+//   - 2 outer positions (dim 0 = 0, 1) × 1 remainder iteration = 2 scf.if blocks
+//
+// CHECK-LABEL: func.func @fallback_with_outer_dims
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<2x8xf32, strided<[64, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<2x8xf32, strided<[64, 1]>, #gpu.address_space<workgroup>>
+#executable_target_rocm_hsaco_fb_outer = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [128]>>}>
+
+#translation_32_outer = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+func.func @fallback_with_outer_dims(
+    %source: memref<2x8xf32, strided<[64, 1]>, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<2x8xf32, strided<[64, 1]>, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_outer,
+    translation_info = #translation_32_outer} {
+  // CHECK: scf.forall (%[[LANE_ID:.+]]) in (32)
+  scf.forall (%arg6) in (32) {
+    // Outer iteration 0 (dim 0 = 0):
+    // CHECK: %[[OUTER0:.+]] = arith.constant 0 : index
+    // CHECK: %[[LIN0:.+]] = arith.addi %{{.+}}, %[[LANE_ID]]
+    // CHECK: %[[C8_0:.+]] = arith.constant 8 : index
+    // CHECK: %[[CMP0:.+]] = arith.cmpi ult, %[[LIN0]], %[[C8_0]]
+    // CHECK: scf.if %[[CMP0]]
+    // CHECK:   %[[DELIN0:.+]] = affine.delinearize_index %[[LIN0]] into (8)
+    // CHECK:   %[[VEC0:.+]] = vector.transfer_read %[[SRC]][%[[OUTER0]], %[[DELIN0]]], %{{.+}} {in_bounds = [true]} : memref<2x8xf32, strided<[64, 1]>, {{.+}}>, vector<1xf32>
+    // CHECK:   vector.transfer_write %[[VEC0]], %[[DST]][%[[OUTER0]], %[[DELIN0]]] {in_bounds = [true]} : vector<1xf32>, memref<2x8xf32, strided<[64, 1]>, {{.+}}>
+    //
+    // Outer iteration 1 (dim 0 = 1):
+    // CHECK: %[[OUTER1:.+]] = arith.constant 1 : index
+    // CHECK: %[[LIN1:.+]] = arith.addi %{{.+}}, %[[LANE_ID]]
+    // CHECK: %[[C8_1:.+]] = arith.constant 8 : index
+    // CHECK: %[[CMP1:.+]] = arith.cmpi ult, %[[LIN1]], %[[C8_1]]
+    // CHECK: scf.if %[[CMP1]]
+    // CHECK:   %[[DELIN1:.+]] = affine.delinearize_index %[[LIN1]] into (8)
+    // CHECK:   %[[VEC1:.+]] = vector.transfer_read %[[SRC]][%[[OUTER1]], %[[DELIN1]]], %{{.+}} {in_bounds = [true]} : memref<2x8xf32, strided<[64, 1]>, {{.+}}>, vector<1xf32>
+    // CHECK:   vector.transfer_write %[[VEC1]], %[[DST]][%[[OUTER1]], %[[DELIN1]]] {in_bounds = [true]} : vector<1xf32>, memref<2x8xf32, strided<[64, 1]>, {{.+}}>
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
+      memref<2x8xf32, strided<[64, 1]>, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<2x8xf32, strided<[64, 1]>, #gpu.address_space<workgroup>>, index
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1278,6 +1278,213 @@ func.func @gather_dma_inner_dim_oob_64x62(
 
 // -----
 
+// Fallback tests: these use dma_sizes = [128] (128-bit only) with f32 elements,
+// meaning the fast path (gather_to_lds) needs 128 elements per transfer
+// (32 lanes * 4 elements/lane). All tests below have fewer contiguous elements,
+// forcing the fallback to vector.transfer_read/vector.transfer_write.
+
+// Test: 1D fallback with 48 elements. 48/32 = 1 full iteration + 16 remainder.
+// The remainder is guarded by scf.if(linearOffset < 48).
+//
+// CHECK-LABEL: func.func @fallback_1d_basic
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<48xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<48xf32, #gpu.address_space<workgroup>>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [128]>>}>
+
+#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+func.func @fallback_1d_basic(
+    %source: memref<48xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<48xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb,
+    translation_info = #translation_32} {
+  // CHECK: scf.forall (%[[LANE_ID:.+]]) in (32)
+  scf.forall (%arg6) in (32) {
+    // Full iteration: linearOffset = 0 + laneId
+    // CHECK: %[[PAD:.+]] = arith.constant 0.000000e+00 : f32
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[LIN0:.+]] = arith.addi %[[C0]], %[[LANE_ID]]
+    // CHECK: %[[DELIN0:.+]] = affine.delinearize_index %[[LIN0]] into (48)
+    // CHECK: vector.transfer_read %[[SRC]][%[[DELIN0]]], %[[PAD]] {in_bounds = [true]} : memref<48xf32, {{.+}}>, vector<1xf32>
+    // CHECK: vector.transfer_write %{{.+}}, %[[DST]][%[[DELIN0]]] {in_bounds = [true]} : vector<1xf32>
+    //
+    // Remainder iteration: linearOffset = 32 + laneId, guarded by < 48
+    // CHECK: %[[C32:.+]] = arith.constant 32 : index
+    // CHECK: %[[LIN1:.+]] = arith.addi %[[C32]], %[[LANE_ID]]
+    // CHECK: %[[C48:.+]] = arith.constant 48 : index
+    // CHECK: %[[CMP:.+]] = arith.cmpi ult, %[[LIN1]], %[[C48]]
+    // CHECK: scf.if %[[CMP]]
+    // CHECK:   affine.delinearize_index %[[LIN1]] into (48)
+    // CHECK:   vector.transfer_read {{.+}} {in_bounds = [true]} : memref<48xf32, {{.+}}>, vector<1xf32>
+    // CHECK:   vector.transfer_write
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
+      memref<48xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<48xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
+// Test: 2D fallback with 3x16=48 elements. Same distribution as 1D but with
+// 2D delinearization into (3, 16).
+//
+// CHECK-LABEL: func.func @fallback_2d_basic
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<3x16xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<3x16xf32, #gpu.address_space<workgroup>>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [128]>>}>
+
+#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+func.func @fallback_2d_basic(
+    %source: memref<3x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<3x16xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb,
+    translation_info = #translation_32} {
+  // CHECK: scf.forall (%[[LANE_ID:.+]]) in (32)
+  scf.forall (%arg6) in (32) {
+    // Full iteration: 2D delinearization
+    // CHECK: %[[LIN0:.+]] = arith.addi %{{.+}}, %[[LANE_ID]]
+    // CHECK: %[[DELIN0:.+]]:2 = affine.delinearize_index %[[LIN0]] into (3, 16)
+    // CHECK: vector.transfer_read %[[SRC]][%[[DELIN0]]#0, %[[DELIN0]]#1], %{{.+}} {in_bounds = [true]} : memref<3x16xf32, {{.+}}>, vector<1xf32>
+    // CHECK: vector.transfer_write %{{.+}}, %[[DST]][%[[DELIN0]]#0, %[[DELIN0]]#1] {in_bounds = [true]} : vector<1xf32>
+    //
+    // Remainder iteration: guarded
+    // CHECK: arith.cmpi ult
+    // CHECK: scf.if
+    // CHECK:   affine.delinearize_index {{.+}} into (3, 16)
+    // CHECK:   vector.transfer_read
+    // CHECK:   vector.transfer_write
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
+      memref<3x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<3x16xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
+// Test: Gather fallback with row indices. 2x16=32 elements = exactly 1 full
+// iteration (no remainder). Source row is loaded via memref.load from indices.
+//
+// CHECK-LABEL: func.func @fallback_gather_with_indices
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<1024x16xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[IDX:[a-zA-Z0-9]+]]: memref<2xindex>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<2x16xf32, #gpu.address_space<workgroup>>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [128]>>}>
+
+#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+func.func @fallback_gather_with_indices(
+    %source: memref<1024x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %row_indices: memref<2xindex>,
+    %dest: memref<2x16xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb,
+    translation_info = #translation_32} {
+  // CHECK: scf.forall (%[[LANE_ID:.+]]) in (32)
+  scf.forall (%arg6) in (32) {
+    // Single full iteration (32 elements, 32 lanes).
+    // Gather index loaded from indices memref.
+    // CHECK: %[[LIN:.+]] = arith.addi %{{.+}}, %[[LANE_ID]]
+    // CHECK: %[[DELIN:.+]]:2 = affine.delinearize_index %[[LIN]] into (2, 16)
+    // CHECK: %[[ROW_IDX:.+]] = memref.load %[[IDX]][%[[DELIN]]#0]
+    // CHECK: vector.transfer_read %[[SRC]][%[[ROW_IDX]], %[[DELIN]]#1], %{{.+}} {in_bounds = [true]} : memref<1024x16xf32, {{.+}}>, vector<1xf32>
+    // CHECK: vector.transfer_write %{{.+}}, %[[DST]][%[[DELIN]]#0, %[[DELIN]]#1] {in_bounds = [true]} : vector<1xf32>
+    // CHECK-NOT: scf.if
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source[%row_indices] into %dest lane(%arg6) :
+      memref<1024x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<2xindex>,
+      memref<2x16xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
+// Test: Fallback with non-outermost OOB dimension. Source inner dim (12) is
+// smaller than dest inner dim (16). in_bounds = [true, false] means dim 1 may
+// be OOB. The OOB trick checks dim 1 >= 12 and replaces dim 0 with
+// sourceShape[0]=4 to force hardware OOB clamping.
+//
+// CHECK-LABEL: func.func @fallback_non_outermost_oob
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x12xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<4x16xf32, #gpu.address_space<workgroup>>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [128]>>}>
+
+#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+func.func @fallback_non_outermost_oob(
+    %source: memref<4x12xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<4x16xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb,
+    translation_info = #translation_32} {
+  // CHECK: scf.forall (%[[LANE_ID:.+]]) in (32)
+  scf.forall (%arg6) in (32) {
+    // First iteration: linearOffset = 0 + laneId
+    // CHECK: %[[DELIN:.+]]:2 = affine.delinearize_index %{{.+}} into (4, 16)
+    // OOB check on dim 1: index >= 12
+    // CHECK: %[[C12:.+]] = arith.constant 12 : index
+    // CHECK: %[[IS_OOB:.+]] = arith.cmpi uge, %[[DELIN]]#1, %[[C12]]
+    // CHECK: %[[ANY_OOB:.+]] = arith.ori %{{.+}}, %[[IS_OOB]]
+    // Replace outermost index with sourceShape[0]=4 if OOB
+    // CHECK: %[[C4:.+]] = arith.constant 4 : index
+    // CHECK: %[[SRC_IDX:.+]] = arith.select %[[ANY_OOB]], %[[C4]], %[[DELIN]]#0
+    // Transfer with in_bounds=[false] for innermost dim
+    // CHECK: vector.transfer_read %[[SRC]][%[[SRC_IDX]], %[[DELIN]]#1], %{{.+}} : memref<4x12xf32, {{.+}}>, vector<1xf32>
+    // CHECK: vector.transfer_write %{{.+}}, %[[DST]][%[[DELIN]]#0, %[[DELIN]]#1] {in_bounds = [true]} : vector<1xf32>
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) in_bounds [true, false] :
+      memref<4x12xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<4x16xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
 // Test: in_bounds with OOB dimensions on non-fat_raw_buffer source should
 // not be lowered (pattern fails because hardware OOB clamping is unavailable).
 


### PR DESCRIPTION
* When gather_to_lds lowering fails due to DMA size alignment, fall back to element-by-element coalesced vector.transfer_read/vector.transfer_write.
* Each lane transfers one element per iteration across the subgroup.
* Remainder elements guarded by scf.if for partial iterations.
* OOB handling replicates the fast path's outermost-index-replacement trick.
* New lit tests for 1D, 2D, gather, and OOB fallback cases.