### PR TITLE
[GPUHeuristics] Add min-based tile distribution for imbalanced M/N problems

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -533,8 +533,9 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
   // Redirect remaining tiles to the starved (dominant) dimension.
   auto redirectRemainingTiles = [&](bool condition, int64_t totalTiles,
                                     int64_t &tileSizeDistributed) {
-    if (!condition || remainingTiles <= 1)
+    if (!condition || remainingTiles <= 1) {
       return;
+    }
     int64_t newTile = std::min(remainingTiles, totalTiles);
     if (newTile > tileSizeDistributed) {
       remainingTiles /= (newTile / tileSizeDistributed);
@@ -553,7 +554,7 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
   LDBG() << "Collapsed tile sizes: M: " << mTileSizeDistributed
          << ", N: " << nTileSizeDistributed;
 
-  // Distribute collapsed counts to per-dimension M and N (inner → outer).
+  // Distribute collapsed counts to per-dimension M and N (inner -> outer).
   // Use min-based distribution for the dominant dimension in imbalanced
   // problems, since GCD fails for non-power-of-2 tile counts.
   auto distributeToDims = [](MutableArrayRef<int64_t> tileCounts,
@@ -561,8 +562,8 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                              MutableArrayRef<int64_t> tileSizes,
                              int64_t &subgroupBudget, int64_t &tileBudget,
                              bool useMin) {
-    auto distribute = useMin ? distributeTilesUsingMin
-                             : distributeTilesUsingGCD;
+    int64_t distribute =
+        useMin ? distributeTilesUsingMin : distributeTilesUsingGCD;
     for (size_t e = tileCounts.size(), i = e - 1; i < e; --i) {
       subgroupCounts[i] = distribute(tileCounts[i], subgroupBudget);
       tileSizes[i] = distribute(tileCounts[i], tileBudget);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -359,6 +359,16 @@ static int64_t distributeTilesUsingGCD(int64_t &totalTiles,
   return distributeTileCount;
 }
 
+/// Like distributeTilesUsingGCD but uses min instead of GCD. This handles
+/// non-power-of-2 tile counts where GCD fails (e.g., prime tile counts).
+static int64_t distributeTilesUsingMin(int64_t &totalTiles,
+                                       int64_t &tilesToDistribute) {
+  int64_t distributeTileCount = std::min(tilesToDistribute, totalTiles);
+  totalTiles = llvm::divideCeil(totalTiles, distributeTileCount);
+  tilesToDistribute /= distributeTileCount;
+  return distributeTileCount;
+}
+
 /// Distributes the square root of the subgroup and tile counts to both M and N
 /// dimensions. The first argument servers as a flag to indicate whether the
 /// distribution is for the M or N dimension. Both total tiles and remaining
@@ -505,11 +515,37 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                         remainingSubgroups, remainingTiles);
   }
 
-  // Note: Experimentation has proved that leaving the leftover factors
-  // unassigned is better than greedily assigning them to the larger collapsed
-  // dimension. This is likely because assigning leftover factors often results
-  // in overly aggressive tiling that ended up reducing occupancy and increasing
-  // shared memory usage.
+  // Leaving leftover factors unassigned generally works better than greedily
+  // assigning them, as it avoids overly aggressive tiling that reduces
+  // occupancy. However, for heavily imbalanced problems (4:1+ tile ratio),
+  // GCD fails for non-power-of-2 tile counts (e.g., 149 tiles for F=2376/16).
+  // In such cases, redirect remaining tiles to the starved dimension using
+  // min-based distribution. Only do this when both dimensions have enough
+  // tiles (>= 8) to avoid hurting small shapes like group convolutions.
+  constexpr int64_t kMinTileCountThreshold = 8;
+  int64_t minMNTileCount =
+      std::min(mTotalTileCounts.back(), nTotalTileCounts.back());
+  bool useMinForM = minMNTileCount >= kMinTileCountThreshold &&
+                    mTotalTileCounts.back() >= 4 * nTotalTileCounts.back();
+  bool useMinForN = minMNTileCount >= kMinTileCountThreshold &&
+                    nTotalTileCounts.back() >= 4 * mTotalTileCounts.back();
+
+  // Redirect remaining tiles to the starved (dominant) dimension.
+  auto redirectRemainingTiles = [&](bool condition, int64_t totalTiles,
+                                    int64_t &tileSizeDistributed) {
+    if (!condition || remainingTiles <= 1)
+      return;
+    int64_t newTile = std::min(remainingTiles, totalTiles);
+    if (newTile > tileSizeDistributed) {
+      remainingTiles /= (newTile / tileSizeDistributed);
+      tileSizeDistributed = newTile;
+    }
+  };
+  redirectRemainingTiles(useMinForM, mTotalTileToDistribute,
+                         mTileSizeDistributed);
+  redirectRemainingTiles(useMinForN, nTotalTileToDistribute,
+                         nTileSizeDistributed);
+
   LDBG() << "Leftover factors: subgroups: " << remainingSubgroups
          << ", tiles: " << remainingTiles;
   LDBG() << "Collapsed subgroup counts: M: " << mSubgroupDistributed
@@ -517,26 +553,31 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
   LDBG() << "Collapsed tile sizes: M: " << mTileSizeDistributed
          << ", N: " << nTileSizeDistributed;
 
+  // Distribute collapsed counts to per-dimension M and N (inner → outer).
+  // Use min-based distribution for the dominant dimension in imbalanced
+  // problems, since GCD fails for non-power-of-2 tile counts.
+  auto distributeToDims = [](MutableArrayRef<int64_t> tileCounts,
+                             MutableArrayRef<int64_t> subgroupCounts,
+                             MutableArrayRef<int64_t> tileSizes,
+                             int64_t &subgroupBudget, int64_t &tileBudget,
+                             bool useMin) {
+    auto distribute = useMin ? distributeTilesUsingMin
+                             : distributeTilesUsingGCD;
+    for (size_t e = tileCounts.size(), i = e - 1; i < e; --i) {
+      subgroupCounts[i] = distribute(tileCounts[i], subgroupBudget);
+      tileSizes[i] = distribute(tileCounts[i], tileBudget);
+    }
+  };
+
   SmallVector<int64_t> mSubgroupCounts(problem.mSizes.size(), 0),
       nSubgroupCounts(problem.nSizes.size(), 0),
       mTileSizes(problem.mSizes.size(), 0),
       nTileSizes(problem.nSizes.size(), 0);
 
-  // Distribute collapsed tile to M dims from inner -> outer.
-  for (size_t e = problem.mSizes.size(), i = e - 1; i < e; --i) {
-    mSubgroupCounts[i] =
-        distributeTilesUsingGCD(mTotalTileCounts[i], mSubgroupDistributed);
-    mTileSizes[i] =
-        distributeTilesUsingGCD(mTotalTileCounts[i], mTileSizeDistributed);
-  }
-
-  // Distribute collapsed tile to N dims from inner -> outer.
-  for (size_t e = problem.nSizes.size(), i = e - 1; i < e; --i) {
-    nSubgroupCounts[i] =
-        distributeTilesUsingGCD(nTotalTileCounts[i], nSubgroupDistributed);
-    nTileSizes[i] =
-        distributeTilesUsingGCD(nTotalTileCounts[i], nTileSizeDistributed);
-  }
+  distributeToDims(mTotalTileCounts, mSubgroupCounts, mTileSizes,
+                   mSubgroupDistributed, mTileSizeDistributed, useMinForM);
+  distributeToDims(nTotalTileCounts, nSubgroupCounts, nTileSizes,
+                   nSubgroupDistributed, nTileSizeDistributed, useMinForN);
 
   SmallVector<int64_t> kTileSizes =
       getBestKTileSizes(problem, intrinsic, seeds);
@@ -551,7 +592,7 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
 ///   dimension of the problem.
 ///   2) M/N-alignment. We prefer intrinsics that can evenly divide the M
 ///   and N dimensions of the problem.
-///   3) Intrinsic with larger gemm size.
+///   3) Intrinsic with larger gemm input size.
 ///   4) Intrinsic with larger K size.
 ///
 /// This function acts as a comparison function object for std::sort, which

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -562,7 +562,7 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                              MutableArrayRef<int64_t> tileSizes,
                              int64_t &subgroupBudget, int64_t &tileBudget,
                              bool useMin) {
-    int64_t distribute =
+    int64_t (*distribute)(int64_t &, int64_t &) =
         useMin ? distributeTilesUsingMin : distributeTilesUsingGCD;
     for (size_t e = tileCounts.size(), i = e - 1; i < e; --i) {
       subgroupCounts[i] = distribute(tileCounts[i], subgroupBudget);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -389,3 +389,32 @@ func.func @conv_with_dps_init_producer(
 
 //     CHECK-LABEL: conv_with_dps_init_producer
 //           CHECK: promote_operands = [0, 1, 2]
+
+// -----
+
+// Backward weight conv where M=F=2376 has a prime tile count (149),
+// causing GCD to fail; the min-based distribution override assigns tiles to M.
+#map_bwd_lhs = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
+#map_bwd_rhs = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
+#map_bwd_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+func.func @conv_bwd_weight_igemm(%lhs: tensor<32x27x27x256xf16>, %rhs: tensor<32x25x25x2376xf16>) -> tensor<2376x3x3x256xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<2376x3x3x256xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<2376x3x3x256xf32>) -> tensor<2376x3x3x256xf32>
+  %result = linalg.generic {indexing_maps = [#map_bwd_lhs, #map_bwd_rhs, #map_bwd_out], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%lhs, %rhs : tensor<32x27x27x256xf16>, tensor<32x25x25x2376xf16>) outs(%fill : tensor<2376x3x3x256xf32>) {
+  ^bb0(%in: f16, %in_1: f16, %out: f32):
+    %0 = arith.extf %in : f16 to f32
+    %1 = arith.extf %in_1 : f16 to f32
+    %2 = arith.mulf %0, %1 : f32
+    %3 = arith.addf %2, %out : f32
+    linalg.yield %3 : f32
+  } -> tensor<2376x3x3x256xf32>
+  return %result : tensor<2376x3x3x256xf32>
+}
+
+//     CHECK-LABEL: conv_bwd_weight_igemm
+//           CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//      CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+//      CHECK-SAME:     reduction = [0, 0, 0, 0, 2]
+//      CHECK-SAME:     subgroup = [4, 1, 1, 2, 0]
+//      CHECK-SAME:     workgroup = [64, 1, 1, 128, 0]


### PR DESCRIPTION
For imbalanced problems (4:1+ M/N tile ratio), GCD-based distribution fails when the dominant dimension has non-power-of-2 tile counts (e.g., 149 tiles for F=2376). This PR adds a min-based distribution fallback that redirects remaining tiles to the starved dimension, and uses min-based per-dimension assignment to handle odd tile counts.

Backward weight conv benchmarks on Mi355:

| Shape | Speedup | Baseline (μs) | This PR (μs) |
|-------|---------|---------------|--------------|
| convfp16 -n 32 -c 256 -H 100 -W 100 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -F 4 | 2.36x | 20776.2 | 8817.2 |
| convfp16 -n 32 -c 256 -H 13 -W 13 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -F 4 | 2.15x | 377.9 | 176.1 |
| convfp16 -n 32 -c 256 -H 25 -W 25 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -F 4 | 2.14x | 1866.8 | 872.4 |
| convfp16 -n 32 -c 256 -H 50 -W 50 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -F 4 | 1.66x | 3279.5 | 1981.1 |
| convfp16 -n 32 -c 256 -H 7 -W 7 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -F 4 | 1.54x | 129.7 | 83.9 |