### PR TITLE
[Python][CMake] Set py_limited_api on CMakeExtension for abi3 wheels

### DIFF
--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -503,13 +503,21 @@ setup(
     },
     ext_modules=[
         CMakeExtension("iree.compiler._mlir_libs._mlir", py_limited_api=_is_abi3_build),
-        CMakeExtension("iree.compiler._mlir_libs._ireeDialects", py_limited_api=_is_abi3_build),
+        CMakeExtension(
+            "iree.compiler._mlir_libs._ireeDialects", py_limited_api=_is_abi3_build
+        ),
         # TODO: MHLO has been broken for a while so disabling. If re-enabling,
         # it also needs to be enabled on the build side.
         # CMakeExtension("iree.compiler._mlir_libs._mlirHlo"),
-        CMakeExtension("iree.compiler._mlir_libs._mlirLinalgPasses", py_limited_api=_is_abi3_build),
-        CMakeExtension("iree.compiler._mlir_libs._mlirGPUPasses", py_limited_api=_is_abi3_build),
-        CMakeExtension("iree.compiler._mlir_libs._site_initialize_0", py_limited_api=_is_abi3_build),
+        CMakeExtension(
+            "iree.compiler._mlir_libs._mlirLinalgPasses", py_limited_api=_is_abi3_build
+        ),
+        CMakeExtension(
+            "iree.compiler._mlir_libs._mlirGPUPasses", py_limited_api=_is_abi3_build
+        ),
+        CMakeExtension(
+            "iree.compiler._mlir_libs._site_initialize_0", py_limited_api=_is_abi3_build
+        ),
     ],
     cmdclass=dict(
         {

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -358,8 +358,8 @@ class CustomBuild(_build):
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=""):
-        Extension.__init__(self, name, sources=[])
+    def __init__(self, name, sourcedir="", **kwargs):
+        Extension.__init__(self, name, sources=[], **kwargs)
         self.sourcedir = os.path.abspath(sourcedir)
 
 
@@ -502,14 +502,14 @@ setup(
         "documentation": "https://iree.dev/reference/bindings/python/",
     },
     ext_modules=[
-        CMakeExtension("iree.compiler._mlir_libs._mlir"),
-        CMakeExtension("iree.compiler._mlir_libs._ireeDialects"),
+        CMakeExtension("iree.compiler._mlir_libs._mlir", py_limited_api=_is_abi3_build),
+        CMakeExtension("iree.compiler._mlir_libs._ireeDialects", py_limited_api=_is_abi3_build),
         # TODO: MHLO has been broken for a while so disabling. If re-enabling,
         # it also needs to be enabled on the build side.
         # CMakeExtension("iree.compiler._mlir_libs._mlirHlo"),
-        CMakeExtension("iree.compiler._mlir_libs._mlirLinalgPasses"),
-        CMakeExtension("iree.compiler._mlir_libs._mlirGPUPasses"),
-        CMakeExtension("iree.compiler._mlir_libs._site_initialize_0"),
+        CMakeExtension("iree.compiler._mlir_libs._mlirLinalgPasses", py_limited_api=_is_abi3_build),
+        CMakeExtension("iree.compiler._mlir_libs._mlirGPUPasses", py_limited_api=_is_abi3_build),
+        CMakeExtension("iree.compiler._mlir_libs._site_initialize_0", py_limited_api=_is_abi3_build),
     ],
     cmdclass=dict(
         {

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -474,8 +474,8 @@ class CustomBuild(_build):
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=""):
-        Extension.__init__(self, name, sources=[])
+    def __init__(self, name, sourcedir="", **kwargs):
+        Extension.__init__(self, name, sources=[], **kwargs)
         self.sourcedir = os.path.abspath(sourcedir)
 
 
@@ -601,10 +601,10 @@ setup(
     python_requires=">=3.10",
     ext_modules=(
         [
-            CMakeExtension("iree._runtime_libs._runtime"),
+            CMakeExtension("iree._runtime_libs._runtime", py_limited_api=_is_abi3_build),
         ]
         + (
-            [CMakeExtension("iree._runtime_libs_tracy._runtime")]
+            [CMakeExtension("iree._runtime_libs_tracy._runtime", py_limited_api=_is_abi3_build)]
             if ENABLE_TRACY
             else []
         )

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -601,10 +601,16 @@ setup(
     python_requires=">=3.10",
     ext_modules=(
         [
-            CMakeExtension("iree._runtime_libs._runtime", py_limited_api=_is_abi3_build),
+            CMakeExtension(
+                "iree._runtime_libs._runtime", py_limited_api=_is_abi3_build
+            ),
         ]
         + (
-            [CMakeExtension("iree._runtime_libs_tracy._runtime", py_limited_api=_is_abi3_build)]
+            [
+                CMakeExtension(
+                    "iree._runtime_libs_tracy._runtime", py_limited_api=_is_abi3_build
+                )
+            ]
             if ENABLE_TRACY
             else []
         )


### PR DESCRIPTION
In abi3 mode, CMake produces `.abi3.so` extensions but setuptools' default `build_ext` looks for `.cpython-3XX.so`.

Pass `py_limited_api=True` on CMakeExtension when building abi3 wheels so setuptools computes the correct `.abi3.so` filename.

This should fix the latest wheel release failures: https://github.com/iree-org/iree/actions/runs/22609682568.

Assisted-by: claude