### PR TITLE
[Codegen][VectorExt] Add TransferScatterOp interface implementations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cstdint>
+#include <type_traits>
+#include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
@@ -584,111 +586,161 @@ struct DistributeTransferWrite final
   std::optional<int64_t> numThreadsInWorkgroup = std::nullopt;
 };
 
-/// Pattern to distribute `vector.transfer_gather` ops with nested layouts.
-struct DistributeTransferGather final
-    : OpDistributionPattern<IREE::VectorExt::TransferGatherOp> {
-  using OpDistributionPattern::OpDistributionPattern;
+/// Distribute index vecs and mask for transfer_gather/scatter. Returns failure
+/// if any vector has a non-nested layout.
+static LogicalResult distributeIndexVecsAndMask(
+    const DistributionPattern &pattern, Operation *op,
+    PatternRewriter &rewriter, DistributionSignature &signature,
+    OperandRange indexVecs,
+    SmallVectorImpl<NestedLayoutAttr> &indexVecLayouts,
+    SmallVectorImpl<VectorValue> &disIndexVecs, VectorValue &mask,
+    NestedLayoutAttr &maskLayout) {
+  for (Value indexVec : indexVecs) {
+    auto vec = cast<VectorValue>(indexVec);
+    NestedLayoutAttr layout = dyn_cast<NestedLayoutAttr>(signature[vec]);
+    if (!layout) {
+      return rewriter.notifyMatchFailure(op, "non-nested index vec layout");
+    }
+    indexVecLayouts.push_back(layout);
+    vec = pattern.getDistributed(rewriter, vec, layout);
+    vec = getDeinterleavedUnpackedForm(rewriter, vec, layout);
+    disIndexVecs.push_back(vec);
+  }
 
-  DistributeTransferGather(MLIRContext *context, Value threadId,
-                           int64_t subgroupSize)
-      : OpDistributionPattern(context), threadId(threadId),
+  if (mask) {
+    maskLayout = dyn_cast<NestedLayoutAttr>(signature[mask]);
+    if (!maskLayout) {
+      return rewriter.notifyMatchFailure(op, "non-nested mask vector layout");
+    }
+    mask = pattern.getDistributed(rewriter, mask, maskLayout);
+    mask = getDeinterleavedUnpackedForm(rewriter, mask, maskLayout);
+  }
+  return success();
+}
+
+/// Pre-compute all mask offsets and index vec offset iterators.
+static void precomputeOffsetIterators(
+    VectorValue mask, NestedLayoutAttr maskLayout,
+    ArrayRef<NestedLayoutAttr> indexVecLayouts,
+    SmallVectorImpl<SmallVector<int64_t>> &allMaskOffsets,
+    std::vector<StaticTileOffsetRange::IteratorTy> &allIndexVecOffsets) {
+  if (mask) {
+    SmallVector<int64_t> maskDistShape = maskLayout.getDistributedShape();
+    SmallVector<int64_t> maskTileShape = getElementVectorTileShape(maskLayout);
+    allMaskOffsets =
+        llvm::to_vector(StaticTileOffsetRange(maskDistShape, maskTileShape));
+  }
+  for (NestedLayoutAttr layout : indexVecLayouts) {
+    SmallVector<int64_t> vecDistShape = layout.getDistributedShape();
+    SmallVector<int64_t> vecTileShape = getElementVectorTileShape(layout);
+    allIndexVecOffsets.push_back(
+        StaticTileOffsetRange(vecDistShape, vecTileShape).begin());
+  }
+}
+
+/// Slice index vecs and mask for a single iteration of the distribution loop.
+static void sliceIndexVecsAndMask(
+    PatternRewriter &rewriter, Location loc, int64_t idx,
+    ArrayRef<VectorValue> disIndexVecs,
+    ArrayRef<NestedLayoutAttr> indexVecLayouts,
+    std::vector<StaticTileOffsetRange::IteratorTy> &allIndexVecOffsets,
+    VectorValue mask, NestedLayoutAttr maskLayout,
+    const SmallVector<SmallVector<int64_t>> &allMaskOffsets,
+    SmallVectorImpl<Value> &slicedIndexVecs, VectorValue &slicedMask) {
+  for (auto [indexVecIdx, disIndexVec, layout] :
+       llvm::enumerate(disIndexVecs, indexVecLayouts)) {
+    SmallVector<int64_t> offsets =
+        llvm::to_vector(*(allIndexVecOffsets[indexVecIdx]));
+    ++allIndexVecOffsets[indexVecIdx];
+    VectorValue slicedIndexVec =
+        getSlicedPermutedValue(rewriter, loc, offsets, layout, disIndexVec);
+    slicedIndexVecs.push_back(slicedIndexVec);
+  }
+
+  slicedMask = nullptr;
+  if (mask) {
+    SmallVector<int64_t> maskOffsets = allMaskOffsets[idx];
+    slicedMask =
+        getSlicedPermutedValue(rewriter, loc, maskOffsets, maskLayout, mask);
+  }
+}
+
+/// Pattern to distribute `iree_vector_ext.transfer_gather` and
+/// `iree_vector_ext.transfer_scatter` ops with nested layouts.
+template <typename OpTy>
+struct DistributeTransferGatherScatter final
+    : OpDistributionPattern<OpTy> {
+  using OpDistributionPattern<OpTy>::OpDistributionPattern;
+
+  DistributeTransferGatherScatter(MLIRContext *context, Value threadId,
+                                  int64_t subgroupSize)
+      : OpDistributionPattern<OpTy>(context), threadId(threadId),
         subgroupSize(subgroupSize) {}
 
-  LogicalResult matchAndRewrite(IREE::VectorExt::TransferGatherOp gatherOp,
-                                DistributionSignature &signature,
+  LogicalResult matchAndRewrite(OpTy op, DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
-
+    // Both ops name their vector operand/result $vector, so getVector() works
+    // for looking up the layout in both cases.
     NestedLayoutAttr vectorLayout =
-        dyn_cast<NestedLayoutAttr>(signature[gatherOp.getResult()]);
+        dyn_cast<NestedLayoutAttr>(signature[op.getVector()]);
     if (!vectorLayout) {
-      return rewriter.notifyMatchFailure(gatherOp,
-                                         "non-nested transfer_gather layout");
+      return rewriter.notifyMatchFailure(op, "non-nested layout");
     }
 
     SmallVector<NestedLayoutAttr> indexVecLayouts;
     SmallVector<VectorValue> disIndexVecs;
-    for (Value indexVec : gatherOp.getIndexVecs()) {
-      auto vec = cast<VectorValue>(indexVec);
-      NestedLayoutAttr layout = dyn_cast<NestedLayoutAttr>(signature[vec]);
-      if (!layout) {
-        return rewriter.notifyMatchFailure(gatherOp,
-                                           "non-nested index vec layout");
-      }
-      indexVecLayouts.push_back(layout);
-      vec = getDistributed(rewriter, vec, layout);
-      vec = getDeinterleavedUnpackedForm(rewriter, vec, layout);
-      disIndexVecs.push_back(vec);
-    }
-
-    VectorValue mask = gatherOp.getMask();
+    VectorValue mask = op.getMask();
     NestedLayoutAttr maskLayout;
-    if (mask) {
-      maskLayout = dyn_cast<NestedLayoutAttr>(signature[mask]);
-      if (!maskLayout) {
-        return rewriter.notifyMatchFailure(gatherOp,
-                                           "non-nested mask vector layout");
-      }
-      mask = getDistributed(rewriter, mask, maskLayout);
-      mask = getDeinterleavedUnpackedForm(rewriter, mask, maskLayout);
+    if (failed(distributeIndexVecsAndMask(*this, op, rewriter, signature,
+                                          op.getIndexVecs(), indexVecLayouts,
+                                          disIndexVecs, mask, maskLayout))) {
+      return failure();
     }
 
-    // Guard on memrefs for distribution. In isolation this pattern is agnostic
-    // to tensors or memrefs.
-    if (!isa<MemRefType>(gatherOp.getBase().getType())) {
-      return rewriter.notifyMatchFailure(gatherOp,
-                                         "distribution expects memrefs");
+    if (!isa<MemRefType>(op.getBase().getType())) {
+      return rewriter.notifyMatchFailure(op, "distribution expects memrefs");
     }
 
     SmallVector<int64_t> distShape = vectorLayout.getDistributedShape();
     SmallVector<int64_t> tileShape = getElementVectorTileShape(vectorLayout);
     int64_t rank = vectorLayout.getRank();
 
-    Type elementType = gatherOp.getBase().getType().getElementType();
-    auto vectorType = VectorType::get(distShape, elementType);
-    // The shape of the vector we read is pre-permutation. The permutation is
-    // a transpose on the resulting read vector.
-    auto innerVectorType =
-        VectorType::get(vectorLayout.getElementTile(), elementType);
-
-    // Initialize the full distributed vector for unrolling the batch/outer
-    // vector dimensions.
-    Value zero =
-        arith::ConstantOp::create(rewriter, gatherOp.getLoc(), vectorType,
-                                  rewriter.getZeroAttr(vectorType));
-    VectorValue acc = cast<VectorValue>(zero);
-
     SmallVector<Value> warpIndices, threadIndices;
     if (failed(populateWarpAndThreadIndices(rewriter, threadId, subgroupSize,
                                             vectorLayout, warpIndices,
                                             threadIndices))) {
       return rewriter.notifyMatchFailure(
-          gatherOp, "warp or thread tiles have overlapping strides");
+          op, "warp or thread tiles have overlapping strides");
     }
 
-    ValueRange indices = gatherOp.getOffsets();
-    SmallVector<int64_t> strides(rank, 1);
+    // Gather: create an accumulator to assemble the distributed result.
+    // Scatter: distribute the input vector for slicing.
+    VectorValue acc;
+    Value distributedVector;
+    VectorType innerVectorType;
+    if constexpr (std::is_same_v<OpTy,
+                                 IREE::VectorExt::TransferGatherOp>) {
+      Type elementType = op.getBase().getType().getElementType();
+      auto vectorType = VectorType::get(distShape, elementType);
+      innerVectorType =
+          VectorType::get(vectorLayout.getElementTile(), elementType);
+      Value zero =
+          arith::ConstantOp::create(rewriter, op.getLoc(), vectorType,
+                                    rewriter.getZeroAttr(vectorType));
+      acc = cast<VectorValue>(zero);
+    } else {
+      distributedVector =
+          this->getDistributed(rewriter, op.getVector(), vectorLayout);
+    }
 
-    // getPermutationMap inverts the source map, mapping gathered (symbol) and
-    // broadcast (constant) dims to constant 0. This is correct here because
-    // getTransferIndicesFromNestedLayout treats constant-0 dims as broadcast,
-    // leaving the original base offset unchanged for gathered dimensions.
-    AffineMap permMap = gatherOp.getPermutationMap();
+    ValueRange indices = op.getOffsets();
+    SmallVector<int64_t> strides(rank, 1);
+    AffineMap permMap = op.getPermutationMap();
 
     SmallVector<SmallVector<int64_t>> allMaskOffsets;
     std::vector<StaticTileOffsetRange::IteratorTy> allIndexVecOffsets;
-    if (mask) {
-      SmallVector<int64_t> maskDistShape = maskLayout.getDistributedShape();
-      SmallVector<int64_t> maskTileShape =
-          getElementVectorTileShape(maskLayout);
-      allMaskOffsets =
-          llvm::to_vector(StaticTileOffsetRange(maskDistShape, maskTileShape));
-    }
-    for (NestedLayoutAttr layout : indexVecLayouts) {
-      SmallVector<int64_t> vecDistShape = layout.getDistributedShape();
-      SmallVector<int64_t> vecTileShape = getElementVectorTileShape(layout);
-      allIndexVecOffsets.push_back(
-          StaticTileOffsetRange(vecDistShape, vecTileShape).begin());
-    }
+    precomputeOffsetIterators(mask, maskLayout, indexVecLayouts, allMaskOffsets,
+                              allIndexVecOffsets);
 
     for (auto [idx, offsets] :
          llvm::enumerate(StaticTileOffsetRange(distShape, tileShape))) {
@@ -696,45 +748,44 @@ struct DistributeTransferGather final
           rewriter, indices, offsets, vectorLayout, permMap, warpIndices,
           threadIndices);
 
-      // Extract offset from index_vecs.
       SmallVector<Value> slicedIndexVecs;
-      for (auto [indexVecIdx, disIndexVec, layout] :
-           llvm::enumerate(disIndexVecs, indexVecLayouts)) {
-        SmallVector<int64_t> offsets =
-            llvm::to_vector(*(allIndexVecOffsets[indexVecIdx]));
-        ++allIndexVecOffsets[indexVecIdx];
-        VectorValue slicedIndexVec = getSlicedPermutedValue(
-            rewriter, gatherOp.getLoc(), offsets, layout, disIndexVec);
-        slicedIndexVecs.push_back(slicedIndexVec);
-      }
+      VectorValue slicedMask;
+      sliceIndexVecsAndMask(rewriter, op.getLoc(), idx, disIndexVecs,
+                            indexVecLayouts, allIndexVecOffsets, mask,
+                            maskLayout, allMaskOffsets, slicedIndexVecs,
+                            slicedMask);
 
-      VectorValue slicedMask = nullptr;
-      if (mask) {
-        SmallVector<int64_t> maskDistShape = maskLayout.getDistributedShape();
-        SmallVector<int64_t> maskTileShape =
-            getElementVectorTileShape(maskLayout);
-        SmallVector<int64_t> maskOffsets = allMaskOffsets[idx];
-        slicedMask = getSlicedPermutedValue(rewriter, gatherOp.getLoc(),
-                                            maskOffsets, maskLayout, mask);
-      }
-
-      VectorValue slicedGather = IREE::VectorExt::TransferGatherOp::create(
-          rewriter, gatherOp.getLoc(), innerVectorType, gatherOp.getBase(),
-          slicedIndices, slicedIndexVecs, gatherOp.getIndexingMapsAttr(),
-          gatherOp.getPadding(), slicedMask);
-
-      if (acc.getType().getRank() == 0) {
-        // TODO: This should really be a folding pattern in
-        // insert_strided_slice, but instead insert_strided_slice just doesn't
-        // support 0-d vectors...
-        acc = slicedGather;
+      if constexpr (std::is_same_v<OpTy,
+                                   IREE::VectorExt::TransferGatherOp>) {
+        VectorValue slicedGather =
+            IREE::VectorExt::TransferGatherOp::create(
+                rewriter, op.getLoc(), innerVectorType, op.getBase(),
+                slicedIndices, slicedIndexVecs, op.getIndexingMapsAttr(),
+                op.getPadding(), slicedMask);
+        if (acc.getType().getRank() == 0) {
+          acc = slicedGather;
+        } else {
+          acc = vector::InsertStridedSliceOp::create(
+              rewriter, op.getLoc(), slicedGather, acc, offsets, strides);
+        }
       } else {
-        acc = vector::InsertStridedSliceOp::create(
-            rewriter, gatherOp.getLoc(), slicedGather, acc, offsets, strides);
+        ArrayRef<int64_t> offsetArray(offsets);
+        VectorValue slicedVector = extractSliceAsVector(
+            rewriter, op.getLoc(), distributedVector,
+            offsetArray.take_front(rank * 2));
+        IREE::VectorExt::TransferScatterOp::create(
+            rewriter, op.getLoc(), /*resultTypes=*/TypeRange{}, op.getBase(),
+            slicedVector, slicedIndices, slicedIndexVecs,
+            op.getIndexingMapsAttr(), slicedMask);
       }
     }
 
-    replaceOpWithDistributedValues(rewriter, gatherOp, acc);
+    if constexpr (std::is_same_v<OpTy,
+                                 IREE::VectorExt::TransferGatherOp>) {
+      this->replaceOpWithDistributedValues(rewriter, op, acc);
+    } else {
+      rewriter.eraseOp(op);
+    }
     return success();
   }
 
@@ -2212,9 +2263,13 @@ struct DistributeInnerTiled final
 void IREE::VectorExt::populateNestedLayoutDistributionPatterns(
     RewritePatternSet &patterns, Value threadId, int64_t subgroupSize,
     ArrayRef<int64_t> workgroupSize, int64_t maxBitsPerShuffle) {
-  patterns.add<DistributeTransferRead, DistributeTransferGather,
-               DistributeMapStore>(patterns.getContext(), threadId,
-                                   subgroupSize);
+  patterns.add<DistributeTransferRead,
+               DistributeTransferGatherScatter<
+                   IREE::VectorExt::TransferGatherOp>,
+               DistributeTransferGatherScatter<
+                   IREE::VectorExt::TransferScatterOp>,
+               DistributeMapStore>(
+      patterns.getContext(), threadId, subgroupSize);
   patterns.add<DistributeTransferWrite>(patterns.getContext(), threadId,
                                         subgroupSize, workgroupSize);
   patterns.add<DistributeBroadcast, DistributeTranspose, DistributeShapeCast>(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -591,8 +591,7 @@ struct DistributeTransferWrite final
 static LogicalResult distributeIndexVecsAndMask(
     const DistributionPattern &pattern, Operation *op,
     PatternRewriter &rewriter, DistributionSignature &signature,
-    OperandRange indexVecs,
-    SmallVectorImpl<NestedLayoutAttr> &indexVecLayouts,
+    OperandRange indexVecs, SmallVectorImpl<NestedLayoutAttr> &indexVecLayouts,
     SmallVectorImpl<VectorValue> &disIndexVecs, VectorValue &mask,
     NestedLayoutAttr &maskLayout) {
   for (Value indexVec : indexVecs) {
@@ -668,8 +667,7 @@ static void sliceIndexVecsAndMask(
 /// Pattern to distribute `iree_vector_ext.transfer_gather` and
 /// `iree_vector_ext.transfer_scatter` ops with nested layouts.
 template <typename OpTy>
-struct DistributeTransferGatherScatter final
-    : OpDistributionPattern<OpTy> {
+struct DistributeTransferGatherScatter final : OpDistributionPattern<OpTy> {
   using OpDistributionPattern<OpTy>::OpDistributionPattern;
 
   DistributeTransferGatherScatter(MLIRContext *context, Value threadId,
@@ -718,15 +716,13 @@ struct DistributeTransferGatherScatter final
     VectorValue acc;
     Value distributedVector;
     VectorType innerVectorType;
-    if constexpr (std::is_same_v<OpTy,
-                                 IREE::VectorExt::TransferGatherOp>) {
+    if constexpr (std::is_same_v<OpTy, IREE::VectorExt::TransferGatherOp>) {
       Type elementType = op.getBase().getType().getElementType();
       auto vectorType = VectorType::get(distShape, elementType);
       innerVectorType =
           VectorType::get(vectorLayout.getElementTile(), elementType);
-      Value zero =
-          arith::ConstantOp::create(rewriter, op.getLoc(), vectorType,
-                                    rewriter.getZeroAttr(vectorType));
+      Value zero = arith::ConstantOp::create(rewriter, op.getLoc(), vectorType,
+                                             rewriter.getZeroAttr(vectorType));
       acc = cast<VectorValue>(zero);
     } else {
       distributedVector =
@@ -755,13 +751,11 @@ struct DistributeTransferGatherScatter final
                             maskLayout, allMaskOffsets, slicedIndexVecs,
                             slicedMask);
 
-      if constexpr (std::is_same_v<OpTy,
-                                   IREE::VectorExt::TransferGatherOp>) {
-        VectorValue slicedGather =
-            IREE::VectorExt::TransferGatherOp::create(
-                rewriter, op.getLoc(), innerVectorType, op.getBase(),
-                slicedIndices, slicedIndexVecs, op.getIndexingMapsAttr(),
-                op.getPadding(), slicedMask);
+      if constexpr (std::is_same_v<OpTy, IREE::VectorExt::TransferGatherOp>) {
+        VectorValue slicedGather = IREE::VectorExt::TransferGatherOp::create(
+            rewriter, op.getLoc(), innerVectorType, op.getBase(), slicedIndices,
+            slicedIndexVecs, op.getIndexingMapsAttr(), op.getPadding(),
+            slicedMask);
         if (acc.getType().getRank() == 0) {
           acc = slicedGather;
         } else {
@@ -770,9 +764,9 @@ struct DistributeTransferGatherScatter final
         }
       } else {
         ArrayRef<int64_t> offsetArray(offsets);
-        VectorValue slicedVector = extractSliceAsVector(
-            rewriter, op.getLoc(), distributedVector,
-            offsetArray.take_front(rank * 2));
+        VectorValue slicedVector =
+            extractSliceAsVector(rewriter, op.getLoc(), distributedVector,
+                                 offsetArray.take_front(rank * 2));
         IREE::VectorExt::TransferScatterOp::create(
             rewriter, op.getLoc(), /*resultTypes=*/TypeRange{}, op.getBase(),
             slicedVector, slicedIndices, slicedIndexVecs,
@@ -780,8 +774,7 @@ struct DistributeTransferGatherScatter final
       }
     }
 
-    if constexpr (std::is_same_v<OpTy,
-                                 IREE::VectorExt::TransferGatherOp>) {
+    if constexpr (std::is_same_v<OpTy, IREE::VectorExt::TransferGatherOp>) {
       this->replaceOpWithDistributedValues(rewriter, op, acc);
     } else {
       rewriter.eraseOp(op);
@@ -2263,13 +2256,11 @@ struct DistributeInnerTiled final
 void IREE::VectorExt::populateNestedLayoutDistributionPatterns(
     RewritePatternSet &patterns, Value threadId, int64_t subgroupSize,
     ArrayRef<int64_t> workgroupSize, int64_t maxBitsPerShuffle) {
-  patterns.add<DistributeTransferRead,
-               DistributeTransferGatherScatter<
-                   IREE::VectorExt::TransferGatherOp>,
-               DistributeTransferGatherScatter<
-                   IREE::VectorExt::TransferScatterOp>,
-               DistributeMapStore>(
-      patterns.getContext(), threadId, subgroupSize);
+  patterns
+      .add<DistributeTransferRead,
+           DistributeTransferGatherScatter<IREE::VectorExt::TransferGatherOp>,
+           DistributeTransferGatherScatter<IREE::VectorExt::TransferScatterOp>,
+           DistributeMapStore>(patterns.getContext(), threadId, subgroupSize);
   patterns.add<DistributeTransferWrite>(patterns.getContext(), threadId,
                                         subgroupSize, workgroupSize);
   patterns.add<DistributeBroadcast, DistributeTranspose, DistributeShapeCast>(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1343,6 +1343,47 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // -----
 
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4, 1],
+  batch_tile = [4, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [1, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @paged_transfer_scatter(%indices: vector<16xindex>,
+  %vector: vector<16x8xf16>,
+  %dest: memref<4096x512x8xf16>) {
+
+  %c0 = arith.constant 0 : index
+
+  %l_vec = iree_vector_ext.to_layout %vector to layout(#layout) : vector<16x8xf16>
+
+  iree_vector_ext.transfer_scatter %l_vec into %dest[%c0, %c0, %c0]
+  [%indices : vector<16xindex>] {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>]
+  } : vector<16x8xf16>, memref<4096x512x8xf16>
+
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: @paged_transfer_scatter
+// CHECK-COUNT-4: vector_ext.transfer_scatter
+
+// -----
+
 #layout_row_major = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile    = [2, 2],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -416,3 +416,55 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[MASK3:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
 // CHECK: %[[CMASK3:.+]] = vector.shape_cast %[[MASK3]] : vector<1x8xi1> to vector<8xi1>
 // CHECK: vector.transfer_read {{.+}} %[[CMASK3]]
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4, 1],
+  batch_tile = [4, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [1, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @paged_transfer_scatter_mask(%indices: vector<16xindex>,
+  %vector: vector<16x8xf16>,
+  %dest: memref<4096x512x8xf16>) {
+
+  %cst0 = arith.constant 0.0 : f16
+  %c0 = arith.constant 0 : index
+  %c7 = arith.constant 7 : index
+  %mask = vector.create_mask %c7, %c7 : vector<16x8xi1>
+
+  %l_vec = iree_vector_ext.to_layout %vector to layout(#layout) : vector<16x8xf16>
+
+  iree_vector_ext.transfer_scatter %l_vec into %dest[%c0, %c0, %c0]
+  [%indices : vector<16xindex>], %mask {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>,
+                     affine_map<(d0, d1)[s0] -> (d0, d1)>]
+  } : vector<16x8xf16>, memref<4096x512x8xf16>, vector<16x8xi1>
+
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: @paged_transfer_scatter_mask
+// CHECK: %[[MASK0:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
+// CHECK: transfer_scatter {{.+}} %[[MASK0]]
+// CHECK: %[[MASK1:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
+// CHECK: transfer_scatter {{.+}} %[[MASK1]]
+// CHECK: %[[MASK2:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
+// CHECK: transfer_scatter {{.+}} %[[MASK2]]
+// CHECK: %[[MASK3:.+]] = vector.create_mask %{{.+}}, %c7 : vector<1x8xi1>
+// CHECK: transfer_scatter {{.+}} %[[MASK3]]

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -89,6 +89,11 @@ struct LayoutAnalysis {
   void fixupRegion(Region &region);
   void fixupOp(Operation *op);
   void setLayoutOrClone(OpOperand *val, VectorLayoutInterface layout);
+  void propagateLayoutToIndexVecsAndMask(
+      VectorLayoutInterface layout, MutableOperandRange indexVecOperands,
+      int64_t numIndexVecs,
+      std::optional<std::reference_wrapper<OpOperand>> maskOperand,
+      ArrayRef<AffineMap> indexingMaps);
 };
 
 } // namespace
@@ -266,6 +271,12 @@ void LayoutAnalysis::propagateOneForward(Value val,
       continue;
     }
 
+    if (isa<TransferScatterOp>(user)) {
+      // Scatter consumes the vector; index vec/mask layouts are assigned
+      // during Phase 2 fixup. Nothing to propagate forward.
+      continue;
+    }
+
     if (auto shapeCast = dyn_cast<vector::ShapeCastOp>(user)) {
       addCandidate(shapeCast.getResult(),
                    layout.reshape(shapeCast.getResultVectorType().getShape()));
@@ -415,21 +426,31 @@ void LayoutAnalysis::fixupOp(Operation *op) {
       return;
     }
     SmallVector<AffineMap> maps = gather.getIndexingMapsArray();
-    int64_t numIndexVecs = gather.getIndexVecs().size();
-    for (auto [i, operand] : llvm::enumerate(gather.getIndexVecsMutable())) {
-      AffineMap indexVecMap = maps[1 + i];
-      AffineMap projected =
-          AffineMap::get(indexVecMap.getNumDims(), 0, indexVecMap.getResults(),
-                         indexVecMap.getContext());
-      setLayoutOrClone(&operand, layout.apply(projected));
-    }
+    std::optional<std::reference_wrapper<OpOperand>> maskOp;
     if (gather.getMask()) {
-      OpOperand &mask = gather.getMaskMutable()[0];
-      AffineMap maskMap = maps[1 + numIndexVecs];
-      AffineMap projected = AffineMap::get(
-          maskMap.getNumDims(), 0, maskMap.getResults(), maskMap.getContext());
-      setLayoutOrClone(&mask, layout.apply(projected));
+      maskOp = gather.getMaskMutable()[0];
     }
+    propagateLayoutToIndexVecsAndMask(layout, gather.getIndexVecsMutable(),
+                                      gather.getIndexVecs().size(), maskOp,
+                                      maps);
+    return;
+  }
+
+  // transfer_scatter: vector layout -> index vecs + mask get projected layouts.
+  if (auto scatter = dyn_cast<TransferScatterOp>(op)) {
+    VectorLayoutInterface layout =
+        getResolvedLayout(scatter.getVector());
+    if (!layout) {
+      return;
+    }
+    SmallVector<AffineMap> maps = scatter.getIndexingMapsArray();
+    std::optional<std::reference_wrapper<OpOperand>> maskOp;
+    if (scatter.getMask()) {
+      maskOp = scatter.getMaskMutable()[0];
+    }
+    propagateLayoutToIndexVecsAndMask(layout, scatter.getIndexVecsMutable(),
+                                      scatter.getIndexVecs().size(), maskOp,
+                                      maps);
     return;
   }
 
@@ -461,6 +482,27 @@ void LayoutAnalysis::fixupOp(Operation *op) {
   // (e.g. scf.forall, scf.if, vector.mask).
   for (Region &region : op->getRegions()) {
     fixupRegion(region);
+  }
+}
+
+void LayoutAnalysis::propagateLayoutToIndexVecsAndMask(
+    VectorLayoutInterface layout, MutableOperandRange indexVecOperands,
+    int64_t numIndexVecs,
+    std::optional<std::reference_wrapper<OpOperand>> maskOperand,
+    ArrayRef<AffineMap> indexingMaps) {
+  for (auto [i, operand] : llvm::enumerate(indexVecOperands)) {
+    AffineMap indexVecMap = indexingMaps[1 + i];
+    AffineMap projected =
+        AffineMap::get(indexVecMap.getNumDims(), 0, indexVecMap.getResults(),
+                       indexVecMap.getContext());
+    setLayoutOrClone(&operand, layout.apply(projected));
+  }
+  if (maskOperand) {
+    OpOperand &mask = maskOperand->get();
+    AffineMap maskMap = indexingMaps[1 + numIndexVecs];
+    AffineMap projected = AffineMap::get(
+        maskMap.getNumDims(), 0, maskMap.getResults(), maskMap.getContext());
+    setLayoutOrClone(&mask, layout.apply(projected));
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -438,8 +438,7 @@ void LayoutAnalysis::fixupOp(Operation *op) {
 
   // transfer_scatter: vector layout -> index vecs + mask get projected layouts.
   if (auto scatter = dyn_cast<TransferScatterOp>(op)) {
-    VectorLayoutInterface layout =
-        getResolvedLayout(scatter.getVector());
+    VectorLayoutInterface layout = getResolvedLayout(scatter.getVector());
     if (!layout) {
       return;
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3125,6 +3125,22 @@ func.func @transfer_gather(%source : tensor<?x64xf16>, %indices: vector<8xindex>
 
 // -----
 
+func.func @transfer_scatter(%dest : tensor<?x64xf16>, %vector: vector<8x64xf16>, %indices: vector<8xindex>) -> tensor<?x64xf16> {
+  %c0 = arith.constant 0 : index
+  %out = iree_vector_ext.transfer_scatter %vector into %dest[%c0, %c0]
+  [%indices : vector<8xindex>] {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>]
+  } : vector<8x64xf16>, tensor<?x64xf16> -> tensor<?x64xf16>
+  return %out : tensor<?x64xf16>
+}
+
+// CHECK-LABEL: func.func @transfer_scatter
+// CHECK-SAME: %[[DEST:.+]]: tensor<?x64xf16>, %[[VECTOR:.+]]: vector<8x64xf16>, %[[INDICES:.+]]: vector<8xindex>
+// CHECK: iree_vector_ext.transfer_scatter %[[VECTOR]] into %{{.+}}[%{{.+}}, %{{.+}}] [%[[INDICES]] : vector<8xindex>]
+
+// -----
+
 func.func @swizzle_hint(%arg0: tensor<1024xf32>) -> tensor<1024xf32> {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -938,6 +938,55 @@ func.func @clone_shared_mask_on_layout_conflict(
 // have no resolved layout (no to_layout anchor). Without null-guards, fixup
 // would call layout.permute() / layout.project() on a null layout.
 
+// -----
+
+#layout_1d = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4],
+  batch_tile = [4],
+  outer_tile = [1],
+  thread_tile = [1],
+  element_tile = [1],
+
+  subgroup_strides = [1],
+  thread_strides = [0]
+>
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4, 1],
+  batch_tile = [4, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [1, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @paged_transfer_scatter(%indices: vector<16xindex>,
+  %vector: vector<16x8xf16>,
+  %dest: memref<4096x512x8xf16>) {
+
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant dense<1> : vector<16xindex>
+  // expected-remark @above {{element_tile = [1]}}
+  %c7 = arith.constant 7 : index
+  %mask = vector.create_mask %c7, %c7 : vector<16x8xi1>
+  // expected-remark @above {{element_tile = [1, 8]}}
+  %indices1 = arith.addi %indices, %c1 : vector<16xindex>
+  // expected-remark @above {{element_tile = [1]}}
+  %l_vec = iree_vector_ext.to_layout %vector to layout(#layout) : vector<16x8xf16>
+  iree_vector_ext.transfer_scatter %l_vec into %dest[%c0, %c0, %c0]
+  [%indices1 : vector<16xindex>], %mask {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (0, s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>,
+                     affine_map<(d0, d1)[s0] -> (d0, d1)>]
+  } : vector<16x8xf16>, memref<4096x512x8xf16>, vector<16x8xi1>
+
+  return
+}
+
+// -----
+
 func.func @fixup_null_layout_transpose_broadcast(
     %a: vector<16x16xf16>,
     %b: vector<16xf16>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BufferizationInterfaces.cpp
@@ -106,9 +106,8 @@ struct TransferScatterOpInterface
     // Create a new scatter op with memref base (no result).
     IREE::VectorExt::TransferScatterOp::create(
         rewriter, scatterOp.getLoc(), /*resultTypes=*/TypeRange{}, *buffer,
-        scatterOp.getVector(), scatterOp.getOffsets(),
-        scatterOp.getIndexVecs(), scatterOp.getIndexingMapsAttr(),
-        scatterOp.getMask());
+        scatterOp.getVector(), scatterOp.getOffsets(), scatterOp.getIndexVecs(),
+        scatterOp.getIndexingMapsAttr(), scatterOp.getMask());
     bufferization::replaceOpWithBufferizedValues(rewriter, op, *buffer);
     return success();
   }
@@ -117,12 +116,11 @@ struct TransferScatterOpInterface
 } // namespace
 
 void registerIREEVectorExtBufferizationInterfaces(DialectRegistry &registry) {
-  registry.addExtension(
-      +[](MLIRContext *context, IREEVectorExtDialect *dialect) {
-        TransferGatherOp::attachInterface<TransferGatherOpInterface>(*context);
-        TransferScatterOp::attachInterface<TransferScatterOpInterface>(
-            *context);
-      });
+  registry.addExtension(+[](MLIRContext *context,
+                            IREEVectorExtDialect *dialect) {
+    TransferGatherOp::attachInterface<TransferGatherOpInterface>(*context);
+    TransferScatterOp::attachInterface<TransferScatterOpInterface>(*context);
+  });
 }
 
 } // namespace mlir::iree_compiler::IREE::VectorExt

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BufferizationInterfaces.cpp
@@ -67,12 +67,61 @@ struct TransferGatherOpInterface
   }
 };
 
+struct TransferScatterOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          TransferScatterOpInterface, IREE::VectorExt::TransferScatterOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    auto scatterOp = cast<IREE::VectorExt::TransferScatterOp>(op);
+    return &opOperand == &scatterOp.getBaseMutable();
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    auto scatterOp = cast<IREE::VectorExt::TransferScatterOp>(op);
+    return &opOperand == &scatterOp.getBaseMutable();
+  }
+
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *op, OpOperand &opOperand,
+                    const AnalysisState &state) const {
+    auto scatterOp = cast<IREE::VectorExt::TransferScatterOp>(op);
+    if (&opOperand == &scatterOp.getBaseMutable() && scatterOp.getResult()) {
+      return {{scatterOp.getResult(), BufferRelation::Equivalent}};
+    }
+    return {};
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          BufferizationState &state) const {
+    auto scatterOp = cast<IREE::VectorExt::TransferScatterOp>(op);
+    assert(isa<TensorType>(scatterOp.getBase().getType()) &&
+           "only tensor types expected");
+    FailureOr<Value> buffer =
+        getBuffer(rewriter, scatterOp.getBase(), options, state);
+    if (failed(buffer)) {
+      return failure();
+    }
+    // Create a new scatter op with memref base (no result).
+    IREE::VectorExt::TransferScatterOp::create(
+        rewriter, scatterOp.getLoc(), /*resultTypes=*/TypeRange{}, *buffer,
+        scatterOp.getVector(), scatterOp.getOffsets(),
+        scatterOp.getIndexVecs(), scatterOp.getIndexingMapsAttr(),
+        scatterOp.getMask());
+    bufferization::replaceOpWithBufferizedValues(rewriter, op, *buffer);
+    return success();
+  }
+};
+
 } // namespace
 
 void registerIREEVectorExtBufferizationInterfaces(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *context, IREEVectorExtDialect *dialect) {
         TransferGatherOp::attachInterface<TransferGatherOpInterface>(*context);
+        TransferScatterOp::attachInterface<TransferScatterOpInterface>(
+            *context);
       });
 }
 


### PR DESCRIPTION
Add bufferization, GPU nested layout distribution, and vector layout analysis support for TransferScatterOp.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Part 3/4 from https://github.com/iree-org/iree/pull/23610