### PR TITLE
[Utils] Add MultiPipelineNest and revise MultiOpNest for cross-type parallelism

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.cpp
@@ -31,8 +31,9 @@ void buildTransformPassPipeline(OpPassManager &passManager,
 
   // Cleanup the IR after manipulating it.
   passManager.addPass(createInlinerPass());
-  FunctionLikeNest(passManager).addPass(createCanonicalizerPass);
-  FunctionLikeNest(passManager).addPass(createCSEPass);
+  FunctionLikeNest(passManager)
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass);
   passManager.addPass(createSymbolDCEPass());
 }
 

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/Passes.cpp
@@ -25,8 +25,9 @@ void buildTransformPassPipeline(OpPassManager &passManager) {
 
   // Cleanup the IR after manipulating it.
   passManager.addPass(createInlinerPass());
-  FunctionLikeNest(passManager).addPass(createCanonicalizerPass);
-  FunctionLikeNest(passManager).addPass(createCSEPass);
+  FunctionLikeNest(passManager)
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass);
   passManager.addPass(createSymbolDCEPass());
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1060,7 +1060,16 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
                         : createEmulateNarrowTypePass();
       })
       .addPass(createIREECodegenAffineExpandIndexOpsPass)
-      .addPass(createIREECodegenLowerAffinePass);
+      .addPass(createIREECodegenLowerAffinePass)
+      // Software emulation for small float types (fp4/fp8).
+      .addPredicatedPass(forROCDL, [] {
+        return createConvertUnsupportedFloatArithPass(
+            ConvertUnsupportedFloatArithPassOptions{
+                clLLVMGPUEnableSmallFloatEmulation});
+      });
+
+  // Commit the func-level adaptor before adding module-level passes.
+  funcPassManager.commitPass();
 
   if (!preserveDebugInfo) {
     modulePassManager.addPass(createStripDebugInfoPass());
@@ -1071,20 +1080,12 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       IREE::Util::DropCompilerHintsPassOptions{/*keepAssumeInt=*/true}));
 
   if (forROCDL) {
-    // convert to ROCDL.
-    // Software emulation for small float types (fp4/fp8) is controlled by
-    // --iree-llvmgpu-enable-small-float-emulation. When disabled (default),
-    // ConvertToROCDL will error on unsupported types.
-    funcPassManager.addPass([] {
-      return createConvertUnsupportedFloatArithPass(
-          ConvertUnsupportedFloatArithPassOptions{
-              clLLVMGPUEnableSmallFloatEmulation});
-    });
+    // Convert to ROCDL.
     modulePassManager.addPass(createConvertToROCDLPass());
     modulePassManager.addNestedPass<LLVM::LLVMFuncOp>(
         createROCDLAnnotateKernelForTranslationPass());
   } else {
-    // convert to NVVM.
+    // Convert to NVVM.
     modulePassManager.addPass(createConvertToNVVMPass());
   }
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -222,6 +222,9 @@ static void addMemRefLoweringPasses(OpPassManager &modulePassManager) {
       .addPass(createCSEPass)
       .addPass([&]() { return createOptimizeVectorTransferPass(); });
 
+  // Commit the func-level adaptor before adding module-level passes.
+  funcPassManager.commitPass();
+
   // Turn multi-dimension memref into one-dimension. This is needed for
   // SPIR-V because we don't use upstream memref descriptors.
   modulePassManager.addPass(createFlattenMemRefSubspanPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -181,49 +181,49 @@ static void addLoopMaterializationPasses(OpPassManager &funcPassManager) {
 /// cross loop nest optimizations. This should be invoked after structured op
 /// lowering and before final SPIR-V conversion.
 static void addMemRefLoweringPasses(OpPassManager &modulePassManager) {
-  FunctionLikeNest funcPassManager(modulePassManager);
-
-  funcPassManager.addPass(createCanonicalizerPass)
-      .addPass(createCSEPass)
-      .addPass(createConvertComplexToStandardPass)
-      // Math dialect ops rewrites, approximations, casts.
-      .addPass(createMathTransformPass)
-      .addPass(createPadDynamicAllocPass);
-
   // TODO: query this from the target.
   auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 32; };
-  funcPassManager
-      .addPass(
-          [&]() { return createGPUCheckResourceUsagePass(getIndexBitwidth); })
 
-      // Fold load/store from/to subview ops into the original memref when
-      // possible. In SPIR-V we don't use memref descriptor so it's not possible
-      // to handle subview ops.
-      .addPass(memref::createFoldMemRefAliasOpsPass)
-      .addPass(createConvertUnsupportedFloatArithPass)
-      .addPass(createEmulateNarrowTypePass)
-      .addPass(createCanonicalizerPass)
-      .addPass(createCSEPass)
+  {
+    FunctionLikeNest funcPassManager(modulePassManager);
+    funcPassManager.addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
+        .addPass(createConvertComplexToStandardPass)
+        // Math dialect ops rewrites, approximations, casts.
+        .addPass(createMathTransformPass)
+        .addPass(createPadDynamicAllocPass)
+        .addPass([&]() {
+          return createGPUCheckResourceUsagePass(getIndexBitwidth);
+        })
 
-      // Turn scalar load/store from memrefs into vectorized ones if possible.
-      // This gives better memory access patterns, which is very important for
-      // perf.
-      .addPass(createSPIRVVectorizeLoadStorePass)
-      // Perform optimizations that need to across the scf.for region boundary.
-      .addPass(createForOpCanonicalizationPass)
-      // Perform various vector-level cross-op optimizations like load-store
-      // forwarding, shape casting and casting op cancelling.
-      .addPass([&]() { return createOptimizeVectorTransferPass(); })
-      .addPass(createSPIRVBreakDownLargeVectorPass)
+        // Fold load/store from/to subview ops into the original memref when
+        // possible. In SPIR-V we don't use memref descriptor so it's not
+        // possible to handle subview ops.
+        .addPass(memref::createFoldMemRefAliasOpsPass)
+        .addPass(createConvertUnsupportedFloatArithPass)
+        .addPass(createEmulateNarrowTypePass)
+        .addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
 
-      // Perform optimizations that need to across the scf.for region boundary.
-      .addPass(createForOpCanonicalizationPass)
-      .addPass(createCanonicalizerPass)
-      .addPass(createCSEPass)
-      .addPass([&]() { return createOptimizeVectorTransferPass(); });
+        // Turn scalar load/store from memrefs into vectorized ones if possible.
+        // This gives better memory access patterns, which is very important for
+        // perf.
+        .addPass(createSPIRVVectorizeLoadStorePass)
+        // Perform optimizations that need to across the scf.for region
+        // boundary.
+        .addPass(createForOpCanonicalizationPass)
+        // Perform various vector-level cross-op optimizations like load-store
+        // forwarding, shape casting and casting op cancelling.
+        .addPass([&]() { return createOptimizeVectorTransferPass(); })
+        .addPass(createSPIRVBreakDownLargeVectorPass)
 
-  // Commit the func-level adaptor before adding module-level passes.
-  funcPassManager.commitPass();
+        // Perform optimizations that need to across the scf.for region
+        // boundary.
+        .addPass(createForOpCanonicalizationPass)
+        .addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
+        .addPass([&]() { return createOptimizeVectorTransferPass(); });
+  }
 
   // Turn multi-dimension memref into one-dimension. This is needed for
   // SPIR-V because we don't use upstream memref descriptors.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -192,9 +192,8 @@ static void addMemRefLoweringPasses(OpPassManager &modulePassManager) {
         // Math dialect ops rewrites, approximations, casts.
         .addPass(createMathTransformPass)
         .addPass(createPadDynamicAllocPass)
-        .addPass([&]() {
-          return createGPUCheckResourceUsagePass(getIndexBitwidth);
-        })
+        .addPass(
+            [&]() { return createGPUCheckResourceUsagePass(getIndexBitwidth); })
 
         // Fold load/store from/to subview ops into the original memref when
         // possible. In SPIR-V we don't use memref descriptor so it's not

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -408,12 +408,12 @@ void buildStreamOptimizationPassPipeline(
     // Try to reuse transient allocations that would not increase resource
     // lifetimes.
     FunctionLikeNest(passManager)
-        .addPass(IREE::Stream::createReuseAllocationsPass);
-
-    // If any scf ops crept in we get rid of them here. We should be able to
-    // support them all the way through the stream dialect but some passes are
-    // not currently set up to handle them (such as elide timepoints).
-    FunctionLikeNest(passManager).addPass(mlir::createSCFToControlFlowPass);
+        .addPass(IREE::Stream::createReuseAllocationsPass)
+        // If any scf ops crept in we get rid of them here. We should be able
+        // to support them all the way through the stream dialect but some
+        // passes are not currently set up to handle them (such as elide
+        // timepoints).
+        .addPass(mlir::createSCFToControlFlowPass);
 
     // Elide timepoints in dependency chains where one is known to have been
     // reached by the time another is (A -> B -> A|C).

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -94,26 +94,30 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   // together.
   passManager.addPass(IREE::Util::createCombineInitializersPass());
 
-  FunctionLikeNest(passManager)
-      .addPass(mlir::createSCFForLoopCanonicalizationPass);
+  {
+    MultiPipelineNest nest(passManager);
+    nest.nest<func::FuncOp, IREE::Util::InitializerOp, IREE::Util::FuncOp>();
 
-  // This pass is sketchy as it can pessimize tight loops due to affine
-  // treating all indices as signed and the unsigned conversion pass not being
-  // able to handle that. The scf.for canonicalization does a decent job of
-  // removing trivial loops above and this catches the rest. It inserts nasty
-  // rem/div ops that we can never safely remove inside of the hot inner loop
-  // and that sucks. We still have this here for now as the cost of the rem/div
-  // are less than the cost of an additional loop that this could remove.
-  passManager.addNestedPass<func::FuncOp>(affine::createLoopCoalescingPass());
+    nest.addPass(mlir::createSCFForLoopCanonicalizationPass);
 
-  FunctionLikeNest(passManager)
-      .addPass(mlir::createLoopInvariantCodeMotionPass)
-      .addPass(mlir::createSCFToControlFlowPass)
-      // TODO: Maybe this should be a part of Affine lowering pass.
-      // Remove if it is added there.
-      // https://github.com/llvm/llvm-project/issues/78458
-      .addPass(createIREECodegenAffineExpandIndexOpsPass)
-      .addPass(createIREECodegenLowerAffinePass);
+    // This pass is sketchy as it can pessimize tight loops due to affine
+    // treating all indices as signed and the unsigned conversion pass not being
+    // able to handle that. The scf.for canonicalization does a decent job of
+    // removing trivial loops above and this catches the rest. It inserts nasty
+    // rem/div ops that we can never safely remove inside of the hot inner loop
+    // and that sucks. We still have this here for now as the cost of the
+    // rem/div are less than the cost of an additional loop that this could
+    // remove.
+    nest.addPassFor<func::FuncOp>(affine::createLoopCoalescingPass);
+
+    nest.addPass(mlir::createLoopInvariantCodeMotionPass)
+        .addPass(mlir::createSCFToControlFlowPass)
+        // TODO: Maybe this should be a part of Affine lowering pass.
+        // Remove if it is added there.
+        // https://github.com/llvm/llvm-project/issues/78458
+        .addPass(createIREECodegenAffineExpandIndexOpsPass)
+        .addPass(createIREECodegenLowerAffinePass);
+  }
 
   passManager.addPass(mlir::arith::createArithUnsignedWhenEquivalentPass());
 

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -106,13 +106,10 @@ void buildGlobalOptimizationPassPipeline(
         importParametersOptions));
   }
 
-  if (clWarnOnUninitializedValues) {
-    FunctionLikeNest(mainPassManager)
-        .addPass(createWarnOnUninitializedValuesPass);
-  }
-
   // Preprocessing passes to get the program into a canonical state.
   FunctionLikeNest(mainPassManager)
+      .addPredicatedPass(clWarnOnUninitializedValues,
+                         createWarnOnUninitializedValuesPass)
       .addPredicatedPass(transformOptions.stripAssertions,
                          IREE::Util::createStripDebugOpsPass)
       .addPass(IREE::Util::createOptimizeIntArithmeticPass)
@@ -154,9 +151,7 @@ void buildGlobalOptimizationPassPipeline(
         GeneralizeLinalgNamedOpsPassOptions opt;
         opt.enableGeneralizeMatmul = transformOptions.generalizeMatmul;
         return createGeneralizeLinalgNamedOpsPass(opt);
-      });
-
-  FunctionLikeNest(mainPassManager)
+      })
       .addPredicatedPass(!clEnableEdgeReshapePropagation,
                          DispatchCreation::createInsertTensorBarriersPass);
   mainPassManager.addPass(DispatchCreation::createFoldUnitExtentDimsPass());
@@ -214,10 +209,9 @@ void buildGlobalOptimizationPassPipeline(
   }
   // Generalize transposes and any other remaining named linalg ops that can
   // now be represented as generics.
-  FunctionLikeNest(mainPassManager).addPass(createGeneralizeLinalgNamedOpsPass);
-
   // Hoist loop invariants (e.g. from scf loops) with zero-trip-check.
   FunctionLikeNest(mainPassManager)
+      .addPass(createGeneralizeLinalgNamedOpsPass)
       .addPass(createGlobalLoopInvariantCodeMotionPass)
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -207,11 +207,12 @@ void buildGlobalOptimizationPassPipeline(
     mainPassManager.addPass(createSimplifyPackUnpackPass());
     FunctionLikeNest(mainPassManager).addPass(createDataLayoutPropagationPass);
   }
-  // Generalize transposes and any other remaining named linalg ops that can
-  // now be represented as generics.
-  // Hoist loop invariants (e.g. from scf loops) with zero-trip-check.
+
   FunctionLikeNest(mainPassManager)
+      // Generalize transposes and any other remaining named linalg ops that can
+      // now be represented as generics.
       .addPass(createGeneralizeLinalgNamedOpsPass)
+      // Hoist loop invariants (e.g. from scf loops) with zero-trip-check.
       .addPass(createGlobalLoopInvariantCodeMotionPass)
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -7,8 +7,10 @@
 #include "iree/compiler/Utils/PassUtils.h"
 
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
+#include "mlir/IR/Threading.h"
 
