### PR TITLE
Drop myself from runtime/src/iree/hal/ CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,9 +89,8 @@
 
 # Runtime
 /runtime/src/iree/ @benvanik
-/runtime/src/iree/hal/cts/ @ScottTodd
 /runtime/src/iree/hal/drivers/amdgpu/ @benvanik @AWoloszyn
 /runtime/src/iree/hal/drivers/cuda/ @antiagainst
 /runtime/src/iree/hal/drivers/hip/ @AWoloszyn
 /runtime/src/iree/hal/drivers/metal/ @antiagainst
-/runtime/src/iree/hal/drivers/vulkan/ @antiagainst @ScottTodd
+/runtime/src/iree/hal/drivers/vulkan/ @antiagainst


### PR DESCRIPTION
I haven't been very active in this project lately so I want to relax expectations for code reviews from me to these paths.

See also:
* https://github.com/iree-org/iree/pull/23726