### PR TITLE
Async proactor fixes: TSAN bridge and progress callback starvation

### DIFF
--- a/runtime/src/iree/async/cts/core/BUILD.bazel
+++ b/runtime/src/iree/async/cts/core/BUILD.bazel
@@ -97,6 +97,21 @@ iree_runtime_cc_library(
     alwayslink = True,
 )
 
+# TSAN bridge stress tests: validates proactor submit→complete ordering under
+# multi-threaded operation reuse.
+iree_runtime_cc_library(
+    name = "tsan_bridge_test",
+    testonly = True,
+    srcs = ["tsan_bridge_test.cc"],
+    deps = [
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/async/cts/util:registry",
+        "//runtime/src/iree/async/cts/util:test_base",
+        "//runtime/src/iree/base/internal",
+    ],
+    alwayslink = True,
+)
+
 #===------------------------------------------------------------------------===#
 # Convenience targets
 #===------------------------------------------------------------------------===#
@@ -112,6 +127,7 @@ iree_runtime_cc_library(
         ":resource_exhaustion_test",
         ":sequence_test",
         ":timer_test",
+        ":tsan_bridge_test",
     ],
 )
 

--- a/runtime/src/iree/async/cts/core/CMakeLists.txt
+++ b/runtime/src/iree/async/cts/core/CMakeLists.txt
@@ -96,6 +96,21 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    tsan_bridge_test
+  SRCS
+    "tsan_bridge_test.cc"
+  DEPS
+    iree::async
+    iree::async::cts::util::registry
+    iree::async::cts::util::test_base
+    iree::base::internal
+  TESTONLY
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     all_tests
   DEPS
     ::error_propagation_test
@@ -104,6 +119,7 @@ iree_cc_library(
     ::resource_exhaustion_test
     ::sequence_test
     ::timer_test
+    ::tsan_bridge_test
   TESTONLY
   PUBLIC
 )