-#define DEBUG_TYPE "iree-utils"
+#define DEBUG_TYPE "iree-pass-utils"
 
 namespace mlir::iree_compiler {
 
@@ -22,6 +24,315 @@ void signalFixedPointModified(Operation *rootOp) {
 
   LLVM_DEBUG(llvm::dbgs() << "Signalling fixed-point iterator modification");
   rootOp->setAttr("iree.fixedpoint.modified", UnitAttr::get(context));
+}
+
+//===----------------------------------------------------------------------===//
+// OpPipelineAdaptorPass
+//===----------------------------------------------------------------------===//
+
+namespace detail {
+
+OpPipelineAdaptorPass::OpPipelineAdaptorPass(const OpPipelineAdaptorPass &other)
+    : PassWrapper(other) {
+  entries.reserve(other.entries.size());
+  for (const Entry &e : other.entries) {
+    entries.emplace_back(e.condition, OpPassManager(e.pipeline), e.opTypeID,
+                         e.batchIndex);
+  }
+}
+
+OpPassManager &OpPipelineAdaptorPass::addEntry(ConditionFn condition,
+                                               StringRef anchorOpName,
+                                               std::optional<TypeID> opTypeID) {
+  if (anchorOpName.empty()) {
+    entries.emplace_back(std::move(condition), OpPassManager(), opTypeID);
+  } else {
+    entries.emplace_back(std::move(condition), OpPassManager(anchorOpName),
+                         opTypeID);
+  }
+  return entries.back().pipeline;
+}
+
+void OpPipelineAdaptorPass::mergeFrom(OpPipelineAdaptorPass &other) {
+  // Determine the next batch index for incoming entries.
+  unsigned newBatch = 0;
+  for (const Entry &e : entries) {
+    newBatch = std::max(newBatch, e.batchIndex + 1);
+  }
+  for (Entry &e : other.entries) {
+    e.batchIndex = newBatch;
+    entries.push_back(std::move(e));
+  }
+  other.entries.clear();
+  // Invalidate async executors since entries changed.
+  asyncExecutors.clear();
+}
+
+void OpPipelineAdaptorPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  for (const Entry &e : entries) {
+    e.pipeline.getDependentDialects(registry);
+  }
+}
+
+void OpPipelineAdaptorPass::runOnOperation() {
+  if (getContext().isMultithreadingEnabled()) {
+    runOnOperationAsync();
+  } else {
+    runOnOperationSync();
+  }
+}
+
+void OpPipelineAdaptorPass::runOnOperationSync() {
+  Operation *parentOp = getOperation();
+  LDBG() << "Running op pipeline adaptor synchronously on '"
+         << parentOp->getName() << "'";
+
+  for (Region &region : parentOp->getRegions()) {
+    for (Operation &op : region.getOps()) {
+      // Within a batch, first match wins. Across batches (from merged
+      // adaptors), all matching batches run.
+      std::optional<unsigned> lastMatchedBatch;
+      for (Entry &e : entries) {
+        if (lastMatchedBatch && e.batchIndex == *lastMatchedBatch) {
+          continue;
+        }
+        if (e.condition(&op)) {
+          LDBG() << "  Dispatching '" << op.getName() << "' to pipeline"
+                 << " (batch " << e.batchIndex << ")";
+          if (failed(runPipeline(e.pipeline, &op))) {
+            return signalPassFailure();
+          }
+          lastMatchedBatch = e.batchIndex;
+        }
+      }
+    }
+  }
+}
+
+void OpPipelineAdaptorPass::runOnOperationAsync() {
+  Operation *parentOp = getOperation();
+  MLIRContext *context = &getContext();
+
+  LDBG() << "Running op pipeline adaptor asynchronously on '"
+         << parentOp->getName() << "'";
+
+  // --- Phase 1: Collect matched operations (sequential). ---
+
+  // Information for a single matched operation. An op may match multiple
+  // entries when batches from merged adaptors are present.
+  struct OpDispatchInfo {
+    SmallVector<unsigned, 2> entryIndices;
+    Operation *op;
+  };
+
+  SmallVector<OpDispatchInfo> opInfos;
+  for (Region &region : parentOp->getRegions()) {
+    for (Operation &op : region.getOps()) {
+      OpDispatchInfo info;
+      info.op = &op;
+      // Within a batch, first match wins. Across batches, all matching
+      // batches run.
+      std::optional<unsigned> lastMatchedBatch;
+      for (unsigned i = 0, e = entries.size(); i < e; ++i) {
+        if (lastMatchedBatch && entries[i].batchIndex == *lastMatchedBatch) {
+          continue;
+        }
+        if (entries[i].condition(&op)) {
+          info.entryIndices.push_back(i);
+          lastMatchedBatch = entries[i].batchIndex;
+        }
+      }
+      if (!info.entryIndices.empty()) {
+        opInfos.push_back(std::move(info));
+      }
+    }
+  }
+
+  if (opInfos.empty()) {
+    return;
+  }
+
+  // Pre-create nested analysis managers so that the dynamic pipeline
+  // callback (invoked from runPipeline) only performs lookups — not
+  // insertions — on the parent AnalysisManager's child map during the
+  // parallel section. This is required because DenseMap insertion is not
+  // thread-safe.
+  AnalysisManager am = getAnalysisManager();
+  for (OpDispatchInfo &info : opInfos) {
+    (void)am.nest(info.op);
+  }
+
+  // --- Phase 2: Ensure per-thread entry clones exist. ---
+
+  unsigned numThreads = context->getThreadPool().getMaxConcurrency();
+  // Entries are immutable after pipeline construction, so size comparison
+  // suffices for staleness detection.
+  if (asyncExecutors.empty() ||
+      asyncExecutors.front().size() != entries.size()) {
+    LDBG() << "  Creating " << numThreads << " async executors with "
+           << entries.size() << " entries each";
+    asyncExecutors.clear();
+    asyncExecutors.resize(numThreads);
+    for (SmallVector<Entry> &executor : asyncExecutors) {
+      executor.reserve(entries.size());
+      for (const Entry &e : entries) {
+        executor.emplace_back(e.condition, OpPassManager(e.pipeline),
+                              e.opTypeID, e.batchIndex);
+      }
+    }
+  }
+
+  // --- Phase 3: Parallel dispatch. ---
+
+  // Track which executors are in use (one per thread).
+  std::vector<std::atomic<bool>> activeExecutors(asyncExecutors.size());
+  for (std::atomic<bool> &active : activeExecutors) {
+    active.store(false);
+  }
+  std::atomic<bool> hasFailure(false);
+
+  // NOTE: Using the dynamic pipeline API (Pass::runPipeline) rather than
+  // the internal OpToOpPassAdaptor::runPipeline means instrumentation events
+  // will report the parent thread ID rather than the actual worker thread.
+  // This is acceptable since OpPipelineAdaptorPass is an internal
+  // implementation detail.
+  parallelForEach(context, opInfos, [&](OpDispatchInfo &info) {
+    // Claim an inactive executor via atomic compare-and-swap.
+    auto it = llvm::find_if(activeExecutors, [](std::atomic<bool> &isActive) {
+      bool expected = false;
+      return isActive.compare_exchange_strong(expected, true);
+    });
+    assert(it != activeExecutors.end() &&
+           "more concurrent tasks than available executor slots");
+    unsigned executorIdx = it - activeExecutors.begin();
+
+    // Run all matched pipelines from this executor's clone. Multiple entries
+    // can match when batches from merged adaptors are present.
+    for (unsigned entryIdx : info.entryIndices) {
+      OpPassManager &pm = asyncExecutors[executorIdx][entryIdx].pipeline;
+      if (failed(runPipeline(pm, info.op))) {
+        hasFailure.store(true);
+        break;
+      }
+    }
+
+    // Release the executor.
+    activeExecutors[executorIdx].store(false);
+  });
+
+  if (hasFailure) {
+    signalPassFailure();
+  }
+}
+
+} // namespace detail
+
+//===----------------------------------------------------------------------===//
+// MultiPipelineNest
+//===----------------------------------------------------------------------===//
+
+MultiPipelineNest::MultiPipelineNest(OpPassManager &parentPm)
+    : parentPm(&parentPm),
+      ownedPass(std::make_unique<detail::OpPipelineAdaptorPass>()),
+      adaptorPass(ownedPass.get()) {}
+
+MultiPipelineNest::~MultiPipelineNest() {
+  if (!adaptorPass) {
+    return;
+  }
+  // Already committed to the PM — nothing to do.
+  if (!ownedPass) {
+    return;
+  }
+  // No entries were added — discard the pass silently.
+  if (adaptorPass->getEntries().empty()) {
+    return;
+  }
+  // Try to merge into the predecessor. On success the entries are moved
+  // and ownedPass is destroyed (now empty) when we return.
+  if (tryMergeIntoPredecessor()) {
+    return;
+  }
+  // No merge — insert the pass into the parent PM.
+  parentPm->addPass(std::move(ownedPass));
+}
+
+MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other) noexcept
+    : parentPm(other.parentPm), ownedPass(std::move(other.ownedPass)),
+      adaptorPass(other.adaptorPass) {
+  other.parentPm = nullptr;
+  other.adaptorPass = nullptr;
+}
+
+MultiPipelineNest &
+MultiPipelineNest::operator=(MultiPipelineNest &&other) noexcept {
+  if (this != &other) {
+    // Flush the current pass before replacing.
+    if (adaptorPass && ownedPass && !adaptorPass->getEntries().empty()) {
+      if (!tryMergeIntoPredecessor()) {
+        parentPm->addPass(std::move(ownedPass));
+      }
+    }
+    parentPm = other.parentPm;
+    ownedPass = std::move(other.ownedPass);
+    adaptorPass = other.adaptorPass;
+    other.parentPm = nullptr;
+    other.adaptorPass = nullptr;
+  }
+  return *this;
+}
+
+void MultiPipelineNest::commitPass() {
+  if (!ownedPass) {
+    return; // Already committed.
+  }
+  parentPm->addPass(std::move(ownedPass));
+  // adaptorPass remains valid — it now points into the PM.
+}
+
+bool MultiPipelineNest::tryMergeIntoPredecessor() {
+  // Can't merge if we have no entries.
+  if (adaptorPass->getEntries().empty()) {
+    return false;
+  }
+
+  // Can only merge if all our entries have TypeIDs.
+  for (const auto &e : adaptorPass->getEntries()) {
+    if (!e.opTypeID) {
+      return false;
+    }
+  }
+
+  // Our pass is NOT in the PM (deferred). Check the last pass in the PM.
+  if (parentPm->empty()) {
+    return false;
+  }
+  Pass &lastPass = *std::prev(parentPm->end());
+  if (lastPass.getTypeID() != TypeID::get<detail::OpPipelineAdaptorPass>()) {
+    return false;
+  }
+  auto &predAdaptor = static_cast<detail::OpPipelineAdaptorPass &>(lastPass);
+  // Predecessor must have entries and all must have TypeIDs.
+  if (predAdaptor.getEntries().empty()) {
+    return false;
+  }
+  for (const auto &e : predAdaptor.getEntries()) {
+    if (!e.opTypeID) {
+      return false;
+    }
+  }
+  LDBG() << "Merging adaptor (" << adaptorPass->getEntries().size()
+         << " entries) into predecessor (" << predAdaptor.getEntries().size()
+         << " entries)";
+  predAdaptor.mergeFrom(*adaptorPass);
+  return true;
+}
+
+OpPassManager &MultiPipelineNest::nestIf(ConditionFn condition,
+                                         StringRef anchorOpName,
+                                         std::optional<TypeID> opTypeID) {
+  return adaptorPass->addEntry(std::move(condition), anchorOpName, opTypeID);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -270,6 +270,7 @@ MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other)
       ownedPass(std::move(other.ownedPass)), adaptorPass(other.adaptorPass) {
   other.parentPm = nullptr;
   other.adaptorPass = nullptr;
+  other.parentPmSizeAtConstruction = 0;
 }
 
 MultiPipelineNest &MultiPipelineNest::operator=(MultiPipelineNest &&other) {
@@ -292,6 +293,7 @@ MultiPipelineNest &MultiPipelineNest::operator=(MultiPipelineNest &&other) {
     adaptorPass = other.adaptorPass;
     other.parentPm = nullptr;
     other.adaptorPass = nullptr;
+    other.parentPmSizeAtConstruction = 0;
   }
   return *this;
 }

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -53,6 +53,15 @@ OpPassManager &OpPipelineAdaptorPass::addEntry(ConditionFn condition,
   return entries.back().pipeline;
 }
 
