### PR TITLE
[Codegen] Do not vectorize with invalid vector sizes from lowering config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -67,9 +67,14 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
           return std::nullopt;
         }
       }
-      // Replace zeros in canonical vector shape to turn it into a valid shape.
-      std::replace(vectorSizes->begin(), vectorSizes->end(), 0, 1);
-      return std::make_pair(*vectorSizes, scalableFlags);
+      // Zero vector sizes are invalid (VectorType requires positive dims).
+      // Bail out to the IR inference path which derives correct sizes from
+      // the tensor shapes after tiling.
+      if (llvm::is_contained(*vectorSizes, 0)) {
+        LDBG() << "Vector sizes contain zeros, fall back to inference";
+      } else {
+        return std::make_pair(*vectorSizes, scalableFlags);
+      }
     }
     LDBG() << "Failed to get configured vector sizes, fall back to inference";
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -1001,3 +1001,27 @@ func.func @arg_compare_with_index_base(%input: tensor<4x128xf32>,
 // CHECK:         %[[WRITE_VAL:.+]] = vector.transfer_write %[[RESULT_VAL]], %[[OUT_VAL]]
 // CHECK:         %[[WRITE_IDX:.+]] = vector.transfer_write %[[RESULT_IDX]], %[[OUT_IDX]]
 // CHECK:         return %[[WRITE_VAL]], %[[WRITE_IDX]]
+
+// -----
+
+// When the lowering config has zero vector sizes, the vectorizer bails out
+// to the IR inference path which derives correct sizes from tensor shapes.
+
+#config = #iree_cpu.lowering_config<vector_common_parallel = [4, 0]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @configured_zero_vector_size_falls_back_to_inference(
+    %arg0: tensor<4x1xf32>, %arg1: tensor<4x1xf32>) -> tensor<4x1xf32> {
+  %result = linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel"]}
+      {lowering_config = #config}
+      ins(%arg0, %arg1 : tensor<4x1xf32>, tensor<4x1xf32>)
+      outs(%arg1 : tensor<4x1xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %add = arith.addf %in, %in_0 : f32
+    linalg.yield %add : f32
+  } -> tensor<4x1xf32>
+  return %result : tensor<4x1xf32>
+}
+// CHECK-LABEL: func.func @configured_zero_vector_size_falls_back_to_inference(
+// CHECK:         arith.addf {{.*}} : vector<4x1xf32>


### PR DESCRIPTION
Vectorization with zero sizes is incorrect, and we should just bail out. It is much better than vectorizing with incorrect tile sizes that may lead to correctness issue.