### PR TITLE
[docs] Update python versions listed on the website

### DIFF
--- a/docs/website/docs/developers/debugging/integration-tests.md
+++ b/docs/website/docs/developers/debugging/integration-tests.md
@@ -41,7 +41,7 @@ E.g.,
 [ RUN      ] MobilenetV2Int8Test.test_compile_tflite
 I0401 17:27:04.084272 140182373025024 test_util.py:119] Setting up for IREE
 I0401 17:27:04.085064 140182373025024 binaries.py:218] Invoke IREE Pipeline:
-  /tmp/iree-experimental/iree-experimental.venv/lib/python3.9/site-packages/iree/tools/tflite/iree-import-tflite
+  /tmp/iree-experimental/iree-experimental.venv/lib/python3.11/site-packages/iree/tools/tflite/iree-import-tflite
     /tmp/iree-experimental/tflitehub/tmp/mobilenet_v2_int8_test.py/model.tflite
     --mlir-print-debuginfo
     --save-temp-tfl-input=/tmp/iree-experimental/tflitehub/tmp/mobilenet_v2_int8_test.py/tflite.mlir

--- a/docs/website/docs/developers/debugging/releases.md
+++ b/docs/website/docs/developers/debugging/releases.md
@@ -60,7 +60,7 @@ The default system Python is 2.x, so you must select one of the more modern
 ones:
 
 ```shell
-export PATH=/opt/python/cp39-cp39/bin:$PATH
+export PATH=/opt/python/cp310-cp310/bin:$PATH
 ```
 
 Build core installation:

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -42,6 +42,14 @@ To use IREE's Python bindings, you will first need to install
 [Python 3](https://www.python.org/downloads/) and
 [pip](https://pip.pypa.io/en/stable/installing/), as needed.
 
+???+ Info "Note - Python version compatibility"
+    IREE's release wheels use the
+    [Python Stable ABI (abi3)](https://docs.python.org/3/c-api/stable.html).
+    The `cp312-abi3` wheels are compatible with any standard (with GIL)
+    Python 3.12+ version. Separate `cp310` and `cp311` wheels are provided
+    for older supported versions. A free-threaded (`cp313t`) wheel is also
+    available for Python 3.13t (no GIL).
+
 ???+ Tip "Tip - Virtual environments"
     We recommend using virtual environments to manage python packages, such as
     through `venv`


### PR DESCRIPTION
Add a note on python 3.12+ support via abi3.

Fixes: https://github.com/iree-org/iree/issues/23646