### PR TITLE
[CI] Add typos pre-commit hook and dictionary. (6/6)

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -331,7 +331,7 @@ jobs:
       ##########################################################################
       # TF Compiler Tools
       # These wheels are not Python version specific and include only Python
-      # code (no C/C++), so just build for one examplar python version on Linux.
+      # code (no C/C++), so just build for one exemplar python version on Linux.
       ##########################################################################
 
       - name: Build TF Compiler Tools wheels

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     hooks:
       - id: typos
         name: Check for typos
-        args: ["--config", "build_tools/linters/typos.toml"]
+        args: ["--config", "build_tools/linters/typos.toml", "--force-exclude"]
 
   - repo: https://github.com/jlebar/pre-commit-hooks.git
     rev: f2d115a052860b09b2888b4f104be614bf3b4779

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,12 @@ repos:
       - id: forbid-tabs
         exclude: ".gitmodules|Makefile"
 
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.44.0
+    hooks:
+      - id: typos
+        name: Check for typos
+
   - repo: https://github.com/jlebar/pre-commit-hooks.git
     rev: f2d115a052860b09b2888b4f104be614bf3b4779
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     hooks:
       - id: typos
         name: Check for typos
+        args: ["--config", "build_tools/linters/typos.toml"]
 
   - repo: https://github.com/jlebar/pre-commit-hooks.git
     rev: f2d115a052860b09b2888b4f104be614bf3b4779

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,6 @@
+# Configuration file for the typos-rs spell checker used by pre-commit.
+# See https://crates.io/crates/typos for tool usage details.
+
 [files]
 extend-exclude = [
     "third_party/",

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,80 @@
+[files]
+extend-exclude = [
+    "third_party/",
+    "runtime/src/iree/tokenizer/**/*_test.*",
+    "runtime/src/iree/tokenizer/**/*_fuzz.*",
+    "runtime/src/iree/tokenizer/testdata/",
+]
+
+[default.extend-words]
+# AMD Heterogeneous System Architecture.
+hsa = "hsa"
+# ARM Scalable Matrix Extension.
+sme = "sme"
+# MLIR OpFoldResult abbreviation.
+ofr = "ofr"
+# GPU instruction conversion suffix (dp4xi8toi32).
+toi = "toi"
+# Memory copy operation abbreviation (createMemCpy).
+cpy = "cpy"
+# Greater Than Integer comparison ops (CmpGTI32SOp).
+gti = "gti"
+# Ordered Less Than float predicate (arith.cmpf olt).
+olt = "olt"
+# Serialization abbreviation (serOptions).
+ser = "ser"
+# N-dimensional abbreviation.
+nd = "nd"
+# Processor number variable / math notation.
+pn = "pn"
+# Semaphores abbreviation.
+sems = "sems"
+# Python packaging tool name.
+delocate = "delocate"
+# Valid English word (plural of canonicalization).
+canonicalizations = "canonicalizations"
+# Valid English word.
+inferrable = "inferrable"
+# ELF relocation section type (SHT_RELA).
+rela = "rela"
+# Unicode café test data.
+caf = "caf"
+# CUDA opt-in attribute (MAX_SHARED_MEMORY_PER_BLOCK_OPTIN).
+optin = "optin"
+# One who is invoked.
+invokee = "invokee"
+# Windows Structured Exception Handling.
+seh = "seh"
+# Unique Device Identifier.
+udid = "udid"
+# Intermediate abbreviation.
+interm = "interm"
+# Parameters abbreviation.
+parms = "parms"
+# From CHECKs word splitting.
+chec = "chec"
+# FileCheck variable name in tests.
+tpos = "tpos"
+# From SIZExi8 word splitting in comments.
+siz = "siz"
+# Hex byte value 0xBA in generated tables.
+ba = "ba"
+# From ANDed/ORed/XORed word splitting.
+ded = "ded"
+# BPE subword tokens in tokenizer implementation.
+hel = "hel"
+ois = "ois"
+# MSVC assembler output flag (/Fo) and notebook cell IDs.
+fo = "fo"
+# Valid prefix (mis-compiled, mis-detected) and notebook cell IDs.
+mis = "mis"
+ot = "ot"
+# Notebook cell IDs.
+mye = "mye"
+# Workgroup coordinate variables (iz, iy).
+iz = "iz"
+iy = "iy"
+# Upstream MLIR API name (warpSyncronizationFn).
+syncronization = "syncronization"
+# Upstream MLIR error message typo (faild to tile operation).
+faild = "faild"

--- a/build_tools/linters/typos.toml
+++ b/build_tools/linters/typos.toml
@@ -1,5 +1,8 @@
-# Configuration file for the typos-rs spell checker used by pre-commit.
-# See https://crates.io/crates/typos for tool usage details.
+# Configuration file for the typos spell checker used by pre-commit.
+# https://github.com/crate-ci/typos
+#
+# To run manually from the repo root:
+#   typos --config build_tools/linters/typos.toml
 
 [files]
 extend-exclude = [

--- a/build_tools/linters/typos.toml
+++ b/build_tools/linters/typos.toml
@@ -6,7 +6,7 @@
 
 [files]
 extend-exclude = [
-    "third_party/",
+    "**/third_party/",
     "**/runtime/src/iree/tokenizer/**/*_test.*",
     "**/runtime/src/iree/tokenizer/**/*_fuzz.*",
     "**/runtime/src/iree/tokenizer/testdata/",

--- a/build_tools/linters/typos.toml
+++ b/build_tools/linters/typos.toml
@@ -7,9 +7,9 @@
 [files]
 extend-exclude = [
     "third_party/",
-    "runtime/src/iree/tokenizer/**/*_test.*",
-    "runtime/src/iree/tokenizer/**/*_fuzz.*",
-    "runtime/src/iree/tokenizer/testdata/",
+    "**/runtime/src/iree/tokenizer/**/*_test.*",
+    "**/runtime/src/iree/tokenizer/**/*_fuzz.*",
+    "**/runtime/src/iree/tokenizer/testdata/",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
Configure crate-ci/typos as a pre-commit spell checker. Add a dictionary of domain-specific terms (HSA, SME, OLT, OFR, etc.) to suppress false positives. Exclude tokenizer test files that contain intentional subword fragments.