### PR TITLE
[Codegen] Remove attention transpose intrinsic hacks

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -82,11 +82,9 @@ transform.named_sequence
   // - `Q` is not promoted since the `QK` matrix multiplication uses VMFMA instructions,
   //   which operate efficiently with `vector<8xf16>` from global memory.
   %decomposition_config = transform.param.constant {
-    qk_attrs = {attention_qk_matmul,
-                lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
+    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16, col_major = true>,
                                                               subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
-    pv_attrs = {attention_pv_matmul,
-                lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>,
                                                               subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
   } -> !transform.any_param
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -954,25 +954,56 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1, 2});
 
+  // Check if transposing both intrinsics eliminates the layout conflict
+  // between QK output and PV LHS input.
+  auto matchLayout = [](IREE::GPU::MMASingleSubgroupLayout a,
+                        IREE::GPU::MMASingleSubgroupLayout b) -> bool {
+    return (a.element == b.element) && (a.thread == b.thread) &&
+           (a.tstrides == b.tstrides);
+  };
+  IREE::GPU::MMASingleSubgroupLayout qkOutLayout =
+      IREE::GPU::getSingleSubgroupLayout(qkSchedule.mmaKind,
+                                         IREE::GPU::kMMAOperandAcc);
+  IREE::GPU::MMASingleSubgroupLayout pvRhsLayout =
+      IREE::GPU::getSingleSubgroupLayout(pvSchedule.mmaKind,
+                                         IREE::GPU::kMMAOperandRhs);
+  bool useColMajor = matchLayout(qkOutLayout, pvRhsLayout);
+
+  auto getColMajorIntrinsic =
+      [&](IREE::Codegen::InnerTileDescAttrInterface mmaKind)
+      -> IREE::Codegen::InnerTileDescAttrInterface {
+    if (auto mma = dyn_cast<IREE::GPU::MMAAttr>(mmaKind)) {
+      return IREE::GPU::MMAAttr::get(context, mma.getIntrinsic(),
+                                     /*colMajor=*/true);
+    }
+    if (auto vmma = dyn_cast<IREE::GPU::VirtualMMAAttr>(mmaKind)) {
+      return IREE::GPU::VirtualMMAAttr::get(context, vmma.getIntrinsic(),
+                                            /*colMajor=*/true);
+    }
+    return mmaKind;
+  };
+
   SmallVector<NamedAttribute, 2> qkConfig;
   SmallVector<NamedAttribute, 2> pvConfig;
 
   // Configuring for qk matmul.
   IREE::GPU::appendPromotedOperandsList(context, qkConfig, {0, 1});
-  IREE::GPU::setMmaKind(context, qkConfig, qkSchedule.mmaKind);
+  IREE::GPU::setMmaKind(context, qkConfig,
+                        useColMajor ? getColMajorIntrinsic(qkSchedule.mmaKind)
+                                    : qkSchedule.mmaKind);
   IREE::GPU::setBasis(context, qkConfig, IREE::GPU::TilingLevel::Subgroup,
                       projectBasis(subgroupBasis, opInfo.getNDims()));
 
   // Configuring for pv matmul.
   IREE::GPU::appendPromotedOperandsList(context, pvConfig, {1});
-  IREE::GPU::setMmaKind(context, pvConfig, pvSchedule.mmaKind);
+  IREE::GPU::setMmaKind(context, pvConfig,
+                        useColMajor ? getColMajorIntrinsic(pvSchedule.mmaKind)
+                                    : pvSchedule.mmaKind);
   IREE::GPU::setBasis(context, pvConfig, IREE::GPU::TilingLevel::Subgroup,
                       projectBasis(subgroupBasis, opInfo.getK1Dims()));
 
-  SmallVector<NamedAttribute, 2> qkAttrs = {
-      {"attention_qk_matmul", b.getUnitAttr()}};
-  SmallVector<NamedAttribute, 2> pvAttrs = {
-      {"attention_pv_matmul", b.getUnitAttr()}};
+  SmallVector<NamedAttribute, 2> qkAttrs;
+  SmallVector<NamedAttribute, 2> pvAttrs;
 
   auto qkConfigDict = b.getDictionaryAttr(qkConfig);
   auto pvConfigDict = b.getDictionaryAttr(pvConfig);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -969,17 +969,19 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
                                          IREE::GPU::kMMAOperandRhs);
   bool useColMajor = matchLayout(qkOutLayout, pvRhsLayout);
 