+bool OpPipelineAdaptorPass::allEntriesHaveTypeID() const {
+  for (const Entry &e : entries) {
+    if (!e.opTypeID) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void OpPipelineAdaptorPass::mergeFrom(OpPipelineAdaptorPass &other) {
   // Determine the next batch index for incoming entries.
   unsigned newBatch = 0;
@@ -246,7 +255,7 @@ MultiPipelineNest::~MultiPipelineNest() {
     return;
   }
   // No entries were added — discard the pass silently.
-  if (adaptorPass->getEntries().empty()) {
+  if (adaptorPass->empty()) {
     return;
   }
   // Try to merge into the predecessor. On success the entries are moved
@@ -269,7 +278,7 @@ MultiPipelineNest &
 MultiPipelineNest::operator=(MultiPipelineNest &&other) noexcept {
   if (this != &other) {
     // Flush the current pass before replacing.
-    if (adaptorPass && ownedPass && !adaptorPass->getEntries().empty()) {
+    if (adaptorPass && ownedPass && !adaptorPass->empty()) {
       if (!tryMergeIntoPredecessor()) {
         parentPm->addPass(std::move(ownedPass));
       }
@@ -292,16 +301,9 @@ void MultiPipelineNest::commitPass() {
 }
 
 bool MultiPipelineNest::tryMergeIntoPredecessor() {
-  // Can't merge if we have no entries.
-  if (adaptorPass->getEntries().empty()) {
+  // Can't merge if we have no entries or any lack TypeIDs.
+  if (adaptorPass->empty() || !adaptorPass->allEntriesHaveTypeID()) {
     return false;
-  }
-
-  // Can only merge if all our entries have TypeIDs.
-  for (const auto &e : adaptorPass->getEntries()) {
-    if (!e.opTypeID) {
-      return false;
-    }
   }
 
   // Our pass is NOT in the PM (deferred). Check the last pass in the PM.
@@ -314,17 +316,9 @@ bool MultiPipelineNest::tryMergeIntoPredecessor() {
   }
   auto &predAdaptor = static_cast<detail::OpPipelineAdaptorPass &>(lastPass);
   // Predecessor must have entries and all must have TypeIDs.
-  if (predAdaptor.getEntries().empty()) {
+  if (predAdaptor.empty() || !predAdaptor.allEntriesHaveTypeID()) {
     return false;
   }
-  for (const auto &e : predAdaptor.getEntries()) {
-    if (!e.opTypeID) {
-      return false;
-    }
-  }
-  LDBG() << "Merging adaptor (" << adaptorPass->getEntries().size()
-         << " entries) into predecessor (" << predAdaptor.getEntries().size()
-         << " entries)";
   predAdaptor.mergeFrom(*adaptorPass);
   return true;
 }

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -54,12 +54,8 @@ OpPassManager &OpPipelineAdaptorPass::addEntry(ConditionFn condition,
 }
 
 bool OpPipelineAdaptorPass::allEntriesHaveTypeID() const {
-  for (const Entry &e : entries) {
-    if (!e.opTypeID) {
-      return false;
-    }
-  }
-  return true;
+  return llvm::all_of(entries,
+                      [](const Entry &e) { return e.opTypeID.has_value(); });
 }
 
 void OpPipelineAdaptorPass::mergeFrom(OpPipelineAdaptorPass &other) {
@@ -103,7 +99,7 @@ void OpPipelineAdaptorPass::runOnOperationSync() {
       // adaptors), all matching batches run.
       std::optional<unsigned> lastMatchedBatch;
       for (Entry &e : entries) {
-        if (lastMatchedBatch && e.batchIndex == *lastMatchedBatch) {
+        if (lastMatchedBatch == e.batchIndex) {
           continue;
         }
         if (e.condition(&op)) {
@@ -131,8 +127,8 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
   // Information for a single matched operation. An op may match multiple
   // entries when batches from merged adaptors are present.
   struct OpDispatchInfo {
+    Operation *op = nullptr;
     SmallVector<unsigned, 2> entryIndices;
-    Operation *op;
   };
 
   SmallVector<OpDispatchInfo> opInfos;
@@ -143,13 +139,13 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
       // Within a batch, first match wins. Across batches, all matching
       // batches run.
       std::optional<unsigned> lastMatchedBatch;
-      for (unsigned i = 0, e = entries.size(); i < e; ++i) {
-        if (lastMatchedBatch && entries[i].batchIndex == *lastMatchedBatch) {
+      for (auto [i, entry] : llvm::enumerate(entries)) {
+        if (lastMatchedBatch == entry.batchIndex) {
           continue;
         }
-        if (entries[i].condition(&op)) {
+        if (entry.condition(&op)) {
           info.entryIndices.push_back(i);
-          lastMatchedBatch = entries[i].batchIndex;
+          lastMatchedBatch = entry.batchIndex;
         }
       }
       if (!info.entryIndices.empty()) {
@@ -163,8 +159,8 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
   }
 
   // Pre-create nested analysis managers so that the dynamic pipeline
-  // callback (invoked from runPipeline) only performs lookups — not
-  // insertions — on the parent AnalysisManager's child map during the
+  // callback (invoked from runPipeline) only performs lookups -- not
+  // insertions -- on the parent AnalysisManager's child map during the
   // parallel section. This is required because DenseMap insertion is not
   // thread-safe.
   AnalysisManager am = getAnalysisManager();
@@ -183,7 +179,7 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
            << entries.size() << " entries each";
     asyncExecutors.clear();
     asyncExecutors.resize(numThreads);
-    for (SmallVector<Entry> &executor : asyncExecutors) {
+    for (SmallVectorImpl<Entry> &executor : asyncExecutors) {
       executor.reserve(entries.size());
       for (const Entry &e : entries) {
         executor.emplace_back(e.condition, OpPassManager(e.pipeline),
@@ -194,11 +190,11 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
 
   // --- Phase 3: Parallel dispatch. ---
 
-  // Track which executors are in use (one per thread).
-  std::vector<std::atomic<bool>> activeExecutors(asyncExecutors.size());
-  for (std::atomic<bool> &active : activeExecutors) {
-    active.store(false);
-  }
+  // Track which executors are in use (one per thread). Using unique_ptr<T[]>
+  // because std::atomic is neither copyable nor moveable, which is required
+  // by std::vector's contract even if we never resize.
+  auto activeExecutors =
+      std::make_unique<std::atomic<bool>[]>(asyncExecutors.size());
   std::atomic<bool> hasFailure(false);
 
   // NOTE: Using the dynamic pipeline API (Pass::runPipeline) rather than
@@ -206,15 +202,19 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
   // will report the parent thread ID rather than the actual worker thread.
   // This is acceptable since OpPipelineAdaptorPass is an internal
   // implementation detail.
+  //
+  // The number of active executors will never exceed numThreads because
+  // parallelForEach dispatches at most that many concurrent tasks.
   parallelForEach(context, opInfos, [&](OpDispatchInfo &info) {
     // Claim an inactive executor via atomic compare-and-swap.
-    auto it = llvm::find_if(activeExecutors, [](std::atomic<bool> &isActive) {
+    unsigned executorIdx = 0;
+    for (unsigned i = 0, e = asyncExecutors.size(); i < e; ++i) {
       bool expected = false;
-      return isActive.compare_exchange_strong(expected, true);
-    });
-    assert(it != activeExecutors.end() &&
-           "more concurrent tasks than available executor slots");
-    unsigned executorIdx = it - activeExecutors.begin();
+      if (activeExecutors[i].compare_exchange_strong(expected, true)) {
+        executorIdx = i;
+        break;
+      }
+    }
 
     // Run all matched pipelines from this executor's clone. Multiple entries
     // can match when batches from merged adaptors are present.
@@ -247,15 +247,8 @@ MultiPipelineNest::MultiPipelineNest(OpPassManager &parentPm)
       adaptorPass(ownedPass.get()) {}
 
 MultiPipelineNest::~MultiPipelineNest() {
-  if (!adaptorPass) {
-    return;
-  }
-  // Already committed to the PM — nothing to do.
-  if (!ownedPass) {
-    return;
-  }
-  // No entries were added — discard the pass silently.
-  if (adaptorPass->empty()) {
+  // Nothing to do if moved-from, already committed, or no entries added.
+  if (!adaptorPass || !ownedPass || adaptorPass->empty()) {
     return;
   }
   assert(parentPm->size() == parentPmSizeAtConstruction &&
@@ -267,11 +260,11 @@ MultiPipelineNest::~MultiPipelineNest() {
   if (tryMergeIntoPredecessor()) {
     return;
   }
-  // No merge — insert the pass into the parent PM.
+  // No merge -- insert the pass into the parent PM.
   parentPm->addPass(std::move(ownedPass));
 }
 
-MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other) noexcept
+MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other)
     : parentPm(other.parentPm),
       parentPmSizeAtConstruction(other.parentPmSizeAtConstruction),
       ownedPass(std::move(other.ownedPass)), adaptorPass(other.adaptorPass) {
@@ -280,7 +273,7 @@ MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other) noexcept
 }
 
 MultiPipelineNest &
-MultiPipelineNest::operator=(MultiPipelineNest &&other) noexcept {
+MultiPipelineNest::operator=(MultiPipelineNest &&other) {
   if (this != &other) {
     // Flush the current pass before replacing.
     if (adaptorPass && ownedPass && !adaptorPass->empty()) {
@@ -306,12 +299,17 @@ void MultiPipelineNest::commitPass() {
   if (!ownedPass) {
     return; // Already committed.
   }
+  // No entries were added -- discard the pass silently.
+  if (adaptorPass->empty()) {
+    ownedPass.reset();
+    return;
+  }
   assert(parentPm->size() == parentPmSizeAtConstruction &&
          "passes were added to the parent PM between MultiPipelineNest "
          "construction and commitPass(); call commitPass() before adding "
          "parent passes");
   parentPm->addPass(std::move(ownedPass));
-  // adaptorPass remains valid — it now points into the PM.
+  // adaptorPass remains valid -- it now points into the PM.
 }
 
 bool MultiPipelineNest::tryMergeIntoPredecessor() {

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -285,7 +285,9 @@ MultiPipelineNest &MultiPipelineNest::operator=(MultiPipelineNest &&other) {
       }
     }
     parentPm = other.parentPm;
-    parentPmSizeAtConstruction = other.parentPmSizeAtConstruction;
+    // Use the current PM size rather than other's snapshot -- if the flush
+    // above inserted a pass into the same PM, the size has grown.
+    parentPmSizeAtConstruction = parentPm ? parentPm->size() : 0;
     ownedPass = std::move(other.ownedPass);
     adaptorPass = other.adaptorPass;
     other.parentPm = nullptr;

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -195,7 +195,9 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
   // by std::vector's contract even if we never resize.
   auto activeExecutors =
       std::make_unique<std::atomic<bool>[]>(asyncExecutors.size());
-  llvm::fill(activeExecutors, false);
+  for (unsigned i = 0, e = asyncExecutors.size(); i < e; ++i) {
+    activeExecutors[i].store(false, std::memory_order_relaxed);
+  }
   std::atomic<bool> hasFailure(false);
 
   // NOTE: Using the dynamic pipeline API (Pass::runPipeline) rather than

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -195,6 +195,7 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
   // by std::vector's contract even if we never resize.
   auto activeExecutors =
       std::make_unique<std::atomic<bool>[]>(asyncExecutors.size());
+  llvm::fill(activeExecutors, false);
   std::atomic<bool> hasFailure(false);
 
   // NOTE: Using the dynamic pipeline API (Pass::runPipeline) rather than
@@ -274,27 +275,29 @@ MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other)
 }
 
 MultiPipelineNest &MultiPipelineNest::operator=(MultiPipelineNest &&other) {
-  if (this != &other) {
-    // Flush the current pass before replacing.
-    if (adaptorPass && ownedPass && !adaptorPass->empty()) {
-      if (!tryMergeIntoPredecessor()) {
-        assert(parentPm->size() == parentPmSizeAtConstruction &&
-               "passes were added to the parent PM between MultiPipelineNest "
-               "construction and destruction; use commitPass() to insert the "
-               "adaptor at the desired position before adding parent passes");
-        parentPm->addPass(std::move(ownedPass));
-      }
-    }
-    parentPm = other.parentPm;
-    // Use the current PM size rather than other's snapshot -- if the flush
-    // above inserted a pass into the same PM, the size has grown.
-    parentPmSizeAtConstruction = parentPm ? parentPm->size() : 0;
-    ownedPass = std::move(other.ownedPass);
-    adaptorPass = other.adaptorPass;
-    other.parentPm = nullptr;
-    other.adaptorPass = nullptr;
-    other.parentPmSizeAtConstruction = 0;
+  if (this == &other) {
+    return *this;
   }
+
+  // Flush the current pass before replacing.
+  if (adaptorPass && ownedPass && !adaptorPass->empty()) {
+    if (!tryMergeIntoPredecessor()) {
+      assert(parentPm->size() == parentPmSizeAtConstruction &&
+             "passes were added to the parent PM between MultiPipelineNest "
+             "construction and destruction; use commitPass() to insert the "
+             "adaptor at the desired position before adding parent passes");
+      parentPm->addPass(std::move(ownedPass));
+    }
+  }
+  parentPm = other.parentPm;
+  // Use the current PM size rather than other's snapshot -- if the flush
+  // above inserted a pass into the same PM, the size has grown.
+  parentPmSizeAtConstruction = parentPm ? parentPm->size() : 0;
+  ownedPass = std::move(other.ownedPass);
+  adaptorPass = other.adaptorPass;
+  other.parentPm = nullptr;
+  other.adaptorPass = nullptr;
+  other.parentPmSizeAtConstruction = 0;
   return *this;
 }
 

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -242,7 +242,7 @@ void OpPipelineAdaptorPass::runOnOperationAsync() {
 //===----------------------------------------------------------------------===//
 
 MultiPipelineNest::MultiPipelineNest(OpPassManager &parentPm)
-    : parentPm(&parentPm),
+    : parentPm(&parentPm), parentPmSizeAtConstruction(parentPm.size()),
       ownedPass(std::make_unique<detail::OpPipelineAdaptorPass>()),
       adaptorPass(ownedPass.get()) {}
 
@@ -258,6 +258,10 @@ MultiPipelineNest::~MultiPipelineNest() {
   if (adaptorPass->empty()) {
     return;
   }
+  assert(parentPm->size() == parentPmSizeAtConstruction &&
+         "passes were added to the parent PM between MultiPipelineNest "
+         "construction and destruction; use commitPass() to insert the "
+         "adaptor at the desired position before adding parent passes");
   // Try to merge into the predecessor. On success the entries are moved
   // and ownedPass is destroyed (now empty) when we return.
   if (tryMergeIntoPredecessor()) {
@@ -268,8 +272,9 @@ MultiPipelineNest::~MultiPipelineNest() {
 }
 
 MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other) noexcept
-    : parentPm(other.parentPm), ownedPass(std::move(other.ownedPass)),
-      adaptorPass(other.adaptorPass) {
+    : parentPm(other.parentPm),
+      parentPmSizeAtConstruction(other.parentPmSizeAtConstruction),
+      ownedPass(std::move(other.ownedPass)), adaptorPass(other.adaptorPass) {
   other.parentPm = nullptr;
   other.adaptorPass = nullptr;
 }
@@ -284,6 +289,7 @@ MultiPipelineNest::operator=(MultiPipelineNest &&other) noexcept {
       }
     }
     parentPm = other.parentPm;
+    parentPmSizeAtConstruction = other.parentPmSizeAtConstruction;
     ownedPass = std::move(other.ownedPass);
     adaptorPass = other.adaptorPass;
     other.parentPm = nullptr;
@@ -296,6 +302,10 @@ void MultiPipelineNest::commitPass() {
   if (!ownedPass) {
     return; // Already committed.
   }
+  assert(parentPm->size() == parentPmSizeAtConstruction &&
+         "passes were added to the parent PM between MultiPipelineNest "
+         "construction and commitPass(); call commitPass() before adding "
+         "parent passes");
   parentPm->addPass(std::move(ownedPass));
   // adaptorPass remains valid — it now points into the PM.
 }

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -285,6 +285,10 @@ MultiPipelineNest::operator=(MultiPipelineNest &&other) noexcept {
     // Flush the current pass before replacing.
     if (adaptorPass && ownedPass && !adaptorPass->empty()) {
       if (!tryMergeIntoPredecessor()) {
+        assert(parentPm->size() == parentPmSizeAtConstruction &&
+               "passes were added to the parent PM between MultiPipelineNest "
+               "construction and destruction; use commitPass() to insert the "
+               "adaptor at the desired position before adding parent passes");
         parentPm->addPass(std::move(ownedPass));
       }
     }

--- a/compiler/src/iree/compiler/Utils/PassUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/PassUtils.cpp
@@ -272,8 +272,7 @@ MultiPipelineNest::MultiPipelineNest(MultiPipelineNest &&other)
   other.adaptorPass = nullptr;
 }
 
-MultiPipelineNest &
-MultiPipelineNest::operator=(MultiPipelineNest &&other) {
+MultiPipelineNest &MultiPipelineNest::operator=(MultiPipelineNest &&other) {
   if (this != &other) {
     // Flush the current pass before replacing.
     if (adaptorPass && ownedPass && !adaptorPass->empty()) {

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -7,9 +7,10 @@
 #ifndef IREE_COMPILER_UTILS_PASSUTILS_H_
 #define IREE_COMPILER_UTILS_PASSUTILS_H_
 
-#include <array>
+#include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 #include "llvm/ADT/DenseMap.h"
 #include "mlir/IR/Attributes.h"
@@ -17,6 +18,14 @@
 #include "mlir/Pass/PassManager.h"
 
 namespace mlir::iree_compiler {
+
+// If running under a FixedPointIterator pass, annotate that a modification
+// has been made which requires another iteration. No-op otherwise.
+void signalFixedPointModified(Operation *rootOp);
+
+//===----------------------------------------------------------------------===//
+// PipelineCache
+//===----------------------------------------------------------------------===//
 
 // Thread-safe cache for compiled pass pipelines keyed by target attribute.
 // When multiple executable variants share the same target attribute, the pass
@@ -50,7 +59,246 @@ struct PipelineCache {
   }
 };
 
+//===----------------------------------------------------------------------===//
+// OpPipelineAdaptorPass
+//===----------------------------------------------------------------------===//
+
+namespace detail {
+
+/// An unregistered pass that adapts a parent pass manager to run sub-pipelines
+/// on child operations. The pass walks top-level operations in all regions of
+/// the parent operation, evaluates conditions in order for each child, and runs
+/// the first matching sub-pipeline. Children that match no condition are
+/// skipped.
+///
+/// When MLIR multithreading is enabled, child operations are dispatched in
+/// parallel using the same pattern as OpToOpPassAdaptor: sub-pipelines are
+/// cloned per thread, and operations are processed via parallelForEach.
+///
+/// This pass is used internally by MultiPipelineNest and is not intended for
+/// direct use.
+class OpPipelineAdaptorPass final
+    : public PassWrapper<OpPipelineAdaptorPass, OperationPass<>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(OpPipelineAdaptorPass)
+
+  using ConditionFn = std::function<bool(Operation *)>;
+
+  struct Entry {
+    ConditionFn condition;
+    OpPassManager pipeline;
+    /// TypeID of the op type this entry targets (set by nest<T>()). Entries
+    /// without a TypeID cannot participate in automatic merging.
+    std::optional<TypeID> opTypeID;
+    /// Batch index for merge-aware dispatch. Entries from the same original
+    /// MultiPipelineNest share a batch index. Within a batch, first-match-wins
+    /// semantics apply. Across batches (from merged adaptors), all matching
+    /// batches run.
+    unsigned batchIndex = 0;
+
+    Entry(ConditionFn condition, OpPassManager pipeline,
+          std::optional<TypeID> opTypeID = std::nullopt,
+          unsigned batchIndex = 0)
+        : condition(std::move(condition)), pipeline(std::move(pipeline)),
+          opTypeID(opTypeID), batchIndex(batchIndex) {}
+  };
+
+  /// Construct with no entries. Entries are added later via addEntry().
+  OpPipelineAdaptorPass() = default;
+
+  /// Copy for thread-safe cloning. OpPassManagers are deep-copied;
+  /// ConditionFn objects are value-copied (safe because they are read-only).
+  OpPipelineAdaptorPass(const OpPipelineAdaptorPass &other);
+
+  StringRef getArgument() const override { return "iree-op-pipeline-adaptor"; }
+
+  StringRef getDescription() const override {
+    return "Adapts a parent pass manager to run sub-pipelines on child "
+           "operations based on conditions.";
+  }
+
+  /// Add a condition+pipeline entry. Returns the pipeline for the caller
+  /// to populate with passes. Must only be called during pipeline
+  /// construction, before the pass manager is run.
+  OpPassManager &addEntry(ConditionFn condition, StringRef anchorOpName = "",
+                          std::optional<TypeID> opTypeID = std::nullopt);
+
+  /// Merge entries from another adaptor into this one. Entries from |other|
+  /// are assigned a new batch index so that dispatch preserves
+  /// first-match-wins within each original nest scope while running all
+  /// matching batches. |other| is left with empty entries after the merge.
+  void mergeFrom(OpPipelineAdaptorPass &other);
+
+  /// Access entries for iteration (e.g., to add passes to all pipelines).
+  MutableArrayRef<Entry> getEntries() { return entries; }
+
+  void getDependentDialects(DialectRegistry &registry) const override;
+  void runOnOperation() override;
+
+private:
+  /// Run dispatch synchronously (single-threaded).
+  void runOnOperationSync();
+
+  /// Run dispatch in parallel using parallelForEach.
+  void runOnOperationAsync();
+
+  /// The condition+pipeline entries. First match wins.
+  SmallVector<Entry> entries;
+
+  /// Per-thread copies of entries for parallel execution. Lazily initialized
+  /// when multithreading is enabled. Each element is a complete copy of
+  /// `entries` for one thread.
+  SmallVector<SmallVector<Entry>> asyncExecutors;
+};
+
+} // namespace detail
+
+//===----------------------------------------------------------------------===//
+// MultiPipelineNest
+//===----------------------------------------------------------------------===//
+
+/// Builder for conditional pipeline dispatch over child operations. Each
+/// sub-pipeline is guarded by a condition predicate; the first matching
+/// condition wins at runtime. When MLIR multithreading is enabled, matched
+/// operations are processed in parallel.
+///
+/// Pass insertion is deferred: the adaptor pass is owned by this builder and
+/// only inserted into the parent pass manager on destruction (or via an
+/// explicit commitPass() call). On destruction, the builder first attempts to
+/// merge with the immediately preceding adaptor pass in the parent PM (if
+/// both have TypeID-annotated entries). If merging succeeds, the pass is
+/// never inserted and no empty shell remains. If merging fails (or there is
+/// no compatible predecessor), the pass is inserted at the back of the PM.
+///
+/// For most usage patterns (temporaries destroyed at end-of-statement), the
+/// deferred insertion produces identical ordering to eager insertion. When
+/// a named MultiPipelineNest must coexist with interleaved parent-level
+/// passes, call commitPass() at the desired insertion point.
+///
+/// Usage:
+///   // Typical: temporary destroyed at semicolon — pass inserted here.
+///   MultiPipelineNest(pm).nest<FuncOp>().addPass(createMyPass);
+///
+///   // Named variable with explicit commit point:
+///   MultiPipelineNest nest(pm);
+///   nest.nest<FuncOp>();
+///   nest.commitPass();           // insert now, before subsequent passes
+///   pm.addPass(createOtherPass); // guaranteed to be after nest's pass
+class MultiPipelineNest {
+public:
+  using ConditionFn = std::function<bool(Operation *)>;
+
+  /// Construct a builder targeting \p parentPm. The adaptor pass is created
+  /// but NOT yet inserted into the PM. It will be inserted on destruction
+  /// (possibly merged with the predecessor) or when commitPass() is called.
+  explicit MultiPipelineNest(OpPassManager &parentPm);
+
+  /// On destruction: if the pass has not been committed, attempt to merge
+  /// with the predecessor adaptor. If merge fails, insert the pass.
+  ~MultiPipelineNest();
+
+  // Movable but not copyable. The moved-from object is left in a null state.
+  MultiPipelineNest(MultiPipelineNest &&other) noexcept;
+  MultiPipelineNest &operator=(MultiPipelineNest &&other) noexcept;
+  MultiPipelineNest(const MultiPipelineNest &) = delete;
+  MultiPipelineNest &operator=(const MultiPipelineNest &) = delete;
+
+  /// Immediately insert the pass into the parent PM at the current position.
+  /// After this call, the pass is owned by the PM and no merge will be
+  /// attempted on destruction. Use this when interleaving parent-level and
+  /// nested passes with a named MultiPipelineNest variable.
+  void commitPass();
+
+  /// Add a sub-pipeline that runs when the condition returns true.
+  /// Returns the OpPassManager for the caller to populate with passes.
+  /// The first matching condition wins at runtime.
+  ///
+  /// NOTE: The returned reference is invalidated by subsequent nestIf/nest
+  /// calls (due to SmallVector reallocation). Use addPassFor<OpT>() for
+  /// safe per-type pass addition after all entries are created.
+  OpPassManager &nestIf(ConditionFn condition, StringRef anchorOpName = "",
+                        std::optional<TypeID> opTypeID = std::nullopt);
+
+  /// Convenience: add a sub-pipeline for a specific op type. The pipeline
+  /// is anchored to OpT so that typed passes can be added directly.
+  /// Records the TypeID for automatic merging.
+  template <typename OpT>
+  OpPassManager &nest() {
+    return nestIf([](Operation *op) { return isa<OpT>(op); },
+                  OpT::getOperationName(), TypeID::get<OpT>());
+  }
+
+  /// Variadic convenience: add sub-pipelines for multiple op types at once.
+  /// Equivalent to calling nest<T>() for each type individually.
+  template <typename T1, typename T2, typename... Rest>
+  void nest() {
+    nest<T1>();
+    nest<T2>();
+    (nest<Rest>(), ...);
+  }
+
+  /// Add a pass to ALL existing sub-pipelines.
+  template <typename F = std::unique_ptr<Pass> (*)()>
+  MultiPipelineNest &addPass(F constructor) {
+    for (detail::OpPipelineAdaptorPass::Entry &entry :
+         adaptorPass->getEntries()) {
+      entry.pipeline.addPass(constructor());
+    }
+    return *this;
+  }
+
+  /// Add a pass to ALL existing sub-pipelines if the predicate is true.
+  template <typename F = std::unique_ptr<Pass> (*)()>
+  MultiPipelineNest &addPredicatedPass(bool enable, F constructor) {
+    if (enable) {
+      addPass(constructor);
+    }
+    return *this;
+  }
+
+  /// Add a pass only to sub-pipelines targeting the given op type.
+  /// This is safe to call at any point (unlike holding a reference from
+  /// nest<T>(), which can be invalidated by subsequent nest calls).
+  template <typename OpT, typename F = std::unique_ptr<Pass> (*)()>
+  MultiPipelineNest &addPassFor(F constructor) {
+    TypeID targetID = TypeID::get<OpT>();
+    for (detail::OpPipelineAdaptorPass::Entry &entry :
+         adaptorPass->getEntries()) {
+      if (entry.opTypeID == targetID) {
+        entry.pipeline.addPass(constructor());
+      }
+    }
+    return *this;
+  }
+
+private:
+  /// Try to merge this adaptor's entries into the last pass in the parent PM
+  /// (if it is a compatible OpPipelineAdaptorPass). Returns true on success.
+  bool tryMergeIntoPredecessor();
+
+  /// Pointer to the parent pass manager.
+  OpPassManager *parentPm = nullptr;
+
+  /// The adaptor pass. Owned here until commitPass() or destructor transfers
+  /// it to the parent PM (or discards it after a successful merge).
+  std::unique_ptr<detail::OpPipelineAdaptorPass> ownedPass;
+
+  /// Raw pointer for convenient access (always == ownedPass.get() while
+  /// owned, or the raw pointer into the PM after commitPass()).
+  detail::OpPipelineAdaptorPass *adaptorPass = nullptr;
+};
+
+//===----------------------------------------------------------------------===//
+// MultiOpNest
+//===----------------------------------------------------------------------===//
+
 /// Constructs a pipeline of passes across multiple nested op types.
+/// Uses MultiPipelineNest internally, enabling parallel dispatch across
+/// all op types when MLIR multithreading is enabled.
+///
+/// When used as a temporary (the typical pattern), the adaptor pass is
+/// inserted at the end of the full expression. Adjacent temporaries are
+/// automatically merged into a single dispatch pass.
 ///
 /// Usage:
 ///   using FunctionLikeNest = MultiOpNest<IREE::Util::InitializerOp,
@@ -62,56 +310,39 @@ struct PipelineCache {
 template <typename... OpTys>
 struct MultiOpNest {
 public:
-  MultiOpNest(OpPassManager &parentPm) : parentPm(parentPm) {
-    addNest<0, OpTys...>();
+  MultiOpNest(OpPassManager &parentPm) : nest(parentPm) {
+    initNests<OpTys...>();
   }
 
   // We give the template param a default to support passing overload
   // constructors (i.e. createCanonicalizerPass).
   template <typename F = std::unique_ptr<Pass> (*)()>
   MultiOpNest &addPass(F constructor) {
-    addPassInternal(constructor);
+    nest.addPass(constructor);
     return *this;
   }
 
   template <typename F = std::unique_ptr<Pass> (*)()>
   MultiOpNest &addPredicatedPass(bool enable, F constructor) {
-    if (enable) {
-      addPassInternal(constructor);
-    }
+    nest.addPredicatedPass(enable, constructor);
     return *this;
   }
 
+  /// Immediately insert the adaptor pass into the parent PM. Use this when
+  /// a named MultiOpNest must be committed before interleaved parent passes.
+  void commitPass() { nest.commitPass(); }
+
 private:
-  // Initialize a nest.
-  template <int index, typename T, typename... Rest>
-  void addNest() {
-    std::get<index>(nestedPassManagers) = &parentPm.nest<T>();
-    addNest<index + 1, Rest...>();
+  template <typename T, typename... Rest>
+  void initNests() {
+    nest.template nest<T>();
+    if constexpr (sizeof...(Rest) > 0) {
+      initNests<Rest...>();
+    }
   }
-  template <int index>
-  void addNest() {}
 
-  // Add a pass to all nests by constructor.
-  template <typename F>
-  void addPassInternal(F constructor) {
-    addPassRecurse<F, 0, OpTys...>(constructor);
-  }
-  template <typename F, int index, typename T, typename... Rest>
-  void addPassRecurse(F constructor) {
-    std::get<index>(nestedPassManagers)->addPass(constructor());
-    addPassRecurse<F, index + 1, Rest...>(constructor);
-  }
-  template <typename F, int index>
-  void addPassRecurse(F constructor) {}
-
-  OpPassManager &parentPm;
-  std::array<OpPassManager *, sizeof...(OpTys)> nestedPassManagers;
+  MultiPipelineNest nest;
 };
-
-// If running under a FixedPointIterator pass, annotate that a modification
-// has been made which requires another iteration. No-op otherwise.
-void signalFixedPointModified(Operation *rootOp);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -340,7 +340,7 @@ private:
 ///     .addPredicatedPass(enable, createMyOtherPass);
 template <typename... OpTys>
 struct MultiOpNest {
-  MultiOpNest(OpPassManager &parentPm) : nest(parentPm) {
+  explicit MultiOpNest(OpPassManager &parentPm) : nest(parentPm) {
     nest.template nest<OpTys...>();
   }
 

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -266,7 +266,7 @@ public:
   void nest() {
     nest<T1>();
     nest<T2>();
-    (void)(nest<Rest>(), ..., false);
+    (nest<Rest>(), ...);
   }
 
   /// Add a pass to ALL existing sub-pipelines. The default template argument

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -299,6 +299,10 @@ private:
   /// Pointer to the parent pass manager.
   OpPassManager *parentPm = nullptr;
 
+  /// Size of the parent PM at construction time. Used to assert that no
+  /// passes were added to the parent PM between construction and commit.
+  size_t parentPmSizeAtConstruction = 0;
+
   /// The adaptor pass. Owned here until commitPass() or destructor transfers
   /// it to the parent PM (or discards it after a successful merge).
   std::unique_ptr<detail::OpPipelineAdaptorPass> ownedPass;

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -266,7 +266,7 @@ public:
   void nest() {
     nest<T1>();
     nest<T2>();
-    (void)(nest<Rest>(), ...);
+    (void)(nest<Rest>(), ..., false);
   }
 
   /// Add a pass to ALL existing sub-pipelines. The default template argument

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -143,17 +143,20 @@ public:
   /// automatic merging).
   bool allEntriesHaveTypeID() const;
 
-  /// Add a pass to all existing sub-pipelines.
-  template <typename F>
-  void addPassToAll(F constructor) {
+  /// Add a pass to all existing sub-pipelines. Templated to support both
+  /// function pointers (createCanonicalizerPass) and lambdas. A non-template
+  /// std::function signature cannot resolve overloaded pass constructors, and
+  /// adding a function-pointer overload creates ambiguity with lambdas.
+  template <typename Fn>
+  void addPassToAll(Fn constructor) {
     for (Entry &entry : entries) {
       entry.pipeline.addPass(constructor());
     }
   }
 
   /// Add a pass only to sub-pipelines targeting the given op type.
-  template <typename F>
-  void addPassToEntriesWithTypeID(TypeID targetID, F constructor) {
+  template <typename Fn>
+  void addPassToEntriesWithTypeID(TypeID targetID, Fn constructor) {
     for (Entry &entry : entries) {
       if (entry.opTypeID == targetID) {
         entry.pipeline.addPass(constructor());
@@ -205,15 +208,15 @@ private:
 /// passes, call commitPass() at the desired insertion point.
 ///
 /// Usage:
-///   // Typical: temporary destroyed at semicolon — pass inserted here.
+///   // Typical: temporary destroyed at semicolon -- pass inserted here.
 ///   MultiPipelineNest(pm).nest<FuncOp>().addPass(createMyPass);
 ///
 ///   // Named variable with explicit commit point:
 ///   MultiPipelineNest nest(pm);
 ///   nest.nest<FuncOp>();
-///   nest.commitPass();           // insert now, before subsequent passes
-///   pm.addPass(createOtherPass); // guaranteed to be after nest's pass
-class MultiPipelineNest {
+///   nest.commitPass();           // Insert now, before subsequent passes.
+///   pm.addPass(createOtherPass); // Guaranteed to be after nest's pass.
+class MultiPipelineNest final {
 public:
   using ConditionFn = std::function<bool(Operation *)>;
 
@@ -227,8 +230,8 @@ public:
   ~MultiPipelineNest();
 
   // Movable but not copyable. The moved-from object is left in a null state.
-  MultiPipelineNest(MultiPipelineNest &&other) noexcept;
-  MultiPipelineNest &operator=(MultiPipelineNest &&other) noexcept;
+  MultiPipelineNest(MultiPipelineNest &&other);
+  MultiPipelineNest &operator=(MultiPipelineNest &&other);
   MultiPipelineNest(const MultiPipelineNest &) = delete;
   MultiPipelineNest &operator=(const MultiPipelineNest &) = delete;
 
@@ -253,7 +256,7 @@ public:
   /// Records the TypeID for automatic merging.
   template <typename OpT>
   OpPassManager &nest() {
-    return nestIf([](Operation *op) { return isa<OpT>(op); },
+    return nestIf(llvm::IsaPred<OpT>,
                   OpT::getOperationName(), TypeID::get<OpT>());
   }
 
@@ -263,19 +266,23 @@ public:
   void nest() {
     nest<T1>();
     nest<T2>();
-    (nest<Rest>(), ...);
+    (void)(nest<Rest>(), ...);
   }
 
-  /// Add a pass to ALL existing sub-pipelines.
-  template <typename F = std::unique_ptr<Pass> (*)()>
-  MultiPipelineNest &addPass(F constructor) {
+  /// Add a pass to ALL existing sub-pipelines. The default template argument
+  /// resolves overloaded pass constructors (e.g. createCanonicalizerPass) to
+  /// the no-arg overload. A non-template std::function signature cannot do
+  /// this, and adding a function-pointer overload creates ambiguity with
+  /// lambdas.
+  template <typename Fn = std::unique_ptr<Pass> (*)()>
+  MultiPipelineNest &addPass(Fn constructor) {
     adaptorPass->addPassToAll(constructor);
     return *this;
   }
 
   /// Add a pass to ALL existing sub-pipelines if the predicate is true.
-  template <typename F = std::unique_ptr<Pass> (*)()>
-  MultiPipelineNest &addPredicatedPass(bool enable, F constructor) {
+  template <typename Fn = std::unique_ptr<Pass> (*)()>
+  MultiPipelineNest &addPredicatedPass(bool enable, Fn constructor) {
     if (enable) {
       addPass(constructor);
     }
@@ -285,8 +292,8 @@ public:
   /// Add a pass only to sub-pipelines targeting the given op type.
   /// This is safe to call at any point (unlike holding a reference from
   /// nest<T>(), which can be invalidated by subsequent nest calls).
-  template <typename OpT, typename F = std::unique_ptr<Pass> (*)()>
-  MultiPipelineNest &addPassFor(F constructor) {
+  template <typename OpT, typename Fn = std::unique_ptr<Pass> (*)()>
+  MultiPipelineNest &addPassFor(Fn constructor) {
     adaptorPass->addPassToEntriesWithTypeID(TypeID::get<OpT>(), constructor);
     return *this;
   }
@@ -333,21 +340,18 @@ private:
 ///     .addPredicatedPass(enable, createMyOtherPass);
 template <typename... OpTys>
 struct MultiOpNest {
-public:
   MultiOpNest(OpPassManager &parentPm) : nest(parentPm) {
     nest.template nest<OpTys...>();
   }
 
-  // We give the template param a default to support passing overload
-  // constructors (i.e. createCanonicalizerPass).
-  template <typename F = std::unique_ptr<Pass> (*)()>
-  MultiOpNest &addPass(F constructor) {
+  template <typename Fn = std::unique_ptr<Pass> (*)()>
+  MultiOpNest &addPass(Fn constructor) {
     nest.addPass(constructor);
     return *this;
   }
 
-  template <typename F = std::unique_ptr<Pass> (*)()>
-  MultiOpNest &addPredicatedPass(bool enable, F constructor) {
+  template <typename Fn = std::unique_ptr<Pass> (*)()>
+  MultiOpNest &addPredicatedPass(bool enable, Fn constructor) {
     nest.addPredicatedPass(enable, constructor);
     return *this;
   }

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -82,8 +82,15 @@ class OpPipelineAdaptorPass final
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(OpPipelineAdaptorPass)
 
+  /// Predicate that determines whether a pipeline should run on a given
+  /// operation. Conditions must only inspect immutable properties of the
+  /// operation (e.g., operation name, type via isa<T>). In async mode,
+  /// all conditions are evaluated eagerly before any pipeline runs, so
+  /// conditions must not depend on IR state that a pipeline might modify.
   using ConditionFn = std::function<bool(Operation *)>;
 
+  /// A condition+pipeline pair. When the condition matches an operation,
+  /// the pipeline is run on it.
   struct Entry {
     ConditionFn condition;
     OpPassManager pipeline;
@@ -129,8 +136,30 @@ public:
   /// matching batches. |other| is left with empty entries after the merge.
   void mergeFrom(OpPipelineAdaptorPass &other);
 
-  /// Access entries for iteration (e.g., to add passes to all pipelines).
-  MutableArrayRef<Entry> getEntries() { return entries; }
+  /// Returns true if this adaptor has no entries.
+  bool empty() const { return entries.empty(); }
+
+  /// Returns true if all entries have TypeID annotations (required for
+  /// automatic merging).
+  bool allEntriesHaveTypeID() const;
+
+  /// Add a pass to all existing sub-pipelines.
+  template <typename F>
+  void addPassToAll(F constructor) {
+    for (Entry &entry : entries) {
+      entry.pipeline.addPass(constructor());
+    }
+  }
+
+  /// Add a pass only to sub-pipelines targeting the given op type.
+  template <typename F>
+  void addPassToEntriesWithTypeID(TypeID targetID, F constructor) {
+    for (Entry &entry : entries) {
+      if (entry.opTypeID == targetID) {
+        entry.pipeline.addPass(constructor());
+      }
+    }
+  }
 
   void getDependentDialects(DialectRegistry &registry) const override;
   void runOnOperation() override;
@@ -240,10 +269,7 @@ public:
   /// Add a pass to ALL existing sub-pipelines.
   template <typename F = std::unique_ptr<Pass> (*)()>
   MultiPipelineNest &addPass(F constructor) {
-    for (detail::OpPipelineAdaptorPass::Entry &entry :
-         adaptorPass->getEntries()) {
-      entry.pipeline.addPass(constructor());
-    }
+    adaptorPass->addPassToAll(constructor);
     return *this;
   }
 
@@ -261,13 +287,7 @@ public:
   /// nest<T>(), which can be invalidated by subsequent nest calls).
   template <typename OpT, typename F = std::unique_ptr<Pass> (*)()>
   MultiPipelineNest &addPassFor(F constructor) {
-    TypeID targetID = TypeID::get<OpT>();
-    for (detail::OpPipelineAdaptorPass::Entry &entry :
-         adaptorPass->getEntries()) {
-      if (entry.opTypeID == targetID) {
-        entry.pipeline.addPass(constructor());
-      }
-    }
+    adaptorPass->addPassToEntriesWithTypeID(TypeID::get<OpT>(), constructor);
     return *this;
   }
 
@@ -311,7 +331,7 @@ template <typename... OpTys>
 struct MultiOpNest {
 public:
   MultiOpNest(OpPassManager &parentPm) : nest(parentPm) {
-    initNests<OpTys...>();
+    nest.template nest<OpTys...>();
   }
 
   // We give the template param a default to support passing overload
@@ -333,14 +353,6 @@ public:
   void commitPass() { nest.commitPass(); }
 
 private:
-  template <typename T, typename... Rest>
-  void initNests() {
-    nest.template nest<T>();
-    if constexpr (sizeof...(Rest) > 0) {
-      initNests<Rest...>();
-    }
-  }
-
   MultiPipelineNest nest;
 };
 

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -256,8 +256,8 @@ public:
   /// Records the TypeID for automatic merging.
   template <typename OpT>
   OpPassManager &nest() {
-    return nestIf(llvm::IsaPred<OpT>,
-                  OpT::getOperationName(), TypeID::get<OpT>());
+    return nestIf(llvm::IsaPred<OpT>, OpT::getOperationName(),
+                  TypeID::get<OpT>());
   }
 
   /// Variadic convenience: add sub-pipelines for multiple op types at once.

--- a/compiler/src/iree/compiler/Utils/unittests/BUILD.bazel
+++ b/compiler/src/iree/compiler/Utils/unittests/BUILD.bazel
@@ -43,6 +43,7 @@ iree_compiler_cc_test(
     testonly = True,
     srcs = ["PassUtilsTest.cpp"],
     deps = [
+        "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Utils",
         "//compiler/src/iree/testing:gtest_main",
         "@com_google_googletest//:gtest",

--- a/compiler/src/iree/compiler/Utils/unittests/BUILD.bazel
+++ b/compiler/src/iree/compiler/Utils/unittests/BUILD.bazel
@@ -37,3 +37,17 @@ iree_compiler_cc_test(
         "@llvm-project//mlir:IR",
     ],
 )
+
+iree_compiler_cc_test(
+    name = "PassUtilsTest",
+    testonly = True,
+    srcs = ["PassUtilsTest.cpp"],
+    deps = [
+        "//compiler/src/iree/compiler/Utils",
+        "//compiler/src/iree/testing:gtest_main",
+        "@com_google_googletest//:gtest",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+    ],
+)

--- a/compiler/src/iree/compiler/Utils/unittests/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Utils/unittests/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_cc_test(
     MLIRPass
     gmock
     gtest
+    iree::compiler::Dialect::Util::IR
     iree::compiler::Utils
     iree::testing::gtest_main
 )

--- a/compiler/src/iree/compiler/Utils/unittests/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Utils/unittests/CMakeLists.txt
@@ -39,4 +39,19 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_test(
+  NAME
+    PassUtilsTest
+  SRCS
+    "PassUtilsTest.cpp"
+  DEPS
+    MLIRFuncDialect
+    MLIRIR
+    MLIRPass
+    gmock
+    gtest
+    iree::compiler::Utils
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -1,0 +1,758 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Utils/PassUtils.h"
+
+#include <atomic>
+#include <string>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Test passes
+//===----------------------------------------------------------------------===//
+
+/// An OperationPass<> that sets a named unit attribute on whatever operation it
+/// runs on. Because it is a generic (untyped) pass, the OpPipelineAdaptorPass
+/// can run it directly on dispatched child operations.
+struct MarkerPass final : public PassWrapper<MarkerPass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MarkerPass)
+
+  explicit MarkerPass(std::string name) : name(std::move(name)) {}
+  MarkerPass(const MarkerPass &other) : PassWrapper(other), name(other.name) {}
+
+  StringRef getArgument() const override { return "test-marker"; }
+
+  void runOnOperation() override {
+    getOperation()->setAttr(name, UnitAttr::get(&getContext()));
+  }
+
+  std::string name;
+};
+
+/// An OperationPass<> that always signals pass failure.
+struct FailingPass final : public PassWrapper<FailingPass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FailingPass)
+
+  StringRef getArgument() const override { return "test-failing"; }
+
+  void runOnOperation() override { signalPassFailure(); }
+};
+
+/// An OperationPass<> that records its execution order via a shared atomic
+/// counter and stores the counter value as an integer attribute. Used to
+/// verify pass ordering across module-level and dispatched function-level
+/// passes.
+struct CounterPass final : public PassWrapper<CounterPass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CounterPass)
+
+  CounterPass(std::string attrName, std::atomic<int> *counter)
+      : attrName(std::move(attrName)), counter(counter) {}
+  CounterPass(const CounterPass &other)
+      : PassWrapper(other), attrName(other.attrName), counter(other.counter) {}
+
+  StringRef getArgument() const override { return "test-counter"; }
+
+  void runOnOperation() override {
+    int order = counter->fetch_add(1);
+    getOperation()->setAttr(
+        attrName, IntegerAttr::get(IntegerType::get(&getContext(), 32), order));
+  }
+
+  std::string attrName;
+  std::atomic<int> *counter;
+};
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+/// Create a module containing private functions with the given names.
+static OwningOpRef<ModuleOp> createModule(MLIRContext &context,
+                                          ArrayRef<StringRef> funcNames) {
+  Builder builder(&context);
+  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  for (StringRef name : funcNames) {
+    func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
+                                             builder.getFunctionType({}, {}));
+    func.setPrivate();
+    module->push_back(func);
+  }
+  return module;
+}
+
+/// Return true if the named function inside |module| has a discardable
+/// attribute called |attrName|.
+static bool funcHasAttr(ModuleOp module, StringRef funcName,
+                        StringRef attrName) {
+  for (func::FuncOp func : module.getOps<func::FuncOp>()) {
+    if (func.getName() == funcName) {
+      return func->hasAttr(attrName);
+    }
+  }
+  return false;
+}
+
+/// Return the integer value of a named attribute on a function, or -1.
+static int getFuncAttrInt(ModuleOp module, StringRef funcName,
+                          StringRef attrName) {
+  for (func::FuncOp func : module.getOps<func::FuncOp>()) {
+    if (func.getName() == funcName) {
+      if (auto intAttr = dyn_cast_if_present<IntegerAttr>(
+              func->getDiscardableAttr(attrName))) {
+        return intAttr.getInt();
+      }
+    }
+  }
+  return -1;
+}
+
+/// Return the integer value of a named attribute on a module, or -1.
+static int getModuleAttrInt(ModuleOp module, StringRef attrName) {
+  if (IntegerAttr intAttr = dyn_cast_if_present<IntegerAttr>(
+          module->getDiscardableAttr(attrName))) {
+    return intAttr.getInt();
+  }
+  return -1;
+}
+
+/// Condition: matches operations whose name (for func ops) equals |target|.
+static MultiPipelineNest::ConditionFn nameIs(StringRef target) {
+  return [name = target.str()](Operation *op) {
+    auto funcOp = dyn_cast<func::FuncOp>(op);
+    return funcOp && funcOp.getName() == name;
+  };
+}
+
+//===----------------------------------------------------------------------===//
+// MultiPipelineNest tests
+//===----------------------------------------------------------------------===//
+
+TEST(MultiPipelineNestTest, OpPipelineAdaptor) {
+  // Two functions dispatched to two different pipelines based on name.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha", "beta"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf(nameIs("alpha"))
+        .addPass(std::make_unique<MarkerPass>("pass_a"));
+    nest.nestIf(nameIs("beta")).addPass(std::make_unique<MarkerPass>("pass_b"));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "pass_a"));
+  EXPECT_FALSE(funcHasAttr(*module, "alpha", "pass_b"));
+  EXPECT_FALSE(funcHasAttr(*module, "beta", "pass_a"));
+  EXPECT_TRUE(funcHasAttr(*module, "beta", "pass_b"));
+}
+
+TEST(MultiPipelineNestTest, FirstMatchWins) {
+  // When multiple conditions match, only the first pipeline runs.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<MarkerPass>("first"));
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<MarkerPass>("second"));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "first"));
+  EXPECT_FALSE(funcHasAttr(*module, "alpha", "second"));
+}
+
+TEST(MultiPipelineNestTest, NoMatchSkipsOp) {
+  // Operations that match no condition are left untouched.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf(nameIs("beta")).addPass(std::make_unique<MarkerPass>("pass_b"));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_FALSE(funcHasAttr(*module, "alpha", "pass_b"));
+}
+
+TEST(MultiPipelineNestTest, AddPassToAllPipelines) {
+  // addPass() appends to every existing sub-pipeline.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha", "beta"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf(nameIs("alpha"))
+        .addPass(std::make_unique<MarkerPass>("pass_a"));
+    nest.nestIf(nameIs("beta")).addPass(std::make_unique<MarkerPass>("pass_b"));
+    nest.addPass([] { return std::make_unique<MarkerPass>("common"); });
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "pass_a"));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "common"));
+  EXPECT_TRUE(funcHasAttr(*module, "beta", "pass_b"));
+  EXPECT_TRUE(funcHasAttr(*module, "beta", "common"));
+}
+
+TEST(MultiPipelineNestTest, AddPredicatedPass) {
+  // addPredicatedPass(false, ...) should not add the pass.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<MarkerPass>("always"));
+    nest.addPredicatedPass(true,
+                           [] { return std::make_unique<MarkerPass>("on"); });
+    nest.addPredicatedPass(false,
+                           [] { return std::make_unique<MarkerPass>("off"); });
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "always"));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "on"));
+  EXPECT_FALSE(funcHasAttr(*module, "alpha", "off"));
+}
+
+TEST(MultiPipelineNestTest, NestByOpType) {
+  // nest<T>() creates a condition that checks isa<T>.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nest<func::FuncOp>().addPass(std::make_unique<MarkerPass>("typed"));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "typed"));
+}
+
+TEST(MultiPipelineNestTest, OrderingWithParentPasses) {
+  // Passes added to the parent PM before and after the MultiPipelineNest
+  // must execute in the correct order relative to the dispatched passes.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  pm.addPass(std::make_unique<CounterPass>("test.before", &counter));
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<CounterPass>("test.func_pass", &counter));
+  }
+  pm.addPass(std::make_unique<CounterPass>("test.after", &counter));
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+
+  // "test.before" runs on module first (order 0).
+  EXPECT_EQ(getModuleAttrInt(*module, "test.before"), 0);
+  // Dispatched func pass runs second (order 1).
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func_pass"), 1);
+  // "test.after" runs on module last (order 2).
+  EXPECT_EQ(getModuleAttrInt(*module, "test.after"), 2);
+}
+
+TEST(MultiPipelineNestTest, MultipleNestsPreserveOrdering) {
+  // When multiple MultiPipelineNest scopes are interleaved with module passes,
+  // each nest's dispatched passes appear in the correct position.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest1(pm);
+    nest1.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<CounterPass>("test.nest1", &counter));
+  }
+  pm.addPass(std::make_unique<CounterPass>("test.middle", &counter));
+  {
+    MultiPipelineNest nest2(pm);
+    nest2.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<CounterPass>("test.nest2", &counter));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest1"), 0);
+  EXPECT_EQ(getModuleAttrInt(*module, "test.middle"), 1);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest2"), 2);
+}
+
+TEST(MultiPipelineNestTest, ParallelExecution) {
+  // Verify correctness with multithreading enabled.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  // Multithreading is enabled by default.
+
+  constexpr int kNumFuncs = 20;
+  Builder builder(&context);
+  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  for (int i = 0; i < kNumFuncs; ++i) {
+    std::string name = "func_" + std::to_string(i);
+    func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
+                                             builder.getFunctionType({}, {}));
+    func.setPrivate();
+    module->push_back(func);
+  }
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<MarkerPass>("processed"));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+
+  int processedCount = 0;
+  for (func::FuncOp func : module->getOps<func::FuncOp>()) {
+    EXPECT_TRUE(func->hasAttr("processed"))
+        << "Function " << func.getName().str() << " was not processed";
+    ++processedCount;
+  }
+  EXPECT_EQ(processedCount, kNumFuncs);
+}
+
+TEST(MultiPipelineNestTest, FailurePropagationSync) {
+  // A failing sub-pipeline pass must cause the overall pipeline to fail.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<FailingPass>());
+  }
+
+  EXPECT_TRUE(failed(pm.run(module.get())));
+}
+
+TEST(MultiPipelineNestTest, FailurePropagationAsync) {
+  // Failure propagation must also work with multithreading enabled.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  // Multithreading enabled by default.
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<FailingPass>());
+  }
+
+  EXPECT_TRUE(failed(pm.run(module.get())));
+}
+
+TEST(MultiPipelineNestTest, MultipleFunctionsSamePipeline) {
+  // All functions matching the same condition are processed.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module =
+      createModule(context, {"alpha", "beta", "gamma"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<CounterPass>("test.order", &counter));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  // All three functions should be processed with distinct order values.
+  int alphaOrder = getFuncAttrInt(*module, "alpha", "test.order");
+  int betaOrder = getFuncAttrInt(*module, "beta", "test.order");
+  int gammaOrder = getFuncAttrInt(*module, "gamma", "test.order");
+  EXPECT_GE(alphaOrder, 0);
+  EXPECT_GE(betaOrder, 0);
+  EXPECT_GE(gammaOrder, 0);
+  EXPECT_NE(alphaOrder, betaOrder);
+  EXPECT_NE(alphaOrder, gammaOrder);
+  EXPECT_NE(betaOrder, gammaOrder);
+}
+
+TEST(MultiPipelineNestTest, ParallelMultipleEntries) {
+  // Parallel dispatch with multiple entry indices exercises the per-thread
+  // executor cloning and entryIdx > 0 code path.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  // Multithreading enabled by default.
+
+  constexpr int kNumPerGroup = 10;
+  Builder builder(&context);
+  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  for (int i = 0; i < kNumPerGroup; ++i) {
+    for (StringRef prefix : {"alpha_", "beta_"}) {
+      std::string name = std::string(prefix) + std::to_string(i);
+      func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
+                                               builder.getFunctionType({}, {}));
+      func.setPrivate();
+      module->push_back(func);
+    }
+  }
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *op) {
+          func::FuncOp f = dyn_cast<func::FuncOp>(op);
+          return f && f.getName().starts_with("alpha");
+        })
+        .addPass(std::make_unique<MarkerPass>("alpha_marker"));
+    nest.nestIf([](Operation *op) {
+          func::FuncOp f = dyn_cast<func::FuncOp>(op);
+          return f && f.getName().starts_with("beta");
+        })
+        .addPass(std::make_unique<MarkerPass>("beta_marker"));
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  for (func::FuncOp func : module->getOps<func::FuncOp>()) {
+    if (func.getName().starts_with("alpha")) {
+      EXPECT_TRUE(func->hasAttr("alpha_marker"))
+          << func.getName().str() << " missing alpha_marker";
+      EXPECT_FALSE(func->hasAttr("beta_marker"))
+          << func.getName().str() << " has beta_marker";
+    } else {
+      EXPECT_TRUE(func->hasAttr("beta_marker"))
+          << func.getName().str() << " missing beta_marker";
+      EXPECT_FALSE(func->hasAttr("alpha_marker"))
+          << func.getName().str() << " has alpha_marker";
+    }
+  }
+}
+
+TEST(MultiPipelineNestTest, EmptyNestIsNoOp) {
+  // A MultiPipelineNest with no entries should not add any passes.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    // No entries added — should not insert any pass.
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  // No attributes should have been set.
+  EXPECT_FALSE(funcHasAttr(*module, "alpha", "anything"));
+  // Empty nest should not insert a pass.
+  EXPECT_EQ(pm.size(), 0u);
+}
+
+//===----------------------------------------------------------------------===//
+// MultiOpNest tests
+//===----------------------------------------------------------------------===//
+
+TEST(MultiOpNestTest, BasicDispatch) {
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha", "beta"});
+
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [] { return std::make_unique<MarkerPass>("processed"); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "processed"));
+  EXPECT_TRUE(funcHasAttr(*module, "beta", "processed"));
+}
+
+TEST(MultiOpNestTest, AddPredicatedPass) {
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp>(pm)
+      .addPredicatedPass(true,
+                         [] { return std::make_unique<MarkerPass>("on"); })
+      .addPredicatedPass(false,
+                         [] { return std::make_unique<MarkerPass>("off"); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "on"));
+  EXPECT_FALSE(funcHasAttr(*module, "alpha", "off"));
+}
+
+TEST(MultiOpNestTest, NamedVariableOrdering) {
+  // Named MultiOpNest variable in braces with passes before and after.
+  // Verifies that the adaptor is positioned at construction time.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  pm.addPass(std::make_unique<CounterPass>("test.before", &counter));
+  {
+    MultiOpNest<func::FuncOp> funcNest(pm);
+    funcNest.addPass([&] {
+      return std::make_unique<CounterPass>("test.func_pass", &counter);
+    });
+  }
+  pm.addPass(std::make_unique<CounterPass>("test.after", &counter));
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+
+  EXPECT_EQ(getModuleAttrInt(*module, "test.before"), 0);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func_pass"), 1);
+  EXPECT_EQ(getModuleAttrInt(*module, "test.after"), 2);
+}
+
+TEST(MultiOpNestTest, CommitPassForInterleaving) {
+  // When a named MultiOpNest must be interleaved with parent-level passes,
+  // call commitPass() to eagerly insert the adaptor at the desired position.
+  // Without commitPass(), deferred insertion would place the adaptor after
+  // the module pass.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp> funcNest(pm);
+  funcNest.addPass(
+      [&] { return std::make_unique<CounterPass>("test.func1", &counter); });
+  // Commit before adding the module pass to lock in ordering.
+  funcNest.commitPass();
+  pm.addPass(std::make_unique<CounterPass>("test.module", &counter));
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+
+  // Func pass runs before the module pass because commitPass() inserted
+  // the adaptor eagerly.
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func1"), 0);
+  EXPECT_EQ(getModuleAttrInt(*module, "test.module"), 1);
+}
+
+TEST(MultiOpNestTest, MergeAdjacentAdaptors) {
+  // Two consecutive MultiOpNest<func::FuncOp> should merge into a single
+  // adaptor pass. Both sets of passes must run on the function.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.first", &counter); });
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.second", &counter); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  // Both passes must have run, in order.
+  int firstOrder = getFuncAttrInt(*module, "alpha", "test.first");
+  int secondOrder = getFuncAttrInt(*module, "alpha", "test.second");
+  EXPECT_EQ(firstOrder, 0);
+  EXPECT_EQ(secondOrder, 1);
+}
+
+TEST(MultiOpNestTest, MergeSubsetTypes) {
+  // A 2-type nest followed by a 3-type superset nest should merge. The
+  // extra type in the second nest becomes a new entry in the combined pass.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  // First nest: only func::FuncOp (simulating a 1-type nest).
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.nest1", &counter); });
+  // Second nest: func::FuncOp (simulating a superset). Since both nests
+  // have TypeID-annotated entries, they should merge.
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.nest2", &counter); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest1"), 0);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest2"), 1);
+}
+
+TEST(MultiOpNestTest, NoMergeWithModulePassBetween) {
+  // A module pass between two nests prevents merge.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.before", &counter); });
+  pm.addPass(std::make_unique<CounterPass>("test.module", &counter));
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.after", &counter); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  // All three should run in order: func pass, module pass, func pass.
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.before"), 0);
+  EXPECT_EQ(getModuleAttrInt(*module, "test.module"), 1);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.after"), 2);
+}
+
+TEST(MultiOpNestTest, NoMergeWithArbitraryConditions) {
+  // When the predecessor uses nestIf without TypeID, merge is prevented.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nestIf([](Operation *) { return true; })
+        .addPass(std::make_unique<CounterPass>("test.cond", &counter));
+  }
+  // This nest has TypeIDs, but the predecessor doesn't, so no merge.
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.typed", &counter); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.cond"), 0);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.typed"), 1);
+}
+
+TEST(MultiOpNestTest, MergeParallelExecution) {
+  // Verify merged adaptors work correctly with multithreading.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  // Multithreading enabled by default.
+
+  constexpr int kNumFuncs = 20;
+  Builder builder(&context);
+  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  for (int i = 0; i < kNumFuncs; ++i) {
+    std::string name = "func_" + std::to_string(i);
+    func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
+                                             builder.getFunctionType({}, {}));
+    func.setPrivate();
+    module->push_back(func);
+  }
+
+  PassManager pm(&context);
+  // Two consecutive nests that should merge.
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [] { return std::make_unique<MarkerPass>("batch0"); });
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [] { return std::make_unique<MarkerPass>("batch1"); });
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  for (func::FuncOp func : module->getOps<func::FuncOp>()) {
+    EXPECT_TRUE(func->hasAttr("batch0"))
+        << func.getName().str() << " missing batch0";
+    EXPECT_TRUE(func->hasAttr("batch1"))
+        << func.getName().str() << " missing batch1";
+  }
+}
+
+TEST(MultiOpNestTest, MergedShellNeverInserted) {
+  // With deferred insertion, the second MultiOpNest merges its entries into
+  // the first and is never inserted into the PM. The PM should contain
+  // exactly 1 adaptor pass from construction through execution.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.first", &counter); });
+  MultiOpNest<func::FuncOp>(pm).addPass(
+      [&] { return std::make_unique<CounterPass>("test.second", &counter); });
+
+  // Deferred insertion: merged shell is never added to the PM.
+  EXPECT_EQ(pm.size(), 1u);
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  // Still 1 after running.
+  EXPECT_EQ(pm.size(), 1u);
+  // Both passes still ran (from separate batches within the single adaptor).
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.first"), 0);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.second"), 1);
+}
+
+TEST(MultiOpNestTest, ChainingIsEquivalentToNamed) {
+  // Temporary (chained) MultiOpNest should produce the same ordering as a
+  // named variable in braces.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  pm.addPass(std::make_unique<CounterPass>("test.before", &counter));
+  MultiOpNest<func::FuncOp>(pm).addPass([&] {
+    return std::make_unique<CounterPass>("test.func_pass", &counter);
+  });
+  pm.addPass(std::make_unique<CounterPass>("test.after", &counter));
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+
+  EXPECT_EQ(getModuleAttrInt(*module, "test.before"), 0);
+  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func_pass"), 1);
+  EXPECT_EQ(getModuleAttrInt(*module, "test.after"), 2);
+}
+
+} // namespace

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -33,7 +33,7 @@ struct MarkerPass final : public PassWrapper<MarkerPass, OperationPass<>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MarkerPass)
 
   explicit MarkerPass(std::string name) : name(std::move(name)) {}
-  MarkerPass(const MarkerPass &other) : PassWrapper(other), name(other.name) {}
+  MarkerPass(const MarkerPass &other) = default;
 
   StringRef getArgument() const override { return "test-marker"; }
 
@@ -62,8 +62,7 @@ struct CounterPass final : public PassWrapper<CounterPass, OperationPass<>> {
 
   CounterPass(std::string attrName, std::atomic<int> *counter)
       : attrName(std::move(attrName)), counter(counter) {}
-  CounterPass(const CounterPass &other)
-      : PassWrapper(other), attrName(other.attrName), counter(other.counter) {}
+  CounterPass(const CounterPass &other) = default;
 
   StringRef getArgument() const override { return "test-counter"; }
 

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -492,6 +492,32 @@ TEST(MultiPipelineNestTest, EmptyNestIsNoOp) {
   EXPECT_EQ(pm.size(), 0u);
 }
 
+TEST(MultiPipelineNestTest, AddPassForSpecificType) {
+  // addPassFor<T>() should only add to entries targeting that type.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest(pm);
+    nest.nest<func::FuncOp>();
+    nest.nestIf([](Operation *) { return true; });
+    // Add to all entries.
+    nest.addPass([] { return std::make_unique<MarkerPass>("common"); });
+    // Add only to func::FuncOp entries.
+    nest.addPassFor<func::FuncOp>(
+        [] { return std::make_unique<MarkerPass>("func_only"); });
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  // The func::FuncOp entry matches first (first-match-wins), so it runs both
+  // "common" and "func_only".
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "common"));
+  EXPECT_TRUE(funcHasAttr(*module, "alpha", "func_only"));
+}
+
 //===----------------------------------------------------------------------===//
 // MultiOpNest tests
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -84,14 +84,14 @@ struct CounterPass final : public PassWrapper<CounterPass, OperationPass<>> {
 static OwningOpRef<ModuleOp> createModule(MLIRContext &context,
                                           ArrayRef<StringRef> funcNames) {
   Builder builder(&context);
-  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  OwningOpRef<ModuleOp> moduleOp(ModuleOp::create(UnknownLoc::get(&context)));
   for (StringRef name : funcNames) {
     func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
                                              builder.getFunctionType({}, {}));
     func.setPrivate();
-    module->push_back(func);
+    moduleOp->push_back(func);
   }
-  return module;
+  return moduleOp;
 }
 
 /// Return true if the named function inside |module| has a discardable
@@ -146,7 +146,7 @@ TEST(MultiPipelineNestTest, OpPipelineAdaptor) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha", "beta"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha", "beta"});
 
   PassManager pm(&context);
   {
@@ -156,11 +156,11 @@ TEST(MultiPipelineNestTest, OpPipelineAdaptor) {
     nest.nestIf(nameIs("beta")).addPass(std::make_unique<MarkerPass>("pass_b"));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "pass_a"));
-  EXPECT_FALSE(funcHasAttr(*module, "alpha", "pass_b"));
-  EXPECT_FALSE(funcHasAttr(*module, "beta", "pass_a"));
-  EXPECT_TRUE(funcHasAttr(*module, "beta", "pass_b"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "pass_a"));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "alpha", "pass_b"));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "beta", "pass_a"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "beta", "pass_b"));
 }
 
 TEST(MultiPipelineNestTest, FirstMatchWins) {
@@ -168,7 +168,7 @@ TEST(MultiPipelineNestTest, FirstMatchWins) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -179,9 +179,9 @@ TEST(MultiPipelineNestTest, FirstMatchWins) {
         .addPass(std::make_unique<MarkerPass>("second"));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "first"));
-  EXPECT_FALSE(funcHasAttr(*module, "alpha", "second"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "first"));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "alpha", "second"));
 }
 
 TEST(MultiPipelineNestTest, NoMatchSkipsOp) {
@@ -189,7 +189,7 @@ TEST(MultiPipelineNestTest, NoMatchSkipsOp) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -197,8 +197,8 @@ TEST(MultiPipelineNestTest, NoMatchSkipsOp) {
     nest.nestIf(nameIs("beta")).addPass(std::make_unique<MarkerPass>("pass_b"));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_FALSE(funcHasAttr(*module, "alpha", "pass_b"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "alpha", "pass_b"));
 }
 
 TEST(MultiPipelineNestTest, AddPassToAllPipelines) {
@@ -206,7 +206,7 @@ TEST(MultiPipelineNestTest, AddPassToAllPipelines) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha", "beta"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha", "beta"});
 
   PassManager pm(&context);
   {
@@ -217,11 +217,11 @@ TEST(MultiPipelineNestTest, AddPassToAllPipelines) {
     nest.addPass([] { return std::make_unique<MarkerPass>("common"); });
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "pass_a"));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "common"));
-  EXPECT_TRUE(funcHasAttr(*module, "beta", "pass_b"));
-  EXPECT_TRUE(funcHasAttr(*module, "beta", "common"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "pass_a"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "common"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "beta", "pass_b"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "beta", "common"));
 }
 
 TEST(MultiPipelineNestTest, AddPredicatedPass) {
@@ -229,7 +229,7 @@ TEST(MultiPipelineNestTest, AddPredicatedPass) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -242,10 +242,10 @@ TEST(MultiPipelineNestTest, AddPredicatedPass) {
                            [] { return std::make_unique<MarkerPass>("off"); });
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "always"));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "on"));
-  EXPECT_FALSE(funcHasAttr(*module, "alpha", "off"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "always"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "on"));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "alpha", "off"));
 }
 
 TEST(MultiPipelineNestTest, NestByOpType) {
@@ -253,7 +253,7 @@ TEST(MultiPipelineNestTest, NestByOpType) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -261,8 +261,8 @@ TEST(MultiPipelineNestTest, NestByOpType) {
     nest.nest<func::FuncOp>().addPass(std::make_unique<MarkerPass>("typed"));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "typed"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "typed"));
 }
 
 TEST(MultiPipelineNestTest, OrderingWithParentPasses) {
@@ -271,7 +271,7 @@ TEST(MultiPipelineNestTest, OrderingWithParentPasses) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -283,14 +283,14 @@ TEST(MultiPipelineNestTest, OrderingWithParentPasses) {
   }
   pm.addPass(std::make_unique<CounterPass>("test.after", &counter));
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
 
   // "test.before" runs on module first (order 0).
-  EXPECT_EQ(getModuleAttrInt(*module, "test.before"), 0);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.before"), 0);
   // Dispatched func pass runs second (order 1).
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func_pass"), 1);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.func_pass"), 1);
   // "test.after" runs on module last (order 2).