--- a/runtime/src/iree/async/cts/core/tsan_bridge_test.cc
+++ b/runtime/src/iree/async/cts/core/tsan_bridge_test.cc
@@ -1,0 +1,319 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// TSAN stress test for proactor submit→complete ordering.
+//
+// Proactor backends may use kernel-mediated mechanisms (shared memory rings,
+// completion ports) where the submit→complete ordering is invisible to TSAN's
+// userspace instrumentation. The iree_async_operation_t::tsan_bridge atomic
+// provides a release/acquire pair that makes this ordering visible.
+//
+// This test exercises the pattern that exposes missing bridges: a fixed pool
+// of operation structs is reused across many submit/complete cycles from
+// multiple threads. Each cycle writes base struct fields (type, completion_fn,
+// user_data) before submit and reads them during completion dispatch. Without
+// proper ordering, TSAN reports a data race on these fields.
+//
+// Proactor-only — no carriers, no sockets, no network code. NOP operations
+// exercise the full submit→complete pipeline with the same TSAN bridge path
+// as all other operation types.
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "iree/async/cts/util/registry.h"
+#include "iree/async/cts/util/test_base.h"
+#include "iree/async/operations/scheduling.h"
+#include "iree/base/internal/math.h"
+
+namespace iree::async::cts {
+
+class TsanBridgeTest : public CtsTestBase<> {};
+
+//===----------------------------------------------------------------------===//
+// Operation pool with bitmap-based free tracking
+//===----------------------------------------------------------------------===//
+
+// Fixed-size pool of NOP operations with atomic bitmap free tracking.
+// Mimics the carrier send slot pattern: claim via CAS, release via OR.
+struct OperationPool {
+  static constexpr int kSlotCount = 8;
+
+  iree_async_nop_operation_t slots[kSlotCount];
+
+  // Bitmap: bit i set = slot i is free. All slots start free.
+  std::atomic<uint32_t> free_bitmap{(1u << kSlotCount) - 1};
+
+  // Total completions observed (for test termination).
+  std::atomic<int> completions{0};
+
+  // Claims a free slot, returns index or -1 if none available.
+  int Claim() {
+    uint32_t bitmap = free_bitmap.load(std::memory_order_acquire);
+    while (bitmap != 0) {
+      int index = iree_math_count_trailing_zeros_u32(bitmap);
+      uint32_t cleared = bitmap & ~(1u << index);
+      if (free_bitmap.compare_exchange_weak(bitmap, cleared,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  // Releases a slot back to the pool.
+  void Release(int index) {
+    free_bitmap.fetch_or(1u << index, std::memory_order_release);
+  }
+
+  // Completion callback: reads operation fields (the TSAN-sensitive part),
+  // then releases the slot back to the pool for reuse.
+  static void CompletionCallback(void* user_data,
+                                 iree_async_operation_t* operation,
+                                 iree_status_t status,
+                                 iree_async_completion_flags_t flags) {
+    auto* pool = static_cast<OperationPool*>(user_data);
+    iree_status_ignore(status);
+
+    // Read fields that were written during initialization. These are the
+    // accesses that race without proper submit→complete ordering visible
+    // to TSAN.
+    IREE_ASSERT_EQ(operation->type, IREE_ASYNC_OPERATION_TYPE_NOP);
+    IREE_ASSERT_EQ(operation->completion_fn, CompletionCallback);
+    IREE_ASSERT_EQ(operation->user_data, pool);
+
+    // Find which slot this is by pointer arithmetic.
+    auto* nop = reinterpret_cast<iree_async_nop_operation_t*>(operation);
+    int index = static_cast<int>(nop - pool->slots);
+    IREE_ASSERT(index >= 0 && index < kSlotCount);
+
+    pool->completions.fetch_add(1, std::memory_order_relaxed);
+    pool->Release(index);
+  }
+};
+
+// 2-slot pool for maximum reuse frequency in high-contention tests.
+// Defined at namespace scope because C++ disallows static constexpr members
+// in local structs.
+struct TinyPool {
+  static constexpr int kSlotCount = 2;
+  iree_async_nop_operation_t slots[kSlotCount];
+  std::atomic<uint32_t> free_bitmap{(1u << kSlotCount) - 1};
+  std::atomic<int> completions{0};
+
+  int Claim() {
+    uint32_t bitmap = free_bitmap.load(std::memory_order_acquire);
+    while (bitmap != 0) {
+      int index = iree_math_count_trailing_zeros_u32(bitmap);
+      uint32_t cleared = bitmap & ~(1u << index);
+      if (free_bitmap.compare_exchange_weak(bitmap, cleared,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  void Release(int index) {
+    free_bitmap.fetch_or(1u << index, std::memory_order_release);
+  }
+
+  static void Callback(void* user_data, iree_async_operation_t* operation,
+                       iree_status_t status,
+                       iree_async_completion_flags_t flags) {
+    auto* pool = static_cast<TinyPool*>(user_data);
+    iree_status_ignore(status);
+    IREE_ASSERT_EQ(operation->type, IREE_ASYNC_OPERATION_TYPE_NOP);
+    auto* nop = reinterpret_cast<iree_async_nop_operation_t*>(operation);
+    int index = static_cast<int>(nop - pool->slots);
+    pool->completions.fetch_add(1, std::memory_order_relaxed);
+    pool->Release(index);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Single-threaded reuse stress
+//===----------------------------------------------------------------------===//
+
+// Rapidly reuses operation structs from a single thread. Validates that the
+// proactor handles same-thread submit→complete→reinitialize→resubmit without
+// TSAN false positives.
+TEST_P(TsanBridgeTest, SingleThreadReuse) {
+  constexpr int kIterations = 200;
+
+  OperationPool pool;
+
+  for (int i = 0; i < kIterations; ++i) {
+    int index = pool.Claim();
+    ASSERT_GE(index, 0) << "Pool exhausted at iteration " << i;
+
+    iree_async_nop_operation_t* nop = &pool.slots[index];
+    iree_async_operation_zero(&nop->base, sizeof(*nop));
+    iree_async_operation_initialize(&nop->base, IREE_ASYNC_OPERATION_TYPE_NOP,
+                                    IREE_ASYNC_OPERATION_FLAG_NONE,
+                                    OperationPool::CompletionCallback, &pool);
+
+    IREE_ASSERT_OK(iree_async_proactor_submit_one(proactor_, &nop->base));
+    PollUntil(/*min_completions=*/1,
+              /*total_budget=*/iree_make_duration_ms(500));
+  }
+
+  EXPECT_EQ(pool.completions.load(), kIterations);
+}
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded reuse stress
+//===----------------------------------------------------------------------===//
+
+// Sender thread function: claim slot, initialize, submit, repeat.
+// Uses a simple index+bitmap protocol compatible with both pool types.
+struct SenderArgs {
+  iree_async_nop_operation_t* slots;
+  std::atomic<uint32_t>* free_bitmap;
+  std::atomic<int>* completions;
+  iree_async_proactor_t* proactor;
+  iree_async_completion_fn_t callback;
+  void* callback_user_data;
+  int sends_per_thread;
+  std::atomic<bool>* stop;
+};
+
+static void SenderThreadFn(SenderArgs args) {
+  for (int j = 0; j < args.sends_per_thread; ++j) {
+    if (args.stop->load(std::memory_order_relaxed)) return;
+
+    // Spin until a slot is available or stop is requested.
+    int index;
+    for (;;) {
+      if (args.stop->load(std::memory_order_relaxed)) return;
+      uint32_t bitmap = args.free_bitmap->load(std::memory_order_acquire);
+      while (bitmap != 0) {
+        index = iree_math_count_trailing_zeros_u32(bitmap);
+        uint32_t cleared = bitmap & ~(1u << index);
+        if (args.free_bitmap->compare_exchange_weak(
+                bitmap, cleared, std::memory_order_acq_rel,
+                std::memory_order_acquire)) {
+          goto claimed;
+        }
+      }
+      std::this_thread::yield();
+    }
+  claimed:
+
+    iree_async_nop_operation_t* nop = &args.slots[index];
+    iree_async_operation_zero(&nop->base, sizeof(*nop));
+    iree_async_operation_initialize(&nop->base, IREE_ASYNC_OPERATION_TYPE_NOP,
+                                    IREE_ASYNC_OPERATION_FLAG_NONE,
+                                    args.callback, args.callback_user_data);
+
+    iree_status_t status =
+        iree_async_proactor_submit_one(args.proactor, &nop->base);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      args.free_bitmap->fetch_or(1u << index, std::memory_order_release);
+      --j;
+      std::this_thread::yield();
+    }
+  }
+}
+
+// Polls until the expected number of completions arrive or timeout.
+static void PollUntilComplete(iree_async_proactor_t* proactor,
+                              std::atomic<int>& completions,
+                              int expected_total) {
+  iree_time_t deadline_ns = iree_time_now() + iree_make_duration_ms(30000);
+  while (completions.load(std::memory_order_relaxed) < expected_total) {
+    if (iree_time_now() >= deadline_ns) break;
+    iree_host_size_t completed = 0;
+    iree_status_t status = iree_async_proactor_poll(
+        proactor, iree_make_timeout_ms(10), &completed);
+    if (!iree_status_is_deadline_exceeded(status)) {
+      IREE_ASSERT_OK(status);
+    } else {
+      iree_status_ignore(status);
+    }
+  }
+}
+
+// Multiple sender threads contend for a shared operation pool, submitting NOP
+// operations that the main thread polls. Different threads write the same
+// operation fields (type, completion_fn) across reuse cycles, with only the
+// proactor's internal mechanism mediating the ordering.
+TEST_P(TsanBridgeTest, MultiThreadReuse) {
+  constexpr int kSenderCount = 4;
+  constexpr int kSendsPerThread = 10;
+  constexpr int kTotalSends = kSenderCount * kSendsPerThread;
+
+  OperationPool pool;
+  std::atomic<bool> stop{false};
+
+  SenderArgs args = {pool.slots,
+                     &pool.free_bitmap,
+                     &pool.completions,
+                     proactor_,
+                     OperationPool::CompletionCallback,
+                     &pool,
+                     kSendsPerThread,
+                     &stop};
+
+  std::vector<std::thread> senders;
+  for (int i = 0; i < kSenderCount; ++i) {
+    senders.emplace_back(SenderThreadFn, args);
+  }
+
+  PollUntilComplete(proactor_, pool.completions, kTotalSends);
+
+  stop.store(true, std::memory_order_relaxed);
+  for (auto& sender : senders) {
+    sender.join();
+  }
+  DrainPending();
+
+  EXPECT_EQ(pool.completions.load(), kTotalSends);
+}
+
+//===----------------------------------------------------------------------===//
+// High-frequency reuse from two threads targeting same slots
+//===----------------------------------------------------------------------===//
+
+// Two sender threads aggressively contend for a tiny pool (2 slots), forcing
+// maximum reuse frequency. This maximizes the chance of TSAN false positives
+// if the proactor's submit→complete ordering bridge is insufficient.
+TEST_P(TsanBridgeTest, TwoThreadsTwoSlots) {
+  constexpr int kSendsPerThread = 20;
+  constexpr int kTotalSends = 2 * kSendsPerThread;
+
+  TinyPool pool;
+  std::atomic<bool> stop{false};
+
+  SenderArgs args = {pool.slots,         &pool.free_bitmap,
+                     &pool.completions,  proactor_,
+                     TinyPool::Callback, &pool,
+                     kSendsPerThread,    &stop};
+
+  std::thread sender_a(SenderThreadFn, args);
+  std::thread sender_b(SenderThreadFn, args);
+
+  PollUntilComplete(proactor_, pool.completions, kTotalSends);
+
+  stop.store(true, std::memory_order_relaxed);
+  sender_a.join();
+  sender_b.join();
+  DrainPending();
+
+  EXPECT_EQ(pool.completions.load(), kTotalSends);
+}
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+CTS_REGISTER_TEST_SUITE(TsanBridgeTest);
+
+}  // namespace iree::async::cts

--- a/runtime/src/iree/async/notification.h
+++ b/runtime/src/iree/async/notification.h
@@ -117,7 +117,13 @@ typedef struct iree_async_notification_t {
     // POLL_ADD + READ SQE patterns.
     struct {
       // Eventfd for poll-based async waits (EVENT mode only).
+      // Monitored for POLLIN by io_uring POLL_ADD SQEs and sync poll().
       iree_async_primitive_t primitive;
+      // Fd written to by signal() to trigger POLLIN on the monitored end.
+      // For local notifications: same as primitive (eventfd is bidirectional).
+      // For shared notifications: caller-provided signal fd (may differ from
+      // primitive when the notification is a proxy for a remote peer).
+      iree_async_primitive_t signal_primitive;
       // Buffer target for linked READ SQEs that drain the eventfd.
       uint64_t drain_buffer;
       // Count of relays with in-flight FUTEX_WAIT SQEs on this notification.

--- a/runtime/src/iree/async/operation.h
+++ b/runtime/src/iree/async/operation.h
@@ -225,6 +225,23 @@ typedef struct iree_async_operation_t {
 
   // Tracing: timestamp of submission for latency measurement.
   IREE_TRACE(iree_time_t submit_time_ns;)
+
+#if defined(IREE_SANITIZER_THREAD)
+  // Atomic bridge for TSAN across kernel-mediated completion dispatch.
+  // Proactor backends that use kernel-managed shared memory rings (io_uring CQ,
+  // IOCP completion ports) have a submit→completion ordering gap that TSAN
+  // cannot observe: the submitter thread writes operation fields, the kernel
+  // processes the I/O, and the poll thread reads the operation fields from a
+  // completion event — but TSAN sees no userspace synchronization between the
+  // write and the read.
+  //
+  // This atomic provides a release/acquire pair that TSAN intercepts through
+  // its compiler instrumentation (atomic operations are TSAN's core tracking
+  // mechanism). The submitter stores with release ordering after filling the
+  // operation; the completer loads with acquire ordering before reading
+  // operation fields. This makes the kernel-provided ordering visible to TSAN.
+  iree_atomic_int32_t tsan_bridge;
+#endif  // IREE_SANITIZER_THREAD
 } iree_async_operation_t;
 
 //===----------------------------------------------------------------------===//
@@ -266,6 +283,25 @@ IREE_API_EXPORT void iree_async_operation_release_resources(
 // Inline helpers
 //===----------------------------------------------------------------------===//
 
+// Zero-initializes an operation subtype struct for reuse.
+//
+// Unlike raw memset(), this avoids non-atomic writes to the atomic fields in
+// the base struct (internal_flags, tsan_bridge). C11 forbids mixing atomic and
+// non-atomic accesses to the same object, and TSAN correctly flags violations.
+// The base fields are set by iree_async_operation_initialize() below.
+//
+// Usage:
+//   iree_async_operation_zero(&send_op->base, sizeof(*send_op));
+//   iree_async_operation_initialize(&send_op->base, ...);
+//   send_op->socket = ...;  // subtype fields are zeroed, set as needed
+static inline void iree_async_operation_zero(iree_async_operation_t* operation,
+                                             iree_host_size_t total_size) {
+  iree_host_size_t base_size = sizeof(iree_async_operation_t);
+  if (total_size > base_size) {
+    memset((char*)operation + base_size, 0, total_size - base_size);
+  }
+}
+
 // Initializes the base fields of an operation.
 // Caller must still fill subtype-specific fields after this call.
 static inline void iree_async_operation_initialize(
@@ -281,6 +317,9 @@ static inline void iree_async_operation_initialize(
   operation->pool = NULL;
   operation->linked_next = NULL;
   IREE_TRACE({ operation->submit_time_ns = 0; });
+#if defined(IREE_SANITIZER_THREAD)
+  iree_atomic_store(&operation->tsan_bridge, 0, iree_memory_order_relaxed);
+#endif  // IREE_SANITIZER_THREAD
 }
 
 // Atomically loads the internal flags of an operation (acquire ordering).

--- a/runtime/src/iree/async/platform/io_uring/notification.c
+++ b/runtime/src/iree/async/platform/io_uring/notification.c
@@ -56,8 +56,10 @@ iree_status_t iree_async_io_uring_notification_create(
     // counter. This allows wake_count to control how many waiters are woken.
     int eventfd_result = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE);
     if (eventfd_result >= 0) {
-      notification->platform.io_uring.primitive =
+      iree_async_primitive_t event_primitive =
           iree_async_primitive_from_fd(eventfd_result);
+      notification->platform.io_uring.primitive = event_primitive;
+      notification->platform.io_uring.signal_primitive = event_primitive;
       notification->platform.io_uring.drain_buffer = 0;
     } else {
       status = iree_make_status(iree_status_code_from_errno(errno),
@@ -109,8 +111,12 @@ iree_status_t iree_async_io_uring_notification_create_shared(
 #endif  // IREE_RUNTIME_USE_FUTEX
   {
     notification->mode = IREE_ASYNC_NOTIFICATION_MODE_EVENT;
-    // Use caller-provided wake primitive instead of creating our own eventfd.
+    // Use caller-provided primitives instead of creating our own eventfd.
+    // For proxy notifications (peer wake): wake_primitive may be NONE (not
+    // polled locally) while signal_primitive is the peer's eventfd.
     notification->platform.io_uring.primitive = options->wake_primitive;
+    notification->platform.io_uring.signal_primitive =
+        options->signal_primitive;
     notification->platform.io_uring.drain_buffer = 0;
   }
 
@@ -182,9 +188,12 @@ void iree_async_io_uring_notification_signal(
 #endif  // IREE_RUNTIME_USE_FUTEX
 
   // With EFD_SEMAPHORE, write(N) allows N read()s to succeed.
+  // Write to signal_primitive — for local notifications this is the same
+  // eventfd as primitive; for shared/proxy notifications it's the peer's fd.
   uint64_t value = (wake_count > 0) ? (uint64_t)wake_count : UINT32_MAX;
-  ssize_t result = write(notification->platform.io_uring.primitive.value.fd,
-                         &value, sizeof(value));
+  ssize_t result =
+      write(notification->platform.io_uring.signal_primitive.value.fd, &value,
+            sizeof(value));
   // The vtable signature returns void so we cannot propagate errors, but an
   // eventfd write failure means waiters will not be woken — assert in debug.
   IREE_ASSERT(result == sizeof(value),

--- a/runtime/src/iree/async/platform/io_uring/proactor.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor.c
@@ -1292,12 +1292,15 @@ static iree_status_t iree_async_proactor_io_uring_poll(
                                 /*min_complete=*/0,
                                 /*flags=*/IREE_IORING_ENTER_GETEVENTS));
 
-  // Run registered progress callbacks (e.g., SHM carrier SPSC ring polling).
-  // If any made progress, force non-blocking poll to avoid sleeping when
-  // user-space work is available.
+  // Run registered progress callbacks (e.g., SHM carrier MPSC ring polling).
+  // Force non-blocking poll whenever progress callbacks are registered: they
+  // exist to be polled, and blocking in io_uring_enter would prevent them from
+  // running until an unrelated CQE arrives. The carrier's idle spin threshold
+  // naturally transitions back to sleep mode and removes the callback, bounding
+  // the busy-loop duration.
   iree_host_size_t progress_count =
       iree_async_proactor_run_progress(base_proactor);
-  if (progress_count > 0) is_immediate = true;
+  if (progress_count > 0 || base_proactor->progress_list) is_immediate = true;
 
   // If no CQEs are available after flushing and timeout allows blocking,
   // wait for completions.

--- a/runtime/src/iree/async/platform/io_uring/proactor.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor.c
@@ -42,6 +42,29 @@
 #include "iree/base/internal/atomics.h"
 #include "iree/base/internal/memory.h"
 
+// TSAN cannot observe the happens-before relationship provided by io_uring's
+// shared memory rings (SQ/CQ). When a submitter thread fills an SQE and the
+// poll thread later processes the corresponding CQE, the kernel's ring protocol
+// provides ordering, but TSAN sees no userspace synchronization between the
+// submitter's writes and the completer's reads.
+//
+// We bridge this gap with a C11 atomic on the operation struct
+// (iree_async_operation_t::tsan_bridge). The submitter stores with release
+// ordering after filling the operation; the completer loads with acquire
+// ordering before reading operation fields. TSAN intercepts C11 atomics
+// through compiler instrumentation (its core tracking mechanism).
+//
+// After the TSAN release on submit, the submitter must NOT read any operation
+// fields — the operation is logically owned by the kernel and then the poll
+// thread. Phase 3 (software op execution) uses a bitmap from Phase 1 analysis
+// to skip kernel ops without re-reading their types.
+#if defined(IREE_SANITIZER_THREAD)
+#define IREE_IO_URING_TSAN_COMPLETE(operation) \
+  iree_atomic_load(&(operation)->tsan_bridge, iree_memory_order_acquire)
+#else
+#define IREE_IO_URING_TSAN_COMPLETE(operation) ((void)0)
+#endif  // IREE_SANITIZER_THREAD
+
 static void iree_async_proactor_io_uring_destroy(
     iree_async_proactor_t* base_proactor);
 static iree_status_t iree_async_proactor_io_uring_cancel(
@@ -828,7 +851,8 @@ static iree_status_t iree_async_proactor_io_uring_cqe_to_status(
   }
 
   return iree_make_status(iree_status_code_from_errno(-cqe->res),
-                          "io_uring operation failed (%d)", -cqe->res);
+                          "io_uring operation type %d failed (%d)",
+                          (int)operation->type, -cqe->res);
 }
 
 // Handles SOCKET_ACCEPT completion: imports the accepted fd as a socket.
@@ -1176,6 +1200,10 @@ static iree_host_size_t iree_async_proactor_io_uring_process_cqe(
   // User operation: extract the operation pointer.
   iree_async_operation_t* operation =
       (iree_async_operation_t*)(uintptr_t)cqe->user_data;
+
+  // Acquire pairs with the release store to tsan_bridge in submit_one.
+  // Makes the submitter's writes to operation fields visible to this thread.
+  IREE_IO_URING_TSAN_COMPLETE(operation);
 
   // Convert kernel result to status.
   iree_status_t status =

--- a/runtime/src/iree/async/platform/io_uring/proactor_submit.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor_submit.c
@@ -39,6 +39,14 @@
 #include "iree/async/platform/io_uring/socket.h"
 #include "iree/async/semaphore.h"
 
+// See proactor.c for the rationale behind the TSAN annotation bridge.
+#if defined(IREE_SANITIZER_THREAD)
+#define IREE_IO_URING_TSAN_SUBMIT(operation) \
+  iree_atomic_fetch_add(&(operation)->tsan_bridge, 1, iree_memory_order_release)
+#else
+#define IREE_IO_URING_TSAN_SUBMIT(operation) ((void)0)
+#endif  // IREE_SANITIZER_THREAD
+
 //===----------------------------------------------------------------------===//
 // Submit
 //===----------------------------------------------------------------------===//
@@ -922,7 +930,7 @@ static void iree_async_proactor_io_uring_fill_notification_signal_event(
   iree_atomic_fetch_add(signal->notification->epoch_ptr, 1,
                         iree_memory_order_release);
 
-  int fd = signal->notification->platform.io_uring.primitive.value.fd;
+  int fd = signal->notification->platform.io_uring.signal_primitive.value.fd;
 
   // With EFD_SEMAPHORE, write(N) allows N read()s to succeed.
   signal->write_value =
@@ -1425,16 +1433,25 @@ iree_status_t iree_async_proactor_io_uring_submit(
   // Phase 1: Analyze the batch.
   //=========================================================================
 
-  // Count kernel SQEs needed. Software operations (SEMAPHORE_SIGNAL,
-  // SEMAPHORE_WAIT) execute in userspace with no kernel SQE — they are handled
-  // in Phase 3. SEQUENCE operations were dispatched in the pre-scan above.
+  // Count kernel SQEs needed and record software op positions. Software
+  // operations (SEMAPHORE_SIGNAL, SEMAPHORE_WAIT) execute in userspace with no
+  // kernel SQE — they are handled in Phase 3. SEQUENCE operations were
+  // dispatched in the pre-scan above.
+  //
+  // The software_op_mask bitmap records which positions are software ops so
+  // Phase 3 can skip kernel ops without re-reading their types. After Phase 2
+  // submits kernel SQEs, another thread's flush can make them visible to the
+  // kernel. If a kernel op completes and its operation struct is reused before
+  // Phase 3 runs, reading that op's type would be a data race.
   iree_host_size_t sqes_needed = 0;
   bool has_software_ops = false;
+  uint64_t software_op_mask = 0;
   for (iree_host_size_t i = 0; i < operations.count; ++i) {
     iree_async_operation_type_t type = operations.values[i]->type;
     if (type == IREE_ASYNC_OPERATION_TYPE_SEQUENCE) continue;
     if (iree_async_proactor_io_uring_is_software_op(type)) {
       has_software_ops = true;
+      software_op_mask |= (UINT64_C(1) << i);
       continue;
     }
     if (type == IREE_ASYNC_OPERATION_TYPE_EVENT_WAIT) {
@@ -1449,6 +1466,8 @@ iree_status_t iree_async_proactor_io_uring_submit(
       sqes_needed += 1;
     }
   }
+  IREE_ASSERT(operations.count <= 64,
+              "batch exceeds 64 operations; software_op_mask overflow");
 
   // If all operations were SEQUENCE (handled in pre-scan) with no software
   // ops and no kernel ops, there is nothing left to do.
@@ -1773,6 +1792,10 @@ iree_status_t iree_async_proactor_io_uring_submit(
         return status;
       }
 
+      // Publish all writes to the operation (fill, resource retain, user data)
+      // via the TSAN atomic bridge. Pairs with TSAN_COMPLETE in process_cqe.
+      IREE_IO_URING_TSAN_SUBMIT(operation);
+
       IREE_TRACE({ operation->submit_time_ns = iree_time_now(); });
     }
 
@@ -1797,12 +1820,15 @@ iree_status_t iree_async_proactor_io_uring_submit(
   // Completions are pushed BEFORE dispatching continuation chains to preserve
   // callback ordering: the trigger's callback fires before its continuations.
 
-  for (iree_host_size_t i = 0; i < effective_count; ++i) {
-    iree_async_operation_t* operation = operations.values[i];
-    if (!iree_async_proactor_io_uring_is_software_op(operation->type)) {
-      continue;
-    }
+  for (iree_host_size_t i = 0; i < effective_count && has_software_ops; ++i) {
+    // Use the bitmap from Phase 1 to skip kernel ops without reading their
+    // types. After Phase 2 submits kernel SQEs, another thread's Phase 4 flush
+    // can make them visible to the kernel. A fast-completing kernel op (NOP,
+    // expired timer) could have its slot reused before Phase 3 iterates past
+    // it. Reading that reused op's type would race with the new owner's writes.
+    if (!(software_op_mask & (UINT64_C(1) << i))) continue;
 
+    iree_async_operation_t* operation = operations.values[i];
     iree_async_operation_retain_resources(operation);
 
     iree_status_t op_status = iree_ok_status();

--- a/runtime/src/iree/async/platform/iocp/proactor.c
+++ b/runtime/src/iree/async/platform/iocp/proactor.c
@@ -1382,9 +1382,12 @@ static iree_status_t iree_async_proactor_iocp_poll(
   completed_count +=
       iree_async_proactor_iocp_drain_event_wait_cancellations(proactor);
 
-  // Phase 2.7: Run registered progress callbacks (e.g., SHM carrier SPSC ring
-  // polling). If any made progress, force non-blocking GQCS to avoid sleeping
-  // when user-space work is available.
+  // Phase 2.7: Run registered progress callbacks (e.g., SHM carrier MPSC ring
+  // polling). Force non-blocking GQCS whenever progress callbacks are
+  // registered: they exist to be polled, and blocking in GQCS would prevent
+  // them from running until an unrelated completion arrives. The carrier's idle
+  // spin threshold naturally transitions back to sleep mode and removes the
+  // callback, bounding the busy-loop duration.
   iree_host_size_t progress_count =
       iree_async_proactor_run_progress(base_proactor);
   completed_count += progress_count;
@@ -1392,7 +1395,7 @@ static iree_status_t iree_async_proactor_iocp_poll(
   // Phase 3: Calculate effective timeout considering timer deadlines.
   DWORD timeout_ms =
       iree_async_proactor_iocp_calculate_timeout_ms(proactor, timeout);
-  if (progress_count > 0) timeout_ms = 0;
+  if (progress_count > 0 || base_proactor->progress_list) timeout_ms = 0;
 
   // Phase 4: Dequeue completions from the IOCP port.
   OVERLAPPED_ENTRY entries[IREE_ASYNC_IOCP_MAX_COMPLETIONS_PER_POLL];

--- a/runtime/src/iree/async/platform/posix/proactor.c
+++ b/runtime/src/iree/async/platform/posix/proactor.c
@@ -672,7 +672,6 @@ static void iree_async_proactor_posix_drain_pending_queue(
   iree_atomic_slist_entry_t* entry = NULL;
   while ((entry = iree_atomic_slist_pop(&proactor->pending_queue)) != NULL) {
     iree_async_operation_t* operation = (iree_async_operation_t*)entry;
-
     // Check if the operation was cancelled while sitting in the queue.
     // Retained resources (sockets, events, notifications) are released via
     // release_operation_resources — either during drain_completion_queue
@@ -2800,17 +2799,28 @@ static iree_status_t iree_async_proactor_posix_poll(
   completed_count += iree_async_proactor_posix_drain_completion_queue(proactor);
   iree_async_proactor_posix_drain_incoming_messages(proactor);
 
-  // Run registered progress callbacks (e.g., SHM carrier SPSC ring polling).
-  // If any made progress, force non-blocking poll to avoid sleeping when
-  // user-space work is available.
+  // Run registered progress callbacks (e.g., SHM carrier MPSC ring polling).
+  // Force non-blocking poll whenever progress callbacks are registered: they
+  // exist to be polled, and blocking in event_set_wait would prevent them from
+  // running until an unrelated fd becomes ready. The carrier's idle spin
+  // threshold naturally transitions back to sleep mode and removes the
+  // callback, bounding the busy-loop duration.
   iree_host_size_t progress_count =
       iree_async_proactor_run_progress(base_proactor);
   completed_count += progress_count;
 
+  // Drain operations submitted by callbacks. Completion callbacks may submit
+  // new operations (e.g., a notification scan re-posting NOTIFICATION_WAIT)
+  // that go to the pending queue. These must be registered with event_set
+  // before event_set_wait, otherwise their fds won't be monitored and the
+  // poll will miss wakeups. Process any resulting immediate completions too.
+  iree_async_proactor_posix_drain_pending_queue(proactor);
+  completed_count += iree_async_proactor_posix_drain_completion_queue(proactor);
+
   // Calculate timeout considering both user request and pending timers.
   int timeout_ms =
       iree_async_proactor_posix_calculate_timeout_ms(proactor, timeout);
-  if (progress_count > 0) timeout_ms = 0;
+  if (progress_count > 0 || base_proactor->progress_list) timeout_ms = 0;
 
   // Poll for ready fds.
   iree_host_size_t ready_count = 0;

--- a/runtime/src/iree/async/proactor.h
+++ b/runtime/src/iree/async/proactor.h
@@ -697,9 +697,11 @@ IREE_API_EXPORT void iree_async_proactor_unregister_progress(
 // completions they processed. Entries with remove_requested set are removed
 // from the list after their callback returns.
 //
-// Called by backend poll() implementations before the blocking wait. If the
-// return value is > 0, backends should force a non-blocking poll to avoid
-// sleeping when user-space progress is available.
+// Called by backend poll() implementations before the blocking wait. Backends
+// must force a non-blocking poll whenever progress callbacks are registered
+// (progress_list is non-NULL), regardless of whether they returned progress
+// this iteration. Progress callbacks exist to be polled; blocking while they
+// are registered would starve them until an unrelated I/O event arrives.
 IREE_API_EXPORT iree_host_size_t
 iree_async_proactor_run_progress(iree_async_proactor_t* proactor);
 


### PR DESCRIPTION
Two fixes for the async proactor infrastructure, both motivated by SHM carrier integration work.

## TSAN bridge for kernel-mediated completion ordering

Proactor backends that use kernel-managed shared memory rings (io_uring SQ/CQ, IOCP completion ports) have an ordering gap invisible to TSAN: the submitter thread writes operation fields, the kernel processes the I/O, and the poll thread reads those fields from a completion event — but TSAN sees no userspace synchronization between the write and the read.

This adds a C11 atomic bridge (`iree_async_operation_t::tsan_bridge`) that makes the kernel-provided ordering visible. The submitter stores with release ordering after filling the operation; the completer loads with acquire ordering before reading operation fields. The field and both macros compile to nothing outside `IREE_SANITIZER_THREAD` builds.

Supporting changes:

- **`iree_async_operation_zero()`**: Replaces raw `memset` for operation struct reuse. C11 forbids mixing atomic and non-atomic accesses to the same object; `memset` over atomic fields is a non-atomic write that TSAN correctly flags. The new helper zeroes only the subtype-specific tail, leaving the base struct's atomic fields to be set properly by `iree_async_operation_initialize()`.

- **`software_op_mask` bitmap in io_uring submit**: After Phase 2 submits kernel SQEs, another thread's flush can make them visible to the kernel. A fast-completing kernel op (NOP, expired timer) could have its operation struct reused before Phase 3 iterates past it. Previously Phase 3 re-read `operation->type` to decide whether to skip kernel ops — a data race with the new owner's writes. Now Phase 1 records which batch positions are software ops in a bitmap, and Phase 3 uses the bitmap instead of re-reading types.

- **CTS stress tests**: Three test cases exercise the bridge under TSAN — single-thread rapid reuse (200 cycles), multi-thread contention (4 threads, 8-slot pool), and high-frequency reuse (2 threads, 2-slot pool forcing maximum reuse rate).

## Progress callback starvation fix

All three proactor backends (io_uring, IOCP, POSIX) previously only forced non-blocking poll when progress callbacks returned > 0 completions. A newly registered callback that hadn't yet observed progress would not prevent the proactor from blocking in its platform wait (`io_uring_enter`, `GetQueuedCompletionStatusEx`, `event_set_wait`), starving the callback until an unrelated I/O event broke the wait.

Fix: force non-blocking poll whenever any progress callback is registered (`progress_list != NULL`), not just when one returns progress. The carrier's idle spin threshold naturally removes the callback when the ring goes quiet, bounding the busy-loop duration.

The POSIX backend also adds a pending queue drain after progress callbacks, ensuring that operations submitted by callbacks (e.g., notification re-posts) are registered with the event set before the blocking wait. Without this, their fds wouldn't be monitored and the poll would miss wakeups.

## Notification `signal_primitive`

Adds a `signal_primitive` field to the io_uring notification struct, separate from the polled `primitive`. For local notifications both are the same eventfd. For shared/proxy notifications (SHM carrier peer wake), `signal_primitive` is the peer's eventfd while `primitive` may be `NONE` (not polled locally). This enables asymmetric notification patterns where the signaling end differs from the monitoring end.