### PR TITLE
[Base] Fix shm write-seal remap on kernels < 6.1.

### DIFF
--- a/runtime/src/iree/base/internal/shm_posix.c
+++ b/runtime/src/iree/base/internal/shm_posix.c
@@ -655,11 +655,24 @@ iree_status_t iree_shm_seal(iree_shm_mapping_t* mapping,
                             "fcntl(F_ADD_SEALS) failed (%d)", saved_errno);
   }
 
-  // Remap as read-only now that the seal is applied. If this fails, the seal
-  // is permanent but we have no mapping — tear down cleanly so the caller
-  // can reopen the region via the handle if needed.
+  // Remap as read-only now that the seal is applied. We prefer MAP_SHARED
+  // because it preserves the kernel's mprotect enforcement: a MAP_SHARED
+  // mapping on a write-sealed memfd cannot be made writable via mprotect,
+  // providing defense-in-depth for sealed model parameters and other
+  // immutable data.
+  //
+  // On kernels prior to 6.1, MAP_SHARED fails with EPERM here because
+  // mmap_region() unconditionally calls mapping_map_writable() for all
+  // MAP_SHARED mappings — even read-only ones — and F_SEAL_WRITE has made
+  // the writable refcount negative. Fall back to MAP_PRIVATE, which bypasses
+  // that check. MAP_PRIVATE is semantically equivalent for reads (the sealed
+  // data cannot change, so there is nothing to CoW) but loses the mprotect
+  // guard.
   if (flags & IREE_SHM_SEAL_WRITE) {
     void* base = mmap(NULL, old_size, PROT_READ, MAP_SHARED, fd, 0);
+    if (IREE_UNLIKELY(base == MAP_FAILED) && errno == EPERM) {
+      base = mmap(NULL, old_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    }
     if (IREE_UNLIKELY(base == MAP_FAILED)) {
       int saved_errno = errno;
       close(fd);

--- a/runtime/src/iree/base/internal/shm_posix.c
+++ b/runtime/src/iree/base/internal/shm_posix.c
@@ -62,13 +62,22 @@ static inline int iree_shm_handle_to_fd(iree_shm_handle_t handle) {
 static iree_status_t iree_shm_map_fd(int fd, iree_host_size_t size,
                                      void** out_base) {
   int prot = PROT_READ | PROT_WRITE;
+  int map_flags = MAP_SHARED;
 #if defined(IREE_PLATFORM_LINUX)
   int seals = fcntl(fd, IREE_F_GET_SEALS);
   if (seals != -1 && (seals & IREE_F_SEAL_WRITE)) {
     prot = PROT_READ;
   }
 #endif  // IREE_PLATFORM_LINUX
-  void* base = mmap(NULL, size, prot, MAP_SHARED, fd, 0);
+  void* base = mmap(NULL, size, prot, map_flags, fd, 0);
+  if (IREE_UNLIKELY(base == MAP_FAILED) && prot == PROT_READ &&
+      errno == EPERM) {
+    // On kernels prior to 6.1, MAP_SHARED with PROT_READ on a write-sealed
+    // memfd fails with EPERM because mmap_region() unconditionally calls
+    // mapping_map_writable() for all MAP_SHARED mappings. Fall back to
+    // MAP_PRIVATE, which is equivalent for reads on sealed data.
+    base = mmap(NULL, size, prot, MAP_PRIVATE, fd, 0);
+  }
   if (IREE_UNLIKELY(base == MAP_FAILED)) {
     return iree_make_status(iree_status_code_from_errno(errno),
                             "mmap failed for shared memory region of %" PRIhsz


### PR DESCRIPTION
On kernels prior to 6.1, `mmap(PROT_READ, MAP_SHARED)` on a write-sealed memfd fails with `EPERM` because `mmap_region()` unconditionally calls `mapping_map_writable()` for all `MAP_SHARED` mappings, and `F_SEAL_WRITE` has made the writable refcount negative.

Try `MAP_SHARED` first (preserves `mprotect` defense-in-depth on 6.1+), falling back to `MAP_PRIVATE` on `EPERM` for older kernels. Applied in both the seal remap path (`iree_shm_seal`) and the open path (`iree_shm_map_fd`) which maps already-sealed fds.

Fixes arm64 CI failures on Ubuntu 22.04 (kernel 5.15).

ci-extra: all