### PR TITLE
[VMVX] Enable scf.forall distribution for VMVX pipelines.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -16,6 +16,7 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
 #include "iree/compiler/Codegen/Interfaces/HoistableRegionOpInterface.h"
 #include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -392,6 +393,19 @@ LogicalResult materializeSliceFromOrdinals(
         map.map(result, constVal);
       }
       continue;
+    }
+    // Same WAR as above, but for the lowered ukernel form. When ukernels are
+    // enabled, CPULowerToUKernelsPass lowers QueryTileSizesOp to
+    // iree_codegen.ukernel.generic before this point.
+    if (auto ukernelOp = dyn_cast<IREE::Codegen::UKernelGenericOp>(op)) {
+      if (ukernelOp.getUKernelFnName().contains("query_tile_sizes")) {
+        Value constVal =
+            arith::ConstantIndexOp::create(rewriter, op->getLoc(), 16);
+        for (auto result : op->getResults()) {
+          map.map(result, constVal);
+        }
+        continue;
+      }
     }
 
     // TODO(#21317, #21590): Currently, we cannot evaluate `vector.vscale` ops

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
@@ -19,9 +19,27 @@ namespace mlir::iree_compiler {
 
 constexpr int kDefaultDistTileSize = 64;
 
+/// Returns true if the operation is nested inside a tiled and distributed loop.
+static bool isInsideDistributedLoop(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+      if (isTiledAndDistributedLoop(forOp)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 static SmallVector<int64_t>
 getDefaultDistributionTileSizes(TilingInterface op) {
+  // If the op is already inside a distributed loop, skip distribution.
   unsigned numLoops = op.getLoopIteratorTypes().size();
+  if (isInsideDistributedLoop(op)) {
+    return SmallVector<int64_t>(numLoops, 0);
+  }
+
   auto partitionedLoops = cast<PartitionableLoopsInterface>(op.getOperation())
                               .getPartitionableLoops(kNumMaxParallelDims);
   SmallVector<int64_t> distTileSizes(numLoops, kDefaultDistTileSize);

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -34,23 +34,11 @@ static llvm::cl::opt<bool> clEnableUKernelsDecomposeLinalgGeneric(
                    "ukernels are enabled (experimental)"),
     llvm::cl::init(true));
 
-static llvm::cl::opt<bool> clTileDispatchUsingForall(
-    "iree-vmvx-tile-dispatch-using-forall",
-    llvm::cl::desc("Enable tile and distribute to workgroups using scf.forall"),
-    llvm::cl::init(true));
-
 static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
-  if (clTileDispatchUsingForall) {
-    funcPassManager.addPass(
-        createTileAndDistributeToWorkgroupsUsingForallOpPass());
-    funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass());
-    funcPassManager.addPass(createCombineResultLayoutTransformationPass());
-  } else {
-    funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass());
-    funcPassManager.addPass(createCSEPass());
-    funcPassManager.addPass(createConvertToDestinationPassingStylePass());
-    funcPassManager.addPass(createFoldAffineMinInDistributedLoopsPass());
-  }
+  funcPassManager.addPass(
+      createTileAndDistributeToWorkgroupsUsingForallOpPass());
+  funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass());
+  funcPassManager.addPass(createCombineResultLayoutTransformationPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -34,11 +34,24 @@ static llvm::cl::opt<bool> clEnableUKernelsDecomposeLinalgGeneric(
                    "ukernels are enabled (experimental)"),
     llvm::cl::init(true));
 
+static llvm::cl::opt<bool> clTileDispatchUsingForall(
+    "iree-vmvx-tile-dispatch-using-forall",
+    llvm::cl::desc(
+        "Enable tile and distribute to workgroups using scf.forall"),
+    llvm::cl::init(true));
+
 static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
