### PR TITLE
TileSwizzle: `distributionFactor`, `symbolicMultiplier`, serialization fix, documentation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -325,8 +325,6 @@ getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
 Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
                                          int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
-  using Kind = TileSwizzle::Dim::Kind;
-
   auto maybeMnkTuple = getRowMajorTilesMNKShape(mma);
   if (!maybeMnkTuple) {
     // Whenever one adds support for a new intrinsic that doesn't have a
@@ -339,7 +337,7 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
   swizzle.expandShape().resize(2);
   auto expandIfNonUnit = [](TileSwizzle &swizzle, int dim, int size) {
     if (size > 1) {
-      Codegen::expand(swizzle, dim, TileSwizzle::Dim{Kind::Internal, size});
+      Codegen::expand(swizzle, dim, TileSwizzle::Dim::internal(size));
     }
   };
 
@@ -362,11 +360,13 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
 Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
                                 int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
-  using Kind = TileSwizzle::Dim::Kind;
   TileSwizzle swizzle = getIntrinsicSwizzle(mma.getIntrinsic(), operandIdx);
-  TileSwizzle::Dim intrinsicsM = {Kind::CrossIntrinsic, mma.getIntrinsicsM()};
-  TileSwizzle::Dim intrinsicsN = {Kind::CrossIntrinsic, mma.getIntrinsicsN()};
-  TileSwizzle::Dim intrinsicsK = {Kind::CrossIntrinsic, mma.getIntrinsicsK()};
+  TileSwizzle::Dim intrinsicsM =
+      TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsM());
+  TileSwizzle::Dim intrinsicsN =
+      TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsN());
+  TileSwizzle::Dim intrinsicsK =
+      TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsK());
   // LHS: (M, K); RHS: (K, N); Acc: (M, N).
   if (operandIdx == 0) {
     constexpr int M = 0, K = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IR_IREECODEGENTYPES_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IR_IREECODEGENTYPES_H_
 
+#include <cassert>
 #include <cstdint>
 
 #include "llvm/ADT/SmallVector.h"
@@ -58,36 +59,39 @@ public:
       CrossIntrinsic
     };
 
-    // Support constructing from any size type.
-    template <typename T>
-    Dim(Kind kind, T size) : kind_(kind), size_(size) {
-      if (kind_ == Kind::CrossThread) {
-        distributionSize_ = size;
-      }
+    Dim(Kind kind, int64_t size) : kind_(kind), size_(size) {}
+
+    static Dim crossThread(int64_t size, int64_t distributionFactor = 1) {
+      Dim dim(Kind::CrossThread, size);
+      dim.distributionFactor_ = distributionFactor;
+      return dim;
     }
-    template <typename T>
-    Dim(Kind kind, T size, T distributionSize)
-        : kind_(kind), size_(size), distributionSize_(distributionSize) {}
 
     Kind kind() const { return kind_; }
     int size() const { return size_; }
-    int distributionSize() const { return distributionSize_; }
+    int distributionFactor() const {
+      assert(kind() == Kind::CrossThread &&
+             "distributionFactor() only defined for CrossThread dims");
+      return distributionFactor_;
+    }
 
   private:
     Kind kind_ = Kind::Internal;
 
-    // The size of the dimension.
-    int16_t size_ = 0;
+    // The distribution multiplier on the size of the dimension, for
+    // distribution purposes. This applies only to CrossThread dimensions and
+    // describes the situation where multiple threads see the same data.
+    // `distributionFactor_` is the number of threads sharing the same data. In
+    // that case, the size of the dimension becomes  `distributionFactor_` times
+    // larger for distribution purposes. `distributionFactor_` consecutive
+    // positions along the dimension are the same data, seen by
+    // `distributionFactor_` threads.
+    int8_t distributionFactor_ = 1;
 
-    // The size of the dimension for distribution. This is used for CrossThread
-    // dimensions, because we may want to distribute more than `size` threads to
-    // this dimension. The `distributionSize` is expected to be greater than or
-    // equal to `size`, and the mapping of the delinearized (by the distribution
-    // sizes) thread ID index to the offset into the Dim is
-    // `delinearized_tid / (distributionSize / size)`. The `distributionSize`
-    // for non-CrossThread dimensions should always be 1, since there is no
-    // distribution for these dimensions.
-    int16_t distributionSize_ = 1;
+    // The size of the dimension.
+    // For CrossThread dimensions, this may get multiplied by
+    // distributionFactor.
+    int16_t size_ = 0;
   };
 
   using ExpandShapeDimVectorType = SmallVector<Dim, 4>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -104,12 +104,9 @@ public:
       // introduce a separate enum value for each streaming mode.
       ArmSveVLIn128bitUnits,
       // The multiplier is the VLEN parameter in the RISC-V ISA, expressed in
-      // multiples of 128 bits. This is just a placeholder for future use. I
-      // have no idea if 128 bits is the right granularity for this. Note
-      // however that we can only multiply, not divide, so the unit better not
-      // be too small. If no one unit satisfies all use cases, we can introduce
-      // separate enum values for different units.
-      RiscvVlenIn128bitUnits
+      // multiples of 64 bits. If no one unit satisfies all use cases, we can
+      // introduce a separate enum value for each unit.
+      RiscvVlenIn64bitUnits
     };
 
     //

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -96,14 +96,13 @@ public:
       // The multiplier is the constant value 1. This is the common case, used
       // for all but the scalable dimensions.
       One,
-      // The multiplier is the `vscale` parameter of the Arm ISA. By definition,
-      // it is vector length divided by 128 bits, e.g. vscale=2 means 256 bits.
-      // Note that with SME, the value of vscale depends on the streaming mode.
+      // The SVE vector length in 128-bit units.
+      // Note that with SME, this value depends on the streaming mode.
       // The current semantics is that we just allow that dependenced on the
       // streaming mode to exist. Whenever we get to implementing data-tiling
       // with SME, we will find out if this works in practice or if we need to
       // introduce a separate enum value for each streaming mode.
-      ArmVscale,
+      ArmSveVLIn128bitUnits,
       // The multiplier is the VLEN parameter in the RISC-V ISA, expressed in
       // multiples of 128 bits. This is just a placeholder for future use. I
       // have no idea if 128 bits is the right granularity for this. Note

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -70,6 +70,7 @@ public:
       // one intrinsic on one thread. That dimension of size 4 is 'Internal'.
       Internal,
       // This dimension is internal to one intrinsic, but is across threads.
