### PR TITLE
[Python] Add Stable ABI (abi3) support for Python 3.12+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -726,6 +726,13 @@ include(iree_setup_toolchain)
 # Otherwise, for features that just require the interpreter, find that alone.
 #-------------------------------------------------------------------------------
 
+# Build Python bindings with Python Stable ABI (abi3) for Python 3.12+.
+# When enabled, a single extension module can be used across Python 3.12+.
+# nanobind handles the interaction with FREE_THREADED: if the interpreter
+# is free-threaded, STABLE_ABI is ignored and the free-threaded ABI is used.
+# Declared here (before first use) and also cascaded to MLIR below.
+option(IREE_ENABLE_PYTHON_STABLE_ABI "Build Python bindings with Stable ABI (abi3) for Python 3.12+" OFF)
+
 if(IREE_BUILD_PYTHON_BINDINGS)
   # After CMake 3.18, we are able to limit the scope of the search to just
   # Development.Module. Searching for Development will fail in situations where
@@ -739,13 +746,19 @@ if(IREE_BUILD_PYTHON_BINDINGS)
   # See: https://reviews.llvm.org/D118148
   # If building Python packages, we have a hard requirement on 3.10+.
   find_package(Python3 3.10 COMPONENTS Interpreter Development NumPy)
-  find_package(Python3 3.10 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+  # Development.SABIModule is needed for Stable ABI (abi3) builds. CMake 3.26+
+  # provides it; on older CMake it is silently ignored if not found.
+  set(_PYTHON_SABI_COMPONENT "")
+  if(IREE_ENABLE_PYTHON_STABLE_ABI)
+    set(_PYTHON_SABI_COMPONENT Development.SABIModule)
+  endif()
+  find_package(Python3 3.10 COMPONENTS Interpreter Development.Module NumPy ${_PYTHON_SABI_COMPONENT} REQUIRED)
   # Some parts of the build use FindPython instead of FindPython3. Why? No
   # one knows, but they are different. So make sure to bootstrap this one too.
   # Not doing this here risks them diverging, which on multi-Python systems,
   # can be troublesome. Note that nanobind requires FindPython.
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
-  find_package(Python 3.10 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+  find_package(Python 3.10 COMPONENTS Interpreter Development.Module NumPy ${_PYTHON_SABI_COMPONENT} REQUIRED)
 elseif(IREE_BUILD_COMPILER OR IREE_BUILD_TESTS)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
@@ -869,6 +882,11 @@ endif()
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Dependency
 #-------------------------------------------------------------------------------
+
+# Cascade IREE_ENABLE_PYTHON_STABLE_ABI to MLIR.
+if(IREE_ENABLE_PYTHON_STABLE_ABI)
+  set(MLIR_ENABLE_PYTHON_STABLE_ABI ON CACHE BOOL "" FORCE)
+endif()
 
 # Both the IREE and MLIR Python bindings require nanobind. We initialize it here
 # at the top level so that everything uses ours consistently.

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -65,7 +65,9 @@ this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4" }')}"
-python_versions="${override_python_versions:-cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp313-cp313t}"
+# Python versions to build. cp312 is the abi3 build (produces a wheel
+# compatible with 3.12+). Per-version builds are used for <3.12 and 3.13t.
+python_versions="${override_python_versions:-cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313t}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-base-runtime iree-base-compiler}"
 package_suffix="${package_suffix:-}"
@@ -173,8 +175,14 @@ function build_iree_compiler() {
 function run_audit_wheel() {
   local wheel_basename="$1"
   local python_version="$2"
+  # For abi3 builds (cp312 non-free-threaded), the wheel tag is cp312-abi3
+  # instead of cp312-cp312.
+  local wheel_tag="${python_version}"
+  if [[ "${python_version}" == "cp312-cp312" ]]; then
+    wheel_tag="cp312-abi3"
+  fi
   # Force wildcard expansion here
-  generic_wheel="$(echo "${output_dir}/${wheel_basename}-"*"-${python_version}-linux_$(uname -m).whl")"
+  generic_wheel="$(echo "${output_dir}/${wheel_basename}-"*"-${wheel_tag}-linux_$(uname -m).whl")"
   ls "${generic_wheel}"
   echo ":::: Auditwheel ${generic_wheel}"
   auditwheel repair -w "${output_dir}" "${generic_wheel}"
@@ -186,6 +194,10 @@ function clean_wheels() {
   local python_version="$2"
   echo ":::: Clean wheels ${wheel_basename} ${python_version}"
   rm -f -v "${output_dir}/${wheel_basename}-"*"-${python_version}-"*".whl"
+  # Also clean abi3 wheels for cp312.
+  if [[ "${python_version}" == "cp312-cp312" ]]; then
+    rm -f -v "${output_dir}/${wheel_basename}-"*"-cp312-abi3-"*".whl"
+  fi
 }
 
 function prepare_python() {

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -21,7 +21,9 @@ set -eu -o errtrace
 
 this_dir="$(cd $(dirname $0) && pwd)"
 repo_root="$(cd $this_dir/../../ && pwd)"
-python_versions="${override_python_versions:-3.11}"
+# Python versions to build. 3.12 produces an abi3 wheel (compatible with 3.12+).
+# Per-version builds are used for <3.12 and free-threaded builds.
+python_versions="${override_python_versions:-3.11 3.12}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-base-runtime iree-base-compiler}"
 

--- a/build_tools/python_deploy/build_windows_packages.ps1
+++ b/build_tools/python_deploy/build_windows_packages.ps1
@@ -9,7 +9,9 @@
 
 # Configure settings with script parameters.
 param(
-    [array]$python_versions=@("3.11"),
+    # Python versions to build. 3.12 produces an abi3 wheel (compatible with 3.12+).
+    # Per-version builds are used for <3.12 and free-threaded builds.
+    [array]$python_versions=@("3.11", "3.12"),
     [array]$packages=@("iree-base-runtime", "iree-base-compiler"),
     [System.String]$output_dir
 )

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -41,6 +41,13 @@ from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.egg_info import egg_info
 
+# Detect whether we should build an abi3 (Stable ABI) wheel.
+# This applies to CPython 3.12+ when not in free-threaded mode.
+_is_abi3_build = (
+    sys.version_info >= (3, 12)
+    and not sysconfig.get_config_var("Py_GIL_DISABLED")
+)
+
 
 def check_pip_version():
     from packaging import version
@@ -269,6 +276,8 @@ def prepare_installation():
             get_env_cmake_option("IREE_TARGET_BACKEND_CUDA", "OFF"),
             get_env_cmake_option("IREE_ENABLE_LLD", "OFF"),
         ]
+        if _is_abi3_build:
+            cmake_args.append("-DIREE_ENABLE_PYTHON_STABLE_ABI=ON")
         cmake_args.extend(get_cmake_version_info_args())
 
         # These usually flow through the environment, but we add them explicitly
@@ -382,6 +391,24 @@ class CleanEggInfo(egg_info):
         egg_info.run(self)
 
 
+# Override bdist_wheel to produce abi3 wheel tags when applicable.
+_bdist_wheel_cmdclass = {}
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    class bdist_wheel(_bdist_wheel):
+        def get_tag(self):
+            python, abi, plat = _bdist_wheel.get_tag(self)
+            if _is_abi3_build:
+                python, abi = "cp312", "abi3"
+            return python, abi, plat
+
+    _bdist_wheel_cmdclass = {"bdist_wheel": bdist_wheel}
+except ImportError:
+    # wheel package not available (e.g., during sdist). Not an error.
+    pass
+
+
 def generate_version_py():
     return f"""# Auto-generated version info.
 PACKAGE_SUFFIX = "{PACKAGE_SUFFIX}"
@@ -485,12 +512,15 @@ setup(
         CMakeExtension("iree.compiler._mlir_libs._mlirGPUPasses"),
         CMakeExtension("iree.compiler._mlir_libs._site_initialize_0"),
     ],
-    cmdclass={
-        "build": CustomBuild,
-        "built_ext": NoopBuildExtension,
-        "build_py": CMakeBuildPy,
-        "egg_info": CleanEggInfo,
-    },
+    cmdclass=dict(
+        {
+            "build": CustomBuild,
+            "built_ext": NoopBuildExtension,
+            "build_py": CMakeBuildPy,
+            "egg_info": CleanEggInfo,
+        },
+        **_bdist_wheel_cmdclass,
+    ),
     zip_safe=False,
     package_dir={
         # Note: Must be relative path, so we line this up with the absolute

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -43,9 +43,8 @@ from setuptools.command.egg_info import egg_info
 
 # Detect whether we should build an abi3 (Stable ABI) wheel.
 # This applies to CPython 3.12+ when not in free-threaded mode.
-_is_abi3_build = (
-    sys.version_info >= (3, 12)
-    and not sysconfig.get_config_var("Py_GIL_DISABLED")
+_is_abi3_build = sys.version_info >= (3, 12) and not sysconfig.get_config_var(
+    "Py_GIL_DISABLED"
 )
 
 

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -42,8 +42,13 @@ iree_select_compiler_opts(_RTTI_AND_EXCEPTION_COPTS
     "/GR"
 )
 
+set(_STABLE_ABI_FLAG "")
+if(IREE_ENABLE_PYTHON_STABLE_ABI)
+  set(_STABLE_ABI_FLAG STABLE_ABI)
+endif()
+
 nanobind_add_module(iree_runtime_bindings_python_PyExtRt
-  NB_STATIC LTO FREE_THREADED
+  NB_STATIC LTO FREE_THREADED ${_STABLE_ABI_FLAG}
   "binding.h"
   "initialize_module.cc"
   "invoke.h"
@@ -87,8 +92,6 @@ target_link_libraries(iree_runtime_bindings_python_PyExtRt
   iree::tooling::modules
   iree::vm
   iree::vm::bytecode::module
-
-  Python::NumPy
 )
 
 target_compile_options(iree_runtime_bindings_python_PyExtRt

--- a/runtime/bindings/python/binding.h
+++ b/runtime/bindings/python/binding.h
@@ -58,7 +58,15 @@ class ApiRefCounted {
   }
   void operator=(const ApiRefCounted&) = delete;
 
-  ~ApiRefCounted() { Release(); }
+  ~ApiRefCounted() {
+    // In stable ABI (abi3) mode, types are heap-allocated via PyType_FromSpec
+    // and instances may be destroyed during Py_FinalizeEx after IREE's type
+    // registry is no longer valid. Skip release when nanobind's internals
+    // are being torn down since the process is exiting anyway.
+    if (instance_ && py::is_alive()) {
+      Release();
+    }
+  }
 
   // Steals the reference to the object referenced by the given raw pointer and
   // returns a wrapper (transfers ownership).
@@ -130,37 +138,39 @@ inline py::object create_empty_tuple() {
   return py::steal(py::handle(PyTuple_New(0)));
 }
 
-// For a bound class, binds the buffer protocol. This will result in a call
-// to on the CppType:
-//   HandleBufferProtocol(Py_buffer *view, int flags)
-// This is a low level callback and must not raise any exceptions. If
-// error conditions are warranted the usual PyErr_SetString approach must be
-// used (and -1 returned). Return 0 on success.
+// Returns a nanobind::type_slots() descriptor for the buffer protocol on
+// CppType. CppType must implement HandleBufferProtocol(Py_buffer*, int).
+// The slots are only read during py::class_ construction, so the static local
+// array inside is fine (no persistent global state).
 template <typename CppType>
-void BindBufferProtocol(py::handle clazz) {
-  PyBufferProcs buffer_procs;
-  memset(&buffer_procs, 0, sizeof(buffer_procs));
-  buffer_procs.bf_getbuffer =
-      // It is not legal to raise exceptions from these callbacks.
-      +[](PyObject* raw_self, Py_buffer* view, int flags) -> int {
-    if (view == NULL) {
-      PyErr_SetString(PyExc_ValueError, "NULL view in getbuffer");
-      return -1;
-    }
+py::type_slots buffer_protocol_slots() {
+  // It is not legal to raise exceptions from buffer protocol callbacks.
+  static const PyType_Slot slots[] = {
+      {Py_bf_getbuffer,
+       reinterpret_cast<void*>(
+           +[](PyObject* raw_self, Py_buffer* view, int flags) -> int {
+             if (!view) {
+               PyErr_SetString(PyExc_ValueError, "NULL view in getbuffer");
+               return -1;
+             }
 
-    // Cast must succeed due to invariants.
-    auto self = py::cast<CppType*>(py::handle(raw_self));
+             // Cast must succeed due to invariants.
+             auto self = py::cast<CppType*>(py::handle(raw_self));
 
-    Py_INCREF(raw_self);
-    view->obj = raw_self;
-    return self->HandleBufferProtocol(view, flags);
-  };
-  buffer_procs.bf_releasebuffer =
-      +[](PyObject* raw_self, Py_buffer* view) -> void {};
-  auto heap_type = reinterpret_cast<PyHeapTypeObject*>(clazz.ptr());
-  assert(heap_type->ht_type.tp_flags & Py_TPFLAGS_HEAPTYPE &&
-         "must be heap type");
-  heap_type->as_buffer = buffer_procs;
+             int rc = self->HandleBufferProtocol(view, flags);
+             if (rc == 0) {
+               Py_INCREF(raw_self);
+               view->obj = raw_self;
+             }
+             return rc;
+           })},
+      // No-op: PyBuffer_Release handles Py_DECREF(view->obj) after calling
+      // this callback, so the Py_INCREF in getbuffer is already balanced.
+      {Py_bf_releasebuffer,
+       reinterpret_cast<void*>(
+           +[](PyObject* raw_self, Py_buffer* view) -> void {})},
+      {0, nullptr}};
+  return py::type_slots(slots);
 }
 
 // Nanobind 2.0 had a backwards compatibility bug where it left out the

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -1239,6 +1239,24 @@ int HalModuleDebugSinkTpClear(PyObject* self) {
 }
 
 //------------------------------------------------------------------------------
+// HalMappedMemory buffer protocol
+//------------------------------------------------------------------------------
+
+int HalMappedMemory::HandleBufferProtocol(Py_buffer* view, int flags) {
+  view->buf = mapped_memory_.contents.data;
+  view->len = mapped_memory_.contents.data_length;
+  view->readonly = 1;  // Mapped with IREE_HAL_MEMORY_ACCESS_READ
+  view->itemsize = 1;
+  view->format = (char*)"B";
+  view->ndim = 1;
+  view->shape = nullptr;
+  view->strides = nullptr;
+  view->suboffsets = nullptr;
+  view->internal = nullptr;
+  return 0;
+}
+
+//------------------------------------------------------------------------------
 // Bindings
 //------------------------------------------------------------------------------
 
@@ -1344,9 +1362,7 @@ void SetupHalBindings(nanobind::module_ m) {
   hal_element_type
       .def_static("map_to_dtype",
                   [](iree_hal_element_type_t element_type) {
-                    int typenum = numpy::ConvertHalElementTypeToNumPyTypeNum(
-                        element_type);
-                    return numpy::DescrNewFromType(typenum);
+                    return numpy::DescrNewFromType(element_type);
                   })
       .def_static("is_byte_aligned",
                   [](iree_hal_element_type_t element_type) {
@@ -1856,7 +1872,9 @@ void SetupHalBindings(nanobind::module_ m) {
           py::arg("timeout") = py::none(), py::arg("deadline") = py::none(),
           kHalWait);
 
-  py::class_<HalMappedMemory>(m, "MappedMemory")
+  py::class_<HalMappedMemory>(
+      m, "MappedMemory",
+      buffer_protocol_slots<HalMappedMemory>())
       .def(
           "asarray",
           [](HalMappedMemory* self, py::handle shape, py::object dtype_descr) {
@@ -1867,8 +1885,7 @@ void SetupHalBindings(nanobind::module_ m) {
             for (size_t i = 0; i < rank; ++i) {
               dims[i] = py::cast<intptr_t>(shape[i]);
             }
-            int typenum = numpy::TypenumFromDescr(dtype_descr);
-            return numpy::SimpleNewFromData(rank, dims, typenum,
+            return numpy::SimpleNewFromData(rank, dims, dtype_descr,
                                             self->mapped_memory().contents.data,
                                             py_mapped_memory);
           },

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -1872,9 +1872,8 @@ void SetupHalBindings(nanobind::module_ m) {
           py::arg("timeout") = py::none(), py::arg("deadline") = py::none(),
           kHalWait);
 
-  py::class_<HalMappedMemory>(
-      m, "MappedMemory",
-      buffer_protocol_slots<HalMappedMemory>())
+  py::class_<HalMappedMemory>(m, "MappedMemory",
+                              buffer_protocol_slots<HalMappedMemory>())
       .def(
           "asarray",
           [](HalMappedMemory* self, py::handle shape, py::object dtype_descr) {

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -286,6 +286,9 @@ class HalMappedMemory {
 
   iree_hal_buffer_mapping_t& mapped_memory() { return mapped_memory_; }
 
+  // Buffer protocol for PyMemoryView_FromObject (used by SimpleNewFromData).
+  int HandleBufferProtocol(Py_buffer* view, int flags);
+
  private:
   iree_hal_buffer_mapping_t mapped_memory_ = {{0}};
   iree_hal_buffer_t* buffer_ = nullptr;

--- a/runtime/bindings/python/initialize_module.cc
+++ b/runtime/bindings/python/initialize_module.cc
@@ -14,7 +14,6 @@
 #include "./invoke.h"
 #include "./io.h"
 #include "./loop.h"
-#include "./numpy_interop.h"
 #include "./py_module.h"
 #include "./status_utils.h"
 #include "./vm.h"
@@ -33,7 +32,6 @@ namespace iree {
 namespace python {
 
 NB_MODULE(_runtime, m) {
-  numpy::InitializeNumPyInterop();
   IREE_TRACE_APP_ENTER();
 
   IREE_CHECK_OK(iree_hal_register_all_available_drivers(

--- a/runtime/bindings/python/invoke.cc
+++ b/runtime/bindings/python/invoke.cc
@@ -21,6 +21,23 @@ namespace python {
 
 namespace {
 
+// nanobind::python_error::what() is noexcept but under the limited API
+// (Py_LIMITED_API / abi3) it uses a code path that can internally throw,
+// causing std::terminate. This helper safely extracts the error message.
+// Note: only safe to call when the Python error indicator has been cleared
+// (i.e., after nanobind's catch has stored the exception). Not safe in
+// C callbacks where the exception may still be active.
+static std::string get_exception_message(const std::exception& e) {
+  if (auto* pe = dynamic_cast<const py::python_error*>(&e)) {
+    try {
+      return py::cast<std::string>(py::str(pe->value()));
+    } catch (...) {
+      return "(Python exception)";
+    }
+  }
+  return e.what();
+}
+
 class InvokeContext {
  public:
   InvokeContext(HalDevice& device) : device_(device) {}
@@ -128,7 +145,7 @@ class InvokeStatics {
       std::string msg("could not map dtype ");
       msg.append(py::cast<std::string>(py::repr(dtype)));
       msg.append(" to element type: ");
-      msg.append(e.what());
+      msg.append(get_exception_message(e));
       throw std::invalid_argument(std::move(msg));
     }
   }
@@ -191,7 +208,7 @@ class InvokeStatics {
               std::string msg("could not convert value to numpy array: dtype=");
               msg.append(py::cast<std::string>(py::repr(target_dtype)));
               msg.append(", error='");
-              msg.append(e.what());
+              msg.append(get_exception_message(e));
               msg.append("', value=");
               msg.append(py::cast<std::string>(py::repr(py_value)));
               throw std::invalid_argument(std::move(msg));
@@ -246,7 +263,7 @@ class InvokeStatics {
               msg.append(" from: ");
               msg.append(py::cast<std::string>(py::repr(py_value)));
               msg.append(": ");
-              msg.append(e.what());
+              msg.append(get_exception_message(e));
               throw std::invalid_argument(std::move(msg));
             }
             sub_packers[i](c, item_list.raw_ptr(), item_py_value);
@@ -291,7 +308,7 @@ class InvokeStatics {
               msg.append(" from: ");
               msg.append(py::cast<std::string>(py::repr(py_value)));
               msg.append(": ");
-              msg.append(e.what());
+              msg.append(get_exception_message(e));
               throw std::invalid_argument(std::move(msg));
             }
             sub_packers[i].second(c, item_list.raw_ptr(), item_py_value);
@@ -392,7 +409,7 @@ class InvokeStatics {
       } catch (std::exception& e) {
         std::string msg("could not convert value to numpy array: ");
         msg.append("error='");
-        msg.append(e.what());
+        msg.append(get_exception_message(e));
         msg.append("', value=");
         msg.append(py::cast<std::string>(py::repr(py_value)));
         throw std::invalid_argument(std::move(msg));

--- a/runtime/bindings/python/io.cc
+++ b/runtime/bindings/python/io.cc
@@ -217,8 +217,8 @@ int FileHandle::HandleBufferProtocol(Py_buffer* view, int flags) {
 void SetupIoBindings(py::module_& m) {
   m.def("create_io_parameters_module", &CreateIoParametersModule);
 
-  auto file_handle = py::class_<FileHandle>(m, "FileHandle");
-  BindBufferProtocol<FileHandle>(file_handle);
+  auto file_handle = py::class_<FileHandle>(
+      m, "FileHandle", buffer_protocol_slots<FileHandle>());
   file_handle
       .def_static(
           "wrap_memory",

--- a/runtime/bindings/python/loop.cc
+++ b/runtime/bindings/python/loop.cc
@@ -239,14 +239,19 @@ class HalDeviceLoopBridge {
                                       value_owned = std::move(value_owned),
                                       message = std::move(message)]() {
       PyErr_SetString(PyExc_RuntimeError, message.c_str());
+#if PY_VERSION_HEX >= 0x030C0000
+      PyObject* exc = PyErr_GetRaisedException();
+      future_owned.attr("set_exception")(py::steal(exc));
+#else
       PyObject* exc_type;
       PyObject* exc_value;
       PyObject* exc_tb;
       PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
-      future_owned.attr("set_exception")(exc_value);
+      future_owned.attr("set_exception")(py::handle(exc_value));
       Py_XDECREF(exc_type);
       Py_XDECREF(exc_tb);
       Py_XDECREF(exc_value);
+#endif
     }));
   }
 

--- a/runtime/bindings/python/numpy_interop.cc
+++ b/runtime/bindings/python/numpy_interop.cc
@@ -8,93 +8,110 @@
 
 #include "./binding.h"
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include "numpy/arrayobject.h"
-
 namespace iree::python::numpy {
 
-namespace {
-
-int internal_import_array() {
-  import_array1(-1);
-  return 0;
-}
-
-}  // namespace
-
-void InitializeNumPyInterop() {
-  if (internal_import_array() < 0) {
-    throw py::import_error("numpy.core.multiarray failed to import");
-  }
-}
-
-int ConvertHalElementTypeToNumPyTypeNum(iree_hal_element_type_t t) {
+static const char* ConvertHalElementTypeToDtypeName(iree_hal_element_type_t t) {
   switch (t) {
     case IREE_HAL_ELEMENT_TYPE_BOOL_8:
-      return NPY_BOOL;
+      return "bool";
     case IREE_HAL_ELEMENT_TYPE_INT_8:
     case IREE_HAL_ELEMENT_TYPE_SINT_8:
-      return NPY_INT8;
+      return "int8";
     case IREE_HAL_ELEMENT_TYPE_UINT_8:
-      return NPY_UINT8;
+      return "uint8";
     case IREE_HAL_ELEMENT_TYPE_INT_16:
     case IREE_HAL_ELEMENT_TYPE_SINT_16:
-      return NPY_INT16;
+      return "int16";
     case IREE_HAL_ELEMENT_TYPE_UINT_16:
-      return NPY_UINT16;
+      return "uint16";
     case IREE_HAL_ELEMENT_TYPE_INT_32:
     case IREE_HAL_ELEMENT_TYPE_SINT_32:
-      return NPY_INT32;
+      return "int32";
     case IREE_HAL_ELEMENT_TYPE_UINT_32:
-      return NPY_UINT32;
+      return "uint32";
     case IREE_HAL_ELEMENT_TYPE_INT_64:
     case IREE_HAL_ELEMENT_TYPE_SINT_64:
-      return NPY_INT64;
+      return "int64";
     case IREE_HAL_ELEMENT_TYPE_UINT_64:
-      return NPY_UINT64;
+      return "uint64";
     case IREE_HAL_ELEMENT_TYPE_FLOAT_16:
-      return NPY_FLOAT16;
+      return "float16";
     case IREE_HAL_ELEMENT_TYPE_FLOAT_32:
-      return NPY_FLOAT32;
+      return "float32";
     case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
-      return NPY_FLOAT64;
+      return "float64";
     case IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_64:
-      return NPY_COMPLEX64;
+      return "complex64";
     case IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_128:
-      return NPY_COMPLEX128;
+      return "complex128";
     default:
       throw py::value_error("Unsupported VM Buffer -> numpy dtype mapping");
   }
 }
 
-py::object DescrNewFromType(int typenum) {
-  PyArray_Descr* dtype = PyArray_DescrNewFromType(typenum);
-  if (!dtype) {
-    throw py::python_error();
-  }
-  return py::steal((PyObject*)dtype);
+py::object DescrNewFromType(iree_hal_element_type_t t) {
+  const char* name = ConvertHalElementTypeToDtypeName(t);
+  // import_() is a sys.modules dict lookup, not a full import. Could cache
+  // the module reference if this becomes a hot path.
+  return py::module_::import_("numpy").attr("dtype")(name);
 }
 
-int TypenumFromDescr(py::handle dtype) {
-  if (!PyArray_DescrCheck(dtype.ptr())) {
-    throw py::cast_error();
-  }
-  PyArray_Descr* descr = (PyArray_Descr*)dtype.ptr();
-  return descr->type_num;
-}
 
-py::object SimpleNewFromData(int nd, intptr_t const* dims, int typenum,
-                             void* data, py::handle base_object) {
-  PyObject* array_c = PyArray_SimpleNewFromData(nd, dims, typenum, data);
-  if (!array_c) throw py::python_error();
-  py::object array = py::steal(array_c);
-  if (base_object) {
-    if (PyArray_SetBaseObject(reinterpret_cast<PyArrayObject*>(array.ptr()),
-                              base_object.ptr())) {
-      throw py::python_error();
+py::object SimpleNewFromData(int nd, intptr_t const* dims,
+                             py::handle dtype_descr, void* data,
+                             py::handle base_object) {
+  int itemsize = py::cast<int>(dtype_descr.attr("itemsize"));
+  Py_ssize_t total_elems = 1;
+  for (int i = 0; i < nd; ++i) {
+    total_elems *= dims[i];
+  }
+  Py_ssize_t byte_len = total_elems * itemsize;
+
+  // Create a writable memoryview that keeps base_object alive.
+  // PyBuffer_FillInfo sets buf.obj = base_object (with Py_INCREF), and
+  // PyMemoryView_FromBuffer copies the buffer info. When the memoryview is
+  // released, PyBuffer_Release DECREFs base_object. This maintains the
+  // lifetime chain: array.base -> memoryview -> base_object, matching the
+  // original PyArray_SetBaseObject semantics. The writable flag matches
+  // the original PyArray_SimpleNewFromData behavior.
+  py::object buf;
+  if (base_object.ptr()) {
+    Py_buffer pybuf;
+    if (PyBuffer_FillInfo(&pybuf, base_object.ptr(), static_cast<char*>(data),
+                          byte_len,
+                          /*readonly=*/0, PyBUF_WRITABLE) == 0) {
+      buf = py::steal(PyMemoryView_FromBuffer(&pybuf));
     }
-    base_object.inc_ref();
+    if (!buf.ptr()) PyErr_Clear();
   }
+  if (!buf.ptr()) {
+    // Fallback: base_object is null or PyBuffer_FillInfo failed.
+    buf = py::steal(PyMemoryView_FromMemory(static_cast<char*>(data), byte_len,
+                                            PyBUF_WRITE));
+    if (!buf.ptr()) throw py::python_error();
+  }
+
+  // import_() is a sys.modules dict lookup, not a full import. Could cache
+  // the module reference if this becomes a hot path.
+  py::object array = py::module_::import_("numpy").attr("frombuffer")(
+      buf, py::arg("dtype") = dtype_descr);
+
+  // Reshape if needed (frombuffer always returns 1-D).
+  if (nd != 1) {
+    PyObject* shape_raw = PyTuple_New(nd);
+    if (!shape_raw) throw py::python_error();
+    for (int i = 0; i < nd; ++i) {
+      PyObject* item = PyLong_FromSsize_t(dims[i]);
+      if (!item) {
+        Py_DECREF(shape_raw);
+        throw py::python_error();
+      }
+      PyTuple_SetItem(shape_raw, i, item);
+    }
+    py::object shape_tuple = py::steal(shape_raw);
+    array = array.attr("reshape")(shape_tuple);
+  }
+
   return array;
 }
 

--- a/runtime/bindings/python/numpy_interop.cc
+++ b/runtime/bindings/python/numpy_interop.cc
@@ -56,7 +56,6 @@ py::object DescrNewFromType(iree_hal_element_type_t t) {
   return py::module_::import_("numpy").attr("dtype")(name);
 }
 
-
 py::object SimpleNewFromData(int nd, intptr_t const* dims,
                              py::handle dtype_descr, void* data,
                              py::handle base_object) {

--- a/runtime/bindings/python/numpy_interop.h
+++ b/runtime/bindings/python/numpy_interop.h
@@ -12,21 +12,14 @@
 
 namespace iree::python::numpy {
 
-// Must be called in init of extension module.
-void InitializeNumPyInterop();
+// Creates a numpy.dtype object for an IREE element type.
+py::object DescrNewFromType(iree_hal_element_type_t t);
 
-// Converts an IREE element type to a NumPy NPY_TYPES value.
-int ConvertHalElementTypeToNumPyTypeNum(iree_hal_element_type_t t);
-
-// Wraps a call to PyArray_DescrNewFromType(int).
-py::object DescrNewFromType(int typenum);
-
-// Extracts a typenum from a dtype (descriptor) object.
-int TypenumFromDescr(py::handle dtype);
-
-// Delegates to PyArray_SimpleNewFromData and sets the base_object.
-py::object SimpleNewFromData(int nd, intptr_t const* dims, int typenum,
-                             void* data, py::handle base_object);
+// Creates a numpy array from data using numpy.frombuffer and reshapes it.
+// base_object is kept alive by the returned array via its memoryview base.
+py::object SimpleNewFromData(int nd, intptr_t const* dims,
+                             py::handle dtype_descr, void* data,
+                             py::handle base_object);
 
 }  // namespace iree::python::numpy
 

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -823,11 +823,11 @@ void SetupVmBindings(nanobind::module_ m) {
       .value("EXPORT_OPTIONAL", IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL)
       .export_values();
 
-  auto vm_buffer = py::class_<VmBuffer>(m, "VmBuffer");
+  auto vm_buffer = py::class_<VmBuffer>(
+      m, "VmBuffer", buffer_protocol_slots<VmBuffer>());
   VmRef::BindRefProtocol(vm_buffer, iree_vm_buffer_type,
                          iree_vm_buffer_retain_ref, iree_vm_buffer_deref,
                          iree_vm_buffer_isa);
-  BindBufferProtocol<VmBuffer>(vm_buffer);
   vm_buffer
       .def(
           "__init__",

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -823,8 +823,8 @@ void SetupVmBindings(nanobind::module_ m) {
       .value("EXPORT_OPTIONAL", IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL)
       .export_values();
 
-  auto vm_buffer = py::class_<VmBuffer>(
-      m, "VmBuffer", buffer_protocol_slots<VmBuffer>());
+  auto vm_buffer =
+      py::class_<VmBuffer>(m, "VmBuffer", buffer_protocol_slots<VmBuffer>());
   VmRef::BindRefProtocol(vm_buffer, iree_vm_buffer_type,
                          iree_vm_buffer_retain_ref, iree_vm_buffer_deref,
                          iree_vm_buffer_isa);

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -42,9 +42,8 @@ from setuptools.command.build_py import build_py as _build_py
 
 # Detect whether we should build an abi3 (Stable ABI) wheel.
 # This applies to CPython 3.12+ when not in free-threaded mode.
-_is_abi3_build = (
-    sys.version_info >= (3, 12)
-    and not sysconfig.get_config_var("Py_GIL_DISABLED")
+_is_abi3_build = sys.version_info >= (3, 12) and not sysconfig.get_config_var(
+    "Py_GIL_DISABLED"
 )
 
 

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -40,6 +40,13 @@ from setuptools import Extension, find_namespace_packages, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py as _build_py
 
+# Detect whether we should build an abi3 (Stable ABI) wheel.
+# This applies to CPython 3.12+ when not in free-threaded mode.
+_is_abi3_build = (
+    sys.version_info >= (3, 12)
+    and not sysconfig.get_config_var("Py_GIL_DISABLED")
+)
+
 
 def getenv_bool(key: str, cmake_arg: str, default_value="OFF"):
     if cmake_arg == "" or cmake_arg[0] != "@":
@@ -320,6 +327,8 @@ def build_configuration(cmake_build_dir, cmake_install_dir, extra_cmake_args=())
             ),
             get_env_cmake_list("IREE_EXTERNAL_HAL_DRIVERS", ""),
         ] + list(extra_cmake_args)
+        if _is_abi3_build:
+            cmake_args.append("-DIREE_ENABLE_PYTHON_STABLE_ABI=ON")
         add_env_cmake_setting(cmake_args, "IREE_TRACING_PROVIDER")
         add_env_cmake_setting(cmake_args, "IREE_TRACING_PROVIDER_H")
 
@@ -479,6 +488,24 @@ class NoopBuildExtension(_build_ext):
         pass
 
 
+# Override bdist_wheel to produce abi3 wheel tags when applicable.
+_bdist_wheel_cmdclass = {}
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    class bdist_wheel(_bdist_wheel):
+        def get_tag(self):
+            python, abi, plat = _bdist_wheel.get_tag(self)
+            if _is_abi3_build:
+                python, abi = "cp312", "abi3"
+            return python, abi, plat
+
+    _bdist_wheel_cmdclass = {"bdist_wheel": bdist_wheel}
+except ImportError:
+    # wheel package not available (e.g., during sdist). Not an error.
+    pass
+
+
 def generate_version_py():
     return f"""# Auto-generated version info.
 PACKAGE_SUFFIX = "{PACKAGE_SUFFIX}"
@@ -583,11 +610,14 @@ setup(
             else []
         )
     ),
-    cmdclass={
-        "build": CustomBuild,
-        "built_ext": NoopBuildExtension,
-        "build_py": CMakeBuildPy,
-    },
+    cmdclass=combine_dicts(
+        {
+            "build": CustomBuild,
+            "built_ext": NoopBuildExtension,
+            "build_py": CMakeBuildPy,
+        },
+        _bdist_wheel_cmdclass,
+    ),
     zip_safe=False,
     package_dir=combine_dicts(
         {
@@ -616,6 +646,8 @@ setup(
         {
             "iree._runtime_libs": [
                 f"*{sysconfig.get_config_var('EXT_SUFFIX')}",
+                "*.abi3.so",
+                "*.pyd",
                 "iree-run-module*",
                 "iree-benchmark-executable*",
                 "iree-benchmark-module*",
@@ -633,6 +665,8 @@ setup(
             {
                 "iree._runtime_libs_tracy": [
                     f"*{sysconfig.get_config_var('EXT_SUFFIX')}",
+                    "*.abi3.so",
+                    "*.pyd",
                     "iree-run-module*",
                     "iree-benchmark-executable*",
                     "iree-benchmark-module*",


### PR DESCRIPTION
Build Python bindings against the Limited C API (`Py_LIMITED_API`, PEP 384) so that a single wheel built with Python 3.12 works on all future CPython versions. This reduces the total release artifact size.

The Limited API forbids direct access to CPython struct layouts and most convenience macros. The main impact is replacing the NumPy C API (whose headers use non-limited internals) with Python-level equivalents like `numpy.frombuffer()` and `numpy.dtype()`, and using nanobind's `type_slots()` to register buffer/sequence/mapping protocols instead of casting to `PyHeapTypeObject`.

Limitations:
- Only CPython 3.12+. Per-version wheels are still built for 3.10-3.11.
- Free-threaded builds (3.13t) are excluded: the free-threaded ABI is not yet stable.
- `Development.SABIModule` requires CMake 3.26+ (IREE minimum is 3.21), so `IREE_ENABLE_PYTHON_STABLE_ABI` is OFF by default. setup.py auto-enables it when building with CPython 3.12+. May want to bump it in the future.

The existing release workflow already builds with Python 3.12 on all platforms, so abi3 wheels are produced with no workflow changes. pkgci only builds cp311 by default (no abi3).

The LLVM submodule includes cherry-picks of llvm/llvm-project PRs for MLIR-side abi3 support.

Assisted-by: claude