### PR TITLE
[SPIRV] Enable scf.forall-based workgroup distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -53,11 +53,6 @@ static llvm::cl::opt<int> clSPIRVIndexingBits(
     llvm::cl::desc("Set the bit width of indices in SPIR-V."),
     llvm::cl::init(32));
 
-static llvm::cl::opt<bool> clSPIRVTileDispatchUsingForall(
-    "iree-spirv-tile-dispatch-using-forall",
-    llvm::cl::desc("Enable tile and distribute to workgroups using scf.forall"),
-    llvm::cl::init(true));
-
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration
 //===----------------------------------------------------------------------===//
@@ -122,23 +117,11 @@ static void addTileAndDistributeToWorkgroupsPasses(
     OpPassManager &funcPassManager,
     bool useFuseTensorPadWithConsumerPass = false,
     bool useWARForCooperativeMatrixCodegen = false) {
-  if (clSPIRVTileDispatchUsingForall) {
-    funcPassManager.addPass(createConvertAccGEMMToGEMMPass());
-    funcPassManager.addPass(
-        createTileAndDistributeToWorkgroupsUsingForallOpPass());
-    funcPassManager.addPass(createFoldReshapeIntoInterfaceTensorPass());
-    funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass());
-  } else {
-    funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass(
-        kNumMaxParallelDims,
-        linalg::DistributionMethod::CyclicNumProcsEqNumIters));
-    funcPassManager.addPass(createCSEPass());
-    if (useFuseTensorPadWithConsumerPass) {
-      funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
-    }
-    funcPassManager.addPass(createConvertToDestinationPassingStylePass(
-        useWARForCooperativeMatrixCodegen));
-  }
+  funcPassManager.addPass(createConvertAccGEMMToGEMMPass());
+  funcPassManager.addPass(
+      createTileAndDistributeToWorkgroupsUsingForallOpPass());
+  funcPassManager.addPass(createFoldReshapeIntoInterfaceTensorPass());
+  funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -53,6 +53,11 @@ static llvm::cl::opt<int> clSPIRVIndexingBits(
     llvm::cl::desc("Set the bit width of indices in SPIR-V."),
     llvm::cl::init(32));
 
+static llvm::cl::opt<bool> clSPIRVTileDispatchUsingForall(
+    "iree-spirv-tile-dispatch-using-forall",
+    llvm::cl::desc("Enable tile and distribute to workgroups using scf.forall"),
+    llvm::cl::init(true));
+
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration
 //===----------------------------------------------------------------------===//
@@ -117,15 +122,23 @@ static void addTileAndDistributeToWorkgroupsPasses(
     OpPassManager &funcPassManager,
     bool useFuseTensorPadWithConsumerPass = false,
     bool useWARForCooperativeMatrixCodegen = false) {
-  funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass(
-      kNumMaxParallelDims,
-      linalg::DistributionMethod::CyclicNumProcsEqNumIters));
-  funcPassManager.addPass(createCSEPass());
-  if (useFuseTensorPadWithConsumerPass) {
-    funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
+  if (clSPIRVTileDispatchUsingForall) {
+    funcPassManager.addPass(createConvertAccGEMMToGEMMPass());
+    funcPassManager.addPass(
+        createTileAndDistributeToWorkgroupsUsingForallOpPass());
+    funcPassManager.addPass(createFoldReshapeIntoInterfaceTensorPass());
+    funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass());
+  } else {
+    funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass(
+        kNumMaxParallelDims,
+        linalg::DistributionMethod::CyclicNumProcsEqNumIters));
+    funcPassManager.addPass(createCSEPass());
+    if (useFuseTensorPadWithConsumerPass) {
+      funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
+    }
+    funcPassManager.addPass(createConvertToDestinationPassingStylePass(
+        useWARForCooperativeMatrixCodegen));
   }