-  auto getColMajorIntrinsic =
-      [&](IREE::Codegen::InnerTileDescAttrInterface mmaKind)
-      -> IREE::Codegen::InnerTileDescAttrInterface {
+  auto getIntrinsic =
+      [&](IREE::Codegen::InnerTileDescAttrInterface mmaKind,
+          bool colMajor) -> IREE::Codegen::InnerTileDescAttrInterface {
     if (auto mma = dyn_cast<IREE::GPU::MMAAttr>(mmaKind)) {
       return IREE::GPU::MMAAttr::get(context, mma.getIntrinsic(),
-                                     /*colMajor=*/true);
+                                     /*colMajor=*/colMajor);
     }
     if (auto vmma = dyn_cast<IREE::GPU::VirtualMMAAttr>(mmaKind)) {
       return IREE::GPU::VirtualMMAAttr::get(context, vmma.getIntrinsic(),
-                                            /*colMajor=*/true);
+                                            /*colMajor=*/colMajor);
     }
+    // For intrinsics which do not have a known colMajor layout, just return the
+    // original layout.
     return mmaKind;
   };
 
@@ -989,16 +991,14 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   // Configuring for qk matmul.
   IREE::GPU::appendPromotedOperandsList(context, qkConfig, {0, 1});
   IREE::GPU::setMmaKind(context, qkConfig,
-                        useColMajor ? getColMajorIntrinsic(qkSchedule.mmaKind)
-                                    : qkSchedule.mmaKind);
+                        getIntrinsic(qkSchedule.mmaKind, useColMajor));
   IREE::GPU::setBasis(context, qkConfig, IREE::GPU::TilingLevel::Subgroup,
                       projectBasis(subgroupBasis, opInfo.getNDims()));
 
   // Configuring for pv matmul.
   IREE::GPU::appendPromotedOperandsList(context, pvConfig, {1});
   IREE::GPU::setMmaKind(context, pvConfig,
-                        useColMajor ? getColMajorIntrinsic(pvSchedule.mmaKind)
-                                    : pvSchedule.mmaKind);
+                        getIntrinsic(pvSchedule.mmaKind, useColMajor));
   IREE::GPU::setBasis(context, pvConfig, IREE::GPU::TilingLevel::Subgroup,
                       projectBasis(subgroupBasis, opInfo.getK1Dims()));
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -10,7 +10,6 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
-#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -314,124 +313,6 @@ setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
   return success();
 }
 
