### PR TITLE
Reordered calls to set_external_stream_data_completed.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1559,11 +1559,6 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
   }
   IREE_TRACE_ZONE_END(z3);
 
-  if (device->uses_external_stream) {
-    iree_hal_hip_set_external_stream_data_completed(
-        data->base.external_stream_dispatch_data);
-  }
-
   const iree_hal_hip_dynamic_symbols_t* symbols = device->hip_symbols;
   if (iree_status_is_ok(status)) {
     // Data may get deleted any time after adding it to the cleanup,
@@ -1579,6 +1574,11 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
                               iree_status_clone(status));
     }
     iree_hal_hip_device_destroy_buffer_callback_data(data);
+  }
+
+  if (device->uses_external_stream) {
+    iree_hal_hip_set_external_stream_data_completed(
+        data->base.external_stream_dispatch_data);
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -2144,17 +2144,18 @@ static iree_status_t iree_hal_hip_device_perform_queue_read_now(
     }
   }
 
-  if (device->uses_external_stream) {
-    iree_hal_hip_set_external_stream_data_completed(
-        data->base.external_stream_dispatch_data);
-  }
-
   if (!iree_status_is_ok(status)) {
     for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
          ++i) {
       iree_hal_semaphore_fail(data->base.signal_semaphore_list.semaphores[i],
                               iree_status_clone(status));
     }
+
+    if (device->uses_external_stream) {
+      iree_hal_hip_set_external_stream_data_completed(
+          data->base.external_stream_dispatch_data);
+    }
+
     iree_hal_hip_device_destroy_queue_read_callback_data(data);
   }
 
@@ -2487,11 +2488,6 @@ static iree_status_t iree_hal_hip_device_execute_now(void* user_data,
 
   IREE_TRACE_ZONE_END(z1);
 
-  if (device->uses_external_stream) {
-    iree_hal_hip_set_external_stream_data_completed(
-        data->base.external_stream_dispatch_data);
-  }
-
   // Store symbols, because the cleanup may trigger off-thread
   // before it returns.
   const iree_hal_hip_dynamic_symbols_t* symbols = device->hip_symbols;
@@ -2510,6 +2506,11 @@ static iree_status_t iree_hal_hip_device_execute_now(void* user_data,
                               iree_status_clone(status));
     }
     iree_hal_hip_device_destroy_callback_data(data);
+  }
+
+  if (device->uses_external_stream) {
+    iree_hal_hip_set_external_stream_data_completed(
+        data->base.external_stream_dispatch_data);
   }
 
   IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
This was causing a potential out-of-order issue with preparing and issuing semaphore completion. See #23575