### PR TITLE
Remove 64-operation batch size limit from io_uring submit.

### DIFF
--- a/runtime/src/iree/async/cts/socket/socket_benchmark.cc
+++ b/runtime/src/iree/async/cts/socket/socket_benchmark.cc
@@ -128,7 +128,7 @@ struct LoopbackContext {
 
   void ResetZCTracking() { zc_achieved_count = 0; }
 
-  // Polls until completed or timeout.
+  // Polls until the completed flag is set or timeout.
   bool PollUntilComplete(iree_duration_t budget_ns = 5000000000LL) {
     iree_time_t deadline = iree_time_now() + budget_ns;
     while (!completed) {
@@ -144,6 +144,44 @@ struct LoopbackContext {
       iree_status_ignore(status);
     }
     return status_code == IREE_STATUS_OK;
+  }
+
+  // Polls until at least |target| completions have been observed or timeout.
+  // Completion count comes from iree_async_proactor_poll which counts user
+  // callback invocations. Operations that fail to submit never produce
+  // callbacks, so callers must check submit_one return values before calling
+  // this.
+  bool PollForCompletions(int target,
+                          iree_duration_t budget_ns = 5000000000LL) {
+    iree_time_t deadline = iree_time_now() + budget_ns;
+    int completions = 0;
+    while (completions < target) {
+      if (iree_time_now() >= deadline) return false;
+      iree_host_size_t count = 0;
+      iree_status_t status =
+          iree_async_proactor_poll(proactor, iree_make_timeout_ms(100), &count);
+      if (!iree_status_is_ok(status) &&
+          !iree_status_is_deadline_exceeded(status)) {
+        iree_status_ignore(status);
+        return false;
+      }
+      iree_status_ignore(status);
+      completions += (int)count;
+    }
+    return true;
+  }
+
+  // Submits a single operation and polls until its callback fires.
+  // Resets completion state before submission.
+  bool SubmitAndWait(iree_async_operation_t* operation,
+                     iree_duration_t budget_ns = 5000000000LL) {
+    Reset();
+    iree_status_t status = iree_async_proactor_submit_one(proactor, operation);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      return false;
+    }
+    return PollUntilComplete(budget_ns);
   }
 };
 
@@ -338,25 +376,21 @@ static void BM_Roundtrip(::benchmark::State& state,
     recv_op.buffers.values = &recv_span;
     recv_op.buffers.count = 1;
 
-    ctx->Reset();
-    iree_async_proactor_submit_one(ctx->proactor, &send_op.base);
-    ctx->PollUntilComplete();
-
-    ctx->Reset();
-    iree_async_proactor_submit_one(ctx->proactor, &recv_op.base);
-    ctx->PollUntilComplete();
+    if (!ctx->SubmitAndWait(&send_op.base) ||
+        !ctx->SubmitAndWait(&recv_op.base)) {
+      state.SkipWithError("Roundtrip C->S failed");
+      break;
+    }
 
     // Server -> Client.
     send_op.socket = ctx->server;
     recv_op.socket = ctx->client;
 
-    ctx->Reset();
-    iree_async_proactor_submit_one(ctx->proactor, &send_op.base);
-    ctx->PollUntilComplete();
-
-    ctx->Reset();
-    iree_async_proactor_submit_one(ctx->proactor, &recv_op.base);
-    ctx->PollUntilComplete();
+    if (!ctx->SubmitAndWait(&send_op.base) ||
+        !ctx->SubmitAndWait(&recv_op.base)) {
+      state.SkipWithError("Roundtrip S->C failed");
+      break;
+    }
   }
 
   state.SetBytesProcessed(state.iterations() * message_size * 2);