-/// Let's assume we have an matmul intrinsic (@) doing a matmul
-/// ((M, K) X (K, N)) which produces a particular layout:
-///
-/// C = A @ B
-///
-/// If we transpose and swap the operands, we can keep the same matmul
-/// intrinsic, but transpose the layout of the output intrinsic:
-///
-/// A.T = transpose(A)
-/// B.T = transpose(B)
-/// C.T = B.T @ A.T
-/// C = transpose(C.T)
-///
-/// This is useful when the "@" instruction that the hardware lowers to
-/// has a specific thread layout but the further uses of C expects a transposed
-/// layout to the produced layout.
-///
-/// For example, for "@" lowering to AMDGPU MFMA instructions, the operands
-/// have layout L and L.T and the result has the layout L.T .
-/// So if you have a chain of matmuls:
-///
-/// C (L.T) = A (L) @ B (L.T)
-/// E (L.T) = C (L.T)  @ D (L.T)
-///            ^^^^^^^
-///            Expected layout by instruction is L
-///
-/// To fix this, we can apply this transformation on the first matrix:
-///
-/// C.T (L.T) = B.T (L) @ A (L.T)
-/// C   (L)   = transpose C.T (L.T)
-/// E   (L.T) = C (L)  @ D (L.T)
-///            ^^^^^
-///            Layout matches the instruction!
-///
-/// Note that the mathematical formula
-///   C = A @ B --> C.T = B.T @ A.T
-/// is only defined on standard "@" function, it may be a different
-/// transformation for other indexing maps.
-///
-/// For linalg operands, since the indexing maps are part of the op definition,
-/// we can achieve the same transformation by simply swapping the operands.
-static void swapOperandsToTransposeIntrinsic(RewriterBase &rewriter,
-                                             linalg::GenericOp contractOp) {
-  Value lhs = contractOp->getOperand(0);
-  Value rhs = contractOp->getOperand(1);
-
-  SmallVector<AffineMap> indexingMaps = contractOp.getIndexingMapsArray();
-  std::swap(indexingMaps[0], indexingMaps[1]);
-
-  contractOp.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr(indexingMaps));
-  contractOp->setOperand(0, rhs);
-  contractOp->setOperand(1, lhs);
-}
-
-static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
-                                              linalg::LinalgOp qkMatmul,
-                                              linalg::LinalgOp pvMatmul) {
-  // Check if the intrinsic output for qkMatmul can be reused for pvMatmul.
-  // We know that pvMatmul takes result of qkMatmul as it's lhs.
-  // If the intrinsic output of pvMatmul can be used as rhs of pvMatmul,
-  // we swap operands of both contracts to get output as transposed intrinsic.
-  bool transposeIntrinsic = false;
-
-  IREE::Codegen::InnerTileDescAttrInterface qkIntrinsic =
-      getIntrinsic(qkMatmul);
-  IREE::Codegen::InnerTileDescAttrInterface pvIntrinsic =
-      getIntrinsic(pvMatmul);
-  IREE::GPU::MMASingleSubgroupLayout rhsLayout =
-      IREE::GPU::getSingleSubgroupLayout(pvIntrinsic,
-                                         IREE::GPU::kMMAOperandRhs);
-  IREE::GPU::MMASingleSubgroupLayout outLayout =
-      IREE::GPU::getSingleSubgroupLayout(qkIntrinsic,
-                                         IREE::GPU::kMMAOperandAcc);
-
-  auto matchLayout = [](IREE::GPU::MMASingleSubgroupLayout layoutA,
-                        IREE::GPU::MMASingleSubgroupLayout layoutB) -> bool {
-    return (layoutA.element == layoutB.element) &&
-           (layoutA.thread == layoutB.thread) &&
-           (layoutA.tstrides == layoutB.tstrides);
-  };
-
-  // TODO: Move this check to KernelConfig and set appropriate attributes
-  // in lowering_config for the operation. This allows us to check shared
-  // memory usage and decide what kind of pipelining we can do.
-  if (matchLayout(outLayout, rhsLayout)) {
-    transposeIntrinsic = true;
-  }
-
-  SmallVector<bool> promotedQKOperands = getPromotedOperands(qkMatmul);
-  SmallVector<bool> promotedPVOperands = getPromotedOperands(pvMatmul);
-
-  // Transpose the intrinsic if requested. See docs for
-  // swapOperandsToTransposeIntrinsic for more information on why this is done.
-  if (transposeIntrinsic) {
-    auto qkGeneric = dyn_cast<linalg::GenericOp>(qkMatmul.getOperation());
-    auto pvGeneric = dyn_cast<linalg::GenericOp>(pvMatmul.getOperation());
-    if (!qkGeneric || !pvGeneric) {
-      pvMatmul->emitOpError("Non generic qkMatmul/pvMatmul transpose intrinsic "
-                            "not yet implemented");
-      return failure();
-    }
-    swapOperandsToTransposeIntrinsic(rewriter, qkGeneric);
-    swapOperandsToTransposeIntrinsic(rewriter, pvGeneric);
-
-    // Swap promoted operands.
-    std::swap(promotedQKOperands[0], promotedQKOperands[1]);
-    std::swap(promotedPVOperands[0], promotedPVOperands[1]);
-  }
-
-  if (failed(setContractionAnchor(qkIntrinsic, promotedQKOperands, rewriter,
-                                  qkMatmul))) {
-    return failure();
-  }
-
-  return setContractionAnchor(pvIntrinsic, promotedPVOperands, rewriter,
-                              pvMatmul);
-}
-
 static LogicalResult setDerivedThreadConfigLayout(
     IREE::GPU::DerivedThreadConfigAttr config, linalg::LinalgOp linalgOp,
     ArrayRef<int64_t> workgroupSize, RewriterBase &rewriter) {
@@ -603,24 +484,6 @@ static LogicalResult setGPULoweringConfigLayout(
   return success();
 }
 
-static Operation *getOpWithAttr(Operation *root, StringRef attr) {
-  Operation *result = nullptr;
-  WalkResult walkResult = root->walk([&](Operation *op) {
-    if (op->hasAttr(attr)) {
-      if (result) {
-        return WalkResult::interrupt();
-      }
-      result = op;
-    }
-    return WalkResult::advance();
-  });
-
-  if (walkResult.wasInterrupted()) {
-    return nullptr;
-  }
-  return result;
-}
-
 struct LLVMGPUConfigureTensorLayoutsPass final
     : impl::LLVMGPUConfigureTensorLayoutsPassBase<
           LLVMGPUConfigureTensorLayoutsPass> {
@@ -646,28 +509,6 @@ struct LLVMGPUConfigureTensorLayoutsPass final
                                             rewriter))) {
       return signalPassFailure();
     }
