### PR TITLE
[plugins][nfc] Drop redundant `public` from struct inheritance. 1/5

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/ConvertCollectives.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/ConvertCollectives.cpp
@@ -400,7 +400,7 @@ static Value emitTranspose(ConversionPatternRewriter &rewriter, Location loc,
 
 /// Converts stablehlo.partition_id to (flow.channel.rank % numPartitions)
 struct PartitionIdOpConversion
-    : public OpConversionPattern<mlir::stablehlo::PartitionIdOp> {
+    : OpConversionPattern<mlir::stablehlo::PartitionIdOp> {
   using OpConversionPattern<
       mlir::stablehlo::PartitionIdOp>::OpConversionPattern;
 
@@ -437,7 +437,7 @@ struct PartitionIdOpConversion
 
 /// Converts stablehlo.replica_id to floor_div(flow.channel.rank, numPartitions)
 struct ReplicaIdOpConversion
-    : public OpConversionPattern<mlir::stablehlo::ReplicaIdOp> {
+    : OpConversionPattern<mlir::stablehlo::ReplicaIdOp> {
   using Base::Base;
 
   LogicalResult
@@ -833,7 +833,7 @@ struct ReduceScatterOpConversion final
 };
 
 struct CollectivePermuteOpConversion
-    : public OpConversionPattern<mlir::stablehlo::CollectivePermuteOp> {
+    : OpConversionPattern<mlir::stablehlo::CollectivePermuteOp> {
   using OpConversionPattern<
       mlir::stablehlo::CollectivePermuteOp>::OpConversionPattern;
 

--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeControlFlow.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeControlFlow.cpp
@@ -186,7 +186,7 @@ struct IfOpPattern final : OpConversionPattern<mlir::stablehlo::IfOp> {
 };
 
 // Rewrites `stablehlo.case` to a nested `scf.if`.
-struct CaseOpPattern : public OpConversionPattern<mlir::stablehlo::CaseOp> {
+struct CaseOpPattern : OpConversionPattern<mlir::stablehlo::CaseOp> {
   using Base::Base;
 
   // Recursively create if/else ops to handle each possible value in a case op.

--- a/compiler/plugins/input/StableHLO/Conversion/Passes.h
+++ b/compiler/plugins/input/StableHLO/Conversion/Passes.h
@@ -12,7 +12,7 @@
 
 namespace mlir::iree_compiler::stablehlo {
 
-struct StableHloOptions : public PassPipelineOptions<StableHloOptions> {};
+struct StableHloOptions : PassPipelineOptions<StableHloOptions> {};
 
 //===----------------------------------------------------------------------===//
 // Pipelines

--- a/compiler/plugins/input/StableHLO/PluginRegistration.cpp
+++ b/compiler/plugins/input/StableHLO/PluginRegistration.cpp
@@ -58,8 +58,8 @@ static bool checkOpForTuples(Operation *op) {
 // The StableHLO plugin provides dialects, passes and opt-in options.
 // Therefore, it is appropriate for default activation.
 struct StableHLOSession
-    : public PluginSession<StableHLOSession, StableHLOOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<StableHLOSession, StableHLOOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   static void registerPasses() {
     // TODO(scotttodd): register other StableHLO passes?
     registerStableHLOConversionPasses();

--- a/compiler/plugins/input/TOSA/InputConversion/Converti48Toi64.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/Converti48Toi64.cpp
@@ -26,7 +26,7 @@ public:
   void runOnOperation() override;
 };
 
-struct i48Toi64Converter : public TypeConverter {
+struct i48Toi64Converter : TypeConverter {
 public:
   static Type convertType(Type type) {
     if (type.isInteger(48)) {

--- a/compiler/plugins/input/TOSA/PluginRegistration.cpp
+++ b/compiler/plugins/input/TOSA/PluginRegistration.cpp
@@ -23,9 +23,8 @@ namespace {
 //
 // The TOSA plugin provides dialects, passes and opt-in options.
 // Therefore, it is appropriate for default activation.
-struct TOSASession
-    : public PluginSession<TOSASession, EmptyPluginOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+struct TOSASession : PluginSession<TOSASession, EmptyPluginOptions,
+                                   PluginActivationPolicy::DefaultActivated> {
   static void registerPasses() {
     registerTOSAConversionPasses();
     registerTosaToArithPass();

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -27,7 +27,7 @@ namespace mlir::iree_compiler::TorchInput {
 namespace {
 
 template <typename SrcOpTy, typename TargetOpTy>
-struct TMTensorOpConversion : public OpRewritePattern<SrcOpTy> {
+struct TMTensorOpConversion : OpRewritePattern<SrcOpTy> {
   using OpRewritePattern<SrcOpTy>::OpRewritePattern;
   LogicalResult matchAndRewrite(SrcOpTy srcOp,
                                 PatternRewriter &rewriter) const override {
@@ -46,7 +46,7 @@ struct TMTensorOpConversion : public OpRewritePattern<SrcOpTy> {
 };
 
 struct ScatterOpConversion
-    : public OpRewritePattern<mlir::torch::TMTensor::ScatterOp> {
+    : OpRewritePattern<mlir::torch::TMTensor::ScatterOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(mlir::torch::TMTensor::ScatterOp op,
                                 PatternRewriter &rewriter) const override {
@@ -120,7 +120,7 @@ static SmallVector<AffineMap> getStandardAttentionIndexingMaps(MLIRContext *ctx,
 }
 
 struct AttentionOpConversion
-    : public OpRewritePattern<mlir::torch::TMTensor::AttentionOp> {
+    : OpRewritePattern<mlir::torch::TMTensor::AttentionOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(mlir::torch::TMTensor::AttentionOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -21,8 +21,7 @@ namespace mlir::iree_compiler::TorchInput {
 
 namespace {
 
-struct FftRfftOpConversion
-    : public OpRewritePattern<torch::Torch::AtenFftRfftOp> {
+struct FftRfftOpConversion : OpRewritePattern<torch::Torch::AtenFftRfftOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(torch::Torch::AtenFftRfftOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/Torch/InputConversion/Passes.h
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.h
@@ -29,7 +29,7 @@ struct BackendLegalOps {
 };
 
 struct TorchToIREELoweringPipelineOptions
-    : public PassPipelineOptions<TorchToIREELoweringPipelineOptions> {
+    : PassPipelineOptions<TorchToIREELoweringPipelineOptions> {
   Option<bool> strictSymbolicShapes{
       *this, "strict-symbolic-shapes",
       llvm::cl::desc("Use strict symbolic shapes."), llvm::cl::init(true)};

--- a/compiler/plugins/input/Torch/PluginRegistration.cpp
+++ b/compiler/plugins/input/Torch/PluginRegistration.cpp
@@ -55,9 +55,8 @@ struct TorchOptions {
 
 // The torch plugin provides dialects, passes and opt-in options.
 // Therefore, it is appropriate for default activation.
-struct TorchSession
-    : public PluginSession<TorchSession, TorchOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+struct TorchSession : PluginSession<TorchSession, TorchOptions,
+                                    PluginActivationPolicy::DefaultActivated> {
   static void registerPasses() {
     mlir::torch::registerTorchPasses();
     mlir::torch::registerTorchConversionPasses();

--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -717,8 +717,8 @@ private:
 };
 
 struct CUDASession final
-    : public PluginSession<CUDASession, CUDAOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<CUDASession, CUDAOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) final {
     // #hal.device.target<"cuda", ...
     targets.add("cuda",

--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -865,8 +865,8 @@ private:
 };
 
 struct LLVMCPUSession final
-    : public PluginSession<LLVMCPUSession, LLVMCPUTargetCLOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<LLVMCPUSession, LLVMCPUTargetCLOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetBackends(IREE::HAL::TargetBackendList &targets) final {
     // #hal.executable.target<"llvm-cpu", ...
     // Use session-scoped codegen options bound in createUninitializedSession.

--- a/compiler/plugins/target/Local/LocalTarget.cpp
+++ b/compiler/plugins/target/Local/LocalTarget.cpp
@@ -14,8 +14,8 @@ namespace mlir::iree_compiler::IREE::HAL {
 
 namespace {
 struct LocalSession
-    : public PluginSession<LocalSession, IREE::HAL::LocalDevice::Options,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<LocalSession, IREE::HAL::LocalDevice::Options,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) {
     // #hal.device.target<"local", ...
     targets.add("local", [=]() {

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -321,8 +321,8 @@ private:
 };
 
 struct MetalSPIRVSession final
-    : public PluginSession<MetalSPIRVSession, MetalSPIRVOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<MetalSPIRVSession, MetalSPIRVOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) final {
     // #hal.device.target<"metal", ...
     targets.add("metal",

--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -259,8 +259,8 @@ private:
 };
 
 struct VMVXSession final
-    : public PluginSession<VMVXSession, VMVXOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<VMVXSession, VMVXOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetBackends(IREE::HAL::TargetBackendList &targets) final {
     // #hal.executable.target<"vmvx", ...
     targets.add("vmvx",

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -492,8 +492,8 @@ private:
 };
 
 struct VulkanSPIRVSession final
-    : public PluginSession<VulkanSPIRVSession, VulkanSPIRVTargetOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<VulkanSPIRVSession, VulkanSPIRVTargetOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) final {
     // #hal.device.target<"vulkan", ...
     targets.add("vulkan", [&]() {

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -262,8 +262,8 @@ private:
 };
 
 struct WebGPUSPIRVSession final
-    : public PluginSession<WebGPUSPIRVSession, WebGPUSPIRVOptions,
-                           PluginActivationPolicy::DefaultActivated> {
+    : PluginSession<WebGPUSPIRVSession, WebGPUSPIRVOptions,
+                    PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) final {
     // #hal.device.target<"webgpu", ...
     targets.add("webgpu", [=]() {


### PR DESCRIPTION
`public` is the default access specifier for struct inheritance in C++, so `struct Foo : public Bar` is equivalent to `struct Foo : Bar`.