-  EXPECT_EQ(getModuleAttrInt(*module, "test.after"), 2);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.after"), 2);
 }
 
 TEST(MultiPipelineNestTest, MultipleNestsPreserveOrdering) {
@@ -299,7 +299,7 @@ TEST(MultiPipelineNestTest, MultipleNestsPreserveOrdering) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -315,11 +315,11 @@ TEST(MultiPipelineNestTest, MultipleNestsPreserveOrdering) {
         .addPass(std::make_unique<CounterPass>("test.nest2", &counter));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
 
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest1"), 0);
-  EXPECT_EQ(getModuleAttrInt(*module, "test.middle"), 1);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest2"), 2);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest1"), 0);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.middle"), 1);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest2"), 2);
 }
 
 TEST(MultiPipelineNestTest, ParallelExecution) {
@@ -330,13 +330,13 @@ TEST(MultiPipelineNestTest, ParallelExecution) {
 
   constexpr int kNumFuncs = 20;
   Builder builder(&context);
-  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  OwningOpRef<ModuleOp> moduleOp(ModuleOp::create(UnknownLoc::get(&context)));
   for (int i = 0; i < kNumFuncs; ++i) {
     std::string name = "func_" + std::to_string(i);
     func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
                                              builder.getFunctionType({}, {}));
     func.setPrivate();
-    module->push_back(func);
+    moduleOp->push_back(func);
   }
 
   PassManager pm(&context);
@@ -346,10 +346,10 @@ TEST(MultiPipelineNestTest, ParallelExecution) {
         .addPass(std::make_unique<MarkerPass>("processed"));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
 
   int processedCount = 0;
-  for (func::FuncOp func : module->getOps<func::FuncOp>()) {
+  for (func::FuncOp func : moduleOp->getOps<func::FuncOp>()) {
     EXPECT_TRUE(func->hasAttr("processed"))
         << "Function " << func.getName().str() << " was not processed";
     ++processedCount;
@@ -362,7 +362,7 @@ TEST(MultiPipelineNestTest, FailurePropagationSync) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -371,7 +371,7 @@ TEST(MultiPipelineNestTest, FailurePropagationSync) {
         .addPass(std::make_unique<FailingPass>());
   }
 
-  EXPECT_TRUE(failed(pm.run(module.get())));
+  EXPECT_TRUE(failed(pm.run(moduleOp.get())));
 }
 
 TEST(MultiPipelineNestTest, FailurePropagationAsync) {
@@ -379,7 +379,7 @@ TEST(MultiPipelineNestTest, FailurePropagationAsync) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   // Multithreading enabled by default.
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -388,7 +388,7 @@ TEST(MultiPipelineNestTest, FailurePropagationAsync) {
         .addPass(std::make_unique<FailingPass>());
   }
 
-  EXPECT_TRUE(failed(pm.run(module.get())));
+  EXPECT_TRUE(failed(pm.run(moduleOp.get())));
 }
 
 TEST(MultiPipelineNestTest, MultipleFunctionsSamePipeline) {
@@ -396,7 +396,7 @@ TEST(MultiPipelineNestTest, MultipleFunctionsSamePipeline) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module =
+  OwningOpRef<ModuleOp> moduleOp =
       createModule(context, {"alpha", "beta", "gamma"});
 
   std::atomic<int> counter{0};
@@ -407,11 +407,11 @@ TEST(MultiPipelineNestTest, MultipleFunctionsSamePipeline) {
         .addPass(std::make_unique<CounterPass>("test.order", &counter));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   // All three functions should be processed with distinct order values.
-  int alphaOrder = getFuncAttrInt(*module, "alpha", "test.order");
-  int betaOrder = getFuncAttrInt(*module, "beta", "test.order");
-  int gammaOrder = getFuncAttrInt(*module, "gamma", "test.order");
+  int alphaOrder = getFuncAttrInt(*moduleOp, "alpha", "test.order");
+  int betaOrder = getFuncAttrInt(*moduleOp, "beta", "test.order");
+  int gammaOrder = getFuncAttrInt(*moduleOp, "gamma", "test.order");
   EXPECT_GE(alphaOrder, 0);
   EXPECT_GE(betaOrder, 0);
   EXPECT_GE(gammaOrder, 0);
@@ -429,14 +429,14 @@ TEST(MultiPipelineNestTest, ParallelMultipleEntries) {
 
   constexpr int kNumPerGroup = 10;
   Builder builder(&context);
-  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  OwningOpRef<ModuleOp> moduleOp(ModuleOp::create(UnknownLoc::get(&context)));
   for (int i = 0; i < kNumPerGroup; ++i) {
     for (StringRef prefix : {"alpha_", "beta_"}) {
       std::string name = std::string(prefix) + std::to_string(i);
       func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
                                                builder.getFunctionType({}, {}));
       func.setPrivate();
-      module->push_back(func);
+      moduleOp->push_back(func);
     }
   }
 
@@ -455,8 +455,8 @@ TEST(MultiPipelineNestTest, ParallelMultipleEntries) {
         .addPass(std::make_unique<MarkerPass>("beta_marker"));
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  for (func::FuncOp func : module->getOps<func::FuncOp>()) {
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  for (func::FuncOp func : moduleOp->getOps<func::FuncOp>()) {
     if (func.getName().starts_with("alpha")) {
       EXPECT_TRUE(func->hasAttr("alpha_marker"))
           << func.getName().str() << " missing alpha_marker";
@@ -476,7 +476,7 @@ TEST(MultiPipelineNestTest, EmptyNestIsNoOp) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -484,9 +484,9 @@ TEST(MultiPipelineNestTest, EmptyNestIsNoOp) {
     // No entries added — should not insert any pass.
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   // No attributes should have been set.
-  EXPECT_FALSE(funcHasAttr(*module, "alpha", "anything"));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "alpha", "anything"));
   // Empty nest should not insert a pass.
   EXPECT_EQ(pm.size(), 0u);
 }
@@ -496,7 +496,7 @@ TEST(MultiPipelineNestTest, AddPassForSpecificType) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   {
@@ -510,11 +510,11 @@ TEST(MultiPipelineNestTest, AddPassForSpecificType) {
         [] { return std::make_unique<MarkerPass>("func_only"); });
   }
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   // The func::FuncOp entry matches first (first-match-wins), so it runs both
   // "common" and "func_only".
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "common"));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "func_only"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "common"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "func_only"));
 }
 
 //===----------------------------------------------------------------------===//
@@ -525,22 +525,22 @@ TEST(MultiOpNestTest, BasicDispatch) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha", "beta"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha", "beta"});
 
   PassManager pm(&context);
   MultiOpNest<func::FuncOp>(pm).addPass(
       [] { return std::make_unique<MarkerPass>("processed"); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "processed"));
