### PR TITLE
[Codegen][GPU] Fix shared memory estimation for multi-buffering 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -69,7 +69,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const GemmSize &gemmSize) {
 static int64_t calculateOperandsSharedMemoryUsedInBytes(
     const GPUMMASchedule &schedule, int64_t lhsBitwidth, int64_t rhsBitwidth,
     int64_t lhsScaleBitwidth = 0, int64_t rhsScaleBitwidth = 0,
-    int64_t numRhs = 1) {
+    int64_t numRhs = 1, bool useDirectLoad = false,
+    int64_t prefetchNumStages = 0) {
   int64_t tileM = schedule.getTotalMSize() * schedule.getTotalMTileSize() *
                   schedule.getTotalMSubgroupCount();
   int64_t tileN = schedule.getTotalNSize() * schedule.getTotalNTileSize() *
@@ -83,10 +84,17 @@ static int64_t calculateOperandsSharedMemoryUsedInBytes(
   int64_t tileKb = schedule.kSizes.back() * schedule.kTileSizes.back();
   int64_t tileKo = tileK / tileKb;
 
-  int64_t lhsSharedMemoryUsed = tileM * tileK * lhsBitwidth;
-  int64_t rhsSharedMemoryUsed = numRhs * tileN * tileK * rhsBitwidth;
-  int64_t aScaleSharedMemoryUsed = tileM * tileKo * lhsScaleBitwidth;
-  int64_t bScaleSharedMemoryUsed = numRhs * tileN * tileKo * rhsScaleBitwidth;
+  // Account for multi-buffering when using direct loads.
+  int64_t numBuffers =
+      (useDirectLoad && prefetchNumStages > 0) ? prefetchNumStages : 1;
+
+  int64_t lhsSharedMemoryUsed = numBuffers * tileM * tileK * lhsBitwidth;
+  int64_t rhsSharedMemoryUsed =
+      numBuffers * numRhs * tileN * tileK * rhsBitwidth;
+  int64_t aScaleSharedMemoryUsed =
+      numBuffers * tileM * tileKo * lhsScaleBitwidth;
+  int64_t bScaleSharedMemoryUsed =
+      numBuffers * numRhs * tileN * tileKo * rhsScaleBitwidth;
 
   return (lhsSharedMemoryUsed + rhsSharedMemoryUsed + aScaleSharedMemoryUsed +
           bScaleSharedMemoryUsed) /
@@ -740,7 +748,8 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, std::optional<int64_t> wgpCount, Location loc,
     bool transposedLhs, bool transposedRhs, bool canUpcastAcc,
-    bool mustBeAligned, bool doCPromotion, int64_t splitReductionTripCnt) {
+    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned,
+    bool doCPromotion, int64_t splitReductionTripCnt) {
 
   SmallVector<GPUIntrinsicType> sortedIntrinsics =
       sortMMAIntrinsics(problem, intrinsics);
@@ -776,7 +785,8 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
                              transposedLhs, transposedRhs);
       int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
           schedule, lhsBitwidth, rhsBitwidth, lhsScaleBitwidth,
-          rhsScaleBitwidth, problem.numHorizontallyFusedOps);
+          rhsScaleBitwidth, problem.numHorizontallyFusedOps, useDirectLoad,
+          prefetchNumStages);
       // Add accumulator/result memory when it uses shared memory (LDS):
       // - Result needs padding in shared memory, OR
       // - matmul_accumulate loads accumulator from global memory via shared mem

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -84,21 +84,21 @@ static int64_t calculateOperandsSharedMemoryUsedInBytes(
   int64_t tileKb = schedule.kSizes.back() * schedule.kTileSizes.back();
   int64_t tileKo = tileK / tileKb;
 
-  // Account for multi-buffering when using direct loads.
-  int64_t numBuffers =
-      (useDirectLoad && prefetchNumStages > 0) ? prefetchNumStages : 1;
+  int64_t lhsSharedMemoryUsed = tileM * tileK * lhsBitwidth;
+  int64_t rhsSharedMemoryUsed = numRhs * tileN * tileK * rhsBitwidth;
+  int64_t aScaleSharedMemoryUsed = tileM * tileKo * lhsScaleBitwidth;
+  int64_t bScaleSharedMemoryUsed = numRhs * tileN * tileKo * rhsScaleBitwidth;
 
-  int64_t lhsSharedMemoryUsed = numBuffers * tileM * tileK * lhsBitwidth;
-  int64_t rhsSharedMemoryUsed =
-      numBuffers * numRhs * tileN * tileK * rhsBitwidth;
-  int64_t aScaleSharedMemoryUsed =
-      numBuffers * tileM * tileKo * lhsScaleBitwidth;
-  int64_t bScaleSharedMemoryUsed =
-      numBuffers * numRhs * tileN * tileKo * rhsScaleBitwidth;
+  int64_t totalBits = lhsSharedMemoryUsed + rhsSharedMemoryUsed +
+                      aScaleSharedMemoryUsed + bScaleSharedMemoryUsed;
 
-  return (lhsSharedMemoryUsed + rhsSharedMemoryUsed + aScaleSharedMemoryUsed +
-          bScaleSharedMemoryUsed) /
-         8;
+  // In direct load mode, ROCDLPrefetchSharedMemoryPass multi-buffers shared
+  // memory allocations, where the number of buffers equals prefetchNumStages.
+  if (useDirectLoad && prefetchNumStages > 0) {
+    totalBits *= prefetchNumStages;
+  }
+
+  return totalBits / 8;
 }
 
 static int64_t

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -156,7 +156,8 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, std::optional<int64_t> cuCount, Location loc,
     bool transposedLhs = false, bool transposedRhs = false,