-
-    auto attentionQKMatmul = dyn_cast_if_present<linalg::LinalgOp>(
-        getOpWithAttr(funcOp, "attention_qk_matmul"));
-    auto attentionPVMatmul = dyn_cast_if_present<linalg::LinalgOp>(
-        getOpWithAttr(funcOp, "attention_pv_matmul"));
-
-    if (attentionQKMatmul && !attentionPVMatmul) {
-      funcOp->emitError("Expected attention attributes to be set properly");
-      return signalPassFailure();
-    }
-
-    if (!attentionQKMatmul && attentionPVMatmul) {
-      funcOp->emitError("Expected attention attributes to be set properly");
-      return signalPassFailure();
-    }
-
-    if (attentionQKMatmul && attentionPVMatmul) {
-      if (failed(setAttentionMatmulAnchor(rewriter, attentionQKMatmul,
-                                          attentionPVMatmul))) {
-        return signalPassFailure();
-      }
-    }
   }
 
   LogicalResult setLayoutsFromLoweringConfig(FunctionOpInterface funcOp,
@@ -681,12 +522,6 @@ struct LLVMGPUConfigureTensorLayoutsPass final
     });
 
     for (linalg::LinalgOp candidate : candidates) {
-      // Skip attention candidates.
-      if (candidate->hasAttr("attention_qk_matmul") ||
-          candidate->hasAttr("attention_pv_matmul")) {
-        continue;
-      }
-
       auto result =
           TypeSwitch<IREE::Codegen::LoweringConfigAttrInterface, LogicalResult>(
               getLoweringConfig(candidate))

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -307,7 +307,5 @@ func.func @attention_check_mma_accs_compatible(%arg0: f32, %arg1: tensor<960x409
   return
 }
 //      CHECK: decomposition_config =
-// CHECK-SAME: attention_pv_matmul
 // CHECK-SAME:   #iree_gpu.mma_layout<MFMA_F32_32x32x64_F8E4M3FN>
-// CHECK-SAME: attention_qk_matmul
 // CHECK-SAME:   #iree_gpu.mma_layout<MFMA_F32_32x32x64_F8E4M3FN>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -134,13 +134,11 @@ hal.executable private @matvec_dispatch_0 {
 // -----
 
 #decomposition_config = {
-  pv_attrs = {attention_pv_matmul,
-              lowering_config = #iree_gpu.lowering_config<{
+  pv_attrs = {lowering_config = #iree_gpu.lowering_config<{
                   mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>,
                   promote_operands = [1],
                   subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 3, 4]]}>},
-  qk_attrs = {attention_qk_matmul,
-             lowering_config = #iree_gpu.lowering_config<{
+  qk_attrs = {lowering_config = #iree_gpu.lowering_config<{
                   mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>,
                   promote_operands = [0, 1],
                   subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 2, 3]]}>}}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -846,8 +846,8 @@ hal.executable private @attention_20x4096x64x4096x64 {
                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
                      lowering_config = #config,
                      decomposition_config = {
-                      qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
-                      pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
+                      qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
+                      pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
                      }}
                      ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
                       ^bb0(%score: f32):
