### PR TITLE
[SHM] Add huge page and NUMA placement support

### DIFF
--- a/runtime/src/iree/async/cts/buffer/registration_test.cc
+++ b/runtime/src/iree/async/cts/buffer/registration_test.cc
@@ -370,13 +370,22 @@ TEST_P(BufferRegistrationTest, MultipleSendSlabRegistrations) {
       proactor_, slab_b, IREE_ASYNC_BUFFER_ACCESS_FLAG_READ, &region_b);
 
   if (iree_status_is_ok(status)) {
-    // 5.19+ path: both registrations succeeded with distinct buffer indices.
     ASSERT_NE(region_b, nullptr);
-    EXPECT_EQ(region_a->type, IREE_ASYNC_REGION_TYPE_IOURING);
-    EXPECT_EQ(region_b->type, IREE_ASYNC_REGION_TYPE_IOURING);
-    EXPECT_NE(region_a->handles.iouring.base_buffer_index,
-              region_b->handles.iouring.base_buffer_index)
-        << "Distinct slabs must have different buffer table indices";
+    if (region_a->handles.iouring.base_buffer_index == -1 &&
+        region_b->handles.iouring.base_buffer_index == -1) {
+      // RLIMIT_MEMLOCK too low to pin pages for fixed buffers. Both
+      // registrations succeeded (the proactor gracefully falls back to
+      // copy-based I/O) but neither got kernel-registered buffer indices.
+      // Nothing to assert about indices — the fallback path is valid.
+      GTEST_SKIP() << "RLIMIT_MEMLOCK too low for fixed buffer registration";
+    } else {
+      // 5.19+ path: both registrations succeeded with distinct buffer indices.
+      EXPECT_EQ(region_a->type, IREE_ASYNC_REGION_TYPE_IOURING);
+      EXPECT_EQ(region_b->type, IREE_ASYNC_REGION_TYPE_IOURING);
+      EXPECT_NE(region_a->handles.iouring.base_buffer_index,
+                region_b->handles.iouring.base_buffer_index)
+          << "Distinct slabs must have different buffer table indices";
+    }
     iree_async_region_release(region_b);
   } else {
     // Pre-5.19 path: second registration rejected (singleton buffer table).

--- a/runtime/src/iree/async/cts/buffer/shared_pool_test.cc
+++ b/runtime/src/iree/async/cts/buffer/shared_pool_test.cc
@@ -56,9 +56,8 @@ class SharedBufferPoolTest : public CtsTestBase<> {
     iree_host_size_t total_shm_size = pool_storage + buffer_size * buffer_count;
 
     // Create anonymous shared memory region.
-    iree_shm_options_t shm_options = iree_shm_options_default();
     IREE_RETURN_IF_ERROR(
-        iree_shm_create(shm_options, total_shm_size, &out_creator->shm));
+        iree_shm_create(NULL, total_shm_size, &out_creator->shm));
 
     // Wrap the buffer data portion (after pool metadata) as a slab.
     void* buffer_base = (uint8_t*)out_creator->shm.base + pool_storage;
@@ -118,9 +117,8 @@ class SharedBufferPoolTest : public CtsTestBase<> {
     IREE_RETURN_IF_ERROR(iree_shm_handle_dup(creator.shm.handle, &dup_handle));
 
     // Open a second mapping from the duplicated handle.
-    iree_shm_options_t shm_options = iree_shm_options_default();
-    iree_status_t status = iree_shm_open_handle(
-        dup_handle, shm_options, creator.shm.size, &out_opener->shm);
+    iree_status_t status =
+        iree_shm_open_handle(dup_handle, creator.shm.size, &out_opener->shm);
     // open_handle dups internally; close our copy regardless of outcome.
     iree_shm_handle_close(&dup_handle);
     if (!iree_status_is_ok(status)) {
@@ -240,10 +238,9 @@ TEST_P(SharedBufferPoolTest, OpenValidatesMagic) {
   // Corrupt the magic in a dup'd mapping of the same SHM region.
   iree_shm_handle_t dup_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(creator.shm.handle, &dup_handle));
-  iree_shm_options_t shm_options = iree_shm_options_default();
   iree_shm_mapping_t corrupted;
-  IREE_ASSERT_OK(iree_shm_open_handle(dup_handle, shm_options, creator.shm.size,
-                                      &corrupted));
+  IREE_ASSERT_OK(
+      iree_shm_open_handle(dup_handle, creator.shm.size, &corrupted));
   iree_shm_handle_close(&dup_handle);
 
   // Corrupt the magic field (first 4 bytes).
@@ -278,10 +275,9 @@ TEST_P(SharedBufferPoolTest, OpenValidatesVersionMismatch) {
   // Corrupt the version in a dup'd mapping of the same SHM region.
   iree_shm_handle_t dup_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(creator.shm.handle, &dup_handle));
-  iree_shm_options_t shm_options = iree_shm_options_default();
   iree_shm_mapping_t corrupted;
-  IREE_ASSERT_OK(iree_shm_open_handle(dup_handle, shm_options, creator.shm.size,
-                                      &corrupted));
+  IREE_ASSERT_OK(
+      iree_shm_open_handle(dup_handle, creator.shm.size, &corrupted));
   iree_shm_handle_close(&dup_handle);
 
   // Corrupt the version field (bytes 4-7, immediately after magic).
@@ -314,10 +310,9 @@ TEST_P(SharedBufferPoolTest, OpenValidatesBufferSizeMismatch) {
   // Open a second mapping of the SHM region.
   iree_shm_handle_t dup_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(creator.shm.handle, &dup_handle));
-  iree_shm_options_t shm_options = iree_shm_options_default();
   iree_shm_mapping_t opener_shm;
-  IREE_ASSERT_OK(iree_shm_open_handle(dup_handle, shm_options, creator.shm.size,
-                                      &opener_shm));
+  IREE_ASSERT_OK(
+      iree_shm_open_handle(dup_handle, creator.shm.size, &opener_shm));
   iree_shm_handle_close(&dup_handle);
 
   // Wrap with a different buffer_size to create a mismatched region.

--- a/runtime/src/iree/async/slab.c
+++ b/runtime/src/iree/async/slab.c
@@ -69,10 +69,16 @@ iree_status_t iree_async_slab_create(iree_async_slab_options_t options,
                                           options.buffer_count, &total_size));
 
   // Use placement options directly, overriding node_id from affinity if set.
+  // When placement is zero-initialized (the common case for callers that don't
+  // care about NUMA), node_id == 0 is ambiguous: it could mean "pin to NUMA
+  // node 0" or "I didn't set this." We treat it as "no preference" and let the
+  // affinity struct be the authoritative source for explicit node placement.
   iree_numa_alloc_options_t numa_options = options.placement;
   if (options.affinity &&
       options.affinity->numa_node != IREE_ASYNC_AFFINITY_NUMA_NODE_ANY) {
     numa_options.node_id = options.affinity->numa_node;
+  } else if (numa_options.node_id == 0) {
+    numa_options.node_id = IREE_NUMA_NODE_ANY;
   }
 
   // Allocate buffer memory.

--- a/runtime/src/iree/async/slab.c
+++ b/runtime/src/iree/async/slab.c
@@ -68,16 +68,12 @@ iree_status_t iree_async_slab_create(iree_async_slab_options_t options,
       z0, iree_async_slab_validate_params(options.buffer_size,
                                           options.buffer_count, &total_size));
 
-  // Build NUMA allocation options from slab options.
-  iree_numa_alloc_options_t numa_options = iree_numa_alloc_options_default();
+  // Use placement options directly, overriding node_id from affinity if set.
+  iree_numa_alloc_options_t numa_options = options.placement;
   if (options.affinity &&
       options.affinity->numa_node != IREE_ASYNC_AFFINITY_NUMA_NODE_ANY) {
     numa_options.node_id = options.affinity->numa_node;
   }
-  numa_options.huge_page_size = options.huge_page_size;
-  numa_options.use_explicit_huge_pages = options.use_explicit_huge_pages;
-  numa_options.hint_transparent_huge_pages =
-      options.hint_transparent_huge_pages;
 
   // Allocate buffer memory.
   void* base_ptr = NULL;

--- a/runtime/src/iree/async/slab.h
+++ b/runtime/src/iree/async/slab.h
@@ -97,35 +97,17 @@ typedef struct iree_async_slab_options_t {
   // provided buffer rings).
   iree_host_size_t buffer_count;
 
-  // Size of huge pages to use when use_explicit_huge_pages is true.
-  // Common values:
-  //   0 = auto-detect system default (typically 2MB on x86_64)
-  //   2097152 = 2MB (standard huge pages, good for slabs 8MB-256MB)
-  //   1073741824 = 1GB (requires hugepagesz=1G kernel param, for slabs 256MB+)
-  //
-  // The slab size is rounded up to this alignment. Using 1GB pages for small
-  // slabs wastes significant memory.
-  iree_host_size_t huge_page_size;
-
   // Locality domain for NUMA-aware allocation. NULL means default placement
   // (the system allocator chooses, typically local to the calling thread's
   // NUMA node).
   const iree_async_affinity_t* affinity;
 
-  // If true, attempt to allocate using explicit huge pages (MAP_HUGETLB on
-  // Linux). Provides guaranteed huge page backing with lower TLB pressure,
-  // beneficial for large slabs (32MB+) in latency-sensitive scenarios.
-  //
-  // Falls back gracefully to normal pages if:
-  //   - Huge pages are not configured on the system
-  //   - The requested size is not a multiple of the huge page size
-  //   - The system runs out of huge pages
-  bool use_explicit_huge_pages;
-
-  // If true and explicit huge pages fail or are not requested, hint to the
-  // kernel that transparent huge pages (THP) should be used via MADV_HUGEPAGE.
-  // Best-effort: the kernel may or may not honor the hint.
-  bool hint_transparent_huge_pages;
+  // NUMA/huge page placement options for the slab memory. Controls NUMA node
+  // placement, explicit or transparent huge pages, and huge page size. See
+  // iree_numa_alloc_options_t for details. The node_id field is overridden by
+  // |affinity| when set; all other fields (flags, huge_page_size, alignment)
+  // are passed through directly.
+  iree_numa_alloc_options_t placement;
 } iree_async_slab_options_t;
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -343,6 +343,7 @@ iree_runtime_cc_library(
         ":internal",
         ":memory",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
     ],
 )
 

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -373,6 +373,7 @@ iree_cc_library(
     ::internal
     ::memory
     iree::base
+    iree::base::threading
   PUBLIC
 )
 

--- a/runtime/src/iree/base/internal/shm.h
+++ b/runtime/src/iree/base/internal/shm.h
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include "iree/base/api.h"
+#include "iree/base/threading/numa.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -86,25 +87,11 @@ static inline bool iree_shm_handle_is_valid(iree_shm_handle_t handle) {
 }
 
 // Maximum length of a shared memory name in bytes (excluding NUL terminator).