-    bool canUpcastAcc = false, bool mustBeAligned = true,
+    bool canUpcastAcc = false, bool useDirectLoad = false,
+    int64_t prefetchNumStages = 0, bool mustBeAligned = true,
     bool doCPromotion = false, int64_t splitReductionTripCnt = 0);
 
 /// Returns a schedule for the pvMatmul in attention using one of the given MMA

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -350,9 +350,9 @@ getContractionHeuristicSeeds(GPUMatmulShapeType problem, bool isGemm,
 /// accumulator that needs to be loaded from global memory (matmul_accumulate).
 static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
     IREE::GPU::TargetAttr target, GPUMatmulShapeType problem, Location loc,
-    bool transposedLhs, bool transposedRhs, bool isGemm,
-    bool mustBeAligned = true, bool doCPromotion = false, bool scaled = false,
-    int64_t splitReductionTripCnt = 0) {
+    bool transposedLhs, bool transposedRhs, bool isGemm, bool scaled,
+    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned = true,
+    bool doCPromotion = false, int64_t splitReductionTripCnt = 0) {
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
   SmallVector<GPUIntrinsicType> intrinsics;
   if (scaled) {
@@ -454,7 +454,8 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
   std::optional<GPUMMASchedule> schedule = deduceMMASchedule(
       problem, intrinsics, seeds, maxSharedMemoryBytes, targetSubgroupSize,
       wgpCount, loc, transposedLhs, transposedRhs, /*canUpcastAcc=*/false,
-      /*mustBeAligned=*/mustBeAligned, doCPromotion, splitReductionTripCnt);
+      useDirectLoad, prefetchNumStages, /*mustBeAligned=*/mustBeAligned,
+      doCPromotion, splitReductionTripCnt);
   return schedule;
 }
 
