### PR TITLE
Fixes for UBSan compatibility across the runtime

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -262,6 +262,11 @@ build:ubsan --features=ubsan
 build:ubsan --copt=-fsanitize=undefined
 build:ubsan --linkopt=-fsanitize=undefined
 build:ubsan --linkopt=-lubsan
+# The vptr sanitizer check uses typeid() to verify vtable pointers, which
+# requires RTTI. IREE compiles all C++ with -fno-rtti for LLVM/MLIR
+# compatibility, so the vptr check produces false positives on every
+# virtual dispatch (including gtest internals). Exclude it.
+build:ubsan --cxxopt=-fno-sanitize=vptr
 build:ubsan --cc_output_directory_tag=ubsan
 
 # Fuzzer (libFuzzer) configuration

--- a/build_tools/cmake/iree_setup_toolchain.cmake
+++ b/build_tools/cmake/iree_setup_toolchain.cmake
@@ -192,6 +192,11 @@ macro(iree_setup_toolchain)
   if(IREE_ENABLE_UBSAN)
     string(APPEND CMAKE_CXX_FLAGS " -fsanitize=undefined")
     string(APPEND CMAKE_C_FLAGS " -fsanitize=undefined")
+    # The vptr sanitizer check uses typeid() to verify vtable pointers, which
+    # requires RTTI. IREE compiles all C++ with -fno-rtti for LLVM/MLIR
+    # compatibility, so the vptr check produces false positives on every
+    # virtual dispatch (including gtest internals). Exclude it.
+    string(APPEND CMAKE_CXX_FLAGS " -fno-sanitize=vptr")
   endif()
   if(IREE_ENABLE_FUZZING)
     # Instrument all code for libFuzzer coverage feedback without linking the

--- a/runtime/src/iree/async/cts/sync/notification_test.cc
+++ b/runtime/src/iree/async/cts/sync/notification_test.cc
@@ -182,29 +182,50 @@ TEST_P(NotificationTest, MultipleSignalsWhileWaiting) {
 }
 
 // Repeated wait/signal cycles work correctly.
