### PR TITLE
Add --exclude-libs=ALL to libIREECompiler.so shared library

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -7,6 +7,7 @@
 function(iree_is_bytecode_module_test_excluded_by_labels _DST_IS_EXCLUDED_VAR _SRC_LABELS)
   string(TOLOWER "${CMAKE_BUILD_TYPE}" _LOWERCASE_BUILD_TYPE)
   if(((IREE_ARCH MATCHES "^riscv_") AND ("noriscv" IN_LIST _SRC_LABELS)) OR
+     ((IREE_ARCH STREQUAL "arm_64") AND ("noaarch64" IN_LIST _SRC_LABELS)) OR
      (EMSCRIPTEN AND ("nowasm" IN_LIST _SRC_LABELS)) OR
      (IREE_ENABLE_ASAN AND ("noasan" IN_LIST _SRC_LABELS)) OR
      (IREE_ENABLE_TSAN AND ("notsan" IN_LIST _SRC_LABELS)) OR

--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -214,6 +214,8 @@ declare_mlir_python_extension(IREECompilerPythonExtensions.CompilerDialects
     iree_compiler_API_SharedImpl
   PRIVATE_LINK_LIBS
     LLVMSupport
+    MLIRIR
+    MLIRSupport
 )
 
 ################################################################################

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -168,6 +168,10 @@ iree_cc_library(
   LINKOPTS
     # Linux uses a linker script to version symbols.
     $<$<PLATFORM_ID:Linux>:-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/api_version.ld>
+    # Hide all symbols from static archives (.a) linked into the shared library.
+    # Without this, LLVM/MLIR internal symbols leak through the `global: *`
+    # version script since LLVM is not compiled with -fvisibility=hidden.
+    $<$<PLATFORM_ID:Linux>:LINKER:--exclude-libs,ALL>
   DEPS
     iree::compiler::bindings::c::headers
 )

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -86,6 +86,7 @@ iree_check_single_backend_test_suite(
     compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
     driver = "local-task",
     tags = [
+        "noaarch64",
         "noriscv",
     ],
     target_backend = "llvm-cpu",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-llvmcpu-target-cpu=generic"
   LABELS
+    "noaarch64"
     "noriscv"
 )
 


### PR DESCRIPTION
When building `libIREECompiler.so` in `TheRock` I hit the following error when trying to load the library: 

```
LLVM ERROR: Option 'pbqp' already exists!
```

I'll put the full claude generated description of what happened below but the long and the short of it is `libIREECompiler.so` seems to be exporting quite a few symbols when linking LLVM's static `.a`'s. In my case, `TheRock` has another library that loads `libLLVM.so`, and when loaded it [interposes](https://maskray.me/blog/2021-05-16-elf-interposition-and-bsymbolic) some of the global command line registration machinery. Because of the interposition, `libIREECompiler.so`'s command line registration got routed to `libLLVM.so`'s; luckily, rather than some incredibly hard to diagnose error, the double command line registration crashes on startup.

`--exclude-libs,ALL` hides symbols from static libraries when linking the final `libIREECompiler.so`, preventing LLVM's symbols from being exported and therefore being interposable.

---

Claude generated description

```
Add --exclude-libs=ALL to libIREECompiler.so shared library
libIREECompiler.so statically links LLVM/MLIR but exports ~175K internal
symbols via its version script (api_version.ld uses `global: *`). The
visibility design assumes LLVM is compiled with -fvisibility=hidden, but
LLVM's own CMake build only applies -fvisibility-inlines-hidden — not
-fvisibility=hidden — to the vast majority of its compilation units
(2250/2720 LLVM files, 1049/1145 MLIR files lack the flag). This means
all non-inline LLVM symbols default to visibility("default") and leak
through the version script.

When libIREECompiler.so is loaded via dlopen(RTLD_LOCAL) into a process
that already has libLLVM.so in the global scope (e.g. via HIP runtime's
libamd_comgr.so → libLLVM.so.22.0git), the ELF dynamic linker searches
the global scope first when resolving relocations. LLVM function calls
in libIREECompiler.so that go through the PLT/GOT resolve to
libLLVM.so's copies rather than the compiler's own static LLVM. This
causes LLVM cl::Option static initializers to register duplicate options
into libLLVM.so's global registry, crashing with:

  LLVM ERROR: Option 'pbqp' already exists!

The fix adds --exclude-libs=ALL to the SharedImpl linker options, which
forces all symbols from static archives (.a files) to hidden visibility
at link time. Only symbols from object files (.o) compiled with explicit
__attribute__((visibility("default"))) annotations — i.e. the IREE and
MLIR C API functions marked with IREE_EMBED_EXPORTED / MLIR_CAPI_EXPORTED
— remain visible. This reduces exported dynamic symbols from ~274K to
~2.9K.

This matches the pattern already used by MLIR's own MLIR-C shared
library (mlir/lib/CAPI/CMakeLists.txt):

  target_link_options(MLIR-C PRIVATE "-Wl,-exclude-libs,ALL")
  ```
  
ci-extra: all