### PR TITLE
[Codegen] Migrate PadOp/PackOp/UnPackOp to VectorizableOpInterface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -172,13 +172,15 @@ void GenericVectorizationPass::runOnOperation() {
         return;
       }
       candidates.push_back(op);
-    } else if (enableVectorMasking && isa<tensor::PadOp>(op)) {
-      candidates.push_back(op);
-    } else if (enableVectorMasking &&
-               isa<linalg::PackOp, linalg::UnPackOp>(op)) {
-      candidates.push_back(op);
     } else if (isa<VectorizableOpInterface>(op)) {
       if (!vectorizeMapStore && isa<IREE::LinalgExt::MapStoreOp>(op)) {
+        return;
+      }
+      // Filter out PadOp/PackOp/UnPackOp when masking is disabled.
+      // TODO(hanchung): Enable the vectorization without masking. This is
+      // mostly legacy code because it used to not working without masking.
+      if (!enableVectorMasking &&
+          isa<tensor::PadOp, linalg::PackOp, linalg::UnPackOp>(op)) {
         return;
       }
       candidates.push_back(op);

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -237,6 +237,8 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -172,6 +172,8 @@ iree_cc_library(
     MLIRAnalysis
     MLIRArithDialect
     MLIRIR
+    MLIRLinalgDialect
+    MLIRLinalgTransforms
     MLIRTensorDialect
     MLIRUBDialect
     MLIRVectorDialect

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -13,6 +13,8 @@
 #include "iree/compiler/Utils/Indexing.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -452,6 +454,62 @@ struct MapStoreOpVectorizationModel
     return SmallVector<Value>(vectorizedMapStoreOp->getResults());
   }
 };
+
+/// External model for linalg::PackOp, linalg::UnPackOp.
+/// These go through linalg::vectorize but are not LinalgOp subclasses.
+template <typename OpTy>
+struct NonLinalgStructuredOpVectorizationModel
+    : public VectorizableOpInterface::ExternalModel<
+          NonLinalgStructuredOpVectorizationModel<OpTy>, OpTy> {
+
+  bool isVectorizable(Operation *op, ArrayRef<int64_t> vectorSizes,
+                      ArrayRef<bool> scalableDims,
+                      DictionaryAttr options) const {
+    return succeeded(
+        linalg::vectorizeOpPrecondition(op, vectorSizes, scalableDims));
+  }
+
+  FailureOr<SmallVector<Value>> vectorize(Operation *op, RewriterBase &rewriter,
+                                          ArrayRef<int64_t> vectorSizes,
+                                          ArrayRef<bool> scalableDims,
+                                          DictionaryAttr options) const {
+    FailureOr<linalg::VectorizationResult> result =
+        linalg::vectorize(rewriter, op, vectorSizes, scalableDims);
+
+    if (failed(result)) {
+      return failure();
+    }
+    return result->replacements;
+  }
+};
+
+/// External model for tensor::PadOp. Different dialect, goes through
+/// linalg::vectorize.
+struct PadOpVectorizationModel
+    : public VectorizableOpInterface::ExternalModel<PadOpVectorizationModel,
+                                                    tensor::PadOp> {
+
+  bool isVectorizable(Operation *op, ArrayRef<int64_t> vectorSizes,
+                      ArrayRef<bool> scalableDims,
+                      DictionaryAttr options) const {
+    return succeeded(
+        linalg::vectorizeOpPrecondition(op, vectorSizes, scalableDims));
+  }
+
+  FailureOr<SmallVector<Value>> vectorize(Operation *op, RewriterBase &rewriter,
+                                          ArrayRef<int64_t> vectorSizes,
+                                          ArrayRef<bool> scalableDims,
+                                          DictionaryAttr options) const {
+    FailureOr<linalg::VectorizationResult> result =
+        linalg::vectorize(rewriter, op, vectorSizes, scalableDims);
+
+    if (failed(result)) {
+      return failure();
+    }
+    return result->replacements;
+  }
+};
+
 } // namespace
 
 void registerVectorizableOpInterfaceExternalModels(DialectRegistry &registry) {
@@ -468,6 +526,19 @@ void registerVectorizableOpInterfaceExternalModels(DialectRegistry &registry) {
                             IREE::VectorExt::IREEVectorExtDialect *dialect) {
     IREE::VectorExt::ToLayoutOp::attachInterface<ToLayoutOpVectorizationModel>(
         *ctx);
+  });
+
+  // Upstream linalg ops (PackOp, UnPackOp).
+  registry.addExtension(+[](MLIRContext *ctx, linalg::LinalgDialect *dialect) {
+    linalg::PackOp::attachInterface<
+        NonLinalgStructuredOpVectorizationModel<linalg::PackOp>>(*ctx);
+    linalg::UnPackOp::attachInterface<
+        NonLinalgStructuredOpVectorizationModel<linalg::UnPackOp>>(*ctx);
+  });
+
+  // Upstream tensor ops.
+  registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
+    tensor::PadOp::attachInterface<PadOpVectorizationModel>(*ctx);
   });
 }
 


### PR DESCRIPTION
No new tests because it is an NFC in terms of functionality. It just follows different mechanism for vectorization.

It is a step towards https://lists.lfaidata.foundation/g/iree-technical-discussion/message/15

Assisted-by: Claude