### PR TITLE
[GPU][Codegen] Support unique per-lane load option when prod(threads) < subgroupsize

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -908,7 +908,9 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     ArrayRef<int64_t> permutation, MMASingleSubgroupLayout subgroupLayout,
     SmallVectorImpl<OpFoldResult> &canonicalOffsets,
     SmallVectorImpl<OpFoldResult> &canonicalSizes,
-    SmallVectorImpl<OpFoldResult> &canonicalStrides) {
+    SmallVectorImpl<OpFoldResult> &canonicalStrides,
+    int64_t broadcastFactor = 1) {
+  assert(broadcastFactor >= 1 && "broadcast factor must be at least 1");
   SmallVector<int64_t> rankReducedShape;
 
   for (auto [outer, thread, element] :
@@ -946,6 +948,44 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
   SmallVector<Value> hintedSplitLaneId = createTransposeLoadIndexHint(
       builder, loc, splitLaneId.getResults(), vtidBasis);
 
+  // Find the unique element dimension eligible for lane differentiation:
+  // exactly one dimension with element[dim] > 1 and divisible by
+  // broadcastFactor.
+  std::optional<size_t> splitDim;
+  if (broadcastFactor > 1) {
+    for (auto [dimIdx, element] : llvm::enumerate(subgroupLayout.element)) {
+      if (element > 1 && element % broadcastFactor == 0) {
+        if (splitDim) {
+          splitDim = std::nullopt;
+          break;
+        }
+        splitDim = dimIdx;
+      }
+    }
+  }
+
+  // Build broadcastIndex from unused delinearize results. Unused results
+  // (not mapped by dimToVtid) represent broadcast lanes that see duplicate
+  // data. When a splitDim exists, we use the single unused component as an
+  // index in [0, broadcastFactor) to differentiate those lanes.
+  Value broadcastIndex;
+  if (splitDim) {
+    llvm::SmallDenseSet<size_t, 4> usedResults(dimToVtid.begin(),
+                                               dimToVtid.end());
+    // Find the single unused delinearize result representing broadcast lanes.
+    std::optional<size_t> unusedResultIdx;
+    for (size_t i = 1, e = vtidBasis.size(); i <= e; ++i) {
+      if (!usedResults.contains(i)) {
+        assert(!unusedResultIdx && "expected exactly one unused basis entry");
+        unusedResultIdx = i;
+      }
+    }
+    assert(unusedResultIdx && "expected one unused basis entry for broadcast");
+    assert(vtidBasis[*unusedResultIdx - 1] == broadcastFactor &&
+           "unused basis size must equal broadcast factor");
+    broadcastIndex = splitLaneId.getResult(*unusedResultIdx);
+  }
+
   // Each thread grabs `element` contiguous data, so the vtid needs to be
   // multiplied by `element` to get the next bunch of data.
   // vtid: virtual thread id
@@ -955,11 +995,23 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
   // Instead of computing those maps, we use one big `delinearize` expression
   // in order to prevent unwanted "simplifications" on affine maps that
   // worsen the generated code quality.
-  for (auto [splitResultIdx, element] :
-       llvm::zip_equal(dimToVtid, subgroupLayout.element)) {
+  //
+  // When broadcastFactor > 1, the splitDim offset also incorporates
+  // broadcastIndex so each broadcast lane gets a disjoint slice instead.
+  for (auto [dimIdx, vtidAndElement] :
+       llvm::enumerate(llvm::zip_equal(dimToVtid, subgroupLayout.element))) {
+    auto [splitResultIdx, element] = vtidAndElement;
     Value vtid = hintedSplitLaneId[splitResultIdx];
     int64_t vtidLen = vtidBasis[splitResultIdx - 1];
-    if (element != 1) {
+
+    if (splitDim && dimIdx == *splitDim) {
+      // offset = vtid * element + broadcastIndex * perLaneElement.
+      int64_t perLaneElement = element / broadcastFactor;
+      vtid = affine::AffineLinearizeIndexOp::create(
+          builder, loc, ValueRange{vtid, broadcastIndex, cZero},
+          ArrayRef<int64_t>{vtidLen, broadcastFactor, perLaneElement},
+          /*disjoint=*/true);
+    } else if (element != 1) {
       vtid = affine::AffineLinearizeIndexOp::create(
           builder, loc, ValueRange{vtid, cZero},
           ArrayRef<int64_t>{vtidLen, element},
@@ -968,15 +1020,20 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     vtids.push_back(vtid);
   }
 
-  int64_t idx = 0;
-  for (auto [element, outer] :
-       llvm::zip_equal(subgroupLayout.element, subgroupLayout.outer)) {
+  int64_t vtidIdx = 0;
+  for (auto [dimIdx, elementAndOuter] : llvm::enumerate(
+           llvm::zip_equal(subgroupLayout.element, subgroupLayout.outer))) {
+    auto [element, outer] = elementAndOuter;
+    int64_t perLaneElement = element;
+    if (splitDim && dimIdx == *splitDim) {
+      perLaneElement = element / broadcastFactor;
+    }
     if (outer != 1) {
       canonicalSizes.push_back(builder.getIndexAttr(outer));
       canonicalOffsets.push_back(zero);
     }
-    canonicalSizes.push_back(builder.getIndexAttr(element));
-    canonicalOffsets.push_back(vtids[idx++]);
+    canonicalSizes.push_back(builder.getIndexAttr(perLaneElement));
+    canonicalOffsets.push_back(vtids[vtidIdx++]);
   }
   canonicalOffsets.assign(applyPermutation(canonicalOffsets, permutation));
   canonicalSizes.assign(applyPermutation(canonicalSizes, permutation));

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -909,8 +909,9 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     SmallVectorImpl<OpFoldResult> &canonicalOffsets,
     SmallVectorImpl<OpFoldResult> &canonicalSizes,
     SmallVectorImpl<OpFoldResult> &canonicalStrides,
-    int64_t broadcastFactor = 1) {
-  assert(broadcastFactor >= 1 && "broadcast factor must be at least 1");
+    int64_t physicalLanesPerThread = 1) {
+  assert(physicalLanesPerThread >= 1 &&
+         "physicalLanesPerThread must be at least 1");
   SmallVector<int64_t> rankReducedShape;
 
   for (auto [outer, thread, element] :
@@ -950,11 +951,11 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
 
   // Find the unique element dimension eligible for lane differentiation:
   // exactly one dimension with element[dim] > 1 and divisible by
-  // broadcastFactor.
+  // physicalLanesPerThread.
   std::optional<size_t> splitDim;
-  if (broadcastFactor > 1) {
+  if (physicalLanesPerThread > 1) {
     for (auto [dimIdx, element] : llvm::enumerate(subgroupLayout.element)) {
-      if (element > 1 && element % broadcastFactor == 0) {
+      if (element > 1 && element % physicalLanesPerThread == 0) {
         if (splitDim) {
           splitDim = std::nullopt;
           break;
@@ -964,15 +965,15 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     }
   }
 
-  // Build broadcastIndex from unused delinearize results. Unused results
-  // (not mapped by dimToVtid) represent broadcast lanes that see duplicate
+  // Build laneGroupIndex from unused delinearize results. Unused results
+  // (not mapped by dimToVtid) represent grouped lanes that see duplicate
   // data. When a splitDim exists, we use the single unused component as an
-  // index in [0, broadcastFactor) to differentiate those lanes.
-  Value broadcastIndex;
+  // index in [0, physicalLanesPerThread) to differentiate those lanes.
+  Value laneGroupIndex;
   if (splitDim) {
     llvm::SmallDenseSet<size_t, 4> usedResults(dimToVtid.begin(),
                                                dimToVtid.end());
-    // Find the single unused delinearize result representing broadcast lanes.
+    // Find the single unused delinearize result representing grouped lanes.
     std::optional<size_t> unusedResultIdx;
     for (size_t i = 1, e = vtidBasis.size(); i <= e; ++i) {
       if (!usedResults.contains(i)) {
@@ -980,10 +981,10 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
         unusedResultIdx = i;
       }
     }
-    assert(unusedResultIdx && "expected one unused basis entry for broadcast");
-    assert(vtidBasis[*unusedResultIdx - 1] == broadcastFactor &&
-           "unused basis size must equal broadcast factor");
-    broadcastIndex = splitLaneId.getResult(*unusedResultIdx);
+    assert(unusedResultIdx && "expected one unused basis entry for lane group");
+    assert(vtidBasis[*unusedResultIdx - 1] == physicalLanesPerThread &&
+           "unused basis size must equal physicalLanesPerThread");
+    laneGroupIndex = splitLaneId.getResult(*unusedResultIdx);
   }
 
   // Each thread grabs `element` contiguous data, so the vtid needs to be
@@ -996,8 +997,8 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
   // in order to prevent unwanted "simplifications" on affine maps that
   // worsen the generated code quality.
   //
-  // When broadcastFactor > 1, the splitDim offset also incorporates
-  // broadcastIndex so each broadcast lane gets a disjoint slice instead.
+  // When physicalLanesPerThread > 1, the splitDim offset also incorporates
+  // laneGroupIndex so each grouped lane gets a disjoint slice instead.
   for (auto [dimIdx, vtidAndElement] :
        llvm::enumerate(llvm::zip_equal(dimToVtid, subgroupLayout.element))) {
     auto [splitResultIdx, element] = vtidAndElement;
@@ -1005,11 +1006,11 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     int64_t vtidLen = vtidBasis[splitResultIdx - 1];
 
     if (splitDim && dimIdx == *splitDim) {
-      // offset = vtid * element + broadcastIndex * perLaneElement.
-      int64_t perLaneElement = element / broadcastFactor;
+      // offset = vtid * element + laneGroupIndex * perLaneElement.
+      int64_t perLaneElement = element / physicalLanesPerThread;
       vtid = affine::AffineLinearizeIndexOp::create(
-          builder, loc, ValueRange{vtid, broadcastIndex, cZero},
-          ArrayRef<int64_t>{vtidLen, broadcastFactor, perLaneElement},
+          builder, loc, ValueRange{vtid, laneGroupIndex, cZero},
+          ArrayRef<int64_t>{vtidLen, physicalLanesPerThread, perLaneElement},
           /*disjoint=*/true);
     } else if (element != 1) {
       vtid = affine::AffineLinearizeIndexOp::create(
@@ -1026,7 +1027,7 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     auto [element, outer] = elementAndOuter;
     int64_t perLaneElement = element;
     if (splitDim && dimIdx == *splitDim) {
-      perLaneElement = element / broadcastFactor;
+      perLaneElement = element / physicalLanesPerThread;
     }
     if (outer != 1) {
       canonicalSizes.push_back(builder.getIndexAttr(outer));

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -74,7 +74,9 @@ namespace mlir::iree_compiler::IREE::GPU {
 //    almost always equal to subgroup size. If not, then it is a strict divisor
 //    of subgroup size and that means that multiple threads get the exact same
 //    data, i.e., there is an implied broadcasting, as will be seen in the
-//    modulo (t % thread [0]) below.
+//    modulo (t % thread [0]) below. Callers may opt to split an element
+//    dimension by this factor to give each broadcast lane distinct data;
+//    see broadcastFactor in populateCanonicalOffsetsSizesAndStrides.
 //
 // Detailed semantics: case of semantic rank 1
 // -------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -70,13 +70,15 @@ namespace mlir::iree_compiler::IREE::GPU {
 // 2. The product of all the outer[i] times all the element[i] equals the
 //    length of the vector operand to the intrinsic. It is the number of
 //    elements that one intrinsic consumes on one thread.
-// 3. The product of all the thread[i] is a divisor of subgroup size. It is
-//    almost always equal to subgroup size. If not, then it is a strict divisor
-//    of subgroup size and that means that multiple threads get the exact same
-//    data, i.e., there is an implied broadcasting, as will be seen in the
-//    modulo (t % thread [0]) below. Callers may opt to split an element
-//    dimension by this factor to give each broadcast lane distinct data;
-//    see broadcastFactor in populateCanonicalOffsetsSizesAndStrides.
+// 3. The product of all the thread[i] is a divisor of subgroup size. Let
+//    physicalLanesPerThread = subgroupSize / product(thread[i]). It is
+//    almost always 1. If not, then it is greater than 1 and that means
+//    that multiple threads get the exact same data, i.e., there is an
+//    implied broadcasting, as will be seen in the modulo (t % thread[0])
+//    below. When greater than 1, that many physical lanes share the same
+//    position in the thread[i] decomposition. Which specific lanes are
+//    grouped is determined by tstrides. The element dimension may be split
+//    by this factor so each grouped lane loads a disjoint slice.
 //
 // Detailed semantics: case of semantic rank 1
 // -------------------------------------------


### PR DESCRIPTION
When `prod(thread) < subgroupSize` in `MMASingleSubgroupLayout`, there is implied broadcasting: multiple threads map to the same index in the thread layout and get the same data.

This patch adds an optional physicalLanesPerThread parameter (default 1) to `populateCanonicalOffsetsSizesAndStrides`, enabling callers to opt into element splitting so that broadcast lanes load disjoint slices rather than duplicate data. Existing callsites are unaffected since they use the default. `physicalLanesPerThread` is deliberately a caller provided parameter rather than derived from `MMASingleSubgroupLayout`, keeping the layout struct as a pure hardware description without encoding downstream splitting policy.

For a concrete example, consider a layout with `subgroupSize = 64` and `outer = {1, 1}, thread = {8, 4}, tstrides = {2, 16}, element = {1, 16}`

Here `prod(thread) = 32`, so `physicalLanesPerThread = 2`. The thread assignment looks like:

```
t0t1    t16t17    t32t33    t48t49
t2t3    t18t19    t34t35    t50t51
t4t5    t20t21    t36t37    t52t53
t6t7    t22t23    t38t39    t54t55
t8t9    t24t25    t40t41    t56t57
t10t11  t26t27    t42t43    t58t59
t12t13  t28t29    t44t45    t60t61
t14t15  t30t31    t46t47    t62t63
```

Without `physicalLanesPerThread`, each pair (e.g., t0 and t1) loads the same 16 elements. With `physicalLanesPerThread = 2`, each loads 8 unique elements instead.

The only existing hardware intrinsics which has this broadcast property naturally are WMMAR3 LHS and RHS operands `(thread = {16, 1} or {1, 16}, subgroupSize = 32)`, and for the F16/BF16 variants, the accumulator as well. This mechanism is intended for virtual intrinsics such as VDMFMA (#23677), where broadcast lanes will be assigned disjoint K-slices.

Assisted by: Claude