@@ -667,9 +668,10 @@ checkForDPSOperandComputeOpProducers(DestinationStyleOpInterface dpsOp) {
 static FailureOr<std::pair<LoweringConfigAttr, int64_t>>
 getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     ArrayRef<int64_t> bounds, ArrayRef<AffineMap> maps,
-    ArrayRef<Value> operands, IREE::GPU::TargetAttr target, bool useDirectLoad,
-    bool isGemm, bool scaled, int64_t splitReductionTripCnt,
-    bool cPromoteIfPadding, bool hasExistingAccumulator = false,
+    ArrayRef<Value> operands, IREE::GPU::TargetAttr target, bool isGemm,
+    bool scaled, bool useDirectLoad, int64_t prefetchNumStages,
+    int64_t splitReductionTripCnt, bool cPromoteIfPadding,
+    bool hasExistingAccumulator = false,
     std::optional<ConvToIgemmInfo> convToIgemmInfo = std::nullopt) {
   if (target.getWgp().getMma().empty()) {
     return failure();
@@ -846,6 +848,16 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              lhsScaleType,
                              rhsScaleType};
 
+  // TODO(#22119): We don't use global load DMA for scaled matmuls, because
+  // compilation doesn't support it. Once this is fixed, we should use global
+  // load DMA here when possible.
+  Location loc = operands[0].getLoc();
+  if (scaled && useDirectLoad) {
+    mlir::emitWarning(loc) << "direct load (global load DMA) is not yet "
+                              "supported for scaled matmuls, ignoring";
+    useDirectLoad = false;
+  }
+
   // Accumulator needs shared memory if:
   // - Padding requires C promotion, OR
   // - The operation has an existing accumulator (matmul_accumulate)
@@ -853,10 +865,10 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
       (couldNeedPadding && cPromoteIfPadding) || hasExistingAccumulator;
 
   bool mustBeAligned = true;
-  Location loc = operands[0].getLoc();
   std::optional<GPUMMASchedule> schedule = getMmaScheduleFromProblemAndTarget(
-      target, problem, loc, transposedLhs, transposedRhs, isGemm,
-      /*mustBeAligned=*/true, doCPromotion, scaled, splitReductionTripCnt);
+      target, problem, loc, transposedLhs, transposedRhs, isGemm, scaled,
+      useDirectLoad, prefetchNumStages, /*mustBeAligned=*/true, doCPromotion,
+      splitReductionTripCnt);
 
   if (!schedule && canSupportUnaligned) {
     LDBG() << "Attempting to deduce unaligned TileAndFuse MMA schedule";
@@ -865,8 +877,9 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // accumulator.
     bool doCPromotionUnaligned = cPromoteIfPadding || hasExistingAccumulator;
     schedule = getMmaScheduleFromProblemAndTarget(
-        target, problem, loc, transposedLhs, transposedRhs, isGemm,
-        mustBeAligned, doCPromotionUnaligned, scaled, splitReductionTripCnt);
+        target, problem, loc, transposedLhs, transposedRhs, isGemm, scaled,
+        useDirectLoad, prefetchNumStages, mustBeAligned, doCPromotionUnaligned,
+        splitReductionTripCnt);
   }
 
   if (!schedule) {
@@ -952,13 +965,13 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
 
   // Use global load DMA attribute (subgroup sizes will be derived from
   // translation_info).
-  Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
-  SmallVector<Attribute> promotionArray = {useGlobalDma, useGlobalDma};
+  SmallVector<Attribute> promotionArray;
+  if (useDirectLoad) {
+    Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+    promotionArray = {useGlobalDma, useGlobalDma};
+  }
   SmallVector<int64_t> promotionList = {0, 1};
   if (scaled) {
-    // TODO(#22119): We don't use global load DMA for scaled matmuls, because
-    // compilation doesn't support it. Once this is fixed, we should use global
-    // load DMA here when possible.
     promotionList.append({2, 3});
     auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
     // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
@@ -985,11 +998,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           IREE::GPU::DerivedThreadConfigAttr::get(context));
     }
   }
