### PR TITLE
[Codegen] Fix crash in ROCDLLoadToTransposeLoad on block argument column index

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -258,8 +258,7 @@ analyzeTransferReadForTransposeLoad(vector::TransferReadOp transferOp) {
   // - The group_size must be a multiple of 16 (transpose_load operates on
   //   16-lane groups).
   // - The step must be 1 (column indices must be consecutive).
-  auto indexHintOp =
-      dyn_cast<IREE::Codegen::IndexHintOp>(columnIndex.getDefiningOp());
+  auto indexHintOp = columnIndex.getDefiningOp<IREE::Codegen::IndexHintOp>();
   if (!indexHintOp) {
     return std::nullopt;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
@@ -206,6 +206,24 @@ func.func @no_transform_row_from_block_arg(%row_arg: index) -> vector<4x1xf16> {
 
 // -----
 
+// Test: Column index from block argument (no defining op) - should NOT transform
+// Regression test for https://github.com/iree-org/iree/issues/23741
+// CHECK-LABEL: func.func @no_transform_column_from_block_arg
+// CHECK-NOT: amdgpu.transpose_load
+// CHECK: vector.transfer_read
+func.func @no_transform_column_from_block_arg(%col_arg: index) -> vector<4x1xf16> {
+  %src = memref.alloc() : memref<128x256xf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %row = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%row, %col_arg], %cst
+       {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d0, d1)>}
+       : memref<128x256xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
+  return %0 : vector<4x1xf16>
+}
+
+// -----
+
 // Test: Memref from function argument (not from alloc) - should NOT transform
 // CHECK-LABEL: func.func @no_transform_memref_from_arg
 // CHECK-NOT: amdgpu.transpose_load


### PR DESCRIPTION
Use `getDefiningOp<T>()` instead of `dyn_cast<T>(getDefiningOp())` when analyzing the column index in `analyzeTransferReadForTransposeLoad`. The latter asserts when `getDefiningOp()` returns null (block arguments), while the former returns null safely, allowing the existing null check to bail out as intended.

Fixes #23741
