### PR TITLE
[Codegen] Bail out of foldReshapeIntoMapStore/MapLoad for 0-D tensor.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -120,11 +120,18 @@ static MapStoreOp foldTransposeIntoMapStore(RewriterBase &rewriter,
 /// `mapStoreOp`, by linearizing and then delinearizing the source indices
 /// of the `mapStoreOp`s index transformation.
 template <typename ReshapeOpTy>
-static IREE::LinalgExt::MapStoreOp
+static FailureOr<IREE::LinalgExt::MapStoreOp>
 foldReshapeIntoMapStore(RewriterBase &rewriter, ReshapeOpTy reshapeOp,
                         IREE::LinalgExt::MapStoreOp mapStoreOp) {
   assert(mapStoreOp.getInput() == reshapeOp->getResult(0) &&
          "expected reshapeOp to be the producer of mapStoreOp");
+  // Cannot fold if either side of the reshape is rank-0 (scalar). The source
+  // being rank-0 would make the new map_store input rank-0, and the result
+  // being rank-0 would produce an empty delinearization.
+  if (cast<RankedTensorType>(reshapeOp.getSrc().getType()).getRank() == 0 ||
+      cast<RankedTensorType>(reshapeOp.getResult().getType()).getRank() == 0) {
+    return failure();
+  }
   Location loc = reshapeOp->getLoc();
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointAfter(reshapeOp);
@@ -159,7 +166,7 @@ foldReshapeIntoMapStore(RewriterBase &rewriter, ReshapeOpTy reshapeOp,
 /// Fold a tensor::ExpandShapeOp into a consumer `mapStoreOp`, by linearizing
 /// and then delinearizing the source indices of the `mapStoreOp`s index
 /// transformation.
-static MapStoreOp
+static FailureOr<MapStoreOp>
 foldExpandShapeIntoMapStore(RewriterBase &rewriter,
                             tensor::ExpandShapeOp expandShapeOp,
                             MapStoreOp mapStoreOp) {
@@ -169,7 +176,7 @@ foldExpandShapeIntoMapStore(RewriterBase &rewriter,
 /// Fold a tensor::CollapseShapeOp into a consumer `mapStoreOp`, by
 /// linearizing and then delinearizing the source indices of the
 /// `mapStoreOp`s index transformation.
-static MapStoreOp
+static FailureOr<MapStoreOp>
 foldCollapseShapeIntoMapStore(RewriterBase &rewriter,
                               tensor::CollapseShapeOp collapseShapeOp,
                               MapStoreOp mapStoreOp) {
@@ -903,7 +910,13 @@ static FailureOr<MapLoadOp> foldReshapeIntoMapLoad(RewriterBase &rewriter,
                                                    MapLoadOp mapLoadOp) {
   assert(reshapeOp.getSrc() == mapLoadOp.getResult(0) &&
          "expected mapLoadOp to be the producer of reshapeOp input");
-
+  // Cannot fold if either side of the reshape is rank-0 (scalar). The result
+  // being rank-0 would make the new map_load output rank-0, and the source
+  // being rank-0 would produce an empty delinearization.
+  if (cast<RankedTensorType>(reshapeOp.getSrc().getType()).getRank() == 0 ||
+      cast<RankedTensorType>(reshapeOp.getResult().getType()).getRank() == 0) {
+    return failure();
+  }
   Location loc = reshapeOp->getLoc();
   SmallVector<OpFoldResult> srcDims =
       tensor::getMixedSizes(rewriter, loc, reshapeOp.getSrc());

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_result_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_result_layout_transformation.mlir
@@ -44,6 +44,32 @@ func.func @fold_expand_shape_op(%source : tensor<8x16xf32>, %result : memref<2x4
 
 // -----
 
+// Verify that expand_shape from rank-0 (scalar) does not fold into map_store,
+// because map_store requires non-zero rank input.
+func.func @no_fold_rank0_expand_shape_op(%source : tensor<f32>, %result : memref<1x1x1xf32>) {
+  %expand = tensor.expand_shape %source [] output_shape [1, 1, 1] : tensor<f32> into tensor<1x1x1xf32>
+  iree_codegen.store_to_buffer %expand, %result : tensor<1x1x1xf32> into memref<1x1x1xf32>
+  return
+}
+// DISPATCH-SCOPE-LABEL: @no_fold_rank0_expand_shape_op
+//       DISPATCH-SCOPE:   tensor.expand_shape
+//   DISPATCH-SCOPE-NOT:   iree_linalg_ext.map_store
+
+// -----
+
+// Verify that collapse_shape to rank-0 (scalar) does not fold into map_store,
+// because the delinearization would produce no indices.
+func.func @no_fold_rank0_collapse_shape_op(%source : tensor<1x1x1xf32>, %result : memref<f32>) {
+  %collapse = tensor.collapse_shape %source [] : tensor<1x1x1xf32> into tensor<f32>
+  iree_codegen.store_to_buffer %collapse, %result : tensor<f32> into memref<f32>
+  return
+}
+// DISPATCH-SCOPE-LABEL: @no_fold_rank0_collapse_shape_op
+//       DISPATCH-SCOPE:   tensor.collapse_shape
+//   DISPATCH-SCOPE-NOT:   iree_linalg_ext.map_store
+
+// -----
+
 func.func @fold_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16x2xf32>) {
   %init = tensor.empty() : tensor<4x16x2xf32>
   %transposed = linalg.transpose ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -60,6 +60,32 @@ func.func @fold_collapse_shape(%buffer : memref<2x4x16xf32>) -> tensor<8x16xf32>
 
 // -----
 
+// Verify that collapse_shape to rank-0 (scalar) does not fold into map_load,
+// because map_load requires non-zero rank output.
+func.func @no_fold_rank0_collapse_shape(%buffer : memref<1x1x1xf32>) -> tensor<f32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<1x1x1xf32> -> tensor<1x1x1xf32>
+  %collapse = tensor.collapse_shape %source [] : tensor<1x1x1xf32> into tensor<f32>
+  return %collapse : tensor<f32>
+}
+// CHECK-LABEL: @no_fold_rank0_collapse_shape
+//       CHECK:   tensor.collapse_shape
+//   CHECK-NOT:   iree_linalg_ext.map_load
+
+// -----
+
+// Verify that expand_shape from rank-0 (scalar) does not fold into map_load,
+// because the delinearization would produce no indices.
+func.func @no_fold_rank0_expand_shape(%buffer : memref<f32>) -> tensor<1x1x1xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<f32> -> tensor<f32>
+  %expand = tensor.expand_shape %source [] output_shape [1, 1, 1] : tensor<f32> into tensor<1x1x1xf32>
+  return %expand : tensor<1x1x1xf32>
+}
+// CHECK-LABEL: @no_fold_rank0_expand_shape
+//       CHECK:   tensor.expand_shape
+//   CHECK-NOT:   iree_linalg_ext.map_load
+
+// -----
+
 func.func @fold_extract_slice(%buffer : memref<64xf32>) -> tensor<16xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<64xf32> -> tensor<64xf32>
   %slice = tensor.extract_slice %source[8] [16] [1] : tensor<64xf32> to tensor<16xf32>


### PR DESCRIPTION
0-D is a special case which looks like a broadcasting. There are a few code implementation of MapLoadOp/MapStoreOp assumes that it is not a 0-D case. Thus, plumbing it through the stack may be a longer work. The revision bails out the 0-D cases to unblock #23682.

Fixes #23682.