### PR TITLE
[HAL][HIP][CUDA] Fix hipHostUnregister/cuMemHostUnregister leak on import

### DIFF
--- a/runtime/src/iree/hal/cts/buffer/allocator_test.cc
+++ b/runtime/src/iree/hal/cts/buffer/allocator_test.cc
@@ -10,6 +10,12 @@ namespace iree::hal::cts {
 
 namespace {
 constexpr iree_device_size_t kAllocationSize = 1024;
+
+// Release callback that counts how many times it has been invoked.
+// Used to verify that chained caller callbacks fire exactly once.
+static void CountingReleaseCallback(void* user_data, iree_hal_buffer_t*) {
+  ++*static_cast<int*>(user_data);
+}
 }  // namespace
 
 class AllocatorTest : public CtsTestBase<> {};
@@ -100,6 +106,125 @@ TEST_P(AllocatorTest, AllocateEmptyBuffer) {
       device_allocator_, params, /*allocation_size=*/0, &buffer));
 
   iree_hal_buffer_release(buffer);
+}
+
+// Regression test for hipHostUnregister/cuMemHostUnregister leak:
+// When a HOST_ALLOCATION is imported with a null release callback, the
+// backend allocator must still call hipHostUnregister/cuMemHostUnregister on
+// destroy.  The old code only invoked the stored release_callback, so a null
+// callback meant unregister was never called, leaking the pinned registration.
+//
+// The re-import postcondition (second import must succeed) is a reliable
+// oracle on backends where double-register fails.  On AMD ROCm, hipHostRegister
+// is idempotent so the oracle does not fire there; see HipAllocatorTest in
+// hip_allocator_test.cc for a HIP-specific regression check.
+TEST_P(AllocatorTest, ImportHostAllocationNullCallback) {
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
+
+  iree_device_size_t compat_size = kAllocationSize;
+  iree_hal_buffer_params_t compat_params = params;
+  if (!iree_all_bits_set(iree_hal_allocator_query_buffer_compatibility(
+                             device_allocator_, params, kAllocationSize,
+                             &compat_params, &compat_size),
+                         IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
+    GTEST_SKIP() << "Allocator does not support importing host allocations";
+  }
+
+  // Use the portable aligned allocator to satisfy backend alignment
+  // requirements (64 bytes on HIP/CUDA/local-task).
+  void* host_ptr = nullptr;
+  IREE_ASSERT_OK(iree_allocator_malloc_aligned(
+      iree_allocator_system(), kAllocationSize, /*min_alignment=*/64,
+      /*offset=*/0, &host_ptr));
+
+  iree_hal_external_buffer_t ext = {};
+  ext.type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION;
+  ext.size = kAllocationSize;
+  ext.handle.host_allocation.ptr = host_ptr;
+
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_import_buffer(
+      device_allocator_, params, &ext, iree_hal_buffer_release_callback_null(),
+      &buffer));
+  ASSERT_NE(nullptr, buffer);
+
+  iree_hal_buffer_release(buffer);
+  buffer = nullptr;
+
+  // Re-import the same pointer.  On backends where double-register fails, this
+  // would fail without the fix because the pointer is still registered.
+  IREE_ASSERT_OK(iree_hal_allocator_import_buffer(
+      device_allocator_, params, &ext, iree_hal_buffer_release_callback_null(),
+      &buffer));
+  ASSERT_NE(nullptr, buffer);
+
+  iree_hal_buffer_release(buffer);
+  iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
+}
+
+// Regression test for the chained-callback path: when a HOST_ALLOCATION is
+// imported with a non-null release callback, both backend cleanup
+// (hipHostUnregister/cuMemHostUnregister) and the caller callback must fire.
+// The caller callback must be invoked exactly once.  The re-import
+// postcondition is a reliable oracle on backends where double-register fails;
+// see HipAllocatorTest in hip_allocator_test.cc for a HIP-specific check.
+TEST_P(AllocatorTest, ImportHostAllocationWithCallback) {
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
+
+  iree_device_size_t compat_size = kAllocationSize;
+  iree_hal_buffer_params_t compat_params = params;
+  if (!iree_all_bits_set(iree_hal_allocator_query_buffer_compatibility(
+                             device_allocator_, params, kAllocationSize,
+                             &compat_params, &compat_size),
+                         IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
+    GTEST_SKIP() << "Allocator does not support importing host allocations";
+  }
+
+  void* host_ptr = nullptr;
+  IREE_ASSERT_OK(iree_allocator_malloc_aligned(
+      iree_allocator_system(), kAllocationSize, /*min_alignment=*/64,
+      /*offset=*/0, &host_ptr));
+
+  int release_count = 0;
+  iree_hal_buffer_release_callback_t callback = {};
+  callback.fn = CountingReleaseCallback;
+  callback.user_data = &release_count;
+
+  iree_hal_external_buffer_t ext = {};
+  ext.type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION;
+  ext.size = kAllocationSize;
+  ext.handle.host_allocation.ptr = host_ptr;
+
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_import_buffer(device_allocator_, params,
+                                                  &ext, callback, &buffer));
+  ASSERT_NE(nullptr, buffer);
+  EXPECT_EQ(0, release_count);
+
+  iree_hal_buffer_release(buffer);
+  buffer = nullptr;
+
+  // Caller callback must have been invoked exactly once (via the thunk chain).
+  EXPECT_EQ(1, release_count);
+
+  // Re-import to verify that the unregister fired even when a non-null caller
+  // callback was provided.  On backends where double-register fails, this would
+  // fail without the fix because the pointer is still registered.
+  IREE_ASSERT_OK(iree_hal_allocator_import_buffer(
+      device_allocator_, params, &ext, iree_hal_buffer_release_callback_null(),
+      &buffer));
+  ASSERT_NE(nullptr, buffer);
+
+  iree_hal_buffer_release(buffer);
+  iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
 }
 
 CTS_REGISTER_TEST_SUITE(AllocatorTest);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -539,6 +539,50 @@ static void iree_hal_cuda_buffer_release_callback(void* user_data,
   }
 }
 