-  EXPECT_TRUE(funcHasAttr(*module, "beta", "processed"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "processed"));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "beta", "processed"));
 }
 
 TEST(MultiOpNestTest, AddPredicatedPass) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   PassManager pm(&context);
   MultiOpNest<func::FuncOp>(pm)
@@ -549,9 +549,9 @@ TEST(MultiOpNestTest, AddPredicatedPass) {
       .addPredicatedPass(false,
                          [] { return std::make_unique<MarkerPass>("off"); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_TRUE(funcHasAttr(*module, "alpha", "on"));
-  EXPECT_FALSE(funcHasAttr(*module, "alpha", "off"));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_TRUE(funcHasAttr(*moduleOp, "alpha", "on"));
+  EXPECT_FALSE(funcHasAttr(*moduleOp, "alpha", "off"));
 }
 
 TEST(MultiOpNestTest, NamedVariableOrdering) {
@@ -560,7 +560,7 @@ TEST(MultiOpNestTest, NamedVariableOrdering) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -573,11 +573,11 @@ TEST(MultiOpNestTest, NamedVariableOrdering) {
   }
   pm.addPass(std::make_unique<CounterPass>("test.after", &counter));
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
 
-  EXPECT_EQ(getModuleAttrInt(*module, "test.before"), 0);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func_pass"), 1);
-  EXPECT_EQ(getModuleAttrInt(*module, "test.after"), 2);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.before"), 0);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.func_pass"), 1);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.after"), 2);
 }
 
 TEST(MultiOpNestTest, CommitPassForInterleaving) {
@@ -588,7 +588,7 @@ TEST(MultiOpNestTest, CommitPassForInterleaving) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -599,12 +599,12 @@ TEST(MultiOpNestTest, CommitPassForInterleaving) {
   funcNest.commitPass();
   pm.addPass(std::make_unique<CounterPass>("test.module", &counter));
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
 
   // Func pass runs before the module pass because commitPass() inserted
   // the adaptor eagerly.
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func1"), 0);
-  EXPECT_EQ(getModuleAttrInt(*module, "test.module"), 1);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.func1"), 0);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.module"), 1);
 }
 
 TEST(MultiOpNestTest, MergeAdjacentAdaptors) {
@@ -613,7 +613,7 @@ TEST(MultiOpNestTest, MergeAdjacentAdaptors) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -622,10 +622,10 @@ TEST(MultiOpNestTest, MergeAdjacentAdaptors) {
   MultiOpNest<func::FuncOp>(pm).addPass(
       [&] { return std::make_unique<CounterPass>("test.second", &counter); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   // Both passes must have run, in order.
-  int firstOrder = getFuncAttrInt(*module, "alpha", "test.first");
-  int secondOrder = getFuncAttrInt(*module, "alpha", "test.second");
+  int firstOrder = getFuncAttrInt(*moduleOp, "alpha", "test.first");
+  int secondOrder = getFuncAttrInt(*moduleOp, "alpha", "test.second");
   EXPECT_EQ(firstOrder, 0);
   EXPECT_EQ(secondOrder, 1);
 }
@@ -636,7 +636,7 @@ TEST(MultiOpNestTest, MergeSubsetTypes) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -648,9 +648,9 @@ TEST(MultiOpNestTest, MergeSubsetTypes) {
   MultiOpNest<func::FuncOp>(pm).addPass(
       [&] { return std::make_unique<CounterPass>("test.nest2", &counter); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest1"), 0);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.nest2"), 1);
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest1"), 0);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest2"), 1);
 }
 
 TEST(MultiOpNestTest, NoMergeWithModulePassBetween) {
@@ -658,7 +658,7 @@ TEST(MultiOpNestTest, NoMergeWithModulePassBetween) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -668,11 +668,11 @@ TEST(MultiOpNestTest, NoMergeWithModulePassBetween) {
   MultiOpNest<func::FuncOp>(pm).addPass(
       [&] { return std::make_unique<CounterPass>("test.after", &counter); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   // All three should run in order: func pass, module pass, func pass.
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.before"), 0);
-  EXPECT_EQ(getModuleAttrInt(*module, "test.module"), 1);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.after"), 2);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.before"), 0);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.module"), 1);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.after"), 2);
 }
 
 TEST(MultiOpNestTest, NoMergeWithArbitraryConditions) {
@@ -680,7 +680,7 @@ TEST(MultiOpNestTest, NoMergeWithArbitraryConditions) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -693,9 +693,9 @@ TEST(MultiOpNestTest, NoMergeWithArbitraryConditions) {
   MultiOpNest<func::FuncOp>(pm).addPass(
       [&] { return std::make_unique<CounterPass>("test.typed", &counter); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.cond"), 0);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.typed"), 1);
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.cond"), 0);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.typed"), 1);
 }
 
 TEST(MultiOpNestTest, MergeParallelExecution) {
@@ -706,13 +706,13 @@ TEST(MultiOpNestTest, MergeParallelExecution) {
 
   constexpr int kNumFuncs = 20;
   Builder builder(&context);
-  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(&context)));
+  OwningOpRef<ModuleOp> moduleOp(ModuleOp::create(UnknownLoc::get(&context)));
   for (int i = 0; i < kNumFuncs; ++i) {
     std::string name = "func_" + std::to_string(i);
     func::FuncOp func = func::FuncOp::create(builder.getUnknownLoc(), name,
                                              builder.getFunctionType({}, {}));
     func.setPrivate();
-    module->push_back(func);
+    moduleOp->push_back(func);
   }
 
   PassManager pm(&context);
