### PR TITLE
[CPU] Make pipeline transformation work with single module.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -241,15 +241,16 @@ public:
   void
   buildConfigurationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                  OpPassManager &passManager) final {
-    buildLLVMCPUCodegenConfigurationPassPipeline(passManager, codegenOptions_);
+    buildLLVMCPUCodegenConfigurationPassPipeline(passManager.nest<ModuleOp>(),
+                                                 codegenOptions_);
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                     OpPassManager &passManager) final {
     bool enableAArch64SME = isAArch64(targetAttr.getConfiguration()) &&
                             hasSMEFeature(targetAttr.getConfiguration());
-    buildLLVMCPUCodegenPassPipeline(passManager, codegenOptions_,
-                                    enableAArch64SME);
+    buildLLVMCPUCodegenPassPipeline(passManager.nest<ModuleOp>(),
+                                    codegenOptions_, enableAArch64SME);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) final {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -369,8 +369,10 @@ def ReconcileTranslationInfoPass
     : Pass<"iree-codegen-reconcile-translation-info"> {
   let summary =
       "Reconcile information (like workgroup_size, subgroup_size) across "
-      "`TranslationInfo` set on each function in the dispatch and merge them"
-      "and set them at the appropriate places in the surrounding HAL ops";
+      "`TranslationInfo` set on each function in the dispatch and merge them "
+      "and set them at the appropriate places in the surrounding HAL ops. "
+      "Looks for the enclosing `ExecutableVariantOp` from the parent hierarchy "
+      "and is a no-op when one is not found.";
   let options = [
     Option<"distributeAlong", "distribute-along",
            "::mlir::iree_compiler::IREE::Codegen::WorkgroupId",
@@ -393,12 +395,15 @@ def ReconcileTranslationInfoPass
 
 def ResolveWorkgroupCountHintsPass
     : Pass<"iree-codegen-resolve-workgroup-count-hints"> {
-  let summary = "Materialize workgroup count hints in the workgroup count region per export.";
+  let summary =
+      "Materialize workgroup count hints in the workgroup count region per "
+      "export. Looks for the enclosing `ExecutableVariantOp` from the parent "
+      "hierarchy and is a no-op when one is not found.";
   let description = [{
     Resolves `iree_codegen.workgroup_count_hint` ops by materializing a globally
     agreeable workgroup count per export. This pass performs a depth-first walk
-    of the target variant's call graph constructing the necessary information to
-    materialize workgroup count hints for that function.
+    of the enclosing variant's call graph constructing the necessary information
+    to materialize workgroup count hints for that function.
 
     #### Supported IR Structure
 
@@ -1013,7 +1018,10 @@ def ResolveSwizzleHintsPass :
 
 def SpecializeExportsPass :
     Pass<"iree-codegen-specialize-exports">{
-   let summary = "Specializes exported functions based on annotated ranges";
+   let summary =
+       "Specializes exported functions based on annotated ranges. "
+       "Looks for the enclosing `ExecutableVariantOp` from the parent "
+       "hierarchy and is a no-op when one is not found.";
 }
 
 def StripCompilationInfoPass :

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -366,7 +366,7 @@ def DropVectorUnitDimsPass :
 }
 
 def ReconcileTranslationInfoPass
-    : Pass<"iree-codegen-reconcile-translation-info", "IREE::HAL::ExecutableVariantOp"> {
+    : Pass<"iree-codegen-reconcile-translation-info"> {
   let summary =
       "Reconcile information (like workgroup_size, subgroup_size) across "
       "`TranslationInfo` set on each function in the dispatch and merge them"
@@ -392,7 +392,7 @@ def ReconcileTranslationInfoPass
 }
 
 def ResolveWorkgroupCountHintsPass
-    : Pass<"iree-codegen-resolve-workgroup-count-hints", "IREE::HAL::ExecutableVariantOp"> {
+    : Pass<"iree-codegen-resolve-workgroup-count-hints"> {
   let summary = "Materialize workgroup count hints in the workgroup count region per export.";
   let description = [{
     Resolves `iree_codegen.workgroup_count_hint` ops by materializing a globally
@@ -1012,7 +1012,7 @@ def ResolveSwizzleHintsPass :
 }
 
 def SpecializeExportsPass :
-    Pass<"iree-codegen-specialize-exports", "IREE::HAL::ExecutableVariantOp">{
+    Pass<"iree-codegen-specialize-exports">{
    let summary = "Specializes exported functions based on annotated ranges";
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -26,6 +26,8 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#define DEBUG_TYPE "iree-codegen-reconcile-translation-info"
+
 namespace mlir::iree_compiler {
 
 #define GEN_PASS_DEF_RECONCILETRANSLATIONINFOPASS
@@ -708,7 +710,16 @@ getTranslationInfoAttrs(IREE::Codegen::TranslationInfoAttr translationInfo,
 }
 
 void ReconcileTranslationInfoPass::runOnOperation() {
-  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  auto variantOp = dyn_cast<IREE::HAL::ExecutableVariantOp>(getOperation());
+  if (!variantOp) {
+    variantOp =
+        getOperation()->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  }
+  if (!variantOp) {
+    LLVM_DEBUG(llvm::dbgs() << "Not within an ExecutableVariantOp, skipping "
+                               "translation info reconciliation\n");
+    return;
+  }
   auto innerModuleOp = variantOp.getInnerModule();
   MLIRContext *context = &getContext();
 

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveWorkgroupCountHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveWorkgroupCountHints.cpp
@@ -36,6 +36,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
+#define DEBUG_TYPE "iree-codegen-resolve-workgroup-count-hints"
+
 namespace mlir::iree_compiler {
 
 #define GEN_PASS_DEF_RESOLVEWORKGROUPCOUNTHINTSPASS
@@ -913,7 +915,16 @@ static LogicalResult replaceFromSliceOpWithFunctionSlice(
 //===---------------------------------------------------------------------===//
 
 void ResolveWorkgroupCountHintsPass::runOnOperation() {
-  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  auto variantOp = dyn_cast<IREE::HAL::ExecutableVariantOp>(getOperation());
+  if (!variantOp) {
+    variantOp =
+        getOperation()->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  }
+  if (!variantOp) {
+    LLVM_DEBUG(llvm::dbgs() << "Not within an ExecutableVariantOp, skipping "
+                               "workgroup count hint resolution\n");
+    return;
+  }
   ModuleOp innerModuleOp = variantOp.getInnerModule();
 
   // Run the analysis. If a function that contains a `workgroup_count_hint`

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -419,7 +419,16 @@ public:
   using Base::Base;
 
   void runOnOperation() override {
-    IREE::HAL::ExecutableVariantOp variant = getOperation();
+    auto variant = dyn_cast<IREE::HAL::ExecutableVariantOp>(getOperation());
+    if (!variant) {
+      variant =
+          getOperation()->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+    }
+    if (!variant) {
+      LLVM_DEBUG(llvm::dbgs() << "Not within an ExecutableVariantOp, skipping "
+                                 "export specialization\n");
+      return;
+    }
 
     auto *codegenDialect =
         getContext().getLoadedDialect<IREE::Codegen::IREECodegenDialect>();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -685,62 +685,40 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
 }
 
 void buildLLVMCPUCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts,
-    bool pipelineOnModule) {
-  if (!pipelineOnModule) {
-    variantPassManager.addPass(createSpecializeExportsPass());
-  }
-  OpPassManager &modulePassManager = pipelineOnModule
-                                         ? variantPassManager
-                                         : variantPassManager.nest<ModuleOp>();
+    OpPassManager &modulePassManager, const CPUCodegenOptions &cpuOpts) {
+  modulePassManager.addPass(createSpecializeExportsPass());
   buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager, cpuOpts);
 }
 
-void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
+void buildLLVMCPUCodegenPassPipeline(OpPassManager &modulePassManager,
                                      const CPUCodegenOptions &cpuOpts,
                                      bool enableAArch64SME,
-                                     bool pipelineOnModule,
                                      bool includeLLVMLowering) {
-  {
-    OpPassManager &passManager = pipelineOnModule
-                                     ? variantPassManager
-                                     : variantPassManager.nest<ModuleOp>();
-    passManager.addPass(createLowerExecutableUsingTransformDialectPass());
-    FunctionLikeNest(passManager)
-        .addPass([&]() {
-          return createLLVMCPULowerExecutableTargetPass(
-              LLVMCPULowerExecutableTargetPassOptions{cpuOpts});
-        })
-        .addPredicatedPass(includeLLVMLowering,
-                           createVerifyWorkgroupDistributionPass);
-    if (clPatchFuncOps) {
-      passManager.addPass(createPatchFuncOpsPass());
-    }
+  modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());
+  FunctionLikeNest(modulePassManager)
+      .addPass([&]() {
+        return createLLVMCPULowerExecutableTargetPass(
+            LLVMCPULowerExecutableTargetPassOptions{cpuOpts});
+      })
+      .addPredicatedPass(includeLLVMLowering,
+                         createVerifyWorkgroupDistributionPass);
+  if (clPatchFuncOps) {
+    modulePassManager.addPass(createPatchFuncOpsPass());
   }
 
   if (!includeLLVMLowering) {
     return;
   }
 
-  // Variant-level passes that require ExecutableVariantOp context. Skipped in
-  // pipelineOnModule mode (no exports to reconcile or resolve).
-  if (!pipelineOnModule) {
-    variantPassManager.addPass(createReconcileTranslationInfoPass());
-    variantPassManager.addPass(createResolveWorkgroupCountHintsPass());
-  }
-  variantPassManager.addPass(createIREECodegenLowerAffinePass());
-  variantPassManager.addPass(IREE::Util::createDropCompilerHintsPass());
+  modulePassManager.addPass(createReconcileTranslationInfoPass());
+  modulePassManager.addPass(createResolveWorkgroupCountHintsPass());
+  modulePassManager.addPass(createIREECodegenLowerAffinePass());
+  modulePassManager.addPass(IREE::Util::createDropCompilerHintsPass());
 
-  // Run conversion to LLVM at `ModuleOp` granularity.
-  {
-    OpPassManager &passManager = pipelineOnModule
-                                     ? variantPassManager
-                                     : variantPassManager.nest<ModuleOp>();
-    addLowerToLLVMPasses(passManager, enableAArch64SME, cpuOpts);
-  }
+  addLowerToLLVMPasses(modulePassManager, enableAArch64SME, cpuOpts);
   LLVM_DEBUG({
     llvm::dbgs() << "LLVMCPU codegen pass pipeline:\n";
-    variantPassManager.printAsTextualPipeline(llvm::dbgs());
+    modulePassManager.printAsTextualPipeline(llvm::dbgs());
     llvm::dbgs() << "\n";
   });
 }
@@ -778,29 +756,14 @@ void registerCodegenLLVMCPUPasses() {
   // Generated.
   registerPasses();
 
-  struct LLVMCPUConfigurationPipelineOptions
-      : public PassPipelineOptions<LLVMCPUConfigurationPipelineOptions> {
-    Option<bool> pipelineOnModule{
-        *this, "pipeline-on-module",
-        llvm::cl::desc(
-            "Run the pipeline directly on a module op, skipping "
-            "hal.executable.variant-level passes. This is useful for testing "
-            "with simpler IR that does not require double module nesting."),
-        llvm::cl::init(false)};
-  };
-
-  static PassPipelineRegistration<LLVMCPUConfigurationPipelineOptions>
-      LLVMCPUConfigPipeline(
-          "iree-codegen-llvmcpu-configuration-pipeline",
-          "Runs the translation strategy configuration pipeline on Linalg for "
-          "CPU",
-          [](OpPassManager &passManager,
-             LLVMCPUConfigurationPipelineOptions const &options) {
-            const CPUCodegenOptions &cpuOpts =
-                CPUCodegenOptions::FromFlags::get();
-            buildLLVMCPUCodegenConfigurationPassPipeline(
-                passManager, cpuOpts, options.pipelineOnModule);
-          });
+  static PassPipelineRegistration<> LLVMCPUConfigPipeline(
+      "iree-codegen-llvmcpu-configuration-pipeline",
+      "Runs the translation strategy configuration pipeline on Linalg for "
+      "CPU",
+      [](OpPassManager &passManager) {
+        const CPUCodegenOptions &cpuOpts = CPUCodegenOptions::FromFlags::get();
+        buildLLVMCPUCodegenConfigurationPassPipeline(passManager, cpuOpts);
+      });
 
   static PassPipelineRegistration<> LLVMCPUBufferizationPipeline(
       "iree-codegen-llvmcpu-bufferization-pipeline",
@@ -827,27 +790,19 @@ void registerCodegenLLVMCPUPasses() {
         *this, "include-llvm-lowering",
         llvm::cl::desc("Include the lowering to LLVM dialect."),
         llvm::cl::init(true)};
-    Option<bool> pipelineOnModule{
-        *this, "pipeline-on-module",
-        llvm::cl::desc(
-            "Run the pipeline directly on a module op, skipping "
-            "hal.executable.variant-level passes. This is useful for testing "
-            "with simpler IR that does not require double module nesting."),
-        llvm::cl::init(false)};
   };
 
   static PassPipelineRegistration<LLVMCPULoweringPipelineOptions>
       LLVMCPULoweringPipeline(
           "iree-codegen-llvmcpu-lowering-pipeline",
           "Runs the progressive lowering pipeline from Linalg to LLVM",
-          [](OpPassManager &variantPassManager,
+          [](OpPassManager &passManager,
              LLVMCPULoweringPipelineOptions const &options) {
-            // Use global codegen options for pipeline registration.
             const CPUCodegenOptions &cpuOpts =
                 CPUCodegenOptions::FromFlags::get();
-            buildLLVMCPUCodegenPassPipeline(
-                variantPassManager, cpuOpts, options.enableArmSME,
-                options.pipelineOnModule, options.includeLLVMLowering);
+            buildLLVMCPUCodegenPassPipeline(passManager, cpuOpts,
+                                            options.enableArmSME,
+                                            options.includeLLVMLowering);
           });
 
   static PassPipelineRegistration<> LLVMCPULinkingPipeline(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -685,38 +685,58 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
 }
 
 void buildLLVMCPUCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts) {
-  variantPassManager.addPass(createSpecializeExportsPass());
-  OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
+    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts,
+    bool pipelineOnModule) {
+  if (!pipelineOnModule) {
+    variantPassManager.addPass(createSpecializeExportsPass());
+  }
+  OpPassManager &modulePassManager = pipelineOnModule
+                                         ? variantPassManager
+                                         : variantPassManager.nest<ModuleOp>();
   buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager, cpuOpts);
 }
 
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
                                      const CPUCodegenOptions &cpuOpts,
-                                     bool enableAArch64SME) {
+                                     bool enableAArch64SME,
+                                     bool pipelineOnModule,
+                                     bool includeLLVMLowering) {
   {
-    OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
-    modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());
-    FunctionLikeNest(modulePassManager)
+    OpPassManager &passManager = pipelineOnModule
+                                     ? variantPassManager
+                                     : variantPassManager.nest<ModuleOp>();
+    passManager.addPass(createLowerExecutableUsingTransformDialectPass());
+    FunctionLikeNest(passManager)
         .addPass([&]() {
           return createLLVMCPULowerExecutableTargetPass(
               LLVMCPULowerExecutableTargetPassOptions{cpuOpts});
         })
-        .addPass(createVerifyWorkgroupDistributionPass);
+        .addPredicatedPass(includeLLVMLowering,
+                           createVerifyWorkgroupDistributionPass);
     if (clPatchFuncOps) {
-      modulePassManager.addPass(createPatchFuncOpsPass());
+      passManager.addPass(createPatchFuncOpsPass());
     }
   }
 
-  variantPassManager.addPass(createReconcileTranslationInfoPass());
-  variantPassManager.addPass(createResolveWorkgroupCountHintsPass());
+  if (!includeLLVMLowering) {
+    return;
+  }
+
+  // Variant-level passes that require ExecutableVariantOp context. Skipped in
+  // pipelineOnModule mode (no exports to reconcile or resolve).
+  if (!pipelineOnModule) {
+    variantPassManager.addPass(createReconcileTranslationInfoPass());
+    variantPassManager.addPass(createResolveWorkgroupCountHintsPass());
+  }
   variantPassManager.addPass(createIREECodegenLowerAffinePass());
   variantPassManager.addPass(IREE::Util::createDropCompilerHintsPass());
 
   // Run conversion to LLVM at `ModuleOp` granularity.
   {
-    OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
-    addLowerToLLVMPasses(modulePassManager, enableAArch64SME, cpuOpts);
+    OpPassManager &passManager = pipelineOnModule
+                                     ? variantPassManager
+                                     : variantPassManager.nest<ModuleOp>();
+    addLowerToLLVMPasses(passManager, enableAArch64SME, cpuOpts);
   }
   LLVM_DEBUG({
     llvm::dbgs() << "LLVMCPU codegen pass pipeline:\n";
@@ -758,14 +778,29 @@ void registerCodegenLLVMCPUPasses() {
   // Generated.
   registerPasses();
 
-  static PassPipelineRegistration<> LLVMCPUConfigPipeline(
-      "iree-codegen-llvmcpu-configuration-pipeline",
-      "Runs the translation strategy configuration pipeline on Linalg for CPU",
-      [](OpPassManager &modulePassManager) {
-        const CPUCodegenOptions &cpuOpts = CPUCodegenOptions::FromFlags::get();
-        buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager,
-                                                         cpuOpts);
-      });
+  struct LLVMCPUConfigurationPipelineOptions
+      : public PassPipelineOptions<LLVMCPUConfigurationPipelineOptions> {
+    Option<bool> pipelineOnModule{
+        *this, "pipeline-on-module",
+        llvm::cl::desc(
+            "Run the pipeline directly on a module op, skipping "
+            "hal.executable.variant-level passes. This is useful for testing "
+            "with simpler IR that does not require double module nesting."),
+        llvm::cl::init(false)};
+  };
+
+  static PassPipelineRegistration<LLVMCPUConfigurationPipelineOptions>
+      LLVMCPUConfigPipeline(
+          "iree-codegen-llvmcpu-configuration-pipeline",
+          "Runs the translation strategy configuration pipeline on Linalg for "
+          "CPU",
+          [](OpPassManager &passManager,
+             LLVMCPUConfigurationPipelineOptions const &options) {
+            const CPUCodegenOptions &cpuOpts =
+                CPUCodegenOptions::FromFlags::get();
+            buildLLVMCPUCodegenConfigurationPassPipeline(
+                passManager, cpuOpts, options.pipelineOnModule);
+          });
 
   static PassPipelineRegistration<> LLVMCPUBufferizationPipeline(
       "iree-codegen-llvmcpu-bufferization-pipeline",
@@ -783,24 +818,36 @@ void registerCodegenLLVMCPUPasses() {
         buildLLVMCPUVectorLoweringPipeline(funcPassManager, options);
       });
 
-  struct LinalgToLLVMPipelineOptions
-      : public PassPipelineOptions<LinalgToLLVMPipelineOptions> {
+  struct LLVMCPULoweringPipelineOptions
+      : public PassPipelineOptions<LLVMCPULoweringPipelineOptions> {
     Option<bool> enableArmSME{
         *this, "enable-arm-sme",
         llvm::cl::desc("Enable the ArmSME lowering pipeline.")};
+    Option<bool> includeLLVMLowering{
+        *this, "include-llvm-lowering",
+        llvm::cl::desc("Include the lowering to LLVM dialect."),
+        llvm::cl::init(true)};
+    Option<bool> pipelineOnModule{
+        *this, "pipeline-on-module",
+        llvm::cl::desc(
+            "Run the pipeline directly on a module op, skipping "
+            "hal.executable.variant-level passes. This is useful for testing "
+            "with simpler IR that does not require double module nesting."),
+        llvm::cl::init(false)};
   };
 
-  static PassPipelineRegistration<LinalgToLLVMPipelineOptions>
-      LinalgLLVMPipeline(
-          "iree-codegen-linalg-to-llvm-pipeline",
+  static PassPipelineRegistration<LLVMCPULoweringPipelineOptions>
+      LLVMCPULoweringPipeline(
+          "iree-codegen-llvmcpu-lowering-pipeline",
           "Runs the progressive lowering pipeline from Linalg to LLVM",
           [](OpPassManager &variantPassManager,
-             LinalgToLLVMPipelineOptions const &options) {
+             LLVMCPULoweringPipelineOptions const &options) {
             // Use global codegen options for pipeline registration.
             const CPUCodegenOptions &cpuOpts =
                 CPUCodegenOptions::FromFlags::get();
-            buildLLVMCPUCodegenPassPipeline(variantPassManager, cpuOpts,
-                                            options.enableArmSME);
+            buildLLVMCPUCodegenPassPipeline(
+                variantPassManager, cpuOpts, options.enableArmSME,
+                options.pipelineOnModule, options.includeLLVMLowering);
           });
 
   static PassPipelineRegistration<> LLVMCPULinkingPipeline(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -124,24 +124,20 @@ void addMultiTilingExpertPassPipeline(
 //----------------------------------------------------------------------------//
 
 /// Populates passes needed for preprocessing before codegen lowerings, as well
-/// as high level lowering strategy selection.
-/// When `pipelineOnModule` is true, the pipeline operates directly on a
-/// `ModuleOp` (no variant-level nesting or variant-specific passes), enabling
-/// simpler test IR without double module nesting.
+/// as high level lowering strategy selection. The pass manager should operate
+/// on a `ModuleOp`. Passes that need variant context (e.g., export
+/// specialization) look up the parent `ExecutableVariantOp` and are no-ops
+/// when it is absent.
 void buildLLVMCPUCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts,
-    bool pipelineOnModule = false);
+    OpPassManager &modulePassManager, const CPUCodegenOptions &cpuOpts);
 
 /// Populates passes needed to lower high level ops, e.g., linalg, vector, etc,
-/// to LLVM dialect via the structured ops path. The  `variantPassManager`
-/// should operate on the module within the IREE::HAL::ExecutableOp.
-/// When `pipelineOnModule` is true, the pipeline operates directly on a
-/// `ModuleOp` (no variant-level nesting or variant-specific passes), enabling
-/// simpler test IR without double module nesting.
-void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
+/// to LLVM dialect via the structured ops path. The pass manager should operate
+/// on a `ModuleOp`. Passes that need variant context look up the parent
+/// `ExecutableVariantOp` and are no-ops when it is absent.
+void buildLLVMCPUCodegenPassPipeline(OpPassManager &modulePassManager,
                                      const CPUCodegenOptions &codegenOptions,
                                      bool enableAArch64SME = false,
-                                     bool pipelineOnModule = false,
                                      bool includeLLVMLowering = true);
 
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -125,15 +125,24 @@ void addMultiTilingExpertPassPipeline(
 
 /// Populates passes needed for preprocessing before codegen lowerings, as well
 /// as high level lowering strategy selection.
+/// When `pipelineOnModule` is true, the pipeline operates directly on a
+/// `ModuleOp` (no variant-level nesting or variant-specific passes), enabling
+/// simpler test IR without double module nesting.
 void buildLLVMCPUCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts);
+    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts,
+    bool pipelineOnModule = false);
 
 /// Populates passes needed to lower high level ops, e.g., linalg, vector, etc,
 /// to LLVM dialect via the structured ops path. The  `variantPassManager`
 /// should operate on the module within the IREE::HAL::ExecutableOp.
+/// When `pipelineOnModule` is true, the pipeline operates directly on a
+/// `ModuleOp` (no variant-level nesting or variant-specific passes), enabling
+/// simpler test IR without double module nesting.
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
                                      const CPUCodegenOptions &codegenOptions,
-                                     bool enableAArch64SME = false);
+                                     bool enableAArch64SME = false,
+                                     bool pipelineOnModule = false,
+                                     bool includeLLVMLowering = true);
 
 //----------------------------------------------------------------------------//
 // LLVMCPU Linking Passes and Pipelines

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -44,6 +44,7 @@ iree_lit_test_suite(
             "pipeline_pad_tests.mlir",
             "pipeline_peel_and_vectorize_tests.mlir",
             "pipeline_riscv_aggressive_distribution_tests.mlir",
+            "pipeline_smoke_test.mlir",
             "pipeline_split_reduction_tests.mlir",
             "pipeline_tests.mlir",
             "pipeline_transpose_avx2_tests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_lit_test_suite(
     "pipeline_pad_tests.mlir"
     "pipeline_peel_and_vectorize_tests.mlir"
     "pipeline_riscv_aggressive_distribution_tests.mlir"
+    "pipeline_smoke_test.mlir"
     "pipeline_split_reduction_tests.mlir"
     "pipeline_tests.mlir"
     "pipeline_transpose_avx2_tests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lowering_strategy_from_tuning_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lowering_strategy_from_tuning_spec.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file \
-// RUN:   --pass-pipeline='builtin.module(iree-codegen-llvmcpu-configuration-pipeline{pipeline-on-module=true})' \
+// RUN:   --iree-codegen-llvmcpu-configuration-pipeline \
 // RUN:   --iree-codegen-tuning-spec-path=%p/tuning_spec_matmul.mlir \
 // RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lowering_strategy_from_tuning_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lowering_strategy_from_tuning_spec.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file \
-// RUN:   --pass-pipeline='builtin.module(iree-codegen-llvmcpu-configuration-pipeline)' \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-llvmcpu-configuration-pipeline{pipeline-on-module=true})' \
 // RUN:   --iree-codegen-tuning-spec-path=%p/tuning_spec_matmul.mlir \
 // RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_arm_sme_streaming_mode_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_arm_sme_streaming_mode_tests.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --iree-codegen-linalg-to-llvm-pipeline=enable-arm-sme --split-input-file %s | FileCheck %s
-// RUN: iree-opt --iree-codegen-linalg-to-llvm-pipeline=enable-arm-sme --iree-llvmcpu-force-arm-streaming --split-input-file %s | FileCheck %s -check-prefixes=FORCE-ARM-STREAMING
+// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='enable-arm-sme pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='enable-arm-sme pipeline-on-module=true' --iree-llvmcpu-force-arm-streaming --split-input-file %s | FileCheck %s -check-prefixes=FORCE-ARM-STREAMING
 
 #pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -7,22 +7,18 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_cpu.lowering_config<distribution = [0], vector_common_parallel = [1]>
-module {
-module {
-  func.func @fixed_size_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>} {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    %2 = tensor.empty() : tensor<1xf32>
-    %3 = linalg.fill {lowering_config = #config}
-        ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
-    iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    return
-  }
-}
+func.func @fixed_size_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
+    translation_info = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  %2 = tensor.empty() : tensor<1xf32>
+  %3 = linalg.fill {lowering_config = #config}
+      ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  return
 }
 
 /// A dispatch region that only uses fixed-size vectors should never use
@@ -44,22 +40,18 @@ module {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_cpu.lowering_config<distribution = [0], vector_common_parallel = [[1]]>
-module {
-module {
-  func.func @scalable_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>} {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    %2 = tensor.empty() : tensor<1xf32>
-    %3 = linalg.fill {lowering_config = #config}
-        ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
-    iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    return
-  }
-}
+func.func @scalable_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
+    translation_info = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  %2 = tensor.empty() : tensor<1xf32>
+  %3 = linalg.fill {lowering_config = #config}
+      ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  return
 }
 
 /// A dispatch region that uses scalable vectors (but not ArmSME dialect
@@ -82,22 +74,18 @@ module {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_cpu.lowering_config<distribution = [0, 0], vector_common_parallel = [[4], [4]]>
-module {
-module {
-  func.func @scalable_dispatch_using_za() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>} {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
-    %2 = tensor.empty() : tensor<100x100xf32>
-    %3 = linalg.fill {lowering_config = #config}
-        ins(%cst : f32) outs(%2 : tensor<100x100xf32>) -> tensor<100x100xf32>
-    iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [100, 100], strides = [100, 1] : tensor<100x100xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
-    return
-  }
-}
+func.func @scalable_dispatch_using_za() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
+    translation_info = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
+  %2 = tensor.empty() : tensor<100x100xf32>
+  %3 = linalg.fill {lowering_config = #config}
+      ins(%cst : f32) outs(%2 : tensor<100x100xf32>) -> tensor<100x100xf32>
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [100, 100], strides = [100, 1] : tensor<100x100xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
+  return
 }
 
 /// A dispatch region that uses ArmSME operations (that require the ZA state)

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_arm_sme_streaming_mode_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_arm_sme_streaming_mode_tests.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='enable-arm-sme pipeline-on-module=true' --split-input-file %s | FileCheck %s
-// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='enable-arm-sme pipeline-on-module=true' --iree-llvmcpu-force-arm-streaming --split-input-file %s | FileCheck %s -check-prefixes=FORCE-ARM-STREAMING
+// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='enable-arm-sme' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='enable-arm-sme' --iree-llvmcpu-force-arm-streaming --split-input-file %s | FileCheck %s -check-prefixes=FORCE-ARM-STREAMING
 
 #pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target, iree-llvmcpu-check-ir-before-llvm-conversion))' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
 
 // Test that iree_linalg_ext.map_store op is not generated when distribution
 // is disabled. The op is used in the fallback solution when the pack op is not

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
 
 // Test that iree_linalg_ext.map_store op is not generated when distribution
 // is disabled. The op is used in the fallback solution when the pack op is not

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_conv_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_conv_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_conv_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_conv_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
 // XFAIL: *
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 // XFAIL: *
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-llvmcpu-lower-executable-target))' -split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' -split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' -split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' -split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_riscv_aggressive_distribution_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_riscv_aggressive_distribution_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-llvmcpu-riscv-aggressive-distribution=true --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-llvmcpu-riscv-aggressive-distribution=true --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_riscv_aggressive_distribution_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_riscv_aggressive_distribution_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-llvmcpu-riscv-aggressive-distribution=true --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-llvmcpu-riscv-aggressive-distribution=true --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_smoke_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_smoke_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmcpu-configuration-pipeline, iree-codegen-llvmcpu-lowering-pipeline)))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmcpu-configuration-pipeline, iree-codegen-llvmcpu-lowering-pipeline))))' --split-input-file %s | FileCheck %s
 
 // Smoke test: verify the full LLVMCPU pipeline (configuration + lowering
 // including LLVM conversion) runs end-to-end on a simple dynamic elementwise

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_smoke_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_smoke_test.mlir
@@ -1,0 +1,56 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmcpu-configuration-pipeline, iree-codegen-llvmcpu-lowering-pipeline)))' --split-input-file %s | FileCheck %s
+
+// Smoke test: verify the full LLVMCPU pipeline (configuration + lowering
+// including LLVM conversion) runs end-to-end on a simple dynamic elementwise
+// add using the production IR structure with hal.executable nesting.
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<
+    "llvm-cpu", "embedded-elf-x86_64",
+    {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+     native_vector_size = 16 : index,
+     target_triple = "x86_64-none-elf"}>
+hal.executable private @elementwise_add_exe {
+  hal.executable.variant public @embedded_elf_x86_64 target(#executable_target) {
+    hal.executable.export public @elementwise_add ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %workload: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%workload)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @elementwise_add() {
+        %c0 = arith.constant 0 : index
+        %dim_i32 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %dim_cast = arith.index_castui %dim_i32 : i32 to index
+        %dim = iree_tensor_ext.dispatch.workload.ordinal %dim_cast, 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%dim}
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%dim}
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%dim}
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [%dim], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%dim} -> tensor<?xf32>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [%dim], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%dim} -> tensor<?xf32>
+        %5 = tensor.empty(%dim) : tensor<?xf32>
+        %6 = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>,
+                             affine_map<(d0) -> (d0)>,
+                             affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+            ins(%3, %4 : tensor<?xf32>, tensor<?xf32>)
+            outs(%5 : tensor<?xf32>) {
+        ^bb0(%in0: f32, %in1: f32, %out: f32):
+          %7 = arith.addf %in0, %in1 : f32
+          linalg.yield %7 : f32
+        } -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0], sizes = [%dim], strides = [1] : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%dim}
+        return
+      }
+    }
+  }
+}
+
+// Verify the pipeline produces LLVM IR.
+// CHECK-LABEL: hal.executable private @elementwise_add_exe
+//       CHECK:   llvm.func @elementwise_add
+//       CHECK:     llvm.fadd

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
@@ -1,10 +1,10 @@
 // CPU backend disable fp reassociation for O0 and O1, so the checks should be the same.
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --iree-llvmcpu-mlir-opt-level=O0 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-mlir-opt-level=O0 --split-input-file %s | FileCheck %s
 
 // CPU backend enables fp reassociation strating from O2, so the checks should be the same.
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
@@ -1,10 +1,10 @@
 // CPU backend disable fp reassociation for O0 and O1, so the checks should be the same.
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-mlir-opt-level=O0 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O0 --split-input-file %s | FileCheck %s
 
 // CPU backend enables fp reassociation strating from O2, so the checks should be the same.
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-codegen-llvmcpu-configuration-pipeline, func.func(iree-llvmcpu-lower-executable-target, iree-llvmcpu-check-ir-before-llvm-conversion))' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s
 
 // Check that this dispatch compiles to vectors and that there are no allocas.
 // By proxy checks that destination passing style kicked in correctly

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s
 
 // Check that this dispatch compiles to vectors and that there are no allocas.
 // By proxy checks that destination passing style kicked in correctly

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_transpose_avx2_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_transpose_avx2_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_transpose_avx2_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_transpose_avx2_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vector_masking_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vector_masking_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' -split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' -split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vector_masking_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vector_masking_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' -split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' -split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vectorize_nd_extract_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vectorize_nd_extract_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vectorize_nd_extract_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_vectorize_nd_extract_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='pipeline-on-module=true' --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false pipeline-on-module=true' --split-input-file %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,


### PR DESCRIPTION
There are three passes working on variantOp scope, which makes the setup of pipeline tests weird. E.g., currently it requires either two level of nested module or invoking specific passes.

The revision adds an option to skip variantOp scope passes (like distribution and export specialization) and rename it to `LLVMCPULoweringPipeline`, because it is mainly for lowering. It also introduces an option to stop the lowering before LLVM conversion which makes IR checks much easier, which also aligns with the result of current specific pass invocation.