### PR TITLE
[Util] Add InferIntDivisibilityOpInterface for affine.delinearize_index

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
@@ -71,7 +71,46 @@ util.func @affine_apply_floordiv_non_exact(%arg0 : index) -> index {
 util.func @affine_apply_mod(%arg0 : index) -> index {
   %0 = util.assume.int %arg0<udiv = 16> : index
   %1 = affine.apply affine_map<(d0) -> (d0 mod 16)>(%0)
+  // 16 % 16 == 0, so x mod 16 is always 0 -> divisibility 0 (lattice top).
+  // CHECK: divisibility = "udiv = 0, sdiv = 0"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @affine_apply_mod_always_zero_multiple
+// If x has divisibility 32 and we compute x mod 16, then 32 % 16 == 0 so
+// x is always a multiple of 16, meaning x mod 16 is always 0.
+util.func @affine_apply_mod_always_zero_multiple(%arg0 : index) -> index {
+  %0 = util.assume.int %arg0<udiv = 32> : index
+  %1 = affine.apply affine_map<(d0) -> (d0 mod 16)>(%0)
+  // CHECK: divisibility = "udiv = 0, sdiv = 0"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @affine_apply_mod_non_constant_rhs
+// Non-constant RHS in mod expression -> bail to divisibility 1.
+util.func @affine_apply_mod_non_constant_rhs(%arg0 : index, %arg1 : index) -> index {
+  %0 = util.assume.int %arg0<udiv = 16> : index
+  %1 = affine.apply affine_map<(d0)[s0] -> (d0 mod s0)>(%0)[%arg1]
   // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @affine_apply_mod_gcd_fallback
+// If x has divisibility 12 and we compute x mod 16, then 12 % 16 != 0 so
+// we fall back to gcd(12, 16) = 4.
+util.func @affine_apply_mod_gcd_fallback(%arg0 : index) -> index {
+  %0 = util.assume.int %arg0<udiv = 12> : index
+  %1 = affine.apply affine_map<(d0) -> (d0 mod 16)>(%0)
+  // CHECK: divisibility = "udiv = 4, sdiv = 4"
   %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
   util.return %2 : index
 }
@@ -274,5 +313,62 @@ util.func @scf_forall_multiple_ivs(%arg0 : index, %arg1 : index, %arg2 : index,
     // CHECK: divisibility = "udiv = 1, sdiv = 1"
     %1 = "iree_unregistered.test_int_divisibility"(%iv1) : (index) -> index
   }
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @delinearize_static_no_outer
+util.func @delinearize_static_no_outer(%arg0 : index) {
+  %input = util.assume.int %arg0<udiv = 8> : index
+  %0:3 = affine.delinearize_index %input into (3, 16) : index, index, index
+  // result[0] = input floordiv 48 -> udiv = 1 (8 does not divide 48 evenly)
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe0 = "iree_unregistered.test_int_divisibility"(%0#0) : (index) -> index
+  // result[1] = (input floordiv 16) mod 3 -> udiv = 1
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe1 = "iree_unregistered.test_int_divisibility"(%0#1) : (index) -> index
+  // result[2] = input mod 16 -> gcd(8, 16) = 8
+  // CHECK: divisibility = "udiv = 8, sdiv = 8"
+  %probe2 = "iree_unregistered.test_int_divisibility"(%0#2) : (index) -> index
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @delinearize_static_with_outer
+util.func @delinearize_static_with_outer(%arg0 : index) {
+  %input = util.assume.int %arg0<udiv = 32> : index
+  %0:4 = affine.delinearize_index %input into (2, 4, 8, 16) : index, index, index, index
+  // result[0] = input floordiv 512 -> udiv = 1
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe0 = "iree_unregistered.test_int_divisibility"(%0#0) : (index) -> index
+  // result[1] = (input floordiv 128) mod 4 -> udiv = 1
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe1 = "iree_unregistered.test_int_divisibility"(%0#1) : (index) -> index
+  // result[2] = (input floordiv 16) mod 8 -> 32/16=2, gcd(2,8)=2
+  // CHECK: divisibility = "udiv = 2, sdiv = 2"
+  %probe2 = "iree_unregistered.test_int_divisibility"(%0#2) : (index) -> index
+  // result[3] = input mod 16 -> 32 % 16 == 0, always 0 -> divisibility 0
+  // CHECK: divisibility = "udiv = 0, sdiv = 0"
+  %probe3 = "iree_unregistered.test_int_divisibility"(%0#3) : (index) -> index
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @delinearize_exact_stride_div
+util.func @delinearize_exact_stride_div(%arg0 : index) {
+  %input = util.assume.int %arg0<udiv = 64> : index
+  %0:3 = affine.delinearize_index %input into (4, 16) : index, index, index
+  // result[0] = input floordiv 64 -> 64/64=1
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe0 = "iree_unregistered.test_int_divisibility"(%0#0) : (index) -> index
+  // result[1] = (input floordiv 16) mod 4 -> 64/16=4, 4 % 4 == 0, always 0
+  // CHECK: divisibility = "udiv = 0, sdiv = 0"
+  %probe1 = "iree_unregistered.test_int_divisibility"(%0#1) : (index) -> index
+  // result[2] = input mod 16 -> 64 % 16 == 0, always 0
+  // CHECK: divisibility = "udiv = 0, sdiv = 0"
+  %probe2 = "iree_unregistered.test_int_divisibility"(%0#2) : (index) -> index
   util.return
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
@@ -117,6 +117,19 @@ util.func @affine_apply_mod_gcd_fallback(%arg0 : index) -> index {
 
 // -----
 
+// CHECK-LABEL: @affine_apply_mod_nontrivial_gcd
+// If x has divisibility 12 and we compute x mod 8, then 12 % 8 != 0 so
+// we fall back to gcd(12, 8) = 4.
+util.func @affine_apply_mod_nontrivial_gcd(%arg0 : index) -> index {
+  %0 = util.assume.int %arg0<udiv = 12> : index
+  %1 = affine.apply affine_map<(d0) -> (d0 mod 8)>(%0)
+  // CHECK: divisibility = "udiv = 4, sdiv = 4"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
 // CHECK-LABEL: @affine_apply_composition
 util.func @affine_apply_composition(%arg0 : index) -> index {
   %0 = util.assume.int %arg0<udiv = 8> : index
@@ -370,5 +383,22 @@ util.func @delinearize_exact_stride_div(%arg0 : index) {
   // result[2] = input mod 16 -> 64 % 16 == 0, always 0
   // CHECK: divisibility = "udiv = 0, sdiv = 0"
   %probe2 = "iree_unregistered.test_int_divisibility"(%0#2) : (index) -> index
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @delinearize_dynamic_basis
+// Dynamic basis values force conservative divisibility (udiv=1, sdiv=1)
+// because we cannot statically determine the basis stride.
+util.func @delinearize_dynamic_basis(%arg0 : index, %arg1 : index) {
+  %input = util.assume.int %arg0<udiv = 16> : index
+  %0:2 = affine.delinearize_index %input into (%arg1) : index, index
+  // result[0] = input floordiv %arg1 -> conservative udiv=1
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe0 = "iree_unregistered.test_int_divisibility"(%0#0) : (index) -> index
+  // result[1] = input mod %arg1 -> conservative udiv=1
+  // CHECK: divisibility = "udiv = 1, sdiv = 1"
+  %probe1 = "iree_unregistered.test_int_divisibility"(%0#1) : (index) -> index
   util.return
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
@@ -322,7 +322,7 @@ util.func @scf_forall_multiple_ivs(%arg0 : index, %arg1 : index, %arg2 : index,
 util.func @delinearize_static_no_outer(%arg0 : index) {
   %input = util.assume.int %arg0<udiv = 8> : index
   %0:3 = affine.delinearize_index %input into (3, 16) : index, index, index
-  // result[0] = input floordiv 48 -> udiv = 1 (8 does not divide 48 evenly)
+  // result[0] = input floordiv 48 -> udiv = 1 (48 does not divide 8 evenly)
   // CHECK: divisibility = "udiv = 1, sdiv = 1"
   %probe0 = "iree_unregistered.test_int_divisibility"(%0#0) : (index) -> index
   // result[1] = (input floordiv 16) mod 3 -> udiv = 1

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -299,22 +299,22 @@ struct AffineMaxInferIntDivisibilityOpInterface
 };
 
 struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
-    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           AffineDelinearizeIndexInferIntDivisibilityOpInterface,
           affine::AffineDelinearizeIndexOp> {
 
   void inferResultDivisibility(
       Operation *op, ArrayRef<IREE::Util::IntegerDivisibility> argDivs,
       IREE::Util::SetIntDivisibilityFn setResultDivs) const {
-    auto delinOp = cast<affine::AffineDelinearizeIndexOp>(op);
+    auto delinearizeOp = cast<affine::AffineDelinearizeIndexOp>(op);
     MLIRContext *ctx = op->getContext();
 
     // Operands are: [linear_index, dynamic_basis_values...]
     IREE::Util::ConstantIntDivisibility linearDiv =
-        getDivisibilityOfOperand(delinOp.getLinearIndex(), argDivs[0]);
+        getDivisibilityOfOperand(delinearizeOp.getLinearIndex(), argDivs[0]);
 
-    ArrayRef<int64_t> staticBasis = delinOp.getStaticBasis();
-    int64_t numResults = delinOp.getNumResults();
+    ArrayRef<int64_t> staticBasis = delinearizeOp.getStaticBasis();
+    int64_t numResults = delinearizeOp.getNumResults();
 
     // Build affine expressions for each result.
     // Dim 0 = linear index, symbols = dynamic basis values.
@@ -325,13 +325,14 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
     operandDivs.push_back(linearDiv);
 
     // Map static/dynamic basis values to affine expressions.
-    int dynIdx = 0;
+    int64_t dynIdx = 0;
     SmallVector<AffineExpr> basisExprs;
-    for (int64_t i = 0, e = staticBasis.size(); i < e; ++i) {
+    for (int64_t i = 0, e = static_cast<int64_t>(staticBasis.size()); i < e;
+         ++i) {
       if (ShapedType::isDynamic(staticBasis[i])) {
         basisExprs.push_back(getAffineSymbolExpr(dynIdx, ctx));
         operandDivs.push_back(getDivisibilityOfOperand(
-            delinOp.getDynamicBasis()[dynIdx], argDivs[1 + dynIdx]));
+            delinearizeOp.getDynamicBasis()[dynIdx], argDivs[1 + dynIdx]));
         dynIdx++;
       } else {
         basisExprs.push_back(getAffineConstantExpr(staticBasis[i], ctx));
@@ -339,7 +340,7 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
     }
 
     // The computation basis skips the outer bound if present.
-    bool hasOuter = delinOp.hasOuterBound();
+    bool hasOuter = delinearizeOp.hasOuterBound();
     int64_t basisStart = hasOuter ? 1 : 0;
 
     // Each result[i] can be expressed as an affine expression of the linear
@@ -365,10 +366,11 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
       AffineMap resultMap = AffineMap::get(1, dynIdx, resultExpr, ctx);
       SmallVector<IREE::Util::ConstantIntDivisibility> divs =
           getResultDivisibilities(resultMap, operandDivs);
-      setResultDivs(delinOp.getResult(i), divs[0]);
+      setResultDivs(delinearizeOp.getResult(i), divs[0]);
 
-      if (i > 0)
+      if (i > 0) {
         stride = basisExprs[basisStart + i - 1] * stride;
+      }
     }
   }
 };

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -327,7 +327,7 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
     // Map static/dynamic basis values to affine expressions.
     int dynIdx = 0;
     SmallVector<AffineExpr> basisExprs;
-    for (int64_t i = 0; i < (int64_t)staticBasis.size(); ++i) {
+    for (int64_t i = 0, e = staticBasis.size(); i < e; ++i) {
       if (ShapedType::isDynamic(staticBasis[i])) {
         basisExprs.push_back(getAffineSymbolExpr(dynIdx, ctx));
         operandDivs.push_back(getDivisibilityOfOperand(
@@ -351,12 +351,9 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
     // result[0]   = x floordiv s[0]
     // result[i>0] = (x floordiv s[i]) mod B[i-1]
     // For i=N-1, s[N-1]=1, so result[N-1] = x mod B[N-2].
-    for (int64_t i = 0; i < numResults; ++i) {
-      AffineExpr stride = getAffineConstantExpr(1, ctx);
-      for (int64_t j = basisStart + i; j < (int64_t)basisExprs.size(); ++j) {
-        stride = stride * basisExprs[j];
-      }
 
+    AffineExpr stride = getAffineConstantExpr(1, ctx);
+    for (int64_t i = numResults - 1; i >= 0; --i) {
       AffineExpr resultExpr;
       if (i == 0) {
         resultExpr = linearExpr.floorDiv(stride);
@@ -369,6 +366,9 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
       SmallVector<IREE::Util::ConstantIntDivisibility> divs =
           getResultDivisibilities(resultMap, operandDivs);
       setResultDivs(delinOp.getResult(i), divs[0]);
+
+      if (i > 0)
+        stride = basisExprs[basisStart + i - 1] * stride;
     }
   }
 };

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -29,6 +29,8 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 
+#include <numeric>
+
 namespace mlir::iree_compiler {
 
 namespace {
@@ -129,12 +131,30 @@ public:
     return visitDivExpr(expr);
   }
 
-  /// Mod expressions could be inferred to be zero in some cases, but for now
-  /// just return the minimum divisibility.
-  /// TODO(Max191): Handle evenly divisible cases, and ensure that the zero
-  /// divisibility propagates properly through parent expressions.
+  /// Infer the divisibility of a mod expression. If the RHS is a constant,
+  /// the result divisibility is gcd(lhs_divisibility, rhs_constant), since
+  /// (d * k) mod c is always divisible by gcd(d, c). Furthermore, if the
+  /// LHS divisibility is itself divisible by the constant (i.e., d % c == 0),
+  /// then (d * k) mod c is always zero, represented as divisibility 0.
   IREE::Util::ConstantIntDivisibility visitModExpr(AffineBinaryOpExpr expr) {
-    return visitInvalidExpr(expr);
+    if (divisibilityMap.contains(expr)) {
+      return divisibilityMap[expr];
+    }
+    auto constRhs = dyn_cast<AffineConstantExpr>(expr.getRHS());
+    if (!constRhs || constRhs.getValue() == 0) {
+      return IREE::Util::ConstantIntDivisibility(1, 1);
+    }
+    auto constValue = static_cast<uint64_t>(std::abs(constRhs.getValue()));
+    IREE::Util::ConstantIntDivisibility lhsDiv = visit(expr.getLHS());
+    // If the LHS is always a multiple of constValue, x mod constValue is
+    // always zero. Divisibility 0 is the lattice top ("divides everything").
+    uint64_t modUDiv = (lhsDiv.udiv() % constValue == 0)
+                           ? 0
+                           : std::gcd(lhsDiv.udiv(), constValue);
+    uint64_t modSDiv = (lhsDiv.sdiv() % constValue == 0)
+                           ? 0
+                           : std::gcd(lhsDiv.sdiv(), constValue);
+    return IREE::Util::ConstantIntDivisibility(modUDiv, modSDiv);
   }
 
 private:
@@ -275,6 +295,81 @@ struct AffineMaxInferIntDivisibilityOpInterface
       IREE::Util::SetIntDivisibilityFn setResultDivs) const {
     auto affineMaxOp = cast<affine::AffineMaxOp>(op);
     inferAffineMinOrMaxResultDivisibility(affineMaxOp, argDivs, setResultDivs);
+  }
+};
+
+struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
+    : public IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+          AffineDelinearizeIndexInferIntDivisibilityOpInterface,
+          affine::AffineDelinearizeIndexOp> {
+
+  void inferResultDivisibility(
+      Operation *op, ArrayRef<IREE::Util::IntegerDivisibility> argDivs,
+      IREE::Util::SetIntDivisibilityFn setResultDivs) const {
+    auto delinOp = cast<affine::AffineDelinearizeIndexOp>(op);
+    MLIRContext *ctx = op->getContext();
+
+    // Operands are: [linear_index, dynamic_basis_values...]
+    IREE::Util::ConstantIntDivisibility linearDiv =
+        getDivisibilityOfOperand(delinOp.getLinearIndex(), argDivs[0]);
+
+    ArrayRef<int64_t> staticBasis = delinOp.getStaticBasis();
+    int64_t numResults = delinOp.getNumResults();
+
+    // Build affine expressions for each result.
+    // Dim 0 = linear index, symbols = dynamic basis values.
+    AffineExpr linearExpr = getAffineDimExpr(0, ctx);
+
+    // Collect operand divisibilities: [linear_index_div, dynamic_basis_divs...]
+    SmallVector<IREE::Util::ConstantIntDivisibility> operandDivs;
+    operandDivs.push_back(linearDiv);
+
+    // Map static/dynamic basis values to affine expressions.
+    int dynIdx = 0;
+    SmallVector<AffineExpr> basisExprs;
+    for (int64_t i = 0; i < (int64_t)staticBasis.size(); ++i) {
+      if (ShapedType::isDynamic(staticBasis[i])) {
+        basisExprs.push_back(getAffineSymbolExpr(dynIdx, ctx));
+        operandDivs.push_back(getDivisibilityOfOperand(
+            delinOp.getDynamicBasis()[dynIdx], argDivs[1 + dynIdx]));
+        dynIdx++;
+      } else {
+        basisExprs.push_back(getAffineConstantExpr(staticBasis[i], ctx));
+      }
+    }
+
+    // The computation basis skips the outer bound if present.
+    bool hasOuter = delinOp.hasOuterBound();
+    int64_t basisStart = hasOuter ? 1 : 0;
+
+    // Each result[i] can be expressed as an affine expression of the linear
+    // index using the effective basis (after dropping outer bound if present).
+    // Effective basis B[k] = basisExprs[basisStart + k], for k = 0..N-2.
+    // Stride s[i] = product of B[i..N-2] = product of
+    //               basisExprs[basisStart+i .. end].
+    //
+    // result[0]   = x floordiv s[0]
+    // result[i>0] = (x floordiv s[i]) mod B[i-1]
+    // For i=N-1, s[N-1]=1, so result[N-1] = x mod B[N-2].
+    for (int64_t i = 0; i < numResults; ++i) {
+      AffineExpr stride = getAffineConstantExpr(1, ctx);
+      for (int64_t j = basisStart + i; j < (int64_t)basisExprs.size(); ++j) {
+        stride = stride * basisExprs[j];
+      }
+
+      AffineExpr resultExpr;
+      if (i == 0) {
+        resultExpr = linearExpr.floorDiv(stride);
+      } else {
+        resultExpr =
+            (linearExpr.floorDiv(stride)) % basisExprs[basisStart + i - 1];
+      }
+
+      AffineMap resultMap = AffineMap::get(1, dynIdx, resultExpr, ctx);
+      SmallVector<IREE::Util::ConstantIntDivisibility> divs =
+          getResultDivisibilities(resultMap, operandDivs);
+      setResultDivs(delinOp.getResult(i), divs[0]);
+    }
   }
 };
 
@@ -1225,6 +1320,8 @@ void registerUtilExternalModels(DialectRegistry &registry) {
             AffineMinInferIntDivisibilityOpInterface>(*context);
         affine::AffineMaxOp::attachInterface<
             AffineMaxInferIntDivisibilityOpInterface>(*context);
+        affine::AffineDelinearizeIndexOp::attachInterface<
+            AffineDelinearizeIndexInferIntDivisibilityOpInterface>(*context);
       });
 
   registry.addExtension(


### PR DESCRIPTION
Teaches the integer divisibility analysis to propagate through affine.delinearize_index ops by building per-result affine expressions that mirror the delinearize semantics (floordiv + mod of the linear input by stride products).

Also implements visitModExpr for constant RHS expressions, which previously returned minimum divisibility (1,1) for all mod expressions. Now, it computes gcd(lhs_divisibility, rhs_constant), and returns divisibility 0 (lattice top) when the LHS divisibility is a multiple of the mod constant, since the result is always zero in that case.