### PR TITLE
Add MPSC queue.

### DIFF
--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -388,6 +388,27 @@ cc_binary_benchmark(
 )
 
 iree_runtime_cc_library(
+    name = "mpsc_queue",
+    srcs = ["mpsc_queue.c"],
+    hdrs = ["mpsc_queue.h"],
+    deps = [
+        ":internal",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:core_headers",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "mpsc_queue_test",
+    srcs = ["mpsc_queue_test.cc"],
+    deps = [
+        ":mpsc_queue",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "span",
     hdrs = ["span.h"],
 )

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -426,6 +426,31 @@ iree_cc_binary_benchmark(
 
 iree_cc_library(
   NAME
+    mpsc_queue
+  HDRS
+    "mpsc_queue.h"
+  SRCS
+    "mpsc_queue.c"
+  DEPS
+    ::internal
+    iree::base
+    iree::base::core_headers
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    mpsc_queue_test
+  SRCS
+    "mpsc_queue_test.cc"
+  DEPS
+    ::mpsc_queue
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
     span
   HDRS
     "span.h"

--- a/runtime/src/iree/base/internal/mpsc_queue.c
+++ b/runtime/src/iree/base/internal/mpsc_queue.c
@@ -1,0 +1,409 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/mpsc_queue.h"
+
+#include <string.h>
+
+//===----------------------------------------------------------------------===//
+// Internal helpers
+//===----------------------------------------------------------------------===//
+
+// Returns the total bytes consumed by an entry with |payload_length| bytes,
+// including the 4-byte length prefix and alignment padding.
+static inline iree_host_size_t iree_mpsc_queue_entry_size(
+    uint32_t entry_alignment, iree_host_size_t payload_length) {
+  return iree_host_align(sizeof(uint32_t) + payload_length,
+                         (iree_host_size_t)entry_alignment);
+}
+
+// Populates the queue handle fields from the memory region.
+// Assumes the header at |memory| is valid.
+static void iree_mpsc_queue_bind(void* memory, iree_mpsc_queue_t* out_queue) {
+  uint8_t* base = (uint8_t*)memory;
+  out_queue->header = (iree_mpsc_queue_header_t*)base;
+  out_queue->reserve_position =
+      (iree_mpsc_queue_reserve_position_t*)(base + 1 * 64);
+  out_queue->read_position = (iree_mpsc_queue_read_position_t*)(base + 2 * 64);
+  out_queue->data = base + IREE_MPSC_QUEUE_HEADER_SIZE;
+  out_queue->capacity = out_queue->header->capacity;
+  out_queue->mask = out_queue->capacity - 1;
+  out_queue->entry_alignment = out_queue->header->entry_alignment;
+}
+
+// Validates the header fields of an existing queue.
+static iree_status_t iree_mpsc_queue_validate_header(
+    const iree_mpsc_queue_header_t* header, iree_host_size_t memory_size) {
+  if (IREE_UNLIKELY(header->magic != IREE_MPSC_QUEUE_MAGIC)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "MPSC queue magic mismatch: expected 0x%08X, got 0x%08X",
+        IREE_MPSC_QUEUE_MAGIC, header->magic);
+  }
+  if (IREE_UNLIKELY(header->version != IREE_MPSC_QUEUE_VERSION)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "MPSC queue version mismatch: expected %" PRIu32
+                            ", got %" PRIu32,
+                            IREE_MPSC_QUEUE_VERSION, header->version);
+  }
+  if (IREE_UNLIKELY(header->capacity < IREE_MPSC_QUEUE_MIN_CAPACITY)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "MPSC queue capacity %" PRIu32
+                            " is below minimum %" PRIu32,
+                            header->capacity, IREE_MPSC_QUEUE_MIN_CAPACITY);
+  }
+  if (IREE_UNLIKELY(!iree_host_size_is_power_of_two(
+          (iree_host_size_t)header->capacity))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "MPSC queue capacity %" PRIu32
+                            " is not a power of two",
+                            header->capacity);
+  }
+  if (IREE_UNLIKELY(header->entry_alignment < sizeof(uint32_t))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "MPSC queue entry_alignment %" PRIu32
+                            " is less than minimum %" PRIhsz
+                            " (sizeof uint32_t)",
+                            header->entry_alignment, sizeof(uint32_t));
+  }
+  if (IREE_UNLIKELY(!iree_host_size_is_power_of_two(
+          (iree_host_size_t)header->entry_alignment))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "MPSC queue entry_alignment %" PRIu32
+                            " is not a power of two",
+                            header->entry_alignment);
+  }
+  iree_host_size_t required = iree_mpsc_queue_required_size(header->capacity);
+  if (IREE_UNLIKELY(memory_size < required)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "MPSC queue memory_size %" PRIhsz
+                            " is less than required %" PRIhsz
+                            " for capacity %" PRIu32,
+                            memory_size, required, header->capacity);
+  }
+  return iree_ok_status();
+}
+
+// Returns the available free space given position values.
+static inline iree_host_size_t iree_mpsc_queue_free_space(uint32_t capacity,
+                                                          int64_t reserve_pos,
+                                                          int64_t read_pos) {
+  return (iree_host_size_t)(capacity - (reserve_pos - read_pos));
+}
+
+// Acquire-loads the length prefix (entry state indicator) at the given data
+// ring offset. The acquire ordering pairs with the release-store in
+// commit_write/cancel_write and the release-store in consume (which zeroes
+// the prefix for the next iteration).
+static inline uint32_t iree_mpsc_queue_load_entry_state(
+    const iree_mpsc_queue_t* queue, uint32_t offset) {
+  return (uint32_t)iree_atomic_load((iree_atomic_int32_t*)&queue->data[offset],
+                                    iree_memory_order_acquire);
+}
+
+// Release-stores a value to the length prefix at the given data ring offset.
+static inline void iree_mpsc_queue_store_entry_state(
+    const iree_mpsc_queue_t* queue, uint32_t offset, uint32_t value) {
+  iree_atomic_store((iree_atomic_int32_t*)&queue->data[offset], (int32_t)value,
+                    iree_memory_order_release);
+}
+
+//===----------------------------------------------------------------------===//
+// Initialization
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_mpsc_queue_initialize(void* memory,
+                                         iree_host_size_t memory_size,
+                                         uint32_t capacity,
+                                         iree_mpsc_queue_t* out_queue) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_queue, 0, sizeof(*out_queue));
+
+  if (IREE_UNLIKELY(!memory)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "memory must not be NULL");
+  }
+  if (IREE_UNLIKELY(capacity < IREE_MPSC_QUEUE_MIN_CAPACITY)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "capacity %" PRIu32 " is below minimum %" PRIu32,
+                            capacity, IREE_MPSC_QUEUE_MIN_CAPACITY);
+  }
+  if (IREE_UNLIKELY(
+          !iree_host_size_is_power_of_two((iree_host_size_t)capacity))) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "capacity %" PRIu32 " is not a power of two",
+                            capacity);
+  }
+  iree_host_size_t required = iree_mpsc_queue_required_size(capacity);
+  if (IREE_UNLIKELY(memory_size < required)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "memory_size %" PRIhsz
+                            " is less than required %" PRIhsz,
+                            memory_size, required);
+  }
+
+  // Zero the entire region (header + positions + data).
+  // Zeroing the data region is critical: the consumer relies on length prefixes
+  // being 0 (uncommitted) at any slot that hasn't been committed yet. The
+  // consumer zeroes each slot after consuming it, but the initial pass through
+  // the ring relies on this memset.
+  memset(memory, 0, required);
+
+  // Write the immutable header.
+  iree_mpsc_queue_header_t* header = (iree_mpsc_queue_header_t*)memory;
+  header->magic = IREE_MPSC_QUEUE_MAGIC;
+  header->version = IREE_MPSC_QUEUE_VERSION;
+  header->capacity = capacity;
+  header->entry_alignment = IREE_MPSC_QUEUE_DEFAULT_ENTRY_ALIGNMENT;
+
+  // Bind the queue handle to the memory region.
+  iree_mpsc_queue_bind(memory, out_queue);
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_mpsc_queue_open(void* memory, iree_host_size_t memory_size,
+                                   iree_mpsc_queue_t* out_queue) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_queue, 0, sizeof(*out_queue));
+
+  if (IREE_UNLIKELY(!memory)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "memory must not be NULL");
+  }
+  if (IREE_UNLIKELY(memory_size < IREE_MPSC_QUEUE_HEADER_SIZE)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "memory_size %" PRIhsz
+                            " is less than header size %" PRIhsz,
+                            memory_size, IREE_MPSC_QUEUE_HEADER_SIZE);
+  }
+
+  const iree_mpsc_queue_header_t* header =
+      (const iree_mpsc_queue_header_t*)memory;
+  iree_status_t status = iree_mpsc_queue_validate_header(header, memory_size);
+
+  if (iree_status_is_ok(status)) {
+    iree_mpsc_queue_bind(memory, out_queue);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// Producer API
+//===----------------------------------------------------------------------===//
+
+void* iree_mpsc_queue_begin_write(
+    iree_mpsc_queue_t* queue, iree_host_size_t length,
+    iree_mpsc_queue_reservation_t* out_reservation) {
+  iree_host_size_t total_entry_bytes =
+      iree_mpsc_queue_entry_size(queue->entry_alignment, length);
+
+  // CAS loop: atomically reserve space in the ring.
+  for (;;) {
+    int64_t reserve_pos = iree_atomic_load(&queue->reserve_position->value,
+                                           iree_memory_order_relaxed);
+    int64_t read_pos = iree_atomic_load(&queue->read_position->value,
+                                        iree_memory_order_acquire);
+
+    // Check whether the entry fits without wrapping.
+    uint32_t physical_offset = (uint32_t)(reserve_pos & queue->mask);
+    iree_host_size_t contiguous_at_tail =
+        (iree_host_size_t)(queue->capacity - physical_offset);
+
+    int64_t new_reserve_pos;
+    uint32_t entry_offset;
+    bool needs_skip;
+    iree_host_size_t skip_bytes;
+
+    if (total_entry_bytes <= contiguous_at_tail) {
+      // Entry fits at the current position without wrapping.
+      iree_host_size_t free_space =
+          iree_mpsc_queue_free_space(queue->capacity, reserve_pos, read_pos);
+      if (free_space < total_entry_bytes) {
+        return NULL;
+      }
+      new_reserve_pos = reserve_pos + (int64_t)total_entry_bytes;
+      entry_offset = physical_offset;
+      needs_skip = false;
+      skip_bytes = 0;
+    } else {
+      // Entry doesn't fit at the tail — need a skip marker to wrap.
+      skip_bytes = contiguous_at_tail;
+      iree_host_size_t total_needed = skip_bytes + total_entry_bytes;
+      iree_host_size_t free_space =
+          iree_mpsc_queue_free_space(queue->capacity, reserve_pos, read_pos);
+      if (free_space < total_needed) {
+        return NULL;
+      }
+      new_reserve_pos = reserve_pos + (int64_t)total_needed;
+      entry_offset = 0;
+      needs_skip = true;
+    }
+
+    // Attempt to claim the space.
+    if (!iree_atomic_compare_exchange_strong(
+            &queue->reserve_position->value, &reserve_pos, new_reserve_pos,
+            iree_memory_order_acq_rel, iree_memory_order_relaxed)) {
+      // Another producer won — retry with updated reserve_position.
+      continue;
+    }
+
+    // CAS succeeded — we own the reserved range. Write skip marker if needed.
+    if (needs_skip) {
+      iree_mpsc_queue_store_entry_state(queue, physical_offset,
+                                        IREE_MPSC_QUEUE_SKIP_MARKER);
+    }
+
+    // Fill reservation handle.
+    out_reservation->entry_offset = entry_offset;
+    out_reservation->payload_length = (uint32_t)length;
+
+    // Return pointer to the payload region (after the length prefix).
+    // The length prefix is already 0 (zeroed by initialize or by the consumer
+    // after the previous iteration's consume), marking this entry as
+    // "reserved but uncommitted".
+    return &queue->data[entry_offset + sizeof(uint32_t)];
+  }
+}
+
+void iree_mpsc_queue_commit_write(iree_mpsc_queue_t* queue,
+                                  iree_mpsc_queue_reservation_t reservation) {
+  // Release-store the payload length to the length prefix, making the entry
+  // visible to the consumer. All payload writes (by the caller between
+  // begin_write and commit_write) are ordered before this release-store.
+  iree_mpsc_queue_store_entry_state(queue, reservation.entry_offset,
+                                    reservation.payload_length);
+}
+
+void iree_mpsc_queue_cancel_write(iree_mpsc_queue_t* queue,
+                                  iree_mpsc_queue_reservation_t reservation) {
+  // Release-store the payload length with the cancel bit set. The consumer
+  // will skip past this entry without delivering it.
+  iree_mpsc_queue_store_entry_state(
+      queue, reservation.entry_offset,
+      reservation.payload_length | IREE_MPSC_QUEUE_CANCEL_BIT);
+}
+
+bool iree_mpsc_queue_write(iree_mpsc_queue_t* queue, const void* data,
+                           iree_host_size_t length) {
+  iree_mpsc_queue_reservation_t reservation;
+  void* payload = iree_mpsc_queue_begin_write(queue, length, &reservation);
+  if (!payload) return false;
+  memcpy(payload, data, length);
+  iree_mpsc_queue_commit_write(queue, reservation);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Consumer API
+//===----------------------------------------------------------------------===//
+
+const void* iree_mpsc_queue_peek(iree_mpsc_queue_t* queue,
+                                 iree_host_size_t* out_length) {
+  *out_length = 0;
+
+  int64_t read_pos =
+      iree_atomic_load(&queue->read_position->value, iree_memory_order_relaxed);
+  int64_t reserve_pos = iree_atomic_load(&queue->reserve_position->value,
+                                         iree_memory_order_acquire);
+
+  while (read_pos < reserve_pos) {
+    uint32_t physical_offset = (uint32_t)(read_pos & queue->mask);
+
+    // Acquire-load the length prefix to determine entry state.
+    uint32_t entry_state =
+        iree_mpsc_queue_load_entry_state(queue, physical_offset);
+
+    if (entry_state == 0) {
+      // Reserved but uncommitted — head-of-line blocking. The producer has
+      // claimed this space but hasn't committed or canceled yet.
+      return NULL;
+    }
+
+    if (entry_state == IREE_MPSC_QUEUE_SKIP_MARKER) {
+      // Skip marker: advance past the remaining tail bytes and zero the
+      // marker so the next ring iteration sees an uncommitted slot.
+      iree_host_size_t skip_bytes =
+          (iree_host_size_t)(queue->capacity - physical_offset);
+      iree_mpsc_queue_store_entry_state(queue, physical_offset, 0);
+      read_pos += (int64_t)skip_bytes;
+      iree_atomic_store(&queue->read_position->value, read_pos,
+                        iree_memory_order_release);
+      continue;
+    }
+
+    if (entry_state & IREE_MPSC_QUEUE_CANCEL_BIT) {
+      // Canceled entry: skip past it. Compute the total entry size from the
+      // payload length (lower 31 bits).
+      uint32_t payload_length =
+          entry_state & IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH;
+      iree_host_size_t total_entry_bytes = iree_mpsc_queue_entry_size(
+          queue->entry_alignment, (iree_host_size_t)payload_length);
+      iree_mpsc_queue_store_entry_state(queue, physical_offset, 0);
+      read_pos += (int64_t)total_entry_bytes;
+      iree_atomic_store(&queue->read_position->value, read_pos,
+                        iree_memory_order_release);
+      continue;
+    }
+
+    // Committed entry. The entry_state value is the payload length.
+    *out_length = (iree_host_size_t)entry_state;
+    return &queue->data[physical_offset + sizeof(uint32_t)];
+  }
+
+  return NULL;  // Queue is empty.
+}
+
+void iree_mpsc_queue_consume(iree_mpsc_queue_t* queue) {
+  int64_t read_pos =
+      iree_atomic_load(&queue->read_position->value, iree_memory_order_relaxed);
+  uint32_t physical_offset = (uint32_t)(read_pos & queue->mask);
+
+  // Read the entry length to compute how far to advance.
+  uint32_t entry_state =
+      iree_mpsc_queue_load_entry_state(queue, physical_offset);
+
+  iree_host_size_t total_entry_bytes = iree_mpsc_queue_entry_size(
+      queue->entry_alignment, (iree_host_size_t)entry_state);
+
+  // Zero the length prefix so the next ring iteration sees an uncommitted slot.
+  // This release-store is the critical invariant that makes the MPSC queue
+  // correct: producers rely on length prefixes being 0 at any slot they
+  // reserve. Without this, a producer's CAS-won slot could contain stale
+  // committed data from the previous ring iteration, which the consumer would
+  // misinterpret as a new committed entry.
+  iree_mpsc_queue_store_entry_state(queue, physical_offset, 0);
+
+  read_pos += (int64_t)total_entry_bytes;
+  iree_atomic_store(&queue->read_position->value, read_pos,
+                    iree_memory_order_release);
+}
+
+bool iree_mpsc_queue_read(iree_mpsc_queue_t* queue, void* out_data,
+                          iree_host_size_t out_capacity,
+                          iree_host_size_t* out_length) {
+  iree_host_size_t payload_length = 0;
+  const void* payload = iree_mpsc_queue_peek(queue, &payload_length);
+  if (!payload) {
+    *out_length = 0;
+    return false;
+  }
+
+  *out_length = payload_length;
+  iree_host_size_t copy_length = iree_min(payload_length, out_capacity);
+  memcpy(out_data, payload, copy_length);
+  iree_mpsc_queue_consume(queue);
+  return true;
+}

--- a/runtime/src/iree/base/internal/mpsc_queue.c
+++ b/runtime/src/iree/base/internal/mpsc_queue.c
@@ -96,8 +96,7 @@ static inline iree_host_size_t iree_mpsc_queue_free_space(uint32_t capacity,
 
 // Acquire-loads the length prefix (entry state indicator) at the given data
 // ring offset. The acquire ordering pairs with the release-store in
-// commit_write/cancel_write and the release-store in consume (which zeroes
-// the prefix for the next iteration).
+// commit_write/cancel_write/skip_marker.
 static inline uint32_t iree_mpsc_queue_load_entry_state(
     const iree_mpsc_queue_t* queue, uint32_t offset) {
   return (uint32_t)iree_atomic_load((iree_atomic_int32_t*)&queue->data[offset],
@@ -150,10 +149,10 @@ iree_status_t iree_mpsc_queue_initialize(void* memory,
   }
 
   // Zero the entire region (header + positions + data).
-  // Zeroing the data region is critical: the consumer relies on length prefixes
-  // being 0 (uncommitted) at any slot that hasn't been committed yet. The
-  // consumer zeroes each slot after consuming it, but the initial pass through
-  // the ring relies on this memset.
+  // Zeroing the data region is critical: the consumer relies on all bytes
+  // being 0 at any offset that hasn't been written to yet. After the initial
+  // pass the consumer maintains this invariant by zeroing entire entry regions
+  // on consume, but the first iteration relies on this memset.
   memset(memory, 0, required);
 
   // Write the immutable header.
@@ -207,8 +206,24 @@ iree_status_t iree_mpsc_queue_open(void* memory, iree_host_size_t memory_size,
 void* iree_mpsc_queue_begin_write(
     iree_mpsc_queue_t* queue, iree_host_size_t length,
     iree_mpsc_queue_reservation_t* out_reservation) {
+  // Validate payload length. Zero-length messages are not supported (the
+  // length prefix doubles as the entry state and 0 means "uncommitted").
+  // Lengths above MAX_PAYLOAD_LENGTH would collide with the cancel bit or
+  // skip marker in the 32-bit length prefix.
+  if (IREE_UNLIKELY(length == 0 ||
+                    length > IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH)) {
+    return NULL;
+  }
+
   iree_host_size_t total_entry_bytes =
       iree_mpsc_queue_entry_size(queue->entry_alignment, length);
+
+  // Messages that can never fit regardless of how much space the consumer
+  // frees. Returning NULL here is the same as "queue full" — callers must
+  // check message size against ring capacity before entering retry loops.
+  if (IREE_UNLIKELY(total_entry_bytes > queue->capacity)) {
+    return NULL;
+  }
 
   // CAS loop: atomically reserve space in the ring.
   for (;;) {
@@ -271,9 +286,6 @@ void* iree_mpsc_queue_begin_write(
     out_reservation->payload_length = (uint32_t)length;
 
     // Return pointer to the payload region (after the length prefix).
-    // The length prefix is already 0 (zeroed by initialize or by the consumer
-    // after the previous iteration's consume), marking this entry as
-    // "reserved but uncommitted".
     return &queue->data[entry_offset + sizeof(uint32_t)];
   }
 }
@@ -334,10 +346,10 @@ const void* iree_mpsc_queue_peek(iree_mpsc_queue_t* queue,
 
     if (entry_state == IREE_MPSC_QUEUE_SKIP_MARKER) {
       // Skip marker: advance past the remaining tail bytes and zero the
-      // marker so the next ring iteration sees an uncommitted slot.
+      // entire skip region so the next ring iteration sees clean memory.
       iree_host_size_t skip_bytes =
           (iree_host_size_t)(queue->capacity - physical_offset);
-      iree_mpsc_queue_store_entry_state(queue, physical_offset, 0);
+      memset(&queue->data[physical_offset], 0, skip_bytes);
       read_pos += (int64_t)skip_bytes;
       iree_atomic_store(&queue->read_position->value, read_pos,
                         iree_memory_order_release);
@@ -346,12 +358,12 @@ const void* iree_mpsc_queue_peek(iree_mpsc_queue_t* queue,
 
     if (entry_state & IREE_MPSC_QUEUE_CANCEL_BIT) {
       // Canceled entry: skip past it. Compute the total entry size from the
-      // payload length (lower 31 bits).
+      // payload length (lower 31 bits) and zero the entire entry region.
       uint32_t payload_length =
           entry_state & IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH;
       iree_host_size_t total_entry_bytes = iree_mpsc_queue_entry_size(
           queue->entry_alignment, (iree_host_size_t)payload_length);
-      iree_mpsc_queue_store_entry_state(queue, physical_offset, 0);
+      memset(&queue->data[physical_offset], 0, total_entry_bytes);
       read_pos += (int64_t)total_entry_bytes;
       iree_atomic_store(&queue->read_position->value, read_pos,
                         iree_memory_order_release);
@@ -378,13 +390,22 @@ void iree_mpsc_queue_consume(iree_mpsc_queue_t* queue) {
   iree_host_size_t total_entry_bytes = iree_mpsc_queue_entry_size(
       queue->entry_alignment, (iree_host_size_t)entry_state);
 
-  // Zero the length prefix so the next ring iteration sees an uncommitted slot.
-  // This release-store is the critical invariant that makes the MPSC queue
-  // correct: producers rely on length prefixes being 0 at any slot they
-  // reserve. Without this, a producer's CAS-won slot could contain stale
-  // committed data from the previous ring iteration, which the consumer would
-  // misinterpret as a new committed entry.
-  iree_mpsc_queue_store_entry_state(queue, physical_offset, 0);
+  // Zero the entire entry region (prefix + payload + padding) so that the next
+  // ring iteration sees clean memory at all byte positions. This is the
+  // critical invariant that makes the MPSC queue correct: when a new entry's
+  // prefix lands at an offset that was previously inside a larger entry's
+  // payload, stale payload data could be misinterpreted as an entry state
+  // (committed length, skip marker, or cancel).
+  //
+  // This zeroing MUST happen on the consumer side rather than the producer side
+  // because the producer's CAS advances reserve_position before the producer
+  // can zero the prefix, creating a race window: a preempted producer leaves
+  // stale data visible to the consumer. The consumer is single-threaded, so
+  // its own prior memsets are trivially visible on subsequent ring iterations.
+  // Producers see the zeroed memory through the read_position release/acquire
+  // chain (memset → release-store read_position → producer acquire-loads
+  // read_position in free space check).
+  memset(&queue->data[physical_offset], 0, total_entry_bytes);
 
   read_pos += (int64_t)total_entry_bytes;
   iree_atomic_store(&queue->read_position->value, read_pos,

--- a/runtime/src/iree/base/internal/mpsc_queue.h
+++ b/runtime/src/iree/base/internal/mpsc_queue.h
@@ -227,7 +227,10 @@ bool iree_mpsc_queue_write(iree_mpsc_queue_t* queue, const void* data,
 // The caller MUST call either iree_mpsc_queue_commit_write() or
 // iree_mpsc_queue_cancel_write() after a successful begin_write.
 //
-// |length| must be > 0 and <= IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH.
+// |length| must be > 0 and <= IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH. Returns
+// NULL for invalid lengths. Also returns NULL if the aligned entry size
+// exceeds the ring capacity (the message can never fit regardless of free
+// space — callers should check capacity before entering retry loops).
 //
 // Thread-safe: multiple producers may call this concurrently.
 void* iree_mpsc_queue_begin_write(

--- a/runtime/src/iree/base/internal/mpsc_queue.h
+++ b/runtime/src/iree/base/internal/mpsc_queue.h
@@ -1,0 +1,336 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Lock-free multiple-producer single-consumer (MPSC) queue for variable-length
+// messages operating on caller-provided memory.
+//
+// Designed for cross-process shared memory: producers and consumer may be in
+// different processes mapping the same shared memory region. The queue uses
+// monotonically increasing 64-bit positions with CAS-based reservation for
+// producers and per-entry acquire-release ordering for the consumer.
+//
+// Entry format: each message is framed as a 4-byte length prefix followed by
+// the payload, padded to entry_alignment:
+//
+//   ┌──────────┬───────────────────────────────────┬─────────┐
+//   │ uint32_t │ payload (entry_size bytes)        │ padding │
+//   │entry_size│                                   │ to align│
+//   └──────────┴───────────────────────────────────┴─────────┘
+//              ╰─ entry_size bytes ─╯
+//   ╰────────── padded to entry_alignment ─────────────────╯
+//
+// The length prefix doubles as the entry state indicator:
+//   0x00000000            — reserved but uncommitted (consumer waits)
+//   0x00000001-0x7FFFFFFF — committed (consumer delivers this many bytes)
+//   0x80000001-0xFFFFFFFE — canceled (consumer skips,
+//                           length = value & 0x7FFFFFFF)
+//   0xFFFFFFFF            — skip marker (consumer wraps to offset 0)
+//
+// A skip marker at the end of the data region signals the consumer to wrap
+// to offset 0, same as the SPSC queue.
+//
+// Ordering: entries are delivered in reservation order. If producer A reserves
+// before producer B, A's entry appears first even if B commits first. The
+// consumer waits (head-of-line blocking) for uncommitted entries — this is
+// correct because the transport layer delivers messages in order.
+//
+// ABI versioning: the header contains a magic number and version. The opener
+// validates both and fails loud on mismatch — no forward compatibility.
+//
+// Usage:
+//   Producer (any thread):
+//     iree_mpsc_queue_reservation_t reservation;
+//     void* ptr = iree_mpsc_queue_begin_write(&queue, length, &reservation);
+//     if (ptr) {
+//       memcpy(ptr, data, length);
+//       iree_mpsc_queue_commit_write(&queue, reservation);
+//     }
+//
+//   Consumer (single thread):
+//     iree_host_size_t length;
+//     const void* payload = iree_mpsc_queue_peek(&queue, &length);
+//     if (payload) {
+//       process(payload, length);
+//       iree_mpsc_queue_consume(&queue);
+//     }
+//
+// Thread safety: any number of producers may call begin_write/commit_write/
+// cancel_write concurrently. The consumer API (peek/consume/read) must be
+// called from a single thread.
+
+#ifndef IREE_BASE_INTERNAL_MPSC_QUEUE_H_
+#define IREE_BASE_INTERNAL_MPSC_QUEUE_H_
+
+#include <string.h>
+
+#include "iree/base/alignment.h"
+#include "iree/base/api.h"
+#include "iree/base/internal/atomics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Constants
+//===----------------------------------------------------------------------===//
+
+// Magic number identifying an MPSC queue header ("IRMQ" in little-endian).
+#define IREE_MPSC_QUEUE_MAGIC ((uint32_t)0x514D5249)
+
+// Current ABI version. Exact match required on open — no forward compatibility.
+#define IREE_MPSC_QUEUE_VERSION ((uint32_t)1)
+
+// Total bytes consumed by the header region (4 cache lines).
+#define IREE_MPSC_QUEUE_HEADER_SIZE ((iree_host_size_t)256)
+
+// Minimum data capacity in bytes. Must be a power of two.
+#define IREE_MPSC_QUEUE_MIN_CAPACITY ((uint32_t)64)
+
+// Default byte alignment for entries (length prefix + payload + padding).
+#define IREE_MPSC_QUEUE_DEFAULT_ENTRY_ALIGNMENT ((uint32_t)8)
+
+// Sentinel value in the entry length field indicating a skip-to-wrap marker.
+// The consumer silently advances past these.
+#define IREE_MPSC_QUEUE_SKIP_MARKER UINT32_MAX
+
+// High bit in the entry length field indicating a canceled entry.
+// The consumer silently advances past these. Payload length is the remaining
+// 31 bits.
+#define IREE_MPSC_QUEUE_CANCEL_BIT ((uint32_t)0x80000000u)
+
+// Maximum payload length (2GB - 1). Upper bit is reserved for cancel flag.
+#define IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH ((uint32_t)0x7FFFFFFFu)
+
+//===----------------------------------------------------------------------===//
+// Memory layout structures
+//===----------------------------------------------------------------------===//
+
+// Immutable header at offset 0 of the queue memory region.
+// Occupies one cache line. Written once during initialize, read-only after.
+typedef struct iree_alignas(iree_hardware_destructive_interference_size)
+    iree_mpsc_queue_header_t {
+  uint32_t magic;
+  uint32_t version;
+  // Data region capacity in bytes. Must be a power of two.
+  uint32_t capacity;
+  // Byte alignment for entries. Must be a power of two, >= 4.
+  uint32_t entry_alignment;
+  // Reserved for future use. Must be zero.
+  uint8_t reserved[48];
+} iree_mpsc_queue_header_t;
+
+// Reserve position at offset 64 (cache line 1).
+// CAS-advanced by producers to atomically claim space. Read by the consumer
+// to determine whether entries exist beyond the read position.
+typedef struct iree_alignas(iree_hardware_destructive_interference_size)
+    iree_mpsc_queue_reserve_position_t {
+  iree_atomic_int64_t value;
+} iree_mpsc_queue_reserve_position_t;
+
+// Consumer read position at offset 128 (cache line 2).
+// Written by the consumer, read by producers to determine free space.
+typedef struct iree_alignas(iree_hardware_destructive_interference_size)
+    iree_mpsc_queue_read_position_t {
+  iree_atomic_int64_t value;
+} iree_mpsc_queue_read_position_t;
+
+//===----------------------------------------------------------------------===//
+// Reservation handle
+//===----------------------------------------------------------------------===//
+
+// Opaque handle returned by begin_write, passed to commit_write or
+// cancel_write. Contains the information needed to publish or discard the
+// reserved entry. 8 bytes — fits in a register pair.
+typedef struct iree_mpsc_queue_reservation_t {
+  // Data ring offset where the length prefix lives.
+  uint32_t entry_offset;
+  // Payload length (written as the length prefix on commit, or with the cancel
+  // bit set on cancel).
+  uint32_t payload_length;
+} iree_mpsc_queue_reservation_t;
+
+//===----------------------------------------------------------------------===//
+// Queue handle
+//===----------------------------------------------------------------------===//
+
+// View into an initialized MPSC queue.
+//
+// Holds derived pointers into caller-provided memory — does not own the memory.
+// Initialize with iree_mpsc_queue_initialize() (creator) or
+// iree_mpsc_queue_open() (opener).
+typedef struct iree_mpsc_queue_t {
+  iree_mpsc_queue_header_t* header;
+  iree_mpsc_queue_reserve_position_t* reserve_position;
+  iree_mpsc_queue_read_position_t* read_position;
+  uint8_t* data;
+  // Cached from header for fast access.
+  uint32_t capacity;
+  // capacity - 1: for position-to-offset masking.
+  uint32_t mask;
+  uint32_t entry_alignment;
+} iree_mpsc_queue_t;
+
+//===----------------------------------------------------------------------===//
+// Initialization
+//===----------------------------------------------------------------------===//
+
+// Returns the total memory required for a queue with the given data capacity.
+// |capacity| must be a power of two and >= IREE_MPSC_QUEUE_MIN_CAPACITY.
+static inline iree_host_size_t iree_mpsc_queue_required_size(
+    uint32_t capacity) {
+  return IREE_MPSC_QUEUE_HEADER_SIZE + (iree_host_size_t)capacity;
+}
+
+// Initializes a new queue in |memory| of |memory_size| bytes.
+//
+// Writes the header (magic, version, capacity, entry_alignment) and zeroes
+// all positions. |capacity| must be a power of two and >=
+// IREE_MPSC_QUEUE_MIN_CAPACITY. |memory_size| must be >=
+// iree_mpsc_queue_required_size(capacity).
+iree_status_t iree_mpsc_queue_initialize(void* memory,
+                                         iree_host_size_t memory_size,
+                                         uint32_t capacity,
+                                         iree_mpsc_queue_t* out_queue);
+
+// Opens an existing queue from |memory| of |memory_size| bytes.
+//
+// Validates magic and version. Does NOT reset positions — producers and
+// consumer resume from wherever positions are. Returns an error if the header
+// is invalid (bad magic, version mismatch, non-power-of-two capacity, etc.).
+iree_status_t iree_mpsc_queue_open(void* memory, iree_host_size_t memory_size,
+                                   iree_mpsc_queue_t* out_queue);
+
+//===----------------------------------------------------------------------===//
+// Producer API (thread-safe — any number of concurrent producers)
+//===----------------------------------------------------------------------===//
+
+// Writes |data| of |length| bytes into the queue as a single entry.
+//
+// Returns true if the entry was written, false if there is insufficient space.
+// This is the simple one-shot API; for zero-copy writes use
+// iree_mpsc_queue_begin_write/commit_write.
+//
+// Thread-safe: multiple producers may call this concurrently.
+bool iree_mpsc_queue_write(iree_mpsc_queue_t* queue, const void* data,
+                           iree_host_size_t length);
+
+// Atomically reserves space for an entry of |length| payload bytes.
+//
+// On success, returns a pointer to the payload region where the caller writes
+// directly (zero-copy) and fills |*out_reservation| with a handle for
+// commit_write or cancel_write. On failure (insufficient space), returns NULL.
+//
+// The caller MUST call either iree_mpsc_queue_commit_write() or
+// iree_mpsc_queue_cancel_write() after a successful begin_write.
+//
+// |length| must be > 0 and <= IREE_MPSC_QUEUE_MAX_PAYLOAD_LENGTH.
+//
+// Thread-safe: multiple producers may call this concurrently.
+void* iree_mpsc_queue_begin_write(
+    iree_mpsc_queue_t* queue, iree_host_size_t length,
+    iree_mpsc_queue_reservation_t* out_reservation);
+
+// Commits a previously reserved write, making it visible to the consumer.
+//
+// The reservation handle is consumed and must not be reused. After this call,
+// the producer holds no queue resources.
+//
+// Thread-safe: may be called concurrently with other producer operations.
+void iree_mpsc_queue_commit_write(iree_mpsc_queue_t* queue,
+                                  iree_mpsc_queue_reservation_t reservation);
+
+// Cancels a previously reserved write without publishing any data.
+//
+// The consumer will skip past this entry. The reserved space is not reclaimed
+// until the consumer advances past it.
+//
+// Thread-safe: may be called concurrently with other producer operations.
+void iree_mpsc_queue_cancel_write(iree_mpsc_queue_t* queue,
+                                  iree_mpsc_queue_reservation_t reservation);
+
+//===----------------------------------------------------------------------===//
+// Consumer API (single-threaded — not safe with concurrent consumers)
+//===----------------------------------------------------------------------===//
+
+// Reads the next entry from the queue into |out_data|.
+//
+// Copies up to |out_capacity| bytes of payload into |out_data| and sets
+// |*out_length| to the actual payload length. Advances read_position.
+//
+// Returns true if an entry was read, false if the queue is empty or the next
+// entry is not yet committed (head-of-line blocking).
+// If the payload exceeds |out_capacity|, the entry is consumed but the data
+// is truncated. Callers should size |out_data| to the maximum expected message.
+bool iree_mpsc_queue_read(iree_mpsc_queue_t* queue, void* out_data,
+                          iree_host_size_t out_capacity,
+                          iree_host_size_t* out_length);
+
+// Returns a pointer to the next committed entry's payload without consuming it.
+//
+// Sets |*out_length| to the payload length. Returns NULL if the queue is empty
+// or the next entry is not yet committed (head-of-line blocking). Skip markers
+// and canceled entries are silently advanced past.
+//
+// The returned pointer is valid until the next call to
+// iree_mpsc_queue_consume() or iree_mpsc_queue_read().
+const void* iree_mpsc_queue_peek(iree_mpsc_queue_t* queue,
+                                 iree_host_size_t* out_length);
+
+// Consumes the entry most recently returned by iree_mpsc_queue_peek().
+// Must be called exactly once after each successful peek.
+void iree_mpsc_queue_consume(iree_mpsc_queue_t* queue);
+
+//===----------------------------------------------------------------------===//
+// Query API (safe from either producer or consumer side)
+//===----------------------------------------------------------------------===//
+
+// Returns true if there may be entries available to read.
+//
+// Note: unlike the SPSC queue, this can return true even when no committed
+// entries are available (entries may be reserved but not yet committed).
+static inline bool iree_mpsc_queue_can_read(const iree_mpsc_queue_t* queue) {
+  int64_t reserve_pos =
+      iree_atomic_load((iree_atomic_int64_t*)&queue->reserve_position->value,
+                       iree_memory_order_acquire);
+  int64_t read_pos =
+      iree_atomic_load((iree_atomic_int64_t*)&queue->read_position->value,
+                       iree_memory_order_acquire);
+  return reserve_pos > read_pos;
+}
+
+// Returns the approximate number of reserved bytes beyond the read position.
+// This includes committed, uncommitted, and canceled entries.
+static inline iree_host_size_t iree_mpsc_queue_read_available(
+    const iree_mpsc_queue_t* queue) {
+  int64_t reserve_pos =
+      iree_atomic_load((iree_atomic_int64_t*)&queue->reserve_position->value,
+                       iree_memory_order_acquire);
+  int64_t read_pos =
+      iree_atomic_load((iree_atomic_int64_t*)&queue->read_position->value,
+                       iree_memory_order_acquire);
+  return (iree_host_size_t)(reserve_pos - read_pos);
+}
+
+// Returns the approximate number of bytes available for writing.
+// The consumer may advance read_position between this call and the caller's
+// use, so the actual amount may be larger.
+static inline iree_host_size_t iree_mpsc_queue_write_available(
+    const iree_mpsc_queue_t* queue) {
+  int64_t reserve_pos =
+      iree_atomic_load((iree_atomic_int64_t*)&queue->reserve_position->value,
+                       iree_memory_order_acquire);
+  int64_t read_pos =
+      iree_atomic_load((iree_atomic_int64_t*)&queue->read_position->value,
+                       iree_memory_order_acquire);
+  return (iree_host_size_t)(queue->capacity - (reserve_pos - read_pos));
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_INTERNAL_MPSC_QUEUE_H_

--- a/runtime/src/iree/base/internal/mpsc_queue_test.cc
+++ b/runtime/src/iree/base/internal/mpsc_queue_test.cc
@@ -921,4 +921,83 @@ TEST_F(MpscQueueTest, LargePayload) {
   EXPECT_EQ(memcmp(buffer.data(), expected.data(), payload_size), 0);
 }
 
+// Variable-sized entries across ring iterations. Exercises the scenario where
+// a new entry's prefix falls at a physical offset that was previously inside
+// a larger entry's payload. The consumer's full-entry memset on consume is
+// what prevents stale payload data from being misinterpreted as entry states.
+TEST_F(MpscQueueTest, VariableSizeReuseCorrectness) {
+  SetUp(64);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 64, &queue));
+
+  // Pass 1: write one large entry (24 bytes payload).
+  // entry_size = align(4 + 24, 8) = 32. Occupies bytes 0-31.
+  // Fill payload with 0xAA so any stale prefix byte is obviously non-zero.
+  uint8_t large_payload[24];
+  memset(large_payload, 0xAA, sizeof(large_payload));
+  ASSERT_TRUE(
+      iree_mpsc_queue_write(&queue, large_payload, sizeof(large_payload)));
+
+  // Write another entry to fill the ring further.
+  // entry_size = align(4 + 24, 8) = 32. Occupies bytes 32-63.
+  ASSERT_TRUE(
+      iree_mpsc_queue_write(&queue, large_payload, sizeof(large_payload)));
+
+  // Consume both entries.
+  uint8_t buffer[64];
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, sizeof(large_payload));
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, sizeof(large_payload));
+
+  // Pass 2: write small entries (4 bytes payload each).
+  // entry_size = align(4 + 4, 8) = 8. These will tile the ring in 8-byte
+  // chunks, and several entries' prefixes will land at offsets that were
+  // inside the pass-1 large entries' payload regions (e.g., offset 8, 16, 24).
+  for (int i = 0; i < 8; ++i) {
+    uint32_t value = (uint32_t)(i + 100);
+    ASSERT_TRUE(iree_mpsc_queue_write(&queue, &value, sizeof(value)))
+        << "pass 2 write " << i;
+  }
+
+  // Read them all back — this is where the bug would manifest. Without the
+  // consumer-side full-entry memset on consume, stale 0xAA bytes at prefix
+  // positions would be misinterpreted as entry lengths, corrupting the queue.
+  for (int i = 0; i < 8; ++i) {
+    uint32_t value = 0;
+    ASSERT_TRUE(iree_mpsc_queue_read(&queue, &value, sizeof(value), &length))
+        << "pass 2 read " << i;
+    EXPECT_EQ(length, sizeof(uint32_t));
+    EXPECT_EQ(value, (uint32_t)(i + 100)) << "at index " << i;
+  }
+
+  // Queue should be empty.
+  EXPECT_FALSE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+}
+
+// Validates that zero-length writes are rejected.
+TEST_F(MpscQueueTest, ZeroLengthWriteFails) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+  EXPECT_FALSE(iree_mpsc_queue_write(&queue, "x", 0));
+}
+
+// Validates that oversized writes are rejected immediately.
+TEST_F(MpscQueueTest, OversizedWriteFails) {
+  SetUp(64);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 64, &queue));
+
+  // An entry with 64 bytes of payload needs align(4+64, 8) = 72 bytes, which
+  // exceeds the 64-byte ring capacity.
+  uint8_t payload[64];
+  memset(payload, 0, sizeof(payload));
+  EXPECT_FALSE(iree_mpsc_queue_write(&queue, payload, sizeof(payload)));
+  EXPECT_EQ(iree_mpsc_queue_write_available(&queue), (iree_host_size_t)64);
+}
+
 }  // namespace

--- a/runtime/src/iree/base/internal/mpsc_queue_test.cc
+++ b/runtime/src/iree/base/internal/mpsc_queue_test.cc
@@ -1,0 +1,924 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/mpsc_queue.h"
+
+#include <atomic>
+#include <cstring>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Test fixture
+//===----------------------------------------------------------------------===//
+
+class MpscQueueTest : public ::testing::Test {
+ protected:
+  // Allocates aligned memory for a queue with the given capacity.
+  void SetUp(uint32_t capacity) {
+    iree_host_size_t size = iree_mpsc_queue_required_size(capacity);
+    memory_.resize(size + 64);  // Extra for alignment.
+    // Align to 64 bytes (cache line) for realistic behavior.
+    uintptr_t base = (uintptr_t)memory_.data();
+    uintptr_t aligned = (base + 63) & ~(uintptr_t)63;
+    aligned_memory_ = (void*)aligned;
+    memory_size_ = size;
+  }
+
+  void SetUp() override { SetUp(1024); }
+
+  void* aligned_memory_ = nullptr;
+  iree_host_size_t memory_size_ = 0;
+
+ private:
+  std::vector<uint8_t> memory_;
+};
+
+//===----------------------------------------------------------------------===//
+// Required size computation
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, RequiredSizeComputation) {
+  EXPECT_EQ(iree_mpsc_queue_required_size(64),
+            IREE_MPSC_QUEUE_HEADER_SIZE + 64);
+  EXPECT_EQ(iree_mpsc_queue_required_size(1024),
+            IREE_MPSC_QUEUE_HEADER_SIZE + 1024);
+  EXPECT_EQ(iree_mpsc_queue_required_size(65536),
+            IREE_MPSC_QUEUE_HEADER_SIZE + 65536);
+}
+
+//===----------------------------------------------------------------------===//
+// Initialization and validation
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, InitializeAndOpen) {
+  iree_mpsc_queue_t producer;
+  IREE_ASSERT_OK(iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024,
+                                            &producer));
+
+  // Verify header fields.
+  EXPECT_EQ(producer.header->magic, IREE_MPSC_QUEUE_MAGIC);
+  EXPECT_EQ(producer.header->version, IREE_MPSC_QUEUE_VERSION);
+  EXPECT_EQ(producer.header->capacity, (uint32_t)1024);
+  EXPECT_EQ(producer.header->entry_alignment,
+            IREE_MPSC_QUEUE_DEFAULT_ENTRY_ALIGNMENT);
+  EXPECT_EQ(producer.capacity, (uint32_t)1024);
+  EXPECT_EQ(producer.mask, (uint32_t)1023);
+
+  // Open the same memory as a consumer.
+  iree_mpsc_queue_t consumer;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_open(aligned_memory_, memory_size_, &consumer));
+  EXPECT_EQ(consumer.capacity, (uint32_t)1024);
+  EXPECT_EQ(consumer.mask, (uint32_t)1023);
+  EXPECT_EQ(consumer.entry_alignment, IREE_MPSC_QUEUE_DEFAULT_ENTRY_ALIGNMENT);
+}
+
+TEST_F(MpscQueueTest, InitializeNullMemory) {
+  iree_mpsc_queue_t queue;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_initialize(nullptr, memory_size_, 1024, &queue));
+}
+
+TEST_F(MpscQueueTest, InitializeCapacityTooSmall) {
+  iree_mpsc_queue_t queue;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 32, &queue));
+}
+
+TEST_F(MpscQueueTest, InitializeCapacityNotPowerOfTwo) {
+  iree_mpsc_queue_t queue;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 100, &queue));
+}
+
+TEST_F(MpscQueueTest, InitializeMemoryTooSmall) {
+  iree_mpsc_queue_t queue;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_initialize(aligned_memory_, 200, 1024, &queue));
+}
+
+TEST_F(MpscQueueTest, OpenBadMagic) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+  queue.header->magic = 0xDEADBEEF;
+
+  iree_mpsc_queue_t opener;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_open(aligned_memory_, memory_size_, &opener));
+}
+
+TEST_F(MpscQueueTest, OpenBadVersion) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+  queue.header->version = 99;
+
+  iree_mpsc_queue_t opener;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_open(aligned_memory_, memory_size_, &opener));
+}
+
+TEST_F(MpscQueueTest, OpenNonPowerOfTwoCapacity) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+  queue.header->capacity = 100;
+
+  iree_mpsc_queue_t opener;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_mpsc_queue_open(aligned_memory_, memory_size_, &opener));
+}
+
+//===----------------------------------------------------------------------===//
+// Single-threaded producer/consumer
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, WriteReadSingle) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  const char* message = "hello";
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, message, strlen(message)));
+
+  char buffer[64] = {0};
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, strlen(message));
+  EXPECT_EQ(memcmp(buffer, message, length), 0);
+}
+
+TEST_F(MpscQueueTest, WriteReadMultiple) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    ASSERT_TRUE(iree_mpsc_queue_write(&queue, &i, sizeof(i))) << "write " << i;
+  }
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    uint32_t value = 0;
+    iree_host_size_t length = 0;
+    ASSERT_TRUE(iree_mpsc_queue_read(&queue, &value, sizeof(value), &length))
+        << "read " << i;
+    EXPECT_EQ(length, sizeof(uint32_t));
+    EXPECT_EQ(value, i) << "at index " << i;
+  }
+
+  // Queue should now be empty.
+  uint32_t dummy = 0;
+  iree_host_size_t dummy_length = 0;
+  EXPECT_FALSE(
+      iree_mpsc_queue_read(&queue, &dummy, sizeof(dummy), &dummy_length));
+}
+
+TEST_F(MpscQueueTest, WriteReadVariableSizes) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  uint8_t small = 0xAB;
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, &small, 1));
+
+  uint8_t medium[32];
+  memset(medium, 0xCD, sizeof(medium));
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, medium, sizeof(medium)));
+
+  uint8_t large[200];
+  memset(large, 0xEF, sizeof(large));
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, large, sizeof(large)));
+
+  uint8_t buffer[256];
+  iree_host_size_t length = 0;
+
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)1);
+  EXPECT_EQ(buffer[0], 0xAB);
+
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)32);
+  EXPECT_EQ(memcmp(buffer, medium, 32), 0);
+
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)200);
+  EXPECT_EQ(memcmp(buffer, large, 200), 0);
+}
+
+TEST_F(MpscQueueTest, WriteFullReturnsFalse) {
+  SetUp(64);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 64, &queue));
+
+  // Each entry with 4 bytes of payload consumes 8 bytes (4 prefix + 4 payload,
+  // already aligned to 8). So 64 / 8 = 8 entries should fill the ring.
+  uint32_t value = 0;
+  int written = 0;
+  while (iree_mpsc_queue_write(&queue, &value, sizeof(value))) {
+    ++written;
+    ++value;
+  }
+  EXPECT_GT(written, 0);
+
+  // Verify the ring is full.
+  EXPECT_FALSE(iree_mpsc_queue_write(&queue, &value, sizeof(value)));
+}
+
+TEST_F(MpscQueueTest, ReadEmptyReturnsFalse) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+  uint8_t buffer[64];
+  iree_host_size_t length = 0;
+  EXPECT_FALSE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)0);
+}
+
+TEST_F(MpscQueueTest, PeekAndConsume) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  uint32_t values[] = {100, 200, 300};
+  for (auto v : values) {
+    ASSERT_TRUE(iree_mpsc_queue_write(&queue, &v, sizeof(v)));
+  }
+
+  for (auto expected : values) {
+    iree_host_size_t length = 0;
+    const void* payload = iree_mpsc_queue_peek(&queue, &length);
+    ASSERT_NE(payload, nullptr);
+    EXPECT_EQ(length, sizeof(uint32_t));
+
+    uint32_t value = 0;
+    memcpy(&value, payload, sizeof(value));
+    EXPECT_EQ(value, expected);
+
+    iree_mpsc_queue_consume(&queue);
+  }
+
+  iree_host_size_t length = 0;
+  EXPECT_EQ(iree_mpsc_queue_peek(&queue, &length), nullptr);
+}
+
+TEST_F(MpscQueueTest, PeekEmptyReturnsNull) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+  iree_host_size_t length = 0;
+  EXPECT_EQ(iree_mpsc_queue_peek(&queue, &length), nullptr);
+  EXPECT_EQ(length, (iree_host_size_t)0);
+}
+
+//===----------------------------------------------------------------------===//
+// Begin/commit/cancel write
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, BeginWriteCommit) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  iree_host_size_t payload_size = 16;
+  iree_mpsc_queue_reservation_t reservation;
+  void* payload =
+      iree_mpsc_queue_begin_write(&queue, payload_size, &reservation);
+  ASSERT_NE(payload, nullptr);
+
+  memset(payload, 0x42, payload_size);
+  iree_mpsc_queue_commit_write(&queue, reservation);
+
+  uint8_t buffer[64];
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, payload_size);
+  for (iree_host_size_t i = 0; i < length; ++i) {
+    EXPECT_EQ(buffer[i], 0x42) << "at byte " << i;
+  }
+}
+
+TEST_F(MpscQueueTest, CancelDoesNotDeliver) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  iree_host_size_t payload_size = 16;
+  iree_mpsc_queue_reservation_t reservation;
+  void* payload =
+      iree_mpsc_queue_begin_write(&queue, payload_size, &reservation);
+  ASSERT_NE(payload, nullptr);
+  memset(payload, 0xAA, payload_size);
+  iree_mpsc_queue_cancel_write(&queue, reservation);
+
+  // The canceled entry occupies ring space but the consumer should skip it.
+  // With MPSC, iree_mpsc_queue_can_read returns true (there IS reserved data),
+  // but peek should skip the canceled entry and return NULL (nothing
+  // committed).
+  iree_host_size_t length = 0;
+  EXPECT_EQ(iree_mpsc_queue_peek(&queue, &length), nullptr);
+}
+
+TEST_F(MpscQueueTest, CancelThenCommit) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  // Cancel a write.
+  iree_mpsc_queue_reservation_t cancel_reservation;
+  void* cancel_payload = iree_mpsc_queue_begin_write(&queue, sizeof(uint32_t),
+                                                     &cancel_reservation);
+  ASSERT_NE(cancel_payload, nullptr);
+  uint32_t cancel_value = 0xDEAD;
+  memcpy(cancel_payload, &cancel_value, sizeof(cancel_value));
+  iree_mpsc_queue_cancel_write(&queue, cancel_reservation);
+
+  // Commit a write after the cancel.
+  iree_mpsc_queue_reservation_t commit_reservation;
+  void* commit_payload = iree_mpsc_queue_begin_write(&queue, sizeof(uint32_t),
+                                                     &commit_reservation);
+  ASSERT_NE(commit_payload, nullptr);
+  uint32_t commit_value = 42;
+  memcpy(commit_payload, &commit_value, sizeof(commit_value));
+  iree_mpsc_queue_commit_write(&queue, commit_reservation);
+
+  // Should get only the committed value.
+  uint32_t read_value = 0;
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(
+      iree_mpsc_queue_read(&queue, &read_value, sizeof(read_value), &length));
+  EXPECT_EQ(length, sizeof(uint32_t));
+  EXPECT_EQ(read_value, (uint32_t)42);
+
+  // Queue should be empty now.
+  EXPECT_FALSE(
+      iree_mpsc_queue_read(&queue, &read_value, sizeof(read_value), &length));
+}
+
+TEST_F(MpscQueueTest, BeginWriteFullReturnsNull) {
+  SetUp(64);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 64, &queue));
+
+  // Fill the ring using begin/commit.
+  int committed = 0;
+  for (;;) {
+    iree_mpsc_queue_reservation_t reservation;
+    void* payload =
+        iree_mpsc_queue_begin_write(&queue, sizeof(uint32_t), &reservation);
+    if (!payload) break;
+    uint32_t value = (uint32_t)committed;
+    memcpy(payload, &value, sizeof(value));
+    iree_mpsc_queue_commit_write(&queue, reservation);
+    ++committed;
+  }
+  EXPECT_GT(committed, 0);
+
+  // Should return NULL when full.
+  iree_mpsc_queue_reservation_t reservation;
+  EXPECT_EQ(iree_mpsc_queue_begin_write(&queue, sizeof(uint32_t), &reservation),
+            nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Wrapping and skip markers
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, WrapAround) {
+  SetUp(128);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 128, &queue));
+
+  // Write and read enough entries to wrap around multiple times.
+  const int total_entries = 100;
+  for (int i = 0; i < total_entries; ++i) {
+    uint32_t value = (uint32_t)i;
+    while (!iree_mpsc_queue_write(&queue, &value, sizeof(value))) {
+      uint32_t read_value = 0;
+      iree_host_size_t length = 0;
+      ASSERT_TRUE(iree_mpsc_queue_read(&queue, &read_value, sizeof(read_value),
+                                       &length))
+          << "failed to drain at entry " << i;
+    }
+  }
+
+  // Drain remaining entries.
+  uint32_t read_value = 0;
+  iree_host_size_t length = 0;
+  while (
+      iree_mpsc_queue_read(&queue, &read_value, sizeof(read_value), &length)) {
+  }
+}
+
+TEST_F(MpscQueueTest, SkipMarkerTransparency) {
+  SetUp(64);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 64, &queue));
+
+  // Write 7 entries of uint32_t to advance the write cursor to position 56.
+  // Each entry = 8 bytes (4 prefix + 4 payload, aligned to 8).
+  for (int i = 0; i < 7; ++i) {
+    uint32_t value = (uint32_t)i;
+    ASSERT_TRUE(iree_mpsc_queue_write(&queue, &value, sizeof(value)));
+  }
+  // Read them all to free space. reserve_pos = 56, read_pos = 56, free = 64.
+  for (int i = 0; i < 7; ++i) {
+    uint32_t value = 0;
+    iree_host_size_t length = 0;
+    ASSERT_TRUE(iree_mpsc_queue_read(&queue, &value, sizeof(value), &length));
+    EXPECT_EQ(value, (uint32_t)i);
+  }
+
+  // Now write an 8-byte payload. Entry = align(4 + 8, 8) = 16 bytes.
+  // Tail has only 8 bytes (64 - 56), so a skip marker is needed.
+  uint8_t payload[8];
+  memset(payload, 0xBB, sizeof(payload));
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, payload, sizeof(payload)));
+
+  // Read it back — the skip marker should be transparent to the consumer.
+  uint8_t buffer[64];
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)sizeof(payload));
+  EXPECT_EQ(memcmp(buffer, payload, length), 0);
+}
+
+//===----------------------------------------------------------------------===//
+// Query API
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, WriteAvailableAccuracy) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  EXPECT_EQ(iree_mpsc_queue_write_available(&queue), (iree_host_size_t)1024);
+  EXPECT_EQ(iree_mpsc_queue_read_available(&queue), (iree_host_size_t)0);
+  EXPECT_FALSE(iree_mpsc_queue_can_read(&queue));
+
+  uint32_t value = 42;
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, &value, sizeof(value)));
+
+  EXPECT_EQ(iree_mpsc_queue_write_available(&queue), (iree_host_size_t)1016);
+  EXPECT_EQ(iree_mpsc_queue_read_available(&queue), (iree_host_size_t)8);
+  EXPECT_TRUE(iree_mpsc_queue_can_read(&queue));
+
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, &value, sizeof(value), &length));
+
+  EXPECT_EQ(iree_mpsc_queue_write_available(&queue), (iree_host_size_t)1024);
+  EXPECT_EQ(iree_mpsc_queue_read_available(&queue), (iree_host_size_t)0);
+  EXPECT_FALSE(iree_mpsc_queue_can_read(&queue));
+}
+
+TEST_F(MpscQueueTest, EntryAlignmentPadding) {
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  // Write a 1-byte payload. Entry = 4 prefix + 1 payload = 5, padded to 8.
+  uint8_t byte = 0xFF;
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, &byte, 1));
+
+  // Write a 5-byte payload. Entry = 4 prefix + 5 payload = 9, padded to 16.
+  uint8_t five_bytes[5] = {1, 2, 3, 4, 5};
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, five_bytes, sizeof(five_bytes)));
+
+  // Total consumed: 8 + 16 = 24 bytes.
+  EXPECT_EQ(iree_mpsc_queue_read_available(&queue), (iree_host_size_t)24);
+
+  uint8_t buffer[16];
+  iree_host_size_t length = 0;
+
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)1);
+  EXPECT_EQ(buffer[0], 0xFF);
+
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, (iree_host_size_t)5);
+  EXPECT_EQ(memcmp(buffer, five_bytes, 5), 0);
+}
+
+//===----------------------------------------------------------------------===//
+// Backpressure: fill, drain, refill
+//===----------------------------------------------------------------------===//
+
+TEST_F(MpscQueueTest, BackpressureFull) {
+  SetUp(256);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 256, &queue));
+
+  // Fill the ring.
+  int written = 0;
+  uint32_t value = 0;
+  while (iree_mpsc_queue_write(&queue, &value, sizeof(value))) {
+    ++written;
+    ++value;
+  }
+  ASSERT_GT(written, 0);
+
+  // begin_write should also return NULL.
+  iree_mpsc_queue_reservation_t reservation;
+  EXPECT_EQ(iree_mpsc_queue_begin_write(&queue, sizeof(uint32_t), &reservation),
+            nullptr);
+
+  // Drain everything.
+  int read_count = 0;
+  uint32_t expected = 0;
+  iree_host_size_t length = 0;
+  while (iree_mpsc_queue_read(&queue, &value, sizeof(value), &length)) {
+    EXPECT_EQ(value, expected) << "at read " << read_count;
+    ++expected;
+    ++read_count;
+  }
+  EXPECT_EQ(read_count, written);
+
+  // Now writes should succeed again.
+  value = 0xBEEF;
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, &value, sizeof(value)));
+
+  ASSERT_TRUE(iree_mpsc_queue_read(&queue, &value, sizeof(value), &length));
+  EXPECT_EQ(value, (uint32_t)0xBEEF);
+}
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded stress tests
+//===----------------------------------------------------------------------===//
+
+// Single producer, single consumer — validates MPSC works as a strict superset
+// of SPSC.
+TEST_F(MpscQueueTest, SingleProducerConsumerStress) {
+  SetUp(4096);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 4096, &queue));
+
+  const int total_messages = 100000;
+  std::atomic<int> consumer_count{0};
+
+  std::thread producer([&]() {
+    for (int i = 0; i < total_messages; ++i) {
+      uint32_t value = (uint32_t)i;
+      while (!iree_mpsc_queue_write(&queue, &value, sizeof(value))) {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  std::thread consumer([&]() {
+    uint32_t expected = 0;
+    while (expected < (uint32_t)total_messages) {
+      uint32_t value = 0;
+      iree_host_size_t length = 0;
+      if (iree_mpsc_queue_read(&queue, &value, sizeof(value), &length)) {
+        ASSERT_EQ(length, sizeof(uint32_t))
+            << "wrong length at message " << expected;
+        ASSERT_EQ(value, expected) << "wrong value at message " << expected;
+        ++expected;
+        consumer_count.store((int)expected, std::memory_order_relaxed);
+      }
+    }
+  });
+
+  producer.join();
+  consumer.join();
+
+  EXPECT_EQ(consumer_count.load(), total_messages);
+}
+
+// Multiple producers, single consumer. Each producer writes its own sequence
+// of tagged values. The consumer verifies:
+//   - All values from all producers are received (no loss)
+//   - Within each producer, values arrive in order (per-producer FIFO)
+TEST_F(MpscQueueTest, ConcurrentProducers) {
+  SetUp(8192);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 8192, &queue));
+
+  const int producer_count = 4;
+  const int messages_per_producer = 10000;
+  const int total_messages = producer_count * messages_per_producer;
+
+  // Each message is a (producer_id, sequence_number) pair.
+  struct TaggedMessage {
+    uint32_t producer_id;
+    uint32_t sequence;
+  };
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < producer_count; ++p) {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
+      for (int i = 0; i < messages_per_producer; ++i) {
+        TaggedMessage msg = {(uint32_t)p, (uint32_t)i};
+        while (!iree_mpsc_queue_write(&queue, &msg, sizeof(msg))) {
+          std::this_thread::yield();
+        }
+      }
+    });
+  }
+
+  // Consumer: track per-producer sequence numbers to verify ordering.
+  std::vector<uint32_t> next_expected(producer_count, 0);
+  int received = 0;
+
+  std::thread consumer([&]() {
+    while (received < total_messages) {
+      TaggedMessage msg = {};
+      iree_host_size_t length = 0;
+      if (iree_mpsc_queue_read(&queue, &msg, sizeof(msg), &length)) {
+        ASSERT_EQ(length, sizeof(TaggedMessage));
+        ASSERT_LT(msg.producer_id, (uint32_t)producer_count)
+            << "invalid producer_id";
+        ASSERT_EQ(msg.sequence, next_expected[msg.producer_id])
+            << "out-of-order message from producer " << msg.producer_id;
+        ++next_expected[msg.producer_id];
+        ++received;
+      }
+    }
+  });
+
+  for (auto& t : producers) t.join();
+  consumer.join();
+
+  EXPECT_EQ(received, total_messages);
+  for (int p = 0; p < producer_count; ++p) {
+    EXPECT_EQ(next_expected[p], (uint32_t)messages_per_producer)
+        << "producer " << p << " missing messages";
+  }
+}
+
+// Concurrent producers using begin_write/commit_write (the zero-copy path).
+TEST_F(MpscQueueTest, ConcurrentBeginWriteCommit) {
+  SetUp(8192);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 8192, &queue));
+
+  const int producer_count = 4;
+  const int messages_per_producer = 10000;
+  const int total_messages = producer_count * messages_per_producer;
+
+  struct TaggedMessage {
+    uint32_t producer_id;
+    uint32_t sequence;
+  };
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < producer_count; ++p) {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
+      for (int i = 0; i < messages_per_producer; ++i) {
+        iree_mpsc_queue_reservation_t reservation;
+        void* payload;
+        while (!(payload = iree_mpsc_queue_begin_write(
+                     &queue, sizeof(TaggedMessage), &reservation))) {
+          std::this_thread::yield();
+        }
+        TaggedMessage msg = {(uint32_t)p, (uint32_t)i};
+        memcpy(payload, &msg, sizeof(msg));
+        iree_mpsc_queue_commit_write(&queue, reservation);
+      }
+    });
+  }
+
+  std::vector<uint32_t> next_expected(producer_count, 0);
+  int received = 0;
+
+  std::thread consumer([&]() {
+    while (received < total_messages) {
+      TaggedMessage msg = {};
+      iree_host_size_t length = 0;
+      if (iree_mpsc_queue_read(&queue, &msg, sizeof(msg), &length)) {
+        ASSERT_EQ(length, sizeof(TaggedMessage));
+        ASSERT_LT(msg.producer_id, (uint32_t)producer_count);
+        ASSERT_EQ(msg.sequence, next_expected[msg.producer_id])
+            << "out-of-order from producer " << msg.producer_id;
+        ++next_expected[msg.producer_id];
+        ++received;
+      }
+    }
+  });
+
+  for (auto& t : producers) t.join();
+  consumer.join();
+
+  EXPECT_EQ(received, total_messages);
+}
+
+// Variable-length messages from multiple concurrent producers.
+TEST_F(MpscQueueTest, ConcurrentVariableSizeStress) {
+  SetUp(16384);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 16384, &queue));
+
+  const int producer_count = 4;
+  const int messages_per_producer = 5000;
+  const int total_messages = producer_count * messages_per_producer;
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < producer_count; ++p) {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
+      for (int i = 0; i < messages_per_producer; ++i) {
+        // Variable payload: 8 bytes header + 0-120 bytes of fill.
+        // Header is (producer_id, sequence).
+        iree_host_size_t fill_size = (iree_host_size_t)(i % 121);
+        iree_host_size_t payload_size = sizeof(uint32_t) * 2 + fill_size;
+
+        uint8_t payload[256];
+        uint32_t producer_id = (uint32_t)p;
+        uint32_t sequence = (uint32_t)i;
+        memcpy(payload, &producer_id, sizeof(producer_id));
+        memcpy(payload + sizeof(producer_id), &sequence, sizeof(sequence));
+        memset(payload + sizeof(uint32_t) * 2, (uint8_t)(i & 0xFF), fill_size);
+
+        while (!iree_mpsc_queue_write(&queue, payload, payload_size)) {
+          std::this_thread::yield();
+        }
+      }
+    });
+  }
+
+  std::vector<uint32_t> next_expected(producer_count, 0);
+  int received = 0;
+
+  std::thread consumer([&]() {
+    uint8_t buffer[512];
+    while (received < total_messages) {
+      iree_host_size_t length = 0;
+      if (iree_mpsc_queue_read(&queue, buffer, sizeof(buffer), &length)) {
+        ASSERT_GE(length, sizeof(uint32_t) * 2);
+        uint32_t producer_id = 0;
+        uint32_t sequence = 0;
+        memcpy(&producer_id, buffer, sizeof(producer_id));
+        memcpy(&sequence, buffer + sizeof(producer_id), sizeof(sequence));
+        ASSERT_LT(producer_id, (uint32_t)producer_count);
+        ASSERT_EQ(sequence, next_expected[producer_id])
+            << "out-of-order from producer " << producer_id;
+        ++next_expected[producer_id];
+        ++received;
+      }
+    }
+  });
+
+  for (auto& t : producers) t.join();
+  consumer.join();
+
+  EXPECT_EQ(received, total_messages);
+}
+
+// Test that canceled entries from concurrent producers are correctly skipped.
+TEST_F(MpscQueueTest, ConcurrentCancelStress) {
+  SetUp(8192);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 8192, &queue));
+
+  const int producer_count = 4;
+  const int messages_per_producer = 5000;
+  const int total_committed = producer_count * messages_per_producer;
+
+  struct TaggedMessage {
+    uint32_t producer_id;
+    uint32_t sequence;
+  };
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < producer_count; ++p) {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
+      uint32_t committed = 0;
+      for (int i = 0; committed < (uint32_t)messages_per_producer; ++i) {
+        iree_mpsc_queue_reservation_t reservation;
+        void* payload;
+        while (!(payload = iree_mpsc_queue_begin_write(
+                     &queue, sizeof(TaggedMessage), &reservation))) {
+          std::this_thread::yield();
+        }
+
+        // Cancel every 7th reservation.
+        if (i % 7 == 3) {
+          iree_mpsc_queue_cancel_write(&queue, reservation);
+          continue;
+        }
+
+        TaggedMessage msg = {(uint32_t)p, committed};
+        memcpy(payload, &msg, sizeof(msg));
+        iree_mpsc_queue_commit_write(&queue, reservation);
+        ++committed;
+      }
+    });
+  }
+
+  std::vector<uint32_t> next_expected(producer_count, 0);
+  int received = 0;
+
+  std::thread consumer([&]() {
+    while (received < total_committed) {
+      TaggedMessage msg = {};
+      iree_host_size_t length = 0;
+      if (iree_mpsc_queue_read(&queue, &msg, sizeof(msg), &length)) {
+        ASSERT_EQ(length, sizeof(TaggedMessage));
+        ASSERT_LT(msg.producer_id, (uint32_t)producer_count);
+        ASSERT_EQ(msg.sequence, next_expected[msg.producer_id])
+            << "out-of-order from producer " << msg.producer_id;
+        ++next_expected[msg.producer_id];
+        ++received;
+      }
+    }
+  });
+
+  for (auto& t : producers) t.join();
+  consumer.join();
+
+  EXPECT_EQ(received, total_committed);
+}
+
+// Producer faster than consumer with backpressure.
+TEST_F(MpscQueueTest, ProducerFasterThanConsumer) {
+  SetUp(1024);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  const int total_messages = 10000;
+  std::atomic<int> consumer_count{0};
+
+  std::thread producer([&]() {
+    for (int i = 0; i < total_messages; ++i) {
+      uint32_t value = (uint32_t)i;
+      while (!iree_mpsc_queue_write(&queue, &value, sizeof(value))) {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  std::thread consumer([&]() {
+    uint32_t expected = 0;
+    while (expected < (uint32_t)total_messages) {
+      uint32_t value = 0;
+      iree_host_size_t length = 0;
+      if (iree_mpsc_queue_read(&queue, &value, sizeof(value), &length)) {
+        ASSERT_EQ(value, expected);
+        ++expected;
+        consumer_count.store((int)expected, std::memory_order_relaxed);
+        if (expected % 100 == 0) {
+          std::this_thread::yield();
+        }
+      }
+    }
+  });
+
+  producer.join();
+  consumer.join();
+
+  EXPECT_EQ(consumer_count.load(), total_messages);
+}
+
+// Large payloads near ring capacity.
+TEST_F(MpscQueueTest, LargePayload) {
+  SetUp(65536);
+  iree_mpsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_mpsc_queue_initialize(aligned_memory_, memory_size_, 65536, &queue));
+
+  // Write a payload that's close to half the ring capacity.
+  // align(4 + 32000, 8) = 32008 bytes per entry. Two of these fit in 65536.
+  const iree_host_size_t payload_size = 32000;
+  std::vector<uint8_t> expected(payload_size);
+  for (iree_host_size_t i = 0; i < payload_size; ++i) {
+    expected[i] = (uint8_t)(i & 0xFF);
+  }
+
+  ASSERT_TRUE(iree_mpsc_queue_write(&queue, expected.data(), payload_size));
+
+  std::vector<uint8_t> buffer(payload_size);
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(
+      iree_mpsc_queue_read(&queue, buffer.data(), buffer.size(), &length));
+  EXPECT_EQ(length, payload_size);
+  EXPECT_EQ(memcmp(buffer.data(), expected.data(), payload_size), 0);
+}
+
+}  // namespace

--- a/runtime/src/iree/base/internal/spsc_queue.c
+++ b/runtime/src/iree/base/internal/spsc_queue.c
@@ -300,6 +300,13 @@ void iree_spsc_queue_commit_write(iree_spsc_queue_t* queue,
                     iree_memory_order_release);
 }
 
+void iree_spsc_queue_cancel_write(iree_spsc_queue_t* queue) {
+  // No-op: begin_write only sets pending_* fields without modifying shared
+  // state (write_pos, data region). The next begin_write will overwrite the
+  // pending state, silently reclaiming the reserved space.
+  (void)queue;
+}
+
 bool iree_spsc_queue_write(iree_spsc_queue_t* queue, const void* data,
                            iree_host_size_t length) {
   void* payload = iree_spsc_queue_begin_write(queue, length);

--- a/runtime/src/iree/base/internal/spsc_queue.h
+++ b/runtime/src/iree/base/internal/spsc_queue.h
@@ -211,6 +211,16 @@ void* iree_spsc_queue_begin_write(iree_spsc_queue_t* queue,
 void iree_spsc_queue_commit_write(iree_spsc_queue_t* queue,
                                   iree_host_size_t length);
 
+// Cancels a previously reserved write without publishing.
+//
+// The reserved space is silently reclaimed by the next begin_write, which
+// overwrites the pending write state. This function exists to document intent
+// at call sites and enable debug-mode assertions.
+//
+// Must be called after a successful begin_write and before any subsequent
+// begin_write or commit_write.
+void iree_spsc_queue_cancel_write(iree_spsc_queue_t* queue);
+
 //===----------------------------------------------------------------------===//
 // Consumer API (single-threaded — not safe with concurrent consumers)
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/spsc_queue_test.cc
+++ b/runtime/src/iree/base/internal/spsc_queue_test.cc
@@ -389,6 +389,74 @@ TEST_F(SpscQueueTest, BeginWriteCommit) {
   }
 }
 
+TEST_F(SpscQueueTest, CancelWriteDoesNotPublish) {
+  iree_spsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_spsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  // Begin a write, fill it with a pattern, then cancel.
+  iree_host_size_t payload_size = 16;
+  void* payload = iree_spsc_queue_begin_write(&queue, payload_size);
+  ASSERT_NE(payload, nullptr);
+  memset(payload, 0xAA, payload_size);
+  iree_spsc_queue_cancel_write(&queue);
+
+  // Queue should still be empty — the cancelled write was not published.
+  EXPECT_FALSE(iree_spsc_queue_can_read(&queue));
+
+  // A subsequent begin_write should succeed at the same position (the cancelled
+  // reservation was reclaimed) and commit should work normally.
+  payload = iree_spsc_queue_begin_write(&queue, payload_size);
+  ASSERT_NE(payload, nullptr);
+  memset(payload, 0xBB, payload_size);
+  iree_spsc_queue_commit_write(&queue, payload_size);
+
+  // Read back and verify we get the second write's data, not the first.
+  uint8_t buffer[64];
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(iree_spsc_queue_read(&queue, buffer, sizeof(buffer), &length));
+  EXPECT_EQ(length, payload_size);
+  for (iree_host_size_t i = 0; i < length; ++i) {
+    EXPECT_EQ(buffer[i], 0xBB) << "at byte " << i;
+  }
+
+  // Queue should be empty again.
+  EXPECT_FALSE(iree_spsc_queue_can_read(&queue));
+}
+
+TEST_F(SpscQueueTest, CancelWriteMultiple) {
+  iree_spsc_queue_t queue;
+  IREE_ASSERT_OK(
+      iree_spsc_queue_initialize(aligned_memory_, memory_size_, 1024, &queue));
+
+  // Cancel several writes in a row, then commit one.
+  for (int i = 0; i < 5; ++i) {
+    void* payload = iree_spsc_queue_begin_write(&queue, sizeof(uint32_t));
+    ASSERT_NE(payload, nullptr) << "cancel iteration " << i;
+    uint32_t value = (uint32_t)(i + 100);
+    memcpy(payload, &value, sizeof(value));
+    iree_spsc_queue_cancel_write(&queue);
+    EXPECT_FALSE(iree_spsc_queue_can_read(&queue));
+  }
+
+  // Now commit a real write.
+  void* payload = iree_spsc_queue_begin_write(&queue, sizeof(uint32_t));
+  ASSERT_NE(payload, nullptr);
+  uint32_t final_value = 42;
+  memcpy(payload, &final_value, sizeof(final_value));
+  iree_spsc_queue_commit_write(&queue, sizeof(uint32_t));
+
+  // Should get exactly the committed value.
+  uint32_t read_value = 0;
+  iree_host_size_t length = 0;
+  ASSERT_TRUE(
+      iree_spsc_queue_read(&queue, &read_value, sizeof(read_value), &length));
+  EXPECT_EQ(length, sizeof(uint32_t));
+  EXPECT_EQ(read_value, (uint32_t)42);
+
+  EXPECT_FALSE(iree_spsc_queue_can_read(&queue));
+}
+
 TEST_F(SpscQueueTest, BeginWriteFullReturnsNull) {
   SetUp(64);
   iree_spsc_queue_t queue;


### PR DESCRIPTION
Adds a lock-free MPSC (multiple-producer single-consumer) queue for variable-length messages over caller-provided memory, designed for cross-process shared memory transport. Also adds `cancel_write` to the existing SPSC queue for API symmetry.

- **MPSC queue** (`iree_mpsc_queue_{initialize,open,write,begin_write, commit_write,cancel_write,peek,consume,read}`): CAS-based reservation with monotonic 64-bit positions and power-of-two masking. The 4-byte length prefix doubles as entry state (0=uncommitted, 1-0x7FFFFFFF= committed, 0x80000001-0xFFFFFFFE=canceled, 0xFFFFFFFF=skip marker).
  Entries are delivered in reservation order with head-of-line blocking for uncommitted entries. The consumer zeroes entire entry regions on consume to prevent stale payload data from being misinterpreted as entry states on subsequent ring iterations.

- **SPSC `cancel_write`**: No-op that documents intent at call sites — the SPSC `begin_write` only touches pending state so canceling requires no work, but having the API available lets callers use a uniform begin/commit-or-cancel pattern across both queue types.

- **Input validation**: `begin_write` rejects zero-length payloads (0 collides with the "uncommitted" state), payloads exceeding 2GB-1 (upper bit reserved for cancel flag), and entries whose aligned size exceeds ring capacity (prevents infinite retry loops indistinguishable from backpressure).

- **Test coverage**: ~1000 lines covering initialization/validation, single-threaded producer/consumer, wrapping/skip markers, entry alignment padding, backpressure fill/drain/refill, variable-size reuse correctness (stale prefix detection), zero-copy begin/commit path, cancel-then-commit sequencing, and multi-threaded stress tests (single-producer, multi-producer, variable-size, concurrent cancel, producer-faster-than-consumer).

## Design notes

The MPSC queue shares the SPSC queue's memory layout philosophy — flat header + data region over caller-provided memory, no heap allocation, ABI-versioned header with magic/version for cross-process open. The key difference is the CAS-based reservation protocol: producers atomically advance `reserve_position` to claim ring space, then independently
commit (or cancel) their entries. The consumer processes entries strictly in reservation order, which means a slow producer causes head-of-line blocking — acceptable because the transport layer delivers messages in order.

The consumer maintains the ring invariant by zeroing the full entry region (prefix + payload + padding) on every consume, skip, and cancel advance. This is necessary because variable-length entries across ring iterations can cause a new entry's length prefix to land at a physical offset that was previously inside a larger entry's payload. Without full-region zeroing, stale payload bytes would be misinterpreted as entry states by the consumer.