### PR TITLE
[LLVMGPU] Add CombineSourceLayoutTransformation to TileAndFuse pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -560,6 +560,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 5. Greedily fuse parallel loops and hoist from serial loops.
   funcPassManager.addPass(createGPUFuseAndHoistParallelLoopsPass());
+  funcPassManager.addPass(createCombineSourceLayoutTransformationPass());
   CombineResultLayoutTransformationPassOptions combineLayoutOptions;
   combineLayoutOptions.scope =
       IREE::Codegen::RelayoutCombinationScope::Workgroup;


### PR DESCRIPTION
-- Insert CombineSourceLayoutTransformation in the GPU TileAndFuse pipeline.
-- This is done in order to combine complex relayout op chains from
   load_from_buffer into a map_load op.