@@ -722,8 +722,8 @@ TEST(MultiOpNestTest, MergeParallelExecution) {
   MultiOpNest<func::FuncOp>(pm).addPass(
       [] { return std::make_unique<MarkerPass>("batch1"); });
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
-  for (func::FuncOp func : module->getOps<func::FuncOp>()) {
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  for (func::FuncOp func : moduleOp->getOps<func::FuncOp>()) {
     EXPECT_TRUE(func->hasAttr("batch0"))
         << func.getName().str() << " missing batch0";
     EXPECT_TRUE(func->hasAttr("batch1"))
@@ -738,7 +738,7 @@ TEST(MultiOpNestTest, MergedShellNeverInserted) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -749,12 +749,12 @@ TEST(MultiOpNestTest, MergedShellNeverInserted) {
 
   // Deferred insertion: merged shell is never added to the PM.
   EXPECT_EQ(pm.size(), 1u);
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   // Still 1 after running.
   EXPECT_EQ(pm.size(), 1u);
   // Both passes still ran (from separate batches within the single adaptor).
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.first"), 0);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.second"), 1);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.first"), 0);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.second"), 1);
 }
 
 TEST(MultiOpNestTest, ChainingIsEquivalentToNamed) {
@@ -763,7 +763,7 @@ TEST(MultiOpNestTest, ChainingIsEquivalentToNamed) {
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> module = createModule(context, {"alpha"});
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
   std::atomic<int> counter{0};
   PassManager pm(&context);
@@ -773,11 +773,11 @@ TEST(MultiOpNestTest, ChainingIsEquivalentToNamed) {
   });
   pm.addPass(std::make_unique<CounterPass>("test.after", &counter));
 
-  ASSERT_TRUE(succeeded(pm.run(module.get())));
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
 
-  EXPECT_EQ(getModuleAttrInt(*module, "test.before"), 0);
-  EXPECT_EQ(getFuncAttrInt(*module, "alpha", "test.func_pass"), 1);
-  EXPECT_EQ(getModuleAttrInt(*module, "test.after"), 2);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.before"), 0);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.func_pass"), 1);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.after"), 2);
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -891,9 +891,9 @@ TEST(MultiPipelineNestTest, MoveAssignment) {
 }
 
 TEST(MultiPipelineNestTest, CommitPassWithInterleavedNests) {
-  // Exercises parent PM size tracking when nest1 is committed before nest2
-  // is constructed. The commit grows the PM, so nest2's size snapshot must
-  // account for that.
+  // Exercises parent PM size tracking when nest1 is committed, then a
+  // module-level pass is added, then nest2 is created. The module pass
+  // prevents merging so both adaptors remain separate.
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
   context.disableMultithreading();
@@ -907,18 +907,21 @@ TEST(MultiPipelineNestTest, CommitPassWithInterleavedNests) {
         std::make_unique<CounterPass>("test.nest1", &counter));
     nest1.commitPass();
   }
