### PR TITLE
Set exact flag on index_castui during iree-util-optimize-int-arithmetic

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -104,6 +104,8 @@ struct ConvertOpToUnsigned : public OpRewritePattern<Signed> {
     }
     auto newOp = rewriter.replaceOpWithNewOp<Unsigned>(
         op, op->getResultTypes(), op->getOperands(), op->getAttrs());
+    // This is safe to do because staticallyLegalToConvert makes sure
+    // that op's operand fits in the newOp's type.
     if constexpr (std::is_same_v<Unsigned, arith::IndexCastUIOp>) {
       newOp.setExact(true);
     }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -102,8 +102,11 @@ struct ConvertOpToUnsigned : public OpRewritePattern<Signed> {
     if (failed(staticallyLegalToConvertToUnsignedOp(solver, op))) {
       return failure();
     }
-    rewriter.replaceOpWithNewOp<Unsigned>(op, op->getResultTypes(),
+    auto newOp = rewriter.replaceOpWithNewOp<Unsigned>(op, op->getResultTypes(),
                                           op->getOperands(), op->getAttrs());
+    if constexpr (std::is_same_v<Unsigned, arith::IndexCastUIOp>) {
+      newOp.setExact(true);
+    }
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -102,8 +102,8 @@ struct ConvertOpToUnsigned : public OpRewritePattern<Signed> {
     if (failed(staticallyLegalToConvertToUnsignedOp(solver, op))) {
       return failure();
     }
-    auto newOp = rewriter.replaceOpWithNewOp<Unsigned>(op, op->getResultTypes(),
-                                          op->getOperands(), op->getAttrs());
+    auto newOp = rewriter.replaceOpWithNewOp<Unsigned>(
+        op, op->getResultTypes(), op->getOperands(), op->getAttrs());
     if constexpr (std::is_same_v<Unsigned, arith::IndexCastUIOp>) {
       newOp.setExact(true);
     }


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/183395 was merged upstream,
optimization of index_cast(index_cast(x)) -> x requires the exact flag.
This pattern without the exact flag is unsound since the size of index is assumed to be 64 bits
but that is not always the case.


IREE applies this pattern when running --iree-util-optimize-int-arithmetic. 
This pass uses the util dialect to prove the correctness of transforming signed operations into unsigned operations.
We take advantage of this to set the exact flag which allows the pattern to get applied soundly.