-  ArrayRef<Attribute> promotionTypes = useDirectLoad
-                                           ? ArrayRef<Attribute>(promotionArray)
-                                           : ArrayRef<Attribute>{};
   GPU::appendPromotedOperandsList(context, attrs, promotionList,
-                                  promotionTypes);
+                                  promotionArray);
   if (!mustBeAligned || couldNeedPadding) {
     SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
 
@@ -1102,11 +1112,13 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
   // Detect if the convolution is accumulating (reads existing accumulator).
   bool hasExistingAccumulator = isValidInPlaceAccumulatingOp(
       cast<DestinationStyleOpInterface>(linalgOp.getOperation()));
+  // Default to 2 stages if not specified.
+  int64_t prefetchStages = prefetchNumStages.value_or(2);
   FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
       getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           igemmLoopBounds, igemmContractionMaps, igemmOperands, target,
-          useDirectLoad, /*isGemm=*/false,
-          /*scaled=*/false, splitReductionTripCnt,
+          /*isGemm=*/false, /*scaled=*/false, useDirectLoad, prefetchStages,
+          splitReductionTripCnt,
           /*cPromoteIfPadding=*/cPromoteIfPadding, hasExistingAccumulator,
           convToIgemmInfo);
   if (failed(configAndWgSize)) {
@@ -1116,8 +1128,6 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
   LoweringConfigAttr loweringConfig = configAndWgSize->first;
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
-  // Default to 2 stages if not specified.
-  int64_t prefetchStages = prefetchNumStages.value_or(2);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       linalgOp->getContext(),
       /*prefetchNumStages=*/prefetchStages,
@@ -1167,21 +1177,25 @@ setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
   bool hasExistingAccumulator = isValidInPlaceAccumulatingOp(
       cast<DestinationStyleOpInterface>(linalgOp.getOperation()));
 
+  // Default to 2 stages if not specified.
+  int64_t prefetchStages = prefetchNumStages.value_or(2);
+
+  bool isScaled = false;
   FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
       getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
-          bounds, maps, operands, target, useDirectLoad, /*isGemm=*/true,
-          /*scaled=*/false, splitReductionTripCnt, cPromoteIfPadding,
-          hasExistingAccumulator);
+          bounds, maps, operands, target, /*isGemm=*/true, isScaled,
+          useDirectLoad, prefetchStages, splitReductionTripCnt,
+          cPromoteIfPadding, hasExistingAccumulator);
 
   // TODO (muzasyed) : add generalization for scaled and nonscaled versions of
   // matmul lowering.
   if (failed(configAndWgSize)) {
     // TODO (muzasyed) : Perform padding appropriately for minimizing bank
     // conflicts when dealing with scaled matmuls. For now it is disabled.
-    useDirectLoad = true;
+    isScaled = true;
     configAndWgSize = getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
-        bounds, maps, operands, target, useDirectLoad, /*isGemm=*/true,
-        /*scaled=*/true, splitReductionTripCnt, cPromoteIfPadding,
+        bounds, maps, operands, target, /*isGemm=*/true, isScaled,
+        useDirectLoad, prefetchStages, splitReductionTripCnt, cPromoteIfPadding,
         hasExistingAccumulator);
   }
 
@@ -1192,12 +1206,10 @@ setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
   LoweringConfigAttr loweringConfig = configAndWgSize->first;
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
-  // Default to 2 stages if not specified.
-  int64_t prefetchStages = prefetchNumStages.value_or(2);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       linalgOp->getContext(),
       /*prefetchNumStages=*/prefetchStages,
