### PR TITLE
[Torch] Add flag to enable shape refinement

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -50,6 +50,9 @@ void createTorchToIREEPipeline(
       torch::Torch::createReduceOpVariantsPass(llvm::StringRef()));
   pm.addNestedPass<func::FuncOp>(
       mlir::torch::TorchConversion::createConvertCustomQuantOpPass());
+  if (options.enableShapeRefinement) {
+    torch::Torch::createTorchShapeRefinementPipeline(pm, /*options=*/{});
+  }
   if (options.decompose) {
     pm.addNestedPass<func::FuncOp>(
         torch::Torch::createDecomposeComplexOpsPass(BackendLegalOps::get()));
@@ -57,9 +60,6 @@ void createTorchToIREEPipeline(
   pm.addNestedPass<func::FuncOp>(torch::Torch::createFuseQuantizedOpsPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(torch::Torch::createScalarizeShapesPass());
-  if (options.enableShapeRefinement) {
-    torch::Torch::createTorchShapeRefinementPipeline(pm, /*options=*/{});
-  }
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
   pm.addNestedPass<func::FuncOp>(
       TorchInput::createConvertTMTensorToLinalgExtPass());

--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -57,6 +57,9 @@ void createTorchToIREEPipeline(
   pm.addNestedPass<func::FuncOp>(torch::Torch::createFuseQuantizedOpsPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(torch::Torch::createScalarizeShapesPass());
+  if (options.enableShapeRefinement) {
+    torch::Torch::createTorchShapeRefinementPipeline(pm, /*options=*/{});
+  }
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
   pm.addNestedPass<func::FuncOp>(
       TorchInput::createConvertTMTensorToLinalgExtPass());

--- a/compiler/plugins/input/Torch/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.h
@@ -43,6 +43,9 @@ struct TorchToIREELoweringPipelineOptions
           "program inputs. This buffer will be used for storing transient "
           "memory and must be provided by the user."),
       llvm::cl::init(false)};
+  Option<bool> enableShapeRefinement{*this, "enable-shape-refinement",
+                                     llvm::cl::desc("Enable shape refinement"),
+                                     llvm::cl::init(false)};
 };
 
 // Creates a pipeline that lowers from the torch backend contract to IREE.

--- a/compiler/plugins/input/Torch/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/PluginRegistration.cpp
@@ -30,6 +30,7 @@ struct TorchOptions {
   bool strictSymbolicShapes = true;
   bool decompose = true;
   bool externalizeTransients = false;
+  bool enableShapeRefinement = false;
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("Torch Input");
     binder.opt<bool>(
@@ -46,6 +47,9 @@ struct TorchOptions {
                        "program inputs when converting torch functions to IREE "
                        "input. This buffer will be used for storing transient "
                        "memory and must be provided by the user at runtime."));
+    binder.opt<bool>("iree-torch-enable-shape-refinement",
+                     enableShapeRefinement, llvm::cl::cat(category),
+                     llvm::cl::desc("Enable shape refinement"));
   }
 };
 
@@ -96,6 +100,7 @@ struct TorchSession
       torchOptions.strictSymbolicShapes = options.strictSymbolicShapes;
       torchOptions.decompose = options.decompose;
       torchOptions.externalizeTransients = options.externalizeTransients;
+      torchOptions.enableShapeRefinement = options.enableShapeRefinement;
       TorchInput::createTorchToIREEPipeline(passManager, torchOptions);
       return true;
     }


### PR DESCRIPTION
Allows enabling shape refinement for the torch pipeline which is useful when the input torch MLIR is not as static as it could be. For example, Fusilli's custom ops (https://github.com/iree-org/fusilli/pull/188) use dynamic shapes to prevent having to find and replace each dim size.