### PR TITLE
[Codegen] Emulate `gather_to_lds` when it has narrow element types 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -61,8 +61,8 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
   LogicalResult
   matchAndRewrite(amdgpu::GatherToLDSOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto origSrcType = cast<MemRefType>(op.getSrc().getType());
-    auto origDstType = cast<MemRefType>(op.getDst().getType());
+    MemRefType origSrcType = op.getSrc().getType();
+    MemRefType origDstType = op.getDst().getType();
     auto newSrcType = cast<MemRefType>(adaptor.getSrc().getType());
     auto newDstType = cast<MemRefType>(adaptor.getDst().getType());
 
@@ -119,12 +119,9 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
     Type newTransferType = convertTransferType(
         rewriter.getContext(), op.getTransferType(), origSrcBits, newSrcBits);
 
-    auto newOp = amdgpu::GatherToLDSOp::create(
+    amdgpu::GatherToLDSOp::create(
         rewriter, loc, adaptor.getSrc(), ValueRange{srcIdx}, adaptor.getDst(),
-        ValueRange{dstIdx}, TypeAttr::get(newTransferType));
-    if (op.getAsync()) {
-      newOp.setAsync(true);
-    }
+        ValueRange{dstIdx}, TypeAttr::get(newTransferType), op.getAsyncAttr());
 
     rewriter.eraseOp(op);
     return success();
@@ -141,7 +138,8 @@ private:
                                 int newBits) {
     auto [strides, offset] = origType.getStridesAndOffset();
 
-    // Fail if the offset or any stride is dynamic.
+    // Fail if the offset or any stride is dynamic. Dynamic offsets could be
+    // supported if guaranteed byte-aligned, but that hasn't been needed yet.
     if (ShapedType::isDynamic(offset)) {
       return nullptr;
     }
@@ -178,12 +176,16 @@ private:
   }
 
   // Converts the transfer type from sub-byte elements to byte-sized elements,
-  // preserving the total transfer size in bits.
+  // preserving the total transfer size in bits. The caller must ensure
+  // totalBits is a multiple of newBits (the op verifier enforces that
+  // transfer sizes are 8, 16, 32, 96, or 128 bits, all multiples of 8).
   static Type convertTransferType(MLIRContext *context, Type origType,
                                   int origBits, int newBits) {
     if (auto vecType = dyn_cast<VectorType>(origType)) {
       int64_t totalBits =
           vecType.getNumElements() * vecType.getElementTypeBitWidth();
+      assert(totalBits % newBits == 0 &&
+             "transfer size must be a multiple of the new element bit width");
       int64_t newElems = totalBits / newBits;
       return VectorType::get({newElems}, IntegerType::get(context, newBits));
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -78,10 +78,10 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
     }
 
     Location loc = op.getLoc();
-    int origSrcBits = origSrcType.getElementTypeBitWidth();
-    int newSrcBits = newSrcType.getElementTypeBitWidth();
-    int origDstBits = origDstType.getElementTypeBitWidth();
-    int newDstBits = newDstType.getElementTypeBitWidth();
+    int64_t origSrcBits = origSrcType.getElementTypeBitWidth();
+    int64_t newSrcBits = newSrcType.getElementTypeBitWidth();
+    int64_t origDstBits = origDstType.getElementTypeBitWidth();
+    int64_t newDstBits = newDstType.getElementTypeBitWidth();
 
     // Only convert when the transfer vector's total bits are a multiple of
     // the new element bit width. E.g. vector<3xf4E2M1FN> (12 bits) cannot
@@ -97,23 +97,27 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
       }
     }
 
