### PR TITLE
[VectorDistribute] Overhaul mask distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1937,6 +1937,15 @@ SmallVector<Value> createDistributedMaskBounds(PatternRewriter &rewriter,
     auto distrUpperBound =
         arith::AddIOp::create(rewriter, loc, linearizedLastValidIdx, one);
 
+    // For threads past the boundary thread (tid > u3), all iterations in
+    // batches before the boundary batch are still valid. The count of such
+    // elements is linearize(u1, u2, 0).
+    auto distrUpperBoundPostThreads = affine::AffineLinearizeIndexOp::create(
+        rewriter, loc,
+        ValueRange{packedLastValidIdx[batchIdx], packedLastValidIdx[outerIdx],
+                   zero},
+        distrShape);
+
     // The following code constructs a selection tree
     // that in effect follows the code:
     // * upperbound --> delinearize --> u0, u1, u2, u3, u4
@@ -1949,7 +1958,7 @@ SmallVector<Value> createDistributedMaskBounds(PatternRewriter &rewriter,
     //   if tid < u3:
     //     [u1][u2][max]
     //   if tid > u3:
-    //     all invalid.
+    //     [u1][u2][0]
     //   if tid == u3:
     //     [u1][u2][u4]
 
@@ -1970,9 +1979,10 @@ SmallVector<Value> createDistributedMaskBounds(PatternRewriter &rewriter,
         rewriter, loc, arith::CmpIPredicate::slt,
         subgroupIndices[unDistributedDim], packedLastValidIdx[subgroupIdx]);
 
-    // selectTid0 = tid < u3 ? [u1][u2][max] : all invalid
+    // selectTid0 = tid < u3 ? [u1][u2][max] : [u1][u2][0]
     auto selectTid0 = arith::SelectOp::create(rewriter, loc, cmpBoundTidSlt,
-                                              distrUpperBoundPreThreads, zero);
+                                              distrUpperBoundPreThreads,
+                                              distrUpperBoundPostThreads);
     // selectTid1 = tid == u3 : [u1][u2][u4] : selectTid0
     auto selectTid1 = arith::SelectOp::create(rewriter, loc, cmpBoundTidEq,
                                               distrUpperBound, selectTid0);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Rewrite/PatternApplicator.h"
@@ -1868,229 +1869,204 @@ struct DistributeStep final : OpDistributionPattern<vector::StepOp> {
   int64_t subgroupSize;
 };
 
-SmallVector<Value> createDistributedMaskBounds(PatternRewriter &rewriter,
-                                               Location loc,
-                                               ValueRange upperBounds,
-                                               NestedLayoutAttr layout,
-                                               ArrayRef<Value> subgroupIndices,
-                                               ArrayRef<Value> threadIndices) {
-  constexpr int64_t subgroupIdx = 0;
-  constexpr int64_t batchIdx = 1;
-  constexpr int64_t outerIdx = 2;
-  constexpr int64_t threadIdx = 3;
-  constexpr int64_t elementIdx = 4;
-  SmallVector<Value> bounds;
-  auto zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-  auto one = arith::ConstantIndexOp::create(rewriter, loc, 1);
+/// Decomposes create_mask/constant_mask operations into a combination of
+/// vector.step and comparison with the mask bounds.
+/// The idea is simple: The vector.step will contain all indices in the full
+/// range of the vector. By broadcasting the bound specified for the mask
+/// operation, we can perform a vector comparison that will yield a vector of
+/// true/false telling us which indices are inside the original boundary. This
+/// vector of true/false is our mask.
+/// For multi-dimensional vectors, we can peform this per dimension and combine
+/// the masks through a boolean AND.
+///
+/// To illustrate this with an example, assume a vector<4x8x...> and mask bounds
+/// [3, 6] from create_mask/constant_mask.
+/// Let's look at the two dimensions separately first. For the first dimension,
+/// vector.step gives us `[0, 1, 2, 3]`, broadcasting the bound gives us
+/// [3, 3, 3, 3], so the comparison results in `[1, 1, 1, 0]`. At this point,
+/// the mask for the dimension 0 is still `<4xi1>`, but we need it to match the
+/// original vector shape. To that end, we first broadcast it to <8x4xi1>,
+/// because we want to broadcast in the trailing dimension. This gives us:
+/// [[1, 1, 1, 0],
+///  [1, 1, 1, 0],
+///  [1, 1, 1, 0],
+///  [1, 1, 1, 0],
+///  [1, 1, 1, 0],
+///  [1, 1, 1, 0],
+///  [1, 1, 1, 0],
+///  [1, 1, 1, 0]]
+///
+/// To get the original shape, we now need to tranpose, giving us:
+///  [[1, 1, 1, 1, 1, 1, 1, 1],
+///   [1, 1, 1, 1, 1, 1, 1, 1],
+///   [1, 1, 1, 1, 1, 1, 1, 1],
+///   [0, 0, 0, 0, 0, 0, 0, 0]]
+///
+/// For the second dimension, we do the same, giving us a <8xi1> mask after
+/// comparison, with content [1, 1, 1, 1, 1, 1, 0, 0].
+/// We can broadcast this to the original shape and, as this is already the
+/// trailing dimension of the original layout, we don't need to tranpose. This
+/// yields:
+/// [[1, 1, 1, 1, 1, 1, 0, 0],
+///  [1, 1, 1, 1, 1, 1, 0, 0],
+///  [1, 1, 1, 1, 1, 1, 0, 0],
+///  [1, 1, 1, 1, 1, 1, 0, 0]]
+///
+/// As a final step, we now AND-combine the two masks, yielding the expected
+/// final result:
+///  [[1, 1, 1, 1, 1, 1, 0, 0],
+///   [1, 1, 1, 1, 1, 1, 0, 0],
+///   [1, 1, 1, 1, 1, 1, 0, 0],
+///   [0, 0, 0, 0, 0, 0, 0, 0]]
+///
+/// This pattern doesn't actually distribute the mask operations. Instead, it
+/// attaches the necessary layout information to the operations created
+/// (vector.step, broadcast, ...). The greedy driver will pick up the newly
+/// created operations and distribute them individually with existing patterns.
+template <typename MaskOpTy>
+struct DistributeMask final : OpDistributionPattern<MaskOpTy> {
+  using OpDistributionPattern<MaskOpTy>::OpDistributionPattern;
 
-  for (auto [unDistributedDim, upperBound] : llvm::enumerate(upperBounds)) {
-    SmallVector<int64_t> undistributedShape =
-        layout.getPackedShapeForUndistributedDim(unDistributedDim);
-    std::array<int64_t, 3> distrShape{undistributedShape[batchIdx],
-                                      undistributedShape[outerIdx],
-                                      undistributedShape[elementIdx]};
-    int64_t elementPerThread = ShapedType::getNumElements(distrShape);
-    auto allValid =
-        arith::ConstantIndexOp::create(rewriter, loc, elementPerThread);
-    int64_t elementTileSize = distrShape.back();
-    auto elementTileLastIdx =
-        arith::ConstantIndexOp::create(rewriter, loc, elementTileSize - 1);
+  LogicalResult matchAndRewrite(MaskOpTy maskOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder builder(maskOp.getLoc(), rewriter);
+    VectorValue result = maskOp.getResult();
+    NestedLayoutAttr layout = dyn_cast<NestedLayoutAttr>(signature[result]);
+    if (!layout) {
+      return rewriter.notifyMatchFailure(maskOp,
+                                         "missing nested layout for mask");
+    }
 
-    // A special condition if the pre-distribution bounds match
-    // the mask dimension length, then the distributed bounds
-    // should exhibit the same property.
+    VectorType maskType = maskOp.getType();
+    int64_t rank = maskType.getRank();
 
-    APInt constUpperBound;
-    if (matchPattern(upperBound.getDefiningOp(),
-                     m_ConstantInt(&constUpperBound))) {
-      int64_t undistributedDimLen =
-          ShapedType::getNumElements(undistributedShape);
-      if (constUpperBound.getZExtValue() == undistributedDimLen) {
-        bounds.push_back(allValid);
+    SmallVector<Value> upperBounds = getUpperBounds(builder, maskOp);
+
+    SmallVector<Value> dimMasks;
+    for (int64_t dim = 0; dim < rank; ++dim) {
+      int64_t dimSize = maskType.getDimSize(dim);
+
+      // Get layout just for this dimension.
+      SmallVector<bool> droppedDims(rank, true);
+      droppedDims[dim] = false;
+      auto dimLayout = cast<NestedLayoutAttr>(layout.project(droppedDims));
+
+      // Optimization: if bound is a constant equal to the dim size, all
+      // elements along this dimension are valid and we can skip the step +
+      // comparison.
+      APInt constBound;
+      if (matchPattern(upperBounds[dim], m_ConstantInt(&constBound)) &&
+          constBound.getSExtValue() == dimSize) {
         continue;
       }
-    }
-    auto lastValidIdx = arith::SubIOp::create(rewriter, loc, upperBound, one);
-    auto delineraizedLastValidIdx = affine::AffineDelinearizeIndexOp::create(
-        rewriter, loc, lastValidIdx, undistributedShape);
-    SmallVector<Value> packedLastValidIdx =
-        delineraizedLastValidIdx.getResults();
+      auto stepType = VectorType::get({dimSize}, builder.getIndexType());
+      auto step = vector::StepOp::create(builder, stepType);
+      this->setSignatureForRedistribution(rewriter, step, {}, {dimLayout});
 
-    // When subgroup id is equal to the subgroup that encounters the bound,
-    // Every [vtid] less than [vtid that encounters last valid element] should
-    // have a all valid element tile
-    auto linearizedLastValidIdxPreThreads =
-        affine::AffineLinearizeIndexOp::create(
-            rewriter, loc,
-            ValueRange{packedLastValidIdx[batchIdx],
-                       packedLastValidIdx[outerIdx], elementTileLastIdx},
-            distrShape);
-    // Bound is defined as lastIdx + 1;
-    auto distrUpperBoundPreThreads = arith::AddIOp::create(
-        rewriter, loc, linearizedLastValidIdxPreThreads, one);
+      auto bcastBound =
+          vector::BroadcastOp::create(builder, stepType, upperBounds[dim]);
+      this->setSignatureForRedistribution(rewriter, bcastBound, {},
+                                          {dimLayout});
 
-    auto linearizedLastValidIdx = affine::AffineLinearizeIndexOp::create(
-        rewriter, loc,
-        ValueRange{packedLastValidIdx[batchIdx], packedLastValidIdx[outerIdx],
-                   packedLastValidIdx[elementIdx]},
-        distrShape);
-    auto distrUpperBound =
-        arith::AddIOp::create(rewriter, loc, linearizedLastValidIdx, one);
+      auto cmp = arith::CmpIOp::create(builder, arith::CmpIPredicate::slt, step,
+                                       bcastBound);
+      this->setSignatureForRedistribution(rewriter, cmp, {dimLayout, dimLayout},
+                                          {dimLayout});
 
-    // For threads past the boundary thread (tid > u3), all iterations in
-    // batches before the boundary batch are still valid. The count of such
-    // elements is linearize(u1, u2, 0).
-    auto distrUpperBoundPostThreads = affine::AffineLinearizeIndexOp::create(
-        rewriter, loc,
-        ValueRange{packedLastValidIdx[batchIdx], packedLastValidIdx[outerIdx],
-                   zero},
-        distrShape);
+      if (rank == 1) {
+        rewriter.replaceOp(maskOp, cmp->getResult(0));
+        return success();
+      }
 
-    // The following code constructs a selection tree
-    // that in effect follows the code:
-    // * upperbound --> delinearize --> u0, u1, u2, u3, u4
-    //
-    // if sg < u0,
-    //   all valid.
-    // elif sg > u0,
-    //   all invalid.
-    // elif sg == u0,
-    //   if tid < u3:
-    //     [u1][u2][max]
-    //   if tid > u3:
-    //     [u1][u2][0]
-    //   if tid == u3:
-    //     [u1][u2][u4]
-
-    // tid == u3
-    auto cmpBoundTidEq = arith::CmpIOp::create(
-        rewriter, loc, arith::CmpIPredicate::eq,
-        threadIndices[unDistributedDim], packedLastValidIdx[threadIdx]);
-    // tid < u3
-    auto cmpBoundTidSlt = arith::CmpIOp::create(
-        rewriter, loc, arith::CmpIPredicate::slt,
-        threadIndices[unDistributedDim], packedLastValidIdx[threadIdx]);
-    // sg == u0
-    auto cmpBoundSgEq = arith::CmpIOp::create(
-        rewriter, loc, arith::CmpIPredicate::eq,
-        subgroupIndices[unDistributedDim], packedLastValidIdx[subgroupIdx]);
-    // sg < u0
-    auto cmpBoundSgSlt = arith::CmpIOp::create(
-        rewriter, loc, arith::CmpIPredicate::slt,
-        subgroupIndices[unDistributedDim], packedLastValidIdx[subgroupIdx]);
-
-    // selectTid0 = tid < u3 ? [u1][u2][max] : [u1][u2][0]
-    auto selectTid0 = arith::SelectOp::create(rewriter, loc, cmpBoundTidSlt,
-                                              distrUpperBoundPreThreads,
-                                              distrUpperBoundPostThreads);
-    // selectTid1 = tid == u3 : [u1][u2][u4] : selectTid0
-    auto selectTid1 = arith::SelectOp::create(rewriter, loc, cmpBoundTidEq,
-                                              distrUpperBound, selectTid0);
-    // selectSg0 = sg < u0 ? all valid : all invalid
-    auto selectSg0 =
-        arith::SelectOp::create(rewriter, loc, cmpBoundSgSlt, allValid, zero);
-    // selectSg1 = sg == u0 ? selectTid1 : selectSg0
-    auto selectSg1 = arith::SelectOp::create(rewriter, loc, cmpBoundSgEq,
-                                             selectTid1, selectSg0);
-    bounds.push_back(selectSg1);
-  }
-  return bounds;
-}
-
-struct DistributeCreateMask final
-    : OpDistributionPattern<vector::CreateMaskOp> {
-  using OpDistributionPattern::OpDistributionPattern;
-  DistributeCreateMask(MLIRContext *context, Value threadId,
-                       int64_t subgroupSize)
-      : OpDistributionPattern(context), threadId(threadId),
-        subgroupSize(subgroupSize) {}
-
-  LogicalResult matchAndRewrite(vector::CreateMaskOp maskOp,
-                                DistributionSignature &signature,
-                                PatternRewriter &rewriter) const override {
-    Location loc = maskOp.getLoc();
-    VectorValue result = maskOp.getResult();
-    NestedLayoutAttr resultLayout =
-        dyn_cast<NestedLayoutAttr>(signature[result]);
-    if (!resultLayout) {
-      return rewriter.notifyMatchFailure(
-          maskOp, "missing nested layout for step op result");
-    }
-    SmallVector<Value> subgroupIndices, threadIndices;
-    if (failed(populateWarpAndThreadIndices(rewriter, threadId, subgroupSize,
-                                            resultLayout, subgroupIndices,
-                                            threadIndices))) {
-      return rewriter.notifyMatchFailure(
-          maskOp, "warp or thread tiles have overlapping strides");
+      // Broadcast rank-1 cmp to full mask shape.
+      Value fullMask = broadcastDimMaskToFullShape(builder, rewriter, cmp, dim,
+                                                   maskType, layout, dimLayout);
+      dimMasks.push_back(fullMask);
     }
 
-    SmallVector<Value> distributedBounds = createDistributedMaskBounds(
-        rewriter, loc, maskOp.getOperands(), resultLayout, subgroupIndices,
-        threadIndices);
+    // If all dimensions were skipped (all bounds equal dim sizes), emit
+    // an all-true constant.
+    if (dimMasks.empty()) {
+      auto allTrue = arith::ConstantOp::create(
+          builder, DenseElementsAttr::get(maskType, builder.getBoolAttr(true)));
+      this->setSignatureForRedistribution(rewriter, allTrue, {}, {layout});
+      rewriter.replaceOp(maskOp, allTrue);
+      return success();
+    }
 
-    Type elemType = maskOp.getType().getElementType();
-    auto distrUnpackedType =
-        VectorType::get(resultLayout.getDistributedUnpackedShape(), elemType);
-    auto distrMask = vector::CreateMaskOp::create(
-        rewriter, loc, distrUnpackedType, distributedBounds);
-    VectorValue interleavedDistrMask =
-        getInterleavedPackedForm(rewriter, distrMask, resultLayout);
-    replaceOpWithDistributedValues(rewriter, maskOp, {interleavedDistrMask});
+    // Combine per-dimension masks with AND.
+    Value combined = dimMasks[0];
+    for (size_t i = 1; i < dimMasks.size(); ++i) {
+      auto andi = arith::AndIOp::create(builder, combined, dimMasks[i]);
+      this->setSignatureForRedistribution(rewriter, andi, {layout, layout},
+                                          {layout});
+      combined = andi->getResult(0);
+    }
+    rewriter.replaceOp(maskOp, combined);
     return success();
   }
-  Value threadId;
-  int64_t subgroupSize;
-};
 
-struct DistributeConstantMask final
-    : OpDistributionPattern<vector::ConstantMaskOp> {
-  using OpDistributionPattern::OpDistributionPattern;
-  DistributeConstantMask(MLIRContext *context, Value threadId,
-                         int64_t subgroupSize)
-      : OpDistributionPattern(context), threadId(threadId),
-        subgroupSize(subgroupSize) {}
-
-  LogicalResult matchAndRewrite(vector::ConstantMaskOp maskOp,
-                                DistributionSignature &signature,
-                                PatternRewriter &rewriter) const override {
-    Location loc = maskOp.getLoc();
-    VectorValue result = maskOp.getResult();
-    NestedLayoutAttr resultLayout =
-        dyn_cast<NestedLayoutAttr>(signature[result]);
-    if (!resultLayout) {
-      return rewriter.notifyMatchFailure(
-          maskOp, "missing nested layout for step op result");
-    }
-    SmallVector<Value> subgroupIndices, threadIndices;
-    if (failed(populateWarpAndThreadIndices(rewriter, threadId, subgroupSize,
-                                            resultLayout, subgroupIndices,
-                                            threadIndices))) {
-      return rewriter.notifyMatchFailure(
-          maskOp, "warp or thread tiles have overlapping strides");
+private:
+  /// Broadcast a rank-1 per-dimension mask to the full mask shape.
+  /// For the trailing dimension, this is a simple rank-extension broadcast.
+  /// For non-trailing dimensions, we broadcast with the target dim at trailing
+  /// position and then transpose it back.
+  Value broadcastDimMaskToFullShape(ImplicitLocOpBuilder &builder,
+                                    PatternRewriter &rewriter, Value dimMask,
+                                    int64_t dim, VectorType maskType,
+                                    NestedLayoutAttr fullLayout,
+                                    NestedLayoutAttr dimLayout) const {
+    int64_t rank = maskType.getRank();
+    if (dim == rank - 1) {
+      // Trailing dim: simple rank-extension broadcast.
+      auto bcast = vector::BroadcastOp::create(builder, maskType, dimMask);
+      this->setSignatureForRedistribution(rewriter, bcast, {dimLayout},
+                                          {fullLayout});
+      return bcast->getResult(0);
     }
 
-    SmallVector<Value> constOperands;
-    for (int64_t size : maskOp.getMaskDimSizes()) {
-      Value index = arith::ConstantIndexOp::create(rewriter, loc, size);
-      constOperands.push_back(index);
+    // Non-trailing dim: broadcast to shape with dim at trailing position,
+    // then transpose back.
+    SmallVector<int64_t> bcastShape;
+    SmallVector<int64_t> permToTrailing;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (i != dim) {
+        bcastShape.push_back(maskType.getDimSize(i));
+        permToTrailing.push_back(i);
+      }
     }
+    bcastShape.push_back(maskType.getDimSize(dim));
+    permToTrailing.push_back(dim);
 
-    SmallVector<Value> distributedBounds =
-        createDistributedMaskBounds(rewriter, loc, constOperands, resultLayout,
-                                    subgroupIndices, threadIndices);
+    auto bcastLayout = fullLayout.permute(permToTrailing);
+    auto bcastType = VectorType::get(bcastShape, builder.getI1Type());
+    auto bcast = vector::BroadcastOp::create(builder, bcastType, dimMask);
+    this->setSignatureForRedistribution(rewriter, bcast, {dimLayout},
+                                        {bcastLayout});
 
-    Type elemType = maskOp.getType().getElementType();
-    auto distrUnpackedType =
-        VectorType::get(resultLayout.getDistributedUnpackedShape(), elemType);
-    auto distrMask = vector::CreateMaskOp::create(
-        rewriter, loc, distrUnpackedType, distributedBounds);
-    VectorValue interleavedDistrMask =
-        getInterleavedPackedForm(rewriter, distrMask, resultLayout);
-    replaceOpWithDistributedValues(rewriter, maskOp, {interleavedDistrMask});
-    return success();
+    // Transpose: inverse of permToTrailing moves dim back to position.
+    SmallVector<int64_t> invPerm = invertPermutationVector(permToTrailing);
+    auto transposed = vector::TransposeOp::create(builder, bcast, invPerm);
+    this->setSignatureForRedistribution(rewriter, transposed, {bcastLayout},
+                                        {fullLayout});
+    return transposed->getResult(0);
   }
-  Value threadId;
-  int64_t subgroupSize;
+
+  /// Get the upper bounds as Values from either CreateMaskOp or
+  /// ConstantMaskOp.
+  static SmallVector<Value> getUpperBounds(ImplicitLocOpBuilder &builder,
+                                           MaskOpTy maskOp) {
+    if constexpr (std::is_same_v<MaskOpTy, vector::CreateMaskOp>) {
+      return SmallVector<Value>(maskOp.getOperands());
+    } else {
+      SmallVector<Value> bounds;
+      for (int64_t size : maskOp.getMaskDimSizes()) {
+        bounds.push_back(arith::ConstantIndexOp::create(builder, size));
+      }
+      return bounds;
+    }
+  }
 };
 
 struct DistributeShapeCast final : OpDistributionPattern<vector::ShapeCastOp> {
@@ -2247,8 +2223,8 @@ void populateGPUDistributeNestedLayoutAttrPatterns(
   patterns.add<DistributeBatchOuterToLayoutConversions>(patterns.getContext());
   patterns.add<DistributeInnerTiled>(patterns.getContext());
   patterns.add<DistributeStep>(patterns.getContext(), threadId, subgroupSize);
-  patterns.add<DistributeCreateMask, DistributeConstantMask>(
-      patterns.getContext(), threadId, subgroupSize);
+  patterns.add<DistributeMask<vector::CreateMaskOp>,
+               DistributeMask<vector::ConstantMaskOp>>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1876,7 +1876,7 @@ struct DistributeStep final : OpDistributionPattern<vector::StepOp> {
 /// operation, we can perform a vector comparison that will yield a vector of
 /// true/false telling us which indices are inside the original boundary. This
 /// vector of true/false is our mask.
-/// For multi-dimensional vectors, we can peform this per dimension and combine
+/// For multi-dimensional vectors, we can perform this per dimension and combine
 /// the masks through a boolean AND.
 ///
 /// To illustrate this with an example, assume a vector<4x8x...> and mask bounds
@@ -1896,7 +1896,7 @@ struct DistributeStep final : OpDistributionPattern<vector::StepOp> {
 ///  [1, 1, 1, 0],
 ///  [1, 1, 1, 0]]
 ///
-/// To get the original shape, we now need to tranpose, giving us:
+/// To get the original shape, we now need to transpose, giving us:
 ///  [[1, 1, 1, 1, 1, 1, 1, 1],
 ///   [1, 1, 1, 1, 1, 1, 1, 1],
 ///   [1, 1, 1, 1, 1, 1, 1, 1],
@@ -1905,7 +1905,7 @@ struct DistributeStep final : OpDistributionPattern<vector::StepOp> {
 /// For the second dimension, we do the same, giving us a <8xi1> mask after
 /// comparison, with content [1, 1, 1, 1, 1, 1, 0, 0].
 /// We can broadcast this to the original shape and, as this is already the
-/// trailing dimension of the original layout, we don't need to tranpose. This
+/// trailing dimension of the original layout, we don't need to transpose. This
 /// yields:
 /// [[1, 1, 1, 1, 1, 1, 0, 0],
 ///  [1, 1, 1, 1, 1, 1, 0, 0],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -42,13 +42,14 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[ETILE_VALID_BOUND:.+]] = arith.addi %[[ETILE_VALID]], %c1 : index
 // CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (16, 2) : index
 // CHECK: %[[DISTR_BOUND:.+]] = arith.addi %[[DISTR_LASTIDX]], %c1 : index
+// CHECK: %[[POST_THREADS_BOUND:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c0] by (16, 2) : index
 
 // CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
 // CHECK: %[[LT_BOUND_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
 // CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
 // CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
 
-// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %c0 : index
+// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %[[POST_THREADS_BOUND]] : index
 // CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %[[DISTR_BOUND]], %[[SELTREE0]] : index
 // CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c32, %c0 : index
 // CHECK: %[[SELTREE3:.+]] = arith.select %[[EQ_BOUND_SID]], %[[SELTREE1]], %[[SELTREE2]] : index
@@ -416,3 +417,101 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[MASK3:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
 // CHECK: %[[CMASK3:.+]] = vector.shape_cast %[[MASK3]] : vector<1x8xi1> to vector<8xi1>
 // CHECK: vector.transfer_read {{.+}} %[[CMASK3]]
+
+// -----
+
+// This test covers the case constant_mask [2, 508] on a 2x512
+// vector with element_tile=1 and batch_tile=8 on the masked dimension.
+// Last valid index 507 delinearizes to (u1=7, u3=59). Threads 60-63 (tid > 59)
+// must get postThreadsBound=7 (not 0), because they still have 7 valid batch
+// iterations before the boundary batch.
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 8],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @masked_read_write_unit_element_tile(%arg0 : memref<2x512xf16>, %arg1 : memref<2x512xf16>) {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %mask = vector.constant_mask [2, 508] : vector<2x512xi1>
+  %read = vector.transfer_read %arg0[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<2x512xf16>, vector<2x512xf16>
+  %layout = iree_vector_ext.to_layout %read to layout(#layout) : vector<2x512xf16>
+  vector.transfer_write %layout, %arg1[%c0, %c0], %mask {in_bounds = [true, true]} : vector<2x512xf16>, memref<2x512xf16>
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @masked_read_write_unit_element_tile
+// CHECK-DAG: %[[C7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[C59:.+]] = arith.constant 59 : index
+// CHECK: %[[VTID:.+]]:2 = affine.delinearize_index %thread_id_x into (64) : index, index
+
+// CHECK: %[[EQ_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[C59]] : index
+// CHECK: %[[LT_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[C59]] : index
+// CHECK: %[[SELTID0:.+]] = arith.select %[[LT_TID]], %[[C8]], %[[C7]] : index
+// CHECK: %[[BOUND:.+]] = arith.select %[[EQ_TID]], %[[C8]], %[[SELTID0]] : index
+
+// -----
+
+// This test exercises the three-way thread split when element_tile > 1. With
+// constant_mask [58] on a 64-element vector (batch=4, thread=4, element=4),
+// last valid index 57 delinearizes to (u1=3, u3=2, u4=1). All three cases
+// produce distinct bounds:
+//   tid < 2:  16 (4 full batches)
+//   tid == 2: 14 (3 full batches + partial element tile of 2)
+//   tid > 2:  12 (3 full batches, boundary batch has 0 valid elements)
+
+#layout_1d = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [4],
+  outer_tile = [1],
+  thread_tile = [4],
+  element_tile = [4],
+
+  subgroup_strides = [0],
+  thread_strides = [1]
+>
+
+func.func @masked_read_write_partial_element_tile(%arg0 : memref<64xf16>, %arg1 : memref<64xf16>) {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %mask = vector.constant_mask [58] : vector<64xi1>
+  %read = vector.transfer_read %arg0[%c0], %cst, %mask {in_bounds = [true]} : memref<64xf16>, vector<64xf16>
+  %layout = iree_vector_ext.to_layout %read to layout(#layout_1d) : vector<64xf16>
+  vector.transfer_write %layout, %arg1[%c0], %mask {in_bounds = [true]} : vector<64xf16>, memref<64xf16>
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @masked_read_write_partial_element_tile
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C12:.+]] = arith.constant 12 : index
+// CHECK-DAG: %[[C14:.+]] = arith.constant 14 : index
+// CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+// CHECK: %[[VTID:.+]]:2 = affine.delinearize_index %thread_id_x into (4) : index, index
+// CHECK: %[[EQ_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[C2]] : index
+// CHECK: %[[LT_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[C2]] : index
+// CHECK: %[[SELTID0:.+]] = arith.select %[[LT_TID]], %[[C16]], %[[C12]] : index
+// CHECK: %[[BOUND:.+]] = arith.select %[[EQ_TID]], %[[C14]], %[[SELTID0]] : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -32,31 +32,25 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write
-// CHECK: %[[DIM:.+]] = memref.dim %arg0, %c0 : memref<?x128xf16>
-// CHECK: %[[VSID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64) : index, index, index
-// CHECK: %[[VTID:.+]]:3 = affine.delinearize_index %thread_id_x into (4, 16) : index, index, index
-// CHECK: %[[LASTIDX:.+]] = arith.subi %[[DIM]], %c1 : index
-// CHECK: %[[PACKED_LASTIDX:.+]]:4 = affine.delinearize_index %[[LASTIDX]] into (2, 16, 4, 2) : index, index, index, index
-
-// CHECK: %[[ETILE_VALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c1] by (16, 2) : index
-// CHECK: %[[ETILE_VALID_BOUND:.+]] = arith.addi %[[ETILE_VALID]], %c1 : index
-// CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (16, 2) : index
-// CHECK: %[[DISTR_BOUND:.+]] = arith.addi %[[DISTR_LASTIDX]], %c1 : index
-// CHECK: %[[POST_THREADS_BOUND:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c0] by (16, 2) : index
-
-// CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
-// CHECK: %[[LT_BOUND_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
-// CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
-// CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
-
-// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %[[POST_THREADS_BOUND]] : index
-// CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %[[DISTR_BOUND]], %[[SELTREE0]] : index
-// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c32, %c0 : index
-// CHECK: %[[SELTREE3:.+]] = arith.select %[[EQ_BOUND_SID]], %[[SELTREE1]], %[[SELTREE2]] : index
-// CHECK: %[[MASK:.+]] = vector.create_mask %[[SELTREE3]], %c8 : vector<2x8xi1>
-
-// CHECK: %[[READ:.+]] = vector.transfer_read %arg0{{.*}}, %[[MASK]] {in_bounds = [true, true]} : memref<?x128xf16>, vector<2x8xf16>
-// CHECK: vector.transfer_write %[[READ]], %arg1{{.*}}, %[[MASK]] {in_bounds = [true, true]} : vector<2x8xf16>, memref<?x128xf16>
+// CHECK-DAG: %[[DIM:.+]] = memref.dim %arg0, %c0 : memref<?x128xf16>
+// CHECK: %[[SID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64)
+// CHECK: %[[TID:.+]]:3 = affine.delinearize_index %thread_id_x into (4, 16)
+// CHECK: %[[STEP:.+]] = vector.step : vector<2xindex>
+// CHECK: %[[STEP_BC:.+]] = vector.broadcast %[[STEP]] : vector<2xindex> to vector<16x2xindex>
+// CHECK: %[[BASE_IDX:.+]] = arith.addi %{{.+}}, %[[STEP_BC]] : vector<16x2xindex>
+// CHECK: %[[SID_OFF:.+]] = arith.muli %[[SID]]#1, %c128 : index
+// CHECK: %[[SID_OFF_BC:.+]] = vector.broadcast %[[SID_OFF]] : index to vector<16x2xindex>
+// CHECK: %[[IDX0:.+]] = arith.addi %[[BASE_IDX]], %[[SID_OFF_BC]] : vector<16x2xindex>
+// CHECK: %[[TID_OFF:.+]] = arith.muli %[[TID]]#1, %c2 : index
+// CHECK: %[[TID_OFF_BC:.+]] = vector.broadcast %[[TID_OFF]] : index to vector<16x2xindex>
+// CHECK: %[[IDX1:.+]] = arith.addi %[[IDX0]], %[[TID_OFF_BC]] : vector<16x2xindex>
+// CHECK: %[[IDX_VEC:.+]] = vector.shape_cast %[[IDX1]] : vector<16x2xindex> to vector<8x2x2xindex>
+// CHECK: %[[BOUND_BC:.+]] = vector.broadcast %[[DIM]] : index to vector<8x2x2xindex>
+// CHECK: %[[CMP:.+]] = arith.cmpi slt, %[[IDX_VEC]], %[[BOUND_BC]] : vector<8x2x2xindex>
+// CHECK: %[[FLAT_MASK:.+]] = vector.shape_cast %{{.+}} : vector<8x1x2x1x2x8xi1> to vector<32x8xi1>
+// CHECK: %[[SLICE0:.+]] = vector.extract_strided_slice %[[FLAT_MASK]] {offsets = [0, 0], sizes = [2, 8]{{.*}}} : vector<32x8xi1> to vector<2x8xi1>
+// CHECK: vector.transfer_read %arg0{{.*}}, %[[SLICE0]] {in_bounds = [true, true]} : memref<?x128xf16>, vector<2x8xf16>
+// CHECK: vector.transfer_write {{.*}}, %arg1{{.*}} {in_bounds = [true, true]} : vector<2x8xf16>, memref<?x128xf16>
 
 // -----
 
@@ -91,14 +85,13 @@ builtin.module attributes { transform.with_named_sequence } {
     transform.yield
   }
 }
-
 // CHECK-LABEL: func @masked_read_write_perm
 
 // Here we check the layout enforcement was carried out
 // accounting for permutation
 
-// CHECK: %[[DISTR_MASK:.+]] = vector.create_mask %c8, {{.*}}, %c1 : vector<8x2x1xi1>
-// CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK]]
+// CHECK: %[[SLICE0:.+]] = vector.extract_strided_slice {{.*}} {offsets = [0, 0, 0], sizes = [8, 2, 1]{{.*}}} : vector<8x8x1xi1> to vector<8x2x1xi1>
+// CHECK: vector.transfer_read %arg0{{.*}} %[[SLICE0]] {in_bounds = [true, true, true]{{.*}}} : memref<128x?x1xf16>, vector<1x2x8xf16>
 
 // -----
 
@@ -135,9 +128,8 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write_perm_minor
-
-// CHECK: %[[DISTR_MASK:.+]] = vector.create_mask %c8, {{.*}} : vector<8x2xi1>
-// CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK]]
+// CHECK: %[[SLICE0:.+]] = vector.extract_strided_slice {{.*}} {offsets = [0, 0], sizes = [8, 2]{{.*}}} : vector<8x8xi1> to vector<8x2xi1>
+// CHECK: vector.transfer_read %arg0{{.*}} %[[SLICE0]] {in_bounds = [true, true]{{.*}}} : memref<128x?x1xf16>, vector<2x8xf16>
 
 // -----
 
@@ -176,8 +168,12 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK-LABEL: func @masked_read_write_perm_bcast
 
-// CHECK: %[[DISTR_MASK:.+]] = vector.create_mask {{.*}} : vector<2xi1>
-// CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK]]
+// CHECK: %[[STEP:.+]] = vector.step : vector<2xindex>
+// CHECK: %[[BOUND_BC:.+]] = vector.broadcast %{{.+}} : index to vector<2x2x2xindex>
+// CHECK: %[[CMP:.+]] = arith.cmpi slt, %{{.+}}, %[[BOUND_BC]] : vector<2x2x2xindex>
+// CHECK: %[[FLAT_MASK:.+]] = vector.shape_cast %[[CMP]] : vector<2x2x2xi1> to vector<8xi1>
+// CHECK: %[[SLICE0:.+]] = vector.extract_strided_slice %[[FLAT_MASK]] {offsets = [0], sizes = [2]{{.*}}} : vector<8xi1> to vector<2xi1>
+// CHECK: vector.transfer_read %arg0{{.*}} %[[SLICE0]] {in_bounds = [true, true]{{.*}}} : memref<128x?x1xf16>, vector<2x8xf16>
 
 // -----
 
@@ -216,14 +212,15 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write_reduce
+// CHECK-DAG: %[[RED_IDENTITY:.+]] = arith.constant dense<0.000000e+00> : vector<2x1x2x1x2x8xf16>
 
-// CHECK: %[[RED_IDENTITY:.+]] = arith.constant dense<0.000000e+00> : vector<2x1x2x1x2x8xf16>
+// CHECK: %[[STEP:.+]] = vector.step : vector<2xindex>
+// CHECK: %[[CMP:.+]] = arith.cmpi slt, %{{.+}}, %{{.+}} : vector<2x2x2xindex>
+// CHECK: %[[MASK_BCAST:.+]] = vector.broadcast %[[CMP]] : vector<2x2x2xi1> to vector<1x1x8x2x2x2xi1>
+// CHECK: %[[MASK_PACKED:.+]] = vector.transpose %[[MASK_BCAST]], [3, 0, 4, 1, 5, 2] : vector<1x1x8x2x2x2xi1> to vector<2x1x2x1x2x8xi1>
 
-// CHECK: %[[MASK:.+]] = vector.create_mask
-// CHECK: %[[MASK_PCK:.+]] = vector.shape_cast %[[MASK]] : vector<8x8xi1> to vector<2x1x2x1x2x8xi1>
-
-// CHECK: %[[SELECT:.+]] = arith.select %[[MASK_PCK]], {{.*}}, %[[RED_IDENTITY]] : vector<2x1x2x1x2x8xi1>, vector<2x1x2x1x2x8xf16>
-// CHECK: vector.multi_reduction <add>, %[[SELECT]], {{.*}} [0, 2, 4] : vector<2x1x2x1x2x8xf16> to vector<1x1x8xf16>
+// CHECK: %[[SELECT:.+]] = arith.select %[[MASK_PACKED]], %{{.+}}, %[[RED_IDENTITY]] : vector<2x1x2x1x2x8xi1>, vector<2x1x2x1x2x8xf16>
+// CHECK: vector.multi_reduction <add>, %[[SELECT]], %{{.+}} [0, 2, 4] : vector<2x1x2x1x2x8xf16> to vector<1x1x8xf16>
 
 // -----
 
@@ -292,29 +289,47 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write_contract
-
 // CHECK-DAG: %[[RED_IDENTITY_LHS:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x2xf16>
 // CHECK-DAG: %[[RED_IDENTITY_RHS:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x2x2xf16>
 
-// Note this this transposed to match the second indexing map
-// CHECK-DAG: %[[MASK_LHS:.+]] = vector.create_mask %[[LHSUB:.+]] : vector<2xi1>
-// CHECK-DAG: %[[MASK_OP:.+]] = vector.create_mask %[[OPUB0:.+]], %[[LHSUB]] : vector<2x2xi1>
+//     Step+cmpi patterns produce distributed masks for LHS (reddim) and output (pardim).
+// CHECK: %[[LHS_CMP:.+]] = arith.cmpi slt, %{{.+}}, %{{.+}} : vector<1x1x2xindex>
+// CHECK: %[[OUT_CMP:.+]] = arith.cmpi slt, %{{.+}}, %{{.+}} : vector<1x1x2xindex>
 
-// Note MASK_OP_1D is equivalent to MASK_LHS.
-// Currently, it does not fold away.
-// CHECK-DAG: %[[MASK_OP_1D:.+]] = vector.extract %[[MASK_OP]][0] : vector<2xi1> from vector<2x2xi1>
-// CHECK-DAG: %[[MASK_OP_1D_PACKED:.+]] = vector.shape_cast %[[MASK_OP_1D]] : vector<2xi1> to vector<1x1x2xi1>
-// CHECK-DAG: %[[MASK_OP_PACKED:.+]] = vector.shape_cast %[[MASK_OP]] : vector<2x2xi1> to vector<1x1x1x1x2x2xi1>
-// CHECK-DAG: %[[MASK_OUT:.+]] = vector.create_mask {{.*}} : vector<2xi1>
+//     Broadcast each 1D mask to the full 2D shape.  Because neither is the
+//     trailing dim of its target, each goes through broadcast (permuted) then
+//     transpose back.  CSE deduplicates the broadcasts across the two andi's.
+// CHECK: %[[OUT_BCAST:.+]] = vector.broadcast %[[OUT_CMP]] : vector<1x1x2xi1> to vector<1x1x1x1x2x2xi1>
+// CHECK: %[[OUT_TRANS:.+]] = vector.transpose %[[OUT_BCAST]], [1, 0, 3, 2, 5, 4] : vector<1x1x1x1x2x2xi1> to vector<1x1x1x1x2x2xi1>
+// CHECK: %[[LHS_BCAST:.+]] = vector.broadcast %[[LHS_CMP]] : vector<1x1x2xi1> to vector<1x1x1x1x2x2xi1>
 
-// CHECK-DAG: %[[LHS_READ:.+]] = vector.transfer_read %arg0{{.*}} %[[MASK_LHS]] {in_bounds = [true]} : memref<?xf16>, vector<2xf16>
-// CHECK-DAG: %[[LHS:.+]] = vector.insert_strided_slice %[[LHS_READ]]
-// CHECK-DAG: %[[RHS_READ:.+]] = vector.transfer_read %arg1{{.*}} %[[MASK_OP]] {in_bounds = [true, true]} : memref<?x?xf16>, vector<2x2xf16>
-// CHECK-DAG: %[[RHS:.+]] = vector.insert_strided_slice %[[RHS_READ]]
+//     RHS read mask = pardim (transposed back) & reddim (broadcast).
+// CHECK: %[[RHS_READ_MASK:.+]] = arith.andi %[[OUT_TRANS]], %[[LHS_BCAST]] : vector<1x1x1x1x2x2xi1>
 
-// CHECK-DAG: %[[LHS_SELECT:.+]] = arith.select %[[MASK_OP_1D_PACKED]], %[[LHS]], %[[RED_IDENTITY_LHS]] : vector<1x1x2xi1>, vector<1x1x2xf16>
-// CHECK-DAG: %[[RHS_SELECT:.+]] = arith.select %[[MASK_OP_PACKED]], %[[RHS]], %[[RED_IDENTITY_RHS]] : vector<1x1x1x1x2x2xi1>, vector<1x1x1x1x2x2xf16>
+//     Contraction mask = reddim (transposed back) & pardim (broadcast).
+//     Reuses the CSE'd broadcasts (LHS_BCAST, OUT_BCAST).
+// CHECK: %[[LHS_TRANS:.+]] = vector.transpose %[[LHS_BCAST]], [1, 0, 3, 2, 5, 4] : vector<1x1x1x1x2x2xi1> to vector<1x1x1x1x2x2xi1>
+// CHECK: %[[CONTRACT_MASK:.+]] = arith.andi %[[LHS_TRANS]], %[[OUT_BCAST]] : vector<1x1x1x1x2x2xi1>
 
+//     LHS read uses the reddim mask directly.
+// CHECK: %[[LHS_MASK_FLAT:.+]] = vector.shape_cast %[[LHS_CMP]] : vector<1x1x2xi1> to vector<2xi1>
+// CHECK: vector.transfer_read %arg0{{.*}} %[[LHS_MASK_FLAT]] {in_bounds = [true]} : memref<?xf16>, vector<2xf16>
+
+//     RHS read uses the RHS read mask (pardim anded with reddim).
+// CHECK: %[[RHS_READ_MASK_FLAT:.+]] = vector.shape_cast %[[RHS_READ_MASK]] : vector<1x1x1x1x2x2xi1> to vector<2x2xi1>
+// CHECK: vector.transfer_read %arg1{{.*}} %[[RHS_READ_MASK_FLAT]] {in_bounds = [true, true]} : memref<?x?xf16>, vector<2x2xf16>
+
+//     Contraction mask is flattened, transposed, and split into per-operand
+//     select masks for the reduction identity replacement.
+// CHECK: %[[CM_FLAT:.+]] = vector.shape_cast %[[CONTRACT_MASK]] : vector<1x1x1x1x2x2xi1> to vector<2x2xi1>
+// CHECK: %[[CM_TRANS:.+]] = vector.transpose %[[CM_FLAT]], [1, 0] : vector<2x2xi1> to vector<2x2xi1>
+// CHECK: %[[LHS_SEL_MASK:.+]] = vector.extract %[[CM_TRANS]][0] : vector<2xi1> from vector<2x2xi1>
+// CHECK: %[[LHS_SEL_MASK_3D:.+]] = vector.shape_cast %[[LHS_SEL_MASK]] : vector<2xi1> to vector<1x1x2xi1>
+// CHECK: %[[RHS_SEL_MASK:.+]] = vector.shape_cast %[[CM_TRANS]] : vector<2x2xi1> to vector<1x1x1x1x2x2xi1>
+
+//     Select with reduction identity, then contract.
+// CHECK: %[[LHS_SELECT:.+]] = arith.select %[[LHS_SEL_MASK_3D]], %{{.+}}, %[[RED_IDENTITY_LHS]] : vector<1x1x2xi1>, vector<1x1x2xf16>
+// CHECK: %[[RHS_SELECT:.+]] = arith.select %[[RHS_SEL_MASK]], %{{.+}}, %[[RED_IDENTITY_RHS]] : vector<1x1x1x1x2x2xi1>, vector<1x1x1x1x2x2xf16>
 // CHECK: vector.contract {{.*}} %[[LHS_SELECT]], %[[RHS_SELECT]]
 
 // -----
@@ -349,19 +364,20 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write_unaligned
-// CHECK: %[[VSID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64) : index, index, index
-// CHECK: %[[VTID:.+]]:3 = affine.delinearize_index %thread_id_x into (16, 16) : index, index, index
-
-// CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %c8 : index
-// CHECK: %[[LT_BOUND_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %c8 : index
-// CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]]#1, %c0 : index
-// CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]]#1, %c0 : index
-
-// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %c2, %c0 : index
-// CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %c1, %[[SELTREE0]] : index
-// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c8, %c0 : index
-// CHECK: %[[SELTREE3:.+]] = arith.select %[[EQ_BOUND_SID]], %[[SELTREE1]], %[[SELTREE2]] : index
-// CHECK: %[[MASK:.+]] = vector.create_mask %[[SELTREE3]], %c8 : vector<2x8xi1>
+// CHECK-DAG: %[[BOUND:.+]] = arith.constant dense<17> : vector<2x2x2xindex>
+// CHECK: %[[SID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64)
+// CHECK: %[[TID:.+]]:3 = affine.delinearize_index %thread_id_x into (16, 16)
+// CHECK: %[[STEP:.+]] = vector.step : vector<2xindex>
+// CHECK: %[[STEP_BC:.+]] = vector.broadcast %[[STEP]] : vector<2xindex> to vector<4x2xindex>
+// CHECK: %[[BASE_IDX:.+]] = arith.addi %{{.+}}, %[[STEP_BC]] : vector<4x2xindex>
+// CHECK: %[[SID_OFF:.+]] = arith.muli %[[SID]]#1, %c128 : index
+// CHECK: %[[SID_OFF_BC:.+]] = vector.broadcast %[[SID_OFF]] : index to vector<4x2xindex>
+// CHECK: %[[IDX0:.+]] = arith.addi %[[BASE_IDX]], %[[SID_OFF_BC]] : vector<4x2xindex>
+// CHECK: %[[TID_OFF:.+]] = arith.muli %[[TID]]#1, %c2 : index
+// CHECK: %[[TID_OFF_BC:.+]] = vector.broadcast %[[TID_OFF]] : index to vector<4x2xindex>
+// CHECK: %[[IDX1:.+]] = arith.addi %[[IDX0]], %[[TID_OFF_BC]] : vector<4x2xindex>
+// CHECK: %[[IDX_VEC:.+]] = vector.shape_cast %[[IDX1]] : vector<4x2xindex> to vector<2x2x2xindex>
+// CHECK: %[[CMP:.+]] = arith.cmpi slt, %[[IDX_VEC]], %[[BOUND]] : vector<2x2x2xindex>
 
 // -----
 
@@ -405,18 +421,19 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: @paged_transfer_gather_mask
-// CHECK: %[[MASK0:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
-// CHECK: %[[CMASK0:.+]] = vector.shape_cast %[[MASK0]] : vector<1x8xi1> to vector<8xi1>
-// CHECK: vector.transfer_read {{.+}} %[[CMASK0]]
-// CHECK: %[[MASK1:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
-// CHECK: %[[CMASK1:.+]] = vector.shape_cast %[[MASK1]] : vector<1x8xi1> to vector<8xi1>
-// CHECK: vector.transfer_read {{.+}} %[[CMASK1]]
-// CHECK: %[[MASK2:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
-// CHECK: %[[CMASK2:.+]] = vector.shape_cast %[[MASK2]] : vector<1x8xi1> to vector<8xi1>
-// CHECK: vector.transfer_read {{.+}} %[[CMASK2]]
-// CHECK: %[[MASK3:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
-// CHECK: %[[CMASK3:.+]] = vector.shape_cast %[[MASK3]] : vector<1x8xi1> to vector<8xi1>
-// CHECK: vector.transfer_read {{.+}} %[[CMASK3]]
+// CHECK-DAG: %[[ROW_BOUND:.+]] = arith.constant dense<7> : vector<4x1x1xindex>
+// CHECK-DAG: %[[COL_BOUND:.+]] = arith.constant dense<7> : vector<1x1x8xindex>
+// CHECK: arith.cmpi slt, %{{.+}}, %[[ROW_BOUND]] : vector<4x1x1xindex>
+// CHECK: arith.cmpi slt, %{{.+}}, %[[COL_BOUND]] : vector<1x1x8xindex>
+// CHECK: %[[MASK_2D:.+]] = arith.andi %{{.+}}, %{{.+}} : vector<4x1x1x1x1x8xi1>
+// CHECK: %[[M0:.+]] = vector.extract %[[MASK_2D]][0, 0, 0, 0, 0] : vector<8xi1>
+// CHECK: vector.transfer_read %arg1{{.*}} %[[M0]] {in_bounds = [true, true]{{.*}}} : memref<4096x512x8xf16>, vector<1x8xf16>
+// CHECK: %[[M1:.+]] = vector.extract %[[MASK_2D]][1, 0, 0, 0, 0] : vector<8xi1>
+// CHECK: vector.transfer_read %arg1{{.*}} %[[M1]] {in_bounds = [true, true]{{.*}}} : memref<4096x512x8xf16>, vector<1x8xf16>
+// CHECK: %[[M2:.+]] = vector.extract %[[MASK_2D]][2, 0, 0, 0, 0] : vector<8xi1>
+// CHECK: vector.transfer_read %arg1{{.*}} %[[M2]] {in_bounds = [true, true]{{.*}}} : memref<4096x512x8xf16>, vector<1x8xf16>
+// CHECK: %[[M3:.+]] = vector.extract %[[MASK_2D]][3, 0, 0, 0, 0] : vector<8xi1>
+// CHECK: vector.transfer_read %arg1{{.*}} %[[M3]] {in_bounds = [true, true]{{.*}}} : memref<4096x512x8xf16>, vector<1x8xf16>
 
 // -----
 
@@ -456,15 +473,11 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write_unit_element_tile
-// CHECK-DAG: %[[C7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG: %[[C59:.+]] = arith.constant 59 : index
-// CHECK: %[[VTID:.+]]:2 = affine.delinearize_index %thread_id_x into (64) : index, index
-
-// CHECK: %[[EQ_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[C59]] : index
-// CHECK: %[[LT_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[C59]] : index
-// CHECK: %[[SELTID0:.+]] = arith.select %[[LT_TID]], %[[C8]], %[[C7]] : index
-// CHECK: %[[BOUND:.+]] = arith.select %[[EQ_TID]], %[[C8]], %[[SELTID0]] : index
+// CHECK-DAG: %[[BOUND:.+]] = arith.constant dense<508> : vector<8x1x1xindex>
+// CHECK: arith.cmpi slt, %{{.+}}, %[[BOUND]] : vector<8x1x1xindex>
+// CHECK: %[[FLAT_MASK:.+]] = vector.shape_cast %{{.+}} : vector<2x1x1x8x1x1xi1> to vector<2x8xi1>
+// CHECK: %[[SLICE0:.+]] = vector.extract_strided_slice %[[FLAT_MASK]] {offsets = [0, 0], sizes = [1, 1]{{.*}}} : vector<2x8xi1> to vector<1x1xi1>
+// CHECK: vector.transfer_read %arg0{{.*}}, %[[SLICE0]] {in_bounds = [true, true]} : memref<2x512xf16>, vector<1x1xf16>
 
 // -----
 
@@ -506,12 +519,8 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @masked_read_write_partial_element_tile
-// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG: %[[C12:.+]] = arith.constant 12 : index
-// CHECK-DAG: %[[C14:.+]] = arith.constant 14 : index
-// CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
-// CHECK: %[[VTID:.+]]:2 = affine.delinearize_index %thread_id_x into (4) : index, index
-// CHECK: %[[EQ_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[C2]] : index
-// CHECK: %[[LT_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[C2]] : index
-// CHECK: %[[SELTID0:.+]] = arith.select %[[LT_TID]], %[[C16]], %[[C12]] : index
-// CHECK: %[[BOUND:.+]] = arith.select %[[EQ_TID]], %[[C14]], %[[SELTID0]] : index
+// CHECK-DAG: %[[BOUND:.+]] = arith.constant dense<58> : vector<4x1x4xindex>
+// CHECK: %[[CMP:.+]] = arith.cmpi slt, %{{.+}}, %[[BOUND]] : vector<4x1x4xindex>
+// CHECK: %[[FLAT_MASK:.+]] = vector.shape_cast %[[CMP]] : vector<4x1x4xi1> to vector<16xi1>
+// CHECK: %[[SLICE0:.+]] = vector.extract_strided_slice %[[FLAT_MASK]] {offsets = [0], sizes = [4]{{.*}}} : vector<16xi1> to vector<4xi1>
+// CHECK: vector.transfer_read %arg0{{.*}}, %[[SLICE0]] {in_bounds = [true]} : memref<64xf16>, vector<4xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -208,12 +208,13 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @subgroup_reduction_masked_tail_thread
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[BOUND:.+]] = arith.constant dense<3> : vector<1x1x1xindex>
 // CHECK: vector.transfer_write
 // CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
 // The read will be masked, because we have 4 threads doing a subgroup reduce
 // on 3 elements.
-// CHECK: %[[MASK:.+]] = vector.create_mask %[[C1]], %{{.*}} : vector<1x1xi1>
+// CHECK: %[[CMP:.+]] = arith.cmpi slt, %{{.*}}, %[[BOUND]] : vector<1x1x1xindex>
+// CHECK: %[[MASK:.+]] = vector.shape_cast %[[CMP]] : vector<1x1x1xi1> to vector<1x1xi1>
 // CHECK: vector.transfer_read
 // CHECK-SAME: %[[MASK]]
 // CHECK: gpu.subgroup_reduce


### PR DESCRIPTION
So far, vector distribution of mask operations (`create_mask/constant_mask`) created a selection tree.

This PR overhauls the distribution of mask operations. Instead of the selection tree, a combination of `vector.step` and comparison with bounds provided in the masks is used to calculate the mask. For multi-dimensional vectors, the masks are calculated per dimension and then combined with boolean operations.

The actual distribution happens through distribution of the operations generated as part of the new pattern (`vector.step, ...).

A detailed explanation of the approach can be found on the documentation of the pattern.

This is part of https://github.com/iree-org/iree/issues/23415.

Assisted-by: Claude Code

ci-extra: test_torch