+      // By definition, this only happens on SIMT architectures (GPUs).
       // For example, with AMD MFMA, for the MFMA_F32_16x16x4_F32 intrinsic,
       // the A-matrix tile has shape 16x4, and these two dimensions of size 16
       // and 4 are 'CrossThread': neither is visible at the single-thread level
@@ -100,13 +101,13 @@ public:
       // Note that with SME, the value of vscale depends on the streaming mode.
       // The current semantics is that we just allow that dependenced on the
       // streaming mode to exist. Whenever we get to implementing data-tiling
-      // with SME, we will find out  if this works in practice or if we need to
+      // with SME, we will find out if this works in practice or if we need to
       // introduce a separate enum value for each streaming mode.
       ArmVscale,
       // The multiplier is the VLEN parameter in the RISC-V ISA, expressed in
       // multiples of 128 bits. This is just a placeholder for future use. I
       // have no idea if 128 bits is the right granularity for this. Note
-      // however that  we can only multiply, not divide, so the unit better not
+      // however that we can only multiply, not divide, so the unit better not
       // be too small. If no one unit satisfies all use cases, we can introduce
       // separate enum values for different units.
       RiscvVlenIn128bitUnits
@@ -162,7 +163,12 @@ public:
       // becomes  `distributionFactor_` times larger for distribution purposes.
       // `distributionFactor_` consecutive positions along the dimension are the
       // same data, seen by `distributionFactor_` threads.
-      int8_t distributionFactor_;
+      //
+      // Note about the zero-initialization of this field: we need to
+      // zero-initialize one union member, it doesn't matter which one and it
+      // can't be more than one. The reason why we need to zero-initialize is
+      // that we want to be able to perform equality comparison as memcmp.
+      int8_t distributionFactor_ = 0;
 
       // Only for Internal dimensions.
       // The symbolic multiplier on the size of the dimension, for

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -21,13 +21,42 @@
 // clang-format on
 
 namespace mlir::iree_compiler::IREE::Codegen {
-//===----------------------------------------------------------------------===//
-// Layout Struct Types.
-//===----------------------------------------------------------------------===//
 
-// Metadata for a swizzle, that is, an (expand_shape -> transposition)
-// pair of ops performing a change of layout within the tiles. This is used
-// on GPU, where the tiles themselves can have an arbitrary layout.
+// TileSwizzle describes the layout of a tile. To first approximation, "a tile"
+// means any statically-shaped object, but this is specifically intended for
+// things like the tiles of tiled operands of a inner_tiled operation, e.g.
+// typically a matrix multiplication kernel, and a specific provision is made to
+// allow modelling scalable dimensions on ISAs having scalable vectors (e.g. ARM
+// SVE/SME and RISC-V RVV).
+//
+// The word "swizzle" refers to the sequence of operations transforming a tile
+// from a row-major input layout into the desired layout.
+//
+// The basic observation is that no matter how complex the swizzle, it can
+// always be achieved by the same sequence of 2 MLIR operations:
+// 1. `tensor.expand_shape` to split dimensions into finer dimensions, which in
+//    itself is purely formal and does not change layout. This operation creates
+//    additional internal dimensions to the tile.
+// 2. `linalg.transpose` on the expanded dimensions to change the layout.
+//
+// Thus, to first approximation, TileSwizzle simply captures the defining
+// attributes of these expand_shape and transpose operations:
+// 1. The expandShape_ member captures the reassociation of the expand_shape op.
+// 2. The permutation_ member captures the permutation of the transpose op.
+//
+// What we have described so far is more or less equivalent to CuTe layouts and
+// some de-fragmentation could be envisioned in the future. However, additional
+// expressiveness is added by having the TileSwizzle::Dim nested type hold a
+// little more than merely the integer size of the dimension:
+// 1. TileSwizzle::Dim::Kind describes what varies across this dimension.
+//    By tracking which expanded dimension is cross-thread or cross-intrinsic,
+//    the TileSwizzle is self-contained for purposes of thread-distribution and
+//    code-generation in a way that a CuTe layout is not.
+// 2. For CrossThread dimensions, the distributionFactor allows broadcasting
+//    data to multiple threads.
+// 3. For Internal dimensions, the symbolicMultiplier_ allows modelling scalable
+//    dimensions on ISAs having scalable vectors (e.g. ARM SVE/SME and RISC-V
+//    RVV).
 class TileSwizzle {
 public:
   class Dim {
@@ -59,7 +88,44 @@ public:
       CrossIntrinsic
     };
 
-    Dim(Kind kind, int64_t size) : kind_(kind), size_(size) {}
+    // Describes a symbolic multiplier on this dimension's size. Most dimensions
+    // will use the value One, meaning no multiplier. The other values are
+    // available to support scalable vector ISAs such as ARM SVE/SME and RISC-V.
+    enum class SymbolicMultiplier : int8_t {
+      // The multiplier is the constant value 1. This is the common case, used
+      // for all but the scalable dimensions.
+      One,
+      // The multiplier is the `vscale` parameter of the Arm ISA. By definition,
+      // it is vector length divided by 128 bits, e.g. vscale=2 means 256 bits.
+      // Note that with SME, the value of vscale depends on the streaming mode.
+      // The current semantics is that we just allow that dependenced on the
+      // streaming mode to exist. Whenever we get to implementing data-tiling
+      // with SME, we will find out  if this works in practice or if we need to
+      // introduce a separate enum value for each streaming mode.
+      ArmVscale,
+      // The multiplier is the VLEN parameter in the RISC-V ISA, expressed in
+      // multiples of 128 bits. This is just a placeholder for future use. I
+      // have no idea if 128 bits is the right granularity for this. Note
+      // however that  we can only multiply, not divide, so the unit better not
+      // be too small. If no one unit satisfies all use cases, we can introduce
+      // separate enum values for different units.
+      RiscvVlenIn128bitUnits
+    };
+
+    //
+    // Static factory methods to create Dim objects.
+    //
+    static Dim
+    internal(int64_t size,
+             SymbolicMultiplier symbolicMultiplier = SymbolicMultiplier::One) {
+      Dim dim(Kind::Internal, size);
+      dim.symbolicMultiplier_ = symbolicMultiplier;
+      return dim;
+    }
+
+    static Dim crossIntrinsic(int64_t size) {
+      return Dim(Kind::CrossIntrinsic, size);
+    }
 
     static Dim crossThread(int64_t size, int64_t distributionFactor = 1) {
       Dim dim(Kind::CrossThread, size);
@@ -74,19 +140,35 @@ public:
              "distributionFactor() only defined for CrossThread dims");
       return distributionFactor_;
     }
+    SymbolicMultiplier symbolicMultiplier() const {
+      assert(kind() == Kind::Internal &&
+             "symbolicMultiplier() only defined for Internal dims");
+      return symbolicMultiplier_;
+    }
 
   private:
+    Dim(Kind kind, int64_t size) : kind_(kind), size_(size) {}
+
     Kind kind_ = Kind::Internal;
 
-    // The distribution multiplier on the size of the dimension, for
-    // distribution purposes. This applies only to CrossThread dimensions and
-    // describes the situation where multiple threads see the same data.
-    // `distributionFactor_` is the number of threads sharing the same data. In
-    // that case, the size of the dimension becomes  `distributionFactor_` times
-    // larger for distribution purposes. `distributionFactor_` consecutive
-    // positions along the dimension are the same data, seen by
-    // `distributionFactor_` threads.
-    int8_t distributionFactor_ = 1;
+    // The following members are in a union because they are mutually exclusive,
+    // as they are each specific to a different kind of dimension.
+    union {
+      // Only for CrossThread dimensions.
+      // The distribution multiplier on the size of the dimension, for
+      // distribution purposes. This describes the situation where multiple
+      // threads see the same data. `distributionFactor_` is the number of
+      // threads sharing the same data. In that case, the size of the dimension
+      // becomes  `distributionFactor_` times larger for distribution purposes.
+      // `distributionFactor_` consecutive positions along the dimension are the
+      // same data, seen by `distributionFactor_` threads.
+      int8_t distributionFactor_;
+
+      // Only for Internal dimensions.
+      // The symbolic multiplier on the size of the dimension, for
+      // scalable purposes, on ISAs that have scalable vectors.
+      SymbolicMultiplier symbolicMultiplier_;
+    };
 
     // The size of the dimension.
     // For CrossThread dimensions, this may get multiplied by
@@ -124,6 +206,9 @@ private:
   // the leading dimension of the layout.
   SmallVector<int64_t> permutation_;
 };
