### PR TITLE
[Codegen][Tuner] Move constraints/knob ops under `iree_codegen.smt.`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -733,18 +733,18 @@ def IREECodegen_RootOpAttr : AttrDef<IREECodegen_Dialect, "RootOp"> {
 }
 
 //===---------------------------------------------------------------------===//
-// iree_codegen.int_knob
+// iree_codegen.smt.int_knob
 //===---------------------------------------------------------------------===//
 
-def IREECodegen_IntKnobAttr : AttrDef<IREECodegen_Dialect, "IntKnob"> {
-  let mnemonic = "int_knob";
+def IREECodegen_SMTIntKnobAttr : AttrDef<IREECodegen_Dialect, "SMTIntKnob"> {
+  let mnemonic = "smt.int_knob";
   let summary = "Integer-valued tunable knob placeholder.";
   let description = [{
     Represents a named placeholder for an integer tunable parameter in a
     constraints knobs dictionary. During constraint generation, these appear
     in tiling arrays (workgroup, reduction, thread), workgroup_size, and
     subgroup_size positions. The name matches the corresponding
-    `iree_codegen.knob` op name.
+    `iree_codegen.smt.knob` op name.
   }];
   let parameters = (ins "StringAttr":$name);
   let assemblyFormat = "`<` $name `>`";

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -474,14 +474,16 @@ void WorkgroupCountHintOp::build(OpBuilder &builder, OperationState &state,
 }
 
 //===----------------------------------------------------------------------===//
-// ConstraintsOp
+// SMTConstraintsOp
 //===----------------------------------------------------------------------===//
 
 /// Recursively check whether `name` appears as a knob name in `attr`.
-/// Checks IntKnobAttr names and recurses into DictionaryAttr/ArrayAttr.
+/// Checks SMTIntKnobAttr names and recurses into DictionaryAttr/ArrayAttr.
 static bool hasKnobName(Attribute attr, StringRef name) {
   return TypeSwitch<Attribute, bool>(attr)
-      .Case([&](IntKnobAttr knob) { return knob.getName().getValue() == name; })
+      .Case([&](SMTIntKnobAttr knob) {
+        return knob.getName().getValue() == name;
+      })
       .Case([&](DictionaryAttr dict) {
         return llvm::any_of(dict, [&](NamedAttribute entry) {
           return hasKnobName(entry.getValue(), name);
@@ -495,7 +497,7 @@ static bool hasKnobName(Attribute attr, StringRef name) {
       .Default(false);
 }
 
-LogicalResult ConstraintsOp::verify() {
+LogicalResult SMTConstraintsOp::verify() {
   Block &block = getBody().front();
 
   // Check block arg count matches problem_dims count.
@@ -517,15 +519,16 @@ LogicalResult ConstraintsOp::verify() {
   // Verify knob ops: check names exist in the dict and reject duplicates.
   // Note that we considered using SymbolTable for uniqueness, but the knobs
   // dictionary contains attributes (not ops), so we'd still need custom
-  // verification for dictionary <--> KnobOp correspondence.
+  // verification for dictionary <--> SMTKnobOp correspondence.
   // Rejecting duplicates is not just pedantic -- when this op is lowered to
-  // SMT, each KnobOp becomes an `smt.declare_const`. The SMT dialect creates
-  // a fresh symbolic constant per declaration regardless of the name string,
-  // so two KnobOps with the same name would silently introduce two independent
+  // SMT, each SMTKnobOp becomes an `smt.declare_const`. The SMT dialect
+  // creates a fresh symbolic constant per declaration regardless of the name
+  // string, so two SMTKnobOps with the same name would silently introduce two
+  // independent
   // solver variables where one was intended, producing incorrect constraints.
   DictionaryAttr knobs = getKnobsAttr();
   llvm::StringMap<Location> seenKnobs;
-  for (auto knobOp : block.getOps<KnobOp>()) {
+  for (auto knobOp : block.getOps<SMTKnobOp>()) {
     auto [it, inserted] =
         seenKnobs.try_emplace(knobOp.getName(), knobOp.getLoc());
     if (!inserted) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -617,11 +617,11 @@ def IREECodegen_IndexHintOp : Op<IREECodegen_Dialect, "index_hint", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// ConstraintsOp
+// SMTConstraintsOp
 //===----------------------------------------------------------------------===//
 
-def IREECodegen_ConstraintsOp :
-    Op<IREECodegen_Dialect, "constraints",
+def IREECodegen_SMTConstraintsOp :
+    Op<IREECodegen_Dialect, "smt.constraints",
        [IsolatedFromAbove, SingleBlock, NoTerminator]> {
   let summary = "SMT constraints for a codegen configuration of root ops.";
   let description = [{
@@ -638,8 +638,8 @@ def IREECodegen_ConstraintsOp :
     not decided by the solver.
 
     `knobs`: DictionaryAttr mirroring GPULoweringConfigAttr. Leaves
-    that are `#iree_codegen.int_knob<"name">` attrs name tunable SMT
-    constants (materialized by `iree_codegen.knob` ops in the body).
+    that are `#iree_codegen.smt.int_knob<"name">` attrs name tunable SMT
+    constants (materialized by `iree_codegen.smt.knob` ops in the body).
     Integer/attr leaves are fixed.
 
     `problem_dims`: index-typed problem dimensions; corresponding block
@@ -651,12 +651,12 @@ def IREECodegen_ConstraintsOp :
     Example:
     ```mlir
     // The matmul is marked: {root_op = #iree_codegen.root_op<set = 0>}
-    iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
-     knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">, #iree_codegen.int_knob<"wg_n">]}
+    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+     knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
      dims(%M, %N, %K) {
     ^bb0(%m: !smt.int, %n: !smt.int, %k: !smt.int):
-      %wg_m = iree_codegen.knob "wg_m" : !smt.int
-      %wg_n = iree_codegen.knob "wg_n" : !smt.int
+      %wg_m = iree_codegen.smt.knob "wg_m" : !smt.int
+      %wg_n = iree_codegen.smt.knob "wg_n" : !smt.int
     }
     ```
   }];
@@ -679,16 +679,16 @@ def IREECodegen_ConstraintsOp :
 }
 
 //===----------------------------------------------------------------------===//
-// KnobOp
+// SMTKnobOp
 //===----------------------------------------------------------------------===//
 
-def IREECodegen_KnobOp :
-    Op<IREECodegen_Dialect, "knob", [Pure, HasParent<"ConstraintsOp">]> {
+def IREECodegen_SMTKnobOp :
+    Op<IREECodegen_Dialect, "smt.knob", [Pure, HasParent<"SMTConstraintsOp">]> {
   let summary = "Declare an SMT constant for a tunable configuration knob.";
   let description = [{
     Materializes a named SMT constant (!smt.int) for use in constraint
-    expressions. The name must match an `#iree_codegen.int_knob<"name">`
-    leaf in the enclosing `iree_codegen.constraints` op's `knobs`
+    expressions. The name must match an `#iree_codegen.smt.int_knob<"name">`
+    leaf in the enclosing `iree_codegen.smt.constraints` op's `knobs`
     dictionary.
 
     In SMT terminology this is a constant (0-ary function), not a variable.
@@ -696,7 +696,7 @@ def IREECodegen_KnobOp :
 
     Example:
     ```mlir
-    %wg_m = iree_codegen.knob "wg_m" : !smt.int
+    %wg_m = iree_codegen.smt.knob "wg_m" : !smt.int
     ```
   }];
   let arguments = (ins StrAttr:$name);

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -47,8 +47,8 @@ func.func @store_to_buffer_invalid_element_type(%arg0: tensor<4xf16>, %arg1: mem
 
 // Constraints op: block arg wrong type.
 func.func @constraints_block_arg_wrong_type(%arg0: index) {
-  // expected-error @+1 {{'iree_codegen.constraints' op block argument #0 must be !smt.int but got 'index'}}
-  iree_codegen.constraints target = <set = 0>, pipeline = None,
+  // expected-error @+1 {{'iree_codegen.smt.constraints' op block argument #0 must be !smt.int but got 'index'}}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
    knobs = {}
    dims(%arg0) {
   ^bb0(%m: index):
@@ -58,10 +58,10 @@ func.func @constraints_block_arg_wrong_type(%arg0: index) {
 
 // -----
 
-// KnobOp outside of ConstraintsOp.
+// SMTKnobOp outside of SMTConstraintsOp.
 func.func @knob_outside_constraints() {
-  // expected-error @+1 {{'iree_codegen.knob' op expects parent op 'iree_codegen.constraints'}}
-  %x = iree_codegen.knob "foo" : !smt.int
+  // expected-error @+1 {{'iree_codegen.smt.knob' op expects parent op 'iree_codegen.smt.constraints'}}
+  %x = iree_codegen.smt.knob "foo" : !smt.int
   return
 }
 
@@ -69,8 +69,8 @@ func.func @knob_outside_constraints() {
 
 // Constraints op: block arg count mismatch with problem_dims.
 func.func @constraints_block_arg_mismatch(%arg0: index) {
-  // expected-error @+1 {{'iree_codegen.constraints' op expected 1 block arguments but got 2}}
-  iree_codegen.constraints target = <set = 0>, pipeline = None,
+  // expected-error @+1 {{'iree_codegen.smt.constraints' op expected 1 block arguments but got 2}}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
    knobs = {}
    dims(%arg0) {
   ^bb0(%m: !smt.int, %extra: !smt.int):
@@ -82,14 +82,14 @@ func.func @constraints_block_arg_mismatch(%arg0: index) {
 
 // Knob op: duplicate knob name.
 func.func @duplicate_knob_name(%arg0: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = None,
-   knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">]}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
+   knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">]}
    dims(%arg0) {
   ^bb0(%m: !smt.int):
     // expected-note @+1 {{first occurrence here}}
-    %first = iree_codegen.knob "wg_m" : !smt.int
-    // expected-error @+1 {{'iree_codegen.knob' op duplicate knob name 'wg_m'}}
-    %second = iree_codegen.knob "wg_m" : !smt.int
+    %first = iree_codegen.smt.knob "wg_m" : !smt.int
+    // expected-error @+1 {{'iree_codegen.smt.knob' op duplicate knob name 'wg_m'}}
+    %second = iree_codegen.smt.knob "wg_m" : !smt.int
   }
   return
 }
@@ -98,8 +98,8 @@ func.func @duplicate_knob_name(%arg0: index) {
 
 // Constraints op: too few block args for problem_dims.
 func.func @constraints_block_arg_too_few(%arg0: index, %arg1: index) {
-  // expected-error @+1 {{'iree_codegen.constraints' op expected 2 block arguments but got 1}}
-  iree_codegen.constraints target = <set = 0>, pipeline = None,
+  // expected-error @+1 {{'iree_codegen.smt.constraints' op expected 2 block arguments but got 1}}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
    knobs = {}
    dims(%arg0, %arg1) {
   ^bb0(%m: !smt.int):
@@ -111,12 +111,12 @@ func.func @constraints_block_arg_too_few(%arg0: index, %arg1: index) {
 
 // Knob op: knob name not found in knobs dict.
 func.func @knob_name_not_found(%arg0: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = None,
-   knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">]}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
+   knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">]}
    dims(%arg0) {
   ^bb0(%m: !smt.int):
-    // expected-error @+1 {{'iree_codegen.knob' op knob name 'nonexistent' not found in knobs dict}}
-    %bad = iree_codegen.knob "nonexistent" : !smt.int
+    // expected-error @+1 {{'iree_codegen.smt.knob' op knob name 'nonexistent' not found in knobs dict}}
+    %bad = iree_codegen.smt.knob "nonexistent" : !smt.int
   }
   return
 }
@@ -125,12 +125,12 @@ func.func @knob_name_not_found(%arg0: index) {
 
 // Knob op: bare string in knobs dict does not satisfy knob lookup.
 func.func @string_attr_not_a_knob(%arg0: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = None,
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
    knobs = {name = "wg_m"}
    dims(%arg0) {
   ^bb0(%m: !smt.int):
-    // expected-error @+1 {{'iree_codegen.knob' op knob name 'wg_m' not found in knobs dict}}
-    %bad = iree_codegen.knob "wg_m" : !smt.int
+    // expected-error @+1 {{'iree_codegen.smt.knob' op knob name 'wg_m' not found in knobs dict}}
+    %bad = iree_codegen.smt.knob "wg_m" : !smt.int
   }
   return
 }
@@ -140,8 +140,8 @@ func.func @string_attr_not_a_knob(%arg0: index) {
 // Constraints op: pipeline attr must be DispatchLoweringPassPipelineAttr or
 // PipelineAttrInterface — a plain string attr is neither.
 func.func @constraints_invalid_pipeline(%arg0: index) {
-  // expected-error @+1 {{'iree_codegen.constraints' op attribute 'pipeline' failed to satisfy constraint}}
-  iree_codegen.constraints target = <set = 0>, pipeline = "not_a_pipeline",
+  // expected-error @+1 {{'iree_codegen.smt.constraints' op attribute 'pipeline' failed to satisfy constraint}}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = "not_a_pipeline",
    knobs = {}
    dims(%arg0) {
   ^bb0(%m: !smt.int):

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -116,36 +116,36 @@ func.func private @workgroup_scope_attr_linearize() attributes {
 
 // Test constraints op with knobs and dims.
 func.func @constraints_op(%arg0: index, %arg1: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
-   knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">, #iree_codegen.int_knob<"wg_n">]}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+   knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
    dims(%arg0, %arg1) {
   ^bb0(%m: !smt.int, %n: !smt.int):
-    %wg_m = iree_codegen.knob "wg_m" : !smt.int
-    %wg_n = iree_codegen.knob "wg_n" : !smt.int
+    %wg_m = iree_codegen.smt.knob "wg_m" : !smt.int
+    %wg_n = iree_codegen.smt.knob "wg_n" : !smt.int
   }
   return
 }
 // CHECK-LABEL: func.func @constraints_op(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[N:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
-// CHECK:     knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">, #iree_codegen.int_knob<"wg_n">]}
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+// CHECK:     knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
 // CHECK:     dims(%[[M]], %[[N]])
 // CHECK:    ^bb0(%{{.*}}: !smt.int, %{{.*}}: !smt.int):
-// CHECK:      iree_codegen.knob "wg_m" : !smt.int
-// CHECK:      iree_codegen.knob "wg_n" : !smt.int
+// CHECK:      iree_codegen.smt.knob "wg_m" : !smt.int
+// CHECK:      iree_codegen.smt.knob "wg_n" : !smt.int
 
 // -----
 
 // Test constraints op with nested knobs (multiple dict groups) and SMT body.
 func.func @constraints_op_with_smt_body(%arg0: index, %arg1: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
-   knobs = {reduction = [#iree_codegen.int_knob<"red_k">], workgroup = [#iree_codegen.int_knob<"wg_m">, #iree_codegen.int_knob<"wg_n">]}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+   knobs = {reduction = [#iree_codegen.smt.int_knob<"red_k">], workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
    dims(%arg0, %arg1) {
   ^bb0(%m: !smt.int, %n: !smt.int):
-    %wg_m = iree_codegen.knob "wg_m" : !smt.int
-    %wg_n = iree_codegen.knob "wg_n" : !smt.int
-    %red_k = iree_codegen.knob "red_k" : !smt.int
+    %wg_m = iree_codegen.smt.knob "wg_m" : !smt.int
+    %wg_n = iree_codegen.smt.knob "wg_n" : !smt.int
+    %red_k = iree_codegen.smt.knob "red_k" : !smt.int
     %zero = smt.int.constant 0
     %wg_m_pos = smt.int.cmp gt %wg_m, %zero
     smt.assert %wg_m_pos
@@ -155,13 +155,13 @@ func.func @constraints_op_with_smt_body(%arg0: index, %arg1: index) {
 // CHECK-LABEL: func.func @constraints_op_with_smt_body(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[N:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
-// CHECK:     knobs = {reduction = [#iree_codegen.int_knob<"red_k">], workgroup = [#iree_codegen.int_knob<"wg_m">, #iree_codegen.int_knob<"wg_n">]}
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+// CHECK:     knobs = {reduction = [#iree_codegen.smt.int_knob<"red_k">], workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
 // CHECK:     dims(%[[M]], %[[N]])
 // CHECK:    ^bb0(%{{.*}}: !smt.int, %{{.*}}: !smt.int):
-// CHECK:      iree_codegen.knob "wg_m" : !smt.int
-// CHECK:      iree_codegen.knob "wg_n" : !smt.int
-// CHECK:      iree_codegen.knob "red_k" : !smt.int
+// CHECK:      iree_codegen.smt.knob "wg_m" : !smt.int
+// CHECK:      iree_codegen.smt.knob "wg_n" : !smt.int
+// CHECK:      iree_codegen.smt.knob "red_k" : !smt.int
 // CHECK:      %[[ZERO:.*]] = smt.int.constant 0
 // CHECK:      %[[CMP:.*]] = smt.int.cmp gt
 // CHECK:      smt.assert %[[CMP]]
@@ -170,7 +170,7 @@ func.func @constraints_op_with_smt_body(%arg0: index, %arg1: index) {
 
 // Test constraints op with empty dims.
 func.func @constraints_op_empty_dims() {
-  iree_codegen.constraints target = <set = 1>, pipeline = None,
+  iree_codegen.smt.constraints target = <set = 1>, pipeline = None,
    knobs = {}
    dims() {
   ^bb0:
@@ -178,14 +178,14 @@ func.func @constraints_op_empty_dims() {
   return
 }
 // CHECK-LABEL: func.func @constraints_op_empty_dims(
-// CHECK:    iree_codegen.constraints target = <set = 1>, pipeline = None,
+// CHECK:    iree_codegen.smt.constraints target = <set = 1>, pipeline = None,
 // CHECK:     knobs = {}
 // CHECK:     dims()
 
 // Test constraints op with extra attributes (placed before the body).
 func.func @constraints_op_with_attrs(%arg0: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUTileAndFuse,
-   knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">]}
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUTileAndFuse,
+   knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">]}
    dims(%arg0) attributes {some_tag = "hello"} {
   ^bb0(%m: !smt.int):
   }
@@ -193,14 +193,14 @@ func.func @constraints_op_with_attrs(%arg0: index) {
 }
 // CHECK-LABEL: func.func @constraints_op_with_attrs(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.constraints target = <set = 0>, pipeline = LLVMGPUTileAndFuse,
-// CHECK:     knobs = {workgroup = [#iree_codegen.int_knob<"wg_m">]}
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUTileAndFuse,
+// CHECK:     knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">]}
 // CHECK:     dims(%[[M]]) attributes {some_tag = "hello"}
 // CHECK:    ^bb0(%{{.*}}: !smt.int):
 
 // Test constraints op with PipelineAttrInterface (pass_pipeline attr).
 func.func @constraints_op_with_pass_pipeline(%arg0: index) {
-  iree_codegen.constraints target = <set = 0>, pipeline = #iree_codegen.pass_pipeline<"canonicalize">,
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_codegen.pass_pipeline<"canonicalize">,
    knobs = {}
    dims(%arg0) {
   ^bb0(%m: !smt.int):
@@ -209,6 +209,6 @@ func.func @constraints_op_with_pass_pipeline(%arg0: index) {
 }
 // CHECK-LABEL: func.func @constraints_op_with_pass_pipeline(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.constraints target = <set = 0>, pipeline = #iree_codegen.pass_pipeline<"canonicalize">,
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_codegen.pass_pipeline<"canonicalize">,
 // CHECK:     knobs = {}
 // CHECK:     dims(%[[M]])


### PR DESCRIPTION
These ops only will participate in tuner constraint generation and verification -- they don't interact with the rest of the codegen pipeline. Using the `.smt.*` soft namespace makes this scope explicit without the boilerplate of a dedicated `iree_smt` dialect (which is hard to justify at this stage).

Renames:
  * `iree_codegen.constraints`  -> `iree_codegen.smt.constraints`
  * `iree_codegen.knob`         -> `iree_codegen.smt.knob`
  * `#iree_codegen.int_knob`    -> `#iree_codegen.smt.int_knob`

Issue: https://github.com/iree-org/iree/issues/23535