### PR TITLE
Fix low-frequency typos in compiler (non-Codegen). NFC. (4/6)

### DIFF
--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -535,7 +535,7 @@ NB_MODULE(_ireeCompilerDialects, m) {
             for (py::handle item : mmaIntrinsicObjs) {
               if (!py::isinstance(item, mmaIntrinsicClass) &&
                   !py::isinstance(item, virtualMmaIntrinsicClass)) {
-                throw py::type_error("All items must be MMA atributes");
+                throw py::type_error("All items must be MMA attributes");
               }
               mmaIntrinsicVals.push_back(
                   py::cast<mma_intrinsic_enum_t>(item.attr("value")));

--- a/compiler/bindings/python/iree/build/compile_actions.py
+++ b/compiler/bindings/python/iree/build/compile_actions.py
@@ -101,7 +101,7 @@ class CompilerInvocation:
         raw_flags: list[str] = []
 
         # Set any defaults derived from the input_file metadata. These are set
-        # first because they can be overriden by explicit flag settings.
+        # first because they can be overridden by explicit flag settings.
         meta = CompileSourceMeta.get(self.input_file)
         raw_flags.append(f"--iree-input-type={meta.input_type}")
 

--- a/compiler/bindings/python/iree/build/executor.py
+++ b/compiler/bindings/python/iree/build/executor.py
@@ -449,7 +449,7 @@ class BuildContext(BuildDependency):
     ) -> BuildFile:
         """Allocates a file in the build tree with local path |path|.
 
-        If |path| is absoluate (starts with '/'), then it is used as-is. Otherwise,
+        If |path| is absolute (starts with '/'), then it is used as-is. Otherwise,
         it is joined with the path of this context.
         """
         if not path.startswith("/"):

--- a/compiler/bindings/python/iree/compiler/tools/binaries.py
+++ b/compiler/bindings/python/iree/compiler/tools/binaries.py
@@ -58,7 +58,7 @@ _TOOL_MODULE_PACKAGES = {
 }
 
 # Environment variable holding directories to be searched for named tools.
-# Delimitted by os.pathsep.
+# Delimited by os.pathsep.
 _TOOL_PATH_ENVVAR = "IREE_TOOL_PATH"
 
 # We do complicated logging so retain our own Logger instance.

--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/importer_externalization_overrides.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/importer_externalization_overrides.py
@@ -135,7 +135,7 @@ class IREENodeImporter(onnx_importer.NodeImporter):
                 dims, data_type = self.get_type_info_from_type(t.type)
             else:
                 raise TypeError(
-                    f"Expected an onnx.TensorProto or an onnx.ValueInfoProto, recieved {type(t)} from {name}"
+                    f"Expected an onnx.TensorProto or an onnx.ValueInfoProto, received {type(t)} from {name}"
                 )
 
             vtensor_type = RankedTensorType.get(
@@ -265,7 +265,7 @@ class IREENodeImporter(onnx_importer.NodeImporter):
             dims, data_type = self.get_type_info_from_type(initializer.type)
         else:
             raise TypeError(
-                f"Expected an onnx.TensorProto or an onnx.ValueInfoProto, recieved {type(initializer)} from {initializer_name}"
+                f"Expected an onnx.TensorProto or an onnx.ValueInfoProto, received {type(initializer)} from {initializer_name}"
             )
 
         actual_symbol_name, tensor_type = self.create_tensor_global(initializer)

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -269,7 +269,7 @@ bool isConsecutive(ArrayRef<int64_t> array) {
 /// {batch_dims, parallel_dims, contraction_dims}.
 ///   {batch_dims, contraction_dims, parallel_dims}
 /// After that, batch_dims, contraction_dims, parallel_dims are
-/// in consecutive order and not spliting the domain. This pattern inserts
+/// in consecutive order and not splitting the domain. This pattern inserts
 /// reshapes to collapse consecutive reduction and parallel dims to always
 /// generate a rank-3 dot_general op.
 struct TransposeReshapeGenericDotGeneral final

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -1356,8 +1356,8 @@ void ireeCompilerSetupGlobalCL(int argc, const char **argv, const char *banner,
   if (installSignalHandlers) {
     // A few other things from InitLLVM to setup default command-line signal
     // handlers. See InitLLVM::InitLLVM for the initialization sequence and
-    // commentary, should it ever be necessary to revist this (it hasn't changed
-    // in many years).
+    // commentary, should it ever be necessary to revisit this (it hasn't
+    // changed in many years).
     llvm::sys::SetOneShotPipeSignalFunction(
         llvm::sys::DefaultOneShotPipeSignalHandler);
     static llvm::PrettyStackTraceProgram stackPrinter(argc, argv);

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -968,7 +968,7 @@ static ElementsAttr tensorSlice(ElementsAttr tensor, uint64_t dim,
 
 OpFoldResult TensorSliceOp::fold(FoldAdaptor operands) {
   if (llvm::count(operands.getOperands(), nullptr) == 0) {
-    // Ignore DenseResources for now and do not perfom folding on them.
+    // Ignore DenseResources for now and do not perform folding on them.
     if (isa<DenseResourceElementsAttr>(operands.getSource())) {
       return {};
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -210,7 +210,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
 
   // Move regionOp body into the workgroupsOp.
   rewriter.inlineRegionBefore(region, newBody, newBody.end());
-  // Merge the enrty block of `newBody` with the original entry block from the
+  // Merge the entry block of `newBody` with the original entry block from the
   // region.
   Block *origEntry = &(*(std::next(newBody.begin())));
   rewriter.mergeBlocks(origEntry, newBodyEntry);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h
@@ -40,7 +40,7 @@ namespace mlir::iree_compiler::IREE::Flow {
 FailureOr<IREE::Flow::WorkloadBuilder> getWorkloadBuilder(OpBuilder &builder,
                                                           Operation *rootOp);
 
-/// Simplfy the given tensor::DimOps as much as possible.
+/// Simplify the given tensor::DimOps as much as possible.
 /// * Static dimensions are replaced by constant.
 /// * Dynamic dim ops are pushed as much as possible to the top of the function,
 ///   i.e., if the dim of a value is known to be equal to the dim of a value on

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
@@ -35,7 +35,7 @@ static std::tuple<Value, Value> lookupDeviceAndQueueAffinityFor(
 }
 
 static std::tuple<SmallVector<Value>, SmallVector<Value>>
-lookupDevicesAndQueueAffintiesFor(Operation *op, OpBuilder &builder) {
+lookupDevicesAndQueueAffinitiesFor(Operation *op, OpBuilder &builder) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
   SmallVector<Value> devices;
   SmallVector<Value> queueAffinities;
@@ -67,7 +67,7 @@ std::tuple<Value, Value> lookupDeviceAndQueueAffinityFor(Operation *op,
                                                          Value bufferUsage,
                                                          OpBuilder &builder) {
   auto [devices, queueAffinities] =
-      lookupDevicesAndQueueAffintiesFor(op, builder);
+      lookupDevicesAndQueueAffinitiesFor(op, builder);
   // Returns the device and queue affinity for the first device, if only one
   // exists.
   if (devices.size() == 1) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -26,7 +26,7 @@ namespace mlir::iree_compiler::IREE::HAL {
 
 namespace {
 
-// We aribtrarily say that unbounded dimensions in a torch program cannot
+// We arbitrarily say that unbounded dimensions in a torch program cannot
 // exceed 53bits, making the maximum safe dimension 9007199254740991. The
 // astute reader will note that this is also the maximum safe value in
 // JavaScript, which also "happens" to be the largest mantissa value in a

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.cpp
@@ -18,7 +18,7 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       "IREE HAL executable target options");
 
   // This function is called as part of registering the pass
-  // TranslateAllExecutablesPass. Pass registry is also staticly
+  // TranslateAllExecutablesPass. Pass registry is also statically
   // initialized, so targetBackendsFlags needs to be here to be initialized
   // first.
   binder.list<std::string>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AnnotateTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AnnotateTargetDevices.cpp
@@ -24,7 +24,7 @@ namespace {
 // --iree-hal-annotate-target-devices
 //===----------------------------------------------------------------------===//
 
-// Sorts |attrs| in lexigraphical order.
+// Sorts |attrs| in lexicographical order.
 // We have to do this as the PVS elements we source from are unsorted.
 static void sortAttributes(SmallVectorImpl<Attribute> &attrs) {
   if (attrs.size() <= 1) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -41,7 +41,7 @@ def TopkSplitReductionPass:
   let summary = "Topk split reduction pass.";
   let description = [{
     Produces a "map-reduce" style of parallelizing a Topk Op. The op is split
-    into two, on containing reducitons in parallel and the other contianing the
+    into two, on containing reducitons in parallel and the other containing the
     combination of the parallel reductions into a final result.
   }];
   let options = [

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -440,7 +440,7 @@ func.func @fft_2D(%real: memref<?x16xf32>, %imag: memref<?x16xf32>) {
 // CHECK-SAME:          iterator_types = ["parallel", "parallel"]
 // CHECK-SAME:          outs(%[[L_REAL_SLICE]], %[[L_IMAG_SLICE]], %[[R_REAL_SLICE]], %[[R_IMAG_SLICE]]
 //
-//                    The computation is bascially the same, and they are
+//                    The computation is basically the same, and they are
 //                    checked above. Here only checks the different part.
 // CHECK:             %{{.+}} = linalg.index 1 : index
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
@@ -24,7 +24,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 /// S = reduce QKT dim=2 keep_dims=True
 /// att = S @ V
 ///
-/// By this defination, K1 and K2 can be seen as reduction dimensions and
+/// By this definition, K1 and K2 can be seen as reduction dimensions and
 /// B, M, N can be seen as parallel dimensions.
 ///
 /// Generally, K1 and N are really small (64/128), K2 and M are really large

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -133,7 +133,7 @@ static void permute(SmallVectorImpl<T> &vector) {
   }
 }
 
-/// Return dim expresssions that can be used as replacements in map that
+/// Return dim expressions that can be used as replacements in map that
 /// contains `numSymbols` symbols. The new dim expressions have positions
 /// `numDims, numDims + 1, numDims + 2, ...., numDims + numSymbols - 1`.
 SmallVector<AffineExpr> getDimExprsForSymbols(MLIRContext *context,

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning.h
@@ -85,7 +85,7 @@ void collectConsumedValues(Operation *rootOp, SetVector<Value> &consumedValues);
 // separating non-interfering subgraphs, etc.
 //
 // This is a well-researched area and there are many algorithms to choose from.
-// We'll mostly want to focus on ones that are able to handle multiple critera
+// We'll mostly want to focus on ones that are able to handle multiple criteria
 // (like memory consumption, compute utilization, available capacity, etc).
 //
 // See for example:

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -27,7 +27,7 @@ def ConvertToStreamPass :
     used on the program ABI boundary for interoperating with external buffers
     and fences. These ops, such as `hal.tensor.import` and `hal.tensor.barrier`,
     will be converted to their `stream` dialect form and preserve the implicit
-    synchronization guaranteeds required for proper analysis.
+    synchronization guarantees required for proper analysis.
 
     Dispatched executables are allowed to be in one of the supported input
     dialects (like `flow.executable`), already be lowered into

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -319,7 +319,7 @@ specializeDispatches(IREE::Stream::ExecutableOp executableOp,
   });
 
   // Inline that constant table into the dispatch function and look up the
-  // contants to use based on a parameterized input. All unneeded operands
+  // constants to use based on a parameterized input. All unneeded operands
   // are removed.
   insertConstantTableLookup(funcOp, constantTable);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -143,7 +143,7 @@ static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable &symbolTable,
 }
 
 /// Returns all the stream tensor ops that implement AffinityOpInterface, where
-/// a stream affinity indicates the kind of enviroment the ops are expected run
+/// a stream affinity indicates the kind of environment the ops are expected run
 /// in.
 static SmallVector<IREE::Stream::AffinityOpInterface>
 collectStreamTensorOps(ModuleOp moduleOp, SymbolTable &symbolTable,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings.mlir
@@ -82,7 +82,7 @@ util.func public @rebaseBindings(%operand: index) {
 // Tests that bindings that are duplicated at all dispatch sites are folded.
 // This will happen even if the offsets differ as we are rebasing them to 0 and
 // moving the offsetting into the dispatched function. To ensure that we are
-// offseting things correctly we have pre-offset subspans in the dispatch region
+// offsetting things correctly we have pre-offset subspans in the dispatch region
 // that must have the host binding offsets added to them.
 //
 // NOTE: the offset operands are inserted at the start of the operand list and

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -119,7 +119,7 @@ util.func public @conflictResolution(%cond: i1, %arg0: !stream.resource<transien
 // Tests invalid transfer conflict resolution.
 // Constants cannot be mutated even though it is tied. This survives after
 // copy-on-write materialization because of the transfer and we need to preserve
-// it such that the copy is performed as epxected.
+// it such that the copy is performed as expected.
 
 // CHECK-LABEL: @transferResolution
 // CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<constant>, %[[SIZE:.+]]: index)

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -735,7 +735,7 @@ util.func public @multi_device_set_encoding(%arg0: !stream.resource<external>, %
 
 // -----
 
-// This test is simliar to the set_encoding test, but with unset_encoding ops.
+// This test is similar to the set_encoding test, but with unset_encoding ops.
 
 #executable_target_a = #hal.executable.target<"target_a", "abc", {iree.encoding.resolver = #iree_encoding.specialization_resolver<123>}>
 #executable_target_b = #hal.executable.target<"target_b", "xyz", {iree.encoding.resolver = #iree_encoding.specialization_resolver<456>}>

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -339,7 +339,7 @@ void DispatchTensorLoadOp::getCanonicalizationPatterns(
 
 // Inlining producers of an input to the dispatch region results in the
 // `flow.dispatch.input.load` having a `tensor` type as input. This fails
-// verification. Fold such uses of the offsets, size and strides are emtpy.
+// verification. Fold such uses of the offsets, size and strides are empty.
 // i.e, flow.dispatch.input.load %v -> %v
 OpFoldResult DispatchTensorLoadOp::fold(FoldAdaptor operands) {
   if (getSource().getType() && isa<RankedTensorType>(getSource().getType()) &&

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -579,7 +579,7 @@ def IREETensorExt_CastToRaggedShapeOp :
     - `column_lengths` is [0, 4, 10, 13, 18]
     - result has an encoding attribute of `#iree_tensor_ext.ragged_shape<n>`.
 
-    Contraints are
+    Constraints are
     1. `ragged_dim` < rank(`source`)
     2. rank(`columnLengths`) == 1.
     3. dim(`columnLengths`, 0) == `num_rows` + 1.

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -176,7 +176,7 @@ util.func public @mismatchedRaggedShapeAttr(%source : tensor<?x?x?xf32>,
 // -----
 
 // Error when `column_lengths` is static shaped when `num_ragged_rows` is dynamic.
-util.func public @staticColumnLenghtsWithDynamicNumRaggedRows(%source : tensor<?x?x?xf32>,
+util.func public @staticColumnLengthsWithDynamicNumRaggedRows(%source : tensor<?x?x?xf32>,
     %columnLengths : tensor<4xindex>, %numRaggedRows : index,
     %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
   // expected-error @+1 {{invalid to have static dimensions for `column_lengths` when `num_ragged_rows` is dynamic}}

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.h
@@ -296,7 +296,7 @@ protected:
     SEEDING,
     // Fixed point iteration is running.
     UPDATE,
-    // Iteration has completed; does not indicate whether it coverged.
+    // Iteration has completed; does not indicate whether it converged.
     DONE,
   } phase = Phase::SEEDING;
 

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/State.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/State.h
@@ -181,7 +181,7 @@ struct BooleanState : public IntegerStateBase<bool, 1, 0> {
   // Returns true if the state is known to hold.
   bool isKnown() const { return getKnown(); }
 
-  // Sets the known and asssumed value to |value|.
+  // Sets the known and assumed value to |value|.
   void setKnown(bool value) {
     known |= value;
     assumed |= value;
@@ -414,13 +414,14 @@ struct PotentialValuesState : AbstractState {
   // Returns this set. We should check whether this set is valid or not by
   // isValidState() before calling this function.
   const SetTy &getAssumedSet() const {
-    assert(isValidState() && "This set shoud not be used when it is invalid!");
+    assert(isValidState() && "This set should not be used when it is invalid!");
     return set;
   }
 
   // Returns whether this state contains an undef value or not.
   bool isUndefContained() const {
-    assert(isValidState() && "This flag shoud not be used when it is invalid!");
+    assert(isValidState() &&
+           "This flag should not be used when it is invalid!");
     return undefIsContained;
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -223,8 +223,8 @@ def Util_PreprocessingPipelineAttr : Util_AttrDef<"PreprocessingPassPipeline"> {
   let summary = "[{Preprocessing pass-pipeline to run on the function.}]";
   let description = [{
     Textual description of the preprocessing pass-pipeline to run on the
-    function-like object that the attribute is specified on. Note that the
-    string pipeline is implicitly nested to `builtin.module(func-lik(..))`
+    function-likee object that the attribute is specified on. Note that the
+    string pipeline is implicitly nested to `builtin.module(func-like(..))`
     operation. For example to run the transpose convolution pipeline, the
     attribute is specified as
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -465,7 +465,7 @@ def Util_AssumeIntOp : Util_PureOp<"assume.int", [
     Typically multiple permutations record a specific subset of assumptions
     broken down per call-site in some way that is meaningful to the receiver.
     Implementations can use this information to specialize on each
-    permutation if it is meaninful to do so (i.e. vs unioning across them).
+    permutation if it is meaningful to do so (i.e. vs unioning across them).
     In such cases, there will typically be one such op at the top of a
     function or scope which passes all covered operands through it.
   }];

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -42,7 +42,7 @@ namespace {
 // platforms, demoting to an index is only conservatively correct if all
 // operands and all results are within the unsigned 32bit bounds.
 // While there is a good chance that such arithmetic that exceeds these
-// bounds is simply wrong/overflow-ridden, we opt to do no harm and preseve
+// bounds is simply wrong/overflow-ridden, we opt to do no harm and preserve
 // the exact results. This optimization is targeted at "small" sequences
 // anyway and this catches everything known to exist. If needed, this rule
 // could be dropped if it is ever appropriate to unconditionally assume
@@ -466,7 +466,7 @@ class OptimizeIntArithmeticPass
     expandAffineOps(op);
 
     DataFlowSolver solver;
-    // Needed to make the dead code analyis not be too conservative.
+    // Needed to make the dead code analysis not be too conservative.
     solver.load<SparseConstantPropagation>();
     solver.load<DeadCodeAnalysis>();
     solver.load<IntegerRangeAnalysis>();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -36,7 +36,7 @@ struct ExprHoistingOptions {
   using RegisterDialectsFn = std::function<void(DialectRegistry &)>;
 
   // Hook to register extra dependent dialects needed for types implementing
-  // the `HoistableTypeInterace`.
+  // the `HoistableTypeInterface`.
   std::optional<RegisterDialectsFn> registerDependentDialectsFn = std::nullopt;
 
   // Threshold for controlling the maximum allowed increase in the stored size

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -466,7 +466,7 @@ module @partially_analyzed_op {
 
 // -----
 
-// Check that hoisting happens in a determinsitic order. If this is ordered
+// Check that hoisting happens in a deterministic order. If this is ordered
 // incorrectly it will result in >1 util.initializer.
 
 // CHECK-LABEL: @hoist_multiple_globals_ordered

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic.mlir
@@ -417,7 +417,7 @@ util.func @elide_trunc_of_index_castui(%arg0 : index) -> i32 {
   %1 = arith.index_castui %arg0 : index to i64
   %2 = arith.trunci %1 : i64 to i32
   // CHECK: %[[RESULT:.*]] = arith.index_castui %arg0 : index to i32
-  // CHECH: util.return %[[RESULT]]
+  // CHECK: util.return %[[RESULT]]
   util.return %2 : i32
 }
 
@@ -427,7 +427,7 @@ util.func @elide_trunc_of_index_cast(%arg0 : index) -> i32 {
   %1 = arith.index_cast %arg0 : index to i64
   %2 = arith.trunci %1 : i64 to i32
   // CHECK: %[[RESULT:.*]] = arith.index_castui %arg0 : index to i32
-  // CHECH: util.return %[[RESULT]]
+  // CHECK: util.return %[[RESULT]]
   util.return %2 : i32
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -92,7 +92,7 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
       builder.getArrayAttr({builder.getStringAttr("static")}));
   newFuncOp.setPrivate();
 
-  // This call shold be equivalent to rewriter.inlineRegionBefore()
+  // This call should be equivalent to rewriter.inlineRegionBefore()
   newFuncOp.getFunctionBody().getBlocks().splice(
       newFuncOp.end(), funcOp.getFunctionBody().getBlocks());
 
@@ -1508,7 +1508,7 @@ private:
     // printed as the arguments to the function call.
     SmallVector<Attribute> args_;
 
-    // If the operation has attributes, we need to explicitely build the args
+    // If the operation has attributes, we need to explicitly build the args
     // attribute of the emitc opaque_call op. This consists of index attributes
     // for the operands, followed by the source op attributes themselves.
     if (op->getAttrs().size() > 0) {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -412,7 +412,7 @@ def VM_FuncRefAttr : Util_AliasedSymbolRefAttr;
 def VM_Ordinal : SignlessIntegerAttrBase<I32, "ordinal value">;
 
 // NOTE: today we only support a single bit width for pointers/indices/sizes.
-// This is to keep our compatability matrix smaller but is not a fundamental
+// This is to keep our compatibility matrix smaller but is not a fundamental
 // limitation of the VM.
 // TODO(#5732): allow for this to change and be specified as an attribute of the
 // compiled module (a module compiled with 32-bit indices may not be usable on

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -291,7 +291,7 @@ Operation *VMDialect::materializeConstant(OpBuilder &builder, Attribute value,
   } else if (isa<IREE::VM::RefType>(type)) {
     // The only constant type we support for refs is null so we can just
     // emit that here.
-    // TODO(benvanik): relace unit attr with a proper null ref attr.
+    // TODO(benvanik): replace unit attr with a proper null ref attr.
     return VM::ConstRefZeroOp::create(builder, loc, type);
   }
   // TODO(benvanik): handle other constant value types.

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/ArchiveWriter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/ArchiveWriter.cpp
@@ -257,7 +257,7 @@ struct ZIPFileRef {
   uint32_t crc32;
 };
 
-// Computes the minimum length of the ZIP header we write preceeding the file.
+// Computes the minimum length of the ZIP header we write preceding the file.
 // This can have any alignment. The result value is only a minimum as up to 64KB
 // of padding can be added following it.
 static uint64_t computeMinHeaderLength(StringRef fileName) {

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -115,7 +115,7 @@ static void fixupGlobalMutability(Operation *moduleOp,
   });
 }
 
-// Finds all global variables and moves their inital values/initializer calls
+// Finds all global variables and moves their initial values/initializer calls
 // into a single function. Relies on the inliner to later make the uber function
 // better.
 //

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
@@ -37,7 +37,7 @@ static size_t getGlobalStorageSize(IREE::Util::GlobalOpInterface globalOp) {
 // NOTE: symbols are serialized in ordinal-order (hence the name!) and we have
 // an opportunity here to set the layout of the final binaries, similar to how
 // old-timey games would layout files on their spinning plastic discs to
-// optimize the time spent moving a physical laser carridge around. Functions
+// optimize the time spent moving a physical laser carriage around. Functions
 // related to each other and global data accessed in proximity should be
 // clustered together to make use of paging in memory mapped files.
 class OrdinalAllocationPass

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -446,7 +446,7 @@ struct FromGlobal : public OpRewritePattern<GetBufferDescriptorOp> {
 };
 
 //===---------------------------------------------------------------------===//
-// Pass To resovle descriptors.
+// Pass To resolve descriptors.
 //===---------------------------------------------------------------------===//
 
 class ResolveBufferDescriptorsPass final

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -234,7 +234,7 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
             options);
       })
 
-      // Clone all producers into the dispatch region to perpare for being
+      // Clone all producers into the dispatch region to prepare for being
       // isolated from above. This enables running additional transformations
       // afterwards that would need the full dispatch content but don't want to
       // handle explicit captures as materialized as dispatch workgroup operands

--- a/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
@@ -48,7 +48,7 @@ struct MakeReductionInnermostPattern final
         }
       }
     }
-    // If all the parallel loops are outter loops skip the pattern.
+    // If all the parallel loops are outer loops skip the pattern.
     if (!needInterchange) {
       return failure();
     }

--- a/compiler/src/iree/compiler/DispatchCreation/test/materialize_default_workgroup_count_region.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/materialize_default_workgroup_count_region.mlir
@@ -107,7 +107,7 @@ util.func @error_no_mapping(%arg0 : index, %arg1 : index, %arg2 : index) {
 
 // -----
 
-// Check that mutliple scf.forall loops within dispatch is not supported.
+// Check that multiple scf.forall loops within dispatch is not supported.
 util.func @error_multiple_scf_forall(%arg0 : index, %arg1 : index, %arg2 : index) {
   // expected-error @below {{unhandled multiple scf.forall ops in a dispatch}}
   %0:2 = flow.dispatch.workgroups[%arg0, %arg1](%arg0, %arg1, %arg2)

--- a/compiler/src/iree/compiler/DispatchCreation/test/pad_fusion_with_producer.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pad_fusion_with_producer.mlir
@@ -48,4 +48,4 @@ util.func public @fuse_pad_with_producer(%arg0 : tensor<?x?x?x?xf32>,
 //  CHECK-SAME:         ins(%[[CONV]], %[[ARG3]]
 //       CHECK:     %[[PADDED:.+]] = tensor.pad %[[GENERIC]]
 //       CHECK:     flow.return %[[PADDED]]
-//       CHEKC:   util.return %[[RETURN]]
+//       CHECK:   util.return %[[RETURN]]

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -36,7 +36,7 @@ static Value createTranspose(OpBuilder &builder, Value source,
 }
 
 // Transposes the concatenation dimension to happen along the outer most
-// non-unit dim of the inputs. The idea is that outer dim concatentations
+// non-unit dim of the inputs. The idea is that outer dim concatenations
 // can lower to `flow.tensor.update` and ideally disappear, in the worst case
 // becoming a sequence of copies. The hope then is that the transposes on the
 // inputs and output is then fusable with surrounding operations.

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.h
@@ -26,7 +26,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 /// The CastOpInterface op should extend the bitwidth of the source.
 /// The bitwidth of the source element type should be greater than 1. If it is
 /// casting from i1 types, a std::nullopt is returned. It is dangerous to mix
-/// boalean concept and i1 subtypes concept at graph optimizatoin level. We
+/// boalean concept and i1 subtypes concept at graph optimization level. We
 /// ignore this type of casting ops intentionally.
 /// TODO(hanchung): Remove the restriction about i1 after we can handle i1
 /// sub-type emulation and deprecate TypePropagation pass.

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -81,7 +81,7 @@ struct InputDialectOptions {
   bool promoteF16ToF32 = false;
   bool promoteBF16ToF32 = false;
 
-  // Perfoms early optimizations geared towards optimizing/simplifying the
+  // Performs early optimizations geared towards optimizing/simplifying the
   // types of integer arithmetic inefficiencies that frontends typically
   // include and which are implicated in blocking downstream optimizations.
   bool optimizeIndexArithmetic = true;

--- a/compiler/src/iree/compiler/Preprocessing/Common/ApplyPDLPatterns.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ApplyPDLPatterns.cpp
@@ -38,7 +38,7 @@ namespace mlir::iree_compiler::Preprocessing {
 
 } // namespace mlir::iree_compiler::Preprocessing
 
-/// Get strides for row-major oredering of a tensor with the given `shape`.
+/// Get strides for row-major ordering of a tensor with the given `shape`.
 static SmallVector<int64_t> getStridesFromShape(ArrayRef<int64_t> shape) {
   if (shape.empty()) {
     return {};

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -49,7 +49,7 @@ namespace {
 // Convert linalg.conv_2d_nhwc_hwcf into linalg.generic (for img2col packing)
 // and linalg.matmul.
 //
-// A convolution operaton can be written as a matrix-matrix multiplication by
+// A convolution operation can be written as a matrix-matrix multiplication by
 // unfolding the cross correlation between input and filter and explicitly copy
 // overlapped sliding window inputs.
 //
@@ -78,7 +78,7 @@ namespace {
 // and output (N, Ho, Wo, D) the convolutin is the following matrix-matrix
 // multiplication (Ho x Wo, Kh x Kw x C) * (Kh x Kw x C, D) for each input in
 // the N input. For the case where N > 1 its a batched matrxi-matrix
-// multplication.
+// multiplication.
 class ConvertConv2DNhwcHwcf final
     : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
 public:

--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -154,7 +154,7 @@ public:
     }
   }
 
-  // Bind a flag with a single `opt_initialier` that specifies defaults at a
+  // Bind a flag with a single `opt_initializer` that specifies defaults at a
   // given optimization level.
   template <typename T, typename V, typename... Mods>
   void opt(llvm::StringRef name, V &value,


### PR DESCRIPTION
Preparation for adding a typos pre-commit spell checker (6/6).