+//
+// Each cycle: the worker enters notification_wait, the main thread signals,
+// the worker wakes. The main thread must wait for the worker to be blocked
+// in notification_wait before signaling; otherwise, the signal can arrive
+// between loop iterations and coalesce with a previous signal (epoch-based
+// notifications are level-triggered, so signals that arrive before the wait
+// captures the epoch are invisible to that wait).
 TEST_P(NotificationTest, RepeatedWaitSignalCycles) {
   iree_async_notification_t* notification = nullptr;
   IREE_ASSERT_OK(iree_async_notification_create(
       proactor_, IREE_ASYNC_NOTIFICATION_FLAG_NONE, &notification));
 
   std::atomic<int> cycles_completed{0};
-  std::atomic<bool> stop{false};
+  std::atomic<int> worker_cycle{0};
   constexpr int kCycles = 3;
 
   // Worker thread waits for signals in a loop.
   std::thread worker([&]() {
-    for (int i = 0; i < kCycles && !stop.load(std::memory_order_acquire); ++i) {
+    for (int i = 0; i < kCycles; ++i) {
+      // Publish which cycle we are about to wait on. The main thread spins
+      // on this to ensure it does not signal before we enter the wait.
+      worker_cycle.store(i + 1, std::memory_order_release);
+
       bool result = iree_async_notification_wait(notification,
-                                                 iree_make_timeout_ms(1000));
+                                                 iree_make_timeout_ms(5000));
       if (result) {
         cycles_completed.fetch_add(1, std::memory_order_acq_rel);
       }
     }
   });
 
-  // Signal the worker for each cycle, with delays between.
+  // Signal the worker for each cycle, waiting for readiness first.
   for (int i = 0; i < kCycles; ++i) {
-    iree_wait_until(iree_time_now() + iree_make_duration_ms(20));
+    // Spin until the worker has published that it is entering cycle i+1.
+    while (worker_cycle.load(std::memory_order_acquire) < i + 1) {
+      iree_thread_yield();
+    }
+    // The worker has published its cycle counter but may not yet be blocked
+    // in the kernel wait (there is a small window between the store and the
+    // futex/condvar syscall). A short delay ensures the worker enters the
+    // wait before we signal. This is NOT a load-sensitivity issue — it is
+    // bridging the gap between an observable user-space state (the atomic
+    // store) and the kernel-level blocking state.
+    iree_wait_until(iree_time_now() + iree_make_duration_ms(10));
     iree_async_notification_signal(notification, 1);
   }
 

--- a/runtime/src/iree/async/cts/sync/notification_test.cc
+++ b/runtime/src/iree/async/cts/sync/notification_test.cc
@@ -183,12 +183,12 @@ TEST_P(NotificationTest, MultipleSignalsWhileWaiting) {
 
 // Repeated wait/signal cycles work correctly.
 //
-// Each cycle: the worker enters notification_wait, the main thread signals,
-// the worker wakes. The main thread must wait for the worker to be blocked
-// in notification_wait before signaling; otherwise, the signal can arrive
-// between loop iterations and coalesce with a previous signal (epoch-based
-// notifications are level-triggered, so signals that arrive before the wait
-// captures the epoch are invisible to that wait).
+// Epoch-based notifications coalesce signals that arrive before the waiter
+// captures the epoch (via the internal prepare_wait). There is no way to
+// observe from outside when prepare_wait has executed, so a single signal
+// is not guaranteed to wake the worker. Instead, the main thread signals
+// continuously until the worker acknowledges each cycle. This makes progress
+// unconditional: if a signal coalesces, the next one lands after prepare_wait.
 TEST_P(NotificationTest, RepeatedWaitSignalCycles) {
   iree_async_notification_t* notification = nullptr;
   IREE_ASSERT_OK(iree_async_notification_create(
@@ -201,8 +201,8 @@ TEST_P(NotificationTest, RepeatedWaitSignalCycles) {
   // Worker thread waits for signals in a loop.
   std::thread worker([&]() {
     for (int i = 0; i < kCycles; ++i) {
-      // Publish which cycle we are about to wait on. The main thread spins
-      // on this to ensure it does not signal before we enter the wait.
+      // Publish which cycle we are about to wait on. The main thread uses
+      // this to avoid racing ahead to cycle N+1 before we start cycle N.
       worker_cycle.store(i + 1, std::memory_order_release);
 
       bool result = iree_async_notification_wait(notification,
@@ -213,20 +213,16 @@ TEST_P(NotificationTest, RepeatedWaitSignalCycles) {
     }
   });
 
-  // Signal the worker for each cycle, waiting for readiness first.
   for (int i = 0; i < kCycles; ++i) {
-    // Spin until the worker has published that it is entering cycle i+1.
+    // Wait for the worker to begin this cycle.
     while (worker_cycle.load(std::memory_order_acquire) < i + 1) {
       iree_thread_yield();
     }
-    // The worker has published its cycle counter but may not yet be blocked
-    // in the kernel wait (there is a small window between the store and the
-    // futex/condvar syscall). A short delay ensures the worker enters the
-    // wait before we signal. This is NOT a load-sensitivity issue — it is
-    // bridging the gap between an observable user-space state (the atomic
-    // store) and the kernel-level blocking state.
-    iree_wait_until(iree_time_now() + iree_make_duration_ms(10));
-    iree_async_notification_signal(notification, 1);
+    // Signal continuously until the worker completes this cycle.
+    while (cycles_completed.load(std::memory_order_acquire) < i + 1) {
+      iree_async_notification_signal(notification, 1);
+      iree_thread_yield();
+    }
   }
 
   worker.join();

--- a/runtime/src/iree/async/platform/posix/worker.c
+++ b/runtime/src/iree/async/platform/posix/worker.c
@@ -168,6 +168,11 @@ static bool iree_async_posix_worker_is_zombie(
          IREE_ASYNC_POSIX_WORKER_STATE_ZOMBIE;
 }
 
+// Condition function thunk matching iree_condition_fn_t signature.
+static bool iree_async_posix_worker_is_zombie_thunk(void* arg) {
+  return iree_async_posix_worker_is_zombie((iree_async_posix_worker_t*)arg);
+}
+
 static int iree_async_posix_worker_main(iree_async_posix_worker_t* worker) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -305,6 +310,14 @@ static int iree_async_posix_worker_main(iree_async_posix_worker_t* worker) {
   return 0;
 }
 
+// Thread entry point thunk matching iree_thread_entry_t signature.
+// iree_thread_create expects int (*)(void*) but iree_async_posix_worker_main
+// takes a typed pointer — casting the function pointer directly is undefined
+// behavior (caught by UBSan's -fsanitize=function check).
+static int iree_async_posix_worker_thread_entry(void* entry_arg) {
+  return iree_async_posix_worker_main((iree_async_posix_worker_t*)entry_arg);
+}
+
 //===----------------------------------------------------------------------===//
 // Worker lifecycle
 //===----------------------------------------------------------------------===//
@@ -343,8 +356,8 @@ iree_status_t iree_async_posix_worker_initialize(
 
   // Create and start the worker thread.
   iree_status_t status =
-      iree_thread_create((iree_thread_entry_t)iree_async_posix_worker_main,
-                         out_worker, params, allocator, &out_worker->thread);
+      iree_thread_create(iree_async_posix_worker_thread_entry, out_worker,
+                         params, allocator, &out_worker->thread);
 
   IREE_TRACE_ZONE_END(z0);
   return status;
@@ -382,10 +395,9 @@ void iree_async_posix_worker_await_exit(iree_async_posix_worker_t* worker) {
   iree_async_posix_worker_request_exit(worker);
 
   // Wait for the worker to enter ZOMBIE state.
-  iree_notification_await(
-      &worker->state_notification,
-      (iree_condition_fn_t)iree_async_posix_worker_is_zombie, worker,
-      iree_infinite_timeout());
+  iree_notification_await(&worker->state_notification,
+                          iree_async_posix_worker_is_zombie_thunk, worker,
+                          iree_infinite_timeout());
 
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/base/internal/wait_handle_inproc.c
+++ b/runtime/src/iree/base/internal/wait_handle_inproc.c
@@ -271,6 +271,10 @@ static bool iree_wait_set_check(const iree_wait_set_check_params_t* params) {
   return ready_count == params->set->handle_count;
 }
 
+static bool iree_wait_set_check_thunk(void* arg) {
+  return iree_wait_set_check((const iree_wait_set_check_params_t*)arg);
+}
+
 static iree_status_t iree_wait_multi(iree_wait_set_t* set,
                                      iree_time_t deadline_ns,
                                      iree_wait_handle_t* out_wake_handle) {
@@ -287,8 +291,8 @@ static iree_status_t iree_wait_multi(iree_wait_set_t* set,
       .wake_handle = out_wake_handle,
   };
   if (!iree_notification_await(iree_wait_multi_notification(),
-                               (iree_condition_fn_t)iree_wait_set_check,
-                               &params, iree_make_deadline(deadline_ns))) {
+                               iree_wait_set_check_thunk, &params,
+                               iree_make_deadline(deadline_ns))) {
     return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
   }
   return iree_ok_status();
@@ -315,6 +319,10 @@ static bool iree_futex_handle_check(iree_futex_handle_t* futex) {
   return iree_atomic_load(&futex->value, iree_memory_order_acquire) != 0;
 }
 
+static bool iree_futex_handle_check_thunk(void* arg) {
+  return iree_futex_handle_check((iree_futex_handle_t*)arg);
+}
+
 iree_status_t iree_wait_one(iree_wait_handle_t* handle,
                             iree_time_t deadline_ns) {
   if (handle->type == IREE_WAIT_PRIMITIVE_TYPE_NONE) {
@@ -327,8 +335,8 @@ iree_status_t iree_wait_one(iree_wait_handle_t* handle,
     iree_futex_handle_t* futex =
         (iree_futex_handle_t*)handle->value.local_futex;
     if (!iree_notification_await(&futex->notification,
-                                 (iree_condition_fn_t)iree_futex_handle_check,
-                                 futex, iree_make_deadline(deadline_ns))) {
+                                 iree_futex_handle_check_thunk, futex,
+                                 iree_make_deadline(deadline_ns))) {
       status = iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
     }
   } else {

--- a/runtime/src/iree/hal/drivers/hip/cleanup_thread.c
+++ b/runtime/src/iree/hal/drivers/hip/cleanup_thread.c
@@ -116,8 +116,8 @@ iree_status_t iree_hal_hip_cleanup_thread_initialize(
   memset(&params, 0x00, sizeof(params));
   params.name = iree_make_cstring_view("iree-hal-hip-cleanup");
   iree_status_t status =
-      iree_thread_create((iree_thread_entry_t)iree_hal_hip_cleanup_thread_main,
-                         thread, params, host_allocator, &thread->thread);
+      iree_thread_create(iree_hal_hip_cleanup_thread_main, thread, params,
+                         host_allocator, &thread->thread);
   if (iree_status_is_ok(status)) {
     *out_thread = thread;
   } else {

--- a/runtime/src/iree/hal/drivers/hip/dispatch_thread.c
+++ b/runtime/src/iree/hal/drivers/hip/dispatch_thread.c
@@ -107,8 +107,8 @@ iree_status_t iree_hal_hip_dispatch_thread_initialize(
   memset(&params, 0x00, sizeof(params));
   params.name = iree_make_cstring_view("iree-hal-hip-dispatch");
   iree_status_t status =
-      iree_thread_create((iree_thread_entry_t)iree_hal_hip_dispatch_thread_main,
-                         thread, params, host_allocator, &thread->thread);
+      iree_thread_create(iree_hal_hip_dispatch_thread_main, thread, params,
+                         host_allocator, &thread->thread);
 
   if (iree_status_is_ok(status)) {
     *out_thread = thread;

--- a/runtime/src/iree/hal/drivers/hip/event_semaphore.c
+++ b/runtime/src/iree/hal/drivers/hip/event_semaphore.c
@@ -1164,6 +1164,11 @@ bool iree_hal_hip_semaphore_timepoint_already_exported(
   return ret;
 }
 
+static bool iree_hal_hip_semaphore_timepoint_already_exported_thunk(void* arg) {
+  return iree_hal_hip_semaphore_timepoint_already_exported(
+      (iree_hal_hip_semaphore_external_timepoint_wait_data_t*)arg);
+}
+
 iree_status_t iree_hal_hip_semaphore_for_exported_timepoints(
     iree_hal_semaphore_t* base_semaphore, uint64_t value) {
   int64_t value_to_wait_for = 0;
@@ -1197,8 +1202,8 @@ iree_status_t iree_hal_hip_semaphore_for_exported_timepoints(
         .semaphore = semaphore, .value = value_to_wait_for};
     iree_notification_await(
         &semaphore->external_event_notification,
-        (iree_condition_fn_t)iree_hal_hip_semaphore_timepoint_already_exported,
-        &dat, iree_infinite_timeout());
+        iree_hal_hip_semaphore_timepoint_already_exported_thunk, &dat,
+        iree_infinite_timeout());
     IREE_TRACE_ZONE_END(z0);
   }
   return iree_ok_status();

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1130,6 +1130,11 @@ static bool iree_hal_hip_dispatch_is_completed(
   return ret;
 }
 
+static bool iree_hal_hip_dispatch_is_completed_thunk(void* arg) {
+  return iree_hal_hip_dispatch_is_completed(
+      (iree_hal_hip_dispatch_completed_data_t*)arg);
+}
+
 static void iree_hal_hip_set_external_stream_data_completed(
     iree_hal_hip_dispatch_completed_data_t* data) {
   iree_slim_mutex_lock(&data->completed_mutex);
@@ -1140,10 +1145,9 @@ static void iree_hal_hip_set_external_stream_data_completed(
 
 static void iree_hal_hip_wait_for_dispatch(
     iree_hal_hip_dispatch_completed_data_t* data) {
-  iree_notification_await(
-      &data->notification,
-      (iree_condition_fn_t)iree_hal_hip_dispatch_is_completed, data,
-      iree_infinite_timeout());
+  iree_notification_await(&data->notification,
+                          iree_hal_hip_dispatch_is_completed_thunk, data,
+                          iree_infinite_timeout());
 }
 
 typedef struct iree_hal_hip_semaphore_callback_data_t {

--- a/runtime/src/iree/hal/drivers/local_sync/sync_semaphore.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_semaphore.c
@@ -260,6 +260,11 @@ static bool iree_hal_sync_semaphore_is_signaled(
   return is_signaled;
 }
 
+static bool iree_hal_sync_semaphore_is_signaled_thunk(void* arg) {
+  return iree_hal_sync_semaphore_is_signaled(
+      (iree_hal_sync_semaphore_notify_state_t*)arg);
+}
+
 static iree_status_t iree_hal_sync_semaphore_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t value,
     iree_timeout_t timeout, iree_hal_wait_flags_t flags) {
@@ -294,10 +299,9 @@ static iree_status_t iree_hal_sync_semaphore_wait(
       .semaphore = semaphore,
       .value = value,
   };
-  iree_notification_await(
-      &shared_state->notification,
-      (iree_condition_fn_t)iree_hal_sync_semaphore_is_signaled,
-      (void*)&notify_state, timeout);
+  iree_notification_await(&shared_state->notification,
+                          iree_hal_sync_semaphore_is_signaled_thunk,
+                          (void*)&notify_state, timeout);
 
   iree_status_t status = iree_ok_status();
   iree_slim_mutex_lock(&semaphore->mutex);
@@ -313,7 +317,6 @@ static iree_status_t iree_hal_sync_semaphore_wait(
 }
 
 // Returns true if any semaphore in the list has signaled (or failed).
-// Used with with iree_condition_fn_t and must match that signature.
 static bool iree_hal_sync_semaphore_any_signaled(
     const iree_hal_semaphore_list_t* semaphore_list) {
   for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {
@@ -329,8 +332,12 @@ static bool iree_hal_sync_semaphore_any_signaled(
   return false;
 }
 
+static bool iree_hal_sync_semaphore_any_signaled_thunk(void* arg) {
+  return iree_hal_sync_semaphore_any_signaled(
+      (const iree_hal_semaphore_list_t*)arg);
+}
+
 // Returns true if all semaphores in the list has signaled (or any failed).
-// Used with with iree_condition_fn_t and must match that signature.
 static bool iree_hal_sync_semaphore_all_signaled(
     const iree_hal_semaphore_list_t* semaphore_list) {
   for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {
@@ -344,6 +351,11 @@ static bool iree_hal_sync_semaphore_all_signaled(
     if (!is_signaled) return false;
   }
   return true;
+}
+
+static bool iree_hal_sync_semaphore_all_signaled_thunk(void* arg) {
+  return iree_hal_sync_semaphore_all_signaled(
+      (const iree_hal_semaphore_list_t*)arg);
 }
 
 // Returns a status derived from the |semaphore_list| at the current time:
@@ -417,12 +429,11 @@ iree_status_t iree_hal_sync_semaphore_multi_wait(
   }
 
   // Perform wait on the global notification.
-  iree_notification_await(
-      &shared_state->notification,
-      wait_mode == IREE_HAL_WAIT_MODE_ALL
-          ? (iree_condition_fn_t)iree_hal_sync_semaphore_all_signaled
-          : (iree_condition_fn_t)iree_hal_sync_semaphore_any_signaled,
-      (void*)&semaphore_list, iree_infinite_timeout());
+  iree_notification_await(&shared_state->notification,
+                          wait_mode == IREE_HAL_WAIT_MODE_ALL
+                              ? iree_hal_sync_semaphore_all_signaled_thunk
+                              : iree_hal_sync_semaphore_any_signaled_thunk,
+                          (void*)&semaphore_list, iree_infinite_timeout());
 
   // We may have been successful - or may have a partial failure.
   iree_status_t status =

--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -454,8 +454,19 @@ static void iree_hal_deferred_work_queue_completion_area_deinitialize(
 static int iree_hal_deferred_work_queue_worker_execute(
     iree_hal_deferred_work_queue_t* actions);
 
+static int iree_hal_deferred_work_queue_worker_thread_entry(void* entry_arg) {
+  return iree_hal_deferred_work_queue_worker_execute(
+      (iree_hal_deferred_work_queue_t*)entry_arg);
+}
+
 static int iree_hal_deferred_work_queue_completion_execute(
     iree_hal_deferred_work_queue_t* actions);
+
+static int iree_hal_deferred_work_queue_completion_thread_entry(
+    void* entry_arg) {
+  return iree_hal_deferred_work_queue_completion_execute(
+      (iree_hal_deferred_work_queue_t*)entry_arg);
+}
 
 //===----------------------------------------------------------------------===//
 // Deferred work queue
@@ -567,15 +578,15 @@ iree_status_t iree_hal_deferred_work_queue_create(
   params.name = IREE_SV("iree-hip-queue-worker");
   params.create_suspended = false;
   iree_status_t status = iree_thread_create(
-      (iree_thread_entry_t)iree_hal_deferred_work_queue_worker_execute, actions,
-      params, actions->host_allocator, &actions->worker_thread);
+      iree_hal_deferred_work_queue_worker_thread_entry, actions, params,
+      actions->host_allocator, &actions->worker_thread);
 
   params.name = IREE_SV("iree-hip-queue-completion");
   params.create_suspended = false;
   if (iree_status_is_ok(status)) {
     status = iree_thread_create(
-        (iree_thread_entry_t)iree_hal_deferred_work_queue_completion_execute,
-        actions, params, actions->host_allocator, &actions->completion_thread);
+        iree_hal_deferred_work_queue_completion_thread_entry, actions, params,
+        actions->host_allocator, &actions->completion_thread);
   }
 
   if (iree_status_is_ok(status)) {
@@ -1498,11 +1509,23 @@ static bool iree_hal_deferred_work_queue_worker_has_incoming_request(
   return value == IREE_HAL_WORKER_STATE_WORKLOAD_PENDING;
 }
 
+static bool iree_hal_deferred_work_queue_worker_has_incoming_request_thunk(
+    void* arg) {
+  return iree_hal_deferred_work_queue_worker_has_incoming_request(
+      (iree_hal_deferred_work_queue_working_area_t*)arg);
+}
+
 static bool iree_hal_deferred_work_queue_completion_has_incoming_request(
     iree_hal_deferred_work_queue_completion_area_t* completion_area) {
   iree_hal_deferred_work_queue_worker_state_t value = iree_atomic_load(
       &completion_area->worker_state, iree_memory_order_acquire);
   return value == IREE_HAL_WORKER_STATE_WORKLOAD_PENDING;
+}
+
+static bool iree_hal_deferred_work_queue_completion_has_incoming_request_thunk(
+    void* arg) {
+  return iree_hal_deferred_work_queue_completion_has_incoming_request(
+      (iree_hal_deferred_work_queue_completion_area_t*)arg);
 }
 
 // Processes all ready actions in the given |worklist|.
@@ -1619,8 +1642,7 @@ static int iree_hal_deferred_work_queue_completion_execute(
   while (true) {
     iree_notification_await(
         &completion_area->state_notification,
-        (iree_condition_fn_t)
-            iree_hal_deferred_work_queue_completion_has_incoming_request,
+        iree_hal_deferred_work_queue_completion_has_incoming_request_thunk,
         completion_area, iree_infinite_timeout());
 
     // Immediately flip the state to idle waiting if and only if the previous
@@ -1674,8 +1696,7 @@ static int iree_hal_deferred_work_queue_worker_execute(
     // host stream callbacks.
     iree_notification_await(
         &working_area->state_notification,
-        (iree_condition_fn_t)
-            iree_hal_deferred_work_queue_worker_has_incoming_request,
+        iree_hal_deferred_work_queue_worker_has_incoming_request_thunk,
         working_area, iree_infinite_timeout());
 
     // Immediately flip the state to idle waiting if and only if the previous

--- a/runtime/src/iree/task/poller.c
+++ b/runtime/src/iree/task/poller.c
@@ -14,6 +14,10 @@
 
 static int iree_task_poller_main(iree_task_poller_t* poller);
 
+static int iree_task_poller_thread_entry(void* entry_arg) {
+  return iree_task_poller_main((iree_task_poller_t*)entry_arg);
+}
+
 iree_status_t iree_task_poller_initialize(
     iree_task_executor_t* executor,
     iree_thread_affinity_t ideal_thread_affinity,
@@ -67,8 +71,8 @@ iree_status_t iree_task_poller_initialize(
   // cleanup by calling deinitialize (which is safe because we zero init
   // everything).
   if (iree_status_is_ok(status)) {
-    status = iree_thread_create((iree_thread_entry_t)iree_task_poller_main,
-                                out_poller, thread_params, executor->allocator,
+    status = iree_thread_create(iree_task_poller_thread_entry, out_poller,
+                                thread_params, executor->allocator,
                                 &out_poller->thread);
   }
 
@@ -115,14 +119,18 @@ static bool iree_task_poller_is_zombie(iree_task_poller_t* poller) {
          IREE_TASK_POLLER_STATE_ZOMBIE;
 }
 
+static bool iree_task_poller_is_zombie_thunk(void* arg) {
+  return iree_task_poller_is_zombie((iree_task_poller_t*)arg);
+}
+
 void iree_task_poller_await_exit(iree_task_poller_t* poller) {
   if (!poller->thread) return;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_task_poller_request_exit(poller);
   iree_notification_await(&poller->state_notification,
-                          (iree_condition_fn_t)iree_task_poller_is_zombie,
-                          poller, iree_infinite_timeout());
+                          iree_task_poller_is_zombie_thunk, poller,
+                          iree_infinite_timeout());
 
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/task/scope.c
+++ b/runtime/src/iree/task/scope.c
@@ -156,6 +156,9 @@ void iree_task_scope_end(iree_task_scope_t* scope) {
 bool iree_task_scope_is_idle(iree_task_scope_t* scope) {
   return (iree_atomic_ref_count_load(&scope->pending_submissions) == 0);
 }
+static bool iree_task_scope_is_idle_thunk(void* arg) {
+  return iree_task_scope_is_idle((iree_task_scope_t*)arg);
+}
 
 iree_status_t iree_task_scope_wait_idle(iree_task_scope_t* scope,
                                         iree_time_t deadline_ns) {
@@ -172,8 +175,8 @@ iree_status_t iree_task_scope_wait_idle(iree_task_scope_t* scope,
   } else {
     // Wait for the scope to enter the idle state.
     if (!iree_notification_await(&scope->idle_notification,
-                                 (iree_condition_fn_t)iree_task_scope_is_idle,
-                                 scope, iree_make_deadline(deadline_ns))) {
+                                 iree_task_scope_is_idle_thunk, scope,
+                                 iree_make_deadline(deadline_ns))) {
       status = iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
     }
   }

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -21,6 +21,10 @@
 
 static int iree_task_worker_main(iree_task_worker_t* worker);
 
+static int iree_task_worker_thread_entry(void* entry_arg) {
+  return iree_task_worker_main((iree_task_worker_t*)entry_arg);
+}
+
 iree_status_t iree_task_worker_initialize(
     iree_task_executor_t* executor, iree_host_size_t worker_index,
     const iree_task_topology_group_t* topology_group,
@@ -64,7 +68,7 @@ iree_status_t iree_task_worker_initialize(
   // cleanup by calling deinitialize (which is safe because we zero init
   // everything).
   iree_status_t status = iree_thread_create(
-      (iree_thread_entry_t)iree_task_worker_main, out_worker, thread_params,
+      iree_task_worker_thread_entry, out_worker, thread_params,
       executor->allocator, &out_worker->thread);
 
   IREE_TRACE_ZONE_END(z0);
@@ -105,14 +109,18 @@ static bool iree_task_worker_is_zombie(iree_task_worker_t* worker) {
          IREE_TASK_WORKER_STATE_ZOMBIE;
 }
 
+static bool iree_task_worker_is_zombie_thunk(void* arg) {
+  return iree_task_worker_is_zombie((iree_task_worker_t*)arg);
+}
+
 void iree_task_worker_await_exit(iree_task_worker_t* worker) {
   if (!worker->thread) return;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_task_worker_request_exit(worker);
   iree_notification_await(&worker->state_notification,
-                          (iree_condition_fn_t)iree_task_worker_is_zombie,
-                          worker, iree_infinite_timeout());
+                          iree_task_worker_is_zombie_thunk, worker,
+                          iree_infinite_timeout());
 
   IREE_TRACE_ZONE_END(z0);
 }


### PR DESCRIPTION
A CI failure in `linux_x64_clang_ubsan` surfaced two categories of UBSan issues: false positives from the `vptr` sub-check, and real undefined behavior from function pointer type mismatches.

### vptr false positives

UBSan's `vptr` check uses `typeid()` to verify vtable pointers at every virtual dispatch. IREE compiles all C++ with `-fno-rtti` for LLVM/MLIR compatibility, so `typeid()` is unavailable and the check produces false positives on every virtual call — including gtest internals. This fires before any test code runs, making the entire UBSan CI configuration useless for C++ tests.

Fix: exclude `vptr` from UBSan in both CMake (`-fno-sanitize=vptr` on `CMAKE_CXX_FLAGS`) and Bazel (`--cxxopt=-fno-sanitize=vptr` in `--config=ubsan`). Applied only to C++ since `vptr` is not relevant to C.

### Function pointer type mismatches

The runtime had a pervasive pattern of casting typed-pointer functions to `iree_thread_entry_t` (`int(*)(void*)`) and `iree_condition_fn_t` (`bool(*)(void*)`) at call sites. This is undefined behavior in C — calling a function through a pointer to a different function type — even though it works on every ABI we target. UBSan's `-fsanitize=function` check catches this and aborts.

Fix: replace all 21 cast sites with thin thunk functions that have the correct `void*` signature and cast the argument internally. The thunks are trivially inlineable so there is no runtime cost.

### Notification test race

`RepeatedWaitSignalCycles` assumed a fixed 20ms delay was sufficient for the worker thread to re-enter `notification_wait` between signal cycles. With epoch-based level-triggered notifications, a signal that arrives before `prepare_wait` captures the epoch is invisible to that wait. There is no way to observe from outside when `prepare_wait` has executed, so no delay is provably sufficient — any delay-based approach is fundamentally fragile.

Fix: the main thread now signals continuously (with yields) until the worker acknowledges each cycle via an atomic counter. If a signal coalesces before `prepare_wait`, the next one lands after it. Progress is guaranteed by the retry loop, not by timing. Zero sleeps, zero delays.