### PR TITLE
[Python] Bump minimum required Python version to 3.10

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -2,10 +2,10 @@
 #   * main-dist-linux (CMake 'install')
 #   * py-compiler-pkg (`iree-base-compiler` Python package)
 #     * Linux, macOS, Windows
-#     * All supported Python versions (e.g. 3.9, 3.10, 3.11)
+#     * All supported Python versions (e.g. 3.10, 3.11)
 #   * py-runtime-pkg (`iree-base-runtime` Python package)
 #     * Linux, macOS, Windows
-#     * All supported Python versions (e.g. 3.9, 3.10, 3.11)
+#     * All supported Python versions (e.g. 3.10, 3.11)
 #   * py-tf-compiler-tools-pkg (`iree-tools-[tf, tflite]`, pure Python packages)
 
 name: Build Release Packages

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -37,7 +37,7 @@ jobs:
         id: set_up_python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install python packages
         id: install_python_packages
         run: |

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Check for patch release
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,15 +737,15 @@ if(IREE_BUILD_PYTHON_BINDINGS)
   # "Bootstrapping" by first looking for the optional Development component
   # seems to be robust generally.
   # See: https://reviews.llvm.org/D118148
-  # If building Python packages, we have a hard requirement on 3.9+.
-  find_package(Python3 3.9 COMPONENTS Interpreter Development NumPy)
-  find_package(Python3 3.9 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+  # If building Python packages, we have a hard requirement on 3.10+.
+  find_package(Python3 3.10 COMPONENTS Interpreter Development NumPy)
+  find_package(Python3 3.10 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
   # Some parts of the build use FindPython instead of FindPython3. Why? No
   # one knows, but they are different. So make sure to bootstrap this one too.
   # Not doing this here risks them diverging, which on multi-Python systems,
   # can be troublesome. Note that nanobind requires FindPython.
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
-  find_package(Python 3.9 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+  find_package(Python 3.10 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
 elseif(IREE_BUILD_COMPILER OR IREE_BUILD_TESTS)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -23,7 +23,7 @@
 #
 # Valid Python versions match a subdirectory under /opt/python in the docker
 # image. Typically:
-#   cp39-cp39 cp310-cp310
+#   cp310-cp310 cp311-cp311
 #
 # Valid packages:
 #   iree-base-runtime

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -16,7 +16,7 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp39-cp39 cp310-cp310" \
+#   override_python_versions="cp310-cp310" \
 #   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -16,7 +16,7 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp310-cp310" \
+#   override_python_versions="cp310-cp310 cp310-cp311" \
 #   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -16,7 +16,7 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp310-cp310 cp310-cp311" \
+#   override_python_versions="cp310-cp310 cp311-cp311" \
 #   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -16,14 +16,14 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp39-cp39 cp310-cp310" \
+#   override_python_versions="cp310-cp310" \
 #   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Valid Python versions match a subdirectory under /opt/python in the docker
 # image. Typically:
-#   cp39-cp39 cp310-cp310
+#   cp310-cp310
 #
 # Valid packages:
 #   iree-base-runtime
@@ -65,7 +65,7 @@ this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4" }')}"
-python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp313-cp313t}"
+python_versions="${override_python_versions:-cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp313-cp313t}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-base-runtime iree-base-compiler}"
 package_suffix="${package_suffix:-}"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -16,14 +16,14 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp310-cp310" \
+#   override_python_versions="cp310-cp310 cp311-cp311" \
 #   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Valid Python versions match a subdirectory under /opt/python in the docker
 # image. Typically:
-#   cp310-cp310
+#   cp310-cp310 cp311-cp311
 #
 # Valid packages:
 #   iree-base-runtime

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -12,7 +12,7 @@
 # with directory names under:
 #   /Library/Frameworks/Python.framework/Versions
 #
-# MacOS convention is to refer to this as major.minor (i.e. "3.9", "3.10").
+# MacOS convention is to refer to this as major.minor (i.e. "3.10", "3.11").
 # Valid packages:
 #   iree-base-runtime
 #   iree-base-compiler

--- a/build_tools/python_deploy/install_macos_deps.sh
+++ b/build_tools/python_deploy/install_macos_deps.sh
@@ -23,8 +23,7 @@ PYTHON_SPECS=(
   3.13@https://www.python.org/ftp/python/3.13.1/python-3.13.1-macos11.pkg
   3.12@https://www.python.org/ftp/python/3.12.8/python-3.12.8-macos11.pkg
   3.11@https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg
-  # 3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
-  # 3.9@https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg
+  3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
 )
 
 for python_spec in "${PYTHON_SPECS[@]}"; do

--- a/build_tools/python_deploy/install_macos_deps.sh
+++ b/build_tools/python_deploy/install_macos_deps.sh
@@ -23,7 +23,7 @@ PYTHON_SPECS=(
   3.13@https://www.python.org/ftp/python/3.13.1/python-3.13.1-macos11.pkg
   3.12@https://www.python.org/ftp/python/3.12.8/python-3.12.8-macos11.pkg
   3.11@https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg
-  3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
+  # 3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
 )
 
 for python_spec in "${PYTHON_SPECS[@]}"; do

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -10,16 +10,14 @@ $PYTHON_VERSIONS = @(
   "3.13" #,
   "3.12" #,
   "3.11" #,
-  # "3.10",
-  # "3.9"
+  # "3.10"
 )
 
 $PYTHON_VERSIONS_NO_DOT = @(
   "313" #,
   "312" #,
   "311" #,
-  # "310",
-  # "39"
+  # "310"
 )
 
 # These can be discovered at https://www.python.org/downloads/windows/
@@ -27,8 +25,7 @@ $PYTHON_INSTALLER_URLS = @(
   "https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe" #,
   "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe" #,
   "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" #,
-  # "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe",
-  # "https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe"
+  "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe"
 )
 
 # Multiple Python install locations are valid, so we use the `py` helper to

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -25,7 +25,7 @@ $PYTHON_INSTALLER_URLS = @(
   "https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe" #,
   "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe" #,
   "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" #,
-  "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe"
+  # "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe",
 )
 
 # Multiple Python install locations are valid, so we use the `py` helper to

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -465,7 +465,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -319,7 +319,7 @@ about the bindings themselves.
 You will need Python >=3.10. IREE supports
 [non-EOL Python versions](https://endoflife.date/python), following the same
 lifecycle policy as LLVM's minimum required Python version — see the
-[LLVM minimum Python version RFC](https://discourse.llvm.org/t/rfc-upgrading-llvm-s-minimum-required-python-version/88605).
+[LLVM's Python support policy](https://discourse.llvm.org/t/rfc-adopt-regularly-scheduled-python-minimum-version-bumps/88841).
 
 ???+ Tip "Tip - Managing Python versions"
     Make sure your 'python' is what you expect:

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -316,11 +316,10 @@ about the bindings themselves.
 
 ### Dependencies
 
-You will need a recent Python installation >=3.10 (we aim to support
-[non-eol Python versions](https://endoflife.date/python)). This also aligns
-the Python lifecycle adopted by LLVM's minimum required Python version
-policy — see the
-[LLVM RFC on upgrading the minimum required Python version](https://discourse.llvm.org/t/rfc-upgrading-llvm-s-minimum-required-python-version/88605).
+You will need Python >=3.10. IREE supports
+[non-EOL Python versions](https://endoflife.date/python), following the same
+lifecycle policy as LLVM's minimum required Python version — see the
+[LLVM minimum Python version RFC](https://discourse.llvm.org/t/rfc-upgrading-llvm-s-minimum-required-python-version/88605).
 
 ???+ Tip "Tip - Managing Python versions"
     Make sure your 'python' is what you expect:

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -316,8 +316,11 @@ about the bindings themselves.
 
 ### Dependencies
 
-You will need a recent Python installation >=3.9 (we aim to support
-[non-eol Python versions](https://endoflife.date/python)).
+You will need a recent Python installation >=3.10 (we aim to support
+[non-eol Python versions](https://endoflife.date/python)). This also aligns
+the Python lifecycle adopted by LLVM's minimum required Python version
+policy — see the
+[LLVM RFC on upgrading the minimum required Python version](https://discourse.llvm.org/t/rfc-upgrading-llvm-s-minimum-required-python-version/88605).
 
 ???+ Tip "Tip - Managing Python versions"
     Make sure your 'python' is what you expect:

--- a/docs/website/docs/developers/debugging/releases.md
+++ b/docs/website/docs/developers/debugging/releases.md
@@ -41,7 +41,7 @@ The Linux releases are done in a manylinux2014 docker container defined in the
 [`manylinux_x86_64.Dockerfile`](https://github.com/iree-org/base-docker-images/blob/main/dockerfiles/manylinux_x86_64.Dockerfile)
 file within the
 [iree-org/base-docker-images repository](https://github.com/iree-org/base-docker-images/).
-At the time of this writing, it has Python versions 3.9 - 3.13 under
+At the time of this writing, it has Python versions 3.10 - 3.13 under
 `/opt/python`. Note that this docker image approximates a 2014 era RHEL distro,
 patched with backported (newer) dev packages. It builds with clang by default.
 `yum` can be used to get some packages.

--- a/integrations/tensorflow/python_projects/iree_tf/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tf/setup.py
@@ -55,13 +55,12 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     packages=find_namespace_packages(
         include=[
             "iree.tools.tf",

--- a/integrations/tensorflow/python_projects/iree_tflite/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tflite/setup.py
@@ -55,13 +55,12 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     packages=find_namespace_packages(
         include=[
             "iree.tools.tflite",

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -573,7 +573,7 @@ setup(
         "repository": "https://github.com/iree-org/iree",
         "documentation": "https://iree.dev/reference/bindings/python/",
     },
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     ext_modules=(
         [
             CMakeExtension("iree._runtime_libs._runtime"),

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -562,7 +562,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This PR bumps the minimum Python version required by IREE to Python 3.10. This is following [python lifecycle](https://endoflife.date/python) and [LLVM's python support policy](https://discourse.llvm.org/t/rfc-adopt-regularly-scheduled-python-minimum-version-bumps/88841).
This decision was proposed on Feb.11 and received no objections to date, see [this](https://lists.lfaidata.foundation/g/iree-technical-discussion/message/12).