@@ -397,17 +431,19 @@ static void BM_Throughput(::benchmark::State& state,
 
     // Submit both, wait for both.
     ctx->Reset();
-    iree_async_proactor_submit_one(ctx->proactor, &send_op.base);
-    iree_async_proactor_submit_one(ctx->proactor, &recv_op.base);
-
-    // Wait for recv to complete.
-    int completions = 0;
-    while (completions < 2) {
-      iree_host_size_t count = 0;
-      iree_status_t status = iree_async_proactor_poll(
-          ctx->proactor, iree_make_timeout_ms(1000), &count);
+    iree_status_t status =
+        iree_async_proactor_submit_one(ctx->proactor, &send_op.base);
+    if (iree_status_is_ok(status)) {
+      status = iree_async_proactor_submit_one(ctx->proactor, &recv_op.base);
+    }
+    if (!iree_status_is_ok(status)) {
+      state.SkipWithError("Submit failed");
       iree_status_ignore(status);
-      completions += (int)count;
+      break;
+    }
+    if (!ctx->PollForCompletions(2)) {
+      state.SkipWithError("Completion timeout");
+      break;
     }
   }
 
@@ -484,17 +520,23 @@ static void BM_AcceptRate(::benchmark::State& state,
     connect_op.address = listen_addr;
 
     ctx_data.Reset();
-    iree_async_proactor_submit_one(proactor, &accept_op.base);
-    iree_async_proactor_submit_one(proactor, &connect_op.base);
-
-    // Wait for both.
-    int completions = 0;
-    while (completions < 2) {
-      iree_host_size_t count = 0;
-      status = iree_async_proactor_poll(proactor, iree_make_timeout_ms(1000),
-                                        &count);
+    status = iree_async_proactor_submit_one(proactor, &accept_op.base);
+    if (iree_status_is_ok(status)) {
+      status = iree_async_proactor_submit_one(proactor, &connect_op.base);
+    }
+    if (!iree_status_is_ok(status)) {
+      state.SkipWithError("Submit failed");
       iree_status_ignore(status);
-      completions += (int)count;
+      iree_async_socket_release(client);
+      break;
+    }
+    if (!ctx_data.PollForCompletions(2)) {
+      state.SkipWithError("Accept/connect timeout");
+      if (accept_op.accepted_socket) {
+        iree_async_socket_release(accept_op.accepted_socket);
+      }
+      iree_async_socket_release(client);
+      break;
     }
 
     // Clean up.
@@ -631,17 +673,19 @@ static void BM_ThroughputZC(::benchmark::State& state,
 
     // Submit both, wait for both.
     ctx->Reset();
-    iree_async_proactor_submit_one(ctx->proactor, &send_op.base);
-    iree_async_proactor_submit_one(ctx->proactor, &recv_op.base);
-
-    // Wait for both completions.
-    int completions = 0;
-    while (completions < 2) {
-      iree_host_size_t count = 0;
-      iree_status_t status = iree_async_proactor_poll(
-          ctx->proactor, iree_make_timeout_ms(1000), &count);
+    iree_status_t status =
+        iree_async_proactor_submit_one(ctx->proactor, &send_op.base);
+    if (iree_status_is_ok(status)) {
+      status = iree_async_proactor_submit_one(ctx->proactor, &recv_op.base);
+    }
+    if (!iree_status_is_ok(status)) {
+      state.SkipWithError("Submit failed");
       iree_status_ignore(status);
-      completions += (int)count;
+      break;
+    }
+    if (!ctx->PollForCompletions(2)) {
+      state.SkipWithError("Completion timeout");
+      break;
     }
   }
 

--- a/runtime/src/iree/async/platform/io_uring/proactor_submit.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor_submit.c
@@ -1433,25 +1433,17 @@ iree_status_t iree_async_proactor_io_uring_submit(
   // Phase 1: Analyze the batch.
   //=========================================================================
 
-  // Count kernel SQEs needed and record software op positions. Software
+  // Count kernel SQEs needed and identify software op presence. Software
   // operations (SEMAPHORE_SIGNAL, SEMAPHORE_WAIT) execute in userspace with no
   // kernel SQE — they are handled in Phase 3. SEQUENCE operations were
   // dispatched in the pre-scan above.
-  //
-  // The software_op_mask bitmap records which positions are software ops so
-  // Phase 3 can skip kernel ops without re-reading their types. After Phase 2
-  // submits kernel SQEs, another thread's flush can make them visible to the
-  // kernel. If a kernel op completes and its operation struct is reused before
-  // Phase 3 runs, reading that op's type would be a data race.
   iree_host_size_t sqes_needed = 0;
   bool has_software_ops = false;
-  uint64_t software_op_mask = 0;
   for (iree_host_size_t i = 0; i < operations.count; ++i) {
     iree_async_operation_type_t type = operations.values[i]->type;
     if (type == IREE_ASYNC_OPERATION_TYPE_SEQUENCE) continue;
     if (iree_async_proactor_io_uring_is_software_op(type)) {
       has_software_ops = true;
-      software_op_mask |= (UINT64_C(1) << i);
       continue;
     }
     if (type == IREE_ASYNC_OPERATION_TYPE_EVENT_WAIT) {
@@ -1466,8 +1458,6 @@ iree_status_t iree_async_proactor_io_uring_submit(
       sqes_needed += 1;
     }
   }
-  IREE_ASSERT(operations.count <= 64,
-              "batch exceeds 64 operations; software_op_mask overflow");
 
   // If all operations were SEQUENCE (handled in pre-scan) with no software
   // ops and no kernel ops, there is nothing left to do.
@@ -1821,12 +1811,14 @@ iree_status_t iree_async_proactor_io_uring_submit(
   // callback ordering: the trigger's callback fires before its continuations.
 
   for (iree_host_size_t i = 0; i < effective_count && has_software_ops; ++i) {
-    // Use the bitmap from Phase 1 to skip kernel ops without reading their
-    // types. After Phase 2 submits kernel SQEs, another thread's Phase 4 flush
-    // can make them visible to the kernel. A fast-completing kernel op (NOP,
-    // expired timer) could have its slot reused before Phase 3 iterates past
-    // it. Reading that reused op's type would race with the new owner's writes.
-    if (!(software_op_mask & (UINT64_C(1) << i))) continue;
+    // Skip non-software operations. Reading operations.values[i]->type is safe
+    // here even after Phase 2 releases the SQ lock: the operations array is
+    // caller-local and software ops were never submitted to the kernel, so
+    // their structs cannot have been recycled by a concurrent completion path.
+    if (!iree_async_proactor_io_uring_is_software_op(
+            operations.values[i]->type)) {
+      continue;
+    }
 
     iree_async_operation_t* operation = operations.values[i];
     iree_async_operation_retain_resources(operation);


### PR DESCRIPTION
The submit path used a uint64_t bitmask to track which batch positions contained software operations (semaphore signal/wait), with an assert capping batches at 64 entries. This caused debug-mode crashes for tests submitting larger batches (e.g. MessageTest.MultipleInFlight with 100 messages). In release builds the assert was compiled out and the shift UB happened to be benign for all-kernel-op batches, but batches with software ops at indices >= 64 would silently misidentify operations.

The bitmask was motivated by a concern that concurrent submitters could flush SQEs to the kernel, allowing fast-completing kernel ops to be recycled before Phase 3 reads their type. This race cannot occur: the operations array is caller-local and software ops are never submitted to the kernel, so their structs cannot be recycled by concurrent completion paths. Replace the bitmask with a direct iree_async_proactor_io_uring_is_software_op() type check in Phase 3.