-    // Linearize source indices into a 1D byte-offset index.
-    Value srcIdx = linearizeAndPack(rewriter, loc, op.getSrcIndices(),
-                                    origSrcType, origSrcBits, newSrcBits);
-    if (!srcIdx) {
+    // Check both source and destination convertibility before modifying IR.
+    if (!canLinearizeAndPack(op.getSrcIndices(), origSrcType, origSrcBits,
+                             newSrcBits)) {
       return rewriter.notifyMatchFailure(
           op, "failed to linearize source indices (dynamic or mismatched "
               "strides/offset, or invalid bit-width ratio)");
     }
-
-    // Linearize destination indices.
-    Value dstIdx = linearizeAndPack(rewriter, loc, op.getDstIndices(),
-                                    origDstType, origDstBits, newDstBits);
-    if (!dstIdx) {
+    if (!canLinearizeAndPack(op.getDstIndices(), origDstType, origDstBits,
+                             newDstBits)) {
       return rewriter.notifyMatchFailure(
           op, "failed to linearize destination indices (dynamic or mismatched "
               "strides/offset, or invalid bit-width ratio)");
     }
+
+    // Linearize source indices into a 1D byte-offset index.
+    Value srcIdx = linearizeAndPack(rewriter, loc, op.getSrcIndices(),
+                                    origSrcType, origSrcBits, newSrcBits);
+
+    // Linearize destination indices.
+    Value dstIdx = linearizeAndPack(rewriter, loc, op.getDstIndices(),
+                                    origDstType, origDstBits, newDstBits);
 
     // Adjust transfer type to use the new element type.
     Type newTransferType = convertTransferType(
@@ -128,45 +132,53 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
   }
 
 private:
+  // Checks whether linearizeAndPack can succeed without modifying IR.
+  static bool canLinearizeAndPack(ValueRange indices, MemRefType origType,
+                                  int64_t origBits, int64_t newBits) {
+    auto [strides, offset] = origType.getStridesAndOffset();
+    if (ShapedType::isDynamic(offset)) {
+      return false;
+    }
+    for (int64_t stride : strides) {
+      if (ShapedType::isDynamic(stride)) {
+        return false;
+      }
+    }
+    if (indices.size() != strides.size()) {
+      return false;
+    }
+    if (origBits != newBits &&
+        (newBits <= origBits || newBits % origBits != 0)) {
+      return false;
+    }
+    return true;
+  }
+
   // Linearizes multi-dimensional indices into a 1D index for the packed
-  // byte-addressable memref.
+  // byte-addressable memref. The caller must ensure canLinearizeAndPack()
+  // returns true before calling this.
   //   linearIdx = offset + sum(idx[i] * stride[i])
   //   packedIdx = linearIdx / (newBits / origBits)
   static Value linearizeAndPack(ConversionPatternRewriter &rewriter,
                                 Location loc, ValueRange indices,
-                                MemRefType origType, int origBits,
-                                int newBits) {
+                                MemRefType origType, int64_t origBits,
+                                int64_t newBits) {
     auto [strides, offset] = origType.getStridesAndOffset();
 
-    // Fail if the offset or any stride is dynamic. Dynamic offsets could be
-    // supported if guaranteed byte-aligned, but that hasn't been needed yet.
-    if (ShapedType::isDynamic(offset)) {
-      return nullptr;
-    }
-    for (int64_t stride : strides) {
-      if (ShapedType::isDynamic(stride)) {
-        return nullptr;
-      }
-    }
-
-    // Fail if the number of indices doesn't match the rank.
-    if (indices.size() != strides.size()) {
-      return nullptr;
-    }
-
     // Linearize: offset + sum(idx[i] * stride[i]).
+    auto overflowFlags =
+        arith::IntegerOverflowFlags::nsw | arith::IntegerOverflowFlags::nuw;
     Value linearIdx = arith::ConstantIndexOp::create(rewriter, loc, offset);
     for (auto [idx, stride] : llvm::zip(indices, strides)) {
       Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
-      Value product = arith::MulIOp::create(rewriter, loc, idx, strideVal);
-      linearIdx = arith::AddIOp::create(rewriter, loc, linearIdx, product);
+      Value product =
+          arith::MulIOp::create(rewriter, loc, idx, strideVal, overflowFlags);
+      linearIdx = arith::AddIOp::create(rewriter, loc, linearIdx, product,
+                                        overflowFlags);
     }
 
     // Pack: convert from origBits-element units to newBits-element units.
     if (origBits != newBits) {
-      if (newBits <= origBits || newBits % origBits != 0) {
-        return nullptr;
-      }
       int64_t packRatio = newBits / origBits;
       Value ratioVal = arith::ConstantIndexOp::create(rewriter, loc, packRatio);
       linearIdx = arith::DivUIOp::create(rewriter, loc, linearIdx, ratioVal);
@@ -180,7 +192,7 @@ private:
   // totalBits is a multiple of newBits (the op verifier enforces that
   // transfer sizes are 8, 16, 32, 96, or 128 bits, all multiples of 8).
   static Type convertTransferType(MLIRContext *context, Type origType,
-                                  int origBits, int newBits) {
+                                  int64_t origBits, int64_t newBits) {
     if (auto vecType = dyn_cast<VectorType>(origType)) {
       int64_t totalBits =
           vecType.getNumElements() * vecType.getElementTypeBitWidth();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -91,7 +91,9 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
           vecType.getNumElements() * vecType.getElementTypeBitWidth();
       if (totalBits % newSrcBits != 0) {
         return rewriter.notifyMatchFailure(
-            op, "transfer vector bit-width is not a multiple of byte width");
+            op,
+            "transfer vector bit-width is not a multiple of the new element "
+            "bit width");
       }
     }
 
@@ -100,7 +102,8 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
                                     origSrcType, origSrcBits, newSrcBits);
     if (!srcIdx) {
       return rewriter.notifyMatchFailure(
-          op, "failed to linearize source indices (dynamic strides)");
+          op, "failed to linearize source indices (dynamic or mismatched "
+              "strides/offset, or invalid bit-width ratio)");
     }
 
     // Linearize destination indices.
@@ -108,7 +111,8 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
                                     origDstType, origDstBits, newDstBits);
     if (!dstIdx) {
       return rewriter.notifyMatchFailure(
-          op, "failed to linearize destination indices (dynamic strides)");
+          op, "failed to linearize destination indices (dynamic or mismatched "
+              "strides/offset, or invalid bit-width ratio)");
     }
 
     // Adjust transfer type to use the new element type.
