### PR TITLE
[Build scripts] Exclude async platform on unsupported targets

### DIFF
--- a/runtime/src/iree/async/BUILD.bazel
+++ b/runtime/src/iree/async/BUILD.bazel
@@ -124,9 +124,10 @@ iree_runtime_cc_library(
         "//build_tools/bazel:iree_is_windows": [
             "//runtime/src/iree/async/platform/iocp",
         ],
-        "//conditions:default": [
+        "//build_tools/bazel:iree_is_macos": [
             "//runtime/src/iree/async/platform/posix",
         ],
+        "//conditions:default": [],
     }),
 )
 

--- a/runtime/src/iree/async/CMakeLists.txt
+++ b/runtime/src/iree/async/CMakeLists.txt
@@ -100,7 +100,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
   list(APPEND _platform_platform_deps iree::async::platform::posix)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   list(APPEND _platform_platform_deps iree::async::platform::iocp)
-else()
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   list(APPEND _platform_platform_deps iree::async::platform::posix)
 endif()
 iree_cc_library(

--- a/runtime/src/iree/async/proactor_platform.c
+++ b/runtime/src/iree/async/proactor_platform.c
@@ -10,9 +10,9 @@
 #include "iree/async/platform/io_uring/api.h"
 #endif  // IREE_PLATFORM_LINUX && !IREE_PLATFORM_ANDROID
 
-#if !defined(IREE_PLATFORM_WINDOWS)
+#if !defined(IREE_PLATFORM_WINDOWS) && !defined(IREE_PLATFORM_EMSCRIPTEN)
 #include "iree/async/platform/posix/api.h"
-#endif  // !IREE_PLATFORM_WINDOWS
+#endif  // !IREE_PLATFORM_WINDOWS && !IREE_PLATFORM_EMSCRIPTEN
 
 #if defined(IREE_PLATFORM_WINDOWS)
 #include "iree/async/platform/iocp/api.h"
@@ -43,7 +43,7 @@ iree_status_t iree_async_proactor_create_platform(
     status = iree_async_proactor_create_posix(options, allocator, out_proactor);
   }
 
-#else  // macOS, BSD, Android, etc.
+#elif !defined(IREE_PLATFORM_EMSCRIPTEN)  // macOS, BSD, Android, etc.
 
   status = iree_async_proactor_create_posix(options, allocator, out_proactor);
 


### PR DESCRIPTION
The build script assumed the left over platform was macOS, but we also have emscripten. This meant that iree::async::platform::async got linked with emscripten causing a CMake configuration error.

Assisted-by: Claude