+// ---------------------------------------------------------------------------
+// Chained release callback for HOST_ALLOCATION imports.
+//
+// When a host allocation is imported the CUDA allocator calls cuMemHostRegister
+// to make the memory DMA-accessible.  The release_callback parameter in
+// import_buffer is a *caller* notification ("I'm done with your memory") and
+// carries no internal cleanup.  iree_hal_cuda_buffer_destroy only invokes the
+// stored release_callback, so cuMemHostUnregister is never called when the
+// caller passes a null or non-cleanup callback — leaking the host registration.
+//
+// This thunk is installed as the buffer's release callback whenever a
+// HOST_ALLOCATION is imported.  It always calls cuMemHostUnregister first,
+// then optionally chains the original caller callback.
+//
+// ---------------------------------------------------------------------------
+
+typedef struct iree_hal_cuda_host_reg_release_data_t {
+  const iree_hal_cuda_dynamic_symbols_t* cuda_symbols;
+  iree_allocator_t host_allocator;
+  iree_hal_buffer_release_callback_t caller_release_callback;
+} iree_hal_cuda_host_reg_release_data_t;
+
+static void iree_hal_cuda_host_reg_release(void* user_data,
+                                           iree_hal_buffer_t* buffer) {
+  iree_hal_cuda_host_reg_release_data_t* data =
+      (iree_hal_cuda_host_reg_release_data_t*)user_data;
+  // Capture host_ptr before the caller callback: the callback may free the
+  // underlying host allocation, after which the buffer fields are still
+  // readable (the buffer struct is freed by buffer_destroy after we return)
+  // but capturing here makes the intent explicit.
+  void* host_ptr = iree_hal_cuda_buffer_host_pointer(buffer);
+  // Unregister before notifying the caller so the memory is still live and
+  // definitely registered when cuMemHostUnregister is called.  The caller
+  // callback must not retain the buffer or re-register the same pointer.
+  if (host_ptr) {
+    IREE_CUDA_IGNORE_ERROR(data->cuda_symbols, cuMemHostUnregister(host_ptr));
+  }
+  if (data->caller_release_callback.fn) {
+    data->caller_release_callback.fn(data->caller_release_callback.user_data,
+                                     buffer);
+  }
+  iree_allocator_free(data->host_allocator, data);
+}
+
 static iree_status_t iree_hal_cuda_allocator_import_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