@@ -129,29 +133,31 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
 private:
   // Linearizes multi-dimensional indices into a 1D index for the packed
   // byte-addressable memref.
-  //   linearIdx = sum(idx[i] * stride[i])
+  //   linearIdx = offset + sum(idx[i] * stride[i])
   //   packedIdx = linearIdx * origBits / newBits
   static Value linearizeAndPack(ConversionPatternRewriter &rewriter,
                                 Location loc, ValueRange indices,
                                 MemRefType origType, int origBits,
                                 int newBits) {
-    if (origBits == newBits) {
-      // No packing needed; if also 1D, just pass through.
-      if (indices.size() == 1) {
-        return indices.front();
-      }
-    }
-
     auto [strides, offset] = origType.getStridesAndOffset();
 
+    // Fail if the offset or any stride is dynamic.
+    if (ShapedType::isDynamic(offset)) {
+      return nullptr;
+    }
     for (int64_t stride : strides) {
       if (ShapedType::isDynamic(stride)) {
         return nullptr;
       }
     }
 
-    // Linearize: sum(idx[i] * stride[i]).
-    Value linearIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    // Fail if the number of indices doesn't match the rank.
+    if (indices.size() != strides.size()) {
+      return nullptr;
+    }
+
+    // Linearize: offset + sum(idx[i] * stride[i]).
+    Value linearIdx = arith::ConstantIndexOp::create(rewriter, loc, offset);
     for (auto [idx, stride] : llvm::zip(indices, strides)) {
       Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
       Value product = arith::MulIOp::create(rewriter, loc, idx, strideVal);
@@ -160,7 +166,9 @@ private:
 
     // Pack: convert from origBits-element units to newBits-element units.
     if (origBits != newBits) {
-      assert(newBits > origBits && newBits % origBits == 0);
+      if (newBits <= origBits || newBits % origBits != 0) {
+        return nullptr;
+      }
       int64_t packRatio = newBits / origBits;
       Value ratioVal = arith::ConstantIndexOp::create(rewriter, loc, packRatio);
       linearIdx = arith::DivUIOp::create(rewriter, loc, linearIdx, ratioVal);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -84,8 +84,8 @@ struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
     int newDstBits = newDstType.getElementTypeBitWidth();
 
     // Only convert when the transfer vector's total bits are a multiple of
-    // a byte. E.g. vector<3xf4E2M1FN> (12 bits) cannot be cleanly packed
-    // into i8 elements.
+    // the new element bit width. E.g. vector<3xf4E2M1FN> (12 bits) cannot
+    // be cleanly packed into i8 elements.
     if (auto vecType = dyn_cast<VectorType>(op.getTransferType())) {
       int64_t totalBits =
           vecType.getNumElements() * vecType.getElementTypeBitWidth();
@@ -134,7 +134,7 @@ private:
   // Linearizes multi-dimensional indices into a 1D index for the packed
   // byte-addressable memref.
   //   linearIdx = offset + sum(idx[i] * stride[i])
-  //   packedIdx = linearIdx * origBits / newBits
+  //   packedIdx = linearIdx / (newBits / origBits)
   static Value linearizeAndPack(ConversionPatternRewriter &rewriter,
                                 Location loc, ValueRange indices,
                                 MemRefType origType, int origBits,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/NarrowTypeEmulationConverter.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -50,6 +51,138 @@ struct ConvertRawBufferCast final
   }
 };
 
+/// Converts GatherToLDSOp when its memrefs change from sub-byte types
+/// (e.g. f4E2M1FN) to byte-sized types (i8) during narrow type emulation.
+/// The pattern linearizes multi-dimensional indices into the converted 1D
+/// memref space and adjusts the transfer type accordingly.
+struct ConvertGatherToLDS final : OpConversionPattern<amdgpu::GatherToLDSOp> {
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(amdgpu::GatherToLDSOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto origSrcType = cast<MemRefType>(op.getSrc().getType());
+    auto origDstType = cast<MemRefType>(op.getDst().getType());
+    auto newSrcType = cast<MemRefType>(adaptor.getSrc().getType());
+    auto newDstType = cast<MemRefType>(adaptor.getDst().getType());
+
+    // Only convert sub-byte element types.
+    if (origSrcType.getElementTypeBitWidth() >= 8 &&
+        origDstType.getElementTypeBitWidth() >= 8) {
+      return failure();
+    }
+
+    // If types didn't change, nothing to do.
+    if (newSrcType == origSrcType && newDstType == origDstType) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    int origSrcBits = origSrcType.getElementTypeBitWidth();
+    int newSrcBits = newSrcType.getElementTypeBitWidth();
+    int origDstBits = origDstType.getElementTypeBitWidth();
+    int newDstBits = newDstType.getElementTypeBitWidth();
+
+    // Only convert when the transfer vector's total bits are a multiple of
+    // a byte. E.g. vector<3xf4E2M1FN> (12 bits) cannot be cleanly packed
+    // into i8 elements.
+    if (auto vecType = dyn_cast<VectorType>(op.getTransferType())) {
+      int64_t totalBits =
+          vecType.getNumElements() * vecType.getElementTypeBitWidth();
+      if (totalBits % newSrcBits != 0) {
+        return rewriter.notifyMatchFailure(
+            op, "transfer vector bit-width is not a multiple of byte width");
+      }
+    }
+
+    // Linearize source indices into a 1D byte-offset index.
+    Value srcIdx = linearizeAndPack(rewriter, loc, op.getSrcIndices(),
+                                    origSrcType, origSrcBits, newSrcBits);
+    if (!srcIdx) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to linearize source indices (dynamic strides)");
+    }
+
+    // Linearize destination indices.
+    Value dstIdx = linearizeAndPack(rewriter, loc, op.getDstIndices(),
+                                    origDstType, origDstBits, newDstBits);
+    if (!dstIdx) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to linearize destination indices (dynamic strides)");
+    }
+
+    // Adjust transfer type to use the new element type.
+    Type newTransferType = convertTransferType(
+        rewriter.getContext(), op.getTransferType(), origSrcBits, newSrcBits);
+
+    auto newOp = amdgpu::GatherToLDSOp::create(
+        rewriter, loc, adaptor.getSrc(), ValueRange{srcIdx}, adaptor.getDst(),
+        ValueRange{dstIdx}, TypeAttr::get(newTransferType));
+    if (op.getAsync()) {
+      newOp.setAsync(true);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  // Linearizes multi-dimensional indices into a 1D index for the packed
+  // byte-addressable memref.
+  //   linearIdx = sum(idx[i] * stride[i])
+  //   packedIdx = linearIdx * origBits / newBits
+  static Value linearizeAndPack(ConversionPatternRewriter &rewriter,
+                                Location loc, ValueRange indices,
+                                MemRefType origType, int origBits,
+                                int newBits) {
+    if (origBits == newBits) {
+      // No packing needed; if also 1D, just pass through.
+      if (indices.size() == 1) {
+        return indices.front();
+      }
+    }
+
+    auto [strides, offset] = origType.getStridesAndOffset();
+
+    for (int64_t stride : strides) {
+      if (ShapedType::isDynamic(stride)) {
+        return nullptr;
+      }
+    }
+
+    // Linearize: sum(idx[i] * stride[i]).
+    Value linearIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    for (auto [idx, stride] : llvm::zip(indices, strides)) {
+      Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
+      Value product = arith::MulIOp::create(rewriter, loc, idx, strideVal);
+      linearIdx = arith::AddIOp::create(rewriter, loc, linearIdx, product);
+    }
+
+    // Pack: convert from origBits-element units to newBits-element units.
+    if (origBits != newBits) {
+      assert(newBits > origBits && newBits % origBits == 0);
+      int64_t packRatio = newBits / origBits;
+      Value ratioVal = arith::ConstantIndexOp::create(rewriter, loc, packRatio);
+      linearIdx = arith::DivUIOp::create(rewriter, loc, linearIdx, ratioVal);
+    }
+
+    return linearIdx;
+  }
+
+  // Converts the transfer type from sub-byte elements to byte-sized elements,
+  // preserving the total transfer size in bits.
+  static Type convertTransferType(MLIRContext *context, Type origType,
+                                  int origBits, int newBits) {
+    if (auto vecType = dyn_cast<VectorType>(origType)) {
+      int64_t totalBits =
+          vecType.getNumElements() * vecType.getElementTypeBitWidth();
+      int64_t newElems = totalBits / newBits;
+      return VectorType::get({newElems}, IntegerType::get(context, newBits));
+    }
+    return IntegerType::get(context, newBits);
+  }
+};
+
 struct AMDGPUEmulateNarrowTypePass final
     : impl::AMDGPUEmulateNarrowTypePassBase<AMDGPUEmulateNarrowTypePass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -67,8 +200,8 @@ struct AMDGPUEmulateNarrowTypePass final
           };
           target.addDynamicallyLegalDialect<amdgpu::AMDGPUDialect>(
               opLegalCallback);
-          patterns.add<ConvertRawBufferCast>(typeConverter,
-                                             patterns.getContext());
+          patterns.add<ConvertRawBufferCast, ConvertGatherToLDS>(
+              typeConverter, patterns.getContext());
         };
     if (failed(emulateNarrowType(getOperation(), /*disableAtomic=*/true,
                                  populateAMDGPUPatterns))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
@@ -63,7 +63,13 @@ func.func @gather_to_lds_i4_2d(
 //  CHECK-SAME:     %[[SRC:.*]]: memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
 //  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
-//       CHECK:     amdgpu.gather_to_lds %[[SRC]][{{.*}}], %[[DST]][{{.*}}]
+//   CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
+//   CHECK-DAG:     %[[C32:.*]] = arith.constant 32 : index
+//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C32]]
+//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]]
+//       CHECK:     %[[SRC_IDX:.*]] = arith.divui %[[ADD]], %[[C2]]
+//       CHECK:     %[[DST_IDX:.*]] = arith.divui %[[J0]], %[[C2]]
+//       CHECK:     amdgpu.gather_to_lds %[[SRC]][%[[SRC_IDX]]], %[[DST]][%[[DST_IDX]]]
 //  CHECK-SAME:       : vector<4xi8>
 
 // -----
@@ -105,7 +111,13 @@ func.func @gather_to_lds_f4E2M1FN_2d(
 //  CHECK-SAME:     %[[SRC:.*]]: memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
 //  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
-//       CHECK:     amdgpu.gather_to_lds %[[SRC]][{{.*}}], %[[DST]][{{.*}}]
+//   CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
+//   CHECK-DAG:     %[[C32:.*]] = arith.constant 32 : index
+//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C32]]
+//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]]
+//       CHECK:     %[[SRC_IDX:.*]] = arith.divui %[[ADD]], %[[C2]]
+//       CHECK:     %[[DST_IDX:.*]] = arith.divui %[[J0]], %[[C2]]
+//       CHECK:     amdgpu.gather_to_lds %[[SRC]][%[[SRC_IDX]]], %[[DST]][%[[DST_IDX]]]
 //  CHECK-SAME:       : vector<4xi8>
 
 // -----
@@ -126,5 +138,12 @@ func.func @gather_to_lds_i2_2d(
 // CHECK-LABEL: func.func @gather_to_lds_i2_2d(
 //  CHECK-SAME:     %[[SRC:.*]]: memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
 //  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
-//       CHECK:     amdgpu.gather_to_lds %[[SRC]][{{.*}}], %[[DST]][{{.*}}]
+//  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
+//   CHECK-DAG:     %[[C4:.*]] = arith.constant 4 : index
+//   CHECK-DAG:     %[[C64:.*]] = arith.constant 64 : index
+//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C64]]
+//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]]
+//       CHECK:     %[[SRC_IDX:.*]] = arith.divui %[[ADD]], %[[C4]]
+//       CHECK:     %[[DST_IDX:.*]] = arith.divui %[[J0]], %[[C4]]
+//       CHECK:     amdgpu.gather_to_lds %[[SRC]][%[[SRC_IDX]]], %[[DST]][%[[DST_IDX]]]
 //  CHECK-SAME:       : vector<4xi8>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
@@ -42,3 +42,89 @@ func.func @dim_resolution_with_vector_emulation(%size: index) {
 // Verify vector operations are emulated to i8 (8xi4 -> 4xi8)
 //       CHECK:     vector.load %{{.*}} : memref<?xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<4xi8>
 //       CHECK:     vector.store %{{.*}} : memref<?xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<4xi8>
+
+// -----
+
+// Test that gather_to_lds with sub-byte element types (i4) gets converted
+// to use byte-sized elements (i8), with indices packed and transfer type
+// adjusted to preserve the same number of transferred bits.
+func.func @gather_to_lds_i4_2d(
+    %src: memref<128x32xi4, #amdgpu.address_space<fat_raw_buffer>>,
+    %dst: memref<64xi4, #gpu.address_space<workgroup>>,
+    %i0: index, %i1: index, %j0: index) {
+  amdgpu.gather_to_lds %src[%i0, %i1], %dst[%j0]
+      : vector<8xi4>,
+        memref<128x32xi4, #amdgpu.address_space<fat_raw_buffer>>,
+        memref<64xi4, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: func.func @gather_to_lds_i4_2d(
+//  CHECK-SAME:     %[[SRC:.*]]: memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
+//  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
+//       CHECK:     amdgpu.gather_to_lds %[[SRC]][{{.*}}], %[[DST]][{{.*}}]
+//  CHECK-SAME:       : vector<4xi8>
+
+// -----
+
+// Test gather_to_lds with async attribute is preserved after conversion.
+func.func @gather_to_lds_i4_async(
+    %src: memref<256xi4, #amdgpu.address_space<fat_raw_buffer>>,
+    %dst: memref<64xi4, #gpu.address_space<workgroup>>,
+    %idx: index, %jdx: index) {
+  amdgpu.gather_to_lds async %src[%idx], %dst[%jdx]
+      : vector<8xi4>,
+        memref<256xi4, #amdgpu.address_space<fat_raw_buffer>>,
+        memref<64xi4, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: func.func @gather_to_lds_i4_async(
+//  CHECK-SAME:     %[[SRC:.*]]: memref<128xi8, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
+//       CHECK:     amdgpu.gather_to_lds async
+//  CHECK-SAME:       : vector<4xi8>
+
+// -----
+
+// Test gather_to_lds with f4E2M1FN sub-byte type gets converted
+// (vector<8xf4E2M1FN> = 32 bits -> vector<4xi8>).
+func.func @gather_to_lds_f4E2M1FN_2d(
+    %src: memref<128x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>,
+    %dst: memref<64xf4E2M1FN, #gpu.address_space<workgroup>>,
+    %i0: index, %i1: index, %j0: index) {
+  amdgpu.gather_to_lds %src[%i0, %i1], %dst[%j0]
+      : vector<8xf4E2M1FN>,
+        memref<128x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>,
+        memref<64xf4E2M1FN, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: func.func @gather_to_lds_f4E2M1FN_2d(
+//  CHECK-SAME:     %[[SRC:.*]]: memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
+//  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
+//       CHECK:     amdgpu.gather_to_lds %[[SRC]][{{.*}}], %[[DST]][{{.*}}]
+//  CHECK-SAME:       : vector<4xi8>
+
+// -----
+
+// Test gather_to_lds with i2 sub-byte type gets converted (vector<16xi2> =
+// 32 bits -> vector<4xi8>).
+func.func @gather_to_lds_i2_2d(
+    %src: memref<128x64xi2, #amdgpu.address_space<fat_raw_buffer>>,
+    %dst: memref<128xi2, #gpu.address_space<workgroup>>,
+    %i0: index, %i1: index, %j0: index) {
+  amdgpu.gather_to_lds %src[%i0, %i1], %dst[%j0]
+      : vector<16xi2>,
+        memref<128x64xi2, #amdgpu.address_space<fat_raw_buffer>>,
+        memref<128xi2, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: func.func @gather_to_lds_i2_2d(
+//  CHECK-SAME:     %[[SRC:.*]]: memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
+//  CHECK-SAME:     %[[DST:.*]]: memref<32xi8, #gpu.address_space<workgroup>>
+//       CHECK:     amdgpu.gather_to_lds %[[SRC]][{{.*}}], %[[DST]][{{.*}}]
+//  CHECK-SAME:       : vector<4xi8>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
@@ -65,8 +65,8 @@ func.func @gather_to_lds_i4_2d(
 //  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
 //   CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
 //   CHECK-DAG:     %[[C32:.*]] = arith.constant 32 : index
-//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C32]]
-//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]]
+//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C32]] overflow<nsw, nuw>
+//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]] overflow<nsw, nuw>
 //       CHECK:     %[[SRC_IDX:.*]] = arith.divui %[[ADD]], %[[C2]]
 //       CHECK:     %[[DST_IDX:.*]] = arith.divui %[[J0]], %[[C2]]
 //       CHECK:     amdgpu.gather_to_lds %[[SRC]][%[[SRC_IDX]]], %[[DST]][%[[DST_IDX]]]
@@ -113,8 +113,8 @@ func.func @gather_to_lds_f4E2M1FN_2d(
 //  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
 //   CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
 //   CHECK-DAG:     %[[C32:.*]] = arith.constant 32 : index
-//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C32]]
-//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]]
+//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C32]] overflow<nsw, nuw>
+//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]] overflow<nsw, nuw>
 //       CHECK:     %[[SRC_IDX:.*]] = arith.divui %[[ADD]], %[[C2]]
 //       CHECK:     %[[DST_IDX:.*]] = arith.divui %[[J0]], %[[C2]]
 //       CHECK:     amdgpu.gather_to_lds %[[SRC]][%[[SRC_IDX]]], %[[DST]][%[[DST_IDX]]]
@@ -141,8 +141,8 @@ func.func @gather_to_lds_i2_2d(
 //  CHECK-SAME:     %[[I0:.*]]: index, %[[I1:.*]]: index, %[[J0:.*]]: index
 //   CHECK-DAG:     %[[C4:.*]] = arith.constant 4 : index
 //   CHECK-DAG:     %[[C64:.*]] = arith.constant 64 : index
-//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C64]]
-//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]]
+//       CHECK:     %[[MUL:.*]] = arith.muli %[[I0]], %[[C64]] overflow<nsw, nuw>
+//       CHECK:     %[[ADD:.*]] = arith.addi %[[MUL]], %[[I1]] overflow<nsw, nuw>
 //       CHECK:     %[[SRC_IDX:.*]] = arith.divui %[[ADD]], %[[C4]]
 //       CHECK:     %[[DST_IDX:.*]] = arith.divui %[[J0]], %[[C4]]
 //       CHECK:     amdgpu.gather_to_lds %[[SRC]][%[[SRC_IDX]]], %[[DST]][%[[DST_IDX]]]


### PR DESCRIPTION
First step to support DMA for scaled GEMMs.

* Add `ConvertGatherToLDS` pattern to `AMDGPUEmulateNarrowType pass`.
* In the pass focusing on `gather_to_lds` op, adjust subbyte element type to i8. e.g. `vector<32xf4E2M1FN>` -> `vector<16xi8>`.
* Semantically the same before and after.