### PR TITLE
Simplify RISC-V QEMU configuration and make CPU flags configurable

### DIFF
--- a/.github/workflows/pkgci_test_riscv64.yml
+++ b/.github/workflows/pkgci_test_riscv64.yml
@@ -90,5 +90,5 @@ jobs:
         run: ./build_tools/cmake/build_riscv.sh
       - name: Test riscv64
         env:
-          QEMU_RV64_BIN: ${{ env.QEMU_PATH_PREFIX }}/qemu-riscv64
+          QEMU_BIN: ${{ env.QEMU_PATH_PREFIX }}/qemu-riscv64
         run: ./build_tools/cmake/test_riscv.sh

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -176,6 +176,7 @@ function(iree_cc_test)
         ${_RULE_ARGS}
     )
     iree_configure_test(${_NAME_PATH})
+    list(APPEND _ENVIRONMENT_VARS "QEMU_CPU_FLAGS=${RISCV_QEMU_CPU_FLAGS}")
   else(ANDROID)
     add_test(
       NAME

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -144,6 +144,7 @@ function(iree_native_test)
         ${_TEST_ARGS}
     )
     iree_configure_test(${_TEST_NAME})
+    set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT "QEMU_CPU_FLAGS=${RISCV_QEMU_CPU_FLAGS}")
   elseif(IREE_ARCH STREQUAL "arm_64" AND "requires-arm-sme" IN_LIST _RULE_LABELS)
     add_test(
       NAME

--- a/build_tools/cmake/linux_riscv32.cmake
+++ b/build_tools/cmake/linux_riscv32.cmake
@@ -40,6 +40,7 @@ set(RISCV_COMPILER_FLAGS "\
     -march=rv32i2p1ma2p1f2p2d2p2c2p0 -mabi=ilp32d \
     -Wno-atomic-alignment")
 set(RISCV_LINKER_FLAGS "-lstdc++ -lpthread -lm -ldl -latomic")
+set(RISCV_QEMU_CPU_FLAGS "rv32,Zve32f=true,vlen=512,elen=32,vext_spec=v1.0")
 set(RISCV32_TEST_DEFAULT_LLVM_FLAGS
   "--iree-llvmcpu-target-triple=riscv32"
   "--iree-llvmcpu-target-abi=ilp32d"

--- a/build_tools/cmake/linux_riscv64.cmake
+++ b/build_tools/cmake/linux_riscv64.cmake
@@ -48,6 +48,7 @@ endif()
 # llvm and binutil ISA version.
 set(RISCV_COMPILER_FLAGS "\
     -march=rv64i2p1ma2p1f2p2d2p2c2p0 -mabi=lp64d")
+set(RISCV_QEMU_CPU_FLAGS "rv64,Zve64d=true,vlen=512,elen=64,vext_spec=v1.0")
 set(RISCV64_TEST_DEFAULT_LLVM_FLAGS
   "--iree-llvmcpu-target-triple=riscv64"
   "--iree-llvmcpu-target-abi=lp64d"

--- a/build_tools/cmake/run_riscv_test.sh
+++ b/build_tools/cmake/run_riscv_test.sh
@@ -6,27 +6,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Wrapper script to run the artifact on RISC-V 32/64-bit Linux device.
+# Wrapper script to run the artifact on RISC-V Linux device.
 # This script checks if QEMU emulator is set, and use either the emulator or
 # the actual device to run the cross-compiled RISC-V linux artifacts.
 
 set -x
 set -e
 
-RISCV_PLATFORM="${IREE_TARGET_PLATFORM:-linux}"
-RISCV_ARCH="${IREE_TARGET_ARCH:-riscv_64}"
-
-RISCV_PLATFORM_ARCH="${RISCV_PLATFORM}-${RISCV_ARCH}"
 # A QEMU Linux emulator must be available Within the system that matches the
-# processor architecturue. The emulators are at the path specified by the
-# `QEMU_RV64_BIN` or `QEMU_RV32_BIN` environment variable to run the artifacts
-# under the emulator.
-if [[ "${RISCV_PLATFORM_ARCH}" == "linux-riscv_64" ]] && [[ ! -z "${QEMU_RV64_BIN}" ]]; then
-  "${QEMU_RV64_BIN}" "-cpu" "rv64,Zve64d=true,vlen=512,elen=64,vext_spec=v1.0" \
-  "$@"
-elif [[ "${RISCV_PLATFORM_ARCH}" == "linux-riscv_32" ]] && [[ ! -z "${QEMU_RV32_BIN}" ]]; then
-  "${QEMU_RV32_BIN}" "-cpu" "rv32,Zve32f=true,vlen=512,elen=32,vext_spec=v1.0" \
-  "$@"
+# processor architecturue.
+if [[ ! -z "${QEMU_BIN}" ]] && [[ ! -z "${QEMU_CPU_FLAGS}" ]]; then
+  "${QEMU_BIN}" "-cpu" "${QEMU_CPU_FLAGS}" "$@"
 else
 # TODO(dcaballe): Add on-device run commands.
   "$@"


### PR DESCRIPTION
This change makes two improvements to RISC-V testing infrastructure:

1. Allow toolchain files to control QEMU CPU parameters via RISCV_QEMU_CPU_FLAGS variable, making it easier to customize CPU features for testing.

2. Unify QEMU binary configuration by replacing QEMU_RV64_BIN and QEMU_RV32_BIN with a single QEMU_BIN variable. Since the same build environment cannot support both riscv64 and riscv32 simultaneously, having separate variables is unnecessary.

Changes:
- Add RISCV_QEMU_CPU_FLAGS to linux_riscv32.cmake and linux_riscv64.cmake
- Pass QEMU_CPU_FLAGS environment variable to tests
- Update run_riscv_test.sh to use QEMU_BIN and QEMU_CPU_FLAGS
- Update GitHub workflow to use QEMU_BIN instead of QEMU_RV64_BIN