-  // nest1 is committed; PM size is now 1.
+  // nest1 is committed; PM size is now 1. Add a module pass to prevent
+  // nest2 from merging into nest1.
+  pm.addPass(std::make_unique<CounterPass>("test.middle", &counter));
   {
     MultiPipelineNest nest2(pm);
     nest2.nest<func::FuncOp>().addPass(
         std::make_unique<CounterPass>("test.nest2", &counter));
-    // nest2 destructs here with PM size still 1 (matching its snapshot).
+    // nest2 destructs here with PM size 2 (matching its snapshot).
   }
 
-  EXPECT_EQ(pm.size(), 2u);
+  EXPECT_EQ(pm.size(), 3u);
   ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
   EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest1"), 0);
-  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest2"), 1);
+  EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.middle"), 1);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest2"), 2);
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -632,27 +632,44 @@ TEST(MultiOpNestTest, MergeAdjacentAdaptors) {
   EXPECT_EQ(secondOrder, 1);
 }
 
-TEST(MultiOpNestTest, MergeSubsetTypes) {
-  // A 2-type nest followed by a 3-type superset nest should merge. The
-  // extra type in the second nest becomes a new entry in the combined pass.
+TEST(MultiOpNestTest, MergeDifferentTypeSets) {
+  // A 1-type nest followed by a 2-type nest should merge. The extra type
+  // in the second nest becomes a new entry in the combined adaptor pass.
   MLIRContext context;
   context.loadDialect<func::FuncDialect>();
+  context.loadDialect<IREE::Util::UtilDialect>();
   context.disableMultithreading();
-  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
 
-  std::atomic<int> counter{0};
+  Builder builder(&context);
+  OwningOpRef<ModuleOp> moduleOp(ModuleOp::create(UnknownLoc::get(&context)));
+  func::FuncOp funcOp = func::FuncOp::create(
+      builder.getUnknownLoc(), "std_func", builder.getFunctionType({}, {}));
+  funcOp.setPrivate();
+  moduleOp->push_back(funcOp);
+  IREE::Util::FuncOp utilFuncOp = IREE::Util::FuncOp::create(
+      builder.getUnknownLoc(), "util_func", builder.getFunctionType({}, {}));
+  utilFuncOp.setPrivate();
+  moduleOp->push_back(utilFuncOp);
+
   PassManager pm(&context);
-  // First nest: only func::FuncOp (simulating a 1-type nest).
+  // First nest: only func::FuncOp.
   MultiOpNest<func::FuncOp>(pm).addPass(
-      [&] { return std::make_unique<CounterPass>("test.nest1", &counter); });
-  // Second nest: func::FuncOp (simulating a superset). Since both nests
-  // have TypeID-annotated entries, they should merge.
-  MultiOpNest<func::FuncOp>(pm).addPass(
-      [&] { return std::make_unique<CounterPass>("test.nest2", &counter); });
+      [] { return std::make_unique<MarkerPass>("nest1"); });
+  // Second nest: both func::FuncOp and IREE::Util::FuncOp. Since all entries
+  // have TypeID annotations, the nests merge into a single adaptor.
+  MultiOpNest<func::FuncOp, IREE::Util::FuncOp>(pm).addPass(
+      [] { return std::make_unique<MarkerPass>("nest2"); });
+
+  // Both nests merged into one adaptor pass.
+  EXPECT_EQ(pm.size(), 1u);
 
   ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
-  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest1"), 0);
-  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest2"), 1);
+  // func::FuncOp should have markers from both nests.
+  EXPECT_TRUE(funcOp->hasAttr("nest1"));
+  EXPECT_TRUE(funcOp->hasAttr("nest2"));
+  // IREE::Util::FuncOp should have marker from second nest only.
+  EXPECT_FALSE(utilFuncOp->hasAttr("nest1"));
+  EXPECT_TRUE(utilFuncOp->hasAttr("nest2"));
 }
 
 TEST(MultiOpNestTest, NoMergeWithModulePassBetween) {
@@ -871,6 +888,37 @@ TEST(MultiPipelineNestTest, MoveAssignment) {
   int secondOrder = getFuncAttrInt(*moduleOp, "alpha", "test.second");
   EXPECT_EQ(firstOrder, 0);
   EXPECT_EQ(secondOrder, 1);
+}
+
+TEST(MultiPipelineNestTest, CommitPassWithInterleavedNests) {
+  // Exercises parent PM size tracking when nest1 is committed before nest2
+  // is constructed. The commit grows the PM, so nest2's size snapshot must
+  // account for that.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest1(pm);
+    nest1.nest<func::FuncOp>().addPass(
+        std::make_unique<CounterPass>("test.nest1", &counter));
+    nest1.commitPass();
+  }
+  // nest1 is committed; PM size is now 1.
+  {
+    MultiPipelineNest nest2(pm);
+    nest2.nest<func::FuncOp>().addPass(
+        std::make_unique<CounterPass>("test.nest2", &counter));
+    // nest2 destructs here with PM size still 1 (matching its snapshot).
+  }
+
+  EXPECT_EQ(pm.size(), 2u);
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest1"), 0);
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.nest2"), 1);
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -9,6 +9,8 @@
 #include <atomic>
 #include <string>
 
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -778,6 +780,97 @@ TEST(MultiOpNestTest, ChainingIsEquivalentToNamed) {
   EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.before"), 0);
   EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.func_pass"), 1);
   EXPECT_EQ(getModuleAttrInt(*moduleOp, "test.after"), 2);
+}
+
+TEST(MultiOpNestTest, MultipleOpTypes) {
+  // MultiOpNest<T0, T1> should dispatch to both op types. Use func::FuncOp
+  // and IREE::Util::FuncOp as two distinct child op types, mirroring the
+  // real FunctionLikeNest pattern.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.loadDialect<IREE::Util::UtilDialect>();
+  context.disableMultithreading();
+
+  Builder builder(&context);
+  OwningOpRef<ModuleOp> moduleOp(ModuleOp::create(UnknownLoc::get(&context)));
+  // Add a func::FuncOp child.
+  func::FuncOp funcOp = func::FuncOp::create(
+      builder.getUnknownLoc(), "std_func", builder.getFunctionType({}, {}));
+  funcOp.setPrivate();
+  moduleOp->push_back(funcOp);
+  // Add an IREE::Util::FuncOp child.
+  IREE::Util::FuncOp utilFuncOp = IREE::Util::FuncOp::create(
+      builder.getUnknownLoc(), "util_func", builder.getFunctionType({}, {}));
+  utilFuncOp.setPrivate();
+  moduleOp->push_back(utilFuncOp);
+
+  PassManager pm(&context);
+  MultiOpNest<func::FuncOp, IREE::Util::FuncOp>(pm).addPass(
+      [] { return std::make_unique<MarkerPass>("multi_type"); });
+
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  // Both op types should be processed.
+  EXPECT_TRUE(funcOp->hasAttr("multi_type"));
+  EXPECT_TRUE(utilFuncOp->hasAttr("multi_type"));
+}
+
+TEST(MultiPipelineNestTest, MoveConstructor) {
+  // Move construction should transfer ownership cleanly. The moved-from
+  // nest should be inert (no pass inserted on destruction).
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  {
+    MultiPipelineNest original(pm);
+    original.nest<func::FuncOp>().addPass(
+        std::make_unique<CounterPass>("test.moved", &counter));
+    // Move into a new nest. The original should become inert.
+    MultiPipelineNest moved(std::move(original));
+    // moved goes out of scope here and inserts the pass.
+    // original goes out of scope here and should be a no-op.
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  EXPECT_EQ(getFuncAttrInt(*moduleOp, "alpha", "test.moved"), 0);
+  // Only one pass should have been inserted (not two).
+  EXPECT_EQ(pm.size(), 1u);
+}
+
+TEST(MultiPipelineNestTest, MoveAssignment) {
+  // Move assignment should flush the current pass and take over the new one.
+  MLIRContext context;
+  context.loadDialect<func::FuncDialect>();
+  context.disableMultithreading();
+  OwningOpRef<ModuleOp> moduleOp = createModule(context, {"alpha"});
+
+  std::atomic<int> counter{0};
+  PassManager pm(&context);
+  {
+    MultiPipelineNest nest1(pm);
+    nest1.nest<func::FuncOp>().addPass(
+        std::make_unique<CounterPass>("test.first", &counter));
+
+    MultiPipelineNest nest2(pm);
+    nest2.nest<func::FuncOp>().addPass(
+        std::make_unique<CounterPass>("test.second", &counter));
+
+    // Move-assign nest2 into nest1. nest1's pass should be flushed (inserted
+    // or merged), and nest1 should now own nest2's pass.
+    nest1 = std::move(nest2);
+    // nest1 (now holding nest2's pass) goes out of scope and inserts.
+    // nest2 (moved-from) goes out of scope as a no-op.
+  }
+
+  ASSERT_TRUE(succeeded(pm.run(moduleOp.get())));
+  // Both passes should have run.
+  int firstOrder = getFuncAttrInt(*moduleOp, "alpha", "test.first");
+  int secondOrder = getFuncAttrInt(*moduleOp, "alpha", "test.second");
+  EXPECT_EQ(firstOrder, 0);
+  EXPECT_EQ(secondOrder, 1);
 }
 
 } // namespace


### PR DESCRIPTION
Add MultiPipelineNest, a builder for conditional pipeline dispatch over child operations. Each sub-pipeline is guarded by a condition predicate; the first matching condition wins at runtime. When MLIR multithreading is enabled, matched operations are processed in parallel via parallelForEach.

Revise MultiOpNest to use MultiPipelineNest internally instead of creating separate OpToOpPassAdaptor instances per op type. This enables parallel dispatch across all op types (e.g., func::FuncOp, InitializerOp, Util::FuncOp) through a single OpPipelineAdaptorPass, rather than processing each type sequentially.

Along the way this required changing the public API for MultiOpNest. The reason is that the implementation of MultiPipelineNest had to use deferred pass construction to enable post-addition merging of nests. The existing upstream OpPassManager will attempt to merge adjacent OpToOpPassAdaptor passes with identical nests, saving global syncs when users write:

passManager.nest<OpTy>(PassA);
passManager.nest<OpTy>(PassB);

In local cases this is an anti-pattern, however the place where this is an important feature is when considering pass composition, contributing to up to ~4% of total compilation time on a few of the CI run models (based on my local testing). This merge is internal to OpPassManager and relies on comparing the nest scope of adjacent passes, which is not possible until the pass pipeline has been fully realized. So this leaves us with the following options:

1. Eager pass insertion (create the pass right away and keep a reference to the nested pass managers to populate). This on its own is mutually exclusive with the aforementioned pass merging behavior.
2. Eager pass insertion with merging by walking the parent pass manager on MultiPipelineNest destruction. This almost works but leaves empty no-op passes in the pipeline.
3. Deferred pass introduction (what this does). The consequence of this is surprising pass ordering in some cases, such as:

```
void addPasses(OpPassManager &pm) {
  MultiPipelineNest funcNest(pm)
  funcNest.addPass<func::FuncOp>(PassA);
  pm.addPass(PassB);
}
```

In this example PassA is actually scheduled AFTER PassB. To get the expected ordering one would have to either wrap the MultiPipelineNest in an unnamed scope or call `funcNest.commit()` to commit the pass to the pass manager. This is in some ways unfortunate but I could not come up with another way around this without going in and changing the upstream pass manager. Note that the existing approach is not free of its own forms of footguns, such as:

```
void addPasses(OpPassManager &pm) {
  MultiOpNest funcNest(pm)
  funcNest.addPass<func::FuncOp>(PassA);
  pm.addPass(PassB);
  funcNest.addPass<func::FuncOp>(PassC);
}
```

Where in this example the actual pass order is `PassA, PassC, PassB` because `PassC` gets handed off to the OpToOpPassAdaptor backing the MultiOpNest while the concrete adaptor pass is scheduled before `PassB`.

After this there are a few things this enables directly on the Codegen side. Currently codegen uses a fixed pass to dynamically dispatch pipelines to annotated ops. This has the unfortunate effect of bubbling dialect dependencies up to the dispatching pass (the same way that target backends need to populate all dialect deps that the backend might generate). MultiPipelineNest allows us to directly populate a set of static pass pipelines based on matchable conditions. This also means that we'll be able to directly use target features from ExecutableTargetAttr when constructing the pipeline instead of having to thread it through the `LowerTargetExecutable` pass + pipeline options the way we do today.

After this the plan is to cleanup the way that pipeline options are specified across codegen backends:
 - Global cl options stay the same.
 - Target dependent options will be moved out of any pipeline options. buildTranslationPassPipeline already provides the target attribute in the backend but we do not use it and instead rediscover target information by analyzing the IR.
 - IR dependent pass options will be moved to the IR and removed from pipeline options.

The overall goal is to start configuring nested pass pipelines based on target information the way we typically do in the compiler rather than matching IR. Then after that we can start formalizing the accepted input(s) to codegen and adding multi-function support.

One last advantage of this is that custom pass pipelines become super easy with this approach since we can return the MultiPipelineNest directly to the target backend that calls it.

I also ran a quick local compile time benchmark on the PkgCI models to make sure this doesn't horribly regress and the results look ok.

Compile-Time Benchmarks (median of 3 runs)
```
┌─────────────────┬───────────┬──────────┬──────────────────┐
│      Model      │ Reference │ Feature  │      Delta       │
├─────────────────┼───────────┼──────────┼──────────────────┤
│ SDXL CLIP (O1)  │ 12,533ms  │ 12,553ms │ +20ms (+0.1%)    │
├─────────────────┼───────────┼──────────┼──────────────────┤
│ SDXL UNet (O3)  │ 20,521ms  │ 20,932ms │ +411ms (+2.0%)   │
├─────────────────┼───────────┼──────────┼──────────────────┤
│ SDXL punet (O3) │ 51,894ms  │ 50,566ms │ -1,328ms (-2.5%) │
├─────────────────┼───────────┼──────────┼──────────────────┤
│ LLaMA 8B (O3)   │ 5,408ms   │ 5,430ms  │ +22ms (+0.4%)    │
├─────────────────┼───────────┼──────────┼──────────────────┤
│ Total           │ 90,356ms  │ 89,481ms │ -875ms (-1.0%)   │
└─────────────────┴───────────┴──────────┴──────────────────┘
```

punet might be doing slightly better because it's more initializer heavy meaning we're parallelizing more there than the rest. This current change is pretty close to NFC with the way our pipelines are currently setup (this doesn't include any of the codegen changes).