### PR TITLE
Add new CODEOWNERS for .github and build_tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,11 +36,11 @@
 /experimental/webgpu/ @benvanik @ScottTodd
 
 # Infra Top-Level Directories
-/build_tools/ @ScottTodd
+/build_tools/ @Groverkss @kuhar
 /build_tools/python_deploy/ @stellaraccident
-/build_tools/scripts/ @ScottTodd
+/build_tools/scripts/ @Groverkss @kuhar
 /build_tools/third_party/ @ScottTodd @stellaraccident
-/.github/ @ScottTodd @Groverkss
+/.github/ @amd-eochoalo @kuhar @Groverkss
 
 # llvm-external-projects
 /llvm-external-projects/ @stellaraccident


### PR DESCRIPTION
I haven't been very active in this project lately so I want to relax expectations for code reviews from me to these paths.