### PR TITLE
[Tuner] Add iree_codegen.smt.assert op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -566,3 +566,18 @@ LogicalResult LookupOp::verify() {
   }
   return success();
 }
+
+LogicalResult AssertOp::verify() {
+  size_t placeholderCount = 0;
+  StringRef fmt = getMsg();
+  for (size_t pos = 0; (pos = fmt.find("{}", pos)) != StringRef::npos;
+       pos += 2) {
+    ++placeholderCount;
+  }
+  if (placeholderCount != getPrintArgs().size()) {
+    return emitOpError("format string has ")
+           << placeholderCount << " placeholder(s) but got "
+           << getPrintArgs().size() << " arg(s)";
+  }
+  return success();
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -679,6 +679,52 @@ def IREECodegen_ConstraintsOp :
 }
 
 //===----------------------------------------------------------------------===//
+// AssertOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_AssertOp :
+    Op<IREECodegen_Dialect, "smt.assert", [HasParent<"ConstraintsOp">]> {
+  let summary = "Named SMT assertion for constraint verification.";
+  let description = [{
+    Asserts that a boolean SMT expression holds, with a human-readable
+    format string describing what is being checked. The format string may
+    contain `{}` placeholders that correspond positionally to the `args`
+    operands. An evaluator or verifier can substitute concrete values into
+    the placeholders for diagnostics.
+
+    Args are restricted to `!smt.int` because all constraint knobs and
+    dimension values are integers.
+
+    Used inside `iree_codegen.smt.constraints` regions.
+
+    Examples:
+    ```mlir
+    // Static message (no args):
+    iree_codegen.smt.assert %cond, "dim_0 == 128" : !smt.bool
+
+    // Format string with args:
+    iree_codegen.smt.assert %cond, "wg_x ({}) < wg_y ({})", %x, %y : !smt.bool, !smt.int, !smt.int
+    ```
+  }];
+  let arguments = (ins
+    BoolType:$condition,
+    StrAttr:$msg,
+    Variadic<IntType>:$printArgs
+  );
+  let assemblyFormat = [{
+    $condition `,` $msg (`,` $printArgs^)?
+        `:` type($condition) (`,` type($printArgs)^)? attr-dict
+  }];
+  let builders = [
+    // Convenience builder for assertions with no format args.
+    OpBuilder<(ins "::mlir::Value":$condition, "::llvm::StringRef":$msg), [{
+      build($_builder, $_state, condition, msg, ::mlir::ValueRange{});
+    }]>
+  ];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // KnobOp
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -205,6 +205,40 @@ func.func @smt_lookup_outside_constraints(%arg0: !smt.int) {
 
 // -----
 
+// AssertOp: too few args for format string placeholders.
+func.func @assert_too_few_args(%arg0: index) {
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
+   knobs = {x = #iree_codegen.smt.int_knob<"x">}
+   dims(%arg0) {
+  ^bb0(%m: !smt.int):
+    %x = iree_codegen.smt.knob "x" : !smt.int
+    %zero = smt.int.constant 0
+    %cmp = smt.int.cmp gt %x, %zero
+    // expected-error @+1 {{'iree_codegen.smt.assert' op format string has 2 placeholder(s) but got 1 arg(s)}}
+    iree_codegen.smt.assert %cmp, "x ({}) > {}", %x : !smt.bool, !smt.int
+  }
+  return
+}
+
+// -----
+
+// AssertOp: too many args for format string placeholders.
+func.func @assert_too_many_args(%arg0: index) {
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
+   knobs = {x = #iree_codegen.smt.int_knob<"x">}
+   dims(%arg0) {
+  ^bb0(%m: !smt.int):
+    %x = iree_codegen.smt.knob "x" : !smt.int
+    %zero = smt.int.constant 0
+    %cmp = smt.int.cmp gt %x, %zero
+    // expected-error @+1 {{'iree_codegen.smt.assert' op format string has 1 placeholder(s) but got 2 arg(s)}}
+    iree_codegen.smt.assert %cmp, "x ({})", %x, %zero : !smt.bool, !smt.int, !smt.int
+  }
+  return
+}
+
+// -----
+
 // OneOfKnobAttr: knob name not found in knobs dict.
 func.func @one_of_knob_name_not_found(%arg0: index) {
   iree_codegen.smt.constraints target = <set = 0>, pipeline = None,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -168,6 +168,46 @@ func.func @constraints_op_with_smt_body(%arg0: index, %arg1: index) {
 
 // -----
 
+// Test assert op with static message (no format args).
+func.func @assert_static_message(%arg0: index) {
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
+   knobs = {x = #iree_codegen.smt.int_knob<"x">}
+   dims(%arg0) {
+  ^bb0(%m: !smt.int):
+    %x = iree_codegen.smt.knob "x" : !smt.int
+    %zero = smt.int.constant 0
+    %cmp = smt.int.cmp gt %x, %zero
+    iree_codegen.smt.assert %cmp, "x must be positive" : !smt.bool
+  }
+  return
+}
+// CHECK-LABEL: func.func @assert_static_message(
+// CHECK:      iree_codegen.smt.assert %{{.*}}, "x must be positive" : !smt.bool
+
+// -----
+
+// Test assert op with format string args.
+func.func @assert_with_format_args(%arg0: index) {
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+   knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
+   dims(%arg0) {
+  ^bb0(%m: !smt.int):
+    %wg_m = iree_codegen.smt.knob "wg_m" : !smt.int
+    %wg_n = iree_codegen.smt.knob "wg_n" : !smt.int
+    %cmp = smt.int.cmp lt %wg_m, %wg_n
+    iree_codegen.smt.assert %cmp, "wg_m ({}) < wg_n ({})", %wg_m, %wg_n : !smt.bool, !smt.int, !smt.int
+  }
+  return
+}
+// CHECK-LABEL: func.func @assert_with_format_args(
+// CHECK:    ^bb0(%{{.*}}: !smt.int):
+// CHECK:      %[[WG_M:.*]] = iree_codegen.smt.knob "wg_m"
+// CHECK:      %[[WG_N:.*]] = iree_codegen.smt.knob "wg_n"
+// CHECK:      %[[CMP:.*]] = smt.int.cmp lt %[[WG_M]], %[[WG_N]]
+// CHECK:      iree_codegen.smt.assert %[[CMP]], "wg_m ({}) < wg_n ({})", %[[WG_M]], %[[WG_N]] : !smt.bool, !smt.int, !smt.int
+
+// -----
+
 // Test constraints op with empty dims.
 func.func @constraints_op_empty_dims() {
   iree_codegen.smt.constraints target = <set = 1>, pipeline = None,


### PR DESCRIPTION
Add a named SMT assertion for use inside iree_codegen.smt.constraints regions. Even though the SMT dialect already comes with an assert op, I found constraints to be much more readable when supplemented with the explanation of what is being checked. The new assert op carries a format string with `{}` placeholders and !smt.int args for diagnostics in the evaluator/verifier, so that we can produce proper diagnostics later on.

This is the last op I need before we can start emitting pipeline constraints.

Issue: https://github.com/iree-org/iree/issues/23535