@@ -919,8 +919,8 @@ hal.executable private @attention_multiple_m_transpose {
                                                          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
                                                          lowering_config = #config,
                                                          decomposition_config = {
-                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
-                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
+                                                          qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
                                                          }}
         ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
               ^bb0(%score: f32):
@@ -986,8 +986,8 @@ hal.executable private @attention_mfma_32x32x8 {
                                                          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
                                                          lowering_config = #config,
                                                          decomposition_config = {
-                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
-                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
+                                                          qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
                                                          }}
         ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
               ^bb0(%score: f32):
@@ -1066,8 +1066,8 @@ hal.executable private @online_attention_split_k2 {
                                                                     affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m)>],
                                                                   lowering_config = #config,
                                                                   decomposition_config = {
-                                                                    qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [0, 1]}>},
-                                                                    pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1]}>}
+                                                                    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [0, 1]}>},
+                                                                    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1]}>}
                                                                   }}
         ins(%4, %5, %6, %cst : !Q, !K_SK, !V_SK, f16) outs(%empty_o, %empty_rowmax, %empty_rowsum: !O_SK, !ROWRED_SK, !ROWRED_SK) {
               ^bb0(%score: f32):
@@ -1106,8 +1106,8 @@ hal.executable private @online_attention_split_k2 {
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>]>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {}>
 
-#qk_config = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]]}>}
-#pv_config = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 5]]}>}
+#qk_config = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, promote_operands = [0, 1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]]}>}
+#pv_config = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, promote_operands = [1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 5]]}>}
 #config = #iree_gpu.lowering_config<{promote_operands = [0, 1, 2], reduction = [0, 0, 0, 0, 0, 64], workgroup = [1, 1, 64, 64, 0, 0]}>
 
 module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
@@ -472,8 +472,8 @@ hal.executable private @attention_20x4096x64x4096x64 {
                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
                      lowering_config = #config,
                      decomposition_config = {
-                      qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
-                      pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
+                      qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
+                      pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
                      }}
                      ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
                       ^bb0(%score: f32):
@@ -552,8 +552,8 @@ hal.executable private @attention_mfma_32x32x16 {
                                                          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
                                                          lowering_config = #config,
                                                          decomposition_config = {
-                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
-                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
+                                                          qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
                                                          }}
         ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
               ^bb0(%score: f32):

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
@@ -39,12 +39,10 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
     -> !transform.any_param
 
     %decomposition_config = transform.param.constant {
-      qk_attrs = {attention_qk_matmul,
-                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
+      qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16, col_major = true>,
                                                                subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
 
-      pv_attrs = {attention_pv_matmul,
-                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+      pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>,
                                                                subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
     } -> !transform.any_param
 
@@ -67,11 +65,9 @@ transform.named_sequence @match_attention_f8(%attention: !transform.any_op {tran
     -> !transform.any_param
 
     %decomposition_config = transform.param.constant {
-      qk_attrs = {attention_qk_matmul,
-                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>,
+      qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ, col_major = true>,
                                                                subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
-      pv_attrs = {attention_pv_matmul,
-                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ>,
+      pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ, col_major = true>,
                                                                subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
     } -> !transform.any_param
 

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -35,11 +35,9 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
   -> !transform.any_param
 
   %decomposition_config = transform.param.constant {
-    qk_attrs = {attention_qk_matmul,
-                lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
+    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16, col_major = true>,
                                                               subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
-    pv_attrs = {attention_pv_matmul,
-                lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>,
                                                               subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
   } -> !transform.any_param
 


### PR DESCRIPTION
After https://github.com/iree-org/iree/pull/23631 we will be using the analysis to determine conflicts, which allows us to undo a bunch of hacks we did earlier to not have conflicts between the chained mma in attention.

This patch simply sets the intrinsic to be col major in KernelConfig and rest of the pipeline automatically picks up if there needs to be a intermediate conflict using shared memory or not.