### PR TITLE
[GPU] Make VectorReductionToGPU forall-aware

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorDistribution.h"
@@ -254,24 +255,79 @@ struct VectorReductionToGPUPass final
     }
     SmallVector<int64_t> &workgroupSize = maybeWorkgroupSize.value();
     assert(workgroupSize[1] == 1 && workgroupSize[2] == 1);
-    // 2. Create the warp op and move the function body into it.
+    // 2. Create the warp op and move the body into it.
+    //
+    // When the function body contains a workgroup-level scf.forall, wrap the
+    // forall body rather than the function body. The forall body is
+    // structurally equivalent to the function body on the non-forall path
+    // (same vector ops, just with the forall induction var instead of
+    // hal.interface.workgroup.id). Wrapping the function body would place the
+    // forall inside the warp op, where distribution patterns cannot propagate
+    // through the forall region boundary, leaving vectors at full size.
     const int groupSize = workgroupSize[0];
     Location loc = funcOp.getLoc();
     OpBuilder builder(funcOp);
-    auto threadX = gpu::ThreadIdOp::create(builder, loc, builder.getIndexType(),
-                                           gpu::Dimension::x);
-    auto cstGroupSize = arith::ConstantIndexOp::create(builder, loc, groupSize);
-    auto warpOp = gpu::WarpExecuteOnLane0Op::create(
-        builder, loc, TypeRange(), threadX.getResult(), groupSize);
-    warpOp.getWarpRegion().takeBody(funcOp.getFunctionBody());
-    Block &newBlock = funcOp.getFunctionBody().emplaceBlock();
-    threadX->moveBefore(&newBlock, newBlock.end());
-    cstGroupSize->moveBefore(&newBlock, newBlock.end());
-    warpOp->moveBefore(&newBlock, newBlock.end());
-    warpOp.getWarpRegion().getBlocks().back().back().moveBefore(&newBlock,
-                                                                newBlock.end());
-    builder.setInsertionPointToEnd(&warpOp.getWarpRegion().getBlocks().back());
-    gpu::YieldOp::create(builder, loc);
+
+    // Check for a workgroup-level scf.forall.
+    scf::ForallOp workgroupForall;
+    for (auto &op : funcOp.getFunctionBody().front()) {
+      if (auto forall = dyn_cast<scf::ForallOp>(&op)) {
+        if (forallOpHasMappingType<IREE::Codegen::WorkgroupMappingAttr>(
+                forall)) {
+          workgroupForall = forall;
+          break;
+        }
+      }
+    }
+
+    gpu::WarpExecuteOnLane0Op warpOp;
+    if (workgroupForall) {
+      Block *forallBody = workgroupForall.getBody();
+      Operation *terminator = forallBody->getTerminator();
+
+      builder.setInsertionPoint(terminator);
+      auto threadX = gpu::ThreadIdOp::create(
+          builder, loc, builder.getIndexType(), gpu::Dimension::x);
+      auto cstGroupSize =
+          arith::ConstantIndexOp::create(builder, loc, groupSize);
+      warpOp = gpu::WarpExecuteOnLane0Op::create(
+          builder, loc, TypeRange(), threadX.getResult(), groupSize);
+
+      // Move all existing forall body ops into the warp region. The create
+      // call above produces a region with one empty block; use that block.
+      Block &warpBody = warpOp.getWarpRegion().front();
+      SmallVector<Operation *> opsToMove;
+      for (auto &op : *forallBody) {
+        if (&op == threadX.getOperation() ||
+            &op == cstGroupSize.getOperation() ||
+            &op == warpOp.getOperation() || &op == terminator) {
+          continue;
+        }
+        opsToMove.push_back(&op);
+      }
+      for (auto *op : opsToMove) {
+        op->moveBefore(&warpBody, warpBody.end());
+      }
+      builder.setInsertionPointToEnd(&warpBody);
+      gpu::YieldOp::create(builder, loc);
+    } else {
+      auto threadX = gpu::ThreadIdOp::create(
+          builder, loc, builder.getIndexType(), gpu::Dimension::x);
+      auto cstGroupSize =
+          arith::ConstantIndexOp::create(builder, loc, groupSize);
+      warpOp = gpu::WarpExecuteOnLane0Op::create(
+          builder, loc, TypeRange(), threadX.getResult(), groupSize);
+      warpOp.getWarpRegion().takeBody(funcOp.getFunctionBody());
+      Block &newBlock = funcOp.getFunctionBody().emplaceBlock();
+      threadX->moveBefore(&newBlock, newBlock.end());
+      cstGroupSize->moveBefore(&newBlock, newBlock.end());
+      warpOp->moveBefore(&newBlock, newBlock.end());
+      warpOp.getWarpRegion().getBlocks().back().back().moveBefore(
+          &newBlock, newBlock.end());
+      builder.setInsertionPointToEnd(
+          &warpOp.getWarpRegion().getBlocks().back());
+      gpu::YieldOp::create(builder, loc);
+    }
 
     debugPrint(funcOp, "after step #2: wrapping code with the warp execute op");
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
@@ -71,6 +71,61 @@ module {
 
 // -----
 
+// Check that reduction inside an scf.forall with workgroup mapping gets
+// correctly distributed. The forall body is structurally equivalent to the
+// function body in the non-forall path.
+
+#pipeline_layout_forall = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#translation_info_forall = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
+module {
+  func.func @reduce_forall() attributes {translation_info = #translation_info_forall} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %cst_1 = arith.constant dense<3.840000e+02> : vector<1xf32>
+    %c32 = arith.constant 32 : index
+    %c384 = arith.constant 384 : index
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout_forall) binding(0) alignment(64) offset(%c0) : memref<128x384xf32>
+    %1 = hal.interface.binding.subspan layout(#pipeline_layout_forall) binding(1) alignment(64) offset(%c0) : memref<128xf32>
+    scf.forall (%wg_id) in (64) {
+      %2 = affine.apply affine_map<(d0) -> (d0 * 2)>(%wg_id)
+      %3 = scf.for %arg0 = %c0 to %c384 step %c32 iter_args(%arg1 = %cst) -> (vector<1xf32>) {
+        %5 = vector.transfer_read %0[%2, %arg0], %cst_0 {in_bounds = [true]} : memref<128x384xf32>, vector<32xf32>
+        %6 = vector.broadcast %5 : vector<32xf32> to vector<1x32xf32>
+        %7 = vector.multi_reduction <add>, %6, %arg1 [1] : vector<1x32xf32> to vector<1xf32>
+        scf.yield %7 : vector<1xf32>
+      }
+      %4 = arith.divf %3, %cst_1 : vector<1xf32>
+      vector.transfer_write %4, %1[%2] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+    } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+    return
+  }
+}
+
+//       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (d0 * 2)>
+// CHECK-LABEL: func.func @reduce_forall()
+//   CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C32:.*]] = arith.constant 32 : i32
+//       CHECK:   scf.forall (%[[WG_ID:.*]]) in (64) {
+//       CHECK:     %[[TID:.*]] = gpu.thread_id  x
+//       CHECK:     affine.apply #[[$MAP]](%[[WG_ID]])
+//       CHECK:     scf.for {{.*}} -> (vector<1xf32>) {
+//       CHECK:       vector.transfer_read {{.*}} : memref<128x384xf32>, vector<1xf32>
+// CHECK-COUNT-5:     gpu.shuffle  xor {{.*}} %[[C32]] : f32
+//       CHECK:       scf.yield {{.*}} : vector<1xf32>
+//       CHECK:     }
+//       CHECK:     %[[CMP:.*]] = arith.cmpi eq, %[[TID]], %[[C0]] : index
+//       CHECK:     scf.if %[[CMP]] {
+//       CHECK:       vector.transfer_write {{.*}} : vector<1xf32>, memref<128xf32>
+//       CHECK:     }
+//       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+//       CHECK:   return
+
+// -----
+
 // Make sure memref.load from uniform buffers are hoisted out as uniform code.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [


### PR DESCRIPTION
When the function body contains a workgroup-level `scf.forall`, wrap the forall body in `WarpExecuteOnLane0Op` instead of the function body.

Assisted-by: Claude