@@ -586,6 +630,13 @@ static iree_status_t iree_hal_cuda_allocator_import_buffer(
   void* host_ptr = NULL;
   CUdeviceptr device_ptr = 0;
 
+  // For HOST_ALLOCATION imports we install a chained release callback (thunk)
+  // that always calls cuMemHostUnregister then optionally forwards to the
+  // caller's callback.  For other import types the caller callback is used
+  // as-is.
+  iree_hal_cuda_host_reg_release_data_t* release_data = NULL;
+  iree_hal_buffer_release_callback_t actual_release_callback = release_callback;
+
   switch (external_buffer->type) {
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION: {
       if (iree_all_bits_set(compat_params.type,
@@ -610,6 +661,20 @@ static iree_status_t iree_hal_cuda_allocator_import_buffer(
             allocator->symbols,
             cuMemHostGetDevicePointer(&device_ptr, host_ptr, 0),
             "cuMemHostGetDevicePointer");
+      }
+      // Install the thunk so cuMemHostUnregister is always called on destroy,
+      // regardless of whether the caller provided a release callback.
+      if (iree_status_is_ok(status)) {
+        status =
+            iree_allocator_malloc(allocator->host_allocator,
+                                  sizeof(*release_data), (void**)&release_data);
+      }
+      if (iree_status_is_ok(status)) {
+        release_data->cuda_symbols = allocator->symbols;
+        release_data->host_allocator = allocator->host_allocator;
+        release_data->caller_release_callback = release_callback;
+        actual_release_callback.fn = iree_hal_cuda_host_reg_release;
+        actual_release_callback.user_data = release_data;
       }
       break;
     }
@@ -639,13 +704,18 @@ static iree_status_t iree_hal_cuda_allocator_import_buffer(
         placement, compat_params.type, compat_params.access,
         compat_params.usage, external_buffer->size, /*byte_offset=*/0,
         /*byte_length=*/external_buffer->size, buffer_type, device_ptr,
-        host_ptr, release_callback,
+        host_ptr, actual_release_callback,
         iree_hal_allocator_host_allocator(base_allocator), &buffer);
   }
 
   if (iree_status_is_ok(status)) {
     *out_buffer = buffer;
   } else {
+    // release_data is owned by actual_release_callback; if buffer_wrap failed
+    // it was never stored in the buffer, so free it directly here.
+    if (release_data) {
+      iree_allocator_free(allocator->host_allocator, release_data);
+    }
     if (!buffer && (device_ptr || host_ptr)) {
       iree_hal_cuda_buffer_free(allocator->symbols, buffer_type, device_ptr,
                                 host_ptr);

--- a/runtime/src/iree/hal/drivers/hip/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/hip/BUILD.bazel
@@ -122,3 +122,20 @@ iree_runtime_cc_test(
         "//runtime/src/iree/testing:gtest_main",
     ],
 )
+
+iree_runtime_cc_test(
+    name = "hip_allocator_test",
+    srcs = ["hip_allocator_test.cc"],
+    tags = [
+        "driver=hip",
+        "requires-gpu-amd",
+    ],
+    deps = [
+        ":dynamic_symbols",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/hip/registration",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)

--- a/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
@@ -120,4 +120,21 @@ iree_cc_test(
     "driver=hip"
 )
 
+iree_cc_test(
+  NAME
+    hip_allocator_test
+  SRCS
+    "hip_allocator_test.cc"
+  DEPS
+    ::dynamic_symbols
+    iree::base
+    iree::hal
+    iree::hal::drivers::hip::registration
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "driver=hip"
+    "requires-gpu-amd"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -633,6 +633,50 @@ static void iree_hal_hip_buffer_release_callback(void* user_data,
   iree_status_ignore(status);
 }
 
+// ---------------------------------------------------------------------------
+// Chained release callback for HOST_ALLOCATION imports.
+//
+// When a host allocation is imported the HIP allocator calls hipHostRegister()
+// to make the memory DMA-accessible.  The release_callback parameter in
+// import_buffer is a *caller* notification ("I'm done with your memory") and
+// carries no internal cleanup.  iree_hal_hip_buffer_destroy only invokes the
+// stored release_callback, so hipHostUnregister is never called when the
+// caller passes a null or non-cleanup callback — leaking the host registration.
+//
+// This thunk is installed as the buffer's release callback whenever a
+// HOST_ALLOCATION is imported.  It always calls hipHostUnregister first,
+// then optionally chains the original caller callback.
+//
+// ---------------------------------------------------------------------------
+
+typedef struct iree_hal_hip_host_reg_release_data_t {
+  const iree_hal_hip_dynamic_symbols_t* hip_symbols;
+  iree_allocator_t host_allocator;
+  iree_hal_buffer_release_callback_t caller_release_callback;
+} iree_hal_hip_host_reg_release_data_t;
+
+static void iree_hal_hip_host_reg_release(void* user_data,
+                                          iree_hal_buffer_t* buffer) {
+  iree_hal_hip_host_reg_release_data_t* data =
+      (iree_hal_hip_host_reg_release_data_t*)user_data;
+  // Capture host_ptr before the caller callback: the callback may free the
+  // underlying host allocation, after which the buffer fields are still
+  // readable (the buffer struct is freed by buffer_destroy after we return)
+  // but capturing here makes the intent explicit.
+  void* host_ptr = iree_hal_hip_buffer_host_pointer(buffer);
+  // Unregister before notifying the caller so the memory is still live and
+  // definitely registered when hipHostUnregister is called.  The caller
+  // callback must not retain the buffer or re-register the same pointer.
+  if (host_ptr) {
+    IREE_HIP_IGNORE_ERROR(data->hip_symbols, hipHostUnregister(host_ptr));
+  }
+  if (data->caller_release_callback.fn) {
+    data->caller_release_callback.fn(data->caller_release_callback.user_data,
+                                     buffer);
+  }
+  iree_allocator_free(data->host_allocator, data);
+}
+
 static iree_status_t iree_hal_hip_allocator_import_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
@@ -688,6 +732,13 @@ static iree_status_t iree_hal_hip_allocator_import_buffer(
   void* host_ptr = NULL;
   hipDeviceptr_t device_ptr = NULL;
 
+  // For HOST_ALLOCATION imports we install a chained release callback (thunk)
+  // that always calls hipHostUnregister then optionally forwards to the
+  // caller's callback.  For other import types the caller callback is used
+  // as-is.
+  iree_hal_hip_host_reg_release_data_t* release_data = NULL;
+  iree_hal_buffer_release_callback_t actual_release_callback = release_callback;
+
   switch (external_buffer->type) {
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION: {
       if (iree_all_bits_set(compat_params.type,
@@ -708,6 +759,20 @@ static iree_status_t iree_hal_hip_allocator_import_buffer(
             allocator->symbols,
             hipHostGetDevicePointer(&device_ptr, host_ptr, 0),
             "hipHostGetDevicePointer");
+      }
+      // Install the thunk so hipHostUnregister is always called on destroy,
+      // regardless of whether the caller provided a release callback.
+      if (iree_status_is_ok(status)) {
+        status =
+            iree_allocator_malloc(allocator->host_allocator,
+                                  sizeof(*release_data), (void**)&release_data);
+      }
+      if (iree_status_is_ok(status)) {
+        release_data->hip_symbols = allocator->symbols;
+        release_data->host_allocator = allocator->host_allocator;
+        release_data->caller_release_callback = release_callback;
+        actual_release_callback.fn = iree_hal_hip_host_reg_release;
+        actual_release_callback.user_data = release_data;
       }
       break;
     }
@@ -739,13 +804,18 @@ static iree_status_t iree_hal_hip_allocator_import_buffer(
         compat_params.usage, external_buffer->size,
         /*byte_offset=*/0,
         /*byte_length=*/external_buffer->size, buffer_type, device_ptr,
-        host_ptr, release_callback,
+        host_ptr, actual_release_callback,
         iree_hal_allocator_host_allocator(base_allocator), &buffer);
   }
 
   if (iree_status_is_ok(status)) {
     *out_buffer = buffer;
   } else {
+    // release_data is owned by actual_release_callback; if buffer_wrap failed
+    // it was never stored in the buffer, so free it directly here.
+    if (release_data) {
+      iree_allocator_free(allocator->host_allocator, release_data);
+    }
     if (!buffer && (device_ptr || host_ptr)) {
       iree_hal_hip_buffer_free(allocator->symbols, buffer_type, device_ptr,
                                host_ptr);

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
@@ -1,0 +1,202 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// HIP-specific regression test for the hipHostUnregister lifecycle fix.
+//
+// Background: when a HOST_ALLOCATION is imported via
+// iree_hal_allocator_import_buffer the HIP allocator calls hipHostRegister to
+// pin the memory.  The allocator must call hipHostUnregister on buffer destroy
+// to release that registration.  Before the fix, destroying a buffer imported
+// with a null release callback silently skipped the unregister call.
+//
+// CTS generic tests verify functional correctness (re-import succeeds), but
+// on AMD ROCm hipHostRegister is idempotent, so double-register doesn't fail
+// and those tests pass even without the fix.
+//
+// This test uses hipHostUnregister as a white-box oracle: after the buffer is
+// destroyed, calling hipHostUnregister on the original host pointer should
+// return hipErrorHostMemoryNotRegistered — meaning the fix already called it.
+// Without the fix the pointer is still registered and the call returns
+// hipSuccess instead.
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/hip/dynamic_symbols.h"
+#include "iree/hal/drivers/hip/registration/driver_module.h"
+#include "iree/testing/gtest.h"
+
+namespace iree::hal::hip {
+namespace {
+
+// Fixture that initializes HIP symbols and creates a HAL device/allocator once
+// per test.  Tests are skipped gracefully if HIP is unavailable.
+class HipAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
+        iree_allocator_system(), /*hip_lib_search_path_count=*/0,
+        /*hip_lib_search_paths=*/nullptr, &syms_);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HIP symbols not available";
+    }
+    syms_initialized_ = true;
+
+    status =
+        iree_hal_hip_driver_module_register(iree_hal_driver_registry_default());
+    if (iree_status_is_already_exists(status)) {
+      iree_status_ignore(status);
+      status = iree_ok_status();
+    }
+    ASSERT_TRUE(iree_status_is_ok(status));
+
+    status = iree_hal_driver_registry_try_create(
+        iree_hal_driver_registry_default(), iree_make_cstring_view("hip"),
+        iree_allocator_system(), &driver_);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HIP driver not available";
+    }
+
+    status = iree_hal_driver_create_default_device(
+        driver_, iree_allocator_system(), &device_);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      GTEST_SKIP() << "No HIP device available";
+    }
+  }
+
+  void TearDown() override {
+    iree_hal_device_release(device_);
+    device_ = nullptr;
+    iree_hal_driver_release(driver_);
+    driver_ = nullptr;
+    if (syms_initialized_) {
+      iree_hal_hip_dynamic_symbols_deinitialize(&syms_);
+      syms_initialized_ = false;
+    }
+  }
+
+  iree_hal_hip_dynamic_symbols_t syms_ = {};
+  bool syms_initialized_ = false;
+  iree_hal_driver_t* driver_ = nullptr;
+  iree_hal_device_t* device_ = nullptr;
+};
+
+// After importing a HOST_ALLOCATION and releasing the buffer, the HIP
+// allocator must have called hipHostUnregister.  We verify this by attempting
+// a manual hipHostUnregister on the same pointer: if the fix fired it returns
+// hipErrorHostMemoryNotRegistered; without the fix it returns hipSuccess.
+TEST_F(HipAllocatorTest, ImportHostAllocationUnregistersOnDestroy) {
+  iree_hal_allocator_t* allocator = iree_hal_device_allocator(device_);
+
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
+
+  constexpr iree_device_size_t kSize = 1024;
+  iree_hal_buffer_params_t compat_params = params;
+  iree_device_size_t compat_size = kSize;
+  if (!iree_all_bits_set(
+          iree_hal_allocator_query_buffer_compatibility(
+              allocator, params, kSize, &compat_params, &compat_size),
+          IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
+    GTEST_SKIP() << "Allocator does not support importing host allocations";
+  }
+
+  void* host_ptr = nullptr;
+  ASSERT_TRUE(iree_status_is_ok(iree_allocator_malloc_aligned(
+      iree_allocator_system(), kSize, /*min_alignment=*/64, /*offset=*/0,
+      &host_ptr)));
+
+  iree_hal_external_buffer_t ext = {};
+  ext.type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION;
+  ext.size = kSize;
+  ext.handle.host_allocation.ptr = host_ptr;
+
+  iree_hal_buffer_t* buffer = nullptr;
+  ASSERT_TRUE(iree_status_is_ok(iree_hal_allocator_import_buffer(
+      allocator, params, &ext, iree_hal_buffer_release_callback_null(),
+      &buffer)));
+  ASSERT_NE(nullptr, buffer);
+
+  iree_hal_buffer_release(buffer);
+  buffer = nullptr;
+
+  // Oracle: hipHostUnregister should fail because the fix already called it
+  // on buffer destroy.  On the buggy path the pointer is still registered and
+  // this returns hipSuccess instead.
+  hipError_t result = syms_.hipHostUnregister(host_ptr);
+  EXPECT_EQ(hipErrorHostMemoryNotRegistered, result)
+      << "Expected hipErrorHostMemoryNotRegistered — the fix should have "
+         "called hipHostUnregister on buffer destroy, but got: "
+      << syms_.hipGetErrorName(result);
+
+  iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
+}
+
+// Same oracle test for the non-null caller callback path.
+TEST_F(HipAllocatorTest, ImportHostAllocationWithCallbackUnregistersOnDestroy) {
+  iree_hal_allocator_t* allocator = iree_hal_device_allocator(device_);
+
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
+
+  constexpr iree_device_size_t kSize = 1024;
+  iree_hal_buffer_params_t compat_params = params;
+  iree_device_size_t compat_size = kSize;
+  if (!iree_all_bits_set(
+          iree_hal_allocator_query_buffer_compatibility(
+              allocator, params, kSize, &compat_params, &compat_size),
+          IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
+    GTEST_SKIP() << "Allocator does not support importing host allocations";
+  }
+
+  void* host_ptr = nullptr;
+  ASSERT_TRUE(iree_status_is_ok(iree_allocator_malloc_aligned(
+      iree_allocator_system(), kSize, /*min_alignment=*/64, /*offset=*/0,
+      &host_ptr)));
+
+  int release_count = 0;
+  iree_hal_buffer_release_callback_t callback = {};
+  callback.fn = [](void* user_data, iree_hal_buffer_t*) {
+    ++*static_cast<int*>(user_data);
+  };
+  callback.user_data = &release_count;
+
+  iree_hal_external_buffer_t ext = {};
+  ext.type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION;
+  ext.size = kSize;
+  ext.handle.host_allocation.ptr = host_ptr;
+
+  iree_hal_buffer_t* buffer = nullptr;
+  ASSERT_TRUE(iree_status_is_ok(iree_hal_allocator_import_buffer(
+      allocator, params, &ext, callback, &buffer)));
+  ASSERT_NE(nullptr, buffer);
+
+  iree_hal_buffer_release(buffer);
+  buffer = nullptr;
+
+  // Caller callback must have fired exactly once via the thunk chain.
+  EXPECT_EQ(1, release_count);
+
+  // Oracle: hipHostUnregister must have been called (pointer now unregistered).
+  hipError_t result = syms_.hipHostUnregister(host_ptr);
+  EXPECT_EQ(hipErrorHostMemoryNotRegistered, result)
+      << "Expected hipErrorHostMemoryNotRegistered — the fix should have "
+         "called hipHostUnregister on buffer destroy, but got: "
+      << syms_.hipGetErrorName(result);
+
+  iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
+}
+
+}  // namespace
+}  // namespace iree::hal::hip


### PR DESCRIPTION
When a HOST_ALLOCATION is imported, hipHostRegister/cuMemHostRegister pins the memory. The old code only invoked the caller's release_callback on destroy — so a null callback (e.g.  from Python's import_host_allocation)
meant hipHostUnregister/cuMemHostUnregister was never called, leaking the pinned registration on every to_host() call.

Fix: install a chained thunk as the buffer release callback for HOST_ALLOCATION imports. The thunk always calls unregister, then optionally chains the original caller callback.

CTS AllocatorTest: null-callback and chained-callback cases. Oracle is re-import success after release; on ROCm hipHostRegister is idempotent so these pass either way on HIP, but provide lifecycle coverage and may catch the bug on backends where double-register fails.

HipAllocatorTest: HIP white-box test using hipHostUnregister as the oracle — expects hipErrorHostMemoryNotRegistered after buffer destroy. Verified to fail without the fix.