-      /*no_reduce_shared_memory_bank_conflicts=*/useDirectLoad,
+      /*no_reduce_shared_memory_bank_conflicts=*/useDirectLoad || isScaled,
       /*use_igemm_convolution=*/false,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(
@@ -1953,19 +1965,23 @@ LogicalResult setDirectConvolutionLoweringConfig(
   }
   bool transposedLhs = mPos > lhsKPos;
   bool transposedRhs = rhsKPos > nPos;
+  // By default, prefetch shared memory is kept off.
+  int64_t prefetchStages = prefetchNumStages.value_or(0);
   bool mustBeAligned = true;
   std::optional<GPUMMASchedule> schedule = getMmaScheduleFromProblemAndTarget(
       target, problem, linalgOp.getLoc(), transposedLhs, transposedRhs,
-      /*isGemm=*/false, mustBeAligned, /*doCPromotion=*/false,
-      /*scaled=*/false, splitReductionTripCnt);
+      /*isGemm=*/false, /*scaled=*/false, /*useDirectLoad=*/false,
+      prefetchStages, mustBeAligned, /*doCPromotion=*/false,
+      splitReductionTripCnt);
 
   if (!schedule && canSupportUnaligned) {
     LDBG() << "Attempting to deduce unaligned TileAndFuse MMA schedule";
     mustBeAligned = false;
     schedule = getMmaScheduleFromProblemAndTarget(
         target, problem, linalgOp.getLoc(), transposedLhs, transposedRhs,
-        /*isGemm=*/false, mustBeAligned, /*doCPromotion=*/false,
-        /*scaled=*/false, splitReductionTripCnt);
+        /*isGemm=*/false, /*scaled=*/false, /*useDirectLoad=*/false,
+        prefetchStages, mustBeAligned, /*doCPromotion=*/false,
+        splitReductionTripCnt);
   }
   if (!schedule) {
     LDBG() << "Failed to deduce TileAndFuse MMA schedule";
@@ -2050,8 +2066,6 @@ LogicalResult setDirectConvolutionLoweringConfig(
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
-  // By default, prefetch shared memory is kept off.
-  int64_t prefetchStages = prefetchNumStages.value_or(0);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       context, /*prefetchNumStages=*/prefetchStages,
       /*no_reduce_shared_memory_bank_conflicts=*/false,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -9,6 +9,18 @@
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS
 
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
+// RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-2
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=3 \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
+// RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-3
+
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
 #rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
 #scale_m = affine_map<(M, N, Ko, Kb) -> (M, Ko)>
@@ -44,6 +56,14 @@ func.func @scaled_matmul(
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=34816
+
+// CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=34816
+
+// CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=34816
 
 // -----
 
@@ -82,6 +102,14 @@ func.func @scaled_matmul_with_batch(
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=34816
+
+// CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=34816
+
+// CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=34816
 
 // -----
 
@@ -149,6 +177,14 @@ func.func @scaled_matmul_with_dynamic_batch(
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=26112
 
+// CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=26112
+
+// CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=26112
+
 // -----
 
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
@@ -186,6 +222,14 @@ func.func @small_scaled_matmul(
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=2176
+
+// CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=2176
+
+// CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=2176
 
 // -----
 
@@ -300,6 +344,14 @@ func.func @scaled_matmul_accumulate(
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=157184
 
+// CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=157184
+
+// CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=157184
+
 // -----
 
 // Very large f16 matmul — compute-bound, so picks 32x32x16 (higher compute per
@@ -316,3 +368,15 @@ func.func @matmul_f16_compute_bound(
 // CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
 // CHECK:   lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME: mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>
+
+// CHECK-REMARKS: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-SAME: Remark=32768
+
+// CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=65536
+
+// CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=98304


### PR DESCRIPTION
- Pass `useDirectLoad` and `prefetchNumStages` through `calculateOperandsSharedMemoryUsedInBytes`, so that it can account
  for multi-buffering when using direct loads with prefetching.
- Properly guard direct load flag for scaled matmuls as forced off (#22119) to avoid inconsistency, by overriding the flag with a
  warning emitted.
- As such, for regular matmul the shared memory usage scales with `prefetchNumStages` when `useDirectLoad` is enabled. For scaled matmul, shared memory usage is unchanged since direct load is forced off.