-// Matches POSIX NAME_MAX (255), which is the most restrictive platform limit.
-// Windows kernel object names can be much longer (~32K wide chars) but we cap
-// at the POSIX limit for portability.
-#define IREE_SHM_MAX_NAME_LENGTH 255
-
-// Options controlling shared memory creation and opening.
-//
-// Initialize with iree_shm_options_default() to get safe defaults. Pass by
-// value to all create and open functions.
-typedef struct iree_shm_options_t {
-  int reserved;
-} iree_shm_options_t;
-
-// Returns default shared memory options. All fields are zero-initialized.
-static inline iree_shm_options_t iree_shm_options_default(void) {
-  iree_shm_options_t options;
-  memset(&options, 0, sizeof(options));
-  return options;
-}
+// macOS limits POSIX shared memory names to PSHMNAMLEN (31) including the
+// leading '/', so 30 usable characters. Linux allows NAME_MAX (255) and Windows
+// kernel object names can be ~32K wide chars, but we cap at the macOS limit for
+// portability.
+#define IREE_SHM_MAX_NAME_LENGTH 30
 
 // A mapped shared memory region.
 //
@@ -137,7 +124,9 @@ iree_host_size_t iree_shm_required_size(iree_host_size_t requested_size);
 // alignment. The caller can write to [base, base + size) immediately.
 //
 // |minimum_size| must be > 0. Returns IREE_STATUS_INVALID_ARGUMENT for 0.