-  funcPassManager.addPass(createConvertToDestinationPassingStylePass(
-      useWARForCooperativeMatrixCodegen));
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
@@ -45,26 +45,28 @@ func.func @i4_dequant_matvec_f32() {
 
 //   CHECK-LABEL:  func.func @i4_dequant_matvec_f32()
 
-//         CHECK:   %[[FOR:.+]] = scf.for %arg0 = %c0 to %c86 step %c2 iter_args({{.+}}) -> (vector<1x4xf32>)
-//         CHECK:     %[[READ0:.+]] = vector.transfer_read {{.+}} : memref<4096x86x128xi4, #hal.descriptor_type<storage_buffer>>, vector<4xi4>
-//         CHECK:     %[[READ1:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
-//         CHECK:     %[[READ2:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
-//         CHECK:     %[[READ3:.+]] = vector.transfer_read {{.+}} : memref<86x128xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//         CHECK:     %[[CVT:.+]] = arith.uitofp %[[READ0]] : vector<4xi4> to vector<4xf32>
-//         CHECK:     %[[EXTRACT0:.+]] = vector.extract %[[READ1]][0] : f32 from vector<1xf32>
-//         CHECK:     %[[BROADCAST0:.+]] = vector.broadcast %[[EXTRACT0]] : f32 to vector<4xf32>
-//         CHECK:     %[[SUB:.+]] = arith.subf %[[CVT]], %[[BROADCAST0]] : vector<4xf32>
-//         CHECK:     %[[EXTRACT1:.+]] = vector.extract %[[READ2]][0] : f32 from vector<1xf32>
-//         CHECK:     %[[BROADCAST1:.+]] = vector.broadcast %[[EXTRACT1]] : f32 to vector<4xf32>
-//         CHECK:     %[[MUL0:.+]] = arith.mulf %[[SUB]], %[[BROADCAST1]] : vector<4xf32>
-//         CHECK:     %[[MUL1:.+]] = arith.mulf %[[READ3]], %[[MUL0]] : vector<4xf32>
-//         CHECK:     %[[SHAPE_CAST:.+]] = vector.shape_cast %arg1 : vector<1x4xf32> to vector<4xf32>
-//         CHECK:     %[[ADD:.+]] = arith.addf %[[MUL1]], %[[SHAPE_CAST]] : vector<4xf32>
-//         CHECK:     %[[SHAPE_CAST2:.+]] = vector.shape_cast %[[ADD]] : vector<4xf32> to vector<1x4xf32>
-//         CHECK:     scf.yield %[[SHAPE_CAST2]] : vector<1x4xf32>
+//         CHECK:   scf.forall (%arg0) in (4096)
+//         CHECK:     %[[FOR:.+]] = scf.for %arg1 = %c0 to %c86 step %c2 iter_args(%arg2 = {{.+}}) -> (vector<1x4xf32>)
+//         CHECK:       %[[READ0:.+]] = vector.transfer_read {{.+}} : memref<4096x86x128xi4, #hal.descriptor_type<storage_buffer>>, vector<4xi4>
+//         CHECK:       %[[READ1:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
+//         CHECK:       %[[READ2:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
+//         CHECK:       %[[READ3:.+]] = vector.transfer_read {{.+}} : memref<86x128xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//         CHECK:       %[[CVT:.+]] = arith.uitofp %[[READ0]] : vector<4xi4> to vector<4xf32>
+//         CHECK:       %[[EXTRACT0:.+]] = vector.extract %[[READ1]][0] : f32 from vector<1xf32>
+//         CHECK:       %[[BROADCAST0:.+]] = vector.broadcast %[[EXTRACT0]] : f32 to vector<4xf32>
+//         CHECK:       %[[SUB:.+]] = arith.subf %[[CVT]], %[[BROADCAST0]] : vector<4xf32>
+//         CHECK:       %[[EXTRACT1:.+]] = vector.extract %[[READ2]][0] : f32 from vector<1xf32>
+//         CHECK:       %[[BROADCAST1:.+]] = vector.broadcast %[[EXTRACT1]] : f32 to vector<4xf32>
+//         CHECK:       %[[MUL0:.+]] = arith.mulf %[[SUB]], %[[BROADCAST1]] : vector<4xf32>
+//         CHECK:       %[[MUL1:.+]] = arith.mulf %[[READ3]], %[[MUL0]] : vector<4xf32>
+//         CHECK:       %[[SHAPE_CAST:.+]] = vector.shape_cast %arg2 : vector<1x4xf32> to vector<4xf32>
+//         CHECK:       %[[ADD:.+]] = arith.addf %[[MUL1]], %[[SHAPE_CAST]] : vector<4xf32>
+//         CHECK:       %[[SHAPE_CAST2:.+]] = vector.shape_cast %[[ADD]] : vector<4xf32> to vector<1x4xf32>
+//         CHECK:       scf.yield %[[SHAPE_CAST2]] : vector<1x4xf32>
 
-//         CHECK:   %[[SHAPE_CAST3:.+]] = vector.shape_cast %[[FOR]] : vector<1x4xf32> to vector<4xf32>
-//         CHECK:   %[[REDUCE:.+]] = vector.reduction <add>, %[[SHAPE_CAST3]] : vector<4xf32> into f32
-//         CHECK:   gpu.subgroup_reduce add %[[REDUCE]] : (f32) -> f32
-//         CHECK:   scf.if
-//         CHECK:     vector.transfer_write
+//         CHECK:     %[[SHAPE_CAST3:.+]] = vector.shape_cast %[[FOR]] : vector<1x4xf32> to vector<4xf32>
+//         CHECK:     %[[REDUCE:.+]] = vector.reduction <add>, %[[SHAPE_CAST3]] : vector<4xf32> into f32
+//         CHECK:     gpu.subgroup_reduce add %[[REDUCE]] : (f32) -> f32
+//         CHECK:     scf.if
+//         CHECK:       vector.transfer_write
+//         CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -126,34 +126,33 @@ func.func @warp_reduction_dispatch_1() attributes {hal.executable.target = #exec
 //     CHECK-DAG:    %[[PV:.+]] = ub.poison : f16
 //     CHECK-DAG:    %[[F0:.+]] = arith.constant 0.000000e+00 : f16
 
-//     CHECK-DAG:    %[[WGIDX:.+]] = hal.interface.workgroup.id[0] upper_bound 65535 : index
-//     CHECK-DAG:    %[[WGIDY:.+]] = hal.interface.workgroup.id[1] upper_bound 65535 : index
-//     CHECK-DAG:    %[[TIDX:.+]] = gpu.thread_id x
-
 //     CHECK-DAG:    %[[SPAN0_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //     CHECK-DAG:    %[[SPAN0:.+]] = memref.assume_alignment %[[SPAN0_BINDING]], 64
 //     CHECK-DAG:    %[[SPAN1_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //     CHECK-DAG:    %[[SPAN1:.+]] = memref.assume_alignment %[[SPAN1_BINDING]], 64
 
-//         CHECK:    gpu.barrier memfence [#gpu.address_space<workgroup>]
-//         CHECK:    %{{.+}}, %{{.+}} = gpu.shuffle xor %{{.+}}, %[[I1]], %[[I32]] : i32
-//         CHECK:    %{{.+}}, %{{.+}} = gpu.shuffle xor %{{.+}}, %[[I2]], %[[I32]] : i32
-//         CHECK:    %{{.+}}, %{{.+}} = gpu.shuffle idx %{{.+}}, %[[I0]], %[[I32]] : i32
-//         CHECK:    %[[TRUNC:.+]] = arith.trunci %{{.+}} : i32 to i16
-//         CHECK:    %[[BCAST:.+]] = arith.bitcast %[[TRUNC]] : i16 to f16
-//         CHECK:    %[[ADD1:.+]] = arith.addf %[[BCAST]], %[[F0]] : f16
-//         CHECK:    %[[BROADCAST:.+]] = vector.broadcast %[[ADD1]] : f16 to vector<4xf16>
-//         CHECK:    scf.for %[[IV:.+]] = %[[C0]] to %[[C9216]] step %[[C1024]] {
-//         CHECK:      %[[OFFSET:.+]] = affine.apply {{.*}}(%[[IV]])[%[[TIDX]]]
-//         CHECK:      %[[READ:.+]] = vector.transfer_read %[[SPAN0]][%[[WGIDY]], %[[WGIDX]], %[[OFFSET]]], %[[PV]] {in_bounds = [true]} : memref<10x9216x9216xf16{{.*}}>, vector<8xf16>
-//         CHECK:      %[[SLICE0:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [0], sizes = [4], strides = [1]}
-//         CHECK:      %[[DIV0:.+]] = arith.divf %[[SLICE0]], %[[BROADCAST]] : vector<4xf16>
-//         CHECK:      %[[SLICE1:.+]] = vector.insert_strided_slice %[[DIV0]], %cst {offsets = [0], strides = [1]}
-//         CHECK:      %[[SLICE2:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [4], sizes = [4], strides = [1]}
-//         CHECK:      %[[DIV1:.+]] = arith.divf %[[SLICE2]], %[[BROADCAST]] : vector<4xf16>
-//         CHECK:      %[[SLICE3:.+]] = vector.insert_strided_slice %[[DIV1]], %[[SLICE1]] {offsets = [4], strides = [1]}
-//         CHECK:      vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[WGIDY]], %[[WGIDX]], %{{.*}}] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
-//         CHECK:    }
+//         CHECK:    scf.forall (%[[WGIDY:.+]], %[[WGIDX:.+]]) in (10, 9216) {
+//         CHECK:      %[[TIDX:.+]] = gpu.thread_id  x
+//         CHECK:      gpu.barrier memfence [#gpu.address_space<workgroup>]
+//         CHECK:      %{{.+}}, %{{.+}} = gpu.shuffle  xor %{{.+}}, %[[I1]], %[[I32]] : i32
+//         CHECK:      %{{.+}}, %{{.+}} = gpu.shuffle  xor %{{.+}}, %[[I2]], %[[I32]] : i32
+//         CHECK:      %{{.+}}, %{{.+}} = gpu.shuffle  idx %{{.+}}, %[[I0]], %[[I32]] : i32
+//         CHECK:      %[[TRUNC:.+]] = arith.trunci %{{.+}} : i32 to i16
+//         CHECK:      %[[BCAST:.+]] = arith.bitcast %[[TRUNC]] : i16 to f16
+//         CHECK:      %[[ADD1:.+]] = arith.addf %[[BCAST]], %[[F0]] : f16
+//         CHECK:      %[[BROADCAST:.+]] = vector.broadcast %[[ADD1]] : f16 to vector<4xf16>
+//         CHECK:      scf.for %[[IV:.+]] = %[[C0]] to %[[C9216]] step %[[C1024]] {
+//         CHECK:        %[[OFFSET:.+]] = affine.apply {{.*}}(%[[IV]])[%[[TIDX]]]
+//         CHECK:        %[[READ:.+]] = vector.transfer_read %[[SPAN0]][%[[WGIDY]], %[[WGIDX]], %[[OFFSET]]], %[[PV]] {in_bounds = [true]} : memref<10x9216x9216xf16{{.*}}>, vector<8xf16>
+//         CHECK:        %[[SLICE0:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [0], sizes = [4], strides = [1]}
+//         CHECK:        %[[DIV0:.+]] = arith.divf %[[SLICE0]], %[[BROADCAST]] : vector<4xf16>
+//         CHECK:        %[[SLICE1:.+]] = vector.insert_strided_slice %[[DIV0]], %cst {offsets = [0], strides = [1]}
+//         CHECK:        %[[SLICE2:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [4], sizes = [4], strides = [1]}
+//         CHECK:        %[[DIV1:.+]] = arith.divf %[[SLICE2]], %[[BROADCAST]] : vector<4xf16>
+//         CHECK:        %[[SLICE3:.+]] = vector.insert_strided_slice %[[DIV1]], %[[SLICE1]] {offsets = [4], strides = [1]}
+//         CHECK:        vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[WGIDY]], %[[WGIDX]], %{{.*}}] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
+//         CHECK:      }
+//         CHECK:    } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -148,10 +148,20 @@ hal.executable public @matmul_256x1024x128_div_exp {
 //         CHECK:     %[[LD6:.+]] = spirv.KHR.CooperativeMatrixLoad %{{.+}}, %[[C9]], <RowMajor> : !spirv.ptr<vector<4xf32>, Workgroup>, i32 -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixB>
 //         CHECK:     %[[LD7:.+]] = spirv.KHR.CooperativeMatrixLoad %{{.+}}, %[[C9]], <RowMajor> : !spirv.ptr<vector<4xf32>, Workgroup>, i32 -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixB>
 
-// CHECK-COUNT-8:     %{{.+}} = spirv.KHR.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
+//         CHECK:     %[[MA0:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD0]], %[[LD4]], %{{.+}}
+//         CHECK:     %[[MA1:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD1]], %[[LD6]], %[[MA0]]
+//         CHECK:     %[[MA2:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD0]], %[[LD5]], %{{.+}}
+//         CHECK:     %[[MA3:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD1]], %[[LD7]], %[[MA2]]
+//         CHECK:     %[[MA4:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD2]], %[[LD4]], %{{.+}}
+//         CHECK:     %[[MA5:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD3]], %[[LD6]], %[[MA4]]
+//         CHECK:     %[[MA6:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD2]], %[[LD5]], %{{.+}}
+//         CHECK:     %[[MA7:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD3]], %[[LD7]], %[[MA6]]
 
 // Matmul results are stored to workgroup memory for the epilogue.
-// CHECK-COUNT-4:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C9]], <RowMajor>
+//         CHECK:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %[[MA7]], %[[C9]], <RowMajor>
+//         CHECK:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %[[MA5]], %[[C9]], <RowMajor>
+//         CHECK:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %[[MA3]], %[[C9]], <RowMajor>
+//         CHECK:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %[[MA1]], %[[C9]], <RowMajor>
 
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -69,16 +69,15 @@ hal.executable public @matmul_256x1024x128_div_exp {
 // loads/stores as well (e.g. stride of 4 to 5 for loads of A).
 //
 // multi-buffering then doubles the shared memory usage for A and B.
-//         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
+// The C matrix is also stored to workgroup memory for the epilogue.
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @matmul_256x1024x128_div_exp
 
 //     CHECK-DAG:     %[[C5:.+]] = spirv.Constant 5 : i32
 //     CHECK-DAG:     %[[C9:.+]] = spirv.Constant 9 : i32
-//     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
-//     CHECK-DAG:     %[[C128:.+]] = spirv.Constant 128 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixAcc>
 
@@ -149,39 +148,28 @@ hal.executable public @matmul_256x1024x128_div_exp {
 //         CHECK:     %[[LD6:.+]] = spirv.KHR.CooperativeMatrixLoad %{{.+}}, %[[C9]], <RowMajor> : !spirv.ptr<vector<4xf32>, Workgroup>, i32 -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixB>
 //         CHECK:     %[[LD7:.+]] = spirv.KHR.CooperativeMatrixLoad %{{.+}}, %[[C9]], <RowMajor> : !spirv.ptr<vector<4xf32>, Workgroup>, i32 -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixB>
 
-//         CHECK:     %[[MA0:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD0]], %[[LD4]], %{{.+}}
-//         CHECK:     %[[MA1:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD1]], %[[LD6]], %[[MA0]]
-//         CHECK:     %[[MA2:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD0]], %[[LD5]], %{{.+}}
-//         CHECK:     %[[MA3:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD1]], %[[LD7]], %[[MA2]]
-//         CHECK:     %[[MA4:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD2]], %[[LD4]], %{{.+}}
-//         CHECK:     %[[MA5:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD3]], %[[LD6]], %[[MA4]]
-//         CHECK:     %[[MA6:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD2]], %[[LD5]], %{{.+}}
-//         CHECK:     %[[MA7:.+]] = spirv.KHR.CooperativeMatrixMulAdd %[[LD3]], %[[LD7]], %[[MA6]]
+// CHECK-COUNT-8:     %{{.+}} = spirv.KHR.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
 
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.KHR.CooperativeMatrixStore %[[AC]], %[[MA7]], %[[C9]], <RowMajor>
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.KHR.CooperativeMatrixStore %[[AC]], %[[MA5]], %[[C9]], <RowMajor>
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.KHR.CooperativeMatrixStore %[[AC]], %[[MA3]], %[[C9]], <RowMajor>
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.KHR.CooperativeMatrixStore %[[AC]], %[[MA1]], %[[C9]], <RowMajor>
+// Matmul results are stored to workgroup memory for the epilogue.
+// CHECK-COUNT-4:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C9]], <RowMajor>
 
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+
+// Epilogue: load from workgroup mem and storage buffer, do FDiv + FAbs on vectors.
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.GL.FAbs %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.GL.FAbs %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.GL.FAbs %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.GL.FAbs %{{.+}} : vector<4xf16>
 
@@ -242,14 +230,14 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-//         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @batch_matmul_16x128x256x512_div
 
 //     CHECK-DAG:     %[[C5:.+]] = spirv.Constant 5 : i32
 //     CHECK-DAG:     %[[C9:.+]] = spirv.Constant 9 : i32
-//     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixAcc>
 
@@ -288,16 +276,32 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 // CHECK-COUNT-4:     %{{.+}} = spirv.KHR.CooperativeMatrixLoad %{{.+}}, %[[C9]], <RowMajor> : !spirv.ptr<vector<4xf32>, Workgroup>, i32 -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixB>
 // CHECK-COUNT-8:     %{{.+}} = spirv.KHR.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
 
-// CHECK-COUNT-4:     %{{.+}} = spirv.KHR.CooperativeMatrixLoad %{{.+}}, %[[C32]], <RowMajor> : !spirv.ptr<vector<4xf32>, StorageBuffer>, i32 -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixAcc>
-// CHECK-COUNT-4:     %{{.+}} = spirv.FDiv %{{.+}}, %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup, MatrixAcc>
-// CHECK-COUNT-4:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C32]], <RowMajor>
+// Matmul results stored to workgroup memory for the epilogue.
+// CHECK-COUNT-4:     spirv.KHR.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C9]], <RowMajor>
+//         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+
+// Epilogue: load from workgroup mem and storage buffer, do FDiv on vectors.
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 
 //   RDNA3-LABEL: spirv.module Logical GLSL450
+//     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 //         RDNA3:   spirv.func @batch_matmul_16x128x256x512_div
 
 //   RDNA4-LABEL: spirv.module Logical GLSL450
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 //         RDNA4:   spirv.func @batch_matmul_16x128x256x512_div
@@ -351,9 +355,11 @@ hal.executable public @matmul_32x32x32_div {
 //   CHECK-LABEL: spirv.module Logical GLSL450
 // CHECK-COUNT-4: spirv.KHR.CooperativeMatrixLoad
 // CHECK-COUNT-2: spirv.KHR.CooperativeMatrixMulAdd
-//         CHECK: spirv.KHR.CooperativeMatrixLoad
-//         CHECK: spirv.FDiv %{{.+}}, %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup, MatrixAcc>
-//         CHECK: spirv.KHR.CooperativeMatrixStore
+//         CHECK: spirv.KHR.CooperativeMatrixStore %{{.+}}, %{{.+}}, %{{.+}}, <RowMajor> : !spirv.ptr<vector<4xf32>, Workgroup>
+//         CHECK: spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+//         CHECK: spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+//         CHECK: spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2: spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 
 // -----
 
@@ -399,15 +405,14 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 // With pipelining + multi-buffering the loop here gets completely unrolled.
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-//         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
+//     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @generic_batch_matmul_32x128x512x64
 
 //     CHECK-DAG:     %[[C5:.+]] = spirv.Constant 5 : i32
 //     CHECK-DAG:     %[[C9:.+]] = spirv.Constant 9 : i32
 //     CHECK-DAG:     %[[C64:.+]] = spirv.Constant 64 : i32
-//     CHECK-DAG:     %[[C256:.+]] = spirv.Constant 256 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup, MatrixAcc>
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -113,11 +113,9 @@ hal.executable @matmul_f16_128x256x64 {
   }
 }
 
-// Ditto on the above.
-//    1024 x vector<4xf32> -> 1056 x vector<4xf32>
-//    256 x vector<4xf32> -> 320 x vector<4xf32>
-// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1056 x vector<4xf32>>)>, Workgroup>
-// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<320 x vector<4xf32>>)>, Workgroup>
+// Ditto on the above but without bank conflict padding for f16.
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1024 x vector<4xf32>>)>, Workgroup>
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<256 x vector<4xf32>>)>, Workgroup>
 
 // CHECK-LABEL: spirv.func @matmul_f16_128x256x64
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -183,17 +183,18 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 //     CHECK-DAG: %[[C0:.+]] = spirv.Constant 0 : i32
 //     CHECK-DAG: %[[CSTVEC4XF16_1:.+]] = spirv.Constant dense<1.000000e+00> : vector<4xf16>
 
-//         CHECK: %[[WIDX:.+]] = spirv.CompositeExtract %{{.*}}[0 : i32] : vector<3xi32>
-//         CHECK: %[[PCPTR:.+]] = spirv.AccessChain %{{.*}}[{{.*}}, %[[C0]]] : !spirv.ptr<!spirv.struct<(!spirv.array<5 x i32, stride=4> [0])>, PushConstant>, i32, i32
-//         CHECK: %[[STREAMBINDING:.+]] = spirv.Load "PushConstant" %[[PCPTR]] : i32
+//         CHECK: %[[PCPTR0:.+]] = spirv.AccessChain %{{.*}}[%[[C0]], %[[C0]]] : !spirv.ptr<!spirv.struct<(!spirv.array<5 x i32, stride=4> [0])>, PushConstant>, i32, i32
+//         CHECK: %[[STREAMBINDING:.+]] = spirv.Load "PushConstant" %[[PCPTR0]] : i32
 
 //         CHECK: %[[RADDR:.+]] = spirv.mlir.addressof @{{.*}} : !spirv.ptr<!spirv.struct<(!spirv.rtarray<i32, stride=4> [0])>, StorageBuffer>
+
+//         CHECK: %[[WIDX:.+]] = spirv.CompositeExtract %{{.*}}[0 : i32] : vector<3xi32>
 
 //         CHECK: spirv.mlir.loop
 
 // Load the quantized weight and get 4xi4 out of it. Ensure that the offset
 // calculation avoids excessive scaling down in computing the element offset.
-//         CHECK:   spirv.IMul %{{.*}}, %[[C64]]  {no_signed_wrap} : i32
+//         CHECK:   spirv.IMul %{{.*}}, %[[C64]] {no_signed_wrap} : i32
 //         CHECK:   spirv.IAdd %{{.*}}, %[[STREAMBINDING]] : i32
 //         CHECK:   spirv.IMul %{{.*}}, %[[C5504]] {no_signed_wrap} : i32
 //         CHECK:   spirv.IAdd %{{.*}}, %{{.*}} : i32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
@@ -45,13 +45,23 @@ hal.executable private @subgroup_reduce {
 // CHECK-DAG:   %[[FV0:.+]] = spirv.Constant dense<0.000000e+00> : vector<4xf32>
 // CHECK-DAG:   %[[FV1:.+]] = spirv.Constant dense<1.000000e+00> : vector<4xf32>
 
+// CHECK:   %[[THREAD_EQ0:.+]] = spirv.IEqual %{{.+}}, %[[C0]] : i32
+// CHECK:   %[[WG_EQ0:.+]] = spirv.IEqual %{{.+}}, %[[C0]] : i32
+
 // CHECK:   %[[LD:.+]] = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 // CHECK:   %[[ADDV0:.+]] = spirv.FAdd %[[LD]], %[[FV0]] : vector<4xf32>
 // CHECK:   %[[ADD2:.+]] = spirv.Dot %[[ADDV0]], %[[FV1]] : vector<4xf32> -> f32
 
 // CHECK:   %[[S0:.+]] = spirv.GroupNonUniformFAdd <Subgroup> <Reduce> %[[ADD2]] : f32 -> f32
 
-// CHECK:   spirv.Store "Workgroup" %{{.+}}, %[[S0]] : f32
+// CHECK:   spirv.mlir.selection {
+// CHECK:     spirv.BranchConditional %[[THREAD_EQ0]], ^bb1, ^bb2
+// CHECK:   ^bb1:
+// CHECK:     spirv.Store "Workgroup" %{{.+}}, %[[S0]] : f32
+// CHECK:     spirv.Branch ^bb2
+// CHECK:   ^bb2:
+// CHECK:     spirv.mlir.merge
+// CHECK:   }
 
 // CHECK:   spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
@@ -65,9 +75,8 @@ hal.executable private @subgroup_reduce {
 // CHECK:   %[[S7:.+]] = spirv.GroupNonUniformShuffle <Subgroup> %[[ADD9]], %[[C0]] : f32, i32
 // CHECK:   %[[ADD10:.+]] = spirv.FAdd %[[S7]], %[[F0]] : f32
 
-// CHECK:   %[[EQ:.+]] = spirv.IEqual %{{.+}}, %[[C0]] : i32
 // CHECK:   spirv.mlir.selection {
-// CHECK:     spirv.BranchConditional %[[EQ]], ^bb1, ^bb2
+// CHECK:     spirv.BranchConditional %[[WG_EQ0]], ^bb1, ^bb2
 // CHECK:   ^bb1:
 // CHECK:     spirv.Store "StorageBuffer" %{{.+}}, %[[ADD10]] : f32
 // CHECK:     spirv.Branch ^bb2


### PR DESCRIPTION
The forall path also requires `ConvertAccGEMMToGEMM` before distribution to avoid accumulating matmul's shared_outs being bufferized to workgroup memory with a copy-out outside the forall, which violates the workgroup
distribution verifier.