### PR TITLE
[Codegen] Fix uninitialized tensorCoreType causing flaky vector_to_gpu tests.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -175,7 +175,7 @@ public:
   }
 
 private:
-  GPUTensorCoreType tensorCoreType;
+  GPUTensorCoreType tensorCoreType = GPUTensorCoreType::WMMA;
 };
 } // namespace
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -100,7 +100,7 @@ struct LLVMGPUVectorToGPUPass final
   }
 
 private:
-  GPUTensorCoreType tensorCoreType;
+  GPUTensorCoreType tensorCoreType = GPUTensorCoreType::WMMA;
 };
 } // namespace
 


### PR DESCRIPTION
Both LLVMGPUVectorToGPUPass and LLVMGPUTensorCoreVectorizationPass had an uninitialized GPUTensorCoreType member. When constructed via the inherited TableGen base class constructor (pipeline string invocation), the member was never set — reading it was undefined behavior. When stack garbage happened to equal MMA_SYNC (1), the passes took a wrong code path (e.g. running populateFoldMemRefAliasOpPatterns which folded subviews back into transfer_reads), producing IR that didn't match CHECK lines.

Initialize both to WMMA, matching the existing explicit constructor default.