### PR TITLE
[CPU] Expose more options to CPUCodegenOptions.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -61,6 +61,36 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
                     initAtOpt(llvm::OptimizationLevel::O2, true)},
                    llvm::cl::desc("Enables reassociation for FP reductions."),
                    llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-llvmcpu-use-fast-min-max-ops", useFastMinMaxOps,
+      llvm::cl::desc(
+          "Use `arith.minf/maxf` instead of `arith.minimumf/maximumf` ops."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-llvmcpu-skip-intermediate-roundings", skipIntermediateRoundings,
+      llvm::cl::desc(
+          "Allow skipping intermediate roundings. For example, in f16 matmul "
+          "kernels on targets with only f32 arithmetic, we have to perform "
+          "each multiply-accumulate in f32, and if this flag is false, then "
+          "we have to round those f32 accumulators to the nearest f16 every "
+          "time, which is slow."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-llvmcpu-use-decompose-softmax-fuse", useSoftmaxInterFusion,
+      llvm::cl::desc(
+          "Enables inter-pass fusion for the DecomposeSoftmax pass."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-llvmcpu-instrument-memory-accesses", instrumentMemoryAccesses,
+      llvm::cl::desc(
+          "Instruments memory reads and writes in dispatches for address "
+          "tracking. Use with --iree-hal-instrument-dispatches=<buffer-size> "
+          "and analyze results with iree-dump-instruments."),
+      llvm::cl::cat(category));
 }
 
 void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -40,6 +40,19 @@ struct CPUCodegenOptions : CodegenOptions {
   // Enables reassociation for FP reductions.
   bool reassociateFpReductions = false;
 
+  // Use arith.minf/maxf instead of arith.minimumf/maximumf.
+  bool useFastMinMaxOps = false;
+
+  // Allow skipping intermediate roundings (e.g., in f16 matmul on f32
+  // hardware).
+  bool skipIntermediateRoundings = true;
+
+  // Enables inter-pass fusion for the DecomposeSoftmax pass.
+  bool useSoftmaxInterFusion = true;
+
+  // Instruments memory reads and writes in dispatches for address tracking.
+  bool instrumentMemoryAccesses = false;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
 };


### PR DESCRIPTION
The revision moves `useFastMinMaxOps`, `skipIntermediateRoundings`, `useSoftmaxInterFusion`, and `instrumentMemoryAccesses` to `CPUCodegenOptions`, and hides the remaining developer CLI flags.

There are three categories of use cases:

- **Users**: They do not need to understand individual flags. The expectation is that they use optimization levels and optional flags recommended by core developers.
- **Core developers**: Internal knobs for debugging or testing specific codegen behaviors. These are hidden from `--help` and may change or disappear at any time.
- **External developers**: Contributors pushing the boundary on specific targets (e.g., ARM SVE/SME). Their flags need discoverability but are not yet stable.

Moving flags related to scalable vectors was considered but ultimately not done because the plumbing would violate layering. For example, `clEnableScalableVectorization` is accessed globally through a free function. It cannot be passed to the encoding materialization pass because that pass should not carry target-specific codegen options. The root cause is that this information is not queryable from the IR. Promoting it to `CPUCodegenOptions` with an `experimental-` prefix was considered, but the layering violation makes it the wrong approach. Thus, it is left where it is.