### PR TITLE
[GPU] [CUDA]  Fix sm_89 target resolution and select a compatible default PTX version

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -54,7 +54,7 @@ namespace mlir::iree_compiler::IREE::HAL {
 namespace {
 struct CUDAOptions {
   std::string clTarget = "sm_60";
-  std::string clTargetFeatures = "+ptx76";
+  std::string clTargetFeatures;
   bool clUsePtxas = false;
   std::string clUsePtxasFrom;
   std::string clUsePtxasParams;
@@ -80,7 +80,8 @@ struct CUDAOptions {
         "iree-cuda-target-features", clTargetFeatures, llvm::cl::cat(category),
         llvm::cl::desc(
             "CUDA target features as expected by LLVM NVPTX backend; e.g. "
-            "use '+ptxNN' to set PTX version to NN."));
+            "use '+ptxNN' to set PTX version to NN. If omitted, IREE picks "
+            "a target-appropriate default."));
 
     binder.opt<bool>(
         "iree-cuda-use-ptxas", clUsePtxas, llvm::cl::cat(category),
@@ -467,7 +468,9 @@ public:
     ModuleOp innerModuleOp = variantOp.getInnerModule();
     auto targetAttr = variantOp.getTargetAttr();
     StringRef targetArch = options.clTarget;
-    StringRef targetFeatures = options.clTargetFeatures;
+    std::string targetFeaturesStorage =
+        GPU::getCUDATargetFeatures(options.clTarget, options.clTargetFeatures);
+    StringRef targetFeatures = targetFeaturesStorage;
     if (auto attr =
             getGPUTargetAttr(executableBuilder.getContext(), targetAttr)) {
       targetArch = attr.getArch();

--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -468,9 +468,8 @@ public:
     ModuleOp innerModuleOp = variantOp.getInnerModule();
     auto targetAttr = variantOp.getTargetAttr();
     StringRef targetArch = options.clTarget;
-    std::string targetFeaturesStorage =
+    StringRef targetFeatures =
         GPU::getCUDATargetFeatures(options.clTarget, options.clTargetFeatures);
-    StringRef targetFeatures = targetFeaturesStorage;
     if (auto attr =
             getGPUTargetAttr(executableBuilder.getContext(), targetAttr)) {
       targetArch = attr.getArch();

--- a/compiler/plugins/target/CUDA/test/smoketest.mlir
+++ b/compiler/plugins/target/CUDA/test/smoketest.mlir
@@ -1,5 +1,7 @@
 // RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline --iree-gpu-test-target=sm_60 %s | FileCheck %s
 // RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline --iree-gpu-test-target=sm_60 --iree-hal-dump-executable-binaries-to=- %s 2>&1 | FileCheck %s --check-prefix=PTX
+// RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline --iree-gpu-test-target=sm_89 %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline --iree-gpu-test-target=sm_89 --iree-hal-dump-executable-binaries-to=- %s 2>&1 | FileCheck %s --check-prefix=PTX
 
 module attributes {
   hal.device.targets = [

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -22,6 +22,8 @@ namespace mlir::iree_compiler::IREE::GPU {
 
 namespace {
 
+StringRef normalizeNVIDIAGPUTarget(StringRef target);
+
 //===----------------------------------------------------------------------===//
 // Target details structs
 //===----------------------------------------------------------------------===//
@@ -937,6 +939,7 @@ const WgpDetails *getPascalWgpDetails() {
 }
 
 std::optional<TargetDetails> getNVIDIAGPUTargetDetails(StringRef target) {
+  target = normalizeNVIDIAGPUTarget(target);
   const WgpDetails *ampereWgp = getAmpereWgpDetails();
   const WgpDetails *turingWgp = getTuringWgpDetails();
   const WgpDetails *voltaWgp = getVoltaWgpDetails();
@@ -968,7 +971,7 @@ std::optional<TargetDetails> getNVIDIAGPUTargetDetails(StringRef target) {
       .Case("rtx3070ti", TargetDetails{ampereWgp, &rtx3070tiChip})
       // https://www.techpowerup.com/gpu-specs/geforce-rtx-3070.c3674
       .Case("rtx3070", TargetDetails{ampereWgp, &rtx3070Chip})
-      .Cases({"ampere", "sm_80", "sm_86", "sm_87"},
+      .Cases({"ampere", "ada", "sm_80", "sm_86", "sm_87", "sm_89"},
              TargetDetails{ampereWgp, nullptr})
       .Cases({"turing", "sm_75"}, TargetDetails{turingWgp, nullptr})
       .Cases({"volta", "sm_70", "sm_72"}, TargetDetails{voltaWgp, nullptr})
@@ -994,6 +997,7 @@ StringRef normalizeNVIDIAGPUTarget(StringRef target) {
 
   return llvm::StringSwitch<StringRef>(target.lower())
       .Case("a100", "sm_80")
+      .Case("ada", "sm_89")
       .Case("ampere", "sm_80") // Or sm_86/87; use smaller version.
       .Case("turing", "sm_75")
       .Case("volta", "sm_70")  // Or sm_72; use smaller version.
@@ -1134,12 +1138,26 @@ TargetAttr getMetalTargetDetails(MLIRContext *context) {
                           /*features=*/"spirv:v1.3,cap:Shader", context);
 }
 
+std::string getCUDATargetFeatures(StringRef target, StringRef features) {
+  if (!features.empty()) {
+    return features.str();
+  }
+
+  StringRef normalizedTarget = normalizeCUDATarget(target);
+  // LLVM NVPTX rejects sm_89 when the PTX ISA level is pinned below 7.8.
+  if (normalizedTarget == "sm_89") {
+    return "+ptx78";
+  }
+  return "+ptx76";
+}
+
 TargetAttr getCUDATargetDetails(StringRef target, StringRef features,
                                 MLIRContext *context) {
+  std::string resolvedFeatures = getCUDATargetFeatures(target, features);
   if (std::optional<TargetDetails> details =
           getNVIDIAGPUTargetDetails(target)) {
     return createTargetAttr(*details, normalizeNVIDIAGPUTarget(target),
-                            features, context);
+                            resolvedFeatures, context);
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -1138,9 +1138,9 @@ TargetAttr getMetalTargetDetails(MLIRContext *context) {
                           /*features=*/"spirv:v1.3,cap:Shader", context);
 }
 
-std::string getCUDATargetFeatures(StringRef target, StringRef features) {
+StringRef getCUDATargetFeatures(StringRef target, StringRef features) {
   if (!features.empty()) {
-    return features.str();
+    return features;
   }
 
   StringRef normalizedTarget = normalizeCUDATarget(target);
@@ -1153,7 +1153,7 @@ std::string getCUDATargetFeatures(StringRef target, StringRef features) {
 
 TargetAttr getCUDATargetDetails(StringRef target, StringRef features,
                                 MLIRContext *context) {
-  std::string resolvedFeatures = getCUDATargetFeatures(target, features);
+  StringRef resolvedFeatures = getCUDATargetFeatures(target, features);
   if (std::optional<TargetDetails> details =
           getNVIDIAGPUTargetDetails(target)) {
     return createTargetAttr(*details, normalizeNVIDIAGPUTarget(target),

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
@@ -7,6 +7,8 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_KNOWNTARGETS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_KNOWNTARGETS_H_
 
+#include <string>
+
 #include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "llvm/ADT/StringRef.h"
@@ -56,6 +58,11 @@ TargetAttr getCUDATargetDetails(llvm::StringRef target,
 // compiling towards CUDA. For example, "sm_80" for "a100", "sm_89" for "ada".
 // if the given |target| is not recognized.
 StringRef normalizeCUDATarget(StringRef target);
+
+// Returns the effective CUDA target features for |target|. If |features| is
+// empty, selects a target-appropriate default PTX ISA level.
+std::string getCUDATargetFeatures(llvm::StringRef target,
+                                  llvm::StringRef features);
 
 // Returns a TargetAttr to describe the details of the given |target|, which can
 // be a product name like "rx7900xtx", an microarchitecture name like "rdna3",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
@@ -7,7 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_KNOWNTARGETS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_KNOWNTARGETS_H_
 
-#include <string>
+#include <optional>
 
 #include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
@@ -61,8 +61,8 @@ StringRef normalizeCUDATarget(StringRef target);
 
 // Returns the effective CUDA target features for |target|. If |features| is
 // empty, selects a target-appropriate default PTX ISA level.
-std::string getCUDATargetFeatures(llvm::StringRef target,
-                                  llvm::StringRef features);
+llvm::StringRef getCUDATargetFeatures(llvm::StringRef target,
+                                      llvm::StringRef features);
 
 // Returns a TargetAttr to describe the details of the given |target|, which can
 // be a product name like "rx7900xtx", an microarchitecture name like "rdna3",


### PR DESCRIPTION
## Summary

Fix CUDA target handling for `sm_89` by centralizing target resolution and choosing a compatible default PTX version.

## Problem

CUDA target handling for `sm_89` was inconsistent causing some GPUs to not be properly resolved:
- target normalization already mapped NVIDIA aliases to `sm_89`
- target-details lookup did not recognize `sm_89`
- default CUDA target features still effectively assumed `+ptx76`

This caused a failure on attempting to compile for CUDA target on `sm_89` GPUs because `getCUDATargetDetails(...)` could return null for `sm_89`, so the executable target was created without `iree_codegen.target_info`, which later failed during kernel configuration.

Even once target metadata was resolved, LLVM NVPTX rejects `sm_89` with PTX 7.6 because `sm_89` requires at least PTX 7.8.

## Fix

This change fixed CUDA target resolution in target utils:
- normalize NVIDIA CUDA targets before target-details lookup
- recognize `sm_89` / `ada` in the centralized NVIDIA target table
- select `+ptx78` for `sm_89` and thus move the hardcoded default ptx selection into a shared resolver with default fallback to `+ptx76`

## Testing
- added CUDA smoketest coverage for `sm_89`
- verified CUDA compilation succeeds for `sm_89` GPU
- verified the emitted PTX uses a compatible ISA level for `sm_89`
