### PR TITLE
[VMVX] Introduce VMVXCodegenOptions

### DIFF
--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 #include "iree/compiler/Codegen/VMVX/Passes.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
@@ -270,6 +271,35 @@ struct VMVXSession final
       return std::make_shared<VMVXInlineTargetBackend>(options);
     });
   }
+
+  // Override Registration to also bind VMVXCodegenOptions to the session.
+  struct Registration : PluginSession::Registration {
+    using PluginSession::Registration::Registration;
+    std::unique_ptr<AbstractPluginSession>
+    createUninitializedSession(OptionsBinder &localOptionsBinder) final {
+      auto instance = std::make_unique<VMVXSession>();
+      // Bootstrap target options from global CLI if available.
+      if (globalCLIOptions) {
+        instance->options = *(*globalCLIOptions);
+      }
+      instance->options.bindOptions(localOptionsBinder);
+
+      // Bootstrap codegen options from global CLI if available.
+      if (globalCLICodegenOptions) {
+        instance->codegenOptions = *(*globalCLICodegenOptions);
+      }
+      instance->codegenOptions.bindOptions(localOptionsBinder);
+
+      return instance;
+    }
+    void initializeCLI() final {
+      PluginSession::Registration::initializeCLI();
+      globalCLICodegenOptions = &VMVXCodegenOptions::FromFlags::get();
+    }
+    std::optional<VMVXCodegenOptions *> globalCLICodegenOptions;
+  };
+
+  VMVXCodegenOptions codegenOptions;
 };
 
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -8,6 +8,7 @@
 
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::CPUCodegenOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::VMVXCodegenOptions);
 
 namespace mlir::iree_compiler {
 
@@ -100,6 +101,28 @@ void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {
   binder.opt<bool>(
       "iree-llvmgpu-enable-prefetch", enablePrefetch,
       llvm::cl::desc("Enable prefetch in the vector distribute pipeline."),
+      llvm::cl::cat(category));
+}
+
+void VMVXCodegenOptions::bindOptions(OptionsBinder &binder) {
+  static llvm::cl::OptionCategory category("IREE VMVX Codegen Options");
+  CodegenOptions::bindOptions(binder);
+
+  binder.opt<bool>(
+      "iree-vmvx-skip-intermediate-roundings", skipIntermediateRoundings,
+      llvm::cl::desc(
+          "Allow skipping intermediate roundings. For example, in f16 matmul "
+          "kernels on targets with only f32 arithmetic, we have to perform "
+          "each multiply-accumulate in f32, and if this flag is false, then "
+          "we have to round those f32 accumulators to the nearest f16 every "
+          "time, which is slow."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
+      "iree-vmvx-enable-ukernels-decompose-linalg-generic",
+      enableUKernelsDecomposeLinalgGeneric,
+      llvm::cl::desc("Enables decomposition of linalg.generic ops when "
+                     "ukernels are enabled (experimental)"),
       llvm::cl::cat(category));
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -65,6 +65,18 @@ struct GPUCodegenOptions : CodegenOptions {
   using FromFlags = OptionsFromFlags<GPUCodegenOptions>;
 };
 
+struct VMVXCodegenOptions : CodegenOptions {
+  // Allow skipping intermediate roundings (e.g., in f16 matmul on f32
+  // hardware).
+  bool skipIntermediateRoundings = true;
+
+  // Enables decomposition of linalg.generic ops when ukernels are enabled.
+  bool enableUKernelsDecomposeLinalgGeneric = true;
+
+  void bindOptions(OptionsBinder &binder);
+  using FromFlags = OptionsFromFlags<VMVXCodegenOptions>;
+};
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_CODEGENOPTIONS_H_

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -15,25 +15,6 @@
 
 namespace mlir::iree_compiler {
 
-/// Command line options used purely for development purposes. Not to be relied
-/// on in any way.
-
-static llvm::cl::opt<bool> clSkipIntermediateRoundings(
-    "iree-vmvx-skip-intermediate-roundings",
-    llvm::cl::desc(
-        "Allow skipping intermediate roundings. For example, in f16 matmul "
-        "kernels on targets with only f32 arithmetic, we have to perform each "
-        "multiply-accumulate in f32, and if this flag is false, then we have "
-        "to round those f32 accumulators to the nearest f16 every time, which "
-        "is slow."),
-    llvm::cl::init(true));
-
-static llvm::cl::opt<bool> clEnableUKernelsDecomposeLinalgGeneric(
-    "iree-vmvx-enable-ukernels-decompose-linalg-generic",
-    llvm::cl::desc("Enables decomposition of linalg.generic ops when "
-                   "ukernels are enabled (experimental)"),
-    llvm::cl::init(true));
-
 static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass());
   funcPassManager.addPass(createCSEPass());
@@ -51,19 +32,20 @@ static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
 }
 
 void addVMVXDefaultPassPipeline(OpPassManager &funcPassManager,
-                                bool enableUKernels) {
+                                bool enableUKernels,
+                                const VMVXCodegenOptions &vmvxOpts) {
   addTileAndDistributePasses(funcPassManager);
 
   if (enableUKernels) {
     funcPassManager.addPass(createCPUPrepareUkernelsPass());
     funcPassManager.addPass(
-        createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
+        createCPULowerToUKernelsPass(vmvxOpts.skipIntermediateRoundings));
   }
 
   // Tensor-level micro-kernel optimizations.
   // Note that this must be done post-tiling because it changes the structure
   // of the dispatch region such that tiling is not always possible.
-  if (enableUKernels && clEnableUKernelsDecomposeLinalgGeneric) {
+  if (enableUKernels && vmvxOpts.enableUKernelsDecomposeLinalgGeneric) {
     funcPassManager.addPass(createDecomposeLinalgGenericPass());
   }
 

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.h
@@ -12,6 +12,7 @@
 #ifndef IREE_COMPILER_CODEGEN_VMVX_PASSES_H_
 #define IREE_COMPILER_CODEGEN_VMVX_PASSES_H_
 
+#include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -25,7 +26,8 @@ namespace mlir::iree_compiler {
 /// Populates the passes to lower to tiled/distributed/bufferized ops,
 /// suitable for library call dispatch and lowering to loops.
 void addVMVXDefaultPassPipeline(OpPassManager &funcPassManager,
-                                bool enableUKernels);
+                                bool enableUKernels,
+                                const VMVXCodegenOptions &vmvxOpts);
 
 //----------------------------------------------------------------------------//
 // VMVX Linking Passes and Pipelines

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.td
@@ -33,6 +33,11 @@ def VMVXLowerExecutableTargetPass :
     InterfacePass<"iree-vmvx-lower-executable-target", "mlir::FunctionOpInterface"> {
   let summary =
       "Lower executable target using an IREE::HAL::DispatchLoweringPassPipeline";
+  let options = [
+    Option<"vmvxOptions", "vmvx-options", "VMVXCodegenOptions",
+      /*default=*/"VMVXCodegenOptions::FromFlags::get()",
+      "Session-scoped VMVX codegen options.">,
+  ];
 }
 
 def VMVXLowerLinalgMicrokernelsPass :

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerExecutableTargetPass.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Utils/CodegenOptions.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Codegen/VMVX/Passes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
@@ -34,6 +35,7 @@ class VMVXLowerExecutableTargetPass
     : public impl::VMVXLowerExecutableTargetPassBase<
           VMVXLowerExecutableTargetPass> {
 public:
+  using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     // clang-format off
     registry.insert<IREE::HAL::HALDialect,
@@ -74,7 +76,8 @@ void VMVXLowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::None:
     return;
   case IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault:
-    addVMVXDefaultPassPipeline(pipeline, enableUKernels);
+    addVMVXDefaultPassPipeline(pipeline, enableUKernels,
+                               vmvxOptions.getValue());
     break;
   default:
     funcOp.emitOpError("Unsupported pipeline on VMVX target.");


### PR DESCRIPTION
The revision moves all the CLI flags from Passes.cpp to the struct. The setup is simliar to LLVMCPU target and ROCM target.