### PR TITLE
[Codegen][GPU] Add explicit async markers for multi-buffered async load pipelining

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -91,7 +91,8 @@ def ROCDLPrefetchSharedMemoryPass :
           "to ROCDL targets because its effectiveness on non-AMD GPUs lacks testing and evaluation.";
   let dependentDialects = [
     "::mlir::affine::AffineDialect",
-    "amdgpu::AMDGPUDialect"
+    "amdgpu::AMDGPUDialect",
+    "ROCDL::ROCDLDialect"
   ];
   let options = [
     Option<"numStages", "num-stages", "unsigned",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
@@ -6,14 +6,11 @@
 
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
-#include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Support/LogicalResult.h"
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/IR/PatternMatch.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/BUILD.bazel
@@ -55,6 +55,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:MemRefUtils",
         "@llvm-project//mlir:NVGPUDialect",
+        "@llvm-project//mlir:ROCDLDialect",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:SideEffectInterfaces",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     MLIRMemRefTransforms
     MLIRMemRefUtils
     MLIRNVGPUDialect
+    MLIRROCDLDialect
     MLIRSCFDialect
     MLIRSCFTransforms
     MLIRSideEffectInterfaces

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1037,11 +1037,9 @@ static void insertAsyncCopyBarriers(RewriterBase &rewriter,
                                 std::prev(body->end()), state,
                                 /*multiBuffered=*/true);
 
-  // Epilogue reads from the last iteration's writes.
-  state.needBarrierBeforeRead = true;
-  Block::iterator epilogueStart = std::next(newForOp->getIterator());
-  insertBarriersInRange(rewriter, loc, epilogueStart, parentBlock->end(),
-                        state);
+  // Epilogue: barrier before reads is handled by insertEpilogueAsyncWait
+  // which places wait.asyncmark + barrier in the correct order (after the
+  // wait, ensuring all wavefronts' DMAs have completed before any reads).
 }
 
 /// Find the first operation with shared memory reads in a block range.
@@ -1109,9 +1107,11 @@ static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
 /// Inserts asyncmark and wait.asyncmark in the loop body.
 ///
 /// An asyncmark is placed after the last gather_to_lds to delineate the DMA
-/// group for this iteration. A wait.asyncmark is placed before the first
-/// shared memory read to maximize overlap between the wait and independent
-/// index computation that may precede the read.
+/// group for this iteration. A wait.asyncmark + barrier pair is placed before
+/// the first shared memory read: the wait ensures this wavefront's previous
+/// DMA group has completed, and the barrier synchronizes all wavefronts so
+/// that every wavefront's DMA writes to the shared buffer are visible before
+/// any wavefront reads from it.
 static void insertLoopBodyAsyncMarkers(RewriterBase &rewriter, Location loc,
                                        scf::ForOp forOp, int16_t waitCount) {
   Block *body = forOp.getBody();
@@ -1128,10 +1128,12 @@ static void insertLoopBodyAsyncMarkers(RewriterBase &rewriter, Location loc,
     rewriter.setInsertionPoint(&**firstRead);
     ROCDL::WaitAsyncmarkOp::create(rewriter, loc,
                                    rewriter.getI16IntegerAttr(waitCount));
+    gpu::BarrierOp::create(rewriter, loc, gpu::AddressSpace::Workgroup);
   }
 }
 
-/// Inserts wait.asyncmark in the epilogue to drain all in-flight DMA groups.
+/// Inserts wait.asyncmark + barrier in the epilogue to drain all in-flight DMA
+/// groups and synchronize all wavefronts before reading from shared memory.
 ///
 /// Placed before the first shared memory read rather than at the epilogue
 /// start to allow independent index computation to overlap with the wait.
@@ -1143,6 +1145,7 @@ static void insertEpilogueAsyncWait(RewriterBase &rewriter, Location loc,
     rewriter.setInsertionPoint(&**firstRead);
     ROCDL::WaitAsyncmarkOp::create(rewriter, loc,
                                    rewriter.getI16IntegerAttr(0));
+    gpu::BarrierOp::create(rewriter, loc, gpu::AddressSpace::Workgroup);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -1043,6 +1044,134 @@ static void insertAsyncCopyBarriers(RewriterBase &rewriter,
                         state);
 }
 
