### PR TITLE
[GPU] Make GPUVectorAlloc allocate shared memory based on layout analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1698,21 +1698,9 @@ struct DistributeBatchOuterToLayoutConversions final
       return rewriter.notifyMatchFailure(toLayoutOp, "non-nested layout");
     }
 
-    // Check if everything other than batch and outer tile matches.
-    if (layoutA.getSubgroupTile() != layoutB.getSubgroupTile()) {
-      return failure();
-    }
-    if (layoutA.getSubgroupStrides() != layoutB.getSubgroupStrides()) {
-      return failure();
-    }
-    if (layoutA.getThreadTile() != layoutB.getThreadTile()) {
-      return failure();
-    }
-    if (layoutA.getThreadStrides() != layoutB.getThreadStrides()) {
-      return failure();
-    }
-    if (layoutA.getElementTile() != layoutB.getElementTile()) {
-      return failure();
+    if (layoutA.needsSharedMemoryForConversion(layoutB)) {
+      return rewriter.notifyMatchFailure(toLayoutOp,
+                                         "conversion requires shared memory");
     }
 
     auto batchTileA = SmallVector<int64_t>(layoutA.getBatchTile());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
 
@@ -205,6 +206,52 @@ static LogicalResult contractOpFilter(Operation *op) {
       linalgOp.getNumParallelLoops() <= 3);
 }
 
+/// Convert stretching broadcasts (broadcasting a non-unit dim from 1) into
+/// broadcast + transpose so the layout analysis can handle them.
+struct RemoveUnitDimStretchingBroadcast final
+    : OpRewritePattern<vector::BroadcastOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::BroadcastOp broadcastOp,
+                                PatternRewriter &rewriter) const override {
+    SetVector<int64_t> stretchedDims = broadcastOp.computeBroadcastedUnitDims();
+    if (stretchedDims.empty()) {
+      return failure();
+    }
+    VectorType srcTy = cast<VectorType>(broadcastOp.getSource().getType());
+    VectorType dstTy = broadcastOp.getResultVectorType();
+    int64_t numLeadingBroadcastDims = dstTy.getRank() - srcTy.getRank();
+    SmallVector<int64_t> broadcastedUnitDims;
+    for (auto i : llvm::seq<int64_t>(numLeadingBroadcastDims)) {
+      if (dstTy.getShape()[i] == 1) {
+        broadcastedUnitDims.push_back(i);
+      }
+    }
+    if (stretchedDims.size() > broadcastedUnitDims.size()) {
+      return failure();
+    }
+    // Build a permutation that swaps the broadcasted unit dims with a leading
+    // unit dim.
+    // Note that the way this permutation is built, makes it involutory, i.e.,
+    // P = P^{-1}.
+    auto perm = llvm::to_vector(llvm::seq<int64_t>(dstTy.getRank()));
+    // We use zip instead of zip_equal because stretchedDims.size() <=
+    // broadcastedUnitDims.size().
+    for (auto [stretchedDim, broadcastedUnitDim] :
+         llvm::zip(stretchedDims.getArrayRef(), broadcastedUnitDims)) {
+      std::swap(perm[stretchedDim], perm[broadcastedUnitDim]);
+    }
+    VectorType permutedBroadcastTy = VectorType::get(
+        applyPermutation(dstTy.getShape(), perm), dstTy.getElementType());
+    Value permutedBroadcast = vector::BroadcastOp::create(
+        rewriter, broadcastOp.getLoc(), permutedBroadcastTy,
+        broadcastOp.getSource());
+    rewriter.replaceOpWithNewOp<vector::TransposeOp>(broadcastOp,
+                                                     permutedBroadcast, perm);
+    return success();
+  }
+};
+
 // A `dealloc` is converted into a call to `free` on the underlying data buffer.
 // The memref descriptor being an SSA value, there is no need to clean it up
 // in any way.
@@ -252,6 +299,10 @@ void populateContractPromotionPatterns(RewritePatternSet &patterns,
           StringAttr::get(context, getWorkgroupMemoryMarker()))
           .setMatchByDefault()
           .addFilter(contractOpFilter));
