### PR TITLE
[NFC][Codegen] Move distribution pattern infrastructure to VectorExt

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -118,6 +118,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Interfaces:TensorMaskingOpInterface",
         "//compiler/src/iree/compiler/Codegen/Transforms",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -152,6 +152,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Dialect::PCF::Transforms
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
+    iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Interfaces::TensorMaskingOpInterface
     iree::compiler::Codegen::Transforms

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cstdint>
-#include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Utils/Indexing.h"
@@ -34,7 +34,7 @@
 
 namespace mlir::iree_compiler {
 
-using namespace mlir::iree_compiler::IREE::VectorExt;
+using namespace IREE::VectorExt;
 using VectorValue = TypedValue<VectorType>;
 
 static bool isBroadcast(AffineExpr expr) {
@@ -2209,7 +2209,7 @@ struct DistributeInnerTiled final
 
 } // namespace
 
-void populateGPUDistributeNestedLayoutAttrPatterns(
+void IREE::VectorExt::populateNestedLayoutDistributionPatterns(
     RewritePatternSet &patterns, Value threadId, int64_t subgroupSize,
     ArrayRef<int64_t> workgroupSize, int64_t maxBitsPerShuffle) {
   patterns.add<DistributeTransferRead, DistributeTransferGather,
@@ -2229,4 +2229,4 @@ void populateGPUDistributeNestedLayoutAttrPatterns(
       patterns.getContext(), threadId, subgroupSize);
 }
 
-}; // namespace mlir::iree_compiler
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.h
@@ -35,10 +35,6 @@ void populateVectorLayoutCanonicalizations(RewritePatternSet &patterns);
 
 void populateGPUDistributionPatterns(RewritePatternSet &patterns);
 
-void populateGPUDistributeNestedLayoutAttrPatterns(
-    RewritePatternSet &patterns, Value threadId, int64_t subgroupSize,
-    ArrayRef<int64_t> workgroupSize, int64_t maxBitsPerShuffle = 32);
-
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_GPUPATTERNS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -8,13 +8,9 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/IR/PatternMatch.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/IR/Verifier.h"
-#include "mlir/IR/Visitors.h"
 #include "mlir/Rewrite/PatternApplicator.h"
-#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include <deque>
@@ -24,231 +20,6 @@
 using namespace mlir::iree_compiler::IREE::VectorExt;
 
 namespace mlir::iree_compiler {
-
-using VectorValue = TypedValue<VectorType>;
-
-constexpr StringLiteral kVectorLayoutFetcherStorageAttrName =
-    "__vector_layout_fetcher_storage";
-
-constexpr StringLiteral kVectorLayoutRedistributeAttrName =
-    "__vector_layout_redistribute";
-
-/// Set signature for the operation based on the analysis. Returns failure if
-/// an operation contains vectors that cannot be distributed i.e. they have no
-/// layout.
-LogicalResult
-setOpSignature(Operation *op,
-               const llvm::MapVector<Value, VectorLayoutInterface> &layouts,
-               const VectorLayoutOptions &options) {
-  SmallVector<Attribute> operands;
-  SmallVector<Attribute> results;
-
-  for (Value operand : op->getOperands()) {
-    if (auto vectorOperand = dyn_cast<VectorValue>(operand)) {
-      if (auto layout = layouts.lookup(vectorOperand)) {
-        operands.push_back(layout);
-        continue;
-      }
-      if (auto layout = options.getDefaultLayout(vectorOperand.getType())) {
-        operands.push_back(layout);
-        continue;
-      }
-      return failure();
-    }
-    operands.push_back(UnitAttr::get(op->getContext()));
-  }
-
-  for (Value result : op->getResults()) {
-    if (auto vectorResult = dyn_cast<VectorValue>(result)) {
-      if (auto layout = layouts.lookup(vectorResult)) {
-        results.push_back(layout);
-        continue;
-      }
-      if (auto layout = options.getDefaultLayout(vectorResult.getType())) {
-        results.push_back(layout);
-        continue;
-      }
-      return failure();
-    }
-    results.push_back(UnitAttr::get(op->getContext()));
-  }
-
-  ArrayAttr operandsAttr = ArrayAttr::get(op->getContext(), operands);
-  ArrayAttr resultsAttr = ArrayAttr::get(op->getContext(), results);
-  Attribute signature[] = {operandsAttr, resultsAttr};
-  op->setAttr(kVectorLayoutFetcherStorageAttrName,
-              ArrayAttr::get(op->getContext(), signature));
-  return success();
-}
-
-static bool hasOpSignature(Operation *op) {
-  return op->hasAttrOfType<ArrayAttr>(kVectorLayoutFetcherStorageAttrName);
-}
-
-static DistributionSignature getOpSignature(Operation *op) {
-  ArrayAttr signatureAttr =
-      op->getAttrOfType<ArrayAttr>(kVectorLayoutFetcherStorageAttrName);
-  assert(signatureAttr && "Op should have a signature attribute.");
-  assert(signatureAttr.size() == 2 && "Malformed signature attribute.");
-
-  ArrayAttr operandsAttr = dyn_cast<ArrayAttr>(signatureAttr[0]);
-  ArrayAttr resultsAttr = dyn_cast<ArrayAttr>(signatureAttr[1]);
-  assert(operandsAttr && resultsAttr && "Malformed signature attribute.");
-  assert(operandsAttr.size() == op->getNumOperands() &&
-         "Malformed signature attribute.");
-  assert(resultsAttr.size() == op->getNumResults() &&
-         "Malformed signature attribute.");
-
-  DistributionSignature signature;
-
-  auto addLayoutToSignature([&](Value value, Attribute layout) {
-    // Ignore null attributes.
-    if (isa<UnitAttr>(layout)) {
-      assert(!isa<VectorValue>(value) &&
-             "Malformed signature attribute: unit attribute for vector value.");
-      return;
-    }
-
-    assert(isa<VectorValue>(value) &&
-           "Malformed signature attribute: non-unit attribute for non-vector "
-           "value.");
-    auto vector = cast<VectorValue>(value);
-
-    auto vectorLayout = cast<VectorLayoutInterface>(layout);
-    assert(vectorLayout && "Malformed signature attribute.");
-    signature[vector] = vectorLayout;
-  });
-
-  for (auto [value, layout] :
-       llvm::zip_equal(op->getOperands(), operandsAttr)) {
-    addLayoutToSignature(value, layout);
-  }
-  for (auto [value, layout] : llvm::zip_equal(op->getResults(), resultsAttr)) {
-    addLayoutToSignature(value, layout);
-  }
-
-  return signature;
-}
-
-VectorValue
-DistributionPattern::getDistributed(RewriterBase &rewriter, VectorValue value,
-                                    VectorLayoutInterface layout) const {
-  // If this is a result of a "to_simd" op, use the source value of it.
-  if (auto toSIMD = value.getDefiningOp<IREE::VectorExt::ToSIMDOp>()) {
-    return cast<VectorValue>(toSIMD.getInput());
-  }
-  // Create a "to_simt" op to convert the value to the distributed layout.
-  SmallVector<int64_t> distributedShape = layout.getDistributedShape();
-  VectorType distributedType =
-      VectorType::get(distributedShape, value.getType().getElementType());
-  auto toSIMT = IREE::VectorExt::ToSIMTOp::create(rewriter, value.getLoc(),
-                                                  distributedType, value);
-  return toSIMT.getResult();
-}
-
-SmallVector<Value> DistributionPattern::getOpDistributedReplacements(
-    RewriterBase &rewriter, Operation *op, ValueRange values) const {
-  SmallVector<Value> replacements;
-  for (auto [opResult, replacement] :
-       llvm::zip_equal(op->getOpResults(), values)) {
-    // If this value is a vector type, it must be converted back to simd.
-    if (isa<VectorType>(replacement.getType())) {
-      auto oldResult = cast<VectorValue>(opResult);
-      // Create a toSIMD op to convert the value back to the simd.
-      rewriter.setInsertionPointAfterValue(oldResult);
-      Value toSIMD = IREE::VectorExt::ToSIMDOp::create(
-          rewriter, oldResult.getLoc(), oldResult.getType(), replacement);
-      // Add to replacements.
-      replacement = toSIMD;
-    }
-    replacements.push_back(replacement);
-  }
-  return replacements;
-}
-
-void DistributionPattern::replaceOpWithDistributedValues(
-    RewriterBase &rewriter, Operation *op, ValueRange values) const {
-  // Replace all OpResults with the given values.
-  SmallVector<Value> replacements =
-      getOpDistributedReplacements(rewriter, op, values);
-  rewriter.replaceOp(op, replacements);
-}
-
-std::optional<DistributionSignature>
-DistributionPattern::getOpSignature(Operation *op) const {
-  if (!hasOpSignature(op)) {
-    return std::nullopt;
-  }
-  return ::mlir::iree_compiler::getOpSignature(op);
-}
-
-void DistributionPattern::setSignatureForRedistribution(
-    RewriterBase &rewriter, Operation *op,
-    ArrayRef<VectorLayoutInterface> inputLayouts,
-    ArrayRef<VectorLayoutInterface> outputLayouts) const {
-  auto unitAttr = UnitAttr::get(rewriter.getContext());
-  auto inputAttrs = SmallVector<Attribute>(op->getNumOperands(), unitAttr);
-  auto outputAttrs = SmallVector<Attribute>(op->getNumResults(), unitAttr);
-
-  auto isVectorType = [](Value x) { return isa<VectorType>(x.getType()); };
-  assert(llvm::count_if(op->getOperands(), isVectorType) ==
-         inputLayouts.size());
-  int64_t currVectorInput = 0;
-  for (auto [idx, operand] : llvm::enumerate(op->getOperands())) {
-    if (isVectorType(operand)) {
-      inputAttrs[idx] = inputLayouts[currVectorInput];
-      ++currVectorInput;
-    }
-  }
-
-  assert(llvm::count_if(op->getResults(), isVectorType) ==
-         outputLayouts.size());
-  int64_t currVectorOutput = 0;
-  for (auto [idx, result] : llvm::enumerate(op->getResults())) {
-    if (isVectorType(result)) {
-      outputAttrs[idx] = outputLayouts[currVectorOutput];
-      ++currVectorOutput;
-    }
-  }
-
-  auto inputArrayAttr = ArrayAttr::get(rewriter.getContext(), inputAttrs);
-  auto outputArrayAttr = ArrayAttr::get(rewriter.getContext(), outputAttrs);
-
-  Attribute signature[] = {inputArrayAttr, outputArrayAttr};
-  rewriter.modifyOpInPlace(op, [&]() {
-    op->setAttr(kVectorLayoutFetcherStorageAttrName,
-                ArrayAttr::get(rewriter.getContext(), signature));
-    op->setAttr(kVectorLayoutRedistributeAttrName, unitAttr);
-  });
-}
-
-LogicalResult
-DistributionPattern::replaceParentMask(PatternRewriter &rewriter,
-                                       vector::MaskOp maskOp) const {
-  OpBuilder::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPoint(maskOp);
-  std::optional<DistributionSignature> signatureMask = getOpSignature(maskOp);
-  if (!signatureMask.has_value()) {
-    return rewriter.notifyMatchFailure(maskOp, "mask should have a signature.");
-  }
-  SmallVector<Value> returns = maskOp.getBody()->getTerminator()->getOperands();
-  for (auto [idx, ret] : llvm::enumerate(returns)) {
-    if (VectorValue vectorRet = dyn_cast<VectorValue>(ret)) {
-      VectorValue maskRet = cast<VectorValue>(maskOp.getResult(idx));
-      VectorLayoutInterface layout =
-          dyn_cast<NestedLayoutAttr>(signatureMask.value()[maskRet]);
-      if (!layout) {
-        return rewriter.notifyMatchFailure(maskOp,
-                                           "layout must be NestedLayoutAttr");
-      }
-      ret = getDistributed(rewriter, vectorRet, layout);
-    }
-  }
-  rewriter.eraseOp(maskOp.getBody()->getTerminator());
-  rewriter.inlineBlockBefore(maskOp.getBody(), maskOp);
-  replaceOpWithDistributedValues(rewriter, maskOp, returns);
-  return success();
-}
 
 static void
 debugPrintUniqueOperationNames(const std::deque<Operation *> &worklist) {
@@ -279,9 +50,8 @@ struct VectorDistributionListener : public RewriterBase::Listener {
   }
 
   void notifyOperationModified(Operation *op) override {
-    if (op->hasAttr(kVectorLayoutRedistributeAttrName) &&
-        op->hasAttrOfType<ArrayAttr>(kVectorLayoutFetcherStorageAttrName)) {
-      op->removeAttr(kVectorLayoutRedistributeAttrName);
+    if (IREE::VectorExt::isMarkedForRedistribution(op)) {
+      IREE::VectorExt::clearRedistributionMark(op);
       toBeDistributed.push_back(op);
     }
   }
@@ -308,7 +78,8 @@ static void applyVectorDistribution(Operation *root,
     // but it will be distributed when the body is
     // distributed. Therefore, we explicitly exclude
     // the yield and the mask op.
-    if (hasOpSignature(op) && !isa<vector::MaskOp, vector::YieldOp>(op)) {
+    if (IREE::VectorExt::hasOpSignature(op) &&
+        !isa<vector::MaskOp, vector::YieldOp>(op)) {
       worklist.push_back(op);
     }
   });
@@ -368,7 +139,7 @@ LogicalResult distributeVectorOps(Operation *root,
   LLVM_DEBUG(
       llvm::dbgs() << "Setting distribution signatures for operations\n");
   root->walk([&](Operation *op) {
-    if (failed(setOpSignature(op, layouts, options))) {
+    if (failed(IREE::VectorExt::setOpSignature(op, layouts, options))) {
       LLVM_DEBUG({
         llvm::dbgs() << "Skipping operation because not all vector "
                         "operands/results have a layout:\n";
@@ -393,9 +164,7 @@ LogicalResult distributeVectorOps(Operation *root,
   }
 
   // Remove signature after distribution.
-  root->walk([](Operation *op) {
-    op->removeDiscardableAttr(kVectorLayoutFetcherStorageAttrName);
-  });
+  root->walk([](Operation *op) { IREE::VectorExt::removeOpSignature(op); });
 
   if (options.verifyConversion()) {
     WalkResult hasConversionOp = root->walk([](Operation *op) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -7,159 +7,9 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_GPU_VECTOR_DISTRIBUTION_H_
 #define IREE_COMPILER_CODEGEN_COMMON_GPU_VECTOR_DISTRIBUTION_H_
 
-#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 
 namespace mlir::iree_compiler {
-
-using IREE::VectorExt::VectorLayoutInterface;
-
-/// A signature describing the layout for each value of vector type which is
-/// an operand or result of this operation.
-///
-/// Two operands may be the same value, but since each value can only have
-/// one layout, we only need to keep track of the value, not the two operands
-/// separately.
-using DistributionSignature =
-    DenseMap<TypedValue<VectorType>, VectorLayoutInterface>;
-
-struct DistributionPattern : RewritePattern {
-  using RewritePattern::RewritePattern;
-
-  /// Lookup the distributed value for the given SIMD value. If the value
-  /// was not distributed yet, wrap it in a ToSIMTOp.
-  TypedValue<VectorType> getDistributed(RewriterBase &rewriter,
-                                        TypedValue<VectorType> value,
-                                        VectorLayoutInterface layout) const;
-
-  /// Get the distributed values that could replace the op
-  SmallVector<Value> getOpDistributedReplacements(RewriterBase &rewriter,
-                                                  Operation *op,
-                                                  ValueRange values) const;
-
-  /// Replace an op with its distributed replacement values.
-  void replaceOpWithDistributedValues(RewriterBase &rewriter, Operation *op,
-                                      ValueRange values) const;
-
-  /// Get the signature for the given operation.
-  std::optional<DistributionSignature> getOpSignature(Operation *op) const;
-
-protected:
-  // Sets new layout/signature for op, and mark it for redistribution.
-  // When "vector layout storage" and "vector layout redistribution"
-  // is defined, VectorDistributionRewriter would add it to worklist
-  // of operations to be distributed.
-  void setSignatureForRedistribution(
-      RewriterBase &rewriter, Operation *op,
-      ArrayRef<VectorLayoutInterface> inputLayouts,
-      ArrayRef<VectorLayoutInterface> outputLayouts) const;
-
-  LogicalResult replaceParentMask(PatternRewriter &rewriter,
-                                  vector::MaskOp) const;
-};
-
-template <typename SourceOp>
-struct OpDistributionPattern : DistributionPattern {
-  OpDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : DistributionPattern(SourceOp::getOperationName(), benefit, context) {}
-
-  virtual LogicalResult matchAndRewrite(SourceOp op,
-                                        DistributionSignature &opSignature,
-                                        PatternRewriter &rewriter) const = 0;
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const final {
-    std::optional<DistributionSignature> opSignature = getOpSignature(op);
-    if (!opSignature) {
-      return failure();
-    }
-    return matchAndRewrite(cast<SourceOp>(op), *opSignature, rewriter);
-  }
-};
-
-template <typename SourceOp>
-struct MaskedOpDistributionPattern : DistributionPattern {
-  MaskedOpDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : DistributionPattern(SourceOp::getOperationName(), benefit, context) {}
-
-  virtual LogicalResult
-  matchAndRewrite(SourceOp op, DistributionSignature &opSignature,
-                  vector::MaskOp maskOp,
-                  std::optional<DistributionSignature> &maskSignature,
-                  PatternRewriter &rewriter) const = 0;
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const final {
-    std::optional<DistributionSignature> opSignature = getOpSignature(op);
-    if (!opSignature) {
-      return failure();
-    }
-    auto maskOp = op->getParentOfType<vector::MaskOp>();
-    std::optional<DistributionSignature> maskSignature;
-    if (maskOp) {
-      maskSignature = getOpSignature(maskOp);
-      if (!maskSignature) {
-        return failure();
-      }
-    }
-    LogicalResult result = matchAndRewrite(cast<SourceOp>(op), *opSignature,
-                                           maskOp, maskSignature, rewriter);
-    if (failed(result)) {
-      return failure();
-    }
-    if (maskOp) {
-      return replaceParentMask(rewriter, maskOp);
-    }
-    return success();
-  }
-};
-
-template <template <typename> class TraitType>
-class OpTraitDistributionPattern : public DistributionPattern {
-public:
-  OpTraitDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : DistributionPattern(Pattern::MatchTraitOpTypeTag(),
-                            TypeID::get<TraitType>(), benefit, context) {}
-
-  virtual LogicalResult matchAndRewrite(Operation *op,
-                                        DistributionSignature &opSignature,
-                                        PatternRewriter &rewriter) const = 0;
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const final {
-    std::optional<DistributionSignature> opSignature = getOpSignature(op);
-    if (!opSignature) {
-      return failure();
-    }
-    return matchAndRewrite(op, *opSignature, rewriter);
-  }
-};
-
-/// Options to control how the layout analysis is initialised for vector
-/// distribution.
-class VectorLayoutOptions {
-public:
-  VectorLayoutOptions(Operation *root) : root(root), fullConversion(true) {
-    assert(root && "root operation must be non-null");
-  }
-  VectorLayoutOptions(Operation *root, bool fullConversion)
-      : root(root), fullConversion(fullConversion) {
-    assert(root && "root operation must be non-null");
-  }
-
-  virtual ~VectorLayoutOptions() = default;
-
-  bool verifyConversion() const { return fullConversion; }
-
-  virtual VectorLayoutInterface getDefaultLayout(VectorType type) const = 0;
-
-protected:
-  Operation *root;
-  bool fullConversion = true;
-}; // namespace iree_compiler
 
 /// Distribute vector operations in the IR rooted at `root`.
 ///
@@ -173,9 +23,9 @@ protected:
 ///   - Run a global analysis to determine how to distribute rest of the vector
 ///     values keeping the initial anchors in mind.
 ///   - Use the analysis information to distribute each operation.
-LogicalResult distributeVectorOps(Operation *root,
-                                  RewritePatternSet &distributionPatterns,
-                                  VectorLayoutOptions &options);
+LogicalResult
+distributeVectorOps(Operation *root, RewritePatternSet &distributionPatterns,
+                    IREE::VectorExt::VectorLayoutOptions &options);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD.bazel
@@ -68,6 +68,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:BufferizationInterfaces",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
+    iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms
     iree::compiler::Codegen::Interfaces::BufferizationInterfaces
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 #include "iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -1072,15 +1073,16 @@ transform_dialect::ShareForallOperandsOp::applyToOne(
 // TestGpuVectorDistribution
 //===----------------------------------------------------------------------===//
 
-class TestVectorLayoutOptions : public VectorLayoutOptions {
+class TestVectorLayoutOptions : public IREE::VectorExt::VectorLayoutOptions {
 public:
   TestVectorLayoutOptions(Operation *root)
       : VectorLayoutOptions(root, /*fullConversion=*/false) {}
 
-  VectorLayoutInterface getDefaultLayout(VectorType type) const override {
+  IREE::VectorExt::VectorLayoutInterface
+  getDefaultLayout(VectorType type) const override {
     // We only allow a default layout for 0-d vectors for now.
     if (type.getRank() > 0) {
-      return VectorLayoutInterface();
+      return IREE::VectorExt::VectorLayoutInterface();
     }
     ArrayRef<int64_t> empty = {};
     return IREE::VectorExt::NestedLayoutAttr::get(
@@ -1108,8 +1110,8 @@ transform_dialect::TestGpuVectorDistribution::applyToOne(
   ArrayRef<int64_t> workgroupSize = getWorkgroupSize();
 
   populateGPUDistributionPatterns(patterns);
-  populateGPUDistributeNestedLayoutAttrPatterns(patterns, laneId, subgroupSize,
-                                                workgroupSize);
+  IREE::VectorExt::populateNestedLayoutDistributionPatterns(
+      patterns, laneId, subgroupSize, workgroupSize);
   if (failed(distributeVectorOps(target, patterns, options))) {
     return emitDefaultDefiniteFailure(target);
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
     name = "VectorExtTransforms",
     srcs = [
         "BufferizationInterfaces.cpp",
+        "DistributionPatterns.cpp",
         "LowerTransferGatherOps.cpp",
         "Passes.cpp",
         "VectorExtFoldUnitExtentDims.cpp",
@@ -43,6 +44,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "BufferizationInterfaces.h",
+        "DistributionPatterns.h",
         "Passes.h",
         "Passes.h.inc",
         "Transforms.h",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
@@ -24,11 +24,13 @@ iree_cc_library(
     VectorExtTransforms
   HDRS
     "BufferizationInterfaces.h"
+    "DistributionPatterns.h"
     "Passes.h"
     "Passes.h.inc"
     "Transforms.h"
   SRCS
     "BufferizationInterfaces.cpp"
+    "DistributionPatterns.cpp"
     "LowerTransferGatherOps.cpp"
     "Passes.cpp"
     "VectorExtFoldUnitExtentDims.cpp"

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.cpp
@@ -1,0 +1,251 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::iree_compiler::IREE::VectorExt {
+
+using VectorValue = TypedValue<VectorType>;
+
+constexpr StringLiteral kVectorLayoutFetcherStorageAttrName =
+    "__vector_layout_fetcher_storage";
+
+constexpr StringLiteral kVectorLayoutRedistributeAttrName =
+    "__vector_layout_redistribute";
+
+/// Set signature for the operation based on the analysis. Returns failure if
+/// an operation contains vectors that cannot be distributed i.e. they have no
+/// layout.
+LogicalResult
+setOpSignature(Operation *op,
+               const llvm::MapVector<Value, VectorLayoutInterface> &layouts,
+               const VectorLayoutOptions &options) {
+  SmallVector<Attribute> operands;
+  SmallVector<Attribute> results;
+
+  for (Value operand : op->getOperands()) {
+    if (auto vectorOperand = dyn_cast<VectorValue>(operand)) {
+      if (auto layout = layouts.lookup(vectorOperand)) {
+        operands.push_back(layout);
+        continue;
+      }
+      if (auto layout = options.getDefaultLayout(vectorOperand.getType())) {
+        operands.push_back(layout);
+        continue;
+      }
+      return failure();
+    }
+    operands.push_back(UnitAttr::get(op->getContext()));
+  }
+
+  for (Value result : op->getResults()) {
+    if (auto vectorResult = dyn_cast<VectorValue>(result)) {
+      if (auto layout = layouts.lookup(vectorResult)) {
+        results.push_back(layout);
+        continue;
+      }
+      if (auto layout = options.getDefaultLayout(vectorResult.getType())) {
+        results.push_back(layout);
+        continue;
+      }
+      return failure();
+    }
+    results.push_back(UnitAttr::get(op->getContext()));
+  }
+
+  ArrayAttr operandsAttr = ArrayAttr::get(op->getContext(), operands);
+  ArrayAttr resultsAttr = ArrayAttr::get(op->getContext(), results);
+  Attribute signature[] = {operandsAttr, resultsAttr};
+  op->setAttr(kVectorLayoutFetcherStorageAttrName,
+              ArrayAttr::get(op->getContext(), signature));
+  return success();
+}
+
+bool hasOpSignature(Operation *op) {
+  return op->hasAttrOfType<ArrayAttr>(kVectorLayoutFetcherStorageAttrName);
+}
+
+void removeOpSignature(Operation *op) {
+  op->removeDiscardableAttr(kVectorLayoutFetcherStorageAttrName);
+}
+
+bool isMarkedForRedistribution(Operation *op) {
+  return op->hasAttr(kVectorLayoutRedistributeAttrName) && hasOpSignature(op);
+}
+
+void clearRedistributionMark(Operation *op) {
+  op->removeAttr(kVectorLayoutRedistributeAttrName);
+}
+
+DistributionSignature getOpSignature(Operation *op) {
+  ArrayAttr signatureAttr =
+      op->getAttrOfType<ArrayAttr>(kVectorLayoutFetcherStorageAttrName);
+  assert(signatureAttr && "Op should have a signature attribute.");
+  assert(signatureAttr.size() == 2 && "Malformed signature attribute.");
+
+  ArrayAttr operandsAttr = dyn_cast<ArrayAttr>(signatureAttr[0]);
+  ArrayAttr resultsAttr = dyn_cast<ArrayAttr>(signatureAttr[1]);
+  assert(operandsAttr && resultsAttr && "Malformed signature attribute.");
+  assert(operandsAttr.size() == op->getNumOperands() &&
+         "Malformed signature attribute.");
+  assert(resultsAttr.size() == op->getNumResults() &&
+         "Malformed signature attribute.");
+
+  DistributionSignature signature;
+
+  auto addLayoutToSignature([&](Value value, Attribute layout) {
+    // Ignore null attributes.
+    if (isa<UnitAttr>(layout)) {
+      assert(!isa<VectorValue>(value) &&
+             "Malformed signature attribute: unit attribute for vector value.");
+      return;
+    }
+
+    assert(isa<VectorValue>(value) &&
+           "Malformed signature attribute: non-unit attribute for non-vector "
+           "value.");
+    auto vector = cast<VectorValue>(value);
+
+    auto vectorLayout = cast<VectorLayoutInterface>(layout);
+    signature[vector] = vectorLayout;
+  });
+
+  for (auto [value, layout] :
+       llvm::zip_equal(op->getOperands(), operandsAttr)) {
+    addLayoutToSignature(value, layout);
+  }
+  for (auto [value, layout] : llvm::zip_equal(op->getResults(), resultsAttr)) {
+    addLayoutToSignature(value, layout);
+  }
+
+  return signature;
+}
+
+VectorValue
+DistributionPattern::getDistributed(RewriterBase &rewriter, VectorValue value,
+                                    VectorLayoutInterface layout) const {
+  // If this is a result of a "to_simd" op, use the source value of it.
+  if (auto toSIMD = value.getDefiningOp<IREE::VectorExt::ToSIMDOp>()) {
+    return cast<VectorValue>(toSIMD.getInput());
+  }
+  // Create a "to_simt" op to convert the value to the distributed layout.
+  SmallVector<int64_t> distributedShape = layout.getDistributedShape();
+  VectorType distributedType =
+      VectorType::get(distributedShape, value.getType().getElementType());
+  auto toSIMT = IREE::VectorExt::ToSIMTOp::create(rewriter, value.getLoc(),
+                                                  distributedType, value);
+  return toSIMT.getResult();
+}
+
+SmallVector<Value> DistributionPattern::getOpDistributedReplacements(
+    RewriterBase &rewriter, Operation *op, ValueRange values) const {
+  SmallVector<Value> replacements;
+  for (auto [opResult, replacement] :
+       llvm::zip_equal(op->getOpResults(), values)) {
+    // If this value is a vector type, it must be converted back to simd.
+    if (isa<VectorType>(replacement.getType())) {
+      auto oldResult = cast<VectorValue>(opResult);
+      // Create a toSIMD op to convert the value back to the simd.
+      rewriter.setInsertionPointAfterValue(oldResult);
+      Value toSIMD = IREE::VectorExt::ToSIMDOp::create(
+          rewriter, oldResult.getLoc(), oldResult.getType(), replacement);
+      // Add to replacements.
+      replacement = toSIMD;
+    }
+    replacements.push_back(replacement);
+  }
+  return replacements;
+}
+
+void DistributionPattern::replaceOpWithDistributedValues(
+    RewriterBase &rewriter, Operation *op, ValueRange values) const {
+  // Replace all OpResults with the given values.
+  SmallVector<Value> replacements =
+      getOpDistributedReplacements(rewriter, op, values);
+  rewriter.replaceOp(op, replacements);
+}
+
+std::optional<DistributionSignature>
+DistributionPattern::getOpSignature(Operation *op) const {
+  if (!IREE::VectorExt::hasOpSignature(op)) {
+    return std::nullopt;
+  }
+  return IREE::VectorExt::getOpSignature(op);
+}
+
+void DistributionPattern::setSignatureForRedistribution(
+    RewriterBase &rewriter, Operation *op,
+    ArrayRef<VectorLayoutInterface> inputLayouts,
+    ArrayRef<VectorLayoutInterface> outputLayouts) const {
+  auto unitAttr = UnitAttr::get(rewriter.getContext());
+  auto inputAttrs = SmallVector<Attribute>(op->getNumOperands(), unitAttr);
+  auto outputAttrs = SmallVector<Attribute>(op->getNumResults(), unitAttr);
+
+  auto isVectorType = [](Value x) { return isa<VectorType>(x.getType()); };
+  assert(llvm::count_if(op->getOperands(), isVectorType) ==
+         inputLayouts.size());
+  int64_t currVectorInput = 0;
+  for (auto [idx, operand] : llvm::enumerate(op->getOperands())) {
+    if (isVectorType(operand)) {
+      inputAttrs[idx] = inputLayouts[currVectorInput];
+      ++currVectorInput;
+    }
+  }
+
+  assert(llvm::count_if(op->getResults(), isVectorType) ==
+         outputLayouts.size());
+  int64_t currVectorOutput = 0;
+  for (auto [idx, result] : llvm::enumerate(op->getResults())) {
+    if (isVectorType(result)) {
+      outputAttrs[idx] = outputLayouts[currVectorOutput];
+      ++currVectorOutput;
+    }
+  }
+
+  auto inputArrayAttr = ArrayAttr::get(rewriter.getContext(), inputAttrs);
+  auto outputArrayAttr = ArrayAttr::get(rewriter.getContext(), outputAttrs);
+
+  Attribute signature[] = {inputArrayAttr, outputArrayAttr};
+  rewriter.modifyOpInPlace(op, [&]() {
+    op->setAttr(kVectorLayoutFetcherStorageAttrName,
+                ArrayAttr::get(rewriter.getContext(), signature));
+    op->setAttr(kVectorLayoutRedistributeAttrName, unitAttr);
+  });
+}
+
+LogicalResult
+DistributionPattern::replaceParentMask(PatternRewriter &rewriter,
+                                       vector::MaskOp maskOp) const {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(maskOp);
+  std::optional<DistributionSignature> signatureMask = getOpSignature(maskOp);
+  if (!signatureMask.has_value()) {
+    return rewriter.notifyMatchFailure(maskOp, "mask should have a signature.");
+  }
+  SmallVector<Value> returns = maskOp.getBody()->getTerminator()->getOperands();
+  for (auto [idx, ret] : llvm::enumerate(returns)) {
+    if (VectorValue vectorRet = dyn_cast<VectorValue>(ret)) {
+      VectorValue maskRet = cast<VectorValue>(maskOp.getResult(idx));
+      VectorLayoutInterface layout =
+          dyn_cast<NestedLayoutAttr>(signatureMask.value()[maskRet]);
+      if (!layout) {
+        return rewriter.notifyMatchFailure(maskOp,
+                                           "layout must be NestedLayoutAttr");
+      }
+      ret = getDistributed(rewriter, vectorRet, layout);
+    }
+  }
+  rewriter.eraseOp(maskOp.getBody()->getTerminator());
+  rewriter.inlineBlockBefore(maskOp.getBody(), maskOp);
+  replaceOpWithDistributedValues(rewriter, maskOp, returns);
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::VectorExt

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h
@@ -1,0 +1,194 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_DISTRIBUTION_PATTERNS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_DISTRIBUTION_PATTERNS_H_
+
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler::IREE::VectorExt {
+
+class VectorLayoutOptions;
+
+/// A signature describing the layout for each value of vector type which is
+/// an operand or result of this operation.
+///
+/// Two operands may be the same value, but since each value can only have
+/// one layout, we only need to keep track of the value, not the two operands
+/// separately.
+using DistributionSignature =
+    DenseMap<TypedValue<VectorType>, VectorLayoutInterface>;
+
+/// Set signature for the operation based on the analysis. Returns failure if
+/// an operation contains vectors that cannot be distributed i.e. they have no
+/// layout.
+LogicalResult
+setOpSignature(Operation *op,
+               const llvm::MapVector<Value, VectorLayoutInterface> &layouts,
+               const VectorLayoutOptions &options);
+
+/// Check if an operation has a distribution signature attribute.
+bool hasOpSignature(Operation *op);
+
+/// Remove the distribution signature attribute from an operation.
+void removeOpSignature(Operation *op);
+
+/// Check if an operation is marked for redistribution.
+bool isMarkedForRedistribution(Operation *op);
+
+/// Clear the redistribution mark from an operation.
+void clearRedistributionMark(Operation *op);
+
+/// Get the distribution signature from an operation's attributes.
+DistributionSignature getOpSignature(Operation *op);
+
+struct DistributionPattern : RewritePattern {
+  using RewritePattern::RewritePattern;
+
+  /// Lookup the distributed value for the given SIMD value. If the value
+  /// was not distributed yet, wrap it in a ToSIMTOp.
+  TypedValue<VectorType> getDistributed(RewriterBase &rewriter,
+                                        TypedValue<VectorType> value,
+                                        VectorLayoutInterface layout) const;
+
+  /// Get the distributed values that could replace the op
+  SmallVector<Value> getOpDistributedReplacements(RewriterBase &rewriter,
+                                                  Operation *op,
+                                                  ValueRange values) const;
+
+  /// Replace an op with its distributed replacement values.
+  void replaceOpWithDistributedValues(RewriterBase &rewriter, Operation *op,
+                                      ValueRange values) const;
+
+  /// Get the signature for the given operation.
+  std::optional<DistributionSignature> getOpSignature(Operation *op) const;
+
+protected:
+  // Sets new layout/signature for op, and mark it for redistribution.
+  // When "vector layout storage" and "vector layout redistribution"
+  // is defined, VectorDistributionRewriter would add it to worklist
+  // of operations to be distributed.
+  void setSignatureForRedistribution(
+      RewriterBase &rewriter, Operation *op,
+      ArrayRef<VectorLayoutInterface> inputLayouts,
+      ArrayRef<VectorLayoutInterface> outputLayouts) const;
+
+  LogicalResult replaceParentMask(PatternRewriter &rewriter,
+                                  vector::MaskOp) const;
+};
+
+template <typename SourceOp>
+struct OpDistributionPattern : DistributionPattern {
+  OpDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : DistributionPattern(SourceOp::getOperationName(), benefit, context) {}
+
+  virtual LogicalResult matchAndRewrite(SourceOp op,
+                                        DistributionSignature &opSignature,
+                                        PatternRewriter &rewriter) const = 0;
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const final {
+    std::optional<DistributionSignature> opSignature = getOpSignature(op);
+    if (!opSignature) {
+      return failure();
+    }
+    return matchAndRewrite(cast<SourceOp>(op), *opSignature, rewriter);
+  }
+};
+
+template <typename SourceOp>
+struct MaskedOpDistributionPattern : DistributionPattern {
+  MaskedOpDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : DistributionPattern(SourceOp::getOperationName(), benefit, context) {}
+
+  virtual LogicalResult
+  matchAndRewrite(SourceOp op, DistributionSignature &opSignature,
+                  vector::MaskOp maskOp,
+                  std::optional<DistributionSignature> &maskSignature,
+                  PatternRewriter &rewriter) const = 0;
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const final {
+    std::optional<DistributionSignature> opSignature = getOpSignature(op);
+    if (!opSignature) {
+      return failure();
+    }
+    auto maskOp = op->getParentOfType<vector::MaskOp>();
+    std::optional<DistributionSignature> maskSignature;
+    if (maskOp) {
+      maskSignature = getOpSignature(maskOp);
+      if (!maskSignature) {
+        return failure();
+      }
+    }
+    LogicalResult result = matchAndRewrite(cast<SourceOp>(op), *opSignature,
+                                           maskOp, maskSignature, rewriter);
+    if (failed(result)) {
+      return failure();
+    }
+    if (maskOp) {
+      return replaceParentMask(rewriter, maskOp);
+    }
+    return success();
+  }
+};
+
+template <template <typename> class TraitType>
+class OpTraitDistributionPattern : public DistributionPattern {
+public:
+  OpTraitDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : DistributionPattern(Pattern::MatchTraitOpTypeTag(),
+                            TypeID::get<TraitType>(), benefit, context) {}
+
+  virtual LogicalResult matchAndRewrite(Operation *op,
+                                        DistributionSignature &opSignature,
+                                        PatternRewriter &rewriter) const = 0;
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const final {
+    std::optional<DistributionSignature> opSignature = getOpSignature(op);
+    if (!opSignature) {
+      return failure();
+    }
+    return matchAndRewrite(op, *opSignature, rewriter);
+  }
+};
+
+/// Options to control how the layout analysis is initialised for vector
+/// distribution.
+class VectorLayoutOptions {
+public:
+  VectorLayoutOptions(Operation *root) : root(root), fullConversion(true) {
+    assert(root && "root operation must be non-null");
+  }
+  VectorLayoutOptions(Operation *root, bool fullConversion)
+      : root(root), fullConversion(fullConversion) {
+    assert(root && "root operation must be non-null");
+  }
+
+  virtual ~VectorLayoutOptions() = default;
+
+  bool verifyConversion() const { return fullConversion; }
+
+  virtual VectorLayoutInterface getDefaultLayout(VectorType type) const = 0;
+
+protected:
+  Operation *root;
+  bool fullConversion = true;
+};
+
+/// Populate patterns for distributing vector operations with NestedLayoutAttr.
+void populateNestedLayoutDistributionPatterns(RewritePatternSet &patterns,
+                                              Value threadId,
+                                              int64_t subgroupSize,
+                                              ArrayRef<int64_t> workgroupSize,
+                                              int64_t maxBitsPerShuffle = 32);
+
+} // namespace mlir::iree_compiler::IREE::VectorExt
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_DISTRIBUTION_PATTERNS_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
 #include "mlir/Analysis/SliceAnalysis.h"
@@ -30,21 +31,21 @@ namespace mlir::iree_compiler {
 ContractionVectorLayoutOptions::ContractionVectorLayoutOptions(
     Operation *root, Value laneId, int64_t subgroupSize,
     ArrayRef<int64_t> workgroupSize)
-    : VectorLayoutOptions(root), patterns(root->getContext()) {
+    : IREE::VectorExt::VectorLayoutOptions(root), patterns(root->getContext()) {
   populateGPUDistributionPatterns(patterns);
-  populateGPUDistributeNestedLayoutAttrPatterns(patterns, laneId, subgroupSize,
-                                                workgroupSize);
+  IREE::VectorExt::populateNestedLayoutDistributionPatterns(
+      patterns, laneId, subgroupSize, workgroupSize);
 }
 
 RewritePatternSet &ContractionVectorLayoutOptions::getPatterns() {
   return patterns;
 }
 
-VectorLayoutInterface
+IREE::VectorExt::VectorLayoutInterface
 ContractionVectorLayoutOptions::getDefaultLayout(VectorType type) const {
   // We only allow a default layout for 0-d vectors for now.
   if (type.getRank() > 0) {
-    return VectorLayoutInterface();
+    return IREE::VectorExt::VectorLayoutInterface();
   }
   ArrayRef<int64_t> empty = {};
   return IREE::VectorExt::NestedLayoutAttr::get(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD.bazel
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",
         "//compiler/src/iree/compiler/Codegen/LLVMGPU/Utils",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
@@ -68,6 +68,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
+    iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms
     iree::compiler::Codegen::LLVMGPU::Utils
     iree::compiler::Codegen::Utils
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/ADT/STLExtras.h"
@@ -919,8 +920,8 @@ transform_dialect::AMDGPUDistributeVectorsOp::applyToOne(
   ArrayRef<int64_t> workgroupSize = getWorkgroupSize();
 
   populateGPUDistributionPatterns(patterns);
-  populateGPUDistributeNestedLayoutAttrPatterns(patterns, laneId, subgroupSize,
-                                                workgroupSize);
+  IREE::VectorExt::populateNestedLayoutDistributionPatterns(
+      patterns, laneId, subgroupSize, workgroupSize);
   if (failed(distributeVectorOps(target, patterns, options))) {
     return emitDefaultSilenceableFailure(target);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h
@@ -32,13 +32,15 @@ class WarpExecuteOnLane0Op;
 
 namespace mlir::iree_compiler {
 
-class TransformVectorLayoutOptions : public VectorLayoutOptions {
+class TransformVectorLayoutOptions
+    : public IREE::VectorExt::VectorLayoutOptions {
 public:
   TransformVectorLayoutOptions(Operation *root, bool fullConversion)
       : VectorLayoutOptions(root, fullConversion) {}
 
-  VectorLayoutInterface getDefaultLayout(VectorType type) const override {
-    return VectorLayoutInterface();
+  IREE::VectorExt::VectorLayoutInterface
+  getDefaultLayout(VectorType type) const override {
+    return IREE::VectorExt::VectorLayoutInterface();
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h
@@ -25,13 +25,15 @@ class ContractionOp;
 namespace iree_compiler {
 class VectorContractOpInfo;
 
-class ContractionVectorLayoutOptions : public VectorLayoutOptions {
+class ContractionVectorLayoutOptions
+    : public IREE::VectorExt::VectorLayoutOptions {
 public:
   ContractionVectorLayoutOptions(Operation *root, Value laneId,
                                  int64_t subgroupSize,
                                  ArrayRef<int64_t> workgroupSize);
   RewritePatternSet &getPatterns();
-  VectorLayoutInterface getDefaultLayout(VectorType type) const override;
+  IREE::VectorExt::VectorLayoutInterface
+  getDefaultLayout(VectorType type) const override;
 
 private:
   RewritePatternSet patterns;


### PR DESCRIPTION
Move DistributionPattern, VectorLayoutOptions, DistributionSignature, and related signature utility functions from Codegen/Common/GPU/ into Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.{h,cpp}.

The concrete NestedLayout distribution patterns remain in Common/GPU/ to avoid pulling Codegen-level dependencies into the VectorExt dialect layer.

This change allows us to define distribution patterns outside of Common/GPU without having a dependency on Common/GPU. This allows us to define new patterns by only taking a dependency on VectorExtTransforms.