+/// Find the first operation with shared memory reads in a block range.
+static std::optional<Block::iterator> findFirstSharedRead(Block::iterator begin,
+                                                          Block::iterator end) {
+  for (auto it = begin; it != end; ++it) {
+    if (hasNestedSharedRead(&*it)) {
+      return it;
+    }
+  }
+  return std::nullopt;
+}
+
+/// Find the last gather_to_lds operation in a block range.
+static std::optional<Block::iterator> findLastGatherToLDS(Block::iterator begin,
+                                                          Block::iterator end) {
+  std::optional<Block::iterator> last;
+  for (auto it = begin; it != end; ++it) {
+    if (isa<amdgpu::GatherToLDSOp>(&*it)) {
+      last = it;
+    }
+  }
+  return last;
+}
+
+/// Sets the async flag on all gather_to_lds ops in the parent block so they
+/// lower to rocdl.load.async.to.lds instead of rocdl.load.to.lds.
+static void enableAsyncOnGatherOps(Block *parentBlock) {
+  parentBlock->walk(
+      [](amdgpu::GatherToLDSOp gatherOp) { gatherOp.setAsync(true); });
+}
+
+/// Inserts asyncmark ops in the prologue to delineate DMA groups.
+///
+/// The prologue contains (numStages - 1) unrolled iterations of DMA writes.
+/// Each iteration group gets one asyncmark after its last gather_to_lds.
+/// Groups are identified by evenly dividing the total prologue gather ops.
+static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
+                                     Block *parentBlock,
+                                     Block::iterator loopStart,
+                                     unsigned numStages) {
+  SmallVector<Operation *> prologueGathers;
+  for (auto it = parentBlock->begin(); it != loopStart; ++it) {
+    if (isa<amdgpu::GatherToLDSOp>(&*it)) {
+      prologueGathers.push_back(&*it);
+    }
+  }
+
+  if (prologueGathers.empty()) {
+    return;
+  }
+
+  unsigned numPrologueIters = numStages - 1;
+  unsigned opsPerGroup = prologueGathers.size() / numPrologueIters;
+  assert(opsPerGroup > 0 && "fewer gather ops than prologue iterations");
+
+  for (unsigned i = 0; i < prologueGathers.size(); i += opsPerGroup) {
+    unsigned lastInGroup =
+        std::min(i + opsPerGroup, (unsigned)prologueGathers.size()) - 1;
+    rewriter.setInsertionPointAfter(prologueGathers[lastInGroup]);
+    ROCDL::AsyncmarkOp::create(rewriter, loc);
+  }
+}
+
+/// Inserts asyncmark and wait.asyncmark in the loop body.
+///
+/// An asyncmark is placed after the last gather_to_lds to delineate the DMA
+/// group for this iteration. A wait.asyncmark is placed before the first
+/// shared memory read to maximize overlap between the wait and independent
+/// index computation that may precede the read.
+static void insertLoopBodyAsyncMarkers(RewriterBase &rewriter, Location loc,
+                                       scf::ForOp forOp, int16_t waitCount) {
+  Block *body = forOp.getBody();
+  auto bodyEnd = std::prev(body->end()); // exclude yield
+
+  auto lastGather = findLastGatherToLDS(body->begin(), bodyEnd);
+  if (lastGather) {
+    rewriter.setInsertionPointAfter(&**lastGather);
+    ROCDL::AsyncmarkOp::create(rewriter, loc);
+  }
+
+  auto firstRead = findFirstSharedRead(body->begin(), bodyEnd);
+  if (firstRead) {
+    rewriter.setInsertionPoint(&**firstRead);
+    ROCDL::WaitAsyncmarkOp::create(rewriter, loc,
+                                   rewriter.getI16IntegerAttr(waitCount));
+  }
+}
+
+/// Inserts wait.asyncmark in the epilogue to drain all in-flight DMA groups.
+///
+/// Placed before the first shared memory read rather than at the epilogue
+/// start to allow independent index computation to overlap with the wait.
+static void insertEpilogueAsyncWait(RewriterBase &rewriter, Location loc,
+                                    Block::iterator epilogueStart,
+                                    Block::iterator epilogueEnd) {
+  auto firstRead = findFirstSharedRead(epilogueStart, epilogueEnd);
+  if (firstRead) {
+    rewriter.setInsertionPoint(&**firstRead);
+    ROCDL::WaitAsyncmarkOp::create(rewriter, loc,
+                                   rewriter.getI16IntegerAttr(0));
+  }
+}
+
+/// Converts gather_to_lds ops to async mode and inserts explicit async markers
+/// for multi-buffered pipelining.
+///
+/// After pipelining with multi-buffering, the IR structure is:
+///   Prologue: gather_to_lds groups (one per prologue iteration, N-1 total)
+///   Loop body: gather_to_lds (new iteration) + ds_reads/compute (old
+///   iteration) Epilogue: ds_reads/compute (last iterations)
+///
+/// The wait count is (numStages - 1): with N-stage pipelining, after issuing a
+/// new DMA group we wait until only (N-1) groups are in flight, ensuring the
+/// oldest group's data is ready for reading.
+static void insertExplicitAsyncMarkers(RewriterBase &rewriter,
+                                       scf::ForOp newForOp,
+                                       unsigned numStages) {
+  Block *parentBlock = newForOp->getBlock();
+  Location loc = newForOp.getLoc();
+  int16_t waitCount = static_cast<int16_t>(numStages - 1);
+
+  enableAsyncOnGatherOps(parentBlock);
+  insertPrologueAsyncMarks(rewriter, loc, parentBlock, newForOp->getIterator(),
+                           numStages);
+  insertLoopBodyAsyncMarkers(rewriter, loc, newForOp, waitCount);
+  insertEpilogueAsyncWait(rewriter, loc, std::next(newForOp->getIterator()),
+                          parentBlock->end());
+}
+
 // Dispatches to the appropriate barrier insertion strategy based on mode.
 static void insertPipelineBarriers(RewriterBase &rewriter, scf::ForOp newForOp,
                                    PipelineMode mode) {
@@ -1175,6 +1304,15 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
 
   // Insert barriers using the appropriate strategy for each mode.
   insertPipelineBarriers(rewriter, newForOp, mode);
+
+  // For async copy mode, convert gather_to_lds to async and insert explicit
+  // async markers (asyncmark + wait.asyncmark). This replaces the backend's
+  // alias-analysis-based vmcnt insertion with precise explicit synchronization,
+  // allowing DMA writes to a new buffer slot to overlap with ds_reads from the
+  // previous slot.
+  if (mode == PipelineMode::AsyncCopy) {
+    insertExplicitAsyncMarkers(rewriter, newForOp, numStages);
+  }
 
   return newForOp;
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1121,14 +1121,13 @@ static void insertLoopBodyAsyncMarkers(RewriterBase &rewriter, Location loc,
   Block *body = forOp.getBody();
   auto bodyEnd = std::prev(body->end()); // exclude yield
 
-  if (auto *lastGather = findLastGatherToLDS(body->begin(), bodyEnd)) {
+  if (Operation *lastGather = findLastGatherToLDS(body->begin(), bodyEnd)) {
     rewriter.setInsertionPointAfter(lastGather);
     ROCDL::AsyncmarkOp::create(rewriter, loc);
   }
 
-  if (auto *readOp = findFirstSharedRead(body->begin(), bodyEnd)) {
-    Operation *insertPt = readOp;
-    if (auto *prev = insertPt->getPrevNode();
+  if (Operation *insertPt = findFirstSharedRead(body->begin(), bodyEnd)) {
+    if (Operation *prev = insertPt->getPrevNode();
         prev && isa<gpu::BarrierOp>(prev)) {
       insertPt = prev;
     }
@@ -1147,9 +1146,8 @@ static void insertLoopBodyAsyncMarkers(RewriterBase &rewriter, Location loc,
 static void insertEpilogueAsyncWait(RewriterBase &rewriter, Location loc,
                                     Block::iterator epilogueStart,
                                     Block::iterator epilogueEnd) {
-  if (auto *readOp = findFirstSharedRead(epilogueStart, epilogueEnd)) {
-    Operation *insertPt = readOp;
-    if (auto *prev = insertPt->getPrevNode();
+  if (Operation *insertPt = findFirstSharedRead(epilogueStart, epilogueEnd)) {
+    if (Operation *prev = insertPt->getPrevNode();
         prev && isa<gpu::BarrierOp>(prev)) {
       insertPt = prev;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -920,7 +920,7 @@ struct SharedBarrierState {
 static SharedBarrierState
 insertBarriersInRange(RewriterBase &rewriter, Location loc,
                       Block::iterator begin, Block::iterator end,
-                      SharedBarrierState state, bool multiBuffered = false) {
+                      SharedBarrierState state, bool addSchedBarrier = false) {
   for (auto it = begin; it != end; ++it) {
     Operation &op = *it;
     bool hasSharedRead = hasNestedSharedRead(&op);
@@ -935,17 +935,19 @@ insertBarriersInRange(RewriterBase &rewriter, Location loc,
     if (hasSharedWrite && state.needBarrierBeforeWrite) {
       rewriter.setInsertionPoint(&op);
       gpu::BarrierOp::create(rewriter, loc, gpu::AddressSpace::Workgroup);
-      amdgpu::SchedBarrierOp::create(
-          rewriter, loc,
-          amdgpu::sched_barrier_opt_enumAttr::get(
-              rewriter.getContext(), amdgpu::sched_barrier_opt_enum::none));
+      if (addSchedBarrier) {
+        amdgpu::SchedBarrierOp::create(
+            rewriter, loc,
+            amdgpu::sched_barrier_opt_enumAttr::get(
+                rewriter.getContext(), amdgpu::sched_barrier_opt_enum::none));
+      }
       state.needBarrierBeforeWrite = false;
     }
 
     if (hasSharedRead) {
       state.needBarrierBeforeWrite = true;
     }
-    if (hasSharedWrite && !multiBuffered) {
+    if (hasSharedWrite) {
       state.needBarrierBeforeRead = true;
     }
   }
@@ -998,7 +1000,8 @@ static void insertStreamCopyBarriers(RewriterBase &rewriter,
   // Loop body (exclude terminator).
   Block *body = newForOp.getBody();
   state = insertBarriersInRange(rewriter, loc, body->begin(),
-                                std::prev(body->end()), state);
+                                std::prev(body->end()), state,
+                                /*addSchedBarrier=*/true);
 
   // Epilogue (operations after the loop).
   Block::iterator epilogueStart = std::next(newForOp->getIterator());
@@ -1030,36 +1033,38 @@ static void insertAsyncCopyBarriers(RewriterBase &rewriter,
   // iteration synchronization.
   state.needBarrierBeforeWrite = true;
 
-  // Loop body: multiBuffered=true because gather_to_lds writes and
-  // subsequent reads target different LDS slots (no write→read barrier).
+  // Loop body: we need barriers for cross-wavefront synchronization
   Block *body = newForOp.getBody();
   state = insertBarriersInRange(rewriter, loc, body->begin(),
-                                std::prev(body->end()), state,
-                                /*multiBuffered=*/true);
+                                std::prev(body->end()), state);
 
-  // Epilogue: barrier before reads is handled by insertEpilogueAsyncWait
-  // which places wait.asyncmark + barrier in the correct order (after the
-  // wait, ensuring all wavefronts' DMAs have completed before any reads).
+  // Epilogue: the loop body's last DMA writes need to be synchronized before
+  // the epilogue reads. Force needBarrierBeforeRead since the epilogue reads
+  // data from a different iteration than the loop body's last reads.
+  state.needBarrierBeforeRead = true;
+  Block::iterator epilogueStart = std::next(newForOp->getIterator());
+  insertBarriersInRange(rewriter, loc, epilogueStart, parentBlock->end(),
+                        state);
 }
 
 /// Find the first operation with shared memory reads in a block range.
-static std::optional<Block::iterator> findFirstSharedRead(Block::iterator begin,
-                                                          Block::iterator end) {
+static Operation *findFirstSharedRead(Block::iterator begin,
+                                      Block::iterator end) {
   for (auto it = begin; it != end; ++it) {
     if (hasNestedSharedRead(&*it)) {
-      return it;
+      return &*it;
     }
   }
-  return std::nullopt;
+  return nullptr;
 }
 
 /// Find the last gather_to_lds operation in a block range.
-static std::optional<Block::iterator> findLastGatherToLDS(Block::iterator begin,
-                                                          Block::iterator end) {
-  std::optional<Block::iterator> last;
+static Operation *findLastGatherToLDS(Block::iterator begin,
+                                      Block::iterator end) {
+  Operation *last = nullptr;
   for (auto it = begin; it != end; ++it) {
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
-      last = it;
+      last = &*it;
     }
   }
   return last;
@@ -1107,45 +1112,50 @@ static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
 /// Inserts asyncmark and wait.asyncmark in the loop body.
 ///
 /// An asyncmark is placed after the last gather_to_lds to delineate the DMA
-/// group for this iteration. A wait.asyncmark + barrier pair is placed before
-/// the first shared memory read: the wait ensures this wavefront's previous
-/// DMA group has completed, and the barrier synchronizes all wavefronts so
-/// that every wavefront's DMA writes to the shared buffer are visible before
-/// any wavefront reads from it.
+/// group for this iteration. A wait.asyncmark is placed before the barrier
+/// that precedes the first shared memory read: the wait ensures this
+/// wavefront's previous DMA group has completed, and the existing barrier
+/// (inserted by insertAsyncCopyBarriers) synchronizes all wavefronts.
 static void insertLoopBodyAsyncMarkers(RewriterBase &rewriter, Location loc,
                                        scf::ForOp forOp, int16_t waitCount) {
   Block *body = forOp.getBody();
   auto bodyEnd = std::prev(body->end()); // exclude yield
 
-  auto lastGather = findLastGatherToLDS(body->begin(), bodyEnd);
-  if (lastGather) {
-    rewriter.setInsertionPointAfter(&**lastGather);
+  if (auto *lastGather = findLastGatherToLDS(body->begin(), bodyEnd)) {
+    rewriter.setInsertionPointAfter(lastGather);
     ROCDL::AsyncmarkOp::create(rewriter, loc);
   }
 
-  auto firstRead = findFirstSharedRead(body->begin(), bodyEnd);
-  if (firstRead) {
-    rewriter.setInsertionPoint(&**firstRead);
+  if (auto *readOp = findFirstSharedRead(body->begin(), bodyEnd)) {
+    Operation *insertPt = readOp;
+    if (auto *prev = insertPt->getPrevNode();
+        prev && isa<gpu::BarrierOp>(prev)) {
+      insertPt = prev;
+    }
+    rewriter.setInsertionPoint(insertPt);
     ROCDL::WaitAsyncmarkOp::create(rewriter, loc,
                                    rewriter.getI16IntegerAttr(waitCount));
-    gpu::BarrierOp::create(rewriter, loc, gpu::AddressSpace::Workgroup);
   }
 }
 
-/// Inserts wait.asyncmark + barrier in the epilogue to drain all in-flight DMA
-/// groups and synchronize all wavefronts before reading from shared memory.
+/// Inserts wait.asyncmark in the epilogue to drain all in-flight DMA groups.
 ///
-/// Placed before the first shared memory read rather than at the epilogue
-/// start to allow independent index computation to overlap with the wait.
+/// Placed before the barrier that precedes the first shared memory read.
+/// The barrier was already inserted by insertAsyncCopyBarriers; this just
+/// adds the wait to ensure DMA completion before the barrier synchronizes
+/// wavefronts.
 static void insertEpilogueAsyncWait(RewriterBase &rewriter, Location loc,
                                     Block::iterator epilogueStart,
                                     Block::iterator epilogueEnd) {
-  auto firstRead = findFirstSharedRead(epilogueStart, epilogueEnd);
-  if (firstRead) {
-    rewriter.setInsertionPoint(&**firstRead);
+  if (auto *readOp = findFirstSharedRead(epilogueStart, epilogueEnd)) {
+    Operation *insertPt = readOp;
+    if (auto *prev = insertPt->getPrevNode();
+        prev && isa<gpu::BarrierOp>(prev)) {
+      insertPt = prev;
+    }
+    rewriter.setInsertionPoint(insertPt);
     ROCDL::WaitAsyncmarkOp::create(rewriter, loc,
                                    rewriter.getI16IntegerAttr(0));
-    gpu::BarrierOp::create(rewriter, loc, gpu::AddressSpace::Workgroup);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1061,13 +1061,14 @@ static Operation *findFirstSharedRead(Block::iterator begin,
 /// Find the last gather_to_lds operation in a block range.
 static Operation *findLastGatherToLDS(Block::iterator begin,
                                       Block::iterator end) {
-  Operation *last = nullptr;
-  for (auto it = begin; it != end; ++it) {
+  auto rbegin = std::make_reverse_iterator(end);
+  auto rend = std::make_reverse_iterator(begin);
+  for (auto it = rbegin; it != rend; ++it) {
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
-      last = &*it;
+      return &*it;
     }
   }
-  return last;
+  return nullptr;
 }
 
 /// Sets the async flag on all gather_to_lds ops in the parent block so they
@@ -1101,9 +1102,8 @@ static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
   unsigned opsPerGroup = prologueGathers.size() / numPrologueIters;
   assert(opsPerGroup > 0 && "fewer gather ops than prologue iterations");
 
-  for (unsigned i = 0; i < prologueGathers.size(); i += opsPerGroup) {
-    unsigned lastInGroup =
-        std::min(i + opsPerGroup, (unsigned)prologueGathers.size()) - 1;
+  for (unsigned i = 0, e = prologueGathers.size(); i < e; i += opsPerGroup) {
+    unsigned lastInGroup = std::min(i + opsPerGroup, e) - 1;
     rewriter.setInsertionPointAfter(prologueGathers[lastInGroup]);
     ROCDL::AsyncmarkOp::create(rewriter, loc);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -423,17 +423,25 @@ func.func @prefetch_gather_to_lds_two_operands(
   %A_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
   %B_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
 
-  // 2-stage: 1 prologue iteration
-  // CHECK-COUNT-2: amdgpu.gather_to_lds
-  // 3-stage: 2 prologue iterations (N-1 for N stages)
-  // CHECK-3STAGE-COUNT-4: amdgpu.gather_to_lds
+  // 2-stage: 1 prologue iteration with async markers
+  // CHECK-COUNT-2: amdgpu.gather_to_lds async
+  // CHECK: rocdl.asyncmark
+  // 3-stage: 2 prologue iterations (N-1 for N stages), each with asyncmark
+  // CHECK-3STAGE-COUNT-2: amdgpu.gather_to_lds async
+  // CHECK-3STAGE: rocdl.asyncmark
+  // CHECK-3STAGE-COUNT-2: amdgpu.gather_to_lds async
+  // CHECK-3STAGE: rocdl.asyncmark
   // CHECK: scf.for
   // CHECK-3STAGE: scf.for
   %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
     // CHECK: gpu.barrier
+    // CHECK-COUNT-2: amdgpu.gather_to_lds async
+    // CHECK: rocdl.asyncmark
+    // CHECK: rocdl.wait.asyncmark 1
     // CHECK-3STAGE: gpu.barrier
-    // CHECK-COUNT-2: amdgpu.gather_to_lds
-    // CHECK-3STAGE-COUNT-2: amdgpu.gather_to_lds
+    // CHECK-3STAGE-COUNT-2: amdgpu.gather_to_lds async
+    // CHECK-3STAGE: rocdl.asyncmark
+    // CHECK-3STAGE: rocdl.wait.asyncmark 2
     amdgpu.gather_to_lds %A_global[%c0, %k], %A_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
     amdgpu.gather_to_lds %B_global[%k, %c0], %B_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
 
@@ -452,10 +460,14 @@ func.func @prefetch_gather_to_lds_two_operands(
     // CHECK-3STAGE: scf.yield
     scf.yield %sum : vector<1xf32>
   }
+  // 2-stage epilogue: wait for all async groups, then compute
   // CHECK: gpu.barrier
+  // CHECK: rocdl.wait.asyncmark 0
   // CHECK: vector.transfer_read
   // CHECK: arith.mulf
+  // 3-stage epilogue: wait for pending groups, then compute
   // CHECK-3STAGE: gpu.barrier
+  // CHECK-3STAGE: rocdl.wait.asyncmark 0
   // CHECK-3STAGE: vector.transfer_read
   // CHECK-3STAGE: arith.mulf
   // CHECK-3STAGE: vector.transfer_read
@@ -486,6 +498,8 @@ func.func @gather_to_lds_inside_if_not_multibuffered(
     // CHECK: scf.if
     %in_bounds = arith.cmpi slt, %k, %bound : index
     // CHECK: amdgpu.gather_to_lds
+    // CHECK-NOT: rocdl.asyncmark
+    // CHECK-NOT: rocdl.wait.asyncmark
     scf.if %in_bounds {
       amdgpu.gather_to_lds %global[%c0, %k], %lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
     }
@@ -559,6 +573,8 @@ func.func @gather_to_lds_mixed_with_stream_copy(
 // CHECK-LABEL: @gather_to_lds_subview_escape_no_multibuffer
 // CHECK: memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
 // CHECK-NOT: memref<2x1xf32
+// CHECK-NOT: rocdl.asyncmark
+// CHECK-NOT: rocdl.wait.asyncmark
 func.func @gather_to_lds_subview_escape_no_multibuffer(
     %global: memref<128x128xf32>,
     %output: memref<128xf32>) {
@@ -631,5 +647,52 @@ func.func @prefetch_transpose_load(%arg0: memref<128xf16>) {
   // CHECK:      arith.addf
   // CHECK:      vector.transfer_write {{.*}}, %[[GLOBAL]]
   vector.transfer_write %0, %arg0[%c0] {in_bounds = [true]} : vector<4xf16>, memref<128xf16>
+  return
+}
+
+// -----
+
+// Test async copy pipelining inside a nested loop.
+// Verifies that prologue barriers are inserted for correctness when the
+// pipelined loop is inside an outer loop (WAR hazard from previous outer
+// iteration's epilogue read).
+
+// CHECK-LABEL: @gather_to_lds_nested_loop_async
+func.func @gather_to_lds_nested_loop_async(
+    %global: memref<128x128xf32>,
+    %output: memref<128xf32>) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+
+  %lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+
+  // CHECK: scf.for
+  scf.for %outer = %c0 to %c4 step %c1 {
+    // Nested loop: prologue gets barrier before first gather write
+    // CHECK: gpu.barrier
+    // CHECK: amdgpu.gather_to_lds async
+    // CHECK: rocdl.asyncmark
+    // CHECK: scf.for
+    %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
+      // CHECK: gpu.barrier
+      // CHECK: amdgpu.gather_to_lds async
+      // CHECK: rocdl.asyncmark
+      // CHECK: rocdl.wait.asyncmark 1
+      amdgpu.gather_to_lds %global[%c0, %k], %lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+      // CHECK: vector.transfer_read
+      %val = vector.transfer_read %lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+      %sum = arith.addf %val, %acc : vector<1xf32>
+      scf.yield %sum : vector<1xf32>
+    }
+    // Epilogue: barrier + wait for all, then read
+    // CHECK: gpu.barrier
+    // CHECK: rocdl.wait.asyncmark 0
+    // CHECK: vector.transfer_read
+    vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  }
   return
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -438,10 +438,12 @@ func.func @prefetch_gather_to_lds_two_operands(
     // CHECK-COUNT-2: amdgpu.gather_to_lds async
     // CHECK: rocdl.asyncmark
     // CHECK: rocdl.wait.asyncmark 1
+    // CHECK: gpu.barrier
     // CHECK-3STAGE: gpu.barrier
     // CHECK-3STAGE-COUNT-2: amdgpu.gather_to_lds async
     // CHECK-3STAGE: rocdl.asyncmark
     // CHECK-3STAGE: rocdl.wait.asyncmark 2
+    // CHECK-3STAGE: gpu.barrier
     amdgpu.gather_to_lds %A_global[%c0, %k], %A_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
     amdgpu.gather_to_lds %B_global[%k, %c0], %B_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
 
@@ -460,14 +462,14 @@ func.func @prefetch_gather_to_lds_two_operands(
     // CHECK-3STAGE: scf.yield
     scf.yield %sum : vector<1xf32>
   }
-  // 2-stage epilogue: wait for all async groups, then compute
-  // CHECK: gpu.barrier
+  // 2-stage epilogue: wait for all async groups, barrier, then compute
   // CHECK: rocdl.wait.asyncmark 0
+  // CHECK: gpu.barrier
   // CHECK: vector.transfer_read
   // CHECK: arith.mulf
-  // 3-stage epilogue: wait for pending groups, then compute
-  // CHECK-3STAGE: gpu.barrier
+  // 3-stage epilogue: wait for pending groups, barrier, then compute
   // CHECK-3STAGE: rocdl.wait.asyncmark 0
+  // CHECK-3STAGE: gpu.barrier
   // CHECK-3STAGE: vector.transfer_read
   // CHECK-3STAGE: arith.mulf
   // CHECK-3STAGE: vector.transfer_read
@@ -682,15 +684,16 @@ func.func @gather_to_lds_nested_loop_async(
       // CHECK: amdgpu.gather_to_lds async
       // CHECK: rocdl.asyncmark
       // CHECK: rocdl.wait.asyncmark 1
+      // CHECK: gpu.barrier
       amdgpu.gather_to_lds %global[%c0, %k], %lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
       // CHECK: vector.transfer_read
       %val = vector.transfer_read %lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
       %sum = arith.addf %val, %acc : vector<1xf32>
       scf.yield %sum : vector<1xf32>
     }
-    // Epilogue: barrier + wait for all, then read
-    // CHECK: gpu.barrier
+    // Epilogue: wait for all, barrier, then read
     // CHECK: rocdl.wait.asyncmark 0
+    // CHECK: gpu.barrier
     // CHECK: vector.transfer_read
     vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
   }


### PR DESCRIPTION
After pipelining and multi-buffering, insert explicit `rocdl.asyncmark` / `rocdl.wait.asyncmark` operations to replace the LLVM backend's conservative `vmcnt(0)` inference with precise per-group synchronization. This allows DMA writes to a new buffer slot to overlap with `ds_read` from the previous slot.

### Algorithm

`insertExplicitAsyncMarkers` runs after pipelining has produced the prologue/loop/epilogue structure. It performs four steps:

1. **Mark all `gather_to_lds` as async** — walks the entire parent block and sets the `async` flag on every `gather_to_lds` op. This changes their lowering target from `rocdl.load.to.lds` (synchronous, tracked by `vmcnt`) to `rocdl.load.async.to.lds`, preventing the backend from inserting conservative `vmcnt(0)` waits.

2. **Prologue: insert `asyncmark` per iteration group** — the prologue has N-1 unrolled iterations of DMA writes (for N-stage pipelining). The total prologue `gather_to_lds` ops are evenly divided into N-1 groups, and one `rocdl.asyncmark` is inserted after the last op of each group.

3. **Loop body: insert `asyncmark` + `wait.asyncmark`** — a `rocdl.asyncmark` is placed after the last `gather_to_lds` to delineate this iteration's DMA group. A `rocdl.wait.asyncmark N-1` is placed before the first shared memory read (`ds_read`). Placement before the read (rather than immediately after the asyncmark) maximizes the overlap window — any independent index computation between the asyncmark and the read can execute while the wait stalls. The wait count N-1 means "block until at most N-1 groups are in flight", ensuring the buffer slot being read belongs to a completed group.

4. **Epilogue: insert `wait.asyncmark 0`** — placed before the first shared memory read in the epilogue. The count 0 drains all remaining in-flight groups since no more DMA writes follow.

### Example (2-stage)

```
// Prologue
gather_to_lds async ...    // DMA group 0
gather_to_lds async ...
rocdl.asyncmark            // end group 0

// Loop
scf.for {
  gpu.barrier
  gather_to_lds async ...  // DMA group N+1
  gather_to_lds async ...
  rocdl.asyncmark          // end group N+1
  rocdl.wait.asyncmark 1   // wait until ≤1 group in flight → group N done
  gpu.barrier
  ds_read ...              // safe to read group N's buffer slot
  mfma ...
}

// Epilogue
rocdl.wait.asyncmark 0     // drain all
gpu.barrier
ds_read ...
mfma ...
```

### Results

**vmcnt**: Zero `vmcnt(0)` in the hot loop. The backend emits `vmcnt(4)` between DMA writes and `ds_read`, allowing proper overlap.

Size | Pipelined (stages=2) | No Pipeline (stages=0) | Speedup
-- | -- | -- | --
1024x1024x1024 | 0.135 ms | 0.131 ms | ~1.0x
2048x2048x2048 | 0.248 ms | 0.306 ms | 1.23x
4096x4096x4096 | 1.24 ms | 1.29 ms | 1.04x
8192x8192x8192 | 9.35 ms | 10.3 ms | 1.10x
