### PR TITLE
[Codegen] Fix ArgCompare vectorization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -115,13 +115,12 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
         }
       })
       .Case([&](IREE::LinalgExt::ArgCompareOp argCompareOp) {
-        // Use input shape instead of output shape to get vectorSizes.
-        // The output is a reduction result (e.g., 0-D for full reduction),
-        // while the input contains the full iteration space including the
-        // reduction dimension that we want to vectorize.
-        auto inputTy = argCompareOp.getInputType();
-        if (inputTy.hasStaticShape()) {
-          vectorSizes = llvm::to_vector(inputTy.getShape());
+        // Infer from the input operand because it contains the full iteration
+        // space, including the reduction dimension, for vectorization.
+        std::optional<VectorizationTileSizes> result =
+            inferSizesFromIR(argCompareOp.getInputValue());
+        if (result) {
+          vectorSizes = result->vectorSizes;
         }
       })
       .Default([&](Operation *) {});

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -115,10 +115,13 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
         }
       })
       .Case([&](IREE::LinalgExt::ArgCompareOp argCompareOp) {
-        std::optional<VectorizationTileSizes> result =
-            inferSizesFromIR(argCompareOp.getDpsInits()[0]);
-        if (result) {
-          vectorSizes = result->vectorSizes;
+        // Use input shape instead of output shape to get vectorSizes.
+        // The output is a reduction result (e.g., 0-D for full reduction),
+        // while the input contains the full iteration space including the
+        // reduction dimension that we want to vectorize.
+        auto inputTy = argCompareOp.getInputType();
+        if (inputTy.hasStaticShape()) {
+          vectorSizes = SmallVector<int64_t>(inputTy.getShape());
         }
       })
       .Default([&](Operation *) {});

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -121,7 +121,7 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
         // reduction dimension that we want to vectorize.
         auto inputTy = argCompareOp.getInputType();
         if (inputTy.hasStaticShape()) {
-          vectorSizes = SmallVector<int64_t>(inputTy.getShape());
+          vectorSizes = llvm::to_vector(inputTy.getShape());
         }
       })
       .Default([&](Operation *) {});

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
@@ -654,6 +654,84 @@ func.func @arg_compare_with_index_base(%input: tensor<4x128xf32>,
 
 // -----
 
+// Test 1D reduction with rank-reducing extract_slice (1D -> 0D).
+// This covers the failure case where output is scalar from extract_slice.
+func.func @arg_compare_1d_reduction_extract_slice(
+    %input: tensor<1024xf32>,
+    %init_val_tile: tensor<1xf32>,
+    %init_idx_tile: tensor<1xi64>)
+    -> (tensor<f32>, tensor<i64>) {
+  %out_val = tensor.extract_slice %init_val_tile[0] [1] [1]
+      : tensor<1xf32> to tensor<f32>
+  %out_idx = tensor.extract_slice %init_idx_tile[0] [1] [1]
+      : tensor<1xi64> to tensor<i64>
+  %result:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%input : tensor<1024xf32>)
+    outs(%out_val, %out_idx : tensor<f32>, tensor<i64>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f32>, tensor<i64>
+  return %result#0, %result#1 : tensor<f32>, tensor<i64>
+}
+// CHECK-LABEL: func.func @arg_compare_1d_reduction_extract_slice
+// CHECK:         %[[OUT_VAL:.+]] = tensor.extract_slice
+// CHECK:         %[[OUT_IDX:.+]] = tensor.extract_slice
+// CHECK:         %[[INPUT_VEC:.+]] = vector.transfer_read
+// CHECK-SAME:      tensor<1024xf32>, vector<1024xf32>
+// CHECK:         %[[OUT_VAL_VEC:.+]] = vector.transfer_read %[[OUT_VAL]]
+// CHECK-SAME:      tensor<f32>, vector<f32>
+// CHECK:         %[[OUT_IDX_VEC:.+]] = vector.transfer_read %[[OUT_IDX]]
+// CHECK-SAME:      tensor<i64>, vector<i64>
+// CHECK:         %[[RESULT_VAL:.+]], %[[RESULT_IDX:.+]] = iree_vector_ext.arg_compare
+// CHECK-SAME:      dimension(0)
+// CHECK-SAME:      ins(%[[INPUT_VEC]] : vector<1024xf32>)
+// CHECK-SAME:      inits(%[[OUT_VAL_VEC]], %[[OUT_IDX_VEC]] : vector<f32>, vector<i64>)
+// CHECK:         -> vector<f32>, vector<i64>
+
+// -----
+
+// Test multi-dimensional batched reduction where output comes from extract_slice
+// (simulates scf.forall batching). The fix ensures vectorSizes comes from input
+// shape [4, 8, 128] even when inferSizesFromIR would return wrong sizes [4, 8, 1]
+// from extract_slice.
+func.func @arg_compare_multidim_batched_extract_slice(
+    %input: tensor<4x8x128xf32>,
+    %out_val_tile: tensor<4x8x1xf32>,
+    %out_idx_tile: tensor<4x8x1xi32>)
+    -> (tensor<4x8xf32>, tensor<4x8xi32>) {
+  %out_val = tensor.extract_slice %out_val_tile[0, 0, 0] [4, 8, 1] [1, 1, 1]
+      : tensor<4x8x1xf32> to tensor<4x8xf32>
+  %out_idx = tensor.extract_slice %out_idx_tile[0, 0, 0] [4, 8, 1] [1, 1, 1]
+      : tensor<4x8x1xi32> to tensor<4x8xi32>
+  %result:2 = iree_linalg_ext.arg_compare
+    dimension(2)
+    ins(%input : tensor<4x8x128xf32>)
+    outs(%out_val, %out_idx : tensor<4x8xf32>, tensor<4x8xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4x8xf32>, tensor<4x8xi32>
+  return %result#0, %result#1 : tensor<4x8xf32>, tensor<4x8xi32>
+}
+// CHECK-LABEL: func.func @arg_compare_multidim_batched_extract_slice
+// CHECK:         %[[OUT_VAL:.+]] = tensor.extract_slice
+// CHECK:         %[[OUT_IDX:.+]] = tensor.extract_slice
+// CHECK:         %[[INPUT_VEC:.+]] = vector.transfer_read
+// CHECK-SAME:      tensor<4x8x128xf32>, vector<4x8x128xf32>
+// CHECK:         %[[OUT_VAL_VEC:.+]] = vector.transfer_read %[[OUT_VAL]]
+// CHECK-SAME:      tensor<4x8xf32>, vector<4x8xf32>
+// CHECK:         %[[OUT_IDX_VEC:.+]] = vector.transfer_read %[[OUT_IDX]]
+// CHECK-SAME:      tensor<4x8xi32>, vector<4x8xi32>
+// CHECK:         %[[RESULT_VAL:.+]], %[[RESULT_IDX:.+]] = iree_vector_ext.arg_compare
+// CHECK-SAME:      dimension(2)
+// CHECK-SAME:      ins(%[[INPUT_VEC]] : vector<4x8x128xf32>)
+// CHECK-SAME:      inits(%[[OUT_VAL_VEC]], %[[OUT_IDX_VEC]] : vector<4x8xf32>, vector<4x8xi32>)
+// CHECK:         -> vector<4x8xf32>, vector<4x8xi32>
+
+// -----
+
 #layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile = [1, 1],

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
@@ -656,15 +656,12 @@ func.func @arg_compare_with_index_base(%input: tensor<4x128xf32>,
 
 // Test 1D reduction with rank-reducing extract_slice (1D -> 0D).
 // This covers the failure case where output is scalar from extract_slice.
-func.func @arg_compare_1d_reduction_extract_slice(
-    %input: tensor<1024xf32>,
-    %init_val_tile: tensor<1xf32>,
-    %init_idx_tile: tensor<1xi64>)
+func.func @arg_compare_1d_reduction_extract_slice(%input: tensor<1024xf32>,
+                                                  %init_val_tile: tensor<1xf32>,
+                                                  %init_idx_tile: tensor<1xi64>)
     -> (tensor<f32>, tensor<i64>) {
-  %out_val = tensor.extract_slice %init_val_tile[0] [1] [1]
-      : tensor<1xf32> to tensor<f32>
-  %out_idx = tensor.extract_slice %init_idx_tile[0] [1] [1]
-      : tensor<1xi64> to tensor<i64>
+  %out_val = tensor.extract_slice %init_val_tile[0] [1] [1] : tensor<1xf32> to tensor<f32>
+  %out_idx = tensor.extract_slice %init_idx_tile[0] [1] [1] : tensor<1xi64> to tensor<i64>
   %result:2 = iree_linalg_ext.arg_compare
     dimension(0)
     ins(%input : tensor<1024xf32>)
@@ -696,15 +693,12 @@ func.func @arg_compare_1d_reduction_extract_slice(
 // (simulates scf.forall batching). The fix ensures vectorSizes comes from input
 // shape [4, 8, 128] even when inferSizesFromIR would return wrong sizes [4, 8, 1]
 // from extract_slice.
-func.func @arg_compare_multidim_batched_extract_slice(
-    %input: tensor<4x8x128xf32>,
-    %out_val_tile: tensor<4x8x1xf32>,
-    %out_idx_tile: tensor<4x8x1xi32>)
+func.func @arg_compare_multidim_batched_extract_slice(%input: tensor<4x8x128xf32>,
+                                                      %out_val_tile: tensor<4x8x1xf32>,
+                                                      %out_idx_tile: tensor<4x8x1xi32>)
     -> (tensor<4x8xf32>, tensor<4x8xi32>) {
-  %out_val = tensor.extract_slice %out_val_tile[0, 0, 0] [4, 8, 1] [1, 1, 1]
-      : tensor<4x8x1xf32> to tensor<4x8xf32>
-  %out_idx = tensor.extract_slice %out_idx_tile[0, 0, 0] [4, 8, 1] [1, 1, 1]
-      : tensor<4x8x1xi32> to tensor<4x8xi32>
+  %out_val = tensor.extract_slice %out_val_tile[0, 0, 0] [4, 8, 1] [1, 1, 1] : tensor<4x8x1xf32> to tensor<4x8xf32>
+  %out_idx = tensor.extract_slice %out_idx_tile[0, 0, 0] [4, 8, 1] [1, 1, 1] : tensor<4x8x1xi32> to tensor<4x8xi32>
   %result:2 = iree_linalg_ext.arg_compare
     dimension(2)
     ins(%input : tensor<4x8x128xf32>)

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -175,18 +175,7 @@ struct ArgCompareOpVectorizationModel
     // Check input shape (includes reduction dimension) to catch dynamic
     // reduction dimensions that wouldn't appear in the static output shape.
     auto inputValTy = cast<ShapedType>(argCompareOp.getInputValue().getType());
-    if (!inputValTy.hasStaticShape()) {
-      return false;
-    }
-    ShapedType outValTy = argCompareOp.getOutputValueType();
-    SmallVector<int64_t> sizes(vectorSizes);
-    if (sizes.empty()) {
-      sizes = llvm::to_vector(outValTy.getShape());
-    }
-    if (sizes != llvm::to_vector(outValTy.getShape())) {
-      return false;
-    }
-    return true;
+    return inputValTy.hasStaticShape();
   }
 
   FailureOr<SmallVector<Value>> vectorize(Operation *op, RewriterBase &rewriter,
@@ -208,12 +197,7 @@ struct ArgCompareOpVectorizationModel
     ShapedType outIdxTy = argCompareOp.getOutputIndexType();
 
     if (vectorSizes.empty()) {
-      vectorSizes = outValTy.getShape();
-    }
-
-    // Ensure full tiles - partial tiles would require masking support.
-    if (vectorSizes != outValTy.getShape()) {
-      return failure();
+      vectorSizes = inputValTy.getShape();
     }
 
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
@@ -240,18 +224,19 @@ struct ArgCompareOpVectorizationModel
       vectorizeInput(inputIndex);
     }
 
+    ArrayRef<int64_t> initShape = outValTy.getShape();
     SmallVector<Value> initVecs;
     for (Value init : argCompareOp.getDpsInits()) {
       auto initTy = cast<ShapedType>(init.getType());
-      SmallVector<Value> readIndices(vectorSizes.size(), zero);
-      auto initVecTy = VectorType::get(vectorSizes, initTy.getElementType());
+      SmallVector<Value> readIndices(initShape.size(), zero);
+      auto initVecTy = VectorType::get(initShape, initTy.getElementType());
       auto readOp = vector::TransferReadOp::create(
           rewriter, loc, initVecTy, init, readIndices, std::nullopt);
       initVecs.push_back(readOp);
     }
 
-    auto outValVecTy = VectorType::get(vectorSizes, outValTy.getElementType());
-    auto outIdxVecTy = VectorType::get(vectorSizes, outIdxTy.getElementType());
+    auto outValVecTy = VectorType::get(initShape, outValTy.getElementType());
+    auto outIdxVecTy = VectorType::get(initShape, outIdxTy.getElementType());
 
     Region &srcRegion = argCompareOp.getRegion();
 
@@ -307,7 +292,7 @@ struct ArgCompareOpVectorizationModel
     SmallVector<Value> results;
     for (auto [result, output] : llvm::zip_equal(
              vectorArgCompareOp.getResults(), argCompareOp.getDpsInits())) {
-      SmallVector<Value> writeIndices(vectorSizes.size(), zero);
+      SmallVector<Value> writeIndices(initShape.size(), zero);
       auto writeOp = vector::TransferWriteOp::create(rewriter, loc, result,
                                                      output, writeIndices);
       results.push_back(writeOp.getResult());


### PR DESCRIPTION
This PR fixes ArgCompare vectorization to use **input** shape instead of the **output** shape for inferring vector sizes. 

The existing implementation uses `inferSizesFromIR(argCompareOp.getDpsInits()[0])`, which fails for rank-reducing operations. Inferring from the output returns incorrect sizes, especially when outputs come from rank-reducing `tensor.extract_slice` operations.

Example failure case: 
 ```mlir
  %extracted_slice_2 = tensor.extract_slice %extracted_slice[0] [1] [1] : tensor<1xf32> to tensor<f32>
  %32:2 = iree_linalg_ext.arg_compare dimension(0)
      ins(%28, %31 : tensor<1024xf32>, tensor<1024xi64>)
      outs(%extracted_slice_2, %extracted_slice_4 : tensor<f32>, tensor<i64>)
 ```     

For reduction ops, `inferSizesFromIR(linalgOp, ...)` uses `linalgOp.getNumLoops()` to map ALL loop dimensions (parallel + reduction) to operands.  
 
 Assisted-by:  [Claude Code](https://claude.ai/code)