+}
+
+void populateVectorLayoutCanonicalizations(RewritePatternSet &patterns) {
+  patterns.add<RemoveUnitDimStretchingBroadcast>(patterns.getContext());
 }
 
 void populateDropSharedMemoryDeallocOpPatterns(RewritePatternSet &patterns) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
@@ -29,6 +29,10 @@ void populateContractPromotionPatterns(RewritePatternSet &patterns,
 
 void populateDropSharedMemoryDeallocOpPatterns(RewritePatternSet &patterns);
 
+/// Adds patterns to convert stretching broadcasts (broadcasting a non-unit dim
+/// from 1) into broadcast + transpose so that layout analysis can handle them.
+void populateVectorLayoutCanonicalizations(RewritePatternSet &patterns);
+
 void populateGPUDistributionPatterns(RewritePatternSet &patterns);
 
 void populateGPUDistributeNestedLayoutAttrPatterns(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
@@ -20,8 +21,8 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler {
 
@@ -29,48 +30,6 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
 
 namespace {
-
-/// Convert stretching broadcasts (broadcasting a non-unit dim from 1) into
-/// broadcast + transpose so the layout analysis can handle them.
-/// Copied from LLVMGPUVectorDistribute.cpp::RemoveUnitDimStrechingBroadcast.
-struct RemoveStretchingBroadcast final : OpRewritePattern<vector::BroadcastOp> {
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(vector::BroadcastOp broadcastOp,
-                                PatternRewriter &rewriter) const override {
-    SetVector<int64_t> stretchedDims = broadcastOp.computeBroadcastedUnitDims();
-    if (stretchedDims.empty()) {
-      return failure();
-    }
-
-    VectorType srcTy = cast<VectorType>(broadcastOp.getSource().getType());
-    VectorType dstTy = broadcastOp.getResultVectorType();
-    int64_t numLeadingBroadcastDims = dstTy.getRank() - srcTy.getRank();
-    SmallVector<int64_t> broadcastedUnitDims;
-    for (auto i : llvm::seq<int64_t>(numLeadingBroadcastDims)) {
-      if (dstTy.getShape()[i] == 1) {
-        broadcastedUnitDims.push_back(i);
-      }
-    }
-    if (stretchedDims.size() > broadcastedUnitDims.size()) {
-      return failure();
-    }
-
-    auto perm = llvm::to_vector(llvm::seq<int64_t>(dstTy.getRank()));
-    for (auto [stretchedDim, broadcastedUnitDim] :
-         llvm::zip(stretchedDims.getArrayRef(), broadcastedUnitDims)) {
-      std::swap(perm[stretchedDim], perm[broadcastedUnitDim]);
-    }
-    VectorType permutedBroadcastTy = VectorType::get(
-        applyPermutation(dstTy.getShape(), perm), dstTy.getElementType());
-    Value permutedBroadcast = vector::BroadcastOp::create(
-        rewriter, broadcastOp.getLoc(), permutedBroadcastTy,
-        broadcastOp.getSource());
-    rewriter.replaceOpWithNewOp<vector::TransposeOp>(broadcastOp,
-                                                     permutedBroadcast, perm);
-    return success();
-  }
-};
 
 // Allocates a tensor to copy the vector into a la bufferization.alloc_tensor.
 // This allocation is always static as vectors are currently always static
@@ -124,9 +83,8 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
     }
   });
 
+  OpBuilder builder(funcOp);
   for (IREE::VectorExt::ToLayoutOp op : opsToPromote) {
-    OpBuilder builder(op);
-
     // HACK: Until proper barrier placement is handled later we have to
     // synchronize explicitly in this pass.
 
@@ -136,9 +94,10 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
     builder.setInsertionPointToStart(op->getBlock());
     gpu::BarrierOp::create(builder, op->getLoc(), gpu::AddressSpace::Workgroup);
 
-    // Promote both of the input operands, excluding the accumulator.
     builder.setInsertionPoint(op);
     OpOperand &operand = op.getInputMutable();
+    // TODO: Since we know the read/write layout for this memory, we can get
+    // optimal swizzling here. Figure out how to do that.
     FailureOr<Value> ret =
         allocateTensorForVector(builder, op->getLoc(), operand.get());
     if (failed(ret)) {
@@ -169,10 +128,8 @@ struct GPUVectorAllocPass final
     // asserts that broadcasts don't stretch.
     {
       RewritePatternSet patterns(funcOp.getContext());
-      patterns.add<RemoveStretchingBroadcast>(funcOp.getContext());
-      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
-        return signalPassFailure();
-      }
+      populateVectorLayoutCanonicalizations(patterns);
+      walkAndApplyPatterns(funcOp, std::move(patterns));
     }
 
     // Run layout analysis to find additional conflict points.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -5,10 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -18,6 +20,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir::iree_compiler {
@@ -27,33 +30,47 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-// For optimal performance we always want to copy 128 bits.
-constexpr int copyVectorNumBits = 128;
+/// Convert stretching broadcasts (broadcasting a non-unit dim from 1) into
+/// broadcast + transpose so the layout analysis can handle them.
+/// Copied from LLVMGPUVectorDistribute.cpp::RemoveUnitDimStrechingBroadcast.
+struct RemoveStretchingBroadcast final : OpRewritePattern<vector::BroadcastOp> {
+  using Base::Base;
 
-/// Filter to decide which contraction ops need allocations.
-static bool contractOpFilter(Operation *op) {
-  auto contractOp = dyn_cast<vector::ContractionOp>(op);
-  if (!contractOp) {
-    return false;
-  }
-  SmallVector<unsigned> dims;
-  for (auto [idx, type] : llvm::enumerate(contractOp.getIteratorTypesArray())) {
-    if (type == vector::IteratorType::parallel) {
-      dims.push_back(idx);
+  LogicalResult matchAndRewrite(vector::BroadcastOp broadcastOp,
+                                PatternRewriter &rewriter) const override {
+    SetVector<int64_t> stretchedDims = broadcastOp.computeBroadcastedUnitDims();
+    if (stretchedDims.empty()) {
+      return failure();
     }
-  }
-  SmallVector<int64_t> shapes;
-  contractOp.getIterationBounds(shapes);
-  // Don't promote vector*matrix kind of case.
-  int numNonUnitParallelLoop = 0;
-  for (unsigned parallelDim : dims) {
-    if (shapes[parallelDim] != 1) {
-      numNonUnitParallelLoop++;
+
+    VectorType srcTy = cast<VectorType>(broadcastOp.getSource().getType());
+    VectorType dstTy = broadcastOp.getResultVectorType();
+    int64_t numLeadingBroadcastDims = dstTy.getRank() - srcTy.getRank();
+    SmallVector<int64_t> broadcastedUnitDims;
+    for (auto i : llvm::seq<int64_t>(numLeadingBroadcastDims)) {
+      if (dstTy.getShape()[i] == 1) {
+        broadcastedUnitDims.push_back(i);
+      }
     }
+    if (stretchedDims.size() > broadcastedUnitDims.size()) {
+      return failure();
+    }
+
+    auto perm = llvm::to_vector(llvm::seq<int64_t>(dstTy.getRank()));
+    for (auto [stretchedDim, broadcastedUnitDim] :
+         llvm::zip(stretchedDims.getArrayRef(), broadcastedUnitDims)) {
+      std::swap(perm[stretchedDim], perm[broadcastedUnitDim]);
+    }
+    VectorType permutedBroadcastTy = VectorType::get(
+        applyPermutation(dstTy.getShape(), perm), dstTy.getElementType());
+    Value permutedBroadcast = vector::BroadcastOp::create(
+        rewriter, broadcastOp.getLoc(), permutedBroadcastTy,
+        broadcastOp.getSource());
+    rewriter.replaceOpWithNewOp<vector::TransposeOp>(broadcastOp,
+                                                     permutedBroadcast, perm);
+    return success();
   }
-  // TODO: Relax this constraint.
-  return numNonUnitParallelLoop > 1 && dims.size() >= 2 && dims.size() <= 3;
-}
+};
 
 // Allocates a tensor to copy the vector into a la bufferization.alloc_tensor.
 // This allocation is always static as vectors are currently always static
@@ -96,51 +113,88 @@ static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
       .getResult();
 }
 
+/// Materialize shared memory for all to_layout ops marked with
+/// shared_memory_conversion. Clears the attribute after materialization.
+static LogicalResult
+materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
+  SmallVector<IREE::VectorExt::ToLayoutOp> opsToPromote;
+  funcOp.walk([&](IREE::VectorExt::ToLayoutOp op) {
+    if (op.getSharedMemoryConversion()) {
+      opsToPromote.push_back(op);
+    }
+  });
+
+  for (IREE::VectorExt::ToLayoutOp op : opsToPromote) {
+    OpBuilder builder(op);
+
+    // HACK: Until proper barrier placement is handled later we have to
+    // synchronize explicitly in this pass.
+
+    // Synchronize before the write to shared memory to avoid stepping over
+    // reads in the previous iteration of a loop. We set this barrier
+    // at the start of this block.
+    builder.setInsertionPointToStart(op->getBlock());
+    gpu::BarrierOp::create(builder, op->getLoc(), gpu::AddressSpace::Workgroup);
+
+    // Promote both of the input operands, excluding the accumulator.
+    builder.setInsertionPoint(op);
+    OpOperand &operand = op.getInputMutable();
+    FailureOr<Value> ret =
+        allocateTensorForVector(builder, op->getLoc(), operand.get());
+    if (failed(ret)) {
+      return failure();
+    }
+
+    // Synchronize after the write to shared memory before we read from it.
+    auto synced =
+        IREE::GPU::ValueBarrierOp::create(builder, op->getLoc(), *ret);
+
+    VectorType inputTy = cast<VectorType>(op.getType());
+    Value read = readVectorFromTensor(builder, inputTy, synced.getResult(0));
+    operand.set(read);
+
+    // Remove the shared_memory_conversion attribute from the to_layout
+    // operation.
+    op.setSharedMemoryConversion(false);
+  }
+  return success();
+}
+
 struct GPUVectorAllocPass final
     : impl::GPUVectorAllocPassBase<GPUVectorAllocPass> {
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
 
-    SmallVector<IREE::VectorExt::ToLayoutOp> opsToPromote;
+    // Remove stretching broadcasts before layout analysis — the analysis
+    // asserts that broadcasts don't stretch.
+    {
+      RewritePatternSet patterns(funcOp.getContext());
+      patterns.add<RemoveStretchingBroadcast>(funcOp.getContext());
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Run layout analysis to find additional conflict points.
+    // The analysis sees the materialized shared memory roundtrips and
+    // only detects genuinely new conflicts.
+    llvm::MapVector<Value, IREE::VectorExt::VectorLayoutInterface> layouts;
+    propagateVectorLayoutInfo(funcOp, layouts);
+
+    // Mark newly-inserted to_layout ops where input/output layouts don't
+    // match — these are genuine conflicts needing shared memory.
     funcOp.walk([&](IREE::VectorExt::ToLayoutOp op) {
-      if (op.getSharedMemoryConversion()) {
-        opsToPromote.push_back(op);
+      auto inputLayout = layouts.lookup(op.getInput());
+      auto outputLayout = layouts.lookup(op.getResult());
+      if (inputLayout && outputLayout &&
+          inputLayout.needsSharedMemoryForConversion(outputLayout)) {
+        op.setSharedMemoryConversion(true);
       }
     });
 
-    for (IREE::VectorExt::ToLayoutOp op : opsToPromote) {
-      OpBuilder builder(op);
-
-      // HACK: Until proper barrier placement is handled later we have to
-      // synchronize explicitly in this pass.
-
-      // Synchronize before the write to shared memory to avoid stepping over
-      // reads in the previous iteration of a loop. We set this barrier
-      // at the start of this block.
-      builder.setInsertionPointToStart(op->getBlock());
-      gpu::BarrierOp::create(builder, op->getLoc(),
-                             gpu::AddressSpace::Workgroup);
-
-      // Promote both of the input operands, excluding the accumulator.
-      builder.setInsertionPoint(op);
-      OpOperand &operand = op.getInputMutable();
-      FailureOr<Value> ret =
-          allocateTensorForVector(builder, op->getLoc(), operand.get());
-      if (failed(ret)) {
-        return signalPassFailure();
-      }
-
-      // Synchronize after the write to shared memory before we read from it.
-      auto synced =
-          IREE::GPU::ValueBarrierOp::create(builder, op->getLoc(), *ret);
-
-      VectorType inputTy = cast<VectorType>(op.getType());
-      Value read = readVectorFromTensor(builder, inputTy, synced.getResult(0));
-      operand.set(read);
-
-      // Remove the shared_memory_conversion attribute from the to_layout
-      // operation.
-      op.setSharedMemoryConversion(false);
+    // Phase 3: Materialize any newly-found conflicts.
+    if (failed(materializeSharedMemoryConversions(funcOp))) {
+      return signalPassFailure();
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -344,6 +344,11 @@ void LayoutAnalysis::fixupOp(Operation *op) {
 
   // to_layout: result layout -> input gets same layout.
   if (auto toLayout = dyn_cast<ToLayoutOp>(op)) {
+    if (toLayout.getSharedMemoryConversion()) {
+      // The layout input is coming through shared memory, skip
+      // back-propagation.
+      return;
+    }
     VectorLayoutInterface layout = getResolvedLayout(toLayout.getResult());
     setLayoutOrClone(&toLayout.getInputMutable(), layout);
     return;

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -610,6 +610,20 @@ NestedLayoutAttr::getRecombinedLayout(ArrayRef<VectorLayoutInterface> layouts,
                                threadStrides);
 }
 
+bool NestedLayoutAttr::needsSharedMemoryForConversion(
+    VectorLayoutInterface targetLayout) const {
+  auto targetNestedLayout =
+      llvm::dyn_cast_if_present<NestedLayoutAttr>(targetLayout);
+  assert(targetNestedLayout &&
+         "expected target layout to also be a nested layout");
+  // Check if everything other than batch and outer tile matches.
+  return getSubgroupTile() != targetNestedLayout.getSubgroupTile() ||
+         getThreadTile() != targetNestedLayout.getThreadTile() ||
+         getElementTile() != targetNestedLayout.getElementTile() ||
+         getSubgroupStrides() != targetNestedLayout.getSubgroupStrides() ||
+         getThreadStrides() != targetNestedLayout.getThreadStrides();
+}
+
 LogicalResult NestedLayoutAttr::verify(
     llvm::function_ref<InFlightDiagnostic()> emitError,
     ArrayRef<int64_t> subgroupTile, ArrayRef<int64_t> batchTile,

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td
@@ -65,6 +65,12 @@ def VectorLayoutInterface : AttrInterface<"VectorLayoutInterface"> {
       /*methodName=*/"getRank",
       /*args=*/(ins)
     >,
+    InterfaceMethod<
+      /*description=*/"Given a target layout, check if we need shared memory for the conversion.",
+      /*retTy=*/"bool",
+      /*methodName=*/"needsSharedMemoryForConversion",
+      /*args=*/(ins "VectorLayoutInterface":$targetLayout)
+    >,
     StaticInterfaceMethod<
       /*description=*/"Given operand layouts and indexing maps, create a recombined layout for result indexing map",
       /*retTy=*/"VectorLayoutInterface",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -375,16 +375,12 @@ static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
   // We know that pvMatmul takes result of qkMatmul as it's lhs.
   // If the intrinsic output of pvMatmul can be used as rhs of pvMatmul,
   // we swap operands of both contracts to get output as transposed intrinsic.
-  bool reuseIntrinsicOutput = false;
   bool transposeIntrinsic = false;
 
   IREE::Codegen::InnerTileDescAttrInterface qkIntrinsic =
       getIntrinsic(qkMatmul);
   IREE::Codegen::InnerTileDescAttrInterface pvIntrinsic =
       getIntrinsic(pvMatmul);
-  IREE::GPU::MMASingleSubgroupLayout lhsLayout =
-      IREE::GPU::getSingleSubgroupLayout(pvIntrinsic,
-                                         IREE::GPU::kMMAOperandLhs);
   IREE::GPU::MMASingleSubgroupLayout rhsLayout =
       IREE::GPU::getSingleSubgroupLayout(pvIntrinsic,
                                          IREE::GPU::kMMAOperandRhs);
@@ -402,18 +398,12 @@ static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
   // TODO: Move this check to KernelConfig and set appropriate attributes
   // in lowering_config for the operation. This allows us to check shared
   // memory usage and decide what kind of pipelining we can do.
-  if (matchLayout(outLayout, lhsLayout)) {
-    reuseIntrinsicOutput = true;
-  } else if (matchLayout(outLayout, rhsLayout)) {
-    reuseIntrinsicOutput = true;
+  if (matchLayout(outLayout, rhsLayout)) {
     transposeIntrinsic = true;
   }
 
   SmallVector<bool> promotedQKOperands = getPromotedOperands(qkMatmul);
   SmallVector<bool> promotedPVOperands = getPromotedOperands(pvMatmul);
-
-  // Do not promote lhs of pvMatmul if we are reusing the intrinsic output.
-  promotedPVOperands[0] = !reuseIntrinsicOutput;
 
   // Transpose the intrinsic if requested. See docs for
   // swapOperandsToTransposeIntrinsic for more information on why this is done.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -54,56 +53,10 @@ ContractionVectorLayoutOptions::getDefaultLayout(VectorType type) const {
 
 namespace {
 
-struct RemoveUnitDimStretchingBroadcast final
-    : OpRewritePattern<vector::BroadcastOp> {
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(vector::BroadcastOp broadcastOp,
-                                PatternRewriter &rewriter) const override {
-    SetVector<int64_t> stretchedDims = broadcastOp.computeBroadcastedUnitDims();
-    if (stretchedDims.empty()) {
-      return failure();
-    }
-    VectorType srcTy = cast<VectorType>(broadcastOp.getSource().getType());
-    VectorType dstTy = broadcastOp.getResultVectorType();
-    int64_t numLeadingBroadcastDims = dstTy.getRank() - srcTy.getRank();
-    SmallVector<int64_t> broadcastedUnitDims;
-    for (auto i : llvm::seq<int64_t>(numLeadingBroadcastDims)) {
-      if (dstTy.getShape()[i] == 1) {
-        broadcastedUnitDims.push_back(i);
-      }
-    }
-    if (stretchedDims.size() > broadcastedUnitDims.size()) {
-      return rewriter.notifyMatchFailure(
-          broadcastOp,
-          "number of stretched dims is greater than broadcasted unit dims");
-    }
-    // Build a permutation that swaps the broadcasted unit dims with a leading
-    // unit dim.
-    // Note that the way this permutation is built, makes it involutory, i.e.,
-    // P = P^{-1}.
-    auto perm = llvm::to_vector(llvm::seq<int64_t>(dstTy.getRank()));
-    // We use zip instead of zip_equal because stretchedDims.size() <=
-    // broadcastedUnitDims.size().
-    for (auto [stretchedDim, broadcastedUnitDim] :
-         llvm::zip(stretchedDims.getArrayRef(), broadcastedUnitDims)) {
-      std::swap(perm[stretchedDim], perm[broadcastedUnitDim]);
-    }
-    VectorType permutedBroadcastTy = VectorType::get(
-        applyPermutation(dstTy.getShape(), perm), dstTy.getElementType());
-    Value permutedBroadcast = vector::BroadcastOp::create(
-        rewriter, broadcastOp.getLoc(), permutedBroadcastTy,
-        broadcastOp.getSource());
-    rewriter.replaceOpWithNewOp<vector::TransposeOp>(broadcastOp,
-                                                     permutedBroadcast, perm);
-    return success();
-  }
-};
-
 static LogicalResult
 preVectorDistributionNormalizations(mlir::FunctionOpInterface funcOp) {
   RewritePatternSet patterns(funcOp.getContext());
-  patterns.add<RemoveUnitDimStretchingBroadcast>(funcOp.getContext());
+  populateVectorLayoutCanonicalizations(patterns);
   return applyPatternsGreedily(funcOp, std::move(patterns));
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -130,3 +130,70 @@ hal.executable private @matvec_dispatch_0 {
 //          CHECK:   scf.forall ({{.*}}) = (0, 0) to (32000, 2) step (16, 1)
 // CHECK-COUNT-16:     gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
 // CHECK-COUNT-16:     gpu.subgroup_reduce  add {{.*}} cluster(size = 4) : (f32) -> f32
+
+// -----
+
+#decomposition_config = {
+  pv_attrs = {attention_pv_matmul,
+              lowering_config = #iree_gpu.lowering_config<{
+                  mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>,
+                  promote_operands = [1],
+                  subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 3, 4]]}>},
+  qk_attrs = {attention_qk_matmul,
+             lowering_config = #iree_gpu.lowering_config<{
+                  mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>,
+                  promote_operands = [0, 1],
+                  subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 2, 3]]}>}}
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 32, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>
+module {
+  hal.executable public @attention {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @attention ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @attention() attributes {translation_info = #translation} {
+          %cst = arith.constant 1.250000e-01 : f16
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>>
+          %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>>
+          %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>>
+          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(Indirect) : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>>
+          %8 = iree_codegen.load_from_buffer %0 : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>> -> tensor<20x4096x64xf16>
+          %9 = iree_codegen.load_from_buffer %2 : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>> -> tensor<20x4096x64xf16>
+          %10 = iree_codegen.load_from_buffer %4 : memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>> -> tensor<20x4096x64xf16>
+          %11 = tensor.empty() : tensor<20x4096x64xf16>
+          %12 = iree_linalg_ext.attention {decomposition_config = #decomposition_config, indexing_maps = [#map, #map1, #map2, #map3, #map4], lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1, 2], reduction = [0, 0, 0, 64, 0], workgroup = [1, 64, 0, 0, 64]}>} ins(%8, %9, %10, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%11 : tensor<20x4096x64xf16>) {
+          ^bb0(%arg0: f32):
+            iree_linalg_ext.yield %arg0 : f32
+          } -> tensor<20x4096x64xf16>
+          iree_codegen.store_to_buffer %12, %6 : tensor<20x4096x64xf16> into memref<20x4096x64xf16, #hal.descriptor_type<storage_buffer>>
+          return
+        }
+      }
+    }
+  }
+}
+
+%alloc = memref.alloc() : memref<1x64x68xf16, #gpu.address_space<workgroup>>
+          %subview = memref.subview %alloc[0, 0, 0] [1, 64, 64] [1, 1, 1] : memref<1x64x68xf16, #gpu.address_space<workgroup>> to memref<1x64x64xf16, strided<[4352, 68, 1]>, #gpu.address_space<workgroup>>
+          %alloc_10 = memref.alloc() : memref<1x64x68xf16, #gpu.address_space<workgroup>>
+          %subview_11 = memref.subview %alloc_10[0, 0, 0] [1, 64, 64] [1, 1, 1] : memref<1x64x68xf16, #gpu.address_space<workgroup>> to memref<1x64x64xf16, strided<[4352, 68, 1]>, #gpu.address_space<workgroup>>
+          %alloc_12 = memref.alloc() : memref<1x64x68xf16, #gpu.address_space<workgroup>>
+          %subview_13 = memref.subview %alloc_12[0, 0, 0] [1, 64, 64] [1, 1, 1] : memref<1x64x68xf16, #gpu.address_space<workgroup>> to memref<1x64x64xf16, strided<[4352, 68, 1]>, #gpu.address_space<workgroup>>
+          %alloc_14 = memref.alloc() : memref<1x64x68xf16, #gpu.address_space<workgroup>>
+
+// There should be only 4 allocs for shared memory. For Q, K, V and one for
+// intermediate P conversion.
+// CHECK-LABEL: func.func @attention
+// CHECK-COUNT-4: memref.alloc() : memref<1x64x68xf16, #gpu.address_space<workgroup>>
+// CHECK-NOT: memref.alloc()


### PR DESCRIPTION
Before this patch, we were doing in hack in layout configuration where we checked if there would be a layout conflict and try to promote the operand for attention. This hack was fragile as well as doesn't really scale beyond simple stuff.

This patch runs vector layout analysis to check if there would be any conflicts and uses shared memory to allocate shared memory for them.

Also removes some dead code from the alloc pass.