### PR TITLE
[CI] Disable internal linkage clang-tidy checks

### DIFF
--- a/compiler/.clang-tidy
+++ b/compiler/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
   -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
   -misc-override-with-different-visibility,
   bugprone-*,
   -bugprone-assignment-in-if-condition,

--- a/llvm-external-projects/iree-dialects/.clang-tidy
+++ b/llvm-external-projects/iree-dialects/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
   -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
   -misc-override-with-different-visibility,
   bugprone-*,
   -bugprone-assignment-in-if-condition,


### PR DESCRIPTION
These generate too many false positives.