### PR TITLE
[CI] Reclaim more disk space on macOS arm64 runner

### DIFF
--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -41,14 +41,29 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - name: "Reclaim disk space"
-        # GitHub-hosted runners have 14GB of disk space -- reclaim some by removing SDKs
-        # we don't need.
         run: |
-          echo "Free space before"
-          df -h
+          echo "=== Free space before ==="
+          df -h /
+          echo "=== Removing unused SDKs and tools ==="
+          # Android SDK (~13Gi)
           sudo rm -rf /Users/runner/Library/Android/sdk
-          echo "Free space after"
-          df -h
+          # iOS simulators (~13Gi)
+          sudo rm -rf /Library/Developer/CoreSimulator/Volumes/iOS_*
+          # .NET SDK (~3Gi)
+          sudo rm -rf /usr/local/share/dotnet
+          # Haskell / GHC (~3Gi)
+          sudo rm -rf /opt/ghc
+          # Cached tool archives (~2Gi)
+          sudo rm -rf /opt/hostedtoolcache
+          # Old Xcode versions if present (~10Gi+ each)
+          for xcode in /Applications/Xcode_*.app; do
+            if [ -d "$xcode" ] && [ "$xcode" != "$(xcode-select -p | sed 's|/Contents/Developer||')" ]; then
+              echo "Removing unused Xcode: $xcode"
+              sudo rm -rf "$xcode"
+            fi
+          done
+          echo "=== Free space after ==="
+          df -h /
       - name: "Installing Python packages"
         run: pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Installing requirements"

--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -55,9 +55,12 @@ jobs:
           sudo rm -rf /opt/ghc
           # Cached tool archives (~2Gi)
           sudo rm -rf /opt/hostedtoolcache
-          # Old Xcode versions if present (~10Gi+ each)
+          # Old Xcode versions if present (~10Gi+ each).
+          # Resolve the symlink since /Applications/Xcode.app is typically a
+          # symlink to one of the versioned Xcode_*.app directories.
+          ACTIVE_XCODE="$(readlink -f "$(xcode-select -p)/../..")"
           for xcode in /Applications/Xcode_*.app; do
-            if [ -d "$xcode" ] && [ "$xcode" != "$(xcode-select -p | sed 's|/Contents/Developer||')" ]; then
+            if [ -d "$xcode" ] && [ "$(readlink -f "$xcode")" != "$ACTIVE_XCODE" ]; then
               echo "Removing unused Xcode: $xcode"
               sudo rm -rf "$xcode"
             fi


### PR DESCRIPTION
- The `macos-14` GitHub-hosted runner has ~320Gi total disk with ~265Gi pre-used by system tools
- Previously only the Android SDK (~13Gi) was removed, leaving ~51Gi free — insufficient for building IREE
- Add removal of iOS simulators (~13Gi), .NET SDK (~3Gi), Haskell/GHC (~3Gi), hostedtoolcache (~2Gi), and unused Xcode versions (~10Gi+ each)
- Preserves the currently selected Xcode version

🤖 Generated with [Claude Code](https://claude.com/claude-code)