-iree_status_t iree_shm_create(iree_shm_options_t options,
+// |options| controls NUMA placement and huge page backing for the region. Pass
+// NULL for default options (no NUMA preference, normal pages).
+iree_status_t iree_shm_create(const iree_numa_alloc_options_t* options,
                               iree_host_size_t minimum_size,
                               iree_shm_mapping_t* out_mapping);
 
@@ -151,8 +140,10 @@ iree_status_t iree_shm_create(iree_shm_options_t options,
 // Use iree_shm_open_named to attach to an existing named region.
 //
 // |minimum_size| must be > 0. Returns IREE_STATUS_INVALID_ARGUMENT for 0.
+// |options| controls NUMA placement and huge page backing for the region. Pass
+// NULL for default options (no NUMA preference, normal pages).
 iree_status_t iree_shm_create_named(iree_string_view_t name,
-                                    iree_shm_options_t options,
+                                    const iree_numa_alloc_options_t* options,
                                     iree_host_size_t minimum_size,
                                     iree_shm_mapping_t* out_mapping);
 
@@ -165,7 +156,6 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
 // |size| specifies the mapping size and must match the original region's size
 // (as returned by iree_shm_required_size of the original minimum_size).
 iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
-                                   iree_shm_options_t options,
                                    iree_host_size_t size,
                                    iree_shm_mapping_t* out_mapping);
 
@@ -178,7 +168,6 @@ iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
 //
 // Returns IREE_STATUS_NOT_FOUND if no region with this name exists.
 iree_status_t iree_shm_open_named(iree_string_view_t name,
-                                  iree_shm_options_t options,
                                   iree_host_size_t size,
                                   iree_shm_mapping_t* out_mapping);
 
@@ -215,20 +204,28 @@ void iree_shm_handle_close(iree_shm_handle_t* handle);
 // removed. Applying a seal that is already set is a no-op.
 //
 // The typical usage is to create a region, populate it with data, then seal it:
-//   iree_shm_create(options, size, &mapping);
+//   iree_shm_create(NULL, size, &mapping);
 //   // ... write model weights into mapping.base ...
 //   iree_shm_seal(&mapping, IREE_SHM_SEAL_WRITE);
 //   // NOTE: mapping.base may have changed — use the updated value.
 //
+// Thread safety: callers must ensure exclusive access to |mapping| during this
+// call. On Linux, IREE_SHM_SEAL_WRITE unmaps and remaps the region, so any
+// concurrent access to mapping->base from other threads will fault. Seal before
+// sharing or coordinate externally.
+//
 // Platform behavior:
 //   Linux:   Applies kernel-level seals via fcntl(F_ADD_SEALS) on the memfd.
+//            Seals are enforced kernel-wide: no process can create a writable
+//            mapping after F_SEAL_WRITE is applied.
 //            Only anonymous (memfd-backed) regions support sealing; named
 //            regions created via shm_open return IREE_STATUS_UNAVAILABLE.
 //            IREE_SHM_SEAL_WRITE remaps the region read-only (base may change).
 //   macOS:   Returns IREE_STATUS_UNAVAILABLE (no kernel sealing support).
 //   Windows: IREE_SHM_SEAL_WRITE changes the view protection to PAGE_READONLY
-//            via VirtualProtect. Other seal flags are inherent (Windows file
-//            mappings are fixed-size) and succeed as no-ops.
+//            via VirtualProtect. This is process-local only — other processes
+//            can still map the section writable. Other seal flags are inherent
+//            (Windows file mappings are fixed-size) and succeed as no-ops.
 //
 // Returns IREE_STATUS_UNAVAILABLE when the platform or region type does not
 // support sealing. Callers implementing defense-in-depth can check for this

--- a/runtime/src/iree/base/internal/shm.h
+++ b/runtime/src/iree/base/internal/shm.h
@@ -87,11 +87,19 @@ static inline bool iree_shm_handle_is_valid(iree_shm_handle_t handle) {
 }
 
 // Maximum length of a shared memory name in bytes (excluding NUL terminator).
+#if defined(IREE_PLATFORM_APPLE)
 // macOS limits POSIX shared memory names to PSHMNAMLEN (31) including the
-// leading '/', so 30 usable characters. Linux allows NAME_MAX (255) and Windows
-// kernel object names can be ~32K wide chars, but we cap at the macOS limit for
-// portability.
+// leading '/', so 30 usable characters.
 #define IREE_SHM_MAX_NAME_LENGTH 30
+#elif defined(IREE_PLATFORM_WINDOWS)
+// Windows kernel object names can be enormous (~32K wide chars). We cap at
+// NAME_MAX (255) for practical stack buffer sizing; this is never the
+// binding constraint.
+#define IREE_SHM_MAX_NAME_LENGTH 255
+#else
+// Linux (and other POSIX): NAME_MAX (255) on the /dev/shm/ tmpfs.
+#define IREE_SHM_MAX_NAME_LENGTH 255
+#endif  // IREE_PLATFORM_*
 
 // A mapped shared memory region.
 //

--- a/runtime/src/iree/base/internal/shm.h
+++ b/runtime/src/iree/base/internal/shm.h
@@ -234,6 +234,8 @@ void iree_shm_handle_close(iree_shm_handle_t* handle);
 //            via VirtualProtect. This is process-local only — other processes
 //            can still map the section writable. Other seal flags are inherent
 //            (Windows file mappings are fixed-size) and succeed as no-ops.
+//            Large-page sections (SEC_LARGE_PAGES) do not support protection
+//            changes; sealing returns IREE_STATUS_UNAVAILABLE in this case.
 //
 // Returns IREE_STATUS_UNAVAILABLE when the platform or region type does not
 // support sealing. Callers implementing defense-in-depth can check for this

--- a/runtime/src/iree/base/internal/shm_posix.c
+++ b/runtime/src/iree/base/internal/shm_posix.c
@@ -30,6 +30,14 @@
 #define IREE_F_SEAL_SHRINK 0x0002
 #define IREE_F_SEAL_GROW 0x0004
 #define IREE_F_SEAL_WRITE 0x0008
+
+// memfd_create flags for huge page backing (kernel 4.14+).
+// MFD_HUGETLB requests hugetlbfs-backed memfd, with the huge page size
+// encoded as log2(page_size) << MFD_HUGE_SHIFT.
+#define IREE_MFD_HUGETLB 0x0004U
+#define IREE_MFD_HUGE_SHIFT 26
+#define IREE_MFD_HUGE_2MB (21U << IREE_MFD_HUGE_SHIFT)
+#define IREE_MFD_HUGE_1GB (30U << IREE_MFD_HUGE_SHIFT)
 #endif  // IREE_PLATFORM_LINUX
 
 //===----------------------------------------------------------------------===//
@@ -117,13 +125,19 @@ static iree_status_t iree_shm_finalize_mapping(
 
 #if defined(IREE_PLATFORM_LINUX)
 
-// Creates anonymous shared memory using memfd_create (Linux 3.17+).
-// No filesystem footprint; the fd is the only reference.
-static iree_status_t iree_shm_create_anonymous_fd(iree_host_size_t size,
+// Returns the MFD_HUGE_* flag for a given page size, or 0 for unsupported.
+static unsigned int iree_shm_mfd_huge_flag(iree_host_size_t page_size) {
+  if (page_size == 0 || page_size == (2 * 1024 * 1024)) {
+    return IREE_MFD_HUGE_2MB;
+  } else if (page_size == (1024 * 1024 * 1024)) {
+    return IREE_MFD_HUGE_1GB;
+  }
+  return 0;
+}
+
+// Creates a normal (non-huge) anonymous memfd with sealing support.
+static iree_status_t iree_shm_create_normal_memfd(iree_host_size_t size,
                                                   int* out_fd) {
-  // memfd_create is not wrapped by all libc versions, so use syscall directly.
-  // MFD_ALLOW_SEALING enables the F_SEAL_* API so callers can later seal the
-  // region against writes via iree_shm_seal().
   int fd = (int)syscall(SYS_memfd_create, "iree_shm",
                         /*MFD_CLOEXEC=*/0x0001U |
                             /*MFD_ALLOW_SEALING=*/0x0002U);
@@ -138,11 +152,9 @@ static iree_status_t iree_shm_create_anonymous_fd(iree_host_size_t size,
     close(fd);
     return status;
   }
-
-  // Seal the memfd against resizing to prevent a peer from ftruncating it
-  // smaller, which would cause SIGBUS when the mapping accesses memory beyond
-  // the new size. We intentionally omit F_SEAL_SEAL so that callers can later
-  // add F_SEAL_WRITE via iree_shm_seal().
+  // Seal against resizing to prevent peers from ftruncating the backing store,
+  // which would cause SIGBUS. We omit F_SEAL_SEAL so callers can later add
+  // F_SEAL_WRITE via iree_shm_seal().
   if (IREE_UNLIKELY(fcntl(fd, IREE_F_ADD_SEALS,
                           IREE_F_SEAL_SHRINK | IREE_F_SEAL_GROW) == -1)) {
     iree_status_t status =
@@ -151,9 +163,103 @@ static iree_status_t iree_shm_create_anonymous_fd(iree_host_size_t size,
     close(fd);
     return status;
   }
-
   *out_fd = fd;
   return iree_ok_status();
+}
+
+// Attempts to create a huge-page-backed anonymous memfd.
+// Returns true on success, false if huge pages are unavailable or the system
+// doesn't have enough huge pages reserved. The caller should fall back to
+// normal pages on failure.
+static bool iree_shm_try_create_hugetlb_memfd(
+    iree_host_size_t size, iree_host_size_t huge_page_size, int* out_fd,
+    iree_host_size_t* out_aligned_size) {
+  unsigned int huge_flag = iree_shm_mfd_huge_flag(huge_page_size);
+  if (huge_flag == 0) return false;
+
+  iree_host_size_t resolved =
+      (huge_page_size == 0) ? (2 * 1024 * 1024) : huge_page_size;
+  iree_host_size_t aligned_size = 0;
+  if (!iree_host_size_checked_align(size, resolved, &aligned_size)) {
+    return false;
+  }
+
+  // MFD_HUGETLB creates a hugetlbfs-backed memfd. We prefer combining with
+  // MFD_ALLOW_SEALING for seal support, but this requires kernel 4.16+.
+  // On kernels 4.14–4.15 (which introduced MFD_HUGETLB but reject the
+  // combination), retry without MFD_ALLOW_SEALING — huge pages are the
+  // explicit request, sealing is defense-in-depth.
+  int fd = (int)syscall(SYS_memfd_create, "iree_shm",
+                        /*MFD_CLOEXEC=*/0x0001U |
+                            /*MFD_ALLOW_SEALING=*/0x0002U | IREE_MFD_HUGETLB |
+                            huge_flag);
+  if (fd == -1) {
+    // Retry without MFD_ALLOW_SEALING for kernels 4.14–4.15.
+    fd = (int)syscall(SYS_memfd_create, "iree_shm",
+                      /*MFD_CLOEXEC=*/0x0001U | IREE_MFD_HUGETLB | huge_flag);
+    if (fd == -1) return false;
+  }
+
+  // hugetlbfs files are sized in whole huge pages. ftruncate sets the size;
+  // the kernel allocates huge pages on first fault.
+  if (ftruncate(fd, (off_t)aligned_size) == -1) {
+    close(fd);
+    return false;
+  }
+
+  // Probe-map the hugetlb memfd to verify huge pages are actually available.
+  // ftruncate succeeds even when no huge pages are reserved; the failure
+  // only surfaces at mmap time (ENOMEM). MAP_POPULATE forces immediate
+  // physical allocation, catching overcommit scenarios where mmap succeeds
+  // but access would SIGBUS.
+  void* probe = mmap(NULL, aligned_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_POPULATE, fd, 0);
+  if (probe == MAP_FAILED) {
+    close(fd);
+    return false;
+  }
+  munmap(probe, aligned_size);
+
+  // Hugetlbfs memfds are inherently fixed-size (the kernel rejects
+  // ftruncate to a different size after mmap), so SHRINK/GROW seals are
+  // implicit. Apply them anyway for consistency with iree_shm_query_seals.
+  // If sealing fails (older kernel without hugetlbfs seal support), proceed
+  // without seals — the inherent fixed-size property still prevents SIGBUS.
+  fcntl(fd, IREE_F_ADD_SEALS, IREE_F_SEAL_SHRINK | IREE_F_SEAL_GROW);
+
+  *out_fd = fd;
+  *out_aligned_size = aligned_size;
+  return true;
+}
+
+// Creates anonymous shared memory using memfd_create (Linux 3.17+).
+// No filesystem footprint; the fd is the only reference.
+//
+// When |options| requests huge pages, the allocation cascade is:
+//   1. Explicit huge pages via MFD_HUGETLB (if EXPLICIT_HUGE_PAGES flag set)
+//   2. Normal memfd + MADV_HUGEPAGE (if TRANSPARENT_HUGE_PAGES flag set,
+//      or as fallback from explicit)
+//   3. Normal memfd (final fallback)
+static iree_status_t iree_shm_create_anonymous_fd(
+    const iree_numa_alloc_options_t* options, iree_host_size_t size,
+    int* out_fd, iree_host_size_t* out_size) {
+  *out_size = size;
+
+  // Try explicit huge pages if requested.
+  if (options &&
+      iree_any_bit_set(options->flags,
+                       IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES)) {
+    iree_host_size_t aligned_size = 0;
+    if (iree_shm_try_create_hugetlb_memfd(size, options->huge_page_size, out_fd,
+                                          &aligned_size)) {
+      *out_size = aligned_size;
+      return iree_ok_status();
+    }
+    // Fall through to THP or normal pages.
+  }
+
+  // Normal memfd (with optional THP hint applied after mmap).
+  return iree_shm_create_normal_memfd(size, out_fd);
 }
 
 #elif defined(IREE_PLATFORM_APPLE)
@@ -161,8 +267,12 @@ static iree_status_t iree_shm_create_anonymous_fd(iree_host_size_t size,
 // Creates anonymous shared memory using shm_open with a unique name, then
 // immediately unlinks the name. The fd and any mappings remain valid after
 // unlinking; only the name is removed from the namespace.
-static iree_status_t iree_shm_create_anonymous_fd(iree_host_size_t size,
-                                                  int* out_fd) {
+// macOS has no huge page or NUMA support, so |options| is ignored.
+static iree_status_t iree_shm_create_anonymous_fd(
+    const iree_numa_alloc_options_t* options, iree_host_size_t size,
+    int* out_fd, iree_host_size_t* out_size) {
+  (void)options;
+  *out_size = size;
   // Generate a unique name. shm_open names must start with '/'.
   // We use the pid and a counter to avoid collisions. If a previous process
   // with the same PID crashed between shm_open and shm_unlink, the name may
@@ -212,7 +322,7 @@ iree_host_size_t iree_shm_required_size(iree_host_size_t requested_size) {
   return (requested_size + page_size - 1) & ~(page_size - 1);
 }
 
-iree_status_t iree_shm_create(iree_shm_options_t options,
+iree_status_t iree_shm_create(const iree_numa_alloc_options_t* options,
                               iree_host_size_t minimum_size,
                               iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -227,19 +337,44 @@ iree_status_t iree_shm_create(iree_shm_options_t options,
 
   iree_host_size_t size = iree_shm_required_size(minimum_size);
   int fd = -1;
-  iree_status_t status = iree_shm_create_anonymous_fd(size, &fd);
+  iree_host_size_t actual_size = size;
+  iree_status_t status =
+      iree_shm_create_anonymous_fd(options, size, &fd, &actual_size);
   if (!iree_status_is_ok(status)) {
     IREE_TRACE_ZONE_END(z0);
     return status;
   }
 
-  status = iree_shm_finalize_mapping(fd, size, out_mapping);
+  status = iree_shm_finalize_mapping(fd, actual_size, out_mapping);
+
+#if defined(IREE_PLATFORM_LINUX)
+  // Apply transparent huge page hint if requested (or as fallback from
+  // explicit huge pages that didn't get hugetlbfs backing).
+  if (iree_status_is_ok(status) && options &&
+      iree_any_bit_set(options->flags,
+                       IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES |
+                           IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES)) {
+#ifdef MADV_HUGEPAGE
+    // Best-effort: the kernel may ignore the hint.
+    madvise(out_mapping->base, out_mapping->size, MADV_HUGEPAGE);
+#endif
+  }
+
+  // Bind to NUMA node if requested. Non-fatal: containers and cgroups may
+  // restrict mbind, and the allocation is still usable on any node.
+  if (iree_status_is_ok(status) && options &&
+      options->node_id != IREE_NUMA_NODE_ANY) {
+    iree_status_ignore(iree_numa_bind_memory(
+        out_mapping->base, out_mapping->size, options->node_id));
+  }
+#endif  // IREE_PLATFORM_LINUX
+
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 iree_status_t iree_shm_create_named(iree_string_view_t name,
-                                    iree_shm_options_t options,
+                                    const iree_numa_alloc_options_t* options,
                                     iree_host_size_t minimum_size,
                                     iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -300,15 +435,36 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
   iree_status_t status = iree_shm_finalize_mapping(fd, size, out_mapping);
   if (!iree_status_is_ok(status)) {
     shm_unlink(name_buffer);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
   }
+
+#if defined(IREE_PLATFORM_LINUX)
+  // Named SHM (shm_open) uses tmpfs, not hugetlbfs, so explicit huge pages
+  // are not available. Apply THP hint if any huge page flag is set.
+  if (options &&
+      iree_any_bit_set(options->flags,
+                       IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES |
+                           IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES)) {
+#ifdef MADV_HUGEPAGE
+    madvise(out_mapping->base, out_mapping->size, MADV_HUGEPAGE);
+#endif
+  }
+
+  // NUMA binding (best-effort).
+  if (options && options->node_id != IREE_NUMA_NODE_ANY) {
+    iree_status_ignore(iree_numa_bind_memory(
+        out_mapping->base, out_mapping->size, options->node_id));
+  }
+#endif  // IREE_PLATFORM_LINUX
+
   IREE_TRACE_ZONE_END(z0);
-  return status;
+  return iree_ok_status();
 
 #endif  // IREE_PLATFORM_ANDROID
 }
 
 iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
-                                   iree_shm_options_t options,
                                    iree_host_size_t size,
                                    iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -343,7 +499,6 @@ iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
 }
 
 iree_status_t iree_shm_open_named(iree_string_view_t name,
-                                  iree_shm_options_t options,
                                   iree_host_size_t size,
                                   iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -352,7 +507,6 @@ iree_status_t iree_shm_open_named(iree_string_view_t name,
 
 #if defined(IREE_PLATFORM_ANDROID)
   (void)name;
-  (void)options;
   (void)size;
   IREE_TRACE_ZONE_END(z0);
   return iree_make_status(

--- a/runtime/src/iree/base/internal/shm_posix.c
+++ b/runtime/src/iree/base/internal/shm_posix.c
@@ -285,7 +285,7 @@ static iree_status_t iree_shm_create_anonymous_fd(
         iree_atomic_fetch_add(&counter, 1, iree_memory_order_relaxed);
     iree_snprintf(name, sizeof(name), "/iree_shm_%d_%d", (int)getpid(),
                   sequence);
-    fd = shm_open(name, O_CREAT | O_RDWR | O_EXCL, 0600);
+    fd = shm_open(name, O_CREAT | O_RDWR | O_EXCL | O_CLOEXEC, 0600);
     if (fd != -1) break;
     if (errno != EEXIST) {
       return iree_make_status(iree_status_code_from_errno(errno),
@@ -415,7 +415,7 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
   iree_host_size_t size = iree_shm_required_size(minimum_size);
 
   // O_EXCL ensures we create a new region; fails if the name already exists.
-  int fd = shm_open(name_buffer, O_CREAT | O_RDWR | O_EXCL, 0600);
+  int fd = shm_open(name_buffer, O_CREAT | O_RDWR | O_EXCL | O_CLOEXEC, 0600);
   if (IREE_UNLIKELY(fd == -1)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_errno(errno),
@@ -485,11 +485,15 @@ iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
   int fd = iree_shm_handle_to_fd(handle);
 
   // Duplicate the fd so the mapping has its own independent handle.
-  int mapping_fd = dup(fd);
+  // F_DUPFD_CLOEXEC is atomic (no race window where a fork+exec could leak
+  // the fd), unlike dup() followed by fcntl(F_SETFD).
+  int mapping_fd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
   if (IREE_UNLIKELY(mapping_fd == -1)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_errno(errno),
-                            "dup failed for shared memory handle (%d)", errno);
+                            "fcntl(F_DUPFD_CLOEXEC) failed for shared memory "
+                            "handle (%d)",
+                            errno);
   }
 
   iree_status_t status =
@@ -532,7 +536,7 @@ iree_status_t iree_shm_open_named(iree_string_view_t name,
   name_buffer[name.size] = '\0';
 
   // O_RDWR without O_CREAT: open existing only.
-  int fd = shm_open(name_buffer, O_RDWR, 0);
+  int fd = shm_open(name_buffer, O_RDWR | O_CLOEXEC, 0);
   if (IREE_UNLIKELY(fd == -1)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_errno(errno),
@@ -565,10 +569,12 @@ iree_status_t iree_shm_handle_dup(iree_shm_handle_t source,
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "cannot duplicate an invalid handle");
   }
-  int new_fd = dup(iree_shm_handle_to_fd(source));
+  // F_DUPFD_CLOEXEC is atomic (no race window where a fork+exec could leak
+  // the fd), unlike dup() followed by fcntl(F_SETFD).
+  int new_fd = fcntl(iree_shm_handle_to_fd(source), F_DUPFD_CLOEXEC, 0);
   if (IREE_UNLIKELY(new_fd == -1)) {
     return iree_make_status(iree_status_code_from_errno(errno),
-                            "dup failed (%d)", errno);
+                            "fcntl(F_DUPFD_CLOEXEC) failed (%d)", errno);
   }
   *out_handle = iree_shm_handle_from_fd(new_fd);
   return iree_ok_status();

--- a/runtime/src/iree/base/internal/shm_test.cc
+++ b/runtime/src/iree/base/internal/shm_test.cc
@@ -316,6 +316,35 @@ TEST_F(ShmNamedTest, CreateNamedEmptyNameFails) {
                                               NULL, 4096, &mapping));
 }
 
+TEST_F(ShmNamedTest, CreateNamedNameTooLongFails) {
+  // Build a name one character beyond the platform limit.
+  char long_name[IREE_SHM_MAX_NAME_LENGTH + 2];
+  long_name[0] = '/';
+  memset(long_name + 1, 'x', IREE_SHM_MAX_NAME_LENGTH + 1);
+  iree_string_view_t name =
+      iree_make_string_view(long_name, IREE_SHM_MAX_NAME_LENGTH + 1);
+  iree_shm_mapping_t mapping;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_shm_create_named(name, NULL, 4096, &mapping));
+}
+
+TEST_F(ShmNamedTest, CreateNamedMaxLengthSucceeds) {
+  // A name at exactly the platform limit must succeed.
+  char max_name[IREE_SHM_MAX_NAME_LENGTH + 1];
+  max_name[0] = '/';
+  memset(max_name + 1, 'y', IREE_SHM_MAX_NAME_LENGTH - 1);
+  iree_string_view_t name =
+      iree_make_string_view(max_name, IREE_SHM_MAX_NAME_LENGTH);
+  TrackName(std::string(max_name, IREE_SHM_MAX_NAME_LENGTH).c_str());
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create_named(name, NULL, 4096, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+  iree_shm_close(&mapping);
+#if !defined(IREE_PLATFORM_WINDOWS)
+  shm_unlink(std::string(max_name, IREE_SHM_MAX_NAME_LENGTH).c_str());
+#endif
+}
+
 #endif  // !IREE_PLATFORM_ANDROID
 
 TEST_F(ShmTest, QuerySealsInitiallyNone) {

--- a/runtime/src/iree/base/internal/shm_test.cc
+++ b/runtime/src/iree/base/internal/shm_test.cc
@@ -17,10 +17,7 @@
 
 namespace {
 
-class ShmTest : public ::testing::Test {
- protected:
-  iree_shm_options_t options_ = iree_shm_options_default();
-};
+class ShmTest : public ::testing::Test {};
 
 TEST_F(ShmTest, RequiredSizeZeroReturnsOnePage) {
   iree_host_size_t page = iree_shm_required_size(0);
@@ -77,12 +74,12 @@ TEST_F(ShmTest, CloseNull) {
 TEST_F(ShmTest, CreateZeroSizeFails) {
   iree_shm_mapping_t mapping;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
-                        iree_shm_create(options_, 0, &mapping));
+                        iree_shm_create(NULL, 0, &mapping));
 }
 
 TEST_F(ShmTest, CreateAnonymous) {
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
 
   EXPECT_NE(mapping.base, nullptr);
   EXPECT_GE(mapping.size, (iree_host_size_t)4096);
@@ -104,7 +101,7 @@ TEST_F(ShmTest, CreateAnonymous) {
 TEST_F(ShmTest, CreateAnonymousSubPageSize) {
   // Requesting less than a page should still get a full page.
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 1, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 1, &mapping));
 
   iree_host_size_t page_size = iree_shm_required_size(0);
   EXPECT_GE(mapping.size, page_size);
@@ -115,7 +112,7 @@ TEST_F(ShmTest, CreateAnonymousSubPageSize) {
 
 TEST_F(ShmTest, HandleDup) {
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
 
   iree_shm_handle_t dup_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(mapping.handle, &dup_handle));
@@ -140,7 +137,7 @@ TEST_F(ShmTest, HandleDupInvalidFails) {
 TEST_F(ShmTest, OpenHandle) {
   // Create a region and write a pattern.
   iree_shm_mapping_t creator;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &creator));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &creator));
   memset(creator.base, 0xCD, creator.size);
 
   // Duplicate the handle (simulates passing to another process).
@@ -149,8 +146,7 @@ TEST_F(ShmTest, OpenHandle) {
 
   // Open a second mapping from the duplicated handle.
   iree_shm_mapping_t opener;
-  IREE_ASSERT_OK(
-      iree_shm_open_handle(shared_handle, options_, creator.size, &opener));
+  IREE_ASSERT_OK(iree_shm_open_handle(shared_handle, creator.size, &opener));
   EXPECT_NE(opener.base, nullptr);
   EXPECT_EQ(opener.size, creator.size);
 
@@ -170,17 +166,16 @@ TEST_F(ShmTest, OpenHandleInvalidFails) {
   iree_shm_mapping_t mapping;
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_INVALID_ARGUMENT,
-      iree_shm_open_handle(IREE_SHM_HANDLE_INVALID, options_, 4096, &mapping));
+      iree_shm_open_handle(IREE_SHM_HANDLE_INVALID, 4096, &mapping));
 }
 
 TEST_F(ShmTest, OpenHandleZeroSizeFails) {
   iree_shm_mapping_t creator;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &creator));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &creator));
 
   iree_shm_mapping_t opener;
-  IREE_EXPECT_STATUS_IS(
-      IREE_STATUS_INVALID_ARGUMENT,
-      iree_shm_open_handle(creator.handle, options_, 0, &opener));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_shm_open_handle(creator.handle, 0, &opener));
 
   iree_shm_close(&creator);
 }
@@ -190,14 +185,14 @@ TEST_F(ShmTest, OpenHandleSizeTooLargeFails) {
   // POSIX: our fstat check catches this before mmap (avoids SIGBUS).
   // Windows: MapViewOfFile fails with an error for the same case.
   iree_shm_mapping_t creator;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &creator));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &creator));
 
   iree_shm_handle_t shared_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(creator.handle, &shared_handle));
 
   iree_shm_mapping_t opener;
-  iree_status_t status = iree_shm_open_handle(shared_handle, options_,
-                                              creator.size * 1024, &opener);
+  iree_status_t status =
+      iree_shm_open_handle(shared_handle, creator.size * 1024, &opener);
   EXPECT_FALSE(iree_status_is_ok(status));
   iree_status_ignore(status);
 
@@ -242,8 +237,8 @@ TEST_F(ShmNamedTest, CreateAndOpenNamed) {
   TrackName(name);
 
   iree_shm_mapping_t creator;
-  IREE_ASSERT_OK(iree_shm_create_named(iree_make_cstring_view(name), options_,
-                                       4096, &creator));
+  IREE_ASSERT_OK(iree_shm_create_named(iree_make_cstring_view(name), NULL, 4096,
+                                       &creator));
   EXPECT_NE(creator.base, nullptr);
   EXPECT_GE(creator.size, (iree_host_size_t)4096);
 
@@ -252,8 +247,8 @@ TEST_F(ShmNamedTest, CreateAndOpenNamed) {
 
   // Open the same region by name.
   iree_shm_mapping_t opener;
-  IREE_ASSERT_OK(iree_shm_open_named(iree_make_cstring_view(name), options_,
-                                     creator.size, &opener));
+  IREE_ASSERT_OK(
+      iree_shm_open_named(iree_make_cstring_view(name), creator.size, &opener));
   EXPECT_NE(opener.base, nullptr);
 
   // Both mappings see the same data.
@@ -273,14 +268,14 @@ TEST_F(ShmNamedTest, CreateNamedDuplicateFails) {
   TrackName(name);
 
   iree_shm_mapping_t first;
-  IREE_ASSERT_OK(iree_shm_create_named(iree_make_cstring_view(name), options_,
-                                       4096, &first));
+  IREE_ASSERT_OK(
+      iree_shm_create_named(iree_make_cstring_view(name), NULL, 4096, &first));
 
   // Creating a second region with the same name must fail.
   iree_shm_mapping_t second;
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_ALREADY_EXISTS,
-                        iree_shm_create_named(iree_make_cstring_view(name),
-                                              options_, 4096, &second));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ALREADY_EXISTS,
+      iree_shm_create_named(iree_make_cstring_view(name), NULL, 4096, &second));
 
   iree_shm_close(&first);
 
@@ -292,8 +287,8 @@ TEST_F(ShmNamedTest, CreateNamedDuplicateFails) {
 TEST_F(ShmNamedTest, OpenNamedNonexistentFails) {
   const char* name = TEST_SHM_NAME("nonexistent");
   iree_shm_mapping_t mapping;
-  iree_status_t status = iree_shm_open_named(iree_make_cstring_view(name),
-                                             options_, 4096, &mapping);
+  iree_status_t status =
+      iree_shm_open_named(iree_make_cstring_view(name), 4096, &mapping);
   EXPECT_FALSE(iree_status_is_ok(status));
   iree_status_ignore(status);
 }
@@ -302,30 +297,30 @@ TEST_F(ShmNamedTest, CreateNamedZeroSizeFails) {
   iree_shm_mapping_t mapping;
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_INVALID_ARGUMENT,
-      iree_shm_create_named(iree_make_cstring_view(TEST_SHM_NAME("zero")),
-                            options_, 0, &mapping));
+      iree_shm_create_named(iree_make_cstring_view(TEST_SHM_NAME("zero")), NULL,
+                            0, &mapping));
 }
 
 TEST_F(ShmNamedTest, OpenNamedZeroSizeFails) {
   iree_shm_mapping_t mapping;
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_INVALID_ARGUMENT,
-      iree_shm_open_named(iree_make_cstring_view(TEST_SHM_NAME("zero")),
-                          options_, 0, &mapping));
+      iree_shm_open_named(iree_make_cstring_view(TEST_SHM_NAME("zero")), 0,
+                          &mapping));
 }
 
 TEST_F(ShmNamedTest, CreateNamedEmptyNameFails) {
   iree_shm_mapping_t mapping;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         iree_shm_create_named(iree_make_string_view("", 0),
-                                              options_, 4096, &mapping));
+                                              NULL, 4096, &mapping));
 }
 
 #endif  // !IREE_PLATFORM_ANDROID
 
 TEST_F(ShmTest, QuerySealsInitiallyNone) {
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
 
   iree_shm_seal_flags_t seals = iree_shm_query_seals(&mapping);
 #if defined(IREE_PLATFORM_LINUX)
@@ -354,7 +349,7 @@ TEST_F(ShmTest, QuerySealsUnmappedRegion) {
 
 TEST_F(ShmTest, SealNoneFlagsSucceeds) {
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
   IREE_EXPECT_OK(iree_shm_seal(&mapping, IREE_SHM_SEAL_NONE));
   iree_shm_close(&mapping);
 }
@@ -366,7 +361,7 @@ TEST_F(ShmTest, SealNullMappingFails) {
 
 TEST_F(ShmTest, SealWrite) {
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
 
   // Write data before sealing.
   memset(mapping.base, 0xAA, mapping.size);
@@ -398,7 +393,7 @@ TEST_F(ShmTest, SealWrite) {
 TEST_F(ShmTest, SealWriteIdempotent) {
   // Sealing the same flag twice must succeed (no-op on second call).
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
   memset(mapping.base, 0xBB, mapping.size);
 
 #if defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_WINDOWS)
@@ -415,15 +410,14 @@ TEST_F(ShmTest, SealWriteFailsWithSecondWritableMapping) {
   // When a second writable mapping exists, F_SEAL_WRITE fails with EBUSY.
   // Verify the rollback restores the original mapping so it's still usable.
   iree_shm_mapping_t creator;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &creator));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &creator));
   memset(creator.base, 0xDD, creator.size);
 
   // Open a second writable mapping of the same fd.
   iree_shm_handle_t dup_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(creator.handle, &dup_handle));
   iree_shm_mapping_t second;
-  IREE_ASSERT_OK(
-      iree_shm_open_handle(dup_handle, options_, creator.size, &second));
+  IREE_ASSERT_OK(iree_shm_open_handle(dup_handle, creator.size, &second));
 
   // Sealing the creator must fail because the second mapping is writable.
   iree_status_t status = iree_shm_seal(&creator, IREE_SHM_SEAL_WRITE);
@@ -445,7 +439,7 @@ TEST_F(ShmTest, SealWriteFailsWithSecondWritableMapping) {
 
 TEST_F(ShmTest, SealSealPreventsNewSeals) {
   iree_shm_mapping_t mapping;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &mapping));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
 
   // Apply SEAL_SEAL — no more seals can be added after this.
   IREE_ASSERT_OK(iree_shm_seal(&mapping, IREE_SHM_SEAL_SEAL));
@@ -463,15 +457,14 @@ TEST_F(ShmTest, SealSealPreventsNewSeals) {
 TEST_F(ShmTest, SealWriteVisibleToSecondMapping) {
   // Seal via the creator, verify the opener sees the sealed data.
   iree_shm_mapping_t creator;
-  IREE_ASSERT_OK(iree_shm_create(options_, 4096, &creator));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &creator));
   memset(creator.base, 0xCC, creator.size);
 
   iree_shm_handle_t shared_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(creator.handle, &shared_handle));
 
   iree_shm_mapping_t opener;
-  IREE_ASSERT_OK(
-      iree_shm_open_handle(shared_handle, options_, creator.size, &opener));
+  IREE_ASSERT_OK(iree_shm_open_handle(shared_handle, creator.size, &opener));
 
 #if defined(IREE_PLATFORM_LINUX)
   // Both mappings must be made read-only for F_SEAL_WRITE to succeed.
@@ -487,8 +480,7 @@ TEST_F(ShmTest, SealWriteVisibleToSecondMapping) {
 
   // Reopen — the new mapping inherits the seal; the kernel won't allow
   // PROT_WRITE since F_SEAL_WRITE is set.
-  IREE_ASSERT_OK(
-      iree_shm_open_handle(shared_handle, options_, creator.size, &opener));
+  IREE_ASSERT_OK(iree_shm_open_handle(shared_handle, creator.size, &opener));
   // The sealed data is readable through both mappings.
   EXPECT_EQ(((uint8_t*)creator.base)[0], 0xCC);
   EXPECT_EQ(((uint8_t*)opener.base)[0], 0xCC);
@@ -510,14 +502,13 @@ TEST_F(ShmTest, SealWriteVisibleToSecondMapping) {
 TEST_F(ShmTest, WriteReadCoherence) {
   // Write via one mapping, read via another opened from a dup'd handle.
   iree_shm_mapping_t writer;
-  IREE_ASSERT_OK(iree_shm_create(options_, 8192, &writer));
+  IREE_ASSERT_OK(iree_shm_create(NULL, 8192, &writer));
 
   iree_shm_handle_t reader_handle = IREE_SHM_HANDLE_INVALID;
   IREE_ASSERT_OK(iree_shm_handle_dup(writer.handle, &reader_handle));
 
   iree_shm_mapping_t reader;
-  IREE_ASSERT_OK(
-      iree_shm_open_handle(reader_handle, options_, writer.size, &reader));
+  IREE_ASSERT_OK(iree_shm_open_handle(reader_handle, writer.size, &reader));
 
   // Write a structured pattern.
   for (iree_host_size_t i = 0; i < writer.size; ++i) {
@@ -534,5 +525,123 @@ TEST_F(ShmTest, WriteReadCoherence) {
   iree_shm_close(&reader);
   iree_shm_close(&writer);
 }
+
+//===----------------------------------------------------------------------===//
+// Placement options tests (huge pages, NUMA, THP)
+//===----------------------------------------------------------------------===//
+
+// These tests verify that placement options are accepted and the allocation
+// succeeds. The specific backing (huge pages, THP, NUMA node) depends on
+// system configuration and privileges; the tests validate the fallback
+// behavior: even without huge pages or NUMA support, creation must succeed
+// with normal pages.
+
+TEST_F(ShmTest, CreateWithExplicitHugePages) {
+  iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
+  options.flags = IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES;
+  options.huge_page_size = 2 * 1024 * 1024;  // 2MB.
+
+  // Allocate 4MB (two huge pages).
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create(&options, 4 * 1024 * 1024, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+  EXPECT_GE(mapping.size, (iree_host_size_t)(4 * 1024 * 1024));
+
+  // Write and verify a pattern.
+  memset(mapping.base, 0xAA, mapping.size);
+  EXPECT_EQ(((uint8_t*)mapping.base)[0], 0xAA);
+  EXPECT_EQ(((uint8_t*)mapping.base)[mapping.size - 1], 0xAA);
+
+  iree_shm_close(&mapping);
+}
+
+TEST_F(ShmTest, CreateWithTransparentHugePages) {
+  iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
+  options.flags = IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES;
+
+  // Allocate 4MB (2x the typical huge page size).
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create(&options, 4 * 1024 * 1024, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+  EXPECT_GE(mapping.size, (iree_host_size_t)(4 * 1024 * 1024));
+
+  memset(mapping.base, 0xBB, mapping.size);
+  EXPECT_EQ(((uint8_t*)mapping.base)[0], 0xBB);
+
+  iree_shm_close(&mapping);
+}
+
+TEST_F(ShmTest, CreateWithNumaNode) {
+  iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
+  options.node_id = 0;  // Node 0 is always valid.
+
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create(&options, 4096, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+
+  memset(mapping.base, 0xCC, mapping.size);
+  EXPECT_EQ(((uint8_t*)mapping.base)[0], 0xCC);
+
+  iree_shm_close(&mapping);
+}
+
+TEST_F(ShmTest, CreateWithAllPlacementOptions) {
+  iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
+  options.node_id = 0;
+  options.flags = IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES |
+                  IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES;
+  options.huge_page_size = 2 * 1024 * 1024;
+
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create(&options, 4 * 1024 * 1024, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+  EXPECT_GE(mapping.size, (iree_host_size_t)(4 * 1024 * 1024));
+
+  memset(mapping.base, 0xDD, mapping.size);
+  EXPECT_EQ(((uint8_t*)mapping.base)[0], 0xDD);
+
+  iree_shm_close(&mapping);
+}
+
+TEST_F(ShmTest, CreateNullOptionsUsesDefaults) {
+  // NULL options is equivalent to default options (no NUMA, no huge pages).
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create(NULL, 4096, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+
+  memset(mapping.base, 0xEE, mapping.size);
+  EXPECT_EQ(((uint8_t*)mapping.base)[0], 0xEE);
+
+  iree_shm_close(&mapping);
+}
+
+#if !defined(IREE_PLATFORM_ANDROID)
+TEST_F(ShmNamedTest, CreateNamedWithHugePagesFallsBack) {
+  // Named SHM on Linux uses shm_open (tmpfs), which doesn't support explicit
+  // huge pages. The implementation should silently fall back to THP or normal
+  // pages. On Windows, named mappings can support large pages if privileged.
+  const char* name = TEST_SHM_NAME("hp_fallback");
+  TrackName(name);
+
+  iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
+  options.flags = IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES;
+  options.huge_page_size = 2 * 1024 * 1024;
+
+  iree_shm_mapping_t mapping;
+  IREE_ASSERT_OK(iree_shm_create_named(iree_make_cstring_view(name), &options,
+                                       4 * 1024 * 1024, &mapping));
+  EXPECT_NE(mapping.base, nullptr);
+  EXPECT_GE(mapping.size, (iree_host_size_t)(4 * 1024 * 1024));
+
+  memset(mapping.base, 0xFF, mapping.size);
+  EXPECT_EQ(((uint8_t*)mapping.base)[0], 0xFF);
+
+  iree_shm_close(&mapping);
+
+#if !defined(IREE_PLATFORM_WINDOWS)
+  shm_unlink(name);
+#endif
+}
+#endif  // !IREE_PLATFORM_ANDROID
 
 }  // namespace

--- a/runtime/src/iree/base/internal/shm_win32.c
+++ b/runtime/src/iree/base/internal/shm_win32.c
@@ -51,6 +51,13 @@ static iree_status_t iree_shm_map_win32(HANDLE mapping_handle,
     base = MapViewOfFileExNuma(mapping_handle, access_flags,
                                /*dwFileOffsetHigh=*/0, /*dwFileOffsetLow=*/0,
                                size, /*lpBaseAddress=*/NULL, (DWORD)numa_node);
+    // NUMA is best-effort: if the NUMA-aware mapping fails (node offline,
+    // insufficient resources on that node, API not supported in VM), fall
+    // back to default placement.
+    if (!base) {
+      base = MapViewOfFile(mapping_handle, access_flags,
+                           /*dwFileOffsetHigh=*/0, /*dwFileOffsetLow=*/0, size);
+    }
   } else {
     base = MapViewOfFile(mapping_handle, access_flags,
                          /*dwFileOffsetHigh=*/0, /*dwFileOffsetLow=*/0, size);

--- a/runtime/src/iree/base/internal/shm_win32.c
+++ b/runtime/src/iree/base/internal/shm_win32.c
@@ -38,12 +38,23 @@ static inline HANDLE iree_shm_handle_to_win32(iree_shm_handle_t handle) {
 }
 
 // Maps a file mapping handle into the process address space.
+// |access_flags| is passed to MapViewOfFile (FILE_MAP_ALL_ACCESS, optionally
+// with FILE_MAP_LARGE_PAGES). |numa_node| is the preferred NUMA node for
+// MapViewOfFileExNuma, or IREE_NUMA_NODE_ANY for default placement.
 static iree_status_t iree_shm_map_win32(HANDLE mapping_handle,
                                         iree_host_size_t size,
+                                        DWORD access_flags,
+                                        iree_numa_node_id_t numa_node,
                                         void** out_base) {
-  void* base =
-      MapViewOfFile(mapping_handle, FILE_MAP_ALL_ACCESS,
-                    /*dwFileOffsetHigh=*/0, /*dwFileOffsetLow=*/0, size);
+  void* base = NULL;
+  if (numa_node != IREE_NUMA_NODE_ANY) {
+    base = MapViewOfFileExNuma(mapping_handle, access_flags,
+                               /*dwFileOffsetHigh=*/0, /*dwFileOffsetLow=*/0,
+                               size, /*lpBaseAddress=*/NULL, (DWORD)numa_node);
+  } else {
+    base = MapViewOfFile(mapping_handle, access_flags,
+                         /*dwFileOffsetHigh=*/0, /*dwFileOffsetLow=*/0, size);
+  }
   if (IREE_UNLIKELY(!base)) {
     return iree_make_status(
         iree_status_code_from_win32_error(GetLastError()),
@@ -57,10 +68,37 @@ static iree_status_t iree_shm_map_win32(HANDLE mapping_handle,
 // Populates an output mapping from a successfully created/opened handle.
 // On failure, closes the handle and returns the error.
 static iree_status_t iree_shm_finalize_mapping_win32(
+    HANDLE mapping_handle, iree_host_size_t size, DWORD access_flags,
+    iree_numa_node_id_t numa_node, iree_shm_mapping_t* out_mapping) {
+  void* base = NULL;
+  iree_status_t status =
+      iree_shm_map_win32(mapping_handle, size, access_flags, numa_node, &base);
+  if (!iree_status_is_ok(status)) {
+    CloseHandle(mapping_handle);
+    return status;
+  }
+  out_mapping->base = base;
+  out_mapping->size = size;
+  out_mapping->handle = iree_shm_handle_from_win32(mapping_handle);
+  return iree_ok_status();
+}
+
+// Convenience wrapper for openers that don't know the creator's flags.
+// Tries FILE_MAP_LARGE_PAGES first (required when the section was created with
+// SEC_LARGE_PAGES), falling back to plain FILE_MAP_ALL_ACCESS for sections
+// created without large pages.
+static iree_status_t iree_shm_finalize_mapping_win32_default(
     HANDLE mapping_handle, iree_host_size_t size,
     iree_shm_mapping_t* out_mapping) {
   void* base = NULL;
-  iree_status_t status = iree_shm_map_win32(mapping_handle, size, &base);
+  iree_status_t status = iree_shm_map_win32(
+      mapping_handle, size, FILE_MAP_ALL_ACCESS | FILE_MAP_LARGE_PAGES,
+      IREE_NUMA_NODE_ANY, &base);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    status = iree_shm_map_win32(mapping_handle, size, FILE_MAP_ALL_ACCESS,
+                                IREE_NUMA_NODE_ANY, &base);
+  }
   if (!iree_status_is_ok(status)) {
     CloseHandle(mapping_handle);
     return status;
@@ -81,7 +119,7 @@ iree_host_size_t iree_shm_required_size(iree_host_size_t requested_size) {
   return (requested_size + page_size - 1) & ~(page_size - 1);
 }
 
-iree_status_t iree_shm_create(iree_shm_options_t options,
+iree_status_t iree_shm_create(const iree_numa_alloc_options_t* options,
                               iree_host_size_t minimum_size,
                               iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -96,11 +134,67 @@ iree_status_t iree_shm_create(iree_shm_options_t options,
 
   iree_host_size_t size = iree_shm_required_size(minimum_size);
 
+  // Determine creation flags based on placement options.
+  DWORD protect_flags = PAGE_READWRITE;
+  DWORD access_flags = FILE_MAP_ALL_ACCESS;
+  iree_numa_node_id_t numa_node = IREE_NUMA_NODE_ANY;
+  bool use_large_pages = false;
+
+  if (options) {
+    numa_node = options->node_id;
+
+    // Try large pages if requested. SEC_LARGE_PAGES requires
+    // SeLockMemoryPrivilege and SEC_COMMIT. The size must be aligned to
+    // GetLargePageMinimum().
+    if (iree_any_bit_set(options->flags,
+                         IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES)) {
+      SIZE_T large_page_min = GetLargePageMinimum();
+      if (large_page_min > 0) {
+        iree_host_size_t aligned_size = 0;
+        if (iree_host_size_checked_align(size, (iree_host_size_t)large_page_min,
+                                         &aligned_size)) {
+          size = aligned_size;
+          protect_flags = PAGE_READWRITE | SEC_LARGE_PAGES | SEC_COMMIT;
+          access_flags |= FILE_MAP_LARGE_PAGES;
+          use_large_pages = true;
+        }
+      }
+    }
+  }
+
+  // CreateFileMappingNumaW is used when a NUMA node preference is set.
   // INVALID_HANDLE_VALUE for hFile creates a page-file backed mapping
   // (anonymous shared memory). NULL name makes it unnamed.
-  HANDLE mapping_handle = CreateFileMappingW(
-      INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, PAGE_READWRITE,
-      (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL);
+  HANDLE mapping_handle = NULL;
+  if (numa_node != IREE_NUMA_NODE_ANY) {
+    mapping_handle = CreateFileMappingNumaW(
+        INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+        (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL,
+        (DWORD)numa_node);
+  } else {
+    mapping_handle = CreateFileMappingW(
+        INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+        (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL);
+  }
+
+  // If large pages failed (no privilege, insufficient large pages), retry
+  // without SEC_LARGE_PAGES. This is the silent fallback behavior.
+  if (!mapping_handle && use_large_pages) {
+    protect_flags = PAGE_READWRITE;
+    access_flags = FILE_MAP_ALL_ACCESS;
+    size = iree_shm_required_size(minimum_size);  // Un-align from large pages.
+    if (numa_node != IREE_NUMA_NODE_ANY) {
+      mapping_handle = CreateFileMappingNumaW(
+          INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+          (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL,
+          (DWORD)numa_node);
+    } else {
+      mapping_handle = CreateFileMappingW(
+          INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+          (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL);
+    }
+  }
+
   if (IREE_UNLIKELY(!mapping_handle)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
@@ -108,14 +202,14 @@ iree_status_t iree_shm_create(iree_shm_options_t options,
                             size);
   }
 
-  iree_status_t status =
-      iree_shm_finalize_mapping_win32(mapping_handle, size, out_mapping);
+  iree_status_t status = iree_shm_finalize_mapping_win32(
+      mapping_handle, size, access_flags, numa_node, out_mapping);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 iree_status_t iree_shm_create_named(iree_string_view_t name,
-                                    iree_shm_options_t options,
+                                    const iree_numa_alloc_options_t* options,
                                     iree_host_size_t minimum_size,
                                     iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -148,9 +242,60 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
 
   iree_host_size_t size = iree_shm_required_size(minimum_size);
 
-  HANDLE mapping_handle = CreateFileMappingW(
-      INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, PAGE_READWRITE,
-      (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name);
+  // Determine creation flags based on placement options (same logic as
+  // anonymous create — named mappings support both large pages and NUMA).
+  DWORD protect_flags = PAGE_READWRITE;
+  DWORD access_flags = FILE_MAP_ALL_ACCESS;
+  iree_numa_node_id_t numa_node = IREE_NUMA_NODE_ANY;
+  bool use_large_pages = false;
+
+  if (options) {
+    numa_node = options->node_id;
+    if (iree_any_bit_set(options->flags,
+                         IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES)) {
+      SIZE_T large_page_min = GetLargePageMinimum();
+      if (large_page_min > 0) {
+        iree_host_size_t aligned_size = 0;
+        if (iree_host_size_checked_align(size, (iree_host_size_t)large_page_min,
+                                         &aligned_size)) {
+          size = aligned_size;
+          protect_flags = PAGE_READWRITE | SEC_LARGE_PAGES | SEC_COMMIT;
+          access_flags |= FILE_MAP_LARGE_PAGES;
+          use_large_pages = true;
+        }
+      }
+    }
+  }
+
+  HANDLE mapping_handle = NULL;
+  if (numa_node != IREE_NUMA_NODE_ANY) {
+    mapping_handle = CreateFileMappingNumaW(
+        INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+        (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name,
+        (DWORD)numa_node);
+  } else {
+    mapping_handle = CreateFileMappingW(
+        INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+        (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name);
+  }
+
+  // Silent fallback from large pages on failure.
+  if (!mapping_handle && use_large_pages) {
+    protect_flags = PAGE_READWRITE;
+    access_flags = FILE_MAP_ALL_ACCESS;
+    size = iree_shm_required_size(minimum_size);
+    if (numa_node != IREE_NUMA_NODE_ANY) {
+      mapping_handle = CreateFileMappingNumaW(
+          INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+          (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name,
+          (DWORD)numa_node);
+    } else {
+      mapping_handle = CreateFileMappingW(
+          INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+          (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name);
+    }
+  }
+
   if (IREE_UNLIKELY(!mapping_handle)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
@@ -168,14 +313,13 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
                             "exists");
   }
 
-  iree_status_t status =
-      iree_shm_finalize_mapping_win32(mapping_handle, size, out_mapping);
+  iree_status_t status = iree_shm_finalize_mapping_win32(
+      mapping_handle, size, access_flags, numa_node, out_mapping);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
-                                   iree_shm_options_t options,
                                    iree_host_size_t size,
                                    iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -204,14 +348,13 @@ iree_status_t iree_shm_open_handle(iree_shm_handle_t handle,
                             "DuplicateHandle failed for shared memory handle");
   }
 
-  iree_status_t status =
-      iree_shm_finalize_mapping_win32(mapping_handle, size, out_mapping);
+  iree_status_t status = iree_shm_finalize_mapping_win32_default(
+      mapping_handle, size, out_mapping);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 iree_status_t iree_shm_open_named(iree_string_view_t name,
-                                  iree_shm_options_t options,
                                   iree_host_size_t size,
                                   iree_shm_mapping_t* out_mapping) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -249,8 +392,8 @@ iree_status_t iree_shm_open_named(iree_string_view_t name,
                             "OpenFileMappingW failed");
   }
 
-  iree_status_t status =
-      iree_shm_finalize_mapping_win32(mapping_handle, size, out_mapping);
+  iree_status_t status = iree_shm_finalize_mapping_win32_default(
+      mapping_handle, size, out_mapping);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/base/internal/shm_win32.c
+++ b/runtime/src/iree/base/internal/shm_win32.c
@@ -178,7 +178,7 @@ iree_status_t iree_shm_create(const iree_numa_alloc_options_t* options,
   }
 
   // If large pages failed (no privilege, insufficient large pages), retry
-  // without SEC_LARGE_PAGES. This is the silent fallback behavior.
+  // without SEC_LARGE_PAGES.
   if (!mapping_handle && use_large_pages) {
     protect_flags = PAGE_READWRITE;
     access_flags = FILE_MAP_ALL_ACCESS;
@@ -193,6 +193,17 @@ iree_status_t iree_shm_create(const iree_numa_alloc_options_t* options,
           INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
           (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL);
     }
+  }
+
+  // NUMA fallback: if NUMA-specific creation failed (invalid node, container
+  // restrictions, NUMA disabled in VM), retry without NUMA preference. This
+  // makes NUMA a best-effort hint, matching the Linux mbind semantics where
+  // binding failures are silently ignored.
+  if (!mapping_handle && numa_node != IREE_NUMA_NODE_ANY) {
+    numa_node = IREE_NUMA_NODE_ANY;
+    mapping_handle = CreateFileMappingW(
+        INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+        (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), /*lpName=*/NULL);
   }
 
   if (IREE_UNLIKELY(!mapping_handle)) {
@@ -279,7 +290,7 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
         (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name);
   }
 
-  // Silent fallback from large pages on failure.
+  // Large page fallback.
   if (!mapping_handle && use_large_pages) {
     protect_flags = PAGE_READWRITE;
     access_flags = FILE_MAP_ALL_ACCESS;
@@ -294,6 +305,14 @@ iree_status_t iree_shm_create_named(iree_string_view_t name,
           INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
           (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name);
     }
+  }
+
+  // NUMA fallback (see iree_shm_create for rationale).
+  if (!mapping_handle && numa_node != IREE_NUMA_NODE_ANY) {
+    numa_node = IREE_NUMA_NODE_ANY;
+    mapping_handle = CreateFileMappingW(
+        INVALID_HANDLE_VALUE, /*lpFileMappingAttributes=*/NULL, protect_flags,
+        (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), wide_name);
   }
 
   if (IREE_UNLIKELY(!mapping_handle)) {
@@ -384,8 +403,14 @@ iree_status_t iree_shm_open_named(iree_string_view_t name,
   }
   wide_name[IREE_SHM_WIN32_PREFIX_LENGTH + name.size] = L'\0';
 
-  HANDLE mapping_handle =
-      OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, wide_name);
+  // Try with FILE_MAP_LARGE_PAGES first — required when the section was
+  // created with SEC_LARGE_PAGES. Fall back to plain FILE_MAP_ALL_ACCESS
+  // for sections created without large pages.
+  HANDLE mapping_handle = OpenFileMappingW(
+      FILE_MAP_ALL_ACCESS | FILE_MAP_LARGE_PAGES, FALSE, wide_name);
+  if (!mapping_handle) {
+    mapping_handle = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, wide_name);
+  }
   if (IREE_UNLIKELY(!mapping_handle)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
@@ -456,8 +481,18 @@ iree_status_t iree_shm_seal(iree_shm_mapping_t* mapping,
     DWORD old_protect = 0;
     if (IREE_UNLIKELY(!VirtualProtect(mapping->base, mapping->size,
                                       PAGE_READONLY, &old_protect))) {
+      DWORD error = GetLastError();
       IREE_TRACE_ZONE_END(z0);
-      return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
+      // Sections created with SEC_LARGE_PAGES do not support page protection
+      // changes. Report as UNAVAILABLE using the same contract as macOS (which
+      // doesn't support sealing at all) so callers implementing defense-in-
+      // depth can check and proceed.
+      if (error == ERROR_INVALID_PARAMETER) {
+        return iree_make_status(
+            IREE_STATUS_UNAVAILABLE,
+            "write sealing not supported (likely large-page-backed section)");
+      }
+      return iree_make_status(iree_status_code_from_win32_error(error),
                               "VirtualProtect(PAGE_READONLY) failed");
     }
   }

--- a/runtime/src/iree/base/threading/numa.h
+++ b/runtime/src/iree/base/threading/numa.h
@@ -36,7 +36,7 @@
 // Allocation with transparent huge pages:
 //
 //   iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
-//   options.hint_transparent_huge_pages = true;
+//   options.flags = IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES;
 //   IREE_RETURN_IF_ERROR(iree_numa_alloc(size, &options, &ptr, &info));
 //
 // ## Platform support
@@ -58,8 +58,6 @@
 #ifndef IREE_BASE_THREADING_NUMA_H_
 #define IREE_BASE_THREADING_NUMA_H_
 
-#include <stdbool.h>
-
 #include "iree/base/api.h"
 
 #ifdef __cplusplus
@@ -76,8 +74,25 @@ typedef uint32_t iree_numa_node_id_t;
 // Sentinel indicating no NUMA placement preference.
 #define IREE_NUMA_NODE_ANY ((iree_numa_node_id_t)UINT32_MAX)
 
-// Options controlling NUMA-aware allocation.
-// Use iree_numa_alloc_options_default() for a zero-initialized default.
+// Bitfield of memory placement flags controlling huge page behavior.
+typedef uint32_t iree_memory_placement_flags_t;
+enum iree_memory_placement_flag_bits_e {
+  IREE_MEMORY_PLACEMENT_FLAG_NONE = 0u,
+  // Attempt allocation using explicit huge pages (MAP_HUGETLB on Linux,
+  // MEM_LARGE_PAGES on Windows, SEC_LARGE_PAGES for shared memory). Falls
+  // back gracefully to smaller pages on failure.
+  IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES = 1u << 0,
+  // Hint to the kernel that transparent huge pages should be used
+  // (MADV_HUGEPAGE on Linux). Best-effort: the kernel may ignore the hint.
+  // Also used as a fallback when explicit huge pages are requested but the
+  // allocation fails.
+  IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES = 1u << 1,
+};
+
+// Options controlling NUMA-aware memory placement.
+//
+// Used for both private allocations (iree_numa_alloc) and shared memory
+// (iree_shm_create). Use iree_numa_alloc_options_default() for safe defaults.
 typedef struct iree_numa_alloc_options_t {
   // NUMA node for memory placement. IREE_NUMA_NODE_ANY = no preference.
   iree_numa_node_id_t node_id;
@@ -86,24 +101,17 @@ typedef struct iree_numa_alloc_options_t {
   // power of two or 0 (= page-aligned by default). When the allocation uses
   // mmap or VirtualAlloc (the common case), the returned pointer is at least
   // page-aligned regardless of this field. This field only affects the
-  // standard allocator fallback, which is used when mmap is unavailable.
+  // standard allocator fallback in iree_numa_alloc; shared memory paths
+  // (iree_shm_create) ignore it since mmap is always page-aligned.
   iree_host_size_t alignment;
 
-  // Huge page size: 0 = normal pages, or specific size (2MB/1GB).
-  // If non-zero and use_explicit_huge_pages is true, the allocation size will
-  // be rounded up to this alignment.
+  // Huge page size: 0 = auto-detect (typically 2MB on x86_64), or a specific
+  // size (2MB/1GB). Only meaningful when EXPLICIT_HUGE_PAGES is set in flags.
+  // The allocation size will be rounded up to this alignment.
   iree_host_size_t huge_page_size;
 
-  // If true, attempt allocation using explicit huge pages (MAP_HUGETLB on
-  // Linux, MEM_LARGE_PAGES on Windows). Falls back gracefully if huge pages
-  // are not available.
-  bool use_explicit_huge_pages;
-
-  // If true, hint to the kernel that transparent huge pages should be used
-  // (MADV_HUGEPAGE on Linux). Best-effort: the kernel may ignore the hint.
-  // Also used as a fallback when use_explicit_huge_pages is set but explicit
-  // huge page allocation fails.
-  bool hint_transparent_huge_pages;
+  // Memory placement flags controlling huge page behavior.
+  iree_memory_placement_flags_t flags;
 } iree_numa_alloc_options_t;
 
 // Allocation method used (for diagnostics and proper cleanup).

--- a/runtime/src/iree/base/threading/numa_linux.c
+++ b/runtime/src/iree/base/threading/numa_linux.c
@@ -301,14 +301,18 @@ iree_numa_alloc(iree_host_size_t size, const iree_numa_alloc_options_t* options,
   bool allocated = false;
 
   // Try explicit huge pages if requested.
-  if (!allocated && options->use_explicit_huge_pages) {
+  if (!allocated &&
+      iree_any_bit_set(options->flags,
+                       IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES)) {
     allocated =
         iree_numa_try_alloc_explicit_huge(size, options, out_ptr, out_info);
   }
 
   // Try transparent huge pages if requested (or as fallback from explicit).
-  if (!allocated && (options->hint_transparent_huge_pages ||
-                     options->use_explicit_huge_pages)) {
+  if (!allocated &&
+      iree_any_bit_set(options->flags,
+                       IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES |
+                           IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES)) {
     allocated = iree_numa_try_alloc_transparent_huge(size, out_ptr, out_info);
   }
 

--- a/runtime/src/iree/base/threading/numa_test.cc
+++ b/runtime/src/iree/base/threading/numa_test.cc
@@ -147,13 +147,12 @@ TEST(NumaTest, DefaultOptionsHaveNoPreference) {
   EXPECT_EQ(options.node_id, IREE_NUMA_NODE_ANY);
   EXPECT_EQ(options.alignment, 0u);
   EXPECT_EQ(options.huge_page_size, 0u);
-  EXPECT_FALSE(options.use_explicit_huge_pages);
-  EXPECT_FALSE(options.hint_transparent_huge_pages);
+  EXPECT_EQ(options.flags, IREE_MEMORY_PLACEMENT_FLAG_NONE);
 }
 
 TEST(NumaTest, TransparentHugePageHint) {
   iree_numa_alloc_options_t options = iree_numa_alloc_options_default();
-  options.hint_transparent_huge_pages = true;
+  options.flags = IREE_MEMORY_PLACEMENT_FLAG_TRANSPARENT_HUGE_PAGES;
   // Allocate 4MB (2x the typical huge page size).
   iree_host_size_t size = 4 * 1024 * 1024;
   void* ptr = NULL;

--- a/runtime/src/iree/base/threading/numa_win32.c
+++ b/runtime/src/iree/base/threading/numa_win32.c
@@ -92,7 +92,8 @@ iree_numa_alloc(iree_host_size_t size, const iree_numa_alloc_options_t* options,
   iree_host_size_t huge_page_size = 0;
 
   // Try large pages if requested.
-  if (options->use_explicit_huge_pages) {
+  if (iree_any_bit_set(options->flags,
+                       IREE_MEMORY_PLACEMENT_FLAG_EXPLICIT_HUGE_PAGES)) {
     // GetLargePageMinimum() returns the minimum large page size, or 0 if large
     // pages are not supported (requires SeLockMemoryPrivilege).
     SIZE_T large_page_min = GetLargePageMinimum();


### PR DESCRIPTION
Unify iree_shm_options_t and iree_numa_alloc_options_t into a single placement type used by both SHM and NUMA allocation paths. SHM create functions now accept iree_numa_alloc_options_t* (NULL for defaults); open functions drop options entirely since openers map existing pages whose backing store was determined at creation time.

Platform implementations:
- Linux: MFD_HUGETLB memfd with probe-mmap validation (MAP_POPULATE),
  MADV_HUGEPAGE for THP, mbind for NUMA. Graceful fallback cascade:
  explicit huge pages -> THP -> normal pages. Retry memfd_create
  without MFD_ALLOW_SEALING for kernel 4.14-4.15 compatibility.
- Windows: SEC_LARGE_PAGES with silent fallback, CreateFileMappingNumaW
  for NUMA placement. Open paths try FILE_MAP_LARGE_PAGES first to
  support cross-process sharing of large-page sections.
- macOS: No-op (no huge page or NUMA support on Apple Silicon).

Also: convert iree_numa_alloc_options_t bool fields to a flag bitfield, embed placement options in iree_async_slab_options_t, reduce IREE_SHM_MAX_NAME_LENGTH to 30 for macOS PSHMNAMLEN portability, and
improve iree_shm_seal documentation with thread-safety requirements and Windows process-local semantics.