### PR TITLE
[build system] Correctly link against -lrt in linux

### DIFF
--- a/build_tools/BUILD.bazel
+++ b/build_tools/BUILD.bazel
@@ -38,3 +38,11 @@ iree_cc_library(
         ],
     }),
 )
+
+iree_cc_library(
+    name = "rt",
+    linkopts = select({
+        "//build_tools/bazel:iree_is_linux": ["-lrt"],
+        "//conditions:default": [],
+    }),
+)

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -19,6 +19,7 @@ class TargetConverter:
                 # Internal utilities to emulate various binary/library options.
                 f"{iree_core_repo}//build_tools:pthreads": [],
                 f"{iree_core_repo}//build_tools:dl": ["${CMAKE_DL_LIBS}"],
+                f"{iree_core_repo}//build_tools:rt": [],
                 f"{iree_core_repo}//compiler/src/iree/compiler/API:CAPI": [
                     "IREECompilerCAPILib"
                 ],

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -342,9 +342,19 @@ iree_runtime_cc_library(
     deps = [
         ":internal",
         ":memory",
+        "//build_tools:rt",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/threading",
     ],
+)
+
+iree_cmake_extra_content(
+    content = """
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(iree_base_internal_shm PUBLIC rt)
+endif()
+""",
+    inline = True,
 )
 
 iree_runtime_cc_test(

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -377,6 +377,10 @@ iree_cc_library(
   PUBLIC
 )
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(iree_base_internal_shm PUBLIC rt)
+endif()
+
 iree_cc_test(
   NAME
     shm_test


### PR DESCRIPTION
Commit c02e48b3ab added `shm_posix.c` which calls `shm_open` and `shm_unlink`. On older systems (like the manylinux CI container) these symbols are located in the `rt` library, and one needs to link against `lrt`.

We make sure to only link `-lrt` when targeting linux.

The original attempt to link against rt used linkopts, but using bazel_to_cmake reveals that conversion from linkopts in bazel to cmake is unimplemented.

```
eochoalo@shark-mkm-2:~/code/iree$ ./build_tools/bazel_to_cmake/bazel_to_cmake.py
Using repo root /home/eochoalo/code/iree
Converting directory tree rooted at: /home/eochoalo/code/iree/compiler
0 CMakeLists.txt files were updated, 7 were skipped, and 285 required no change.
Converting directory tree rooted at: /home/eochoalo/code/iree/runtime
  ERROR generating runtime/src/iree/base/internal.
  Missing a rule handler in bazel_to_cmake_converter.py?
  Reason: `NotImplementedError: Unimplemented linkopts: `
0 CMakeLists.txt files were updated, 17 were skipped, and 117 required no change.
ERROR: Encountered unexpected errors converting 1 directories:
  runtime/src/iree/base/internal
```

Using iree_cc_library appears to be the idiomatic way of doing this.

I was able to build `iree_async_platform_io_uring_cts_buffer_tests` locally after these changes in the same container as CI.

Assisted-by: Claude