### PR TITLE
[CMake][Python] Bump minimum CMake version to 3.26

### DIFF
--- a/.github/workflows/build_clang_tidy.yml
+++ b/.github/workflows/build_clang_tidy.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: "Setting up CMake"
         run: |
           source ./build_tools/cmake/setup_build.sh

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -32,7 +32,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: |
+          python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       # TODO(#18557): enable sccache (watching for network bandwidth charges
       #               between the cache server and AWS VMs)
       - name: CMake - configure

--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: |
+          python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: Build IREE
         run: |
           source ./build_tools/cmake/setup_sccache.sh

--- a/.github/workflows/ci_linux_x64_clang_asan.yml
+++ b/.github/workflows/ci_linux_x64_clang_asan.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: |
+          python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: Build and test with ASan
         env:
           # Use a modern clang explicitly.

--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: "Building and testing with bring-your-own-LLVM"
         run: ./build_tools/cmake/build_and_test_byo_llvm.sh
 

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: |
+          python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: Build IREE
         env:
           CMAKE_BUILD_TYPE: Debug

--- a/.github/workflows/ci_linux_x64_clang_tsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_tsan.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: |
+          python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: Build and test with TSan
         env:
           # Use a modern clang explicitly.

--- a/.github/workflows/ci_linux_x64_clang_ubsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_ubsan.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: |
+          python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: Build and test with UBSan
         env:
           # Use a modern clang explicitly.

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./build_tools/github_actions/ci_requirements.txt
       - name: "Building IREE with gcc"
         env:
           CC: gcc-11

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -71,6 +71,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.local/bin:$PATH"
           uv pip install --system -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+          uv pip install --system -r ./build_tools/github_actions/ci_requirements.txt
 
       - name: Generate compilation database (compile_commands.json)
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.21...3.24)
+cmake_minimum_required(VERSION 3.26...3.29)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/build_tools/cmake/generic_riscv32.cmake
+++ b/build_tools/cmake/generic_riscv32.cmake
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.26)
 
 # CMake invokes the toolchain file twice during the first build, but only once
 # during subsequent rebuilds. This was causing the various flags to be added

--- a/build_tools/cmake/generic_riscv64.cmake
+++ b/build_tools/cmake/generic_riscv64.cmake
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.26)
 
 # CMake invokes the toolchain file twice during the first build, but only once
 # during subsequent rebuilds. This was causing the various flags to be added

--- a/build_tools/cmake/linux_riscv32.cmake
+++ b/build_tools/cmake/linux_riscv32.cmake
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.26)
 
 # CMake invokes the toolchain file twice during the first build, but only once
 # during subsequent rebuilds. This was causing the various flags to be added

--- a/build_tools/cmake/linux_riscv64.cmake
+++ b/build_tools/cmake/linux_riscv64.cmake
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.26)
 
 # CMake invokes the toolchain file twice during the first build, but only once
 # during subsequent rebuilds. This was causing the various flags to be added

--- a/build_tools/github_actions/ci_requirements.txt
+++ b/build_tools/github_actions/ci_requirements.txt
@@ -1,5 +1,5 @@
 # In addition to runtime/bindings/python/iree/runtime/build_requirements.txt.
 # Ensure a recent cmake
-cmake>=3.18.4
+cmake>=3.26
 ninja
 packaging

--- a/build_tools/third_party/tracy/CMakeLists.txt
+++ b/build_tools/third_party/tracy/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.26)
 
 project(IREETracyServer C CXX)
 

--- a/integrations/pjrt/CMakeLists.txt
+++ b/integrations/pjrt/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.21...3.24)
+cmake_minimum_required(VERSION 3.26...3.29)
 
 project(IREE_PJRT)
 cmake_policy(SET CMP0069 NEW)


### PR DESCRIPTION
CMake 3.26 added FindPython's `Development.SABIModule` component, which is required for building Stable ABI (abi3). With this minimum version, we can unconditionally request `SABIModule` upfront in the Python `find_package` calls, before deciding whether to enable abi3. This is appealing because the SABI module must be found early and cannot be deferred to after the abi3 option is resolved; otherwise we need the user to decide through cmake flags.

CMake 3.26 availability:
  pip install cmake: 4.2.3
  Homebrew: 4.2.3
  Chocolatey (Windows CI): 4.2.3
  Ubuntu 24.04 (apt): 3.28.3
  Ubuntu 22.04 (apt): 3.22.1 (use pip or Kitware APT repo)
  Debian 12 bookworm (apt): 3.25.1 (3.31.6 in backports)
  
ci-extra: all