-  funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass());
-  funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(createConvertToDestinationPassingStylePass());
-  funcPassManager.addPass(createFoldAffineMinInDistributedLoopsPass());
+  if (clTileDispatchUsingForall) {
+    funcPassManager.addPass(
+        createTileAndDistributeToWorkgroupsUsingForallOpPass());
+    funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass());
+    funcPassManager.addPass(createCombineResultLayoutTransformationPass());
+  } else {
+    funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass());
+    funcPassManager.addPass(createCSEPass());
+    funcPassManager.addPass(createConvertToDestinationPassingStylePass());
+    funcPassManager.addPass(createFoldAffineMinInDistributedLoopsPass());
+  }
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -36,8 +36,7 @@ static llvm::cl::opt<bool> clEnableUKernelsDecomposeLinalgGeneric(
 
 static llvm::cl::opt<bool> clTileDispatchUsingForall(
     "iree-vmvx-tile-dispatch-using-forall",
-    llvm::cl::desc(
-        "Enable tile and distribute to workgroups using scf.forall"),
+    llvm::cl::desc("Enable tile and distribute to workgroups using scf.forall"),
     llvm::cl::init(true));
 
 static void addTileAndDistributePasses(OpPassManager &funcPassManager) {

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
@@ -162,3 +162,46 @@ func.func @copy_cst() attributes {hal.executable.target = #executable_target_vmv
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = VMVXDefault>
 //      CHECK: func.func @copy_cst
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
+
+// -----
+
+// Verify that ops inside already-distributed loops get zero distribution tiles.
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @already_distributed() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %lhs_binding = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(32) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>>
+  %rhs_binding = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(32) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>>
+  %dst_binding = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(32) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %end = arith.constant 4 : index
+  scf.for %iv = %workgroup_id_x to %end step %workgroup_count_x {
+    %remaining = affine.min affine_map<(d0) -> (-d0 + 4, 1)>(%iv)
+    %lhs = iree_tensor_ext.dispatch.tensor.load %lhs_binding, offsets = [%iv], sizes = [%remaining], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> -> tensor<?xf32>
+    %rhs = iree_tensor_ext.dispatch.tensor.load %rhs_binding, offsets = [%iv], sizes = [%remaining], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> -> tensor<?xf32>
+    %init = tensor.empty(%remaining) : tensor<?xf32>
+    %result = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]
+    } ins(%lhs, %rhs : tensor<?xf32>, tensor<?xf32>)
+      outs(%init : tensor<?xf32>) {
+    ^bb0(%a: f32, %b: f32, %c: f32):
+      %mul = arith.mulf %a, %b : f32
+      linalg.yield %mul : f32
+    } -> tensor<?xf32>
+    iree_tensor_ext.dispatch.tensor.store %result, %dst_binding, offsets = [%iv], sizes = [%remaining], strides = [1] : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  }
+  return
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = VMVXDefault>
+//      CHECK: func.func @already_distributed
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.generic
+// CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -57,14 +57,23 @@ void buildVMVXConfigurationPassPipeline(OpPassManager &variantPassManager) {
 
 static void
 buildVectorVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
-  OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
   // ---------------------------------------------------------------------------
   // Tensor-level optimization, kernel dispatch and lower to buffers.
   // ---------------------------------------------------------------------------
-  {
-    FunctionLikeNest(modulePassManager)
-        .addPass(createVMVXLowerExecutableTargetPass);
-  }
+  FunctionLikeNest(variantPassManager.nest<ModuleOp>())
+      .addPass(createVMVXLowerExecutableTargetPass);
+
+  // Resolve workgroup distribution before lowering ukernels to calls.
+  // CPULowerToUKernelsPass (inside VMVXLowerExecutableTargetPass) lowers
+  // iree_codegen.query_tile_sizes to iree_codegen.ukernel.generic which is
+  // memory-effect-free at the tensor level (no memref operands). The WAR hack
+  // in materializeSliceFromOrdinals replaces it with a constant in the count
+  // region. After LowerUKernelOpsToCallsPass it becomes a func.call which is
+  // memory-effecting and would be rejected by the backward slice.
+  variantPassManager.addPass(createReconcileTranslationInfoPass());
+  variantPassManager.addPass(createResolveWorkgroupCountHintsPass());
+
+  OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
   modulePassManager.addPass(createLowerUKernelOpsToCallsPass());
 
   // ---------------------------------------------------------------------------
@@ -134,8 +143,6 @@ void buildVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
 
   buildVectorVMVXTransformPassPipeline(variantPassManager);
 
-  variantPassManager.addPass(createReconcileTranslationInfoPass());
-  variantPassManager.addPass(createResolveWorkgroupCountHintsPass());
   // ---------------------------------------------------------------------------
   // Standard/Vector/HAL/etc -> VMVX conversion
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
The iree_codegen.query_tile_sizes op was resolved during scf.for distribution. If we go with scf.forall distribution, it becomes `iree_codegen.ukernel.generic` before reconcile+resolve runs. Thus, it requires a workaround similar to the existing one.

Further more, LowerUKernelOpsToCallsPass would lower it to a func.call which is memory-effecting and would be rejected by backward slice analysis. So we put the reconcile+resolve in between, which is the stage that we have enough information.

- Move reconcile+resolve before LowerUKernelOpsToCallsPass in the VMVX variant pipeline.
- Extend the WAR hack in materializeSliceFromOrdinals (TODO #13038) to also handle the lowered UKernelGenericOp form of query_tile_sizes, replacing it with a constant 16 in the workgroup count region.
- Disable the distribution if it identifies that the distribution is already applied.

Fixes https://github.com/iree-org/iree/issues/23588