### PR TITLE
[Integrate] Integrate llvm-project@ae920e2636d3

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -124,7 +124,8 @@ LLVM::DIDerivedTypeAttr
 ExecutableLibraryDI::getConstOf(LLVM::DITypeAttr typeAttr) {
   return LLVM::DIDerivedTypeAttr::get(
       builder.getContext(), llvm::dwarf::DW_TAG_const_type,
-      /*name=*/nullptr, typeAttr, /*sizeInBits=*/0, /*alignInBits=*/0,
+      /*name=*/nullptr, /*file=*/nullptr, /*line=*/0, /*scope=*/nullptr,
+      typeAttr, /*sizeInBits=*/0, /*alignInBits=*/0,
       /*offsetInBits=*/0, /*dwarfAddressSpace=*/std::nullopt,
       /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);
 }
@@ -133,7 +134,8 @@ LLVM::DIDerivedTypeAttr
 ExecutableLibraryDI::getPtrOf(LLVM::DITypeAttr typeAttr) {
   return LLVM::DIDerivedTypeAttr::get(
       builder.getContext(), llvm::dwarf::DW_TAG_pointer_type,
-      /*name=*/nullptr, typeAttr, /*sizeInBits=*/ptrBitwidth,
+      /*name=*/nullptr, /*file=*/nullptr, /*line=*/0, /*scope=*/nullptr,
+      typeAttr, /*sizeInBits=*/ptrBitwidth,
       /*alignInBits=*/0,
       /*offsetInBits=*/0,
       /*dwarfAddressSpace=*/std::nullopt,
@@ -164,7 +166,8 @@ LLVM::DIDerivedTypeAttr
 ExecutableLibraryDI::getTypedefOf(StringRef name, LLVM::DITypeAttr typeAttr) {
   return LLVM::DIDerivedTypeAttr::get(
       builder.getContext(), llvm::dwarf::DW_TAG_typedef,
-      builder.getStringAttr(name), typeAttr, /*sizeInBits=*/0,
+      builder.getStringAttr(name), /*file=*/nullptr, /*line=*/0,
+      /*scope=*/nullptr, typeAttr, /*sizeInBits=*/0,
       /*alignInBits=*/0, /*offsetInBits=*/0, /*dwarfAddressSpace=*/std::nullopt,
       /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);
 }
@@ -177,7 +180,8 @@ ExecutableLibraryDI::getMemberOf(StringRef name, LLVM::DITypeAttr typeAttr,
   *offsetInBits += memberSizeInBits;
   return LLVM::DIDerivedTypeAttr::get(
       builder.getContext(), llvm::dwarf::DW_TAG_member,
-      builder.getStringAttr(name), typeAttr,
+      builder.getStringAttr(name), /*file=*/nullptr, /*line=*/0,
+      /*scope=*/nullptr, typeAttr,
       /*sizeInBits=*/memberSizeInBits, /*alignInBits=*/0,
       /*offsetInBits=*/memberOffsetInBits, /*dwarfAddressSpace=*/std::nullopt,
       /*flags=*/LLVM::DIFlags::Zero, /*extraData=*/nullptr);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -525,8 +525,7 @@ hal.executable private @i4_dequant_matvec {
 //         CHECK:     vector.transfer_read {{.*}} : memref<1x32x4xf16, {{.*}}>, vector<1x1x4xf16>
 //         CHECK:     memref.expand_shape {{.*}} : memref<1x1x128xi4, {{.*}}> into memref<1x1x32x4xi4, {{.*}}>
 //         CHECK:     vector.transfer_read {{.*}} : memref<1x1x32x4xi4, {{.*}}>, vector<1x1x1x4xi4>
-//         CHECK:     arith.extui %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<1x1x1x1x1x1x1x1x1x1x1x4xi32>
-//         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xi32> to vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
 //         CHECK:     arith.subf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
 //         CHECK:     arith.mulf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
 //         CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<1x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<1x1x1x1x1x1x1x1x1xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -141,8 +141,7 @@ hal.executable private @i4_dequant_matvec {
 //     RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x1x1x1x1xf16>
 //         RDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x1x1x1x1xf16>)
 //         RDNA3:   memref.expand_shape {{.*}} : memref<4x1x128xi4, {{.*}}> into memref<4x1x32x4xi4, {{.*}}>
-//         RDNA3:   %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x1x1x1x4xi32>
-//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xi32> to vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
 //         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
 //         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
 //         RDNA3:   vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<4x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<4x1x1x1x1x1x1x1x1xf16>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
@@ -50,8 +50,7 @@ func.func @i4_dequant_matvec_f32() {
 //         CHECK:     %[[READ1:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
 //         CHECK:     %[[READ2:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
 //         CHECK:     %[[READ3:.+]] = vector.transfer_read {{.+}} : memref<86x128xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//         CHECK:     %[[EXTEND:.+]] = arith.extui %[[READ0]] : vector<4xi4> to vector<4xi32>
-//         CHECK:     %[[CVT:.+]] = arith.uitofp %[[EXTEND]] : vector<4xi32> to vector<4xf32>
+//         CHECK:     %[[CVT:.+]] = arith.uitofp %[[READ0]] : vector<4xi4> to vector<4xf32>
 //         CHECK:     %[[EXTRACT0:.+]] = vector.extract %[[READ1]][0] : f32 from vector<1xf32>
 //         CHECK:     %[[BROADCAST0:.+]] = vector.broadcast %[[EXTRACT0]] : f32 to vector<4xf32>
 //         CHECK:     %[[SUB:.+]] = arith.subf %[[CVT]], %[[BROADCAST0]] : vector<4xf32>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -73,7 +73,6 @@ hal.executable @i4_dequant_unit_matmul_f16 {
 
 //   CHECK-LABEL: spirv.func @i4_dequant_unit_matmul_f16
 
-//     CHECK-DAG: %[[CSTVEC4XI32_255:.+]] = spirv.Constant dense<255> : vector<4xi32>
 //     CHECK-DAG: spirv.Constant dense<0> : vector<4xi32>
 //     CHECK-DAG: %[[CSTVEC2XI32_4:.+]] = spirv.Constant dense<4> : vector<2xi32>
 //     CHECK-DAG: %[[CSTVEC2XI32_15:.+]] = spirv.Constant dense<15> : vector<2xi32>
@@ -85,12 +84,12 @@ hal.executable @i4_dequant_unit_matmul_f16 {
 //         CHECK:   %[[SHUF01:.+]] = spirv.VectorShuffle [0 : i32, 1 : i32] %[[LOAD]], %[[LOAD]] : vector<4xi32>, vector<4xi32> -> vector<2xi32>
 //         CHECK:   %[[MASKED:.+]] = spirv.BitwiseAnd %[[SHUF01]], %[[CSTVEC2XI32_15]] : vector<2xi32>
 //         CHECK:   %[[SHIFTED:.+]] = spirv.ShiftRightLogical %[[SHUF01]], %[[CSTVEC2XI32_4]] : vector<2xi32>, vector<2xi32>
-//         CHECK:   %[[SHUF0011:.+]] = spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32] %[[MASKED]], %[[SHIFTED]] : vector<2xi32>, vector<2xi32> -> vector<4xi32>
-//         CHECK:   spirv.BitwiseAnd %[[SHUF0011]], %[[CSTVEC4XI32_255]] : vector<4xi32>
+//         CHECK:   spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32] %[[MASKED]], %[[SHIFTED]] : vector<2xi32>, vector<2xi32> -> vector<4xi32>
+//         CHECK:   spirv.ConvertUToF %{{.+}} : vector<4xi32> to vector<4xf16>
 
 //         CHECK:   spirv.VectorShuffle [2 : i32, 3 : i32] %[[LOAD:.+]], %[[LOAD:.+]] : vector<4xi32>, vector<4xi32> -> vector<2xi32>
-
-// CHECK-COUNT-2:   spirv.ConvertUToF %{{.+}} : vector<4xi32> to vector<4xf16>
+//         CHECK:   spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32]
+//         CHECK:   spirv.ConvertUToF %{{.+}} : vector<4xi32> to vector<4xf16>
 // CHECK-COUNT-2:   spirv.FSub %{{.+}}, %{{.+}} : vector<4xf16>
 // CHECK-COUNT-4:   spirv.FMul %{{.+}}, %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:   spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
@@ -183,7 +182,6 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 //     CHECK-DAG: %[[C2:.+]] = spirv.Constant 2 : i32
 //     CHECK-DAG: %[[C0:.+]] = spirv.Constant 0 : i32
 //     CHECK-DAG: %[[CSTVEC4XF16_1:.+]] = spirv.Constant dense<1.000000e+00> : vector<4xf16>
-//     CHECK-DAG: %[[CSTVEC4XI32_255:.+]] = spirv.Constant dense<255> : vector<4xi32>
 
 //         CHECK: %[[WIDX:.+]] = spirv.CompositeExtract %{{.*}}[0 : i32] : vector<3xi32>
 //         CHECK: %[[PCPTR:.+]] = spirv.AccessChain %{{.*}}[{{.*}}, %[[C0]]] : !spirv.ptr<!spirv.struct<(!spirv.array<5 x i32, stride=4> [0])>, PushConstant>, i32, i32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
@@ -48,13 +48,16 @@ hal.executable @i4_dequant {
 //         CHECK: %[[SHIFTED:.+]] = spirv.ShiftRightLogical %[[BYTE1]]
 //         CHECK: %[[COPIED:.+]] = spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32] %[[MASKED]], %[[SHIFTED]] : vector<2xi32>, vector<2xi32> -> vector<4xi32>
 //         CHECK: spirv.BitwiseAnd %[[COPIED]]
+//         CHECK: spirv.ConvertUToF {{.+}} : vector<4xi32> to vector<4xf32>
 //         CHECK: spirv.VectorShuffle [2 : i32, 3 : i32] {{.*}} : vector<4xi32>, vector<4xi32> -> vector<2xi32>
+//         CHECK: spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32]
+//         CHECK: spirv.ConvertUToF {{.+}} : vector<4xi32> to vector<4xf32>
 //         CHECK: spirv.VectorShuffle [0 : i32, 1 : i32]
 //         CHECK: spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32]
+//         CHECK: spirv.ConvertUToF {{.+}} : vector<4xi32> to vector<4xf32>
 //         CHECK: spirv.VectorShuffle [2 : i32, 3 : i32]
 //         CHECK: spirv.VectorShuffle [0 : i32, 2 : i32, 1 : i32, 3 : i32]
 //     CHECK-NOT: spirv.VectorShuffle
-
-// CHECK-COUNT-4: spirv.ConvertUToF {{.+}} : vector<4xi32> to vector<4xf32>
+//         CHECK: spirv.ConvertUToF {{.+}} : vector<4xi32> to vector<4xf32>
 // CHECK-COUNT-4: spirv.FSub
 // CHECK-COUNT-4: spirv.FMul


### PR DESCRIPTION
Integrate up to
https://github.com/llvm/llvm-project/commit/ae920e2636d3

Changes:
- Bump third_party/llvm-project to ae920e2636d3 (234 commits)
- Fix DIDerivedTypeAttr::get calls after MLIR added file, line, scope parameters (e55805076e05)
- Update tests for arith.extui+uitofp canonicalization fold (5368b8163d50) which now folds extui+uitofp into direct uitofp, and removes the corresponding BitwiseAnd with 255 in SPIRV lowering