+
+static_assert(sizeof(TileSwizzle::Dim) == 4,
+              "TileSwizzle::Dim should be 4 bytes");
 
 /// Returns the swizzled tile shape, but with dim sizes overwritten with 1 if
 /// `predicate` returns false.

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -46,10 +46,10 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, TileSwizzle::Dim dim) {
-  if (dim.size() != dim.distributionSize() &&
-      dim.kind() == TileSwizzle::Dim::Kind::CrossThread) {
-    return os << dim.size() << "|" << dim.distributionSize() << "("
-              << dim.kind() << ")";
+  if (dim.kind() == TileSwizzle::Dim::Kind::CrossThread &&
+      dim.distributionFactor() != 1) {
+    return os << dim.size() << "|" << dim.distributionFactor() * dim.size()
+              << "(" << dim.kind() << ")";
   }
   return os << dim.size() << "(" << dim.kind() << ")";
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -156,8 +156,8 @@ std::string convertSymbolicMultiplierToString(
     return "One";
   case TileSwizzle::Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits:
     return "ArmSveVLIn128bitUnits";
-  case TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn128bitUnits:
-    return "RiscvVlenIn128bitUnits";
+  case TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn64bitUnits:
+    return "RiscvVlenIn64bitUnits";
   }
   assert(false && "unhandled enum value");
   return "";
@@ -171,8 +171,8 @@ convertStringToSymbolicMultiplier(StringRef str) {
   if (str == "ArmSveVLIn128bitUnits") {
     return TileSwizzle::Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits;
   }
-  if (str == "RiscvVlenIn128bitUnits") {
-    return TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn128bitUnits;
+  if (str == "RiscvVlenIn64bitUnits") {
+    return TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn64bitUnits;
   }
   return std::nullopt;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -225,9 +225,6 @@ static std::optional<TileSwizzle::Dim> arrayAttrToSwizzleDim(Attribute attr) {
       }
       if (auto maybeSymbolicMultiplier = convertStringToSymbolicMultiplier(
               symbolicMultiplierAttr.getValue())) {
-        if (!maybeSymbolicMultiplier) {
-          return std::nullopt;
-        }
         symbolicMultiplier = maybeSymbolicMultiplier.value();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -154,8 +154,8 @@ std::string convertSymbolicMultiplierToString(
   switch (symbolicMultiplier) {
   case TileSwizzle::Dim::SymbolicMultiplier::One:
     return "One";
-  case TileSwizzle::Dim::SymbolicMultiplier::ArmVscale:
-    return "ArmVscale";
+  case TileSwizzle::Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits:
+    return "ArmSveVLIn128bitUnits";
   case TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn128bitUnits:
     return "RiscvVlenIn128bitUnits";
   }
@@ -168,8 +168,8 @@ convertStringToSymbolicMultiplier(StringRef str) {
   if (str == "One") {
     return TileSwizzle::Dim::SymbolicMultiplier::One;
   }
-  if (str == "ArmVscale") {
-    return TileSwizzle::Dim::SymbolicMultiplier::ArmVscale;
+  if (str == "ArmSveVLIn128bitUnits") {
+    return TileSwizzle::Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits;
   }
   if (str == "RiscvVlenIn128bitUnits") {
     return TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn128bitUnits;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -24,7 +24,7 @@ namespace mlir::iree_compiler::IREE::Codegen {
 //===----------------------------------------------------------------------===//
 
 bool operator==(TileSwizzle::Dim lhs, TileSwizzle::Dim rhs) {
-  return lhs.kind() == rhs.kind() && lhs.size() == rhs.size();
+  return !memcmp(&lhs, &rhs, sizeof lhs);
 }
 
 bool operator!=(TileSwizzle::Dim lhs, TileSwizzle::Dim rhs) {
@@ -46,12 +46,16 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, TileSwizzle::Dim dim) {
+  os << dim.size();
   if (dim.kind() == TileSwizzle::Dim::Kind::CrossThread &&
       dim.distributionFactor() != 1) {
-    return os << dim.size() << "|" << dim.distributionFactor() * dim.size()
-              << "(" << dim.kind() << ")";
+    os << "*" << dim.distributionFactor();
   }
-  return os << dim.size() << "(" << dim.kind() << ")";
+  if (dim.kind() == TileSwizzle::Dim::Kind::Internal &&
+      dim.symbolicMultiplier() != TileSwizzle::Dim::SymbolicMultiplier::One) {
+    os << "*" << convertSymbolicMultiplierToString(dim.symbolicMultiplier());
+  }
+  return os << "(" << dim.kind() << ")";
 }
 
 static llvm::raw_ostream &
@@ -126,7 +130,7 @@ std::string convertSwizzleKindToString(TileSwizzle::Dim::Kind kind) {
   case TileSwizzle::Dim::Kind::CrossIntrinsic:
     return "CrossIntrinsic";
   default:
-    assert(false && "unhandled enum type");
+    assert(false && "unhandled enum value");
   }
   return "";
 }
@@ -145,11 +149,47 @@ convertStringToSwizzleKind(StringRef str) {
   return std::nullopt;
 }
 
+std::string convertSymbolicMultiplierToString(
+    TileSwizzle::Dim::SymbolicMultiplier symbolicMultiplier) {
+  switch (symbolicMultiplier) {
+  case TileSwizzle::Dim::SymbolicMultiplier::One:
+    return "One";
+  case TileSwizzle::Dim::SymbolicMultiplier::ArmVscale:
+    return "ArmVscale";
+  case TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn128bitUnits:
+    return "RiscvVlenIn128bitUnits";
+  }
+  assert(false && "unhandled enum value");
+  return "";
+}
+
+std::optional<TileSwizzle::Dim::SymbolicMultiplier>
+convertStringToSymbolicMultiplier(StringRef str) {
+  if (str == "One") {
+    return TileSwizzle::Dim::SymbolicMultiplier::One;
+  }
+  if (str == "ArmVscale") {
+    return TileSwizzle::Dim::SymbolicMultiplier::ArmVscale;
+  }
+  if (str == "RiscvVlenIn128bitUnits") {
+    return TileSwizzle::Dim::SymbolicMultiplier::RiscvVlenIn128bitUnits;
+  }
+  return std::nullopt;
+}
+
 static ArrayAttr swizzleDimToArrayAttr(MLIRContext *ctx, TileSwizzle::Dim dim) {
   Builder b(ctx);
-  return b.getArrayAttr(
-      {b.getStringAttr(convertSwizzleKindToString(dim.kind())),
-       b.getI16IntegerAttr(dim.size())});
+  SmallVector<Attribute> attrs;
+  attrs.push_back(b.getStringAttr(convertSwizzleKindToString(dim.kind())));
+  attrs.push_back(b.getI16IntegerAttr(dim.size()));
+  if (dim.kind() == TileSwizzle::Dim::Kind::CrossThread) {
+    attrs.push_back(b.getI8IntegerAttr(dim.distributionFactor()));
+  }
+  if (dim.kind() == TileSwizzle::Dim::Kind::Internal) {
+    attrs.push_back(b.getStringAttr(
+        convertSymbolicMultiplierToString(dim.symbolicMultiplier())));
+  }
+  return b.getArrayAttr(attrs);
 }
 
 static std::optional<TileSwizzle::Dim> arrayAttrToSwizzleDim(Attribute attr) {
@@ -158,7 +198,7 @@ static std::optional<TileSwizzle::Dim> arrayAttrToSwizzleDim(Attribute attr) {
     return std::nullopt;
   }
   ArrayRef<Attribute> attrs = arrayAttr.getValue();
-  if (attrs.size() != 2) {
+  if (attrs.size() < 2) {
     return std::nullopt;
   }
   auto kindAttr = dyn_cast<StringAttr>(attrs[0]);
@@ -171,7 +211,47 @@ static std::optional<TileSwizzle::Dim> arrayAttrToSwizzleDim(Attribute attr) {
   if (!maybeKind) {
     return std::nullopt;
   }
-  return TileSwizzle::Dim(maybeKind.value(), sizeAttr.getInt());
+  const int64_t size = sizeAttr.getInt();
+  if (size <= 0 || size > std::numeric_limits<int16_t>::max()) {
+    return std::nullopt;
+  }
+  if (maybeKind.value() == TileSwizzle::Dim::Kind::Internal) {
+    TileSwizzle::Dim::SymbolicMultiplier symbolicMultiplier =
+        TileSwizzle::Dim::SymbolicMultiplier::One;
+    if (attrs.size() > 2) {
+      auto symbolicMultiplierAttr = dyn_cast<StringAttr>(attrs[2]);
+      if (!symbolicMultiplierAttr) {
+        return std::nullopt;
+      }
+      if (auto maybeSymbolicMultiplier = convertStringToSymbolicMultiplier(
+              symbolicMultiplierAttr.getValue())) {
+        if (!maybeSymbolicMultiplier) {
+          return std::nullopt;
+        }
+        symbolicMultiplier = maybeSymbolicMultiplier.value();
+      }
+    }
+    return TileSwizzle::Dim::internal(size, symbolicMultiplier);
+  }
+  if (maybeKind.value() == TileSwizzle::Dim::Kind::CrossIntrinsic) {
+    return TileSwizzle::Dim::crossIntrinsic(size);
+  }
+  if (maybeKind.value() == TileSwizzle::Dim::Kind::CrossThread) {
+    int64_t distributionFactor = 1;
+    if (attrs.size() > 2) {
+      auto distributionFactorAttr = dyn_cast<IntegerAttr>(attrs[2]);
+      if (!distributionFactorAttr) {
+        return std::nullopt;
+      }
+      distributionFactor = distributionFactorAttr.getInt();
+      if (distributionFactor <= 0 ||
+          distributionFactor > std::numeric_limits<int8_t>::max()) {
+        return std::nullopt;
+      }
+    }
+    return TileSwizzle::Dim::crossThread(size, distributionFactor);
+  }
+  return std::nullopt;
 }
 
 DictionaryAttr serializeTileSwizzle(MLIRContext *ctx,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
@@ -49,6 +49,12 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 std::string convertSwizzleKindToString(TileSwizzle::Dim::Kind kind);
 std::optional<TileSwizzle::Dim::Kind> convertStringToSwizzleKind(StringRef str);
 
+/// Conversion between TileSwizzle::Dim::SymbolicMultiplier and string.
+std::string convertSymbolicMultiplierToString(
+    TileSwizzle::Dim::SymbolicMultiplier symbolicMultiplier);
+std::optional<TileSwizzle::Dim::SymbolicMultiplier>
+convertStringToSymbolicMultiplier(StringRef str);
+
 /// Conversion between TileSwizzle struct and DictionaryAttr.
 DictionaryAttr serializeTileSwizzle(MLIRContext *ctx,
                                     const TileSwizzle &swizzle);

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
@@ -47,8 +47,8 @@ TEST(TileSwizzle, SymbolicMultiplierToString) {
                 SymbolicMultiplier::ArmSveVLIn128bitUnits),
             "ArmSveVLIn128bitUnits");
   EXPECT_EQ(convertSymbolicMultiplierToString(
-                SymbolicMultiplier::RiscvVlenIn128bitUnits),
-            "RiscvVlenIn128bitUnits");
+                SymbolicMultiplier::RiscvVlenIn64bitUnits),
+            "RiscvVlenIn64bitUnits");
 }
 
 TEST(TileSwizzle, StringToDimKind) {
@@ -72,9 +72,9 @@ TEST(TileSwizzle, StringToSymbolicMultiplier) {
   EXPECT_THAT(maybeSymbolicMultiplier,
               Optional(SymbolicMultiplier::ArmSveVLIn128bitUnits));
   maybeSymbolicMultiplier =
-      convertStringToSymbolicMultiplier("RiscvVlenIn128bitUnits");
+      convertStringToSymbolicMultiplier("RiscvVlenIn64bitUnits");
   EXPECT_THAT(maybeSymbolicMultiplier,
-              Optional(SymbolicMultiplier::RiscvVlenIn128bitUnits));
+              Optional(SymbolicMultiplier::RiscvVlenIn64bitUnits));
   maybeSymbolicMultiplier = convertStringToSymbolicMultiplier("deadbeef");
   EXPECT_FALSE(maybeSymbolicMultiplier.has_value());
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
@@ -16,7 +16,9 @@ namespace mlir::iree_compiler::IREE::Codegen {
 namespace {
 
 using testing::Optional;
-using Kind = TileSwizzle::Dim::Kind;
+using Dim = TileSwizzle::Dim;
+using Kind = Dim::Kind;
+using SymbolicMultiplier = Dim::SymbolicMultiplier;
 
 TEST(TileSwizzle, RelationalOperator) {
   TileSwizzle swizzle1;
@@ -25,11 +27,11 @@ TEST(TileSwizzle, RelationalOperator) {
   EXPECT_NE(swizzle1, swizzle2);
   swizzle2.permutation() = swizzle1.permutation();
   EXPECT_EQ(swizzle1, swizzle2);
-  swizzle1.expandShape().push_back({TileSwizzle::Dim(Kind::CrossThread, 16)});
-  swizzle2.expandShape().push_back({TileSwizzle::Dim(Kind::Internal, 16)});
+  swizzle1.expandShape().push_back({Dim::crossThread(16)});
+  swizzle2.expandShape().push_back({Dim::internal(16)});
   EXPECT_NE(swizzle1, swizzle2);
   swizzle2.expandShape()[0][0] =
-      TileSwizzle::Dim(Kind::CrossThread, swizzle2.expandShape()[0][0].size());
+      Dim::crossThread(swizzle2.expandShape()[0][0].size());
   EXPECT_EQ(swizzle1, swizzle2);
 }
 
@@ -39,24 +41,52 @@ TEST(TileSwizzle, DimKindToString) {
   EXPECT_EQ(convertSwizzleKindToString(Kind::CrossThread), "CrossThread");
 }
 
+TEST(TileSwizzle, SymbolicMultiplierToString) {
+  EXPECT_EQ(convertSymbolicMultiplierToString(SymbolicMultiplier::One), "One");
+  EXPECT_EQ(convertSymbolicMultiplierToString(SymbolicMultiplier::ArmVscale),
+            "ArmVscale");
+  EXPECT_EQ(convertSymbolicMultiplierToString(
+                SymbolicMultiplier::RiscvVlenIn128bitUnits),
+            "RiscvVlenIn128bitUnits");
+}
+
 TEST(TileSwizzle, StringToDimKind) {
-  std::optional<TileSwizzle::Dim::Kind> maybeKind;
+  std::optional<Kind> maybeKind;
   maybeKind = convertStringToSwizzleKind("Internal");
-  EXPECT_THAT(maybeKind, Optional(TileSwizzle::Dim::Kind::Internal));
+  EXPECT_THAT(maybeKind, Optional(Kind::Internal));
   maybeKind = convertStringToSwizzleKind("CrossIntrinsic");
-  EXPECT_THAT(maybeKind, Optional(TileSwizzle::Dim::Kind::CrossIntrinsic));
+  EXPECT_THAT(maybeKind, Optional(Kind::CrossIntrinsic));
   maybeKind = convertStringToSwizzleKind("CrossThread");
-  EXPECT_THAT(maybeKind, Optional(TileSwizzle::Dim::Kind::CrossThread));
+  EXPECT_THAT(maybeKind, Optional(Kind::CrossThread));
   maybeKind = convertStringToSwizzleKind("deadbeef");
   EXPECT_FALSE(maybeKind.has_value());
 }
 
-TEST(TileSwizzle, Serialization) {
+TEST(TileSwizzle, StringToSymbolicMultiplier) {
+  std::optional<SymbolicMultiplier> maybeSymbolicMultiplier;
+  maybeSymbolicMultiplier = convertStringToSymbolicMultiplier("One");
+  EXPECT_THAT(maybeSymbolicMultiplier, Optional(SymbolicMultiplier::One));
+  maybeSymbolicMultiplier = convertStringToSymbolicMultiplier("ArmVscale");
+  EXPECT_THAT(maybeSymbolicMultiplier, Optional(SymbolicMultiplier::ArmVscale));
+  maybeSymbolicMultiplier =
+      convertStringToSymbolicMultiplier("RiscvVlenIn128bitUnits");
+  EXPECT_THAT(maybeSymbolicMultiplier,
+              Optional(SymbolicMultiplier::RiscvVlenIn128bitUnits));
+  maybeSymbolicMultiplier = convertStringToSymbolicMultiplier("deadbeef");
+  EXPECT_FALSE(maybeSymbolicMultiplier.has_value());
+}
+
+TEST(TileSwizzle, SerializationDeserialization) {
+  using Dim = Dim;
+  using SymbolicMultiplier = SymbolicMultiplier;
   TileSwizzle swizzle;
-  swizzle.expandShape().push_back({TileSwizzle::Dim(Kind::CrossThread, 16)});
-  swizzle.expandShape().push_back({TileSwizzle::Dim(Kind::CrossIntrinsic, 4),
-                                   TileSwizzle::Dim(Kind::Internal, 4)});
-  swizzle.permutation() = {1, 2, 0};
+  swizzle.expandShape().push_back(
+      {Dim::crossThread(4), Dim::internal(2, SymbolicMultiplier::ArmVscale)});
+  swizzle.expandShape().push_back(
+      {Dim::crossThread(16, /*distributionFactor=*/2), Dim::crossIntrinsic(4),
+       Dim::internal(4)});
+  SmallVector<int64_t> permutation = {3, 2, 4, 1, 0};
+  swizzle.permutation() = permutation;
 
   MLIRContext ctx;
   DictionaryAttr dictAttr = serializeTileSwizzle(&ctx, swizzle);
@@ -79,12 +109,31 @@ TEST(TileSwizzle, Serialization) {
       dictAttr.getNamed("permutation")->getValue());
   EXPECT_EQ(extractedPerm, swizzle.permutation());
 
+  // Verify that deserialization+serialization roundtrip works.
   std::optional<TileSwizzle> deserializedSwizzle =
       deserializeTileSwizzle(dictAttr);
   EXPECT_THAT(deserializedSwizzle, Optional(swizzle));
+
+  // Just because deserialization+serialization roundtrip works, does not mean
+  // the values are preserved. Check them all.
+  auto deserializedExpandShape = deserializedSwizzle.value().expandShape();
+  EXPECT_EQ(deserializedExpandShape[0][0].kind(), Kind::CrossThread);
+  EXPECT_EQ(deserializedExpandShape[0][0].size(), 4);
+  EXPECT_EQ(deserializedExpandShape[0][1].kind(), Kind::Internal);
+  EXPECT_EQ(deserializedExpandShape[0][1].size(), 2);
+  EXPECT_EQ(deserializedExpandShape[0][1].symbolicMultiplier(),
+            SymbolicMultiplier::ArmVscale);
+  EXPECT_EQ(deserializedExpandShape[1][0].kind(), Kind::CrossThread);
+  EXPECT_EQ(deserializedExpandShape[1][0].size(), 16);
+  EXPECT_EQ(deserializedExpandShape[1][0].distributionFactor(), 2);
+  EXPECT_EQ(deserializedExpandShape[1][1].kind(), Kind::CrossIntrinsic);
+  EXPECT_EQ(deserializedExpandShape[1][1].size(), 4);
+  EXPECT_EQ(deserializedExpandShape[1][2].kind(), Kind::Internal);
+  EXPECT_EQ(deserializedExpandShape[1][2].size(), 4);
+  EXPECT_EQ(deserializedSwizzle.value().permutation(), permutation);
 }
 
-TEST(TileSwizzle, Deserialization) {
+TEST(TileSwizzle, DeserializationEdgeCases) {
   MLIRContext ctx;
   Builder b(&ctx);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
@@ -43,8 +43,9 @@ TEST(TileSwizzle, DimKindToString) {
 
 TEST(TileSwizzle, SymbolicMultiplierToString) {
   EXPECT_EQ(convertSymbolicMultiplierToString(SymbolicMultiplier::One), "One");
-  EXPECT_EQ(convertSymbolicMultiplierToString(SymbolicMultiplier::ArmVscale),
-            "ArmVscale");
+  EXPECT_EQ(convertSymbolicMultiplierToString(
+                SymbolicMultiplier::ArmSveVLIn128bitUnits),
+            "ArmSveVLIn128bitUnits");
   EXPECT_EQ(convertSymbolicMultiplierToString(
                 SymbolicMultiplier::RiscvVlenIn128bitUnits),
             "RiscvVlenIn128bitUnits");
@@ -66,8 +67,10 @@ TEST(TileSwizzle, StringToSymbolicMultiplier) {
   std::optional<SymbolicMultiplier> maybeSymbolicMultiplier;
   maybeSymbolicMultiplier = convertStringToSymbolicMultiplier("One");
   EXPECT_THAT(maybeSymbolicMultiplier, Optional(SymbolicMultiplier::One));
-  maybeSymbolicMultiplier = convertStringToSymbolicMultiplier("ArmVscale");
-  EXPECT_THAT(maybeSymbolicMultiplier, Optional(SymbolicMultiplier::ArmVscale));
+  maybeSymbolicMultiplier =
+      convertStringToSymbolicMultiplier("ArmSveVLIn128bitUnits");
+  EXPECT_THAT(maybeSymbolicMultiplier,
+              Optional(SymbolicMultiplier::ArmSveVLIn128bitUnits));
   maybeSymbolicMultiplier =
       convertStringToSymbolicMultiplier("RiscvVlenIn128bitUnits");
   EXPECT_THAT(maybeSymbolicMultiplier,
@@ -79,7 +82,8 @@ TEST(TileSwizzle, StringToSymbolicMultiplier) {
 TEST(TileSwizzle, SerializationDeserialization) {
   TileSwizzle swizzle;
   swizzle.expandShape().push_back(
-      {Dim::crossThread(4), Dim::internal(2, SymbolicMultiplier::ArmVscale)});
+      {Dim::crossThread(4),
+       Dim::internal(2, SymbolicMultiplier::ArmSveVLIn128bitUnits)});
   swizzle.expandShape().push_back(
       {Dim::crossThread(16, /*distributionFactor=*/2), Dim::crossIntrinsic(4),
        Dim::internal(4)});
@@ -120,7 +124,7 @@ TEST(TileSwizzle, SerializationDeserialization) {
   EXPECT_EQ(deserializedExpandShape[0][1].kind(), Kind::Internal);
   EXPECT_EQ(deserializedExpandShape[0][1].size(), 2);
   EXPECT_EQ(deserializedExpandShape[0][1].symbolicMultiplier(),
-            SymbolicMultiplier::ArmVscale);
+            SymbolicMultiplier::ArmSveVLIn128bitUnits);
   EXPECT_EQ(deserializedExpandShape[1][0].kind(), Kind::CrossThread);
   EXPECT_EQ(deserializedExpandShape[1][0].size(), 16);
   EXPECT_EQ(deserializedExpandShape[1][0].distributionFactor(), 2);

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/unittests/UtilsTest.cpp
@@ -77,8 +77,6 @@ TEST(TileSwizzle, StringToSymbolicMultiplier) {
 }
 
 TEST(TileSwizzle, SerializationDeserialization) {
-  using Dim = Dim;
-  using SymbolicMultiplier = SymbolicMultiplier;
   TileSwizzle swizzle;
   swizzle.expandShape().push_back(
       {Dim::crossThread(4), Dim::internal(2, SymbolicMultiplier::ArmVscale)});

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -106,7 +106,7 @@ static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
          "expected subgroupSize to be divisible by numThreadsInLayout");
   assert(subgroupSize >= numThreadsInLayout &&
          "expected at most subgroupSize threads in the layout");
-  int64_t extraDistributionFactor = subgroupSize / numThreadsInLayout;
+  int64_t distributionFactor = subgroupSize / numThreadsInLayout;
   // Based on the MMA layouts, there is expected to be at most one dim with a
   // tstride of 0.
   assert(llvm::count(layout.tstrides, 0) <= 1 &&
@@ -116,9 +116,8 @@ static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
     // swizzle so we can distribute by more than a factor of 1 along the dim.
     if (t != 1 || s == 0) {
       TileSwizzle::Dim tDim =
-          (s == 0) ? TileSwizzle::Dim(Kind::CrossThread, t,
-                                      t * extraDistributionFactor)
-                   : TileSwizzle::Dim(Kind::CrossThread, t);
+          (s == 0) ? TileSwizzle::Dim::crossThread(t, distributionFactor)
+                   : TileSwizzle::Dim::crossThread(t);
       Codegen::expand(swizzle, i, tDim);
     }
   }
@@ -206,15 +205,15 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
       contains(mma.getOperandsInterleavingIntrinsicsN(), operandIdx);
   const bool interleaveK =
       contains(mma.getOperandsInterleavingIntrinsicsK(), operandIdx);
-  TileSwizzle::Dim subgroupsM = {Kind::CrossThread, mma.getSubgroupsM()};
-  TileSwizzle::Dim subgroupsN = {Kind::CrossThread, mma.getSubgroupsN()};
-  TileSwizzle::Dim subgroupsK = {Kind::CrossThread, mma.getSubgroupsK()};
+  TileSwizzle::Dim subgroupsM = TileSwizzle::Dim::crossThread(mma.getSubgroupsM());
+  TileSwizzle::Dim subgroupsN = TileSwizzle::Dim::crossThread(mma.getSubgroupsN());
+  TileSwizzle::Dim subgroupsK = TileSwizzle::Dim::crossThread(mma.getSubgroupsK());
   TileSwizzle::Dim intrinsicsM = {Kind::CrossIntrinsic, mma.getIntrinsicsM()};
   TileSwizzle::Dim intrinsicsN = {Kind::CrossIntrinsic, mma.getIntrinsicsN()};
   TileSwizzle::Dim intrinsicsK = {Kind::CrossIntrinsic, mma.getIntrinsicsK()};
   if (isLhs || isLhsScale) {
-    TileSwizzle::Dim subgroupsMAdj(Kind::CrossThread, mma.getSubgroupsM(),
-                                   mma.getSubgroupsM() * mma.getSubgroupsN());
+    auto subgroupsMAdj = TileSwizzle::Dim::crossThread(
+        mma.getSubgroupsM(), mma.getSubgroupsN());
     subgroupsM = subgroupsMAdj;
     constexpr int M = 0, K = 1;
     expandIfNonUnit(swizzle, K, intrinsicsK, interleaveK);
@@ -229,11 +228,11 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
     expandIfNonUnit(swizzle, N, subgroupsN);
   } else if (isAcc) {
     if (mma.getSubgroupsN() > 1) {
-      subgroupsN = TileSwizzle::Dim(Kind::CrossThread, mma.getSubgroupsN(),
-                                    mma.getSubgroupsN() * mma.getSubgroupsK());
+      subgroupsN = TileSwizzle::Dim::crossThread(
+          mma.getSubgroupsN(), mma.getSubgroupsK());
     } else if (mma.getSubgroupsM() > 1) {
-      subgroupsM = TileSwizzle::Dim(Kind::CrossThread, mma.getSubgroupsM(),
-                                    mma.getSubgroupsM() * mma.getSubgroupsK());
+      subgroupsM = TileSwizzle::Dim::crossThread(
+          mma.getSubgroupsM(), mma.getSubgroupsK());
     }
     constexpr int M = 0, N = 1;
     expandIfNonUnit(swizzle, N, intrinsicsN, interleaveN);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -96,7 +96,7 @@ static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
   for (auto [i, e] : llvm::enumerate(llvm::reverse(layout.element))) {
     if (e != 1) {
       size_t srcIdx = layout.element.size() - 1 - i;
-      Codegen::expand(swizzle, srcIdx, {Kind::Internal, e});
+      Codegen::expand(swizzle, srcIdx, TileSwizzle::Dim::internal(e));
     }
   }
   // Next come `layout.thread` dims.
@@ -140,7 +140,7 @@ static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
   // Finally come `layout.outer` dims, added last so they are outer-most.
   for (auto [i, o] : llvm::enumerate(layout.outer)) {
     if (o != 1) {
-      Codegen::expand(swizzle, i, {Kind::Internal, o});
+      Codegen::expand(swizzle, i, TileSwizzle::Dim::internal(o));
     }
   }
   return swizzle;
@@ -205,16 +205,21 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
       contains(mma.getOperandsInterleavingIntrinsicsN(), operandIdx);
   const bool interleaveK =
       contains(mma.getOperandsInterleavingIntrinsicsK(), operandIdx);
-  TileSwizzle::Dim subgroupsM = TileSwizzle::Dim::crossThread(mma.getSubgroupsM());
-  TileSwizzle::Dim subgroupsN = TileSwizzle::Dim::crossThread(mma.getSubgroupsN());
-  TileSwizzle::Dim subgroupsK = TileSwizzle::Dim::crossThread(mma.getSubgroupsK());
-  TileSwizzle::Dim intrinsicsM = {Kind::CrossIntrinsic, mma.getIntrinsicsM()};
-  TileSwizzle::Dim intrinsicsN = {Kind::CrossIntrinsic, mma.getIntrinsicsN()};
-  TileSwizzle::Dim intrinsicsK = {Kind::CrossIntrinsic, mma.getIntrinsicsK()};
+  TileSwizzle::Dim subgroupsM =
+      TileSwizzle::Dim::crossThread(mma.getSubgroupsM());
+  TileSwizzle::Dim subgroupsN =
+      TileSwizzle::Dim::crossThread(mma.getSubgroupsN());
+  TileSwizzle::Dim subgroupsK =
+      TileSwizzle::Dim::crossThread(mma.getSubgroupsK());
+  TileSwizzle::Dim intrinsicsM =
+      TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsM());
+  TileSwizzle::Dim intrinsicsN =
+      TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsN());
+  TileSwizzle::Dim intrinsicsK =
+      TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsK());
   if (isLhs || isLhsScale) {
-    auto subgroupsMAdj = TileSwizzle::Dim::crossThread(
-        mma.getSubgroupsM(), mma.getSubgroupsN());
-    subgroupsM = subgroupsMAdj;
+    subgroupsM =
+        TileSwizzle::Dim::crossThread(mma.getSubgroupsM(), mma.getSubgroupsN());
     constexpr int M = 0, K = 1;
     expandIfNonUnit(swizzle, K, intrinsicsK, interleaveK);
     expandIfNonUnit(swizzle, M, intrinsicsM, interleaveM);
@@ -228,11 +233,11 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
     expandIfNonUnit(swizzle, N, subgroupsN);
   } else if (isAcc) {
     if (mma.getSubgroupsN() > 1) {
-      subgroupsN = TileSwizzle::Dim::crossThread(
-          mma.getSubgroupsN(), mma.getSubgroupsK());
+      subgroupsN = TileSwizzle::Dim::crossThread(mma.getSubgroupsN(),
+                                                 mma.getSubgroupsK());
     } else if (mma.getSubgroupsM() > 1) {
-      subgroupsM = TileSwizzle::Dim::crossThread(
-          mma.getSubgroupsM(), mma.getSubgroupsK());
+      subgroupsM = TileSwizzle::Dim::crossThread(mma.getSubgroupsM(),
+                                                 mma.getSubgroupsK());
     }
     constexpr int M = 0, N = 1;
     expandIfNonUnit(swizzle, N, intrinsicsN, interleaveN);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -36,9 +36,13 @@ using ::mlir::iree_compiler::IREE::Codegen::TileSwizzle;
 static SmallVector<int64_t>
 getSwizzledDistributionShape(const TileSwizzle &swizzle) {
   SmallVector<int64_t> shape;
-  for (TileSwizzle::ExpandShapeDimVectorType e : swizzle.expandShape()) {
+  for (const TileSwizzle::ExpandShapeDimVectorType &e : swizzle.expandShape()) {
     for (TileSwizzle::Dim d : e) {
-      shape.push_back(d.distributionSize());
+      if (d.kind() == TileSwizzle::Dim::Kind::CrossThread) {
+        shape.push_back(d.distributionFactor() * d.size());
+      } else {
+        shape.push_back(1);
+      }
     }
   }
   applyPermutationToVector(shape, swizzle.permutation());

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -180,7 +180,8 @@ void adjustTileSizesForBitcast(RankedTensorType type,
     int64_t newSize = scaledExpandSize / storageBits;
     switch (innermostDim.kind()) {
     case Codegen::TileSwizzle::Dim::Kind::Internal:
-      innermostExpandDims.back() = Codegen::TileSwizzle::Dim::internal(newSize);
+      innermostExpandDims.back() = Codegen::TileSwizzle::Dim::internal(
+          newSize, innermostDim.symbolicMultiplier());
       break;
     case Codegen::TileSwizzle::Dim::Kind::CrossIntrinsic:
       innermostExpandDims.back() =

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -177,8 +177,20 @@ void adjustTileSizesForBitcast(RankedTensorType type,
     int64_t scaledExpandSize = innermostDim.size() * originalBits;
     assert(scaledExpandSize % storageBits == 0 &&
            "scaled expand size must be divisible by storage bits");
-    innermostExpandDims.back() = Codegen::TileSwizzle::Dim(
-        innermostDim.kind(), scaledExpandSize / storageBits);
+    int64_t newSize = scaledExpandSize / storageBits;
+    switch (innermostDim.kind()) {
+    case Codegen::TileSwizzle::Dim::Kind::Internal:
+      innermostExpandDims.back() = Codegen::TileSwizzle::Dim::internal(newSize);
+      break;
+    case Codegen::TileSwizzle::Dim::Kind::CrossIntrinsic:
+      innermostExpandDims.back() =
+          Codegen::TileSwizzle::Dim::crossIntrinsic(newSize);
+      break;
+    case Codegen::TileSwizzle::Dim::Kind::CrossThread:
+      innermostExpandDims.back() = Codegen::TileSwizzle::Dim::crossThread(
+          newSize, innermostDim.distributionFactor());
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
 A number of things in this PR so we don't spend the rest of the week landing a chain of PRs. It's still divided in two separate commits for review.
* `distributionSize` is replaced by `distributionFactor`, acting as a multiplier on the size.
  * `distributionSize` was never properly supported in serialization/deserialization and equality operators. Now it's supported and tested.
  * The new `distributionFactor` is only defined for CrossThread dims. Previously, `distributionSize` was set to 1 for other dims, and some code (`getSwizzledDistributionShape`) was relying on that.  That logic has been moved to that code, so now TileSwizzle itself has simpler semantics.
* A new `symbolicMultiplier` field is added, for Internal dimensions specifically.
  * It enables using TileSwizzle on scalable vector ISAs.
  * As it is mutually exclusive with `distributionFactor`, it coexists in a `union` with it.
* Brand new class documentation for TileSwizzle.