### PR TITLE
[compiler][nfc] Drop redundant `public` from struct inheritance. 5/5

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -1459,7 +1459,7 @@ void ireeCompilerInvocationSetCrashHandler(
     iree_compiler_error_t *(*onCrashCallback)(
         iree_compiler_output_t **outOutput, void *userData),
     void *userData) {
-  struct StreamImpl : public mlir::ReproducerStream {
+  struct StreamImpl : mlir::ReproducerStream {
     StreamImpl(iree_compiler_output_t *output) : output(output) {
       unwrap(output)->keep();
     }

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/Passes.h
@@ -26,7 +26,7 @@ enum class InvocationModel {
   CoarseFences,
 };
 
-struct InvocationOptions : public PassPipelineOptions<InvocationOptions> {
+struct InvocationOptions : PassPipelineOptions<InvocationOptions> {
   Option<InvocationModel> invocationModel{
       *this,
       "invocation-model",

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -268,7 +268,7 @@ struct EncodingCastableOpPropagationInterfaceHelper {
 /// All dimensions are parallel with identity indexing maps.
 template <typename ConcreteType>
 struct EncodingFusionOpInterfaceAdapter
-    : public IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
+    : IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
           EncodingFusionOpInterfaceAdapter<ConcreteType>, ConcreteType> {
   SmallVector<AffineMap> getIndexingMapsForOperands(Operation *op) const {
     int64_t rank = cast<ConcreteType>(op).getResultType().getRank();

--- a/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.cpp
@@ -26,8 +26,9 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 template <typename IDOp>
-struct IDOpValueBoundsInterface : public ValueBoundsOpInterface::ExternalModel<
-                                      IDOpValueBoundsInterface<IDOp>, IDOp> {
+struct IDOpValueBoundsInterface
+    : ValueBoundsOpInterface::ExternalModel<IDOpValueBoundsInterface<IDOp>,
+                                            IDOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
                                    ValueBoundsConstraintSet &cstr) const {
     auto boundOp = cast<IDOp>(op);
@@ -41,7 +42,7 @@ struct IDOpValueBoundsInterface : public ValueBoundsOpInterface::ExternalModel<
 
 template <typename CountOp>
 struct CountOpValueBoundsInterface
-    : public ValueBoundsOpInterface::ExternalModel<
+    : ValueBoundsOpInterface::ExternalModel<
           CountOpValueBoundsInterface<CountOp>, CountOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
                                    ValueBoundsConstraintSet &cstr) const {
@@ -60,7 +61,7 @@ struct CountOpValueBoundsInterface
 
 // External model to make util.call ops with fence arguments timeline-aware.
 struct TimelineAwareCallExternalModel
-    : public IREE::Stream::TimelineAwareOpInterface::ExternalModel<
+    : IREE::Stream::TimelineAwareOpInterface::ExternalModel<
           TimelineAwareCallExternalModel, IREE::Util::CallOp> {
   static void add(MLIRContext *context) {
     IREE::Util::CallOp::attachInterface<TimelineAwareCallExternalModel>(

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -17,7 +17,7 @@ namespace {
 // Used to register the LinalgFusionOpInterface with the linalg ops.
 template <typename ConcreteType>
 struct LinalgFusionOpInterfaceAdapter
-    : public IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
+    : IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
           LinalgFusionOpInterfaceAdapter<ConcreteType>, ConcreteType> {
 public:
   SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
@@ -65,7 +65,7 @@ public:
 };
 
 struct SoftmaxFusionOpInterfaceAdapter
-    : public IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
+    : IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
           SoftmaxFusionOpInterfaceAdapter, linalg::SoftmaxOp> {
 public:
   SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -20,7 +20,7 @@ namespace {
 
 template <typename OpT>
 struct PreferCloneToConsumersStreamableOpExternalModel
-    : public IREE::Stream::StreamableOpInterface::ExternalModel<
+    : IREE::Stream::StreamableOpInterface::ExternalModel<
           PreferCloneToConsumersStreamableOpExternalModel<OpT>, OpT> {
   static void add(MLIRContext *context) {
     OpT::template attachInterface<
@@ -31,7 +31,7 @@ struct PreferCloneToConsumersStreamableOpExternalModel
 };
 
 struct FlowDispatchStreamableOpExternalModel
-    : public IREE::Stream::StreamableOpInterface::ExternalModel<
+    : IREE::Stream::StreamableOpInterface::ExternalModel<
           FlowDispatchStreamableOpExternalModel, IREE::Flow::DispatchOp> {
   static void add(MLIRContext *context) {
     IREE::Flow::DispatchOp::attachInterface<
@@ -51,7 +51,7 @@ struct FlowDispatchStreamableOpExternalModel
 
 template <typename OpT>
 struct OptionalOpAffinityAttrExternalModel
-    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+    : IREE::Stream::AffinityOpInterface::ExternalModel<
           OptionalOpAffinityAttrExternalModel<OpT>, OpT> {
   static void add(MLIRContext *context) {
     OpT::template attachInterface<OptionalOpAffinityAttrExternalModel<OpT>>(
@@ -87,7 +87,7 @@ struct OptionalOpAffinityAttrExternalModel
 };
 
 struct FlowBarrierTargetAffinityAttrExternalModel
-    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+    : IREE::Stream::AffinityOpInterface::ExternalModel<
           FlowBarrierTargetAffinityAttrExternalModel,
           IREE::Flow::TensorBarrierOp> {
   static void add(MLIRContext *context) {
@@ -117,7 +117,7 @@ struct FlowBarrierTargetAffinityAttrExternalModel
 };
 
 struct FlowTransferTargetAffinityAttrExternalModel
-    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+    : IREE::Stream::AffinityOpInterface::ExternalModel<
           FlowTransferTargetAffinityAttrExternalModel,
           IREE::Flow::TensorTransferOp> {
   static void add(MLIRContext *context) {
@@ -144,7 +144,7 @@ struct FlowTransferTargetAffinityAttrExternalModel
 
 template <typename OpT>
 struct HALTensorAffinityAttrExternalModel
-    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+    : IREE::Stream::AffinityOpInterface::ExternalModel<
           HALTensorAffinityAttrExternalModel<OpT>, OpT> {
   static void add(MLIRContext *context) {
     OpT::template attachInterface<HALTensorAffinityAttrExternalModel<OpT>>(
@@ -178,7 +178,7 @@ struct HALTensorAffinityAttrExternalModel
 
 template <typename OpT>
 struct GlobalOpAffinityAttrExternalModel
-    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+    : IREE::Stream::AffinityOpInterface::ExternalModel<
           GlobalOpAffinityAttrExternalModel<OpT>, OpT> {
   static void add(MLIRContext *context) {
     OpT::template attachInterface<GlobalOpAffinityAttrExternalModel<OpT>>(
@@ -215,7 +215,7 @@ struct GlobalOpAffinityAttrExternalModel
 
 template <typename OpT, bool kRequiresAffinity = true>
 struct AffinityOpAttrExternalModel
-    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+    : IREE::Stream::AffinityOpInterface::ExternalModel<
           AffinityOpAttrExternalModel<OpT, kRequiresAffinity>, OpT> {
   static void add(MLIRContext *context) {
     OpT::template attachInterface<
@@ -248,7 +248,7 @@ struct AffinityOpAttrExternalModel
 };
 
 struct TensorAffinityTypeExternalModel
-    : public IREE::Stream::AffinityTypeInterface::ExternalModel<
+    : IREE::Stream::AffinityTypeInterface::ExternalModel<
           TensorAffinityTypeExternalModel, RankedTensorType> {
   static void add(MLIRContext *context) {
     RankedTensorType::attachInterface<TensorAffinityTypeExternalModel>(

--- a/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
@@ -21,7 +21,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct DispatchTensorLoadOpInterface
-    : public ValueBoundsOpInterface::ExternalModel<
+    : ValueBoundsOpInterface::ExternalModel<
           DispatchTensorLoadOpInterface,
           IREE::TensorExt::DispatchTensorLoadOp> {
   void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
@@ -33,7 +33,7 @@ struct DispatchTensorLoadOpInterface
 };
 
 struct WorkloadOrdinalOpInterface
-    : public ValueBoundsOpInterface::ExternalModel<
+    : ValueBoundsOpInterface::ExternalModel<
           WorkloadOrdinalOpInterface,
           IREE::TensorExt::DispatchWorkloadOrdinalOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
@@ -49,7 +49,7 @@ struct WorkloadOrdinalOpInterface
 //===----------------------------------------------------------------------===//
 
 struct EncodingTypeExternalModel
-    : public IREE::Encoding::EncodingTypeInterface::ExternalModel<
+    : IREE::Encoding::EncodingTypeInterface::ExternalModel<
           EncodingTypeExternalModel, IREE::TensorExt::DispatchTensorType> {
 
   Type getEncodingType(Type type) const {

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -201,7 +201,7 @@ static SmallVector<IREE::Util::ConstantIntDivisibility> getResultDivisibilities(
 }
 
 struct AffineApplyInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           AffineApplyInferIntDivisibilityOpInterface, affine::AffineApplyOp> {
 
   void inferResultDivisibility(
@@ -255,7 +255,7 @@ static void inferAffineMinOrMaxResultDivisibility(
 }
 
 struct AffineMinInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           AffineMinInferIntDivisibilityOpInterface, affine::AffineMinOp> {
 
   void inferResultDivisibility(
@@ -267,7 +267,7 @@ struct AffineMinInferIntDivisibilityOpInterface
 };
 
 struct AffineMaxInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           AffineMaxInferIntDivisibilityOpInterface, affine::AffineMaxOp> {
 
   void inferResultDivisibility(
@@ -279,7 +279,7 @@ struct AffineMaxInferIntDivisibilityOpInterface
 };
 
 struct ArithConstantInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           ArithConstantInferIntDivisibilityOpInterface, arith::ConstantOp> {
 
   void inferResultDivisibility(
@@ -298,7 +298,7 @@ struct ArithConstantInferIntDivisibilityOpInterface
 };
 
 struct ArithMulIInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           ArithMulIInferIntDivisibilityOpInterface, arith::MulIOp> {
 
   void inferResultDivisibility(
@@ -318,7 +318,7 @@ struct ArithMulIInferIntDivisibilityOpInterface
 };
 
 struct ArithDivUIInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           ArithDivUIInferIntDivisibilityOpInterface, arith::DivUIOp> {
 
   void inferResultDivisibility(
@@ -351,8 +351,8 @@ struct ArithDivUIInferIntDivisibilityOpInterface
 
 /// For some reason, this interface has to be done as an external model.
 struct UtilAssumeIntValueBoundsOpInterface
-    : public ValueBoundsOpInterface::ExternalModel<
-          UtilAssumeIntValueBoundsOpInterface, IREE::Util::AssumeIntOp> {
+    : ValueBoundsOpInterface::ExternalModel<UtilAssumeIntValueBoundsOpInterface,
+                                            IREE::Util::AssumeIntOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
                                    ValueBoundsConstraintSet &cstr) const {
     auto assumeOp = cast<IREE::Util::AssumeIntOp>(op);
@@ -393,7 +393,7 @@ struct UtilAssumeIntValueBoundsOpInterface
 //===----------------------------------------------------------------------===//
 
 struct GlobalOpInterfaceExternalModel
-    : public IREE::Util::GlobalOpInterface::ExternalModel<
+    : IREE::Util::GlobalOpInterface::ExternalModel<
           GlobalOpInterfaceExternalModel, ml_program::GlobalOp> {
   Attribute getGlobalInitialValue(Operation *op) const {
     return cast<ml_program::GlobalOp>(op).getValueAttr();
@@ -461,8 +461,8 @@ struct GlobalOpInterfaceExternalModel
 struct GenericNumericCastExternalModel {
   template <typename OpTy>
   struct ExternalModel
-      : public IREE::Util::NumericCastOpInterface::ExternalModel<
-            ExternalModel<OpTy>, OpTy> {};
+      : IREE::Util::NumericCastOpInterface::ExternalModel<ExternalModel<OpTy>,
+                                                          OpTy> {};
 
   template <typename OpTy>
   static void add(MLIRContext *context) {
@@ -481,8 +481,8 @@ struct GenericNumericCastExternalModel {
 //===----------------------------------------------------------------------===//
 
 struct InsertSliceOpTiedOpInterface
-    : public IREE::Util::TiedOpInterface::ExternalModel<
-          InsertSliceOpTiedOpInterface, tensor::InsertSliceOp> {
+    : IREE::Util::TiedOpInterface::ExternalModel<InsertSliceOpTiedOpInterface,
+                                                 tensor::InsertSliceOp> {
   Value getTiedResult(Operation *op, unsigned resultIndex) const {
     auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
     return IREE::Util::TiedOpInterface::findTiedBaseValue(
@@ -501,8 +501,8 @@ struct InsertSliceOpTiedOpInterface
 
 template <typename OpTy>
 struct LinalgOpTiedOpInterface
-    : public IREE::Util::TiedOpInterface::ExternalModel<
-          LinalgOpTiedOpInterface<OpTy>, OpTy> {
+    : IREE::Util::TiedOpInterface::ExternalModel<LinalgOpTiedOpInterface<OpTy>,
+                                                 OpTy> {
   Value getTiedResult(Operation *op, unsigned resultIndex) const {
     auto linalgOp = cast<OpTy>(op);
     return IREE::Util::TiedOpInterface::findTiedBaseValue(
@@ -541,16 +541,15 @@ struct LinalgOpTiedOpInterfaceHelper {
 //===----------------------------------------------------------------------===//
 
 template <typename OpTy>
-struct UnhoistableOpInterface
-    : public IREE::Util::HoistableOpInterface::ExternalModel<
-          UnhoistableOpInterface<OpTy>, OpTy> {
+struct UnhoistableOpInterface : IREE::Util::HoistableOpInterface::ExternalModel<
+                                    UnhoistableOpInterface<OpTy>, OpTy> {
   bool isHoistableOp(Operation *) const { return false; }
   bool isHoistableLeafOp(Operation *) const { return false; }
 };
 
 template <typename OpTy>
 struct HoistableNonLeafOpInterface
-    : public IREE::Util::HoistableOpInterface::ExternalModel<
+    : IREE::Util::HoistableOpInterface::ExternalModel<
           HoistableNonLeafOpInterface<OpTy>, OpTy> {
   bool isHoistableLeafOp(Operation *) const { return false; }
 };
@@ -560,12 +559,12 @@ struct HoistableNonLeafOpInterface
 // first.
 template <typename OpTy>
 struct AlwaysHoistableOpInterface
-    : public IREE::Util::HoistableOpInterface::ExternalModel<
+    : IREE::Util::HoistableOpInterface::ExternalModel<
           AlwaysHoistableOpInterface<OpTy>, OpTy> {};
 
 template <typename OpTy>
 struct HoistableLinalgOpInterface
-    : public IREE::Util::HoistableOpInterface::ExternalModel<
+    : IREE::Util::HoistableOpInterface::ExternalModel<
           HoistableLinalgOpInterface<OpTy>, OpTy> {
   bool isHoistableOp(Operation *) const { return true; }
 
@@ -644,7 +643,7 @@ struct HoistableLinalgOpInterfaceHelper {
 
 // External model for scf.for operation.
 struct SCFForOpMutableRegionBranchOpInterface
-    : public IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
+    : IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
           SCFForOpMutableRegionBranchOpInterface, scf::ForOp> {
   Operation *rebuildWithExpandedTypes(
       Operation *op,
@@ -760,7 +759,7 @@ struct SCFForOpMutableRegionBranchOpInterface
 
 // External model for scf.if operation.
 struct SCFIfOpMutableRegionBranchOpInterface
-    : public IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
+    : IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
           SCFIfOpMutableRegionBranchOpInterface, scf::IfOp> {
   Operation *rebuildWithExpandedTypes(
       Operation *op,
@@ -861,7 +860,7 @@ struct SCFIfOpMutableRegionBranchOpInterface
 
 // External model for scf.while operation.
 struct SCFWhileOpMutableRegionBranchOpInterface
-    : public IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
+    : IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
           SCFWhileOpMutableRegionBranchOpInterface, scf::WhileOp> {
   Operation *rebuildWithExpandedTypes(
       Operation *op,
@@ -1015,7 +1014,7 @@ struct SCFWhileOpMutableRegionBranchOpInterface
 
 // External model for scf.index_switch operation.
 struct SCFIndexSwitchOpMutableRegionBranchOpInterface
-    : public IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
+    : IREE::Util::MutableRegionBranchOpInterface::ExternalModel<
           SCFIndexSwitchOpMutableRegionBranchOpInterface, scf::IndexSwitchOp> {
   Operation *rebuildWithExpandedTypes(
       Operation *op,
@@ -1143,7 +1142,7 @@ struct SCFIndexSwitchOpMutableRegionBranchOpInterface
 // nested operations are hoistable (checked via atomic hoisting).
 template <typename OpTy>
 struct RegionControlFlowHoistableOpInterface
-    : public IREE::Util::HoistableOpInterface::ExternalModel<
+    : IREE::Util::HoistableOpInterface::ExternalModel<
           RegionControlFlowHoistableOpInterface<OpTy>, OpTy> {
   bool isHoistableOp(Operation *op) const {
     // Control flow is hoistable if all nested operations are hoistable.

--- a/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
@@ -136,7 +136,7 @@ public:
 };
 
 struct ConvertStridedContractionToContractionPass
-    : public impl::ConvertStridedContractionToContractionPassBase<
+    : impl::ConvertStridedContractionToContractionPassBase<
           ConvertStridedContractionToContractionPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<arith::ArithDialect, tensor::TensorDialect>();

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutPropagation.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutPropagation.cpp
@@ -17,7 +17,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 namespace {
 
 struct DataLayoutPropagationPass
-    : public impl::DataLayoutPropagationPassBase<DataLayoutPropagationPass> {
+    : impl::DataLayoutPropagationPassBase<DataLayoutPropagationPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     FunctionOpInterface funcOp = getOperation();

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -40,7 +40,7 @@ static Value createTranspose(OpBuilder &builder, Value source,
 // can lower to `flow.tensor.update` and ideally disappear, in the worst case
 // becoming a sequence of copies. The hope then is that the transposes on the
 // inputs and output is then fusable with surrounding operations.
-struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
+struct TransposeInnerConcatenation : OpRewritePattern<tensor::ConcatOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
@@ -90,7 +90,7 @@ struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
 /// folded into other dispatches. Outerdim concats get lowered to
 /// `flow.tensor.update` on conversion to Flow and then they get modified to be
 /// in-place.
-struct DecomposeNonOuterDimConcats : public OpRewritePattern<tensor::ConcatOp> {
+struct DecomposeNonOuterDimConcats : OpRewritePattern<tensor::ConcatOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
@@ -117,7 +117,7 @@ struct DecomposeNonOuterDimConcats : public OpRewritePattern<tensor::ConcatOp> {
 };
 
 struct DecomposeConcatPass
-    : public impl::DecomposeConcatPassBase<DecomposeConcatPass> {
+    : impl::DecomposeConcatPassBase<DecomposeConcatPass> {
   using Base::Base;
   explicit DecomposeConcatPass(bool enableConcatTransposition) {
     this->enableConcatTransposition = enableConcatTransposition;

--- a/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
@@ -25,7 +25,7 @@ namespace {
 
 // For narrowable inputs, selects
 struct DemoteContractionInputsToBF16Pattern
-    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
+    : OpInterfaceRewritePattern<linalg::LinalgOp> {
   using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
   explicit DemoteContractionInputsToBF16Pattern(MLIRContext *ctx,
                                                 DemotionOption &option)

--- a/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
@@ -31,8 +31,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 
 namespace {
 
-struct DetachElementwisePattern
-    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
+struct DetachElementwisePattern : OpInterfaceRewritePattern<linalg::LinalgOp> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
@@ -127,7 +126,7 @@ struct DetachElementwisePattern
 /// to a splat, but both without stack allocations.
 template <typename InterfaceOp>
 struct DetachSplatConstantOutsOperands
-    : public OpInterfaceRewritePattern<InterfaceOp> {
+    : OpInterfaceRewritePattern<InterfaceOp> {
   using OpInterfaceRewritePattern<InterfaceOp>::OpInterfaceRewritePattern;
 
   LogicalResult matchAndRewrite(InterfaceOp interfaceOp,
@@ -186,7 +185,7 @@ struct DetachSplatConstantOutsOperands
 };
 
 struct DetachElementwiseFromNamedOpsPass
-    : public impl::DetachElementwiseFromNamedOpsPassBase<
+    : impl::DetachElementwiseFromNamedOpsPassBase<
           DetachElementwiseFromNamedOpsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<arith::ArithDialect, linalg::LinalgDialect,

--- a/compiler/src/iree/compiler/GlobalOptimization/EraseUnusedLinalgOperands.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/EraseUnusedLinalgOperands.cpp
@@ -18,8 +18,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 
 namespace {
 struct EraseUnusedLinalgOperandsPass
-    : public impl::EraseUnusedLinalgOperandsPassBase<
-          EraseUnusedLinalgOperandsPass> {
+    : impl::EraseUnusedLinalgOperandsPassBase<EraseUnusedLinalgOperandsPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
@@ -766,8 +766,7 @@ static LogicalResult reassociateDequantMatmul(RewriterBase &rewriter,
 }
 
 struct FuseDequantizationMatmulPass
-    : public impl::FuseDequantizationMatmulPassBase<
-          FuseDequantizationMatmulPass> {
+    : impl::FuseDequantizationMatmulPassBase<FuseDequantizationMatmulPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, IREE::Flow::FlowDialect,
                     math::MathDialect>();

--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -34,8 +34,7 @@ static llvm::cl::opt<bool> clDisableConvGeneralization(
 
 namespace {
 struct GeneralizeLinalgNamedOpsPass
-    : public impl::GeneralizeLinalgNamedOpsPassBase<
-          GeneralizeLinalgNamedOpsPass> {
+    : impl::GeneralizeLinalgNamedOpsPassBase<GeneralizeLinalgNamedOpsPass> {
   using Base::Base;
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GlobalLoopInvariantCodeMotion.cpp
@@ -111,7 +111,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 namespace {
 
 struct GlobalLoopInvariantCodeMotionPass
-    : public impl::GlobalLoopInvariantCodeMotionPassBase<
+    : impl::GlobalLoopInvariantCodeMotionPassBase<
           GlobalLoopInvariantCodeMotionPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
@@ -30,7 +30,7 @@ static Value bitcastToStaticTypeImpl(OpBuilder &b, Location loc,
 }
 
 struct HoistableTensorTypeInterface
-    : public IREE::Util::HoistableTypeInterface::ExternalModel<
+    : IREE::Util::HoistableTypeInterface::ExternalModel<
           HoistableTensorTypeInterface, RankedTensorType> {
   bool isHoistableType(Type type) const {
     auto tensorType = cast<RankedTensorType>(type);
@@ -112,7 +112,7 @@ struct HoistableTensorTypeInterface
 };
 
 struct HoistableIndexTypeInterface
-    : public IREE::Util::HoistableTypeInterface::ExternalModel<
+    : IREE::Util::HoistableTypeInterface::ExternalModel<
           HoistableIndexTypeInterface, IndexType> {
   bool isHoistableType(Type type) const { return true; }
   bool isHoistableLeafType(Type type) const { return true; }

--- a/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
@@ -122,7 +122,7 @@ struct TensorEmptyCast
 
 // For a cast produced by a fill, rewrites the cast to be on the fill operands.
 struct LinalgFillCast
-    : public OpInterfaceRewritePattern<IREE::Util::NumericCastOpInterface> {
+    : OpInterfaceRewritePattern<IREE::Util::NumericCastOpInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Util::NumericCastOpInterface castOp,
@@ -156,7 +156,7 @@ struct LinalgFillCast
 };
 
 // For narrowable inputs, selects
-struct LinalgFpMatmulToLowP : public OpRewritePattern<linalg::MatmulOp> {
+struct LinalgFpMatmulToLowP : OpRewritePattern<linalg::MatmulOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -17,7 +17,7 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-struct TransformOptions : public PassPipelineOptions<TransformOptions> {
+struct TransformOptions : PassPipelineOptions<TransformOptions> {
   ListOption<std::string> parameterImportPaths{
       *this,
       "parameter-import-paths",

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1125,8 +1125,7 @@ public:
 
 namespace {
 struct PropagateLinalgTransposePass
-    : public impl::PropagateLinalgTransposePassBase<
-          PropagateLinalgTransposePass> {
+    : impl::PropagateLinalgTransposePassBase<PropagateLinalgTransposePass> {
   using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, tensor::TensorDialect>();

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -124,8 +124,7 @@ Value multiplyDims(ImplicitLocOpBuilder &builder, Value value,
 //
 // This is implementing the math explained in Section 2.3 of
 // https://arxiv.org/abs/1712.05877.
-struct QuantizedConvToConv
-    : public OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
+struct QuantizedConvToConv : OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfQOp op,
@@ -245,7 +244,7 @@ struct QuantizedConvToConv
 // This is implementing the math explained in Section 2.3 of
 // https://arxiv.org/abs/1712.05877.
 struct QuantizedDepthwiseConvToDepthwiseConv
-    : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp> {
+    : OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcQOp op,

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
@@ -34,8 +34,7 @@ bool isConstantZero(Value val) {
 // batch_matmul op.
 // This is implementing the math explained in Section 2.3 of
 // https://arxiv.org/abs/1712.05877.
-struct QuantizedMatmulToMatmul
-    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
+struct QuantizedMatmulToMatmul : OpInterfaceRewritePattern<linalg::LinalgOp> {
   using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::LinalgOp op,

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -1008,7 +1008,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 struct RaiseSpecialOpsPass
-    : public impl::RaiseSpecialOpsPassBase<RaiseSpecialOpsPass> {
+    : impl::RaiseSpecialOpsPassBase<RaiseSpecialOpsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::LinalgExt::IREELinalgExtDialect>();
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
@@ -29,7 +29,7 @@ static std::optional<RankedTensorType> isZeroExtent(Type t) {
 /// Replace operands of the operation that have zero-extent tensors with
 /// a `tensor.empty` op of the same type. This breaks dependencies between
 /// different operations which can be handled subsequently.
-struct ReplaceZeroExtentOperands : public RewritePattern {
+struct ReplaceZeroExtentOperands : RewritePattern {
   ReplaceZeroExtentOperands(MLIRContext *context)
       : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/10, context) {}
 
@@ -63,7 +63,7 @@ struct ReplaceZeroExtentOperands : public RewritePattern {
 
 /// Forward the destination of a `tensor.insert_slice` to its uses
 /// if the source is zero-extent.
-struct FoldZeroExtentInserts : public OpRewritePattern<tensor::InsertSliceOp> {
+struct FoldZeroExtentInserts : OpRewritePattern<tensor::InsertSliceOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,

--- a/compiler/src/iree/compiler/GlobalOptimization/SimplifyPackUnpack.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SimplifyPackUnpack.cpp
@@ -16,7 +16,7 @@ namespace mlir::iree_compiler::GlobalOptimization {
 
 namespace {
 struct SimplifyPackUnpackPass
-    : public impl::SimplifyPackUnpackPassBase<SimplifyPackUnpackPass> {
+    : impl::SimplifyPackUnpackPassBase<SimplifyPackUnpackPass> {
 
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
@@ -87,7 +87,7 @@ Value convertRankedInteger(OpBuilder &builder, Type type, ValueRange inputs,
 
 // Converts from |SourceType| to |TargetType|.
 template <typename SourceType, typename TargetType>
-struct PrimitiveTypeConverter : public TypeConverter {
+struct PrimitiveTypeConverter : TypeConverter {
   explicit PrimitiveTypeConverter() {
     addConversion([](Type type) { return type; });
     addConversion([&](SourceType type) -> Type {
@@ -125,8 +125,7 @@ struct PrimitiveTypeConverter : public TypeConverter {
 };
 
 template <typename SourceType, typename TargetType>
-struct FloatTypeConverter
-    : public PrimitiveTypeConverter<SourceType, TargetType> {
+struct FloatTypeConverter : PrimitiveTypeConverter<SourceType, TargetType> {
   explicit FloatTypeConverter() {
     this->addSourceMaterialization(convertRankedFloat);
     this->addTargetMaterialization(convertRankedFloat);
@@ -134,8 +133,7 @@ struct FloatTypeConverter
 };
 
 template <typename SourceType, typename TargetType>
-struct IntegerTypeConverter
-    : public PrimitiveTypeConverter<SourceType, TargetType> {
+struct IntegerTypeConverter : PrimitiveTypeConverter<SourceType, TargetType> {
   explicit IntegerTypeConverter() {
     this->addSourceMaterialization(convertRankedInteger);
     this->addTargetMaterialization(convertRankedInteger);
@@ -144,7 +142,7 @@ struct IntegerTypeConverter
 
 // Tries to completely convert a generic Operation.
 // This will process attributes, result types, and nested regions.
-struct GenericTypeConversionPattern : public ConversionPattern {
+struct GenericTypeConversionPattern : ConversionPattern {
   GenericTypeConversionPattern(MLIRContext *context,
                                TypeConverter &typeConverter)
       : ConversionPattern(typeConverter, MatchAnyOpTypeTag(), 0, context) {}
@@ -190,7 +188,7 @@ struct GenericTypeConversionPattern : public ConversionPattern {
 };
 
 struct GlobalOpConversionPattern
-    : public OpInterfaceConversionPattern<IREE::Util::GlobalOpInterface> {
+    : OpInterfaceConversionPattern<IREE::Util::GlobalOpInterface> {
   GlobalOpConversionPattern(MLIRContext *context, TypeConverter &typeConverter)
       : OpInterfaceConversionPattern(typeConverter, context) {}
   LogicalResult
@@ -212,7 +210,7 @@ struct GlobalOpConversionPattern
 
 template <typename OpTy, typename TypeTy,
           typename OperandToResultWidthLegalityRelation>
-struct ConvertTypeSensitiveArithCastOp : public OpConversionPattern<OpTy> {
+struct ConvertTypeSensitiveArithCastOp : OpConversionPattern<OpTy> {
   using OpConversionPattern<OpTy>::OpConversionPattern;
   LogicalResult
   matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
@@ -246,7 +244,7 @@ struct ConvertTypeSensitiveArithCastOp : public OpConversionPattern<OpTy> {
 };
 
 template <typename Base, typename Converter>
-struct ConvertTypesPass : public Base {
+struct ConvertTypesPass : Base {
   using Base::Base;
   void runOnOperation() override {
     MLIRContext *context = &this->getContext();
@@ -371,7 +369,7 @@ struct ConvertTypesPass : public Base {
 
 namespace {
 struct DemoteI64ToI32Converter
-    : public PrimitiveTypeConverter<IntegerType, IntegerType> {
+    : PrimitiveTypeConverter<IntegerType, IntegerType> {
   bool isSourceType(IntegerType type) override { return type.isInteger(64); }
   Type getTargetType(IntegerType type) override {
     return IntegerType::get(type.getContext(), 32, type.getSignedness());
@@ -384,7 +382,7 @@ class DemoteI64ToI32Pass final
 
 namespace {
 struct DemoteF32ToF16Converter
-    : public PrimitiveTypeConverter<Float32Type, Float16Type> {
+    : PrimitiveTypeConverter<Float32Type, Float16Type> {
   Type getTargetType(Float32Type type) override {
     return Float16Type::get(type.getContext());
   }
@@ -396,7 +394,7 @@ class DemoteF32ToF16Pass final
 
 namespace {
 struct PromoteF16ToF32Converter
-    : public PrimitiveTypeConverter<Float16Type, Float32Type> {
+    : PrimitiveTypeConverter<Float16Type, Float32Type> {
   Type getTargetType(Float16Type type) override {
     return Float32Type::get(type.getContext());
   }
@@ -409,7 +407,7 @@ class PromoteF16ToF32Pass final
 
 namespace {
 struct PromoteBF16ToF32Converter
-    : public FloatTypeConverter<BFloat16Type, Float32Type> {
+    : FloatTypeConverter<BFloat16Type, Float32Type> {
   Type getTargetType(BFloat16Type type) override {
     return Float32Type::get(type.getContext());
   }
@@ -422,7 +420,7 @@ class PromoteBF16ToF32Pass final
 
 namespace {
 struct DemoteF64ToF32Converter
-    : public PrimitiveTypeConverter<Float64Type, Float32Type> {
+    : PrimitiveTypeConverter<Float64Type, Float32Type> {
   Type getTargetType(Float64Type type) override {
     return Float32Type::get(type.getContext());
   }

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.h
@@ -24,7 +24,7 @@ namespace mlir::iree_compiler::InputConversion {
 // Pipelines
 //===----------------------------------------------------------------------===//
 
-struct TransformOptions : public PassPipelineOptions<TransformOptions> {
+struct TransformOptions : PassPipelineOptions<TransformOptions> {
   InputDialectOptions options;
 };
 

--- a/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
@@ -21,7 +21,7 @@ namespace mlir::iree_compiler::IREE::Check {
 // not compiled in (we just ignore them). This allows us to run benchmarks on
 // modules using the check ops.
 template <typename T, typename Adaptor = typename T::Adaptor>
-struct OptionalCheckImportConversion : public VMImportOpConversion<T, Adaptor> {
+struct OptionalCheckImportConversion : VMImportOpConversion<T, Adaptor> {
   using VMImportOpConversion<T, Adaptor>::VMImportOpConversion;
   LogicalResult
   matchAndRewrite(T op, typename T::Adaptor adaptor,

--- a/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
@@ -15,7 +15,7 @@ namespace mlir::iree_compiler::IREE::Check {
 
 namespace {
 // Rewrites expect_eq_const -> expect_eq
-struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
+struct ExpectEqConstOpToExpectEqOp : OpRewritePattern<ExpectEqConstOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(ExpectEqConstOp op,
                                 PatternRewriter &rewriter) const override {
@@ -28,7 +28,7 @@ struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
 
 // Rewrites expect_almost_eq_const -> expect_almost_eq
 struct ExpectAlmostEqConstOpToExpectAlmostEqOp
-    : public OpRewritePattern<ExpectAlmostEqConstOp> {
+    : OpRewritePattern<ExpectAlmostEqConstOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(ExpectAlmostEqConstOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
@@ -19,8 +19,7 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-struct ElementTypeOpConversion
-    : public OpConversionPattern<IREE::HAL::ElementTypeOp> {
+struct ElementTypeOpConversion : OpConversionPattern<IREE::HAL::ElementTypeOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::ElementTypeOp op, OpAdaptor adaptor,
@@ -37,7 +36,7 @@ struct ElementTypeOpConversion
 };
 
 struct EncodingTypeOpConversion
-    : public OpConversionPattern<IREE::HAL::EncodingTypeOp> {
+    : OpConversionPattern<IREE::HAL::EncodingTypeOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::EncodingTypeOp op, OpAdaptor adaptor,
@@ -52,8 +51,7 @@ struct EncodingTypeOpConversion
   }
 };
 
-struct MemoryTypeOpConversion
-    : public OpConversionPattern<IREE::HAL::MemoryTypeOp> {
+struct MemoryTypeOpConversion : OpConversionPattern<IREE::HAL::MemoryTypeOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::MemoryTypeOp op, OpAdaptor adaptor,
@@ -64,8 +62,7 @@ struct MemoryTypeOpConversion
   }
 };
 
-struct BufferUsageOpConversion
-    : public OpConversionPattern<IREE::HAL::BufferUsageOp> {
+struct BufferUsageOpConversion : OpConversionPattern<IREE::HAL::BufferUsageOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferUsageOp op, OpAdaptor adaptor,
@@ -77,7 +74,7 @@ struct BufferUsageOpConversion
 };
 
 struct BufferSubspanOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferSubspanOp> {
+    : OpConversionPattern<IREE::HAL::BufferSubspanOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferSubspanOp op, OpAdaptor adaptor,
@@ -90,8 +87,7 @@ struct BufferSubspanOpPattern
   }
 };
 
-struct BufferLengthOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferLengthOp> {
+struct BufferLengthOpPattern : OpConversionPattern<IREE::HAL::BufferLengthOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferLengthOp op, OpAdaptor adaptor,
@@ -103,8 +99,7 @@ struct BufferLengthOpPattern
   }
 };
 
-struct BufferLoadOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferLoadOp> {
+struct BufferLoadOpPattern : OpConversionPattern<IREE::HAL::BufferLoadOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferLoadOp op, OpAdaptor adaptor,
@@ -124,8 +119,7 @@ struct BufferLoadOpPattern
   }
 };
 
-struct BufferStoreOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferStoreOp> {
+struct BufferStoreOpPattern : OpConversionPattern<IREE::HAL::BufferStoreOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferStoreOp op, OpAdaptor adaptor,
@@ -145,7 +139,7 @@ struct BufferStoreOpPattern
 };
 
 struct BufferViewCreateOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewCreateOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewCreateOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewCreateOp op, OpAdaptor adaptor,
@@ -159,7 +153,7 @@ struct BufferViewCreateOpPattern
 };
 
 struct BufferViewBufferOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewBufferOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewBufferOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewBufferOp op, OpAdaptor adaptor,
@@ -171,7 +165,7 @@ struct BufferViewBufferOpPattern
 };
 
 struct BufferViewAssertOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewAssertOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewAssertOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewAssertOp op, OpAdaptor adaptor,
@@ -185,7 +179,7 @@ struct BufferViewAssertOpPattern
 };
 
 struct BufferViewElementTypeOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewElementTypeOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewElementTypeOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewElementTypeOp op, OpAdaptor adaptor,
@@ -197,7 +191,7 @@ struct BufferViewElementTypeOpPattern
 };
 
 struct BufferViewEncodingTypeOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewEncodingTypeOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewEncodingTypeOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewEncodingTypeOp op, OpAdaptor adaptor,
@@ -209,7 +203,7 @@ struct BufferViewEncodingTypeOpPattern
 };
 
 struct BufferViewRankOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewRankOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewRankOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewRankOp op, OpAdaptor adaptor,
@@ -221,7 +215,7 @@ struct BufferViewRankOpPattern
 };
 
 struct BufferViewDimOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewDimOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewDimOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewDimOp op, OpAdaptor adaptor,
@@ -234,7 +228,7 @@ struct BufferViewDimOpPattern
 };
 
 struct BufferViewTraceOpPattern
-    : public OpConversionPattern<IREE::HAL::BufferViewTraceOp> {
+    : OpConversionPattern<IREE::HAL::BufferViewTraceOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewTraceOp op, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
@@ -56,7 +56,7 @@ static Storage getResourceStorage(Location loc, Value resource,
 }
 
 struct ResourceAllocOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceAllocOp> {
+    : OpConversionPattern<IREE::Stream::ResourceAllocOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceAllocOp allocOp, OpAdaptor adaptor,
@@ -78,7 +78,7 @@ struct ResourceAllocOpPattern
 };
 
 struct ResourceAllocaOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceAllocaOp> {
+    : OpConversionPattern<IREE::Stream::ResourceAllocaOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceAllocaOp allocaOp, OpAdaptor adaptor,
@@ -103,7 +103,7 @@ struct ResourceAllocaOpPattern
 };
 
 struct ResourceDeallocaOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceDeallocaOp> {
+    : OpConversionPattern<IREE::Stream::ResourceDeallocaOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceDeallocaOp deallocaOp,
@@ -119,7 +119,7 @@ struct ResourceDeallocaOpPattern
 };
 
 struct ResourceRetainOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceRetainOp> {
+    : OpConversionPattern<IREE::Stream::ResourceRetainOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceRetainOp op, OpAdaptor adaptor,
@@ -131,7 +131,7 @@ struct ResourceRetainOpPattern
 };
 
 struct ResourceReleaseOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceReleaseOp> {
+    : OpConversionPattern<IREE::Stream::ResourceReleaseOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceReleaseOp op, OpAdaptor adaptor,
@@ -144,7 +144,7 @@ struct ResourceReleaseOpPattern
 };
 
 struct ResourceIsTerminalOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceIsTerminalOp> {
+    : OpConversionPattern<IREE::Stream::ResourceIsTerminalOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceIsTerminalOp op, OpAdaptor adaptor,
@@ -157,7 +157,7 @@ struct ResourceIsTerminalOpPattern
 };
 
 struct ResourceSizeOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceSizeOp> {
+    : OpConversionPattern<IREE::Stream::ResourceSizeOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceSizeOp sizeOp, OpAdaptor adaptor,
@@ -172,7 +172,7 @@ struct ResourceSizeOpPattern
 // We can thus directly pass along the input buffer that's being mapped
 // (after taking a subspan for the defined range).
 struct ResourceTryMapOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceTryMapOp> {
+    : OpConversionPattern<IREE::Stream::ResourceTryMapOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceTryMapOp tryMapOp, OpAdaptor adaptor,
@@ -189,7 +189,7 @@ struct ResourceTryMapOpPattern
 };
 
 struct ResourceLoadOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceLoadOp> {
+    : OpConversionPattern<IREE::Stream::ResourceLoadOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceLoadOp loadOp, OpAdaptor adaptor,
@@ -209,7 +209,7 @@ struct ResourceLoadOpPattern
 };
 
 struct ResourceStoreOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceStoreOp> {
+    : OpConversionPattern<IREE::Stream::ResourceStoreOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceStoreOp storeOp, OpAdaptor adaptor,
@@ -227,7 +227,7 @@ struct ResourceStoreOpPattern
 };
 
 struct ResourceSubviewOpPattern
-    : public OpConversionPattern<IREE::Stream::ResourceSubviewOp> {
+    : OpConversionPattern<IREE::Stream::ResourceSubviewOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceSubviewOp subviewOp, OpAdaptor adaptor,
@@ -249,7 +249,7 @@ struct ResourceSubviewOpPattern
 };
 
 struct FileConstantOpPattern
-    : public OpConversionPattern<IREE::Stream::FileConstantOp> {
+    : OpConversionPattern<IREE::Stream::FileConstantOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::FileConstantOp constantOp, OpAdaptor adaptor,
@@ -261,8 +261,7 @@ struct FileConstantOpPattern
   }
 };
 
-struct FileReadOpPattern
-    : public OpConversionPattern<IREE::Stream::FileReadOp> {
+struct FileReadOpPattern : OpConversionPattern<IREE::Stream::FileReadOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::FileReadOp readOp, OpAdaptor adaptor,
@@ -284,8 +283,7 @@ struct FileReadOpPattern
   }
 };
 
-struct FileWriteOpPattern
-    : public OpConversionPattern<IREE::Stream::FileWriteOp> {
+struct FileWriteOpPattern : OpConversionPattern<IREE::Stream::FileWriteOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::FileWriteOp writeOp, OpAdaptor adaptor,
@@ -309,7 +307,7 @@ struct FileWriteOpPattern
 };
 
 struct TensorImportBufferOpPattern
-    : public OpConversionPattern<IREE::Stream::TensorImportOp> {
+    : OpConversionPattern<IREE::Stream::TensorImportOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorImportOp importOp, OpAdaptor adaptor,
@@ -326,7 +324,7 @@ struct TensorImportBufferOpPattern
 };
 
 struct TensorImportBufferViewOpPattern
-    : public OpConversionPattern<IREE::Stream::TensorImportOp> {
+    : OpConversionPattern<IREE::Stream::TensorImportOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorImportOp importOp, OpAdaptor adaptor,
@@ -346,7 +344,7 @@ struct TensorImportBufferViewOpPattern
 };
 
 struct TensorExportBufferOpPattern
-    : public OpConversionPattern<IREE::Stream::TensorExportOp> {
+    : OpConversionPattern<IREE::Stream::TensorExportOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorExportOp exportOp, OpAdaptor adaptor,
@@ -360,7 +358,7 @@ struct TensorExportBufferOpPattern
 };
 
 struct TensorExportBufferViewOpPattern
-    : public OpConversionPattern<IREE::Stream::TensorExportOp> {
+    : OpConversionPattern<IREE::Stream::TensorExportOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorExportOp exportOp, OpAdaptor adaptor,
@@ -402,8 +400,7 @@ struct TensorExportBufferViewOpPattern
   }
 };
 
-struct TensorTraceOpPattern
-    : public OpConversionPattern<IREE::Stream::TensorTraceOp> {
+struct TensorTraceOpPattern : OpConversionPattern<IREE::Stream::TensorTraceOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorTraceOp traceOp, OpAdaptor adaptor,
@@ -436,8 +433,7 @@ struct TensorTraceOpPattern
   }
 };
 
-struct CmdFlushOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdFlushOp> {
+struct CmdFlushOpPattern : OpConversionPattern<IREE::Stream::CmdFlushOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdFlushOp op, OpAdaptor adaptor,
@@ -448,7 +444,7 @@ struct CmdFlushOpPattern
 };
 
 struct CmdInvalidateOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdInvalidateOp> {
+    : OpConversionPattern<IREE::Stream::CmdInvalidateOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdInvalidateOp op, OpAdaptor adaptor,
@@ -458,8 +454,7 @@ struct CmdInvalidateOpPattern
   }
 };
 
-struct CmdDiscardOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdDiscardOp> {
+struct CmdDiscardOpPattern : OpConversionPattern<IREE::Stream::CmdDiscardOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdDiscardOp op, OpAdaptor adaptor,
@@ -469,7 +464,7 @@ struct CmdDiscardOpPattern
   }
 };
 
-struct CmdFillOpPattern : public OpConversionPattern<IREE::Stream::CmdFillOp> {
+struct CmdFillOpPattern : OpConversionPattern<IREE::Stream::CmdFillOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdFillOp fillOp, OpAdaptor adaptor,
@@ -484,7 +479,7 @@ struct CmdFillOpPattern : public OpConversionPattern<IREE::Stream::CmdFillOp> {
   }
 };
 
-struct CmdCopyOpPattern : public OpConversionPattern<IREE::Stream::CmdCopyOp> {
+struct CmdCopyOpPattern : OpConversionPattern<IREE::Stream::CmdCopyOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdCopyOp copyOp, OpAdaptor adaptor,
@@ -503,8 +498,7 @@ struct CmdCopyOpPattern : public OpConversionPattern<IREE::Stream::CmdCopyOp> {
   }
 };
 
-struct CmdDispatchOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdDispatchOp> {
+struct CmdDispatchOpPattern : OpConversionPattern<IREE::Stream::CmdDispatchOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdDispatchOp dispatchOp, OpAdaptor adaptor,
@@ -544,7 +538,7 @@ struct CmdDispatchOpPattern
   }
 };
 
-struct CmdFuncOpPattern : public OpConversionPattern<IREE::Stream::CmdFuncOp> {
+struct CmdFuncOpPattern : OpConversionPattern<IREE::Stream::CmdFuncOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdFuncOp funcOp, OpAdaptor adaptor,
@@ -568,7 +562,7 @@ struct CmdFuncOpPattern : public OpConversionPattern<IREE::Stream::CmdFuncOp> {
   }
 };
 
-struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
+struct CmdCallOpPattern : OpConversionPattern<IREE::Stream::CmdCallOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdCallOp callOp, OpAdaptor adaptor,
@@ -611,8 +605,7 @@ struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
   }
 };
 
-struct CmdExecuteOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdExecuteOp> {
+struct CmdExecuteOpPattern : OpConversionPattern<IREE::Stream::CmdExecuteOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdExecuteOp executeOp, OpAdaptor adaptor,
@@ -629,8 +622,7 @@ struct CmdExecuteOpPattern
   }
 };
 
-struct CmdSerialOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdSerialOp> {
+struct CmdSerialOpPattern : OpConversionPattern<IREE::Stream::CmdSerialOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdSerialOp serialOp, OpAdaptor adaptor,
@@ -643,7 +635,7 @@ struct CmdSerialOpPattern
 };
 
 struct CmdConcurrentOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdConcurrentOp> {
+    : OpConversionPattern<IREE::Stream::CmdConcurrentOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdConcurrentOp concurrentOp, OpAdaptor adaptor,
@@ -658,7 +650,7 @@ struct CmdConcurrentOpPattern
 // Annoying we have to have this here, but there's no attribute converter
 // equivalent we have access to so that we could do it in a generic way.
 struct GlobalTimepointConversionPattern
-    : public OpConversionPattern<IREE::Util::GlobalOp> {
+    : OpConversionPattern<IREE::Util::GlobalOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::GlobalOp op, OpAdaptor adaptor,
@@ -677,7 +669,7 @@ struct GlobalTimepointConversionPattern
 };
 
 struct TimepointImmediateOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointImmediateOp> {
+    : OpConversionPattern<IREE::Stream::TimepointImmediateOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointImmediateOp immediateOp,
@@ -689,7 +681,7 @@ struct TimepointImmediateOpPattern
 };
 
 struct TimepointImportOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointImportOp> {
+    : OpConversionPattern<IREE::Stream::TimepointImportOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointImportOp importOp, OpAdaptor adaptor,
@@ -701,7 +693,7 @@ struct TimepointImportOpPattern
 };
 
 struct TimepointExportOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointExportOp> {
+    : OpConversionPattern<IREE::Stream::TimepointExportOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointExportOp exportOp, OpAdaptor adaptor,
@@ -713,7 +705,7 @@ struct TimepointExportOpPattern
 };
 
 struct TimepointChainExternalOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointChainExternalOp> {
+    : OpConversionPattern<IREE::Stream::TimepointChainExternalOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointChainExternalOp exportOp,
@@ -726,7 +718,7 @@ struct TimepointChainExternalOpPattern
 };
 
 struct TimepointJoinOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointJoinOp> {
+    : OpConversionPattern<IREE::Stream::TimepointJoinOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointJoinOp joinOp, OpAdaptor adaptor,
@@ -737,7 +729,7 @@ struct TimepointJoinOpPattern
 };
 
 struct TimepointBarrierOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointBarrierOp> {
+    : OpConversionPattern<IREE::Stream::TimepointBarrierOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointBarrierOp barrierOp, OpAdaptor adaptor,
@@ -752,7 +744,7 @@ struct TimepointBarrierOpPattern
 };
 
 struct TimepointAwaitOpPattern
-    : public OpConversionPattern<IREE::Stream::TimepointAwaitOp> {
+    : OpConversionPattern<IREE::Stream::TimepointAwaitOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointAwaitOp awaitOp, OpAdaptor adaptor,
@@ -762,7 +754,7 @@ struct TimepointAwaitOpPattern
   }
 };
 
-struct ElideYieldOpPattern : public OpConversionPattern<IREE::Stream::YieldOp> {
+struct ElideYieldOpPattern : OpConversionPattern<IREE::Stream::YieldOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::YieldOp yieldOp, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -150,8 +150,7 @@ void BufferViewCreateOp::getAsmResultNames(
 namespace {
 
 /// Folds hal_inline.buffer_view.subspans into buffer view creation subspans.
-struct FoldBufferViewCreateSubspan
-    : public OpRewritePattern<BufferViewCreateOp> {
+struct FoldBufferViewCreateSubspan : OpRewritePattern<BufferViewCreateOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(BufferViewCreateOp op,
                                 PatternRewriter &rewriter) const override {
@@ -200,7 +199,7 @@ namespace {
 
 /// Skips a hal.buffer_view.buffer accessor when the buffer view was created in
 /// the same scope and we know the origin buffer.
-struct SkipBufferViewBufferOp : public OpRewritePattern<BufferViewBufferOp> {
+struct SkipBufferViewBufferOp : OpRewritePattern<BufferViewBufferOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(BufferViewBufferOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
@@ -34,7 +34,7 @@ static Value castToI32(Value value, OpBuilder &builder) {
 }
 
 struct ExecutableLoadOpConversion
-    : public OpConversionPattern<IREE::HAL::Loader::ExecutableLoadOp> {
+    : OpConversionPattern<IREE::HAL::Loader::ExecutableLoadOp> {
   ExecutableLoadOpConversion(MLIRContext *context, SymbolTable &importSymbols,
                              TypeConverter &typeConverter, StringRef importName)
       : OpConversionPattern(context) {
@@ -70,7 +70,7 @@ private:
 };
 
 struct ExecutableDispatchOpConversion
-    : public OpConversionPattern<IREE::HAL::Loader::ExecutableDispatchOp> {
+    : OpConversionPattern<IREE::HAL::Loader::ExecutableDispatchOp> {
   ExecutableDispatchOpConversion(MLIRContext *context,
                                  SymbolTable &importSymbols,
                                  TypeConverter &typeConverter,

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
@@ -36,8 +36,7 @@ static Value getResourceBuffer(Location loc, Value resource,
 }
 
 // Converts a dispatch command into an inline executable dispatch.
-struct CmdDispatchOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdDispatchOp> {
+struct CmdDispatchOpPattern : OpConversionPattern<IREE::Stream::CmdDispatchOp> {
   CmdDispatchOpPattern(TypeConverter &typeConverter, MLIRContext *context)
       : OpConversionPattern(typeConverter, context, PatternBenefit(10000)) {}
   LogicalResult

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.cpp
@@ -161,7 +161,7 @@ namespace {
 
 // Folds subspan ranges into dispatch resource ranges.
 struct FoldBindingSubspansIntoDispatchOp
-    : public OpRewritePattern<ExecutableDispatchOp> {
+    : OpRewritePattern<ExecutableDispatchOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(ExecutableDispatchOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/ParamsToVM/Patterns.cpp
@@ -182,8 +182,7 @@ static Value buildIndirectSpans(Location loc, ValueRange parameterOffsets,
   return clonedBuffer;
 }
 
-struct LoadOpConversion
-    : public OpConversionPattern<IREE::IO::Parameters::LoadOp> {
+struct LoadOpConversion : OpConversionPattern<IREE::IO::Parameters::LoadOp> {
   LoadOpConversion(MLIRContext *context, SymbolTable &importSymbols,
                    TypeConverter &typeConverter, StringRef importName)
       : OpConversionPattern(context) {
@@ -241,7 +240,7 @@ private:
 };
 
 struct GatherOpConversion
-    : public OpConversionPattern<IREE::IO::Parameters::GatherOp> {
+    : OpConversionPattern<IREE::IO::Parameters::GatherOp> {
   GatherOpConversion(MLIRContext *context, SymbolTable &importSymbols,
                      TypeConverter &typeConverter, StringRef importName)
       : OpConversionPattern(context) {
@@ -279,7 +278,7 @@ private:
 };
 
 struct ScatterOpConversion
-    : public OpConversionPattern<IREE::IO::Parameters::ScatterOp> {
+    : OpConversionPattern<IREE::IO::Parameters::ScatterOp> {
   ScatterOpConversion(MLIRContext *context, SymbolTable &importSymbols,
                       TypeConverter &typeConverter, StringRef importName)
       : OpConversionPattern(context) {

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/Patterns.cpp
@@ -23,7 +23,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct CmdParameterLoadOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdParameterLoadOp> {
+    : OpConversionPattern<IREE::Stream::CmdParameterLoadOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdParameterLoadOp loadOp, OpAdaptor adaptor,
@@ -67,7 +67,7 @@ struct CmdParameterLoadOpPattern
 };
 
 struct CmdParameterReadOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdParameterReadOp> {
+    : OpConversionPattern<IREE::Stream::CmdParameterReadOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdParameterReadOp readOp, OpAdaptor adaptor,
@@ -96,7 +96,7 @@ struct CmdParameterReadOpPattern
 };
 
 struct CmdParameterWriteOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdParameterWriteOp> {
+    : OpConversionPattern<IREE::Stream::CmdParameterWriteOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdParameterWriteOp writeOp, OpAdaptor adaptor,
@@ -125,7 +125,7 @@ struct CmdParameterWriteOpPattern
 };
 
 struct CmdParameterGatherOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdParameterGatherOp> {
+    : OpConversionPattern<IREE::Stream::CmdParameterGatherOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdParameterGatherOp gatherOp,
@@ -154,7 +154,7 @@ struct CmdParameterGatherOpPattern
 };
 
 struct CmdParameterScatterOpPattern
-    : public OpConversionPattern<IREE::Stream::CmdParameterScatterOp> {
+    : OpConversionPattern<IREE::Stream::CmdParameterScatterOp> {
   using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdParameterScatterOp scatterOp,

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/IR/IOParametersDialect.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/IR/IOParametersDialect.cpp
@@ -23,7 +23,7 @@ namespace mlir::iree_compiler::IREE::IO::Parameters {
 namespace {
 
 // Used to control inlining behavior.
-struct IOParametersInlinerInterface : public DialectInlinerInterface {
+struct IOParametersInlinerInterface : DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
   bool isLegalToInline(Operation *call, Operation *callable,

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ExportParameters.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ExportParameters.cpp
@@ -82,7 +82,7 @@ static LogicalResult addEntry(IREE::Util::GlobalOpInterface globalOp,
 }
 
 struct ExportParametersPass
-    : public IREE::IO::Parameters::impl::ExportParametersPassBase<
+    : IREE::IO::Parameters::impl::ExportParametersPassBase<
           ExportParametersPass> {
   using IREE::IO::Parameters::impl::ExportParametersPassBase<
       ExportParametersPass>::ExportParametersPassBase;

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/GenerateSplatParameterArchive.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/GenerateSplatParameterArchive.cpp
@@ -63,7 +63,7 @@ static Attribute getDefaultSplatAttr(Type elementType) {
 }
 
 struct GenerateSplatParameterArchivePass
-    : public IREE::IO::Parameters::impl::GenerateSplatParameterArchivePassBase<
+    : IREE::IO::Parameters::impl::GenerateSplatParameterArchivePassBase<
           GenerateSplatParameterArchivePass> {
   using IREE::IO::Parameters::impl::GenerateSplatParameterArchivePassBase<
       GenerateSplatParameterArchivePass>::GenerateSplatParameterArchivePassBase;

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ImportParameters.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ImportParameters.cpp
@@ -278,7 +278,7 @@ importParameter(StringRef fullName, ShapedType globalType,
 }
 
 struct ImportParametersPass
-    : public IREE::IO::Parameters::impl::ImportParametersPassBase<
+    : IREE::IO::Parameters::impl::ImportParametersPassBase<
           ImportParametersPass> {
   using IREE::IO::Parameters::impl::ImportParametersPassBase<
       ImportParametersPass>::ImportParametersPassBase;

--- a/compiler/src/iree/compiler/PluginAPI/Client.h
+++ b/compiler/src/iree/compiler/PluginAPI/Client.h
@@ -214,7 +214,7 @@ public:
   static void registerPasses() {}
   static void registerGlobalDialects(DialectRegistry &registry) {}
 
-  struct Registration : public AbstractPluginRegistration {
+  struct Registration : AbstractPluginRegistration {
     using AbstractPluginRegistration::AbstractPluginRegistration;
     PluginActivationPolicy getActivationPolicy() override {
       return activationPolicy;

--- a/compiler/src/iree/compiler/Preprocessing/Common/AttrBasedPipelinePass.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/AttrBasedPipelinePass.cpp
@@ -24,7 +24,7 @@ namespace mlir::iree_compiler::Preprocessing {
 namespace {
 
 struct AttrBasedPipelinePass
-    : public iree_compiler::Preprocessing::impl::AttrBasedPipelinePassBase<
+    : iree_compiler::Preprocessing::impl::AttrBasedPipelinePassBase<
           AttrBasedPipelinePass> {
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Preprocessing/Common/Convert1X1FilterConv2DToMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Convert1X1FilterConv2DToMatmul.cpp
@@ -79,7 +79,7 @@ public:
 };
 
 struct Convert1X1FilterConv2DToMatmulPass
-    : public impl::Convert1X1FilterConv2DToMatmulPassBase<
+    : impl::Convert1X1FilterConv2DToMatmulPassBase<
           Convert1X1FilterConv2DToMatmulPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect>();

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -85,7 +85,7 @@ convertConvFilterToTargetLayout(linalg::Conv2DNhwcHwcfOp convOp,
 }
 
 namespace {
-struct ConvertHwcfToHwfc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
+struct ConvertHwcfToHwfc : OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
@@ -95,7 +95,7 @@ struct ConvertHwcfToHwfc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
   }
 };
 
-struct ConvertHwcfToFhwc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
+struct ConvertHwcfToFhwc : OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
@@ -106,7 +106,7 @@ struct ConvertHwcfToFhwc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
 };
 
 /// Transpose the generic form filter layout of `CHWF` or `CFHW` to `FHWC`.
-struct ConvertGenericFilterToFhwc : public OpRewritePattern<linalg::GenericOp> {
+struct ConvertGenericFilterToFhwc : OpRewritePattern<linalg::GenericOp> {
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::GenericOp op,

--- a/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
@@ -55,7 +55,7 @@ namespace {
 ///  does. TODO(#17673)
 ///
 struct FoldAttentionAndTranspose
-    : public OpRewritePattern<IREE::LinalgExt::AttentionOp> {
+    : OpRewritePattern<IREE::LinalgExt::AttentionOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::AttentionOp attentionOp,
@@ -185,8 +185,7 @@ struct FoldAttentionAndTranspose
 //===----------------------------------------------------------------------===//
 
 struct FoldAttentionWithTransposePass
-    : public impl::FoldAttentionWithTransposePassBase<
-          FoldAttentionWithTransposePass> {
+    : impl::FoldAttentionWithTransposePassBase<FoldAttentionWithTransposePass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/Preprocessing/Common/GeneralizeLinalgMatMul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/GeneralizeLinalgMatMul.cpp
@@ -19,7 +19,7 @@ namespace mlir::iree_compiler::Preprocessing {
 namespace {
 
 struct GeneralizeLinalgMatMulPass
-    : public iree_compiler::Preprocessing::impl::GeneralizeLinalgMatMulPassBase<
+    : iree_compiler::Preprocessing::impl::GeneralizeLinalgMatMulPassBase<
           GeneralizeLinalgMatMulPass> {
   using iree_compiler::Preprocessing::impl::GeneralizeLinalgMatMulPassBase<
       GeneralizeLinalgMatMulPass>::GeneralizeLinalgMatMulPassBase;

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -26,9 +26,8 @@ namespace mlir::iree_compiler::Preprocessing {
 namespace {
 
 struct MakeSingleDispatchForFunctionPass
-    : public iree_compiler::Preprocessing::impl::
-          MakeSingleDispatchForFunctionPassBase<
-              MakeSingleDispatchForFunctionPass> {
+    : iree_compiler::Preprocessing::impl::MakeSingleDispatchForFunctionPassBase<
+          MakeSingleDispatchForFunctionPass> {
   void runOnOperation() override;
 };
 } // namespace

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -565,7 +565,7 @@ static void padContractionLikeOp(
 }
 
 struct PadToIntrinsicsPass
-    : public impl::PadToIntrinsicsPassBase<PadToIntrinsicsPass> {
+    : impl::PadToIntrinsicsPassBase<PadToIntrinsicsPass> {
   using Base::Base;
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
@@ -16,7 +16,7 @@ namespace mlir::iree_compiler::Preprocessing {
 
 namespace {
 struct TransposeMatmulPass
-    : public impl::TransposeMatmulPassBase<TransposeMatmulPass> {
+    : impl::TransposeMatmulPassBase<TransposeMatmulPass> {
   using Base::Base;
 
   void runOnOperation() override {

--- a/compiler/src/iree/compiler/Preprocessing/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.h
@@ -17,7 +17,7 @@
 namespace mlir::iree_compiler::Preprocessing {
 
 /// Placeholder struct for preprocessing pass pipeline options.
-struct TransformOptions : public PassPipelineOptions<TransformOptions> {};
+struct TransformOptions : PassPipelineOptions<TransformOptions> {};
 
 /// Adds a set of passes to the given pass manager that are run after input
 /// conversion, but before any of the IREE compilation passes. There are many

--- a/compiler/src/iree/compiler/Tools/MlirTransformHarness.h
+++ b/compiler/src/iree/compiler/Tools/MlirTransformHarness.h
@@ -39,7 +39,7 @@
 // Pattern application:
 //   echo 'module { ... }' | iree-bazel-try -e '
 //   #include "iree/compiler/Tools/MlirTransformHarness.h"
-//   struct MyPattern : public mlir::OpRewritePattern<SomeOp> {
+//   struct MyPattern : mlir::OpRewritePattern<SomeOp> {
 //     using OpRewritePattern::OpRewritePattern;
 //     LogicalResult matchAndRewrite(SomeOp op, PatternRewriter &rw) const
 //     override {

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -46,7 +46,7 @@ enum class CompileMode {
   precompile,
 };
 
-struct BytecodeVersionParser : public llvm::cl::parser<std::optional<int64_t>> {
+struct BytecodeVersionParser : llvm::cl::parser<std::optional<int64_t>> {
   BytecodeVersionParser(llvm::cl::Option &O)
       : llvm::cl::parser<std::optional<int64_t>>(O) {}
   bool parse(llvm::cl::Option &O, StringRef /*argName*/, StringRef arg,

--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -574,7 +574,7 @@ struct ByteSize {
   operator bool() const noexcept { return value != 0; }
 };
 
-struct PowerOf2ByteSize : public ByteSize {
+struct PowerOf2ByteSize : ByteSize {
   using ByteSize::ByteSize;
 };
 

--- a/compiler/src/iree/compiler/Utils/PatternUtils.h
+++ b/compiler/src/iree/compiler/Utils/PatternUtils.h
@@ -33,7 +33,7 @@ static void insertGreedyPattern(RewritePatternSet &patterns,
                                 MLIRContext *context,
                                 GenericOpRewritePattern<OpTy> f,
                                 PatternBenefit benefit = 1) {
-  struct Pattern : public OpRewritePattern<OpTy> {
+  struct Pattern : OpRewritePattern<OpTy> {
     Pattern(MLIRContext *context, GenericOpRewritePattern<OpTy> f,
             PatternBenefit benefit)
         : OpRewritePattern<OpTy>(context, benefit), f(f) {}
@@ -60,7 +60,7 @@ static void insertConversionPattern(RewritePatternSet &patterns,
                                     MLIRContext *context,
                                     GenericOpRewritePattern<OpTy> f,
                                     PatternBenefit benefit = 1) {
-  struct Pattern : public OpConversionPattern<OpTy> {
+  struct Pattern : OpConversionPattern<OpTy> {
     Pattern(MLIRContext *context, GenericOpRewritePattern<OpTy> f,
             PatternBenefit benefit)
         : OpConversionPattern<OpTy>(context, benefit), f(f) {}

--- a/compiler/src/iree/compiler/Utils/TracingUtils.h
+++ b/compiler/src/iree/compiler/Utils/TracingUtils.h
@@ -18,7 +18,7 @@ namespace mlir::iree_compiler {
 //
 // Usage:
 //   passManager.addInstrumentation(std::make_unique<PassTracing>());
-struct PassTracing : public PassInstrumentation {
+struct PassTracing : PassInstrumentation {
   PassTracing() {}
   ~PassTracing() override = default;
 

--- a/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/PassUtilsTest.cpp
@@ -31,7 +31,7 @@ namespace {
 /// An OperationPass<> that sets a named unit attribute on whatever operation it
 /// runs on. Because it is a generic (untyped) pass, the OpPipelineAdaptorPass
 /// can run it directly on dispatched child operations.
-struct MarkerPass final : public PassWrapper<MarkerPass, OperationPass<>> {
+struct MarkerPass final : PassWrapper<MarkerPass, OperationPass<>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MarkerPass)
 
   explicit MarkerPass(std::string name) : name(std::move(name)) {}
@@ -47,7 +47,7 @@ struct MarkerPass final : public PassWrapper<MarkerPass, OperationPass<>> {
 };
 
 /// An OperationPass<> that always signals pass failure.
-struct FailingPass final : public PassWrapper<FailingPass, OperationPass<>> {
+struct FailingPass final : PassWrapper<FailingPass, OperationPass<>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FailingPass)
 
   StringRef getArgument() const override { return "test-failing"; }
@@ -59,7 +59,7 @@ struct FailingPass final : public PassWrapper<FailingPass, OperationPass<>> {
 /// counter and stores the counter value as an integer attribute. Used to
 /// verify pass ordering across module-level and dispatched function-level
 /// passes.
-struct CounterPass final : public PassWrapper<CounterPass, OperationPass<>> {
+struct CounterPass final : PassWrapper<CounterPass, OperationPass<>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CounterPass)
 
   CounterPass(std::string attrName, std::atomic<int> *counter)


### PR DESCRIPTION
Covers GlobalOptimization, Modules, Preprocessing, ExternalInterfaces, InputConversion, Utils, and other remaining directories.