### PR TITLE
[Python][CI] Fix release validation installing wrong package versions

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -346,8 +346,6 @@ jobs:
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: wheels-${{ matrix.build-family }}-${{ matrix.build-package }}
-          # We upload all wheels (which includes deps so that subsequent
-          # steps can run without further fetching).
           path: ./bindist/*
           retention-days: 5
 
@@ -375,4 +373,4 @@ jobs:
           workflow: Validate and Publish Release
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
-          inputs: '{"release_id": "${{ github.event.inputs.release_id }}", "package_version": "${{ github.event.inputs.package_version }}", "build_run_id": "${{ github.run_id }}"}'
+          inputs: '{"release_id": "${{ github.event.inputs.release_id }}", "package_version": "${{ github.event.inputs.package_version }}", "compiler_package_version": "${{ github.event.inputs.compiler_package_version }}", "runtime_package_version": "${{ github.event.inputs.runtime_package_version }}", "legacy_package_version": "${{ github.event.inputs.legacy_package_version }}", "build_run_id": "${{ github.run_id }}"}'

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -11,6 +11,15 @@ on:
       package_version:
         description: "Version of the package"
         required: true
+      compiler_package_version:
+        description: "Version of the iree-base-compiler package"
+        required: true
+      runtime_package_version:
+        description: "Version of the iree-base-runtime package"
+        required: true
+      legacy_package_version:
+        description: "Version of the iree-tools-tf and iree-tools-tflite packages"
+        required: true
       build_run_id:
         description: "Run ID for the build_package.yml workflow that triggered this workflow"
         required: true
@@ -41,9 +50,9 @@ jobs:
       - name: Install python packages
         id: install_python_packages
         run: |
-          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-compiler-pkg/ iree-base-compiler[onnx]
-          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-runtime-pkg/ iree-base-runtime
-          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-tf-compiler-tools-pkg/ iree-tools-tflite iree-tools-tf
+          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-compiler-pkg/ "iree-base-compiler[onnx]==${{ github.event.inputs.compiler_package_version }}"
+          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-runtime-pkg/ "iree-base-runtime==${{ github.event.inputs.runtime_package_version }}"
+          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-tf-compiler-tools-pkg/ "iree-tools-tflite==${{ github.event.inputs.legacy_package_version }}" "iree-tools-tf==${{ github.event.inputs.legacy_package_version }}"
       - name: Validate IREE Compiler Package
         id: validate_compiler_package
         run: |

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -154,7 +154,7 @@ function run_in_docker() {
 }
 
 function build_wheel() {
-  python -m pip wheel --disable-pip-version-check -v -w "${output_dir}" "${repo_root}/$@"
+  python -m pip wheel --disable-pip-version-check --no-deps -v -w "${output_dir}" "${repo_root}/$@"
 }
 
 function build_iree_runtime() {

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -75,11 +75,11 @@ function run() {
 
 function build_iree_runtime() {
   export IREE_RUNTIME_BUILD_TRACY=ON
-  python3 -m pip wheel -v -w $output_dir $repo_root/runtime/
+  python3 -m pip wheel --no-deps -v -w $output_dir $repo_root/runtime/
 }
 
 function build_iree_compiler() {
-  python3 -m pip wheel -v -w $output_dir $repo_root/compiler/
+  python3 -m pip wheel --no-deps -v -w $output_dir $repo_root/compiler/
 }
 
 function clean_wheels() {

--- a/build_tools/python_deploy/build_windows_packages.ps1
+++ b/build_tools/python_deploy/build_windows_packages.ps1
@@ -71,14 +71,14 @@ function build_iree_runtime() {
   $env:IREE_HAL_DRIVER_VULKAN = "ON"
   $env:IREE_HAL_DRIVER_HIP = "ON"
   $env:IREE_HAL_DRIVER_CUDA = "ON"
-  & py -${python_version} -m pip wheel -v -w $output_dir $repo_root/runtime/
+  & py -${python_version} -m pip wheel --no-deps -v -w $output_dir $repo_root/runtime/
 }
 
 function build_iree_compiler() {
   param($python_version)
   $env:IREE_TARGET_BACKEND_CUDA = "ON"
   $env:IREE_TARGET_BACKEND_ROCM = "ON"
-  py -${python_version} -m pip wheel -v -w $output_dir $repo_root/compiler/
+  py -${python_version} -m pip wheel --no-deps -v -w $output_dir $repo_root/compiler/
 }
 
 function clean_wheels() {


### PR DESCRIPTION
The validate workflow was silently installing stable releases from PyPI
instead of the just-built release candidate wheels. This happened because
`pip install -f file://... iree-base-compiler` ignores pre-release
versions (e.g., `3.11.0rc20260222`) by default, falling back to the latest
stable (`3.10.0`) on PyPI.

Fix by pinning exact versions (`==`) in all install commands, which also
implicitly allows pre-releases. Thread `compiler_package_version`,
`runtime_package_version`, and `legacy_package_version` from the build
workflow to the validate workflow.

Also add `--no-deps` to `pip wheel` in all platform build scripts so
that only IREE wheels are produced in the output directory, not bundled
copies of `numpy`/`sympy`/`ml_dtypes`. The validate workflow now fetches
these dependencies from PyPI at install time.

Discovered by Scott.