### PR TITLE
[GPUHeuristics] Prefer larger MMA intrinsics for very large compute-bound GEMMs

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -579,11 +579,41 @@ static bool compareIntrinsics(const GPUMatmulShapeType &problem,
     return lhsMNAligned > rhsMNAligned;
   }
 
+  auto intrinsicCompute = [&](const GPUIntrinsicType &intrinsic) {
+    return ShapedType::getNumElements(intrinsic.mSizes) *
+           ShapedType::getNumElements(intrinsic.nSizes) *
+           ShapedType::getNumElements(intrinsic.kSizes);
+  };
   auto intrinsicArea = [&](const GPUIntrinsicType &intrinsic) {
     return (ShapedType::getNumElements(intrinsic.mSizes) +
             ShapedType::getNumElements(intrinsic.nSizes)) *
            ShapedType::getNumElements(intrinsic.kSizes);
   };
+
+  // For compute-bound GEMMs, maximize compute throughput first, then
+  // minimize operand VGPR pressure among equal-compute intrinsics.
+  // E.g., 32x32x16 (compute=16384, area=1024) beats 32x32x8
+  // (compute=8192, area=512) because throughput matters more. Among
+  // 16x16x32 and 32x32x16 (both area=1024), prefer smaller K (16 vs 32)
+  // for less operand staging pressure.
+  if (problem.gemmSize == GemmSize::LargeGemm) {
+    int64_t lhsCompute = intrinsicCompute(lhs);
+    int64_t rhsCompute = intrinsicCompute(rhs);
+    if (lhsCompute != rhsCompute) {
+      return lhsCompute > rhsCompute;
+    }
+
+    int64_t lhsArea = intrinsicArea(lhs);
+    int64_t rhsArea = intrinsicArea(rhs);
+    if (lhsArea != rhsArea) {
+      return lhsArea < rhsArea;
+    }
+
+    return ShapedType::getNumElements(lhs.kSizes) <
+           ShapedType::getNumElements(rhs.kSizes);
+  }
+
+  // For memory-bound GEMMs, prefer larger area to amortize memory latency.
   int64_t lhsArea = intrinsicArea(lhs);
   int64_t rhsArea = intrinsicArea(rhs);
   if (lhsArea != rhsArea) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -58,6 +58,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const GemmSize &gemmSize) {
     return os << "MediumGemm";
   case GemmSize::LargeGemm:
     return os << "LargeGemm";
+  case GemmSize::VeryLargeGemm:
+    return os << "VeryLargeGemm";
   default:
     assert(false && "Unhandled gemm size");
     return os << "NotSet";
@@ -596,7 +598,7 @@ static bool compareIntrinsics(const GPUMatmulShapeType &problem,
   // (compute=8192, area=512) because throughput matters more. Among
   // 16x16x32 and 32x32x16 (both area=1024), prefer smaller K (16 vs 32)
   // for less operand staging pressure.
-  if (problem.gemmSize == GemmSize::LargeGemm) {
+  if (problem.gemmSize == GemmSize::VeryLargeGemm) {
     int64_t lhsCompute = intrinsicCompute(lhs);
     int64_t rhsCompute = intrinsicCompute(rhs);
     if (lhsCompute != rhsCompute) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -10,7 +10,7 @@
 
 namespace mlir::iree_compiler {
 
-enum class GemmSize { NotSet, SmallGemm, MediumGemm, LargeGemm };
+enum class GemmSize { NotSet, SmallGemm, MediumGemm, LargeGemm, VeryLargeGemm };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const GemmSize &gemmSize);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -171,6 +171,7 @@ namespace {
 struct GemmCutoff {
   float smallGemmCutoff = 0.0f;
   float largeGemmCutoff = 0.0f;
+  float veryLargeGemmCutoff = 0.0f;
 };
 } // namespace
 
@@ -180,18 +181,20 @@ static GemmCutoff computeGemmCutoffsForAI(IREE::GPU::TargetAttr target,
                                           Type computeType, bool scaled) {
   float smallGemmCutoff = 1.0f;
   float largeGemmCutoff = 1000.0f;
+  float veryLargeGemmCutoff = 7000.0f;
 
   // Use default gemm cutoffs for scaled matmuls for now. Choosing appropriate
   // cutoffs will require tuning and there is still a lot of performance work
   // left to do before any analysis done on tuning data is actionable.
   // See https://github.com/iree-org/iree/issues/22785 for details.
   if (scaled) {
-    return {100.0f, 10000.0f};
+    return {100.0f, 10000.0f, 70000.0f};
   }
   if (!target.getChip()) {
     LDBG() << "Target chip is not specified, using default gemm cutoffs: "
-           << smallGemmCutoff << ", " << largeGemmCutoff;
-    return {smallGemmCutoff, largeGemmCutoff};
+           << smallGemmCutoff << ", " << largeGemmCutoff << ", "
+           << veryLargeGemmCutoff;
+    return {smallGemmCutoff, largeGemmCutoff, veryLargeGemmCutoff};
   }
 
   TargetChipAttr chip = target.getChip();
@@ -225,8 +228,9 @@ static GemmCutoff computeGemmCutoffsForAI(IREE::GPU::TargetAttr target,
   if (!peakPerfTflopsFound || !memoryBandwidthFound) {
     LDBG() << "Target chip does not have peak performance or memory bandwidth "
               "information, using default gemm cutoffs: "
-           << smallGemmCutoff << ", " << largeGemmCutoff;
-    return {smallGemmCutoff, largeGemmCutoff};
+           << smallGemmCutoff << ", " << largeGemmCutoff << ", "
+           << veryLargeGemmCutoff;
+    return {smallGemmCutoff, largeGemmCutoff, veryLargeGemmCutoff};
   }
 
   // TODO: Attempt to use number of elements loaded per second instead of
@@ -247,9 +251,11 @@ static GemmCutoff computeGemmCutoffsForAI(IREE::GPU::TargetAttr target,
   // based on the approach in https://github.com/iree-org/iree/discussions/21506
   smallGemmCutoff = 0.05f * computeMemoryCutoff;
   largeGemmCutoff = 5.0f * computeMemoryCutoff;
+  veryLargeGemmCutoff = 22.0f * computeMemoryCutoff;
   LDBG() << "Target chip small gemm cutoff: " << smallGemmCutoff
-         << ", large gemm cutoff: " << largeGemmCutoff;
-  return {smallGemmCutoff, largeGemmCutoff};
+         << ", large gemm cutoff: " << largeGemmCutoff
+         << ", very large gemm cutoff: " << veryLargeGemmCutoff;
+  return {smallGemmCutoff, largeGemmCutoff, veryLargeGemmCutoff};
 }
 
 static std::optional<GPUMMAHeuristicSeeds>
@@ -276,6 +282,7 @@ getGemmHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth, bool scaled) {
          /*bestKTileCountPerSubgroup=*/4,
          /*bestKElementCountPerSubgroup=*/2 * kCacheLineSizeBits / inBitWidth});
   case GemmSize::LargeGemm:
+  case GemmSize::VeryLargeGemm:
     if (scaled) {
       return GPUMMAHeuristicSeeds(
           {/*bestSubgroupCountPerWorkgroup=*/8,
@@ -311,6 +318,7 @@ getConvolutionHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth) {
          /*bestKTileCountPerSubgroup=*/4,
          /*bestKElementCountPerSubgroup=*/2 * kCacheLineSizeBits / inBitWidth});
   case GemmSize::LargeGemm:
+  case GemmSize::VeryLargeGemm:
     // Favor more subgroups for convolution to help latency hiding from global
     // loads.
     return GPUMMAHeuristicSeeds(
@@ -414,6 +422,11 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
     // For matmuls with small arithmetic intensity, use small
     // bestMNTileCountPerSubgroup and large bestKTileCountPerSubgroup.
     problem.gemmSize = GemmSize::SmallGemm;
+  } else if (computeIntensity >= gemmCutoffs.veryLargeGemmCutoff) {
+    // For very large matmuls, prefer low-VGPR-pressure intrinsics (e.g.,
+    // 32x32x16 over 16x16x32) which provide higher compute throughput per
+    // register.
+    problem.gemmSize = GemmSize::VeryLargeGemm;
   } else if (computeIntensity >= gemmCutoffs.largeGemmCutoff) {
     // For matmuls with large arithmetic intensity, use large
     // bestMNTileCountPerSubgroup and small bestKTileCountPerSubgroup to

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -299,3 +299,20 @@ func.func @scaled_matmul_accumulate(
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=157184
+
+// -----
+
+// Large f16 matmul — compute-bound, so picks 32x32x16 (higher compute per
+// instruction, lower VGPR pressure than 16x16x32).
+func.func @matmul_f16_compute_bound(
+    %arg0: tensor<4096x4096xf16>,
+    %arg1: tensor<4096x4096xf16>,
+    %arg2: tensor<4096x4096xf32>) -> tensor<4096x4096xf32> {
+  // CHECK-LABEL: func.func @matmul_f16_compute_bound
+  // CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+  // CHECK:   lowering_config = #iree_gpu.lowering_config
+  // CHECK-SAME: mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<4096x4096xf16>, tensor<4096x4096xf16>)
+                      outs(%arg2 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+  return %0 : tensor<4096x4096xf32>
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -308,11 +308,11 @@ func.func @matmul_f16_compute_bound(
     %arg0: tensor<16384x16384xf16>,
     %arg1: tensor<16384x16384xf16>,
     %arg2: tensor<16384x16384xf32>) -> tensor<16384x16384xf32> {
-  // CHECK-LABEL: func.func @matmul_f16_compute_bound
-  // CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-  // CHECK:   lowering_config = #iree_gpu.lowering_config
-  // CHECK-SAME: mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>
   %0 = linalg.matmul ins(%arg0, %arg1 : tensor<16384x16384xf16>, tensor<16384x16384xf16>)
                       outs(%arg2 : tensor<16384x16384xf32>) -> tensor<16384x16384xf32>
   return %0 : tensor<16384x16384xf32>
 }
+// CHECK-LABEL: func.func @matmul_f16_compute_bound
+// CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK:   lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME: mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -302,17 +302,17 @@ func.func @scaled_matmul_accumulate(
 
 // -----
 
-// Large f16 matmul — compute-bound, so picks 32x32x16 (higher compute per
+// Very large f16 matmul — compute-bound, so picks 32x32x16 (higher compute per
 // instruction, lower VGPR pressure than 16x16x32).
 func.func @matmul_f16_compute_bound(
-    %arg0: tensor<4096x4096xf16>,
-    %arg1: tensor<4096x4096xf16>,
-    %arg2: tensor<4096x4096xf32>) -> tensor<4096x4096xf32> {
+    %arg0: tensor<16384x16384xf16>,
+    %arg1: tensor<16384x16384xf16>,
+    %arg2: tensor<16384x16384xf32>) -> tensor<16384x16384xf32> {
   // CHECK-LABEL: func.func @matmul_f16_compute_bound
   // CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
   // CHECK:   lowering_config = #iree_gpu.lowering_config
   // CHECK-SAME: mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>
-  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<4096x4096xf16>, tensor<4096x4096xf16>)
-                      outs(%arg2 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
-  return %0 : tensor<4096x4096xf32>
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<16384x16384xf16>, tensor<16384x16384xf16>)
+                      outs(%arg2 : tensor<16384x16384xf32>) -> tensor<16384x16384xf32>
+  return %0 : tensor<16384x16384xf32>
 }


### PR DESCRIPTION
* add a new category `VeryLargeGemms` for heuristic.
* in `VeryLargeGemms`, prefer intrinsics with higher compute throughput, and lower VGPR pressure from operand staging.
*  The cutoff is set at 22x the compute-memory ratio (perfTflops / memoryBandwidthTbps). On mi355x , this gives ~7000 compute intensity, corresponding to square matmuls around 10k-11k. This is empirical number determined by experiments done on mi355x.
* This change starts to beat the baseline around ~10.5k square matmul, and can do ~14% better for 16k square matmuls with minimal changes to the code. The number continues to grow with the size.
* Reuse heuristic seeds with `LargeGemms`, as the experiments did not show improvements over a dedicated seed.