### PR TITLE
[ROCM][DT] Add gfx950 f8e4m3fn ukernel

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns_driver.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns_driver.mlir
@@ -592,3 +592,42 @@ module attributes {
 // CHECK-REMARKS:      [Analysis] UKernel
 // CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
 // CHECK-REMARKS-SAME:   Remark=pingpong_dt_medium_f4E2M1FN
+
+// -----
+
+#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx950", features = "",
+                                               wgp = <compute = fp16, storage =  b16,
+                                               subgroup =  none,
+                                               subgroup_size_choices = [64],
+                                               max_workgroup_sizes = [1024, 1024, 1024],
+                                               max_thread_count_per_workgroup = 1024,
+                                               max_workgroup_memory_bytes = 163840,
+                                               max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+module attributes {
+  hal.executable.target = #executable_target_rocm_hsaco_fb
+} {
+  func.func @inner_tiled_f8E4M3FN_large(%arg0: tensor<1x4x2x8x4x16x8xf8E4M3FN>, %arg1: tensor<16x4x4x4x4x16x8xf8E4M3FN>) -> tensor<1x16x2x4x8x4x4x16x4xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x16x2x4x8x4x4x16x4xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x16x2x4x8x4x4x16x4xf32>) -> tensor<1x16x2x4x8x4x4x16x4xf32>
+    %2 = iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%1){
+          indexing_maps = [#map1, #map2, #map3],
+          iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+          kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FN, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4>,
+          semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+        } : tensor<1x4x2x8x4x16x8xf8E4M3FN>, tensor<16x4x4x4x4x16x8xf8E4M3FN> into tensor<1x16x2x4x8x4x4x16x4xf32>
+    return %2 : tensor<1x16x2x4x8x4x4x16x4xf32>
+  }
+}
+// CHECK-LABEL: @inner_tiled_f8E4M3FN_large
+// CHECK:         iree_codegen.inner_tiled
+// CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_dt_large_f8E4M3FN", tensor>
+
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_dt_large_f8E4M3FN

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/BUILD.bazel
@@ -56,6 +56,7 @@ iree_c_embed_data(
     name = "iree_mlir_ukernels_amdgpu",
     srcs = [
         "iree_uk_amdgpu_dt_matmul_f16.mlir",
+        "iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir",
         "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir",
         "iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir",
         "iree_uk_amdgpu_matmul_bf16.mlir",
@@ -74,6 +75,7 @@ iree_lit_test_suite(
     name = "verify_mlir_ukernels_amdgpu",
     srcs = [
         "iree_uk_amdgpu_dt_matmul_f16.mlir",
+        "iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir",
         "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir",
         "iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir",
         "iree_uk_amdgpu_matmul_bf16.mlir",

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_c_embed_data(
     iree_mlir_ukernels_amdgpu
   SRCS
     "iree_uk_amdgpu_dt_matmul_f16.mlir"
+    "iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir"
     "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir"
     "iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir"
     "iree_uk_amdgpu_matmul_bf16.mlir"
@@ -62,6 +63,7 @@ iree_lit_test_suite(
     verify_mlir_ukernels_amdgpu
   SRCS
     "iree_uk_amdgpu_dt_matmul_f16.mlir"
+    "iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir"
     "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir"
     "iree_uk_amdgpu_dt_scaled_matmul_f4E2M1FN.mlir"
     "iree_uk_amdgpu_matmul_bf16.mlir"

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir
@@ -1,0 +1,289 @@
+//  RUN: iree-opt %s
+
+!acc_base_ty = tensor<1x1x2x4x8x4x4x16x4xf32>
+!lhs_base_ty = tensor<1x?x2x8x4x16x8xf8E4M3FN>
+!rhs_base_ty = tensor<1x?x4x4x4x16x8xf8E4M3FN>
+!lhs_expand_ty = tensor<1x?x4x2x8x4x8x2x1x8xf8E4M3FN>
+!rhs_expand_ty = tensor<1x?x4x4x4x4x8x2x1x8xf8E4M3FN>
+!lhs_in_ty = tensor<?x4x16x32x16xf8E4M3FN>
+!rhs_in_ty = tensor<?x4x16x32x16xf8E4M3FN>
+!lhs_shared_ty = memref<4x16x64x8xf8E4M3FN, #gpu.address_space<workgroup>>
+!rhs_shared_ty = memref<4x16x64x8xf8E4M3FN, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func @pingpong_dt_large_f8E4M3FN(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      archs = ["gfx950"],
+      types = [f8E4M3FN, f8E4M3FN, f32],
+      iteration_sizes_constraints = [
+        #rocm.ukernel_interation_size_constraint<index = 0, size_min = 64>, #rocm.ukernel_interation_size_constraint<index = 1, size_min = 8192>
+      ]
+    },
+    benefit = 2,
+    mma = #iree_gpu.data_tiled_mma_layout<
+      intrinsic = MFMA_F32_16x16x32_F8E4M3FN,
+      intrinsics_m = 8,
+      subgroups_m = 2,
+      intrinsics_n = 4,
+      subgroups_n = 4,
+      intrinsics_k = 1
+    >
+  >
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.0 : f8E4M3FN
+
+  %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
+  %nDim = arith.divui %dim, %c4 : index
+
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8, 9]] output_shape [1, %nDim, 4, 2, 8, 4, 8, 2, 1, 8] : !lhs_base_ty into !lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8, 9]] output_shape [1, %nDim, 4, 4, 4, 4, 8, 2, 1, 8] : !rhs_base_ty into !rhs_expand_ty
+
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8, 9]] : !lhs_expand_ty into !lhs_in_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8, 9]] : !rhs_expand_ty into !rhs_in_ty
+
+  %lhs_shared = memref.alloc() : !lhs_shared_ty
+  %rhs_shared = memref.alloc() : !rhs_shared_ty
+
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+    %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+    vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !lhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+    %rhs_vec_local_t = vector.shape_cast %rhs_vec_local : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+    vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !rhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  gpu.barrier memfence [#gpu.address_space<workgroup>]
+
+  %0 = tensor.empty() : !acc_base_ty
+  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !acc_base_ty {
+    %ids:3 = affine.delinearize_index %id into (2, 4, 64) : index, index, index
+    %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
+
+    %m_outer = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
+    %n_outer = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
+
+    %glb:2 = affine.delinearize_index %id into (16, 32) : index, index
+    %glb0_lhs = arith.muli %glb#0, %c1 overflow<nsw, nuw> : index
+    %glb0_rhs = arith.muli %glb#0, %c1 overflow<nsw, nuw> : index
+    %glb_inner = arith.muli %glb#1, %c2 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<8x4x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+    %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<8x4x1x4xf32> {
+      // Global loads of lhs.
+      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %glb0_lhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_0_t = vector.shape_cast %lhs_vec_local_0 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %glb0_lhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_1_t = vector.shape_cast %lhs_vec_local_1 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+      %lhs_thread_2 = tensor.extract_slice %lhs [%i, %c2, %glb0_lhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_2_t = vector.shape_cast %lhs_vec_local_2 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+      %lhs_thread_3 = tensor.extract_slice %lhs [%i, %c3, %glb0_lhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !lhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %lhs_vec_local_3_t = vector.shape_cast %lhs_vec_local_3 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb0_rhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_0_t = vector.shape_cast %rhs_vec_local_0 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c1, %glb0_rhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_1_t = vector.shape_cast %rhs_vec_local_1 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c2, %glb0_rhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_2_t = vector.shape_cast %rhs_vec_local_2 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c3, %glb0_rhs, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !rhs_in_ty to tensor<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FN>, vector<1x1x1x16xf8E4M3FN>
+      %rhs_vec_local_3_t = vector.shape_cast %rhs_vec_local_3 : vector<1x1x1x16xf8E4M3FN> to vector<1x1x2x8xf8E4M3FN>
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+      %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } :vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+
+      // Local stores of lhs and rhs.
+      vector.transfer_write %rhs_vec_local_0_t, %rhs_shared [%c0, %glb0_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_1_t, %rhs_shared [%c1, %glb0_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_2_t, %rhs_shared [%c2, %glb0_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_3_t, %rhs_shared [%c3, %glb0_rhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !rhs_shared_ty
+
+      vector.transfer_write %lhs_vec_local_0_t, %lhs_shared [%c0, %glb0_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_1_t, %lhs_shared [%c1, %glb0_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_2_t, %lhs_shared [%c2, %glb0_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_3_t, %lhs_shared [%c3, %glb0_lhs, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FN>, !lhs_shared_ty
+
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier memfence [#gpu.address_space<workgroup>]
+      rocdl.sched.barrier 0
+
+      scf.yield %dot3 : vector<8x4x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+    %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+    %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+    %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !lhs_shared_ty, vector<1x8x1x8xf8E4M3FN>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !rhs_shared_ty, vector<1x4x1x8xf8E4M3FN>
+    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x8x1x8xf8E4M3FN> to vector<8x1x1x8xf8E4M3FN>
+    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x4x1x8xf8E4M3FN> to vector<4x1x1x8xf8E4M3FN>
+
+    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FN>,
+      semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+    } : vector<8x1x1x8xf8E4M3FN>, vector<4x1x1x8xf8E4M3FN> into vector<8x4x1x4xf32>
+
+    %empty = tensor.empty() : tensor<1x1x1x1x8x4x1x1x4xf32>
+    %cast = vector.shape_cast %dot3 : vector<8x4x1x4xf32> to vector<1x1x1x1x8x4x1x1x4xf32>
+    %4 = vector.transfer_write %cast, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true, true, true, true, true, true]} : vector<1x1x1x1x8x4x1x1x4xf32>, tensor<1x1x1x1x8x4x1x1x4xf32>
+
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%c0, %c0, %ids#0, %ids#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, 1, 8, 4, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x8x4x1x1x4xf32> into !acc_base_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !acc_base_ty
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx950.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx950.mlir
@@ -765,3 +765,60 @@ pdl.pattern @annotate_dt_scaled_matmul_like_f4E2M1FN_medium : benefit(1) {
     pdl.apply_native_rewrite "annotateOperation"(%inner_tiled_op, %builtin_attr, %builtin_annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
   }
 }
+
+pdl.pattern @annotate_inner_tiled_f8E4M3FN_large : benefit(2) {
+  %lhs_type = pdl.type
+  %rhs_type = pdl.type
+  %out_type = pdl.type
+
+  %lhs = pdl.operand : %lhs_type
+  %rhs = pdl.operand : %rhs_type
+  %out_init = pdl.operand : %out_type
+
+  // Match the a inner_tiled with specific data layouts.
+  %generic_op = pdl.operation "iree_codegen.inner_tiled" (%lhs, %rhs, %out_init : !pdl.value, !pdl.value, !pdl.value) -> (%out_type : !pdl.type)
+
+  %attr_name = pdl.attribute = "iree_codegen.ukernel"
+  pdl.apply_native_constraint "hasAttr"(%generic_op, %attr_name : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  %lhs_cast_type = pdl.type : tensor<?x?x2x8x4x16x8xf8E4M3FN>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%lhs, %lhs_cast_type : !pdl.value, !pdl.type)
+  %rhs_cast_type = pdl.type : tensor<?x?x4x4x4x16x8xf8E4M3FN>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
+
+  // Pingpong on outer K dim, this kernel has 4 pingpong stages.
+  %empty = pdl.attribute = {}
+  %c1 = pdl.attribute = 1
+  %c4 = pdl.attribute = 4
+  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c4, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+
+  pdl.rewrite {
+    // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.
+    // This modifies the operation in-place.
+    %annotation = pdl.attribute = #iree_codegen.ukernel_descriptor<"pingpong_dt_large_f8E4M3FN", tensor>
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %attr_name, %annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %config_name = pdl.attribute = "compilation_info"
+    %config = pdl.attribute = #iree_codegen.compilation_info<
+      lowering_config = #iree_gpu.lowering_config<{
+        workgroup = [1, 1, 0],
+        workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
+      }>,
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+        workgroup_size = [512, 1, 1] subgroup_size = 64,
+        // This strategy manually prefetches and eliminates bank conflicts on LDS
+        // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
+        // and enable no_reduce_shared_memory_bank_conflicts.
+        {gpu_pipeline_options =
+          #iree_gpu.pipeline_options<
+            no_reduce_shared_memory_bank_conflicts = true>,
+        // This strategy requires 2 waves per SIMD.
+          llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>
+    >
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %config_name, %config : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %builtin_attr = pdl.attribute = "rocm.builtin_name"
+    %builtin_annotation = pdl.attribute = "iree_uk_amdgpu_dt_matmul_f8E4M3FN.mlir"
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %builtin_attr, %builtin_annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2062,7 +2062,7 @@ iree_generated_e2e_runner_test(
     "--lhs_rhs_type=${_F8E4M3_TYPE}"
     "--acc_type=f32"
     "--shapes=custom_mnk"
-    "--mnk=2048,2048,2048"
+    "--mnk=2048,8192,2048"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS


### PR DESCRIPTION
This PR ports the gfx942 data-tiled large ukernel to gfx950, with tuning applied to the specialization range to  address the performance regression observed when directly migrating the gfx942 configs (see https://github.com/iree-org/iree/issues/22121#issuecomment-3563023732).

After experimenting with intrinsic selection, unroll factors, and size constraint, the size constraint was identified as the most impactful tuning knob. And only the large ukernel proved beneficial, when N>=8192.

Results: Llama 8B f8e4m3fn, gfx950, prefill length 2048:
|                                     | Time (us) |
|-------------------------------------|-----------|
| codegen                             | 279       |
| codegen+ukernel                     | 245       |
| data_tiling                         | 253       |
| data_tiling+ukernel (before tuning) | 270       |
| data_tiling+ukernel (after tuning)  | **242**       |