### PR TITLE
Fix Vulkan driver crash from UNIMPLEMENTED `query_capabilities`.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1504,7 +1504,8 @@ static iree_status_t iree_hal_vulkan_device_query_i64(
 static iree_status_t iree_hal_vulkan_device_query_capabilities(
     iree_hal_device_t* base_device,
     iree_hal_device_capabilities_t* out_capabilities) {
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  memset(out_capabilities, 0, sizeof(*out_capabilities));
+  return iree_ok_status();
 }
 
 static const iree_hal_device_topology_info_t*


### PR DESCRIPTION
#23576 added `query_capabilities` to the device vtable but left the Vulkan implementation as a bare `UNIMPLEMENTED` return. Every other driver (local_task, local_sync, HIP, CUDA, Metal, null, AMDGPU) got the correct `memset + ok_status` stub. The Vulkan driver was the sole holdout, which meant device group creation — now required by the HAL module — failed immediately for any Vulkan device.

This broke every Vulkan CI job, but I didn't notice because the AMD GPU runners have been flaky for months and I'd stopped reading those failures carefully. Lesson learned.