### PR TITLE
[LinalgExt] Add unified offset attributes to im2col op definition

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
@@ -173,7 +173,7 @@ module {
       } {
     %4 = iree_linalg_ext.im2col {lowering_config = #config}
       strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-      m_offset = [0] * [1] k_offset = [0] * [1]
+      offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 128]]
       batch_pos = [0] m_pos = [2, 3] k_pos = [1]
       input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
       ins(%2 : tensor<2x34x34x128xf16>)
@@ -184,7 +184,7 @@ module {
 
 // CHECK-LABEL: func.func @inferred_im2col
 //       CHECK:   scf.forall ({{.*}}) = (0, 0, 0) to (2, 128, 8) step (1, 1, 4)
-//       CHECK:     iree_linalg_ext.im2col {{.*}} ins(%{{.*}}: tensor<1x34x34x128xf16>) outs({{.*}}: tensor<1x1x4xf16>)
+//       CHECK:     iree_linalg_ext.im2col {{.*}} ins(%{{.*}}: tensor<2x34x34x128xf16>) outs({{.*}}: tensor<1x1x4xf16>)
 //       CHECK:     scf.forall.in_parallel
 //       CHECK:   mapping = [#gpu.thread<linear_dim_2>, #gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]
 
@@ -198,7 +198,7 @@ module {
       } {
     %4 = iree_linalg_ext.im2col {lowering_config = #config}
       strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-      m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
+      offsets = [0, 0, 0, 0] output_sizes = [[32], [3], [3], [24, 16, 16]]
       batch_pos = [3] m_pos = [1, 2] k_pos = [0]
       input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
       ins(%2 : tensor<16x26x18x32xbf16>)
@@ -209,7 +209,7 @@ module {
 
 // CHECK-LABEL: func.func @inferred_im2col_batch_last
 //       CHECK:   scf.forall ({{.*}}) = (0, 0, 0, 0) to (32, 1, 1, 32) step (4, 1, 1, 1)
-//       CHECK:     iree_linalg_ext.im2col {{.*}} ins(%{{.*}}: tensor<16x26x18x4xbf16>) outs({{.*}}: tensor<4x1x1x1xbf16>)
+//       CHECK:     iree_linalg_ext.im2col {{.*}} ins(%{{.*}}: tensor<16x26x18x32xbf16>) outs({{.*}}: tensor<4x1x1x1xbf16>)
 //       CHECK:     scf.forall.in_parallel
 //       CHECK:   mapping = [#gpu.thread<linear_dim_3>, #gpu.thread<linear_dim_2>, #gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -201,7 +201,7 @@ func.func @promote_with_cache_swizzle(%a: tensor<2x34x34x128xf32>, %b: tensor<2x
 
   %im2col = iree_linalg_ext.im2col
     strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-    m_offset = [0] * [1] k_offset = [0] * [1]
+    offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 128]]
     batch_pos = [0] m_pos = [2, 3] k_pos = [1]
     input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
     ins(%a : tensor<2x34x34x128xf32>)
@@ -242,7 +242,7 @@ func.func @promote_with_cache_swizzle_f4(%a: tensor<2x34x34x128xf4E2M1FN>, %b: t
 
   %im2col = iree_linalg_ext.im2col
     strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-    m_offset = [0] * [1] k_offset = [0] * [1]
+    offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 128]]
     batch_pos = [0] m_pos = [2, 3] k_pos = [1]
     input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
     ins(%a : tensor<2x34x34x128xf4E2M1FN>)
@@ -281,7 +281,7 @@ func.func @promote_with_cache_swizzle_f4_no_stride(%a: tensor<2x34x34x129xf4E2M1
 
   %im2col = iree_linalg_ext.im2col
     strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-    m_offset = [0] * [1] k_offset = [0] * [1]
+    offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 129]]
     batch_pos = [0] m_pos = [2, 3] k_pos = [1]
     input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
     ins(%a : tensor<2x34x34x129xf4E2M1FN>)

--- a/compiler/src/iree/compiler/Codegen/Common/test/convolution_to_igemm.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convolution_to_igemm.mlir
@@ -18,7 +18,7 @@ func.func public @conv_with_consumer(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor
   return %2 : tensor<1x14x14x16xf16>
 }
 // CHECK:      func.func public @conv_with_consumer
-// CHECK-DAG:    %[[IM2COL:.+]] = iree_linalg_ext.im2col {{.*}} : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
+// CHECK-DAG:    %[[IM2COL:.+]] = iree_linalg_ext.im2col {{.*}} -> tensor<1x14x14x36xf32>
 // CHECK-DAG:    %[[FILL:.+]] = linalg.fill {{.*}} -> tensor<1x14x14x16xf32>
 // CHECK:        %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:     iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
@@ -27,7 +27,7 @@ func.func public @conv_with_consumer(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor
 // CHECK:        %[[TRUNCF:.+]] = linalg.generic
 // CHECK-SAME:     iterator_types = ["parallel", "parallel", "parallel", "parallel"]
 // CHECK-SAME:     ins(%[[MATMUL]] : tensor<1x14x14x16xf32>)
-// CHECK:        return %[[TRUNCF]] : tensor<1x14x14x16xf16>
+// CHECK:        return {{.*}} : tensor<1x14x14x16xf16>
 
 // -----
 
@@ -94,14 +94,14 @@ func.func @fold_with_buffer_load_store(
 // CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9]+]]: memref<1x14x14x16xf32>
 // CHECK-DAG:  %[[LHS:.+]] = iree_codegen.load_from_buffer %[[INPUT]] : memref<1x16x16x4xf32> -> tensor<1x16x16x4xf32>
 // CHECK-DAG:  %[[RHS:.+]] = iree_codegen.load_from_buffer {{.*}} : memref<36x16xf32> -> tensor<36x16xf32>
-// CHECK-DAG:  %[[RES:.+]] = iree_codegen.load_from_buffer %[[OUTPUT]] : memref<1x14x14x16xf32> -> tensor<1x14x14x16xf32>
+// CHECK-DAG:  %[[RES:.+]] = iree_codegen.load_from_buffer {{.*}} : memref<1x14x14x16xf32> -> tensor<1x14x14x16xf32>
 // CHECK-DAG:  %[[IM2COL:.+]] = iree_linalg_ext.im2col {{.*}} ins(%[[LHS]] : tensor<1x16x16x4xf32>){{.*}}-> tensor<1x14x14x36xf32>
 // CHECK-DAG:  %[[FILL:.+]] = linalg.fill {{.*}}outs(%[[RES]] : tensor<1x14x14x16xf32>)
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
 // CHECK-SAME:   ins(%[[IM2COL]], %[[RHS]] : tensor<1x14x14x36xf32>, tensor<36x16xf32>)
 // CHECK-SAME:   outs(%[[FILL]] : tensor<1x14x14x16xf32>) {
-// CHECK:      iree_codegen.store_to_buffer %[[MATMUL]], %[[OUTPUT]]
+// CHECK:      iree_codegen.store_to_buffer %[[MATMUL]]
 
 // -----
 
@@ -121,8 +121,8 @@ func.func @conv_with_lowering_config() attributes {translation_info = #iree_code
 }
 
 // CHECK:      func.func @conv_with_lowering_config
-// CHECK:        %[[FILL:.+]] = linalg.fill
-// CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-DAG:    %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-DAG:    %[[FILL:.+]] = linalg.fill
 // CHECK:        %[[MATMUL:.+]] = linalg.generic {{.*}} ins(%[[IM2COL]], {{.*}}) outs(%[[FILL]] : {{.*}}) {{.*}}lowering_config = {{.*}}
 // CHECK:        iree_tensor_ext.dispatch.tensor.store %[[MATMUL]]
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -241,6 +241,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgStructuredOpsIncGen",
         "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -176,6 +176,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgStructuredOpsIncGenLib
     MLIRLinalgTransforms
+    MLIRSupport
     MLIRTensorDialect
     MLIRUBDialect
     MLIRVectorDialect

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/CommandLine.h"
@@ -631,7 +632,7 @@ static std::optional<int64_t>
 chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
                      SmallVector<Range> iterationDomain,
                      SmallVector<OpFoldResult> inputSizes,
-                     OpFoldResult kOffset) {
+                     ArrayRef<OpFoldResult> offsets) {
   int64_t innerInputDim = im2colOp.getInputRank() - 1;
   SmallVector<SmallVector<int64_t>> vectorizationMap =
       im2colOp.getInputToOutputDimVectorizationMap();
@@ -640,6 +641,16 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
     return std::nullopt;
   }
   SetVector<int64_t> kDimSet(llvm::from_range, im2colOp.getKOutputDims());
+
+  // Build a map from actual output dim to canonical index for K dims.
+  SmallVector<int64_t> kOutputDims = im2colOp.getKOutputDims();
+  int64_t batchSize = im2colOp.getBatchPos().size();
+  int64_t numMOutputDims = im2colOp.getNumMOutputDims();
+  DenseMap<int64_t, int64_t> kDimToCanonicalIdx;
+  for (auto [i, actualDim] : llvm::enumerate(kOutputDims)) {
+    kDimToCanonicalIdx[actualDim] = batchSize + numMOutputDims + i;
+  }
+
   // There may be multiple output dims that we can vectorize, so prioritize the
   // innermost dims first.
   llvm::sort(vectorizableOutputDims);
@@ -667,7 +678,8 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
     SetVector<int64_t> mDimSet(llvm::from_range, im2colOp.getMOutputDims());
     OpFoldResult offset = b.getIndexAttr(0);
     if (kDimSet.contains(outputDimToVectorize)) {
-      offset = kOffset;
+      // Use the offset of this specific K dim directly (no linearization).
+      offset = offsets[kDimToCanonicalIdx[outputDimToVectorize]];
     } else if (mDimSet.contains(outputDimToVectorize)) {
       // TODO(Max191): Support vectorization along the M dimension.
       continue;
@@ -696,7 +708,8 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
 /// ```
 ///   %im2col = iree_linalg_ext.im2col
 ///       strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-///       m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
+///       offsets = [0, %m_off, %k_off]
+///       output_sizes = [[2], [32, 32], [3, 3, 640]]
 ///       batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 ///       input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
 ///       ins(%in : tensor<2x34x34x640xf32>)
@@ -720,29 +733,8 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   Location loc = getLoc();
   Value inputSlice = getInput();
 
-  // This is part of the im2col verifier, but check here in case this changes.
-  assert(getConstantIntValue(getMixedMStrides().back()).value() == 1 &&
-         getConstantIntValue(getMixedKStrides().back()).value() == 1 &&
-         "Expected inner m_offset and k_offset to be 1");
-
-  // Get the linearized mOffset and kOffset.
-  auto linearizeIndex = [&](ArrayRef<OpFoldResult> inds,
-                            ArrayRef<OpFoldResult> basis) {
-    MLIRContext *ctx = b.getContext();
-    SmallVector<AffineExpr> dims(inds.size()), symbols(basis.size());
-    bindDimsList<AffineExpr>(ctx, dims);
-    bindSymbolsList<AffineExpr>(ctx, symbols);
-    AffineExpr linearExpr = mlir::linearize(ctx, dims, symbols);
-    SmallVector<OpFoldResult> mapOperands(inds);
-    mapOperands.append(basis.begin(), basis.end());
-    auto linearMap = AffineMap::get(
-        /*dimCount=*/inds.size(), /*symbolCount=*/basis.size(), linearExpr);
-    OpFoldResult linearIdx =
-        affine::makeComposedFoldedAffineApply(b, loc, linearMap, mapOperands);
-    return linearIdx;
-  };
-  OpFoldResult mOffset = linearizeIndex(getMixedMOffset(), getMixedMStrides());
-  OpFoldResult kOffset = linearizeIndex(getMixedKOffset(), getMixedKStrides());
+  // Get the per-output-dim offsets from the unified API.
+  SmallVector<OpFoldResult> mixedOffsets = getMixedOffsets();
 
   // Step 1: Tile the im2col op to loops with contiguous slices in the
   // innermost loop.
@@ -755,8 +747,8 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   SmallVector<Range> iterationDomain(getIterationDomain(b));
   SmallVector<OpFoldResult> inputSizes =
       tensor::getMixedSizes(b, loc, getInput());
-  std::optional<unsigned> maybeOutputDimToVectorize =
-      chooseDimToVectorize(b, loc, *this, iterationDomain, inputSizes, kOffset);
+  std::optional<unsigned> maybeOutputDimToVectorize = chooseDimToVectorize(
+      b, loc, *this, iterationDomain, inputSizes, mixedOffsets);
 
   OpFoldResult innerInputTileSize;
   if (maybeOutputDimToVectorize.has_value()) {
@@ -796,71 +788,60 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   b.setInsertionPoint(loopNest.loops.front());
   SetVector<int64_t> mPosSet(getMPos().begin(), getMPos().end());
 
-  // Compute the basis for the iteration space of the convolution window
-  // (i.e., the H and W dims of the convolution output).
-  SmallVector<Value> mBasis;
   ArrayRef<int64_t> strides = getStrides();
   ArrayRef<int64_t> dilations = getDilations();
-  SmallVector<OpFoldResult> kernelSize = getMixedKernelSize();
-  for (auto [idx, pos] : llvm::enumerate(getMPos())) {
-    AffineExpr x, k;
-    bindDims(getContext(), x, k);
-    AffineExpr mapExpr =
-        (x - 1 - (k - 1) * dilations[idx]).floorDiv(strides[idx]) + 1;
-    OpFoldResult size = affine::makeComposedFoldedAffineApply(
-        b, loc, AffineMap::get(2, 0, {mapExpr}, getContext()),
-        {inputSizes[pos], kernelSize[idx]});
-    mBasis.push_back(getValueOrCreateConstantIndexOp(b, loc, size));
-  }
 
-  // Delinearize the k_offset into an offset into the convolution window and
-  // any reduced channels. For an NHWC conv2d, the basis for delinearization
-  // would be [P, Q, C] for a PxQ kernel with C channels.
   Location nestedLoc =
       loopNest.loops.back().getBody()->getTerminator()->getLoc();
   b.setInsertionPointToStart(loopNest.loops.back().getBody());
 
-  SmallVector<OpFoldResult> kBasis;
-  SmallVector<int64_t> mKernelIdx(getInputRank(), -1);
-  for (auto [idx, mPos] : enumerate(getMPos())) {
-    mKernelIdx[mPos] = idx;
-  }
   SetVector<int64_t> batchPosSet(getBatchPos().begin(), getBatchPos().end());
-  for (auto [idx, size] : enumerate(inputSizes)) {
-    if (batchPosSet.contains(idx)) {
-      continue;
-    }
-    if (mPosSet.contains(idx)) {
-      kBasis.push_back(kernelSize[mKernelIdx[idx]]);
-      continue;
-    }
-    kBasis.push_back(size);
-  }
-
-  // Transpose the order of (P, Q, C) according to `inputKPerm` encoded in
-  // im2col metadata.
   ArrayRef<int64_t> inputKPerm = getInputKPerm();
-  applyPermutationToVector(kBasis, inputKPerm);
+  SmallVector<int64_t> invInputKPerm = invertPermutationVector(inputKPerm);
 
-  OpFoldResult kIndex = kOffset;
-  for (auto [i, ivIdx, stride] :
-       llvm::enumerate(getKOutputDims(), getMixedKStrides())) {
-    if (isConstantIntValue(ivs[ivIdx], 0)) {
-      continue;
+  // Get output_sizes for per-dim delinearization.
+  SmallVector<SmallVector<OpFoldResult>> mixedOutputSizes =
+      getMixedOutputSizes();
+  SmallVector<int64_t> kOutputDims = getKOutputDims();
+  int64_t batchSize = getBatchPos().size();
+  int64_t numMOutputDims = getNumMOutputDims();
+
+  // Delinearize each output dim independently using its output_sizes.
+  // For each output dim at canonical index c with actual output dim d:
+  //   pos = offsets[c] + ivs[d]
+  //   components = delinearize(pos, output_sizes[c])
+  // Concatenate all components into a flat list.
+  auto delinearizeOutputDims =
+      [&](ArrayRef<int64_t> outputDims,
+          int64_t canonicalOffset) -> SmallVector<Value> {
+    SmallVector<Value> results;
+    for (auto [i, actualDim] : llvm::enumerate(outputDims)) {
+      int64_t canonicalIdx = canonicalOffset + i;
+      OpFoldResult pos =
+          addOfrs(b, nestedLoc, mixedOffsets[canonicalIdx], ivs[actualDim]);
+      const SmallVector<OpFoldResult> &innerSizes =
+          mixedOutputSizes[canonicalIdx];
+      if (innerSizes.size() == 1) {
+        results.push_back(getValueOrCreateConstantIndexOp(b, loc, pos));
+      } else {
+        ValueRange components =
+            affine::AffineDelinearizeIndexOp::create(
+                b, nestedLoc, getValueOrCreateConstantIndexOp(b, loc, pos),
+                innerSizes, /*hasOuterBound=*/true)
+                .getResults();
+        results.append(components.begin(), components.end());
+      }
     }
-    OpFoldResult ivOffset = mulOfrs(b, nestedLoc, stride, ivs[ivIdx]);
-    kIndex = addOfrs(b, nestedLoc, kIndex, ivOffset);
-  }
-  ValueRange delinKOffset =
-      affine::AffineDelinearizeIndexOp::create(
-          b, nestedLoc, getValueOrCreateConstantIndexOp(b, loc, kIndex), kBasis,
-          /*hasOuterBound=*/true)
-          .getResults();
+    return results;
+  };
+
+  SmallVector<Value> delinKOffset =
+      delinearizeOutputDims(kOutputDims, batchSize + numMOutputDims);
+
   // Split the delinearized offsets into the window offsets (for M offsets)
   // and the K offsets for the input tensor based on the layout.
   SmallVector<Value> windowOffset, inputKOffset;
   int delinKIdx = 0;
-  SmallVector<int64_t> invInputKPerm = invertPermutationVector(inputKPerm);
   for (int i = 0; i < getInputRank(); ++i) {
     if (batchPosSet.contains(i)) {
       continue;
@@ -872,27 +853,9 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
     inputKOffset.push_back(delinKOffset[invInputKPerm[delinKIdx++]]);
   }
 
-  // Compute offsets for extract. The linearized im2col result M offset is
-  // computed as the m_offset * m_strides inner product plus the linearized
-  // offset from the tiled m loops. The M offsets into the im2col input are then
-  // computed as the delinearized im2col result M offset (in the convolution
-  // result iteration space), plus the convolutional window offsets computed
-  // above.
-  SmallVector<OpFoldResult> mIvs, mOutStrides(getMixedMStrides());
-  for (auto [idx, dim] : llvm::enumerate(getMOutputDims())) {
-    mIvs.push_back(ivs[dim]);
-  }
-  OpFoldResult linearMIv = linearizeIndex(mIvs, mOutStrides);
-  OpFoldResult linearMOffset = addOfrs(b, nestedLoc, linearMIv, mOffset);
-  // Delinearize the m_offset * m_strides into the convolution output space.
-  // `mBasis` contains the basis for the iteration space of result of the
-  // convolution op (i.e., basis for result H and W dims).
-  ValueRange delinMOffset =
-      affine::AffineDelinearizeIndexOp::create(
-          b, nestedLoc, getValueOrCreateConstantIndexOp(b, loc, linearMOffset),
-          mBasis,
-          /*hasOuterBound=*/true)
-          .getResults();
+  SmallVector<int64_t> mOutputDims = getMOutputDims();
+  SmallVector<Value> delinMOffset =
+      delinearizeOutputDims(mOutputDims, batchSize);
 
   // Compute the final offsets into the input tensor.
   OpFoldResult zero = b.getIndexAttr(0);
@@ -924,7 +887,10 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   SmallVector<int64_t> inverseOutputPerm =
       invertPermutationVector(getOutputPerm());
   for (auto [ivIdx, bPos] : llvm::enumerate(getBatchPos())) {
-    sliceOffsets[bPos] = ivs[inverseOutputPerm[ivIdx]];
+    int64_t canonicalIdx = ivIdx;
+    int64_t actualDim = inverseOutputPerm[canonicalIdx];
+    sliceOffsets[bPos] =
+        addOfrs(b, nestedLoc, mixedOffsets[canonicalIdx], ivs[actualDim]);
   }
 
   // Step 3. Decompose the im2col op into:

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -822,12 +822,13 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
       const SmallVector<OpFoldResult> &innerSizes =
           mixedOutputSizes[canonicalIdx];
       if (innerSizes.size() == 1) {
-        results.push_back(getValueOrCreateConstantIndexOp(b, loc, pos));
+        results.push_back(getValueOrCreateConstantIndexOp(b, nestedLoc, pos));
       } else {
         ValueRange components =
             affine::AffineDelinearizeIndexOp::create(
-                b, nestedLoc, getValueOrCreateConstantIndexOp(b, loc, pos),
-                innerSizes, /*hasOuterBound=*/true)
+                b, nestedLoc,
+                getValueOrCreateConstantIndexOp(b, nestedLoc, pos), innerSizes,
+                /*hasOuterBound=*/true)
                 .getResults();
         results.append(components.begin(), components.end());
       }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2254,8 +2254,9 @@ void Im2colOp::setMixedOffsets(SmallVector<OpFoldResult> newOffsets) {
   getOffsetsMutable().assign(dynamicOffsets);
 }
 
-void Im2colOp::setMixedOutputSizes(
-    ArrayRef<SmallVector<OpFoldResult>> outputSizes) {
+static std::pair<SmallVector<Attribute>, SmallVector<Value>>
+dispatchNestedOutputSizes(MLIRContext *ctx,
+                          ArrayRef<SmallVector<OpFoldResult>> outputSizes) {
   SmallVector<Attribute> innerArrayAttrs;
   SmallVector<Value> dynamicValues;
   for (const auto &innerSizes : outputSizes) {
@@ -2268,8 +2269,15 @@ void Im2colOp::setMixedOutputSizes(
         dynamicValues.push_back(cast<Value>(ofr));
       }
     }
-    innerArrayAttrs.push_back(DenseI64ArrayAttr::get(getContext(), staticVals));
+    innerArrayAttrs.push_back(DenseI64ArrayAttr::get(ctx, staticVals));
   }
+  return {innerArrayAttrs, dynamicValues};
+}
+
+void Im2colOp::setMixedOutputSizes(
+    ArrayRef<SmallVector<OpFoldResult>> outputSizes) {
+  auto [innerArrayAttrs, dynamicValues] =
+      dispatchNestedOutputSizes(getContext(), outputSizes);
   setStaticOutputSizesAttr(ArrayAttr::get(getContext(), innerArrayAttrs));
   getOutputSizesMutable().assign(dynamicValues);
 }
@@ -2294,7 +2302,10 @@ int64_t Im2colOp::getNumMOutputDims() {
       return i - batchSize + 1;
     }
   }
-  llvm_unreachable("M/K boundary not found in output_sizes");
+  assert(false &&
+         "M/K boundary not found in output_sizes; verifier should have caught "
+         "this");
+  return 0;
 }
 
 SmallVector<int64_t> Im2colOp::getMOutputDims() {
@@ -2389,21 +2400,8 @@ void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
   dispatchIndexOpFoldResults(offsets, dynamicOffsets, staticOffsets);
 
   // Build the nested ArrayAttr of DenseI64ArrayAttr for output_sizes.
-  SmallVector<Attribute> innerArrayAttrs;
-  SmallVector<Value> dynamicOutputSizes;
-  for (const auto &innerSizes : outputSizes) {
-    SmallVector<int64_t> staticVals;
-    for (auto ofr : innerSizes) {
-      if (auto val = getConstantIntValue(ofr)) {
-        staticVals.push_back(*val);
-      } else {
-        staticVals.push_back(ShapedType::kDynamic);
-        dynamicOutputSizes.push_back(cast<Value>(ofr));
-      }
-    }
-    innerArrayAttrs.push_back(
-        DenseI64ArrayAttr::get(builder.getContext(), staticVals));
-  }
+  auto [innerArrayAttrs, dynamicOutputSizes] =
+      dispatchNestedOutputSizes(builder.getContext(), outputSizes);
   ArrayAttr staticOutputSizesAttr =
       ArrayAttr::get(builder.getContext(), innerArrayAttrs);
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2123,66 +2123,155 @@ LogicalResult ExpReductionOp::verify() {
 // Im2colOp
 //===----------------------------------------------------------------------===//
 
+// Custom printer for the nested dynamic index list used by output_sizes.
+// Prints format: [[2], [%oh, %ow], [3, 3, 640]]. Dynamic positions use SSA
+// values; static positions print integer literals. ShapedType::kDynamic in
+// the static arrays marks dynamic positions. MLIR's parseDynamicIndexList
+// handles only flat lists, not the nested [[...], [...]] structure here.
+static void printNestedDynamicIndexList(OpAsmPrinter &p, Operation *op,
+                                        OperandRange dynamicValues,
+                                        ArrayAttr staticOutputSizes) {
+  int64_t dynamicIdx = 0;
+  p << "[";
+  llvm::interleaveComma(staticOutputSizes, p, [&](Attribute innerAttr) {
+    auto innerArray = cast<DenseI64ArrayAttr>(innerAttr);
+    p << "[";
+    llvm::interleaveComma(innerArray.asArrayRef(), p, [&](int64_t val) {
+      if (ShapedType::isDynamic(val)) {
+        p << dynamicValues[dynamicIdx++];
+      } else {
+        p << val;
+      }
+    });
+    p << "]";
+  });
+  p << "]";
+}
+
+// Custom parser for nested dynamic index lists.
+// Parses format: [[2], [%oh, %ow], [3, 3, 640]]
+// Returns the flat list of dynamic SSA values and the ArrayAttr of
+// DenseI64ArrayAttr with ShapedType::kDynamic as sentinel for dynamic
+// positions.
+static ParseResult parseNestedDynamicIndexList(
+    OpAsmParser &parser,
+    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &dynamicValues,
+    ArrayAttr &staticOutputSizes) {
+  SmallVector<Attribute> innerArrayAttrs;
+  if (parser.parseLSquare()) {
+    return failure();
+  }
+
+  auto parseInnerList = [&]() -> ParseResult {
+    SmallVector<int64_t> staticVals;
+    if (parser.parseLSquare()) {
+      return failure();
+    }
+
+    auto parseElement = [&]() -> ParseResult {
+      // Try to parse an SSA value (dynamic).
+      OpAsmParser::UnresolvedOperand operand;
+      auto res = parser.parseOptionalOperand(operand);
+      if (res.has_value()) {
+        if (failed(res.value())) {
+          return failure();
+        }
+        dynamicValues.push_back(operand);
+        staticVals.push_back(ShapedType::kDynamic);
+        return success();
+      }
+      // Otherwise parse a static integer.
+      int64_t val;
+      if (parser.parseInteger(val)) {
+        return failure();
+      }
+      staticVals.push_back(val);
+      return success();
+    };
+
+    if (parser.parseCommaSeparatedList(parseElement)) {
+      return failure();
+    }
+
+    if (parser.parseRSquare()) {
+      return failure();
+    }
+    innerArrayAttrs.push_back(
+        DenseI64ArrayAttr::get(parser.getContext(), staticVals));
+    return success();
+  };
+
+  if (parser.parseCommaSeparatedList(parseInnerList)) {
+    return failure();
+  }
+
+  if (parser.parseRSquare()) {
+    return failure();
+  }
+  staticOutputSizes = ArrayAttr::get(parser.getContext(), innerArrayAttrs);
+  return success();
+}
+
 /// Return all static and dynamic kernel_size as OpFoldResults.
 SmallVector<OpFoldResult> Im2colOp::getMixedKernelSize() {
   return LinalgExt::getMixedValues(getContext(), getStaticKernelSize(),
                                    getKernelSize());
 }
 
-/// Return all static and dynamic k_offset as OpFoldResults.
-SmallVector<OpFoldResult> Im2colOp::getMixedKOffset() {
-  return LinalgExt::getMixedValues(getContext(), getStaticKOffset(),
-                                   getKOffset());
+/// Return all static and dynamic offsets as OpFoldResults.
+SmallVector<OpFoldResult> Im2colOp::getMixedOffsets() {
+  return LinalgExt::getMixedValues(getContext(), getStaticOffsets(),
+                                   getOffsets());
 }
 
-/// Return all static and dynamic m_offset as OpFoldResults.
-SmallVector<OpFoldResult> Im2colOp::getMixedMOffset() {
-  return LinalgExt::getMixedValues(getContext(), getStaticMOffset(),
-                                   getMOffset());
+/// Return the nested output_sizes as a vector of vectors of OpFoldResults.
+SmallVector<SmallVector<OpFoldResult>> Im2colOp::getMixedOutputSizes() {
+  SmallVector<SmallVector<OpFoldResult>> result;
+  ArrayAttr sizesAttr = getStaticOutputSizes();
+  auto dynamicVals = getOutputSizes();
+  int64_t dynamicIdx = 0;
+  for (Attribute innerAttr : sizesAttr) {
+    auto innerArray = cast<DenseI64ArrayAttr>(innerAttr);
+    SmallVector<OpFoldResult> innerResult;
+    for (int64_t val : innerArray.asArrayRef()) {
+      if (ShapedType::isDynamic(val)) {
+        innerResult.push_back(dynamicVals[dynamicIdx++]);
+      } else {
+        innerResult.push_back(
+            IntegerAttr::get(IndexType::get(getContext()), val));
+      }
+    }
+    result.push_back(std::move(innerResult));
+  }
+  return result;
 }
 
-/// Return all static and dynamic k_strides as OpFoldResults.
-SmallVector<OpFoldResult> Im2colOp::getMixedKStrides() {
-  return LinalgExt::getMixedValues(getContext(), getStaticKStrides(),
-                                   getKStrides());
+void Im2colOp::setMixedOffsets(SmallVector<OpFoldResult> newOffsets) {
+  SmallVector<int64_t> staticOffsets;
+  SmallVector<Value> dynamicOffsets;
+  dispatchIndexOpFoldResults(newOffsets, dynamicOffsets, staticOffsets);
+  setStaticOffsets(staticOffsets);
+  getOffsetsMutable().assign(dynamicOffsets);
 }
 
-/// Return all static and dynamic m_strides as OpFoldResults.
-SmallVector<OpFoldResult> Im2colOp::getMixedMStrides() {
-  return LinalgExt::getMixedValues(getContext(), getStaticMStrides(),
-                                   getMStrides());
-}
-
-void Im2colOp::setMixedKOffset(SmallVector<OpFoldResult> kOffset) {
-  SmallVector<int64_t> staticKOffset;
-  SmallVector<Value> dynamicKOffset;
-  dispatchIndexOpFoldResults(kOffset, dynamicKOffset, staticKOffset);
-  setStaticKOffset(staticKOffset);
-  getKOffsetMutable().assign(dynamicKOffset);
-}
-
-void Im2colOp::setMixedMOffset(SmallVector<OpFoldResult> mOffset) {
-  SmallVector<int64_t> staticMOffset;
-  SmallVector<Value> dynamicMOffset;
-  dispatchIndexOpFoldResults(mOffset, dynamicMOffset, staticMOffset);
-  setStaticMOffset(staticMOffset);
-  getMOffsetMutable().assign(dynamicMOffset);
-}
-
-void Im2colOp::setMixedKStrides(SmallVector<OpFoldResult> kStrides) {
-  SmallVector<int64_t> staticKStrides;
-  SmallVector<Value> dynamicKStrides;
-  dispatchIndexOpFoldResults(kStrides, dynamicKStrides, staticKStrides);
-  setStaticKStrides(staticKStrides);
-  getKStridesMutable().assign(dynamicKStrides);
-}
-
-void Im2colOp::setMixedMStrides(SmallVector<OpFoldResult> mStrides) {
-  SmallVector<int64_t> staticMStrides;
-  SmallVector<Value> dynamicMStrides;
-  dispatchIndexOpFoldResults(mStrides, dynamicMStrides, staticMStrides);
-  setStaticMStrides(staticMStrides);
-  getMStridesMutable().assign(dynamicMStrides);
+void Im2colOp::setMixedOutputSizes(
+    ArrayRef<SmallVector<OpFoldResult>> outputSizes) {
+  SmallVector<Attribute> innerArrayAttrs;
+  SmallVector<Value> dynamicValues;
+  for (const auto &innerSizes : outputSizes) {
+    SmallVector<int64_t> staticVals;
+    for (auto ofr : innerSizes) {
+      if (auto val = getConstantIntValue(ofr)) {
+        staticVals.push_back(*val);
+      } else {
+        staticVals.push_back(ShapedType::kDynamic);
+        dynamicValues.push_back(cast<Value>(ofr));
+      }
+    }
+    innerArrayAttrs.push_back(DenseI64ArrayAttr::get(getContext(), staticVals));
+  }
+  setStaticOutputSizesAttr(ArrayAttr::get(getContext(), innerArrayAttrs));
+  getOutputSizesMutable().assign(dynamicValues);
 }
 
 SmallVector<int64_t> Im2colOp::getBatchOutputDims() {
@@ -2192,9 +2281,25 @@ SmallVector<int64_t> Im2colOp::getBatchOutputDims() {
                              [&](int64_t dim) { return inverseOutPerm[dim]; });
 }
 
+int64_t Im2colOp::getNumMOutputDims() {
+  ArrayAttr sizesAttr = getStaticOutputSizes();
+  int64_t batchSize = getBatchPos().size();
+  int64_t mTarget = getMPos().size();
+  int64_t accumulated = 0;
+  int64_t numDims = static_cast<int64_t>(sizesAttr.size());
+  for (int64_t i = batchSize; i < numDims; ++i) {
+    auto innerSizes = cast<DenseI64ArrayAttr>(sizesAttr[i]);
+    accumulated += innerSizes.size();
+    if (accumulated == mTarget) {
+      return i - batchSize + 1;
+    }
+  }
+  llvm_unreachable("M/K boundary not found in output_sizes");
+}
+
 SmallVector<int64_t> Im2colOp::getMOutputDims() {
   int64_t begin = getBatchPos().size();
-  int64_t end = begin + getMixedMOffset().size();
+  int64_t end = begin + getNumMOutputDims();
   SmallVector<int64_t> inverseOutPerm =
       invertPermutationVector(getOutputPerm());
   return llvm::map_to_vector(llvm::seq<int64_t>(begin, end),
@@ -2202,8 +2307,8 @@ SmallVector<int64_t> Im2colOp::getMOutputDims() {
 }
 
 SmallVector<int64_t> Im2colOp::getKOutputDims() {
-  int64_t begin = getBatchPos().size() + getMixedMOffset().size();
-  int64_t end = begin + getMixedKOffset().size();
+  int64_t begin = getBatchPos().size() + getNumMOutputDims();
+  int64_t end = getOutputRank();
   SmallVector<int64_t> inverseOutPerm =
       invertPermutationVector(getOutputPerm());
   return llvm::map_to_vector(llvm::seq<int64_t>(begin, end),
@@ -2265,27 +2370,43 @@ Im2colOp::getInputToOutputDimVectorizationMap() {
 }
 
 /// Custom builder methods for im2col op.
-void Im2colOp::build(
-    OpBuilder &builder, OperationState &state, Value input, Value output,
-    ArrayRef<int64_t> strides, ArrayRef<int64_t> dilations,
-    ArrayRef<OpFoldResult> kernelSize, ArrayRef<OpFoldResult> mOffset,
-    ArrayRef<OpFoldResult> mStrides, ArrayRef<OpFoldResult> kOffset,
-    ArrayRef<OpFoldResult> kStrides, ArrayRef<int64_t> batchPos,
-    ArrayRef<int64_t> mPos, ArrayRef<int64_t> kPos,
-    ArrayRef<int64_t> inputKPerm, ArrayRef<int64_t> outputPerm) {
+void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
+                     Value output, ArrayRef<int64_t> strides,
+                     ArrayRef<int64_t> dilations,
+                     ArrayRef<OpFoldResult> kernelSize,
+                     ArrayRef<OpFoldResult> offsets,
+                     ArrayRef<SmallVector<OpFoldResult>> outputSizes,
+                     ArrayRef<int64_t> batchPos, ArrayRef<int64_t> mPos,
+                     ArrayRef<int64_t> kPos, ArrayRef<int64_t> inputKPerm,
+                     ArrayRef<int64_t> outputPerm) {
   assert(strides.size() == kernelSize.size() &&
          dilations.size() == kernelSize.size() &&
          mPos.size() == kernelSize.size() &&
          "strides, dilations, m_pos, and kernel expected to be the same rank");
-  SmallVector<int64_t> staticKernelSize, staticMOffset, staticKOffset,
-      staticMStrides, staticKStrides;
-  SmallVector<Value> dynamicKernelSize, dynamicMOffset, dynamicKOffset,
-      dynamicMStrides, dynamicKStrides;
+  SmallVector<int64_t> staticKernelSize, staticOffsets;
+  SmallVector<Value> dynamicKernelSize, dynamicOffsets;
   dispatchIndexOpFoldResults(kernelSize, dynamicKernelSize, staticKernelSize);
-  dispatchIndexOpFoldResults(mOffset, dynamicMOffset, staticMOffset);
-  dispatchIndexOpFoldResults(mStrides, dynamicMStrides, staticMStrides);
-  dispatchIndexOpFoldResults(kOffset, dynamicKOffset, staticKOffset);
-  dispatchIndexOpFoldResults(kStrides, dynamicKStrides, staticKStrides);
+  dispatchIndexOpFoldResults(offsets, dynamicOffsets, staticOffsets);
+
+  // Build the nested ArrayAttr of DenseI64ArrayAttr for output_sizes.
+  SmallVector<Attribute> innerArrayAttrs;
+  SmallVector<Value> dynamicOutputSizes;
+  for (const auto &innerSizes : outputSizes) {
+    SmallVector<int64_t> staticVals;
+    for (auto ofr : innerSizes) {
+      if (auto val = getConstantIntValue(ofr)) {
+        staticVals.push_back(*val);
+      } else {
+        staticVals.push_back(ShapedType::kDynamic);
+        dynamicOutputSizes.push_back(cast<Value>(ofr));
+      }
+    }
+    innerArrayAttrs.push_back(
+        DenseI64ArrayAttr::get(builder.getContext(), staticVals));
+  }
+  ArrayAttr staticOutputSizesAttr =
+      ArrayAttr::get(builder.getContext(), innerArrayAttrs);
+
   SmallVector<Type> resultType;
   auto outputType = output.getType();
   if (isa<RankedTensorType>(outputType)) {
@@ -2294,12 +2415,9 @@ void Im2colOp::build(
   build(builder, state, resultType, input, output,
         builder.getDenseI64ArrayAttr(strides),
         builder.getDenseI64ArrayAttr(dilations), dynamicKernelSize,
-        builder.getDenseI64ArrayAttr(staticKernelSize), dynamicMOffset,
-        builder.getDenseI64ArrayAttr(staticMOffset), dynamicMStrides,
-        builder.getDenseI64ArrayAttr(staticMStrides), dynamicKOffset,
-        builder.getDenseI64ArrayAttr(staticKOffset), dynamicKStrides,
-        builder.getDenseI64ArrayAttr(staticKStrides),
-        builder.getDenseI64ArrayAttr(batchPos),
+        builder.getDenseI64ArrayAttr(staticKernelSize), dynamicOffsets,
+        builder.getDenseI64ArrayAttr(staticOffsets), dynamicOutputSizes,
+        staticOutputSizesAttr, builder.getDenseI64ArrayAttr(batchPos),
         builder.getDenseI64ArrayAttr(mPos), builder.getDenseI64ArrayAttr(kPos),
         builder.getDenseI64ArrayAttr(inputKPerm),
         builder.getDenseI64ArrayAttr(outputPerm));
@@ -2316,34 +2434,6 @@ LogicalResult Im2colOp::verify() {
     return op->emitOpError("expected one output operand");
   }
 
-  // Verify offsets and strides
-  SmallVector<OpFoldResult> kOffset = getMixedKOffset();
-  SmallVector<OpFoldResult> mOffset = getMixedMOffset();
-  SmallVector<OpFoldResult> kStrides = getMixedKStrides();
-  SmallVector<OpFoldResult> mStrides = getMixedMStrides();
-  if (kOffset.size() < 1) {
-    return op->emitOpError("expected at least one k_offset");
-  }
-  if (mOffset.size() < 1) {
-    return op->emitOpError("expected at least one m_offset");
-  }
-  if (kOffset.size() != kStrides.size()) {
-    return op->emitOpError("expected the same size k_offset and k_strides");
-  }
-  if (mOffset.size() != mStrides.size()) {
-    return op->emitOpError("expected the same size m_offset and m_strides");
-  }
-  std::optional<int64_t> constInnerKStrides =
-      getConstantIntValue(kStrides.back());
-  if (!constInnerKStrides.has_value() || constInnerKStrides.value() != 1) {
-    return op->emitOpError("expected inner k_strides to be 1");
-  }
-  std::optional<int64_t> constInnerMStrides =
-      getConstantIntValue(mStrides.back());
-  if (!constInnerMStrides.has_value() || constInnerMStrides.value() != 1) {
-    return op->emitOpError("expected inner m_strides to be 1");
-  }
-
   // Verify operand ranks and dim position sizes.
   auto inputType = getInputType();
   unsigned inputRank = inputType.getRank();
@@ -2356,9 +2446,78 @@ LogicalResult Im2colOp::verify() {
   }
   auto outputType = getOutputType();
   unsigned outputRank = outputType.getRank();
-  if (outputRank != batchPos.size() + kOffset.size() + mOffset.size()) {
-    return op->emitOpError("expected output rank to be the sum of "
-                           "batch_pos, k_offset, and m_offset ranks");
+
+  // Verify offsets and output_sizes.
+  SmallVector<OpFoldResult> mixedOffsets = getMixedOffsets();
+  ArrayAttr sizesAttr = getStaticOutputSizes();
+  if (mixedOffsets.size() != outputRank) {
+    return op->emitOpError("expected offsets size (")
+           << mixedOffsets.size() << ") to match output rank (" << outputRank
+           << ")";
+  }
+  if (static_cast<unsigned>(sizesAttr.size()) != outputRank) {
+    return op->emitOpError("expected output_sizes outer size (")
+           << sizesAttr.size() << ") to match output rank (" << outputRank
+           << ")";
+  }
+
+  // Verify inner sizes for each output dim type (Batch, M, K) separately.
+  // Output dims in canonical order are: [Batch..., M..., K...].
+  //
+  // Batch output dims: each produces 1 coordinate (batch index).
+  //   -> total inner sizes across all batch dims = batchPos.size()
+  //
+  // M output dims: collectively produce mPos.size() coordinates
+  //   (spatial output positions, one per spatial dimension).
+  //   -> total inner sizes across all M dims = mPos.size()
+  //
+  // K output dims: collectively produce (mPos.size() + kPos.size())
+  //   coordinates (kernel window offsets + channel positions,
+  //   indexed by input_k_perm).
+  //   -> total inner sizes across all K dims = mPos.size() + kPos.size()
+  int64_t numBatchOutputDims = batchPos.size();
+  int64_t expectedBatchInner = batchPos.size();
+  int64_t expectedMInner = mPos.size();
+  int64_t expectedKInner = mPos.size() + kPos.size();
+
+  // Count batch inner dims.
+  int64_t batchInnerTotal = 0;
+  for (int64_t i = 0; i < numBatchOutputDims; ++i) {
+    batchInnerTotal += cast<DenseI64ArrayAttr>(sizesAttr[i]).size();
+  }
+  if (batchInnerTotal != expectedBatchInner) {
+    return op->emitOpError(
+        "expected sum of batch output_sizes inner dimensions to equal "
+        "batch_pos size");
+  }
+
+  // Find M/K boundary and count M inner dims.
+  int64_t mInnerTotal = 0;
+  int64_t numMOutputDims = 0;
+  for (int64_t i = numBatchOutputDims;
+       i < static_cast<int64_t>(sizesAttr.size()); ++i) {
+    mInnerTotal += cast<DenseI64ArrayAttr>(sizesAttr[i]).size();
+    if (mInnerTotal == expectedMInner) {
+      numMOutputDims = i - numBatchOutputDims + 1;
+      break;
+    }
+  }
+  if (numMOutputDims == 0) {
+    return op->emitOpError(
+        "M/K boundary not found: accumulated output_sizes inner dimensions "
+        "must equal m_pos size at some output dim boundary");
+  }
+
+  // Count K inner dims.
+  int64_t kInnerTotal = 0;
+  for (int64_t i = numBatchOutputDims + numMOutputDims;
+       i < static_cast<int64_t>(sizesAttr.size()); ++i) {
+    kInnerTotal += cast<DenseI64ArrayAttr>(sizesAttr[i]).size();
+  }
+  if (kInnerTotal != expectedKInner) {
+    return op->emitOpError("expected sum of K output_sizes inner dimensions (")
+           << kInnerTotal << ") to equal m_pos.size() + k_pos.size() ("
+           << expectedKInner << ")";
   }
 
   // Verify convolution metadata.
@@ -2379,11 +2538,11 @@ LogicalResult Im2colOp::verify() {
         "expected dilations rank to be equal to the kernel rank");
   }
 
-  size_t sharedRank = mPos.size() + kPos.size();
+  int64_t sharedRank = mPos.size() + kPos.size();
   if (inputKPerm.size() != sharedRank) {
     return op->emitOpError("expected input_k_perm size (")
            << inputKPerm.size()
-           << ") to match the number of shared dimensions (m_Pos + k_pos = "
+           << ") to match the number of shared dimensions (m_pos + k_pos = "
            << sharedRank << ")";
   }
   SmallVector<int64_t> permVec(inputKPerm);
@@ -2397,7 +2556,6 @@ LogicalResult Im2colOp::verify() {
   }
 
   // Verify input and output shapes.
-  ArrayRef<int64_t> inputShape = inputType.getShape();
   ArrayRef<int64_t> outputShape = outputType.getShape();
   ArrayRef<int64_t> outputPerm = getOutputPerm();
   if (!isPermutationVector(outputPerm)) {
@@ -2408,17 +2566,6 @@ LogicalResult Im2colOp::verify() {
         "expected output_perm to have the same rank as the result");
   }
 
-  // When the op is tiled, the m and k dimensions of the output are tiled, but
-  // they are not tiled in the input, so we cannot verify the output size of
-  // these dimensions. Only verify the shape of the batch dimensions.
-  SmallVector<int64_t> expectedOutputShape(outputShape);
-  SmallVector<int64_t> inverseOutputPerm = invertPermutationVector(outputPerm);
-  for (auto [idx, pos] : llvm::enumerate(batchPos)) {
-    expectedOutputShape[inverseOutputPerm[idx]] = inputShape[pos];
-  }
-  if (failed(verifyCompatibleShape(expectedOutputShape, outputShape))) {
-    return op->emitOpError("incompatible output shape");
-  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1300,7 +1300,7 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     - `kernel_size`: filter kernel extent per m_pos dimension.
 
     **Dimension mapping** — describes which input dimensions are batch, spatial
-    (M), or channel/kernel (K):
+    (M), or reduction (K):
     - `batch_pos`: input dimensions that are batch (pass-through to output).
     - `m_pos`: input dimensions that are spatial (indexed by stride/dilation).
     - `k_pos`: input dimensions that are channels (direct index).
@@ -1316,9 +1316,9 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
       M delinearizes into [OH=32, OW=32], K delinearizes into [KH=3, KW=3, C=640].
 
     **Layout permutations**:
-    - `input_k_perm`: permutation that maps the canonical K coordinate order
-      (m_pos spatial dims followed by k_pos channel dims, all in input dimension
-      order) to the order that they appear in the K output dimensions. Used when
+    - `input_k_perm`: permutation that maps the delinearized K output dimension
+      coordinates (window offsets from spatial dims and channel indices) to their
+      corresponding input dimension positions. Used when
       the filter layout differs from the input layout (e.g., input=HWC,
       filter=CHW requires `input_k_perm = [2, 0, 1]`). The identity permutation
       means the layouts are already aligned.
@@ -1328,7 +1328,9 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
 
     #### Semantics
 
-    For each output position `(b, m, k)`, the op computes input coordinates:
+    For each output position `(b, m, k)`, the op computes input coordinates,
+    where `i` indexes over `m_pos` dimensions (spatial) and `j` indexes over
+    `k_pos` dimensions (channel):
     ```
       spatial_coord[i] = m_coord[i] * stride[i] + window_offset[i] * dilation[i]
       channel_coord[j] = k_coord[j]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1288,102 +1288,78 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
        "generateResultTileValue"]>]> {
   let summary = [{Im2col operation for convolutions.}];
   let description = [{
-    Im2col op for convolutions. The operation performs a transformation on the
-    input to convert it from a convolution input to an equivalent gemm input.
-    The op is defined by its input, output, some conv metadata, and some
-    indexing metadata. The `strides`, `dilations`, and `kernel_size` are taken
-    from the convolution from which this op is generated, and they define how
-    the input operand is indexed when the operation is decomposed. The shape of
-    the output should be `tensor<BxMxK>`, and the `m_pos`, `k_pos`, and
-    `batch_pos` indicate which input dimensions map to which output dimensions.
+    Transforms a convolution input tensor into a GEMM-compatible layout. Each
+    output position `(batch, m, k)` maps to a specific input element determined
+    by the convolution metadata (strides, dilations, kernel_size).
 
-    The `k_offset` is an offset within the output K dimension from which the
-    iteration space of the operation begins. This is used for tiling, since the
-    tiled implementation must leave the output K dimension untiled. Similarly,
-    `m_offset` is the offset within the output M dimension from which the
-    iteration space of the operation begins.
-    The iteration space is the full output shape of the im2col op, so if the
-    im2col op were tiled to loops with a scalar inner tile, it would look like
-    the following:
+    #### Attributes
+
+    **Convolution metadata** — derived from the original convolution:
+    - `strides`: spatial stride per m_pos dimension.
+    - `dilations`: dilation factor per m_pos dimension.
+    - `kernel_size`: filter kernel extent per m_pos dimension.
+
+    **Dimension mapping** — describes which input dimensions are batch, spatial
+    (M), or channel/kernel (K):
+    - `batch_pos`: input dimensions that are batch (pass-through to output).
+    - `m_pos`: input dimensions that are spatial (indexed by stride/dilation).
+    - `k_pos`: input dimensions that are channels (direct index).
+
+    **Indexing**:
+    - `offsets`: one offset per output dimension in canonical
+      `[Batch..., M..., K...]` order. Updated by tiling to reflect the tile
+      position; `output_sizes` remain unchanged.
+    - `output_sizes`: nested list of delinearization sizes per output dimension.
+      Each entry describes how to delinearize that output dimension back to
+      spatial/channel coordinates. For example:
+      `output_sizes = [[2], [32, 32], [3, 3, 640]]` means batch=[2],
+      M delinearizes into [OH=32, OW=32], K delinearizes into [KH=3, KW=3, C=640].
+
+    **Layout permutations**:
+    - `input_k_perm`: permutation that maps the canonical K coordinate order
+      (m_pos spatial dims followed by k_pos channel dims, all in input dimension
+      order) to the order that they appear in the K output dimensions. Used when
+      the filter layout differs from the input layout (e.g., input=HWC,
+      filter=CHW requires `input_k_perm = [2, 0, 1]`). The identity permutation
+      means the layouts are already aligned.
+    - `output_perm`: permutation of the canonical `[Batch, M, K]` order to the
+      actual output tensor layout. For example, `output_perm = [2, 0, 1]` means
+      the result is in `KxBxM` layout.
+
+    #### Semantics
+
+    For each output position `(b, m, k)`, the op computes input coordinates:
     ```
+      spatial_coord[i] = m_coord[i] * stride[i] + window_offset[i] * dilation[i]
+      channel_coord[j] = k_coord[j]
+    ```
+    where `m_coord` and `window_offset`/`k_coord` come from delinearizing the
+    M and K output indices using `output_sizes`.
+
+    #### Examples
+
+    Basic im2col (NHWC conv, 3x3 kernel):
+    ```mlir
       %im2col = iree_linalg_ext.im2col
           strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-          m_offset = [0] * [1] k_offset = [0] * [1]
+          offsets = [0, 0, 0]
+          output_sizes = [[2], [32, 32], [3, 3, 640]]
           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
           ins(%in : tensor<2x34x34x640xf32>)
           outs(%out : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
     ```
-    becomes:
-    ```
-      scf.for %arg0 = %c0 to %c2 step %c1
-        scf.for %arg1 = %c0 to %c1024 step %c1
-          scf.for %arg2 = %c0 to %c5760 step %c1
-            %im2col = iree_linalg_ext.im2col
-                strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-                m_offset = [%arg1] * [1] k_offset = [%arg2] * [1]
-                batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-                ins(%in_tile : tensor<1x34x34x640xf32>)
-                outs(%out_tile : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
-    ```
-    Then, when the tiled op is decomposed, it becomes a loop over the iteration
-    space of the im2col op, with an extract_slice from the `%in_tile` followed
-    by an insert_slice to the `%out_tile`. The indices for the extract slice are
-    computed using the `m_offset` and `k_offset` as:
-    (b, m, k) -> (b, M / 32 + K / (640*3), M % 32 + K % (640*3) / 640, K % 640)
-    Where `(b, m, k)` are the indices of the tiled op's iteration space, and
-    `M = m + m_offset` and `K = k + K_offset`.
 
-    The `m_strides` and `k_strides` fields are used as a basis for linearizing
-    the `m_offset` and `k_offset`. This is used when there are multiple M or K
-    output dimensions, and therefore multiple `m_offset` or `k_offset` values.
-    The strides fields are assembled in the IR as if they are multiplied as an
-    inner product with `m_offset` and `k_offset, indicating that the total
-    linear offset along the dimension is equal to this inner product. These
-    strides fields also determine the strides of the output dimensions along
-    M and K. For example, an op with `m_strides = [32, 1]`, `k_strides = [4, 1]`,
-    and output type `tensor<BxM0xM1xK0xK1>` (expanded from `tensor<BxMxK>`),
-    would have strides along the M dim of 32 for `M0`, meaning as `M0` increases
-    by 1, the index into the flat `M` increases by 32. Along the K dim, strides
-    would be 4 for `K0`, and 1 for `K1`, meaning as `K0` increases by 1, the
-    index into the flat `K` increases by 4. The strides in M from `m_strides`
-    are orthogonal to the strides in `K` from `k_strides`.
-
-    The `input_k_perm` attribute defines the permutation needed to align the
-    reduction dimensions of the input layout with those of the filter layout
-    when computing the K dimension of the im2col output. This is useful when the
-    layout of the filter (e.g., `CHW`) differs from that of the input (e.g., `HWC`).
-    For instance, an `input_k_perm = [2, 0, 1]` indicates the input indices needs
-    to be transposed from `HWC` to `CHW` layout before extracting slices during
-    decomposition. The identity permutation (e.g., input_k_perm = [0, 1, 2])
-    indicates that the input layout is already aligned with the filter layout
-    in terms of reduction dimensions, so no transposition of indices is necessary
-    before slice extraction.
-
-    The `output_perm` attribute defines the layout of the result with respect to
-    the canonical `BxMxK` layout. The layout of the result can be determined by
-    applying the permutation to the `BxMxK` layout. For instance, an
-    `output_perm = [2, 0, 1]` indicates the result is in a `KxMxB` layout.
   }];
 
   let arguments = (ins AnyShaped:$input, AnyShaped:$output,
-                       DenseI64ArrayAttr:$strides,
-                       DenseI64ArrayAttr:$dilations,
-                       Variadic<Index>:$kernel_size,
-                       DenseI64ArrayAttr:$static_kernel_size,
-                       Variadic<Index>:$m_offset,
-                       DenseI64ArrayAttr:$static_m_offset,
-                       Variadic<Index>:$m_strides,
-                       DenseI64ArrayAttr:$static_m_strides,
-                       Variadic<Index>:$k_offset,
-                       DenseI64ArrayAttr:$static_k_offset,
-                       Variadic<Index>:$k_strides,
-                       DenseI64ArrayAttr:$static_k_strides,
-                       DenseI64ArrayAttr:$batch_pos,
-                       DenseI64ArrayAttr:$m_pos,
-                       DenseI64ArrayAttr:$k_pos,
-                       DenseI64ArrayAttr:$input_k_perm,
-                       DenseI64ArrayAttr:$output_perm);
+      DenseI64ArrayAttr:$strides, DenseI64ArrayAttr:$dilations,
+      Variadic<Index>:$kernel_size, DenseI64ArrayAttr:$static_kernel_size,
+      Variadic<Index>:$offsets, DenseI64ArrayAttr:$static_offsets,
+      Variadic<Index>:$output_sizes, ArrayAttr:$static_output_sizes,
+      DenseI64ArrayAttr:$batch_pos, DenseI64ArrayAttr:$m_pos,
+      DenseI64ArrayAttr:$k_pos, DenseI64ArrayAttr:$input_k_perm,
+      DenseI64ArrayAttr:$output_perm);
 
   let results = (outs Variadic<AnyShaped>:$results);
   let hasFolder = 1;
@@ -1393,12 +1369,10 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     `dilations` `=` $dilations
     `kernel_size` `=`
     custom<DynamicIndexList>($kernel_size, $static_kernel_size)
-    `m_offset` `=`
-    custom<DynamicIndexList>($m_offset, $static_m_offset)
-    `*` custom<DynamicIndexList>($m_strides, $static_m_strides)
-    `k_offset` `=`
-    custom<DynamicIndexList>($k_offset, $static_k_offset)
-    `*` custom<DynamicIndexList>($k_strides, $static_k_strides)
+    `offsets` `=`
+    custom<DynamicIndexList>($offsets, $static_offsets)
+    `output_sizes` `=`
+    custom<NestedDynamicIndexList>($output_sizes, $static_output_sizes)
     `batch_pos` `=` $batch_pos
     `m_pos` `=` $m_pos
     `k_pos` `=` $k_pos
@@ -1409,23 +1383,15 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     (`->` type($results)^)?
   }];
 
-  let builders = [
-    OpBuilder<(ins "Value":$input, "Value":$output,
-      "ArrayRef<int64_t>":$strides,
-      "ArrayRef<int64_t>":$dilations,
-      "ArrayRef<OpFoldResult>":$kernel_size,
-      "ArrayRef<OpFoldResult>":$m_offset,
-      "ArrayRef<OpFoldResult>":$m_strides,
-      "ArrayRef<OpFoldResult>":$k_offset,
-      "ArrayRef<OpFoldResult>":$k_strides,
-      "ArrayRef<int64_t>":$batch_dimensions,
-      "ArrayRef<int64_t>":$m_dimensions,
-      "ArrayRef<int64_t>":$k_dimensions,
-      "ArrayRef<int64_t>":$input_k_perm,
-      "ArrayRef<int64_t>":$output_perm)>
-  ];
+  let builders = [OpBuilder<(ins "Value":$input, "Value":$output,
+      "ArrayRef<int64_t>":$strides, "ArrayRef<int64_t>":$dilations,
+      "ArrayRef<OpFoldResult>":$kernel_size, "ArrayRef<OpFoldResult>":$offsets,
+      "ArrayRef<SmallVector<OpFoldResult>>":$output_sizes,
+      "ArrayRef<int64_t>":$batch_dimensions, "ArrayRef<int64_t>":$m_dimensions,
+      "ArrayRef<int64_t>":$k_dimensions, "ArrayRef<int64_t>":$input_k_perm,
+      "ArrayRef<int64_t>":$output_perm)>];
 
-  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration#[{
     ShapedType getInputType() {
       return cast<ShapedType>(getInput().getType());
     }
@@ -1444,6 +1410,9 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     SmallVector<int64_t> getMOutputDims();
     SmallVector<int64_t> getKOutputDims();
 
+    // Returns the number of M output dimensions.
+    int64_t getNumMOutputDims();
+
     // Returns the mapping from input dimensions to the corresponding set of
     // output dimensions that can vectorize along with them. A pair of input and
     // output dims are vectorizable together if incrementing the output
@@ -1461,16 +1430,12 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
 
     // Return op metadata.
     SmallVector<OpFoldResult> getMixedKernelSize();
-    SmallVector<OpFoldResult> getMixedMOffset();
-    SmallVector<OpFoldResult> getMixedKOffset();
-    SmallVector<OpFoldResult> getMixedMStrides();
-    SmallVector<OpFoldResult> getMixedKStrides();
+    SmallVector<OpFoldResult> getMixedOffsets();
+    SmallVector<SmallVector<OpFoldResult>> getMixedOutputSizes();
 
     // Set op metadata.
-    void setMixedKOffset(SmallVector<OpFoldResult> kOffset);
-    void setMixedMOffset(SmallVector<OpFoldResult> mOffset);
-    void setMixedKStrides(SmallVector<OpFoldResult> kStrides);
-    void setMixedMStrides(SmallVector<OpFoldResult> mStrides);
+    void setMixedOffsets(SmallVector<OpFoldResult> offsets);
+    void setMixedOutputSizes(ArrayRef<SmallVector<OpFoldResult>> outputSizes);
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/OpDefinition.h"
@@ -2181,63 +2182,37 @@ Im2colOp::getTiledImplementation(OpBuilder &builder,
                                  ArrayRef<OpFoldResult> sizes) {
   Location loc = getLoc();
   OpFoldResult one = builder.getIndexAttr(1);
-  OpFoldResult zero = builder.getIndexAttr(0);
 
-  ReifiedRankedShapedTypeDims reifiedInputShapes;
-  SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> inputSizes = getDims(builder, loc, getInput());
-
-  // Set batch offsets and sizes for input
-  for (auto [outDim, inDim] :
-       llvm::zip_equal(getBatchOutputDims(), getBatchPos())) {
-    inputOffsets[inDim] = offsets[outDim];
-    inputSizes[inDim] = sizes[outDim];
-  }
-
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-
-  // Input
-  Operation *inputSlice = getSlice(builder, loc, getInput(), inputOffsets,
-                                   inputSizes, inputStrides);
+  Value inputValue = getInput();
 
   SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
   Operation *outputSlice =
       getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides);
 
-  SmallVector<Type, 4> resultTypes;
-  if (hasPureTensorSemantics()) {
-    resultTypes.append(outputSlice->result_type_begin(),
-                       outputSlice->result_type_end());
+  // Adjust offsets by adding the tiling offsets. The offsets are in canonical
+  // [Batch, M, K] order, and output_perm[actual] = canonical, so we use
+  // output_perm directly to map actual tensor dims to canonical positions.
+  SmallVector<OpFoldResult> newOffsets(getMixedOffsets());
+  ArrayRef<int64_t> outPerm = getOutputPerm();
+  for (int64_t actual = 0; actual < getOutputRank(); ++actual) {
+    int64_t canonical = outPerm[actual];
+    newOffsets[canonical] =
+        addOfrs(builder, loc, offsets[actual], newOffsets[canonical]);
   }
 
-  // Adjust m_offset and k_offset by adding the offsets from tiling.
-  SmallVector<OpFoldResult> newKOffsets, newMOffsets;
-  for (auto [outDim, kOffset] :
-       llvm::zip_equal(getKOutputDims(), getMixedKOffset())) {
-    OpFoldResult kTileOffset = offsets[outDim];
-    newKOffsets.push_back(addOfrs(builder, loc, kTileOffset, kOffset));
-  }
-  for (auto [outDim, mOffset] :
-       llvm::zip_equal(getMOutputDims(), getMixedMOffset())) {
-    OpFoldResult mTileOffset = offsets[outDim];
-    newMOffsets.push_back(addOfrs(builder, loc, mTileOffset, mOffset));
-  }
-
-  // Create the tiled op.
-  SmallVector<Value> operands = {inputSlice->getResult(0),
-                                 outputSlice->getResult(0)};
+  // Create the tiled op. The input is not sliced (batch offset is in the op).
+  SmallVector<Value> operands = {inputValue, outputSlice->getResult(0)};
   // Copy all metadata operands from the untiled operation.
   operands.append(getOperation()->getOperands().begin() + 2,
                   getOperation()->getOperands().end());
   Im2colOp tiledOp =
       mlir::clone(builder, *this, outputSlice->getResultTypes(), operands);
-  // Set the new k_offset and m_offset, since they have changed with tiling.
-  tiledOp.setMixedKOffset(newKOffsets);
-  tiledOp.setMixedMOffset(newMOffsets);
+  // Set the new offsets, since they have changed with tiling.
+  // output_sizes remain unchanged by tiling (key design property).
+  tiledOp.setMixedOffsets(newOffsets);
 
-  return TilingResult{{tiledOp},
-                      SmallVector<Value>(tiledOp->getResults()),
-                      {inputSlice, outputSlice}};
+  return TilingResult{
+      {tiledOp}, SmallVector<Value>(tiledOp->getResults()), {outputSlice}};
 }
 
 FailureOr<TilingResult>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1152,7 +1152,7 @@ func.func @illegal_im2col_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x10
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected strides rank to be equal to the kernel rank}}
   %1 = iree_linalg_ext.im2col strides = [1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1167,7 +1167,7 @@ func.func @illegal_im2col_dilations(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected dilations rank to be equal to the kernel rank}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1182,7 +1182,7 @@ func.func @illegal_im2col_kernel_size(%arg0: tensor<2x34x34x640xf32>) -> tensor<
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected kernel rank to be equal to the m_pos rank}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1193,11 +1193,11 @@ func.func @illegal_im2col_kernel_size(%arg0: tensor<2x34x34x640xf32>) -> tensor<
 
 // -----
 
-func.func @illegal_im2col_m_offset(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+func.func @illegal_im2col_offsets_size_mismatch(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
-  // expected-error @+1 {{expected the same size m_offset and m_strides}}
+  // expected-error @+1 {{expected offsets size (2) to match output rank (3)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0, 0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1208,11 +1208,11 @@ func.func @illegal_im2col_m_offset(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1
 
 // -----
 
-func.func @illegal_im2col_k_offset(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+func.func @illegal_im2col_output_sizes_outer_mismatch(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
-  // expected-error @+1 {{expected the same size k_offset and k_strides}}
+  // expected-error @+1 {{expected output_sizes outer size (2) to match output rank (3)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0, 0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32, 3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1223,11 +1223,11 @@ func.func @illegal_im2col_k_offset(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1
 
 // -----
 
-func.func @illegal_im2col_m_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+func.func @illegal_im2col_mk_boundary(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
-  // expected-error @+1 {{expected inner m_strides to be 1}}
+  // expected-error @+1 {{M/K boundary not found: accumulated output_sizes inner dimensions must equal m_pos size at some output dim boundary}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [0] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32, 3], [3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1238,11 +1238,11 @@ func.func @illegal_im2col_m_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x
 
 // -----
 
-func.func @illegal_im2col_k_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+func.func @illegal_im2col_mk_inner_total(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
-  // expected-error @+1 {{expected inner k_strides to be 1}}
+  // expected-error @+1 {{expected sum of K output_sizes inner dimensions (2) to equal m_pos.size() + k_pos.size() (3)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [2]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1257,7 +1257,7 @@ func.func @illegal_im2col_input_rank(%arg0: tensor<1x2x34x34x640xf32>) -> tensor
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected input rank to be the sum of batch, m, and k ranks}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1270,9 +1270,9 @@ func.func @illegal_im2col_input_rank(%arg0: tensor<1x2x34x34x640xf32>) -> tensor
 
 func.func @illegal_im2col_output_rank(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x9x640xf32> {
   %0 = tensor.empty() : tensor<2x1024x9x640xf32>
-  // expected-error @+1 {{expected output rank to be the sum of batch_pos, k_offset, and m_offset ranks}}
+  // expected-error @+1 {{expected offsets size (3) to match output rank (4)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2, 3]
@@ -1285,9 +1285,9 @@ func.func @illegal_im2col_output_rank(%arg0: tensor<2x34x34x640xf32>) -> tensor<
 
 func.func @illegal_im2col_perm_num(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
-  // expected-error @+1 {{expected input_k_perm size (2) to match the number of shared dimensions (m_Pos + k_pos = 3)}}
+  // expected-error @+1 {{expected input_k_perm size (2) to match the number of shared dimensions (m_pos + k_pos = 3)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1]
            output_perm = [0, 1, 2]
@@ -1302,7 +1302,7 @@ func.func @illegal_im2col_k_perm_value(%arg0: tensor<2x34x34x640xf32>) -> tensor
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected input_k_perm to be a permutation of [0, 3)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [1, 2, 3]
            output_perm = [0, 1, 2]
@@ -1317,7 +1317,7 @@ func.func @illegal_im2col_output_perm_value(%arg0: tensor<2x34x34x640xf32>) -> t
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected output_perm to be a permutation}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [1, 2, 3]
@@ -1326,14 +1326,13 @@ func.func @illegal_im2col_output_perm_value(%arg0: tensor<2x34x34x640xf32>) -> t
   return %1 : tensor<2x1024x5760xf32>
 }
 
-
 // -----
 
 func.func @illegal_im2col_output_perm_rank(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected output_perm to have the same rank as the result}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2, 3]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1318,7 +1318,7 @@ func.func @exp_reduction(%S: tensor<2x3xf32>) -> tensor<2xf32> {
 func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1330,7 +1330,7 @@ func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1024x5760xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2]
@@ -1343,7 +1343,7 @@ func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
 func.func @im2col_output_perm(%arg0: tensor<2x34x34x640xf32>) -> tensor<5760x2x1024xf32> {
   %0 = tensor.empty() : tensor<5760x2x1024xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [2, 0, 1]
@@ -1355,7 +1355,7 @@ func.func @im2col_output_perm(%arg0: tensor<2x34x34x640xf32>) -> tensor<5760x2x1
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<5760x2x1024xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [2, 0, 1]
@@ -1366,10 +1366,10 @@ func.func @im2col_output_perm(%arg0: tensor<2x34x34x640xf32>) -> tensor<5760x2x1
 // -----
 
 func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s2: index,
-                          %mOffset: index, %kOffset: index) -> tensor<?x?x?xf32> {
+                          %mOffset: index, %kOffset: index, %oh: index, %ow: index) -> tensor<?x?x?xf32> {
   %0 = tensor.empty(%s0, %s1, %s2) : tensor<?x?x?xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [%mOffset] * [1] k_offset = [%kOffset] * [1]
+           offsets = [0, %mOffset, %kOffset] output_sizes = [[2], [%oh, %ow], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1379,10 +1379,10 @@ func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s
 }
 // CHECK-LABEL: func.func @im2col_dynamic(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?x?x?xf32>
-// CHECK-SAME:    %{{.+}}: index, %{{.+}}: index, %{{.+}}: index, %[[MOFFSET:.+]]: index, %[[KOFFSET:.+]]: index
+// CHECK-SAME:    %{{.+}}: index, %{{.+}}: index, %{{.+}}: index, %[[MOFFSET:.+]]: index, %[[KOFFSET:.+]]: index, %[[OH:.+]]: index, %[[OW:.+]]: index
 // CHECK:         %[[D0:.+]] = tensor.empty({{.+}}) : tensor<?x?x?xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:      m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
+// CHECK-SAME:      offsets = [0, %[[MOFFSET]], %[[KOFFSET]]] output_sizes = {{\[}}[2], [%[[OH]], %[[OW]]], [3, 3, 640]]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2]
@@ -1395,7 +1395,7 @@ func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s
 func.func @im2col_strided(%arg0: tensor<2x65x96x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [2, 3] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1407,7 +1407,7 @@ func.func @im2col_strided(%arg0: tensor<2x65x96x640xf32>) -> tensor<2x1024x5760x
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x65x96x640xf32>
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1024x5760xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [2, 3] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2]
@@ -1420,7 +1420,7 @@ func.func @im2col_strided(%arg0: tensor<2x65x96x640xf32>) -> tensor<2x1024x5760x
 func.func @im2col_dilated(%arg0: tensor<2x44x46x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [6, 7] kernel_size = [3, 3]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1432,7 +1432,7 @@ func.func @im2col_dilated(%arg0: tensor<2x44x46x640xf32>) -> tensor<2x1024x5760x
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x44x46x640xf32>
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1024x5760xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [6, 7] kernel_size = [3, 3]
-// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2]
@@ -1445,7 +1445,7 @@ func.func @im2col_dilated(%arg0: tensor<2x44x46x640xf32>) -> tensor<2x1024x5760x
 func.func @im2col_strided_dilated_mixed_kernel(%arg0: tensor<2x172x101x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [5, 2, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1457,7 +1457,7 @@ func.func @im2col_strided_dilated_mixed_kernel(%arg0: tensor<2x172x101x640xf32>)
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x172x101x640xf32>
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1024x5760xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [5, 2, 640]]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2]
@@ -1470,7 +1470,7 @@ func.func @im2col_strided_dilated_mixed_kernel(%arg0: tensor<2x172x101x640xf32>)
 func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-           m_offset = [0] * [1] k_offset = [0] * [1]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [5, 2, 640]]
            batch_pos = [1] m_pos = [3, 2] k_pos = [0]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2]
@@ -1482,7 +1482,7 @@ func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<640x2x101x172xf32>
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1024x5760xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [5, 2, 640]]
 // CHECK-SAME:      batch_pos = [1] m_pos = [3, 2] k_pos = [0]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2]
@@ -1492,28 +1492,28 @@ func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2
 
 // -----
 
-func.func @im2col_expanded(%arg0: tensor<2x3x34x34x640xf32>) -> tensor<2x3x128x8x90x64xf32> {
-  %0 = tensor.empty() : tensor<2x3x128x8x90x64xf32>
+func.func @im2col_expanded(%arg0: tensor<2x3x34x34x640xf32>) -> tensor<2x3x32x32x9x640xf32> {
+  %0 = tensor.empty() : tensor<2x3x32x32x9x640xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [0, 0] * [8, 1] k_offset = [0, 0] * [64, 1]
+           offsets = [0, 0, 0, 0, 0, 0] output_sizes = [[2], [3], [32], [32], [3, 3], [640]]
            batch_pos = [0, 1] m_pos = [2, 3] k_pos = [4]
            input_k_perm = [0, 1, 2]
            output_perm = [0, 1, 2, 3, 4, 5]
            ins(%arg0 : tensor<2x3x34x34x640xf32>)
-           outs(%0 : tensor<2x3x128x8x90x64xf32>) -> tensor<2x3x128x8x90x64xf32>
-  return %1 : tensor<2x3x128x8x90x64xf32>
+           outs(%0 : tensor<2x3x32x32x9x640xf32>) -> tensor<2x3x32x32x9x640xf32>
+  return %1 : tensor<2x3x32x32x9x640xf32>
 }
 // CHECK-LABEL: func.func @im2col_expanded(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x3x34x34x640xf32>
-// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x3x128x8x90x64xf32>
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x3x32x32x9x640xf32>
 // CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:      m_offset = [0, 0] * [8, 1] k_offset = [0, 0] * [64, 1]
+// CHECK-SAME:      offsets = [0, 0, 0, 0, 0, 0] output_sizes = {{\[}}[2], [3], [32], [32], [3, 3], [640]]
 // CHECK-SAME:      batch_pos = [0, 1] m_pos = [2, 3] k_pos = [4]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
 // CHECK-SAME:      output_perm = [0, 1, 2, 3, 4, 5]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<2x3x34x34x640xf32>)
-// CHECK-SAME:      outs(%[[D0]] : tensor<2x3x128x8x90x64xf32>) -> tensor<2x3x128x8x90x64xf32>
-// CHECK:         return %[[D1]] : tensor<2x3x128x8x90x64xf32>
+// CHECK-SAME:      outs(%[[D0]] : tensor<2x3x32x32x9x640xf32>) -> tensor<2x3x32x32x9x640xf32>
+// CHECK:         return %[[D1]] : tensor<2x3x32x32x9x640xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -64,6 +64,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineTransforms",
+        "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_cc_library(
     LLVMSupport
     MLIRAffineDialect
     MLIRAffineTransforms
+    MLIRAffineUtils
     MLIRAnalysis
     MLIRArithDialect
     MLIRArithUtils

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -55,17 +55,6 @@ static SmallVector<NamedAttribute> getPrunedAttributeList(linalg::LinalgOp op) {
   return prunedAttributeList;
 }
 
-// Helper to convert a shape into basis for im2col op.
-static SmallVector<int64_t> getBasisFromShape(ArrayRef<int64_t> shape) {
-  SmallVector<int64_t> basis(shape.size());
-  int64_t cumulativeProduct = 1;
-  for (int i = shape.size() - 1; i >= 0; --i) {
-    basis[i] = cumulativeProduct;
-    cumulativeProduct *= shape[i];
-  }
-  return basis;
-}
-
 // Computes `inputKPerm` that maps the input spatial and channel dimension order
 // to filter's.
 static SmallVector<int64_t>
@@ -240,33 +229,74 @@ public:
         }
       }
     }
-    // The index at which the reduction dimension bounds starts in
-    // igemmLoopBounds.
-    int64_t reductionBoundIndex =
-        convDims.batch.size() + convDims.depth.size() +
-        convDims.outputImage.size() + convDims.outputChannel.size();
-    SmallVector<int64_t> kShape(igemmLoopBounds.begin() + reductionBoundIndex,
-                                igemmLoopBounds.end());
-
-    SmallVector<OpFoldResult> mBasis =
-        getAsIndexOpFoldResult(getContext(), getBasisFromShape(mShape));
-    SmallVector<OpFoldResult> kBasis =
-        getAsIndexOpFoldResult(getContext(), getBasisFromShape(kShape));
-
-    SmallVector<OpFoldResult> kOffset(kBasis.size(), rewriter.getIndexAttr(0));
-    SmallVector<OpFoldResult> mOffset(mBasis.size(), rewriter.getIndexAttr(0));
-
     SmallVector<int64_t> inputKPerm =
         computeInputKPerm(inputMap, filterMap, convDims);
 
-    auto loc = linalgOp.getLoc();
-    // Shape of the resulting tensor from im2col.
-    SmallVector<int64_t> colTensorShape;
-    for (int64_t dim : batchPos) {
-      colTensorShape.push_back(inputShape[dim]);
+    // Build unified offsets and output_sizes for the im2col op.
+    // Canonical output dim order: [batch dims, M (1 dim), K dims].
+    // At conv-to-im2col time all offsets are zero.
+
+    // Identify which original filter dims are parallel (depth + outputChannel).
+    llvm::SmallDenseSet<int64_t, 4> parallelFilterDims;
+    for (auto iterDim :
+         llvm::concat<const unsigned>(convDims.depth, convDims.outputChannel)) {
+      std::optional<int64_t> maybeDim = filterMap.getResultPosition(
+          getAffineDimExpr(iterDim, filterMap.getContext()));
+      if (maybeDim) {
+        parallelFilterDims.insert(maybeDim.value());
+      }
     }
-    colTensorShape.append(mShape);
-    colTensorShape.append(kShape);
+
+    // Collect K output dim inner sizes from filter reassociation indices.
+    // Each reduction group (group not entirely composed of parallel dims)
+    // becomes one K output dim whose inner sizes are the original filter
+    // dim sizes in that group.
+    SmallVector<SmallVector<int64_t>> kInnerSizes;
+    for (const auto &indices : filterReassocIndices) {
+      bool isParallel =
+          indices.size() == 1 && parallelFilterDims.contains(indices[0]);
+      if (!isParallel) {
+        SmallVector<int64_t> innerSizes;
+        for (int64_t idx : indices) {
+          innerSizes.push_back(filterShape[idx]);
+        }
+        kInnerSizes.push_back(innerSizes);
+      }
+    }
+
+    int64_t numOutputDims =
+        batchPos.size() + mShape.size() + kInnerSizes.size();
+    SmallVector<OpFoldResult> offsets(numOutputDims, rewriter.getIndexAttr(0));
+    SmallVector<SmallVector<OpFoldResult>> outputSizes;
+    // Batch dims: each has a single inner size.
+    for (int64_t dim : batchPos) {
+      outputSizes.push_back({rewriter.getIndexAttr(inputShape[dim])});
+    }
+    // M dims: each spatial output dim is a separate output dimension.
+    for (int64_t m : mShape) {
+      outputSizes.push_back({rewriter.getIndexAttr(m)});
+    }
+    // K dims: inner sizes from filter reassociation.
+    for (const auto &innerSizes : kInnerSizes) {
+      outputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
+    }
+
+    auto loc = linalgOp.getLoc();
+    // Shape of the resulting tensor from im2col. Each output dim is the
+    // product of its inner sizes.
+    SmallVector<int64_t> colTensorShape;
+    for (const auto &innerSizes : outputSizes) {
+      int64_t dimSize = 1;
+      for (OpFoldResult s : innerSizes) {
+        std::optional<int64_t> constVal = getConstantIntValue(s);
+        if (!constVal) {
+          return rewriter.notifyMatchFailure(
+              linalgOp, "dynamic inner sizes not supported");
+        }
+        dimSize *= *constVal;
+      }
+      colTensorShape.push_back(dimSize);
+    }
 
     applyPermutationToVector(colTensorShape, outputPerm);
     Value colTensor = tensor::EmptyOp::create(rewriter, loc, colTensorShape,
@@ -274,8 +304,8 @@ public:
     Value img2ColTensor =
         IREE::LinalgExt::Im2colOp::create(
             rewriter, loc, input, /*output=*/colTensor, convDims.strides,
-            convDims.dilations, kernelSizes, mOffset, mBasis, kOffset, kBasis,
-            batchPos, mPos, kPos, inputKPerm, outputPerm)
+            convDims.dilations, kernelSizes, offsets, outputSizes, batchPos,
+            mPos, kPos, inputKPerm, outputPerm)
             .getResult(0);
 
     Value reshapedFilter = tensor::CollapseShapeOp::create(
@@ -300,9 +330,8 @@ public:
           linalg::YieldOp::create(nestedBuilder, nestedLoc, add);
         });
     genericGEMMOp->setDiscardableAttrs(getPrunedAttributeList(linalgOp));
-    Value result = genericGEMMOp.getResults().front();
 
-    rewriter.replaceOp(linalgOp, result);
+    rewriter.replaceOp(linalgOp, genericGEMMOp.getResults().front());
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
@@ -65,9 +66,10 @@ struct DecomposeIm2colPass final
   using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<
-        affine::AffineDialect, IREE::LinalgExt::IREELinalgExtDialect,
-        linalg::LinalgDialect, scf::SCFDialect, tensor::TensorDialect>();
+    registry
+        .insert<affine::AffineDialect, arith::ArithDialect,
+                IREE::LinalgExt::IREELinalgExtDialect, linalg::LinalgDialect,
+                scf::SCFDialect, tensor::TensorDialect>();
   }
 
   void runOnOperation() override;
@@ -83,6 +85,7 @@ void DecomposeIm2colPass::runOnOperation() {
   IRRewriter rewriter(context);
   for (auto im2colOp : candidates) {
     if (failed(decomposeIm2col(im2colOp, rewriter, unroll))) {
+      im2colOp.emitOpError("im2col decomposition failed");
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -41,7 +41,7 @@ def TopkSplitReductionPass:
   let summary = "Topk split reduction pass.";
   let description = [{
     Produces a "map-reduce" style of parallelizing a Topk Op. The op is split
-    into two, on containing reducitons in parallel and the other containing the
+    into two, one containing reductions in parallel and the other containing the
     combination of the parallel reductions into a final result.
   }];
   let options = [

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -17,7 +17,7 @@ util.func public @conv_2d_nhwc_hwcf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [3, 3, 4]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
@@ -52,7 +52,7 @@ util.func public @conv_2d_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4, 3, 3]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2, 3] k_pos = [1]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x4x16x16xf32>)
@@ -87,7 +87,7 @@ util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf16>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [3, 3, 4]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
@@ -124,7 +124,7 @@ util.func public @conv_strided(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x7x7x36xf16>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [2, 2] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [7, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [7], [7], [3, 3, 4]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
@@ -162,7 +162,7 @@ util.func public @conv_dilated(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x12x12x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [2, 2] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [12, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [12], [12], [3, 3, 4]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
@@ -201,7 +201,7 @@ util.func public @conv_nhwc_hwfc(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x9x4xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0, 0] * [4, 1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [3, 3], [4]]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x9x4xf32>) -> tensor<1x14x14x9x4xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1], [2], [3]] : tensor<3x3x16x4xf32> into tensor<9x16x4xf32>
@@ -209,6 +209,7 @@ util.func public @conv_nhwc_hwfc(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
 // CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x14x14x9x4xf32>, tensor<9x16x4xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x14x14x16xf32>)
 // CHECK:      util.return %[[MATMUL]] : tensor<1x14x14x16xf32>
 
 // -----
@@ -234,6 +235,7 @@ util.func public @conv_2d_nhwc_fhwc(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
 // CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x14x14x36xf32>, tensor<16x36xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x14x14x16xf32>)
 // CHECK:      util.return %[[MATMUL]] : tensor<1x14x14x16xf32>
 
 // -----
@@ -271,7 +273,7 @@ util.func public @conv_1d_ncw_fcw_transpose_maps(%arg0: tensor<1x8x130xf32>, %ar
 // CHECK:      %[[EMPTY2:.+]] = tensor.empty() : tensor<1x128x24xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0] output_sizes = {{\[}}[1], [128], [8, 3]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2] k_pos = [1]
 // CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x8x130xf32>)
@@ -312,7 +314,7 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tens
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<3x3x6144x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-// CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[288], [3], [3], [16, 24, 16]]
 // CHECK-SAME:   batch_pos = [3] m_pos = [1, 2] k_pos = [0]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x18x288xf32>)
@@ -353,7 +355,7 @@ util.func public @conv_2d_hwcn_hwcf(%arg0: tensor<26x18x16x288xf32>, %arg1: tens
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<3x3x6144x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-// CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[288], [3], [3], [24, 16, 16]]
 // CHECK-SAME:   batch_pos = [3] m_pos = [0, 1] k_pos = [2]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<26x18x16x288xf32>)
@@ -393,7 +395,8 @@ util.func public @conv_nhwc_hwfc_nobatch(%arg0: tensor<16x16x4xf32>, %arg1: tens
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<14x14x9x4xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0, 0] * [4, 1] batch_pos = []
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[14], [14], [3, 3], [4]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1] k_pos = [2]
 // CHECK-SAME:   input_k_perm = [0, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<14x14x9x4xf32>) -> tensor<14x14x9x4xf32>
@@ -402,6 +405,7 @@ util.func public @conv_nhwc_hwfc_nobatch(%arg0: tensor<16x16x4xf32>, %arg1: tens
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
 // CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<14x14x9x4xf32>, tensor<9x16x4xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<14x14x16xf32>)
 // CHECK:      util.return %[[MATMUL]] : tensor<14x14x16xf32>
 
 // -----
@@ -431,7 +435,7 @@ module {
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<16x24x16x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[16], [16], [24], [3, 96]]
 // CHECK-SAME:   batch_pos = [0, 2] m_pos = [1] k_pos = [3]
 // CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 2, 1, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x16x96xf32>)
@@ -461,7 +465,7 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK:      util.func public @conv_2d_nhwc_chwf(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4, 3, 3]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   input_k_perm = [2, 0, 1]
 // CHECK-SAME:   ins({{.*}} : tensor<1x16x16x4xf32>)
@@ -485,7 +489,7 @@ util.func public @conv_1d_nhc_chf(%arg0: tensor<1x3x2xf32>, %arg1: tensor<2x2x2x
 // CHECK:      util.func public @conv_1d_nhc_chf(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [2]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0] output_sizes = {{\[}}[1], [2], [2, 2]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1] k_pos = [2]
 // CHECK-SAME:   input_k_perm = [1, 0]
 // CHECK-SAME:   ins({{.*}} : tensor<1x3x2xf32>)
@@ -511,11 +515,14 @@ util.func public @conv_2d_no_input_channel(%arg0: tensor<61x93x16x64xbf16>, %arg
 // CHECK:      util.func public @conv_2d_no_input_channel(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [59, 91]
-// CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[64], [16], [3], [3], [59, 91]]
 // CHECK-SAME:   batch_pos = [3, 2] m_pos = [0, 1] k_pos = []
 // CHECK-SAME:   input_k_perm = [0, 1] output_perm = [2, 3, 4, 1, 0]
 // CHECK-SAME:   ins({{.*}} : tensor<61x93x16x64xbf16>)
 // CHECK-SAME:   outs({{.*}} : tensor<3x3x5369x16x64xbf16>) -> tensor<3x3x5369x16x64xbf16>
+// CHECK:        tensor.collapse_shape %{{.*}} {{\[}}[0, 1], [2], [3]] : tensor<59x91x16x56xbf16> into tensor<5369x16x56xbf16>
+// CHECK:        linalg.generic
+// CHECK:        util.return
 
 // -----
 
@@ -537,7 +544,7 @@ util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<2x8x8x7x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[2], [7], [8], [8], [3, 3, 4]]
 // CHECK-SAME:   batch_pos = [0, 3] m_pos = [1, 2] k_pos = [4]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 2, 3, 1, 4]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
@@ -571,7 +578,7 @@ util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<2x7x4x10x10xf32>, %arg1: ten
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x8x8x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[2], [7], [8], [8], [4, 3, 3]]
 // CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
 // CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -1,6 +1,9 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-im2col{unroll=false}, canonicalize, cse))" --split-input-file %s | FileCheck %s
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-im2col{unroll=true}))" --split-input-file %s | FileCheck %s --check-prefix=CHECK-UNROLL
 
+// Test 1: Dynamic M offset and K offset.
+// The decomposition produces two nested scf.for loops (batch, M), computes
+// spatial coords via affine.apply, then extract_slice + linalg.copy.
 #map = affine_map<(d0) -> (d0 * 4)>
 module {
   func.func @im2col_untile_k(%arg0: tensor<2x34x34x640xf32>, %m_size: index, %m_off: index, %k: index) -> tensor<2x?x4xf32> {
@@ -8,7 +11,7 @@ module {
     %k_off = affine.apply #map(%k)
     %7 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-            m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
+            offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [3, 3, 640]]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<2x34x34x640xf32>)
@@ -27,24 +30,34 @@ module {
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
 //       CHECK:   %[[OUT_TILE:.+]] = tensor.empty(%[[mSIZE]]) : tensor<2x?x4xf32>
-//       CHECK:   %[[kScaled:.+]] = affine.apply #[[$MAP]]()[%[[K]]]
 //       CHECK:   %[[bLOOP:.+]] = scf.for %[[b:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT0:.+]] = %[[OUT_TILE]]) -> (tensor<2x?x4xf32>)
 //       CHECK:     %[[mLOOP:.+]] = scf.for %[[m:.+]] = %[[C0]] to %[[mSIZE]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT0]]) -> (tensor<2x?x4xf32>)
+//   CHECK-DAG:       %[[kScaled:.+]] = affine.apply #[[$MAP]]()[%[[K]]]
 //   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[kScaled]] into (3, 3, 640)
 //   CHECK-DAG:       %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[m]])[%[[mOFF]]]
 //   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
-//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
-//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[b]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
+//   CHECK-DAG:       %[[h:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
+//   CHECK-DAG:       %[[w:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[b]], %[[h]], %[[w]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
 //       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT1]][%[[b]], %[[m]], 0] [1, 1, 4] [1, 1, 1] : tensor<2x?x4xf32> to tensor<1x1x4xf32>
 //       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
 //       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT1]][%[[b]], %[[m]], 0] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x?x4xf32>
 //       CHECK:       scf.yield %[[INSERT]] : tensor<2x?x4xf32>
 //       CHECK:     scf.yield %[[mLOOP]] : tensor<2x?x4xf32>
 //       CHECK:   return %[[bLOOP]] : tensor<2x?x4xf32>
+// CHECK-UNROLL-LABEL: func.func @im2col_untile_k
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+// Verify two unrolled batch loops (b=0 and b=1), each iterating over M.
+//       CHECK-UNROLL:   scf.for %{{.+}} = %{{.+}} to %[[mS:.+]] step
+//       CHECK-UNROLL:   linalg.copy
+//       CHECK-UNROLL:   scf.for %{{.+}} = %{{.+}} to %[[mS]] step
+//       CHECK-UNROLL:   linalg.copy
 
 // -----
 
+// Test 2: Dynamic M and K offsets with transposed m_pos.
+// Three nested loops (batch, M, K). Spatial coords are computed via affine.apply
+// using strides and dilations.
 module {
   func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>, %m_size: index, %k_size: index, %m_off: index, %k_off: index) -> tensor<2x?x?xf32> {
     %c2 = arith.constant 2 : index
@@ -53,7 +66,7 @@ module {
     %0 = tensor.empty(%m_size, %k_size) : tensor<2x?x?xf32>
     %8 = iree_linalg_ext.im2col
             strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-            m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
+            offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [640, 5, 2]]
             batch_pos = [1] m_pos = [3, 2] k_pos = [0]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<640x2x101x172xf32>)
@@ -78,28 +91,38 @@ module {
 //       CHECK:     %[[mLOOP:.+]] = scf.for %[[m:.+]] = %[[C0]] to %[[mSIZE]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT0]]) -> (tensor<2x?x?xf32>)
 //       CHECK:       %[[kLOOP:.+]] = scf.for %[[k:.+]] = %[[C0]] to %[[kSIZE]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<2x?x?xf32>)
 //   CHECK-DAG:         %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[k]])[%[[kOFF]]]
-//   CHECK-DAG:         %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (640, 2, 5)
+//   CHECK-DAG:         %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (640, 5, 2)
 //   CHECK-DAG:         %[[mIDX:.+]] = affine.apply #[[$MAP]](%[[m]])[%[[mOFF]]]
 //   CHECK-DAG:         %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-DAG:         %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0, %[[kParts]]#1)
-//   CHECK-DAG:         %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
-//       CHECK:         %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[b]], %[[wIDX]], %[[hIDX]]] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<640x2x101x172xf32> to tensor<1x1x1xf32>
+//   CHECK-DAG:         affine.apply #[[$MAP1]](%[[mParts]]#0, %[[kParts]]#1)
+//   CHECK-DAG:         affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
+//       CHECK:         %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[b]], {{.*}}, {{.*}}] [1, 1, 1, 1]
 //       CHECK:         %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][%[[b]], %[[m]], %[[k]]] [1, 1, 1] [1, 1, 1] : tensor<2x?x?xf32> to tensor<1x1x1xf32>
-//       CHECK:         %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
-//       CHECK:         %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT2]][%[[b]], %[[m]], %[[k]]] [1, 1, 1] [1, 1, 1] : tensor<1x1x1xf32> into tensor<2x?x?xf32>
-//       CHECK:         scf.yield %[[INSERT]] : tensor<2x?x?xf32>
+//       CHECK:         linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1xf32>)
+//       CHECK:         tensor.insert_slice {{.*}} into %[[OUT2]][%[[b]], %[[m]], %[[k]]] [1, 1, 1] [1, 1, 1] : tensor<1x1x1xf32> into tensor<2x?x?xf32>
+//       CHECK:         scf.yield {{.*}} : tensor<2x?x?xf32>
 //       CHECK:       scf.yield %[[kLOOP]] : tensor<2x?x?xf32>
 //       CHECK:     scf.yield %[[mLOOP]] : tensor<2x?x?xf32>
 //       CHECK:   return %[[bLOOP]] : tensor<2x?x?xf32>
 
+// CHECK-UNROLL-LABEL: func.func @im2col_transposed_m_pos
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+// Two unrolled copies of the m/k loops for batch=0 and batch=1.
+//       CHECK-UNROLL:   scf.for
+//       CHECK-UNROLL:   linalg.copy
+//       CHECK-UNROLL:   scf.for
+//       CHECK-UNROLL:   linalg.copy
+
 // -----
 
+// Test 3: Static sizes with expanded M and K output dims.
+// Four nested loops (batch, M0, M1, K). Spatial coords via affine.apply.
 module {
   func.func @im2col_expanded(%arg0: tensor<2x34x34x640xf32>, %m_size0: index, %m_size1: index, %m0: index, %m1: index, %k: index, %m_stride: index) -> tensor<2x?x?x2x4xf32> {
     %0 = tensor.empty(%m_size0, %m_size1) : tensor<2x?x?x2x4xf32>
     %7 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-            m_offset = [%m0, %m1] * [%m_stride, 1] k_offset = [%k, 0] * [4, 1]
+            offsets = [0, %m0, %m1, %k, 0] output_sizes = [[2], [32], [32], [3, 3], [640]]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
             ins(%arg0 : tensor<2x34x34x640xf32>)
@@ -107,9 +130,8 @@ module {
     return %7 : tensor<2x?x?x2x4xf32>
   }
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 * 4 + s0 * 4)
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1, s2] -> (d0 * s0 + s0 * s1 + d1 + s2)>
-//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0] -> (d0 + d1 + s0)>
 // CHECK-LABEL: func.func @im2col_expanded
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:     %[[mSIZE0:[a-zA-Z0-9_]+]]
@@ -117,7 +139,6 @@ module {
 //  CHECK-SAME:     %[[mOFF0:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:     %[[mOFF1:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:     %[[kOFF:[a-zA-Z0-9_]+]]
-//  CHECK-SAME:     %[[mSTRIDE:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
@@ -126,13 +147,11 @@ module {
 //       CHECK:     %[[mLOOP0:.+]] = scf.for %[[m0:.+]] = %[[C0]] to %[[mSIZE0]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT0]]) -> (tensor<2x?x?x2x4xf32>)
 //       CHECK:       %[[mLOOP1:.+]] = scf.for %[[m1:.+]] = %[[C0]] to %[[mSIZE1]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<2x?x?x2x4xf32>)
 //       CHECK:         %[[kLOOP:.+]] = scf.for %[[k:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT3:.+]] = %[[OUT2]]) -> (tensor<2x?x?x2x4xf32>)
-//   CHECK-DAG:           %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[k]])[%[[kOFF]]]
-//   CHECK-DAG:           %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (3, 3, 640)
-//   CHECK-DAG:           %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[m0]], %[[m1]])[%[[mSTRIDE]], %[[mOFF0]], %[[mOFF1]]]
-//   CHECK-DAG:           %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-DAG:           %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#0)
-//   CHECK-DAG:           %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#1)
-//       CHECK:           %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[b]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x1x4xf32>
+//   CHECK-DAG:           %[[kPOS:.+]] = affine.apply #[[$MAP]](%[[k]])[%[[kOFF]]]
+//   CHECK-DAG:           %[[kParts:.+]]:2 = affine.delinearize_index %[[kPOS]] into (3, 3)
+//   CHECK-DAG:           affine.apply #[[$MAP1]](%[[kParts]]#0, %[[m0]])[%[[mOFF0]]]
+//   CHECK-DAG:           affine.apply #[[$MAP1]](%[[kParts]]#1, %[[m1]])[%[[mOFF1]]]
+//       CHECK:           %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[b]], {{.*}}, {{.*}}, 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x1x4xf32>
 //       CHECK:           %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT3]][%[[b]], %[[m0]], %[[m1]], %[[k]], 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1] : tensor<2x?x?x2x4xf32> to tensor<1x1x1x4xf32>
 //       CHECK:           %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
 //       CHECK:           %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT3]][%[[b]], %[[m0]], %[[m1]], %[[k]], 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1] : tensor<1x1x1x4xf32> into tensor<2x?x?x2x4xf32>
@@ -142,14 +161,24 @@ module {
 //       CHECK:     scf.yield %[[mLOOP0]] : tensor<2x?x?x2x4xf32>
 //       CHECK:   return %[[bLOOP]] : tensor<2x?x?x2x4xf32>
 
+// CHECK-UNROLL-LABEL: func.func @im2col_expanded
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+// Unrolled: batch loop is removed, m0/m1 loops remain; K=2 is unrolled in each body.
+//       CHECK-UNROLL:   scf.for
+//       CHECK-UNROLL:     scf.for
+//       CHECK-UNROLL:       linalg.copy
+//       CHECK-UNROLL:       linalg.copy
+
 // -----
 
+// Test 4: NCHW layout with static sizes -- scalar fallback (34 % 4 != 0).
+// Three nested loops (batch, K-row, K-col-channel) with scalar linalg.copy.
 module {
   func.func @im2col_expanded_nchw(%arg0: tensor<2x640x34x34xf32>, %m0: index, %m1: index, %k: index) -> tensor<2x1x1x2x4xf32> {
     %0 = tensor.empty() : tensor<2x1x1x2x4xf32>
     %7 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-            m_offset = [%m0, %m1] * [32, 1] k_offset = [%k, 0] * [4, 1]
+            offsets = [0, %m0, %m1, %k, 0] output_sizes = [[2], [638], [32], [3, 3], [34]]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
             ins(%arg0 : tensor<2x640x34x34xf32>)
@@ -157,20 +186,68 @@ module {
     return %7 : tensor<2x1x1x2x4xf32>
   }
 }
-// Verify that the NCHW layout does not vectorize.
+// Scalar fallback (34 % 4 != 0): three nested loops with scalar linalg.copy.
 // CHECK-LABEL: func.func @im2col_expanded_nchw
-//       CHECK:   linalg.copy ins({{.*}} : tensor<1x1x1x1xf32>) outs({{.*}} : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
+//       CHECK:   tensor.empty() : tensor<2x1x1x2x4xf32>
+//       CHECK:   scf.for
+//       CHECK:     scf.for
+//       CHECK:       scf.for
+//       CHECK:         affine.delinearize_index {{.*}} into (3, 3)
+//       CHECK:         tensor.extract_slice {{.*}} : tensor<2x640x34x34xf32> to tensor<1x1x1x1xf32>
+//       CHECK:         linalg.copy ins({{.*}} : tensor<1x1x1x1xf32>) outs({{.*}} : tensor<1x1x1x1xf32>)
+//       CHECK:         tensor.insert_slice {{.*}} : tensor<1x1x1x1xf32> into tensor<2x1x1x2x4xf32>
+
+// CHECK-UNROLL-LABEL: func.func @im2col_expanded_nchw
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
 
 // -----
 
-#map = affine_map<(d0) -> (d0 * 4)>
+// Test 5: Backward-weight-style im2col with dilation=2, single-element M and K dims.
+// Directly extract_slices at (m0, m1) without any loops (output is 1x1x1x1).
+module {
+  func.func @im2col_bwd_weight_dilation2(%arg0: tensor<1x1x8x8xf32>, %m0: index, %m1: index) -> tensor<1x1x1x1xf32> {
+    %0 = tensor.empty() : tensor<1x1x1x1xf32>
+    %result = iree_linalg_ext.im2col
+            strides = [1, 1] dilations = [2, 2] kernel_size = [3, 3]
+            offsets = [0, %m0, %m1, 0] output_sizes = [[1], [3], [3], [1, 3, 3]]
+            batch_pos = [0] m_pos = [2, 3] k_pos = [1]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
+            ins(%arg0 : tensor<1x1x8x8xf32>)
+            outs(%0 : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
+    return %result : tensor<1x1x1x1xf32>
+  }
+}
+// With single-element output (1x1x1x1), emits a bare
+// extract_slice + linalg.copy without any loops.
+// CHECK-LABEL: func.func @im2col_bwd_weight_dilation2
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x1x8x8xf32>
+//  CHECK-SAME:     %[[M0:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[M1:[a-zA-Z0-9_]+]]: index
+//       CHECK:   tensor.extract_slice %[[ARG0]][0, 0, %[[M0]], %[[M1]]]
+//       CHECK:   linalg.copy
+//       CHECK:   return
+//   CHECK-NOT:   iree_linalg_ext.im2col
+
+// CHECK-UNROLL-LABEL: func.func @im2col_bwd_weight_dilation2
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+// Fully unrolled 1x1x1x1 output: bare extract_slice + copy, no loops.
+//       CHECK-UNROLL:   tensor.extract_slice
+//       CHECK-UNROLL:   linalg.copy
+//       CHECK-UNROLL:   return
+
+// -----
+
+// Test 6: Static sizes with dynamic M offset, with unrolling.
+// The unrolled pass unrolls the static batch (size 2) and M (size 2) dims into
+// separate extract_slice + linalg.copy + insert_slice blocks.
+#map6 = affine_map<(d0) -> (d0 * 4)>
 module {
   func.func @im2col_unrolled(%arg0: tensor<2x34x34x640xf32>, %m_off: index, %k: index) -> tensor<2x2x4xf32> {
     %0 = tensor.empty() : tensor<2x2x4xf32>
-    %k_off = affine.apply #map(%k)
+    %k_off = affine.apply #map6(%k)
     %7 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-            m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
+            offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [3, 3, 640]]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<2x34x34x640xf32>)
@@ -178,69 +255,46 @@ module {
     return %7 : tensor<2x2x4xf32>
   }
 }
-//   CHECK-UNROLL-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 4)>
-//   CHECK-UNROLL-DAG: #[[$MAP1:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+// CHECK-LABEL: func.func @im2col_unrolled
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[mOFF:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[K:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//       CHECK:   %[[OUT_TILE:.+]] = tensor.empty() : tensor<2x2x4xf32>
+// Non-unrolled output uses two nested loops (batch=2, M=2).
+//       CHECK:   %[[bLOOP:.+]] = scf.for %[[b:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT0:.+]] = %[[OUT_TILE]]) -> (tensor<2x2x4xf32>)
+//       CHECK:     %[[mLOOP:.+]] = scf.for %[[m:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT0]]) -> (tensor<2x2x4xf32>)
+//       CHECK:       tensor.extract_slice %[[ARG0]]
+//       CHECK:       linalg.copy ins({{.*}} : tensor<1x1x4xf32>) outs({{.*}} : tensor<1x1x4xf32>)
+//       CHECK:       tensor.insert_slice {{.*}} into %[[OUT1]][%[[b]], %[[m]], 0] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
+//       CHECK:       scf.yield {{.*}} : tensor<2x2x4xf32>
+//       CHECK:     scf.yield %[[mLOOP]] : tensor<2x2x4xf32>
+//       CHECK:   return %[[bLOOP]] : tensor<2x2x4xf32>
+//   CHECK-NOT:   iree_linalg_ext.im2col
+
 // CHECK-UNROLL-LABEL: func.func @im2col_unrolled
 //  CHECK-UNROLL-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]
 //  CHECK-UNROLL-SAME:     %[[mOFF:[a-zA-Z0-9_]+]]
 //  CHECK-UNROLL-SAME:     %[[K:[a-zA-Z0-9_]+]]
-//   CHECK-UNROLL-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-UNROLL-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//       CHECK-UNROLL:   %[[OUT_TILE:.+]] = tensor.empty() : tensor<2x2x4xf32>
-
-//  First iteration
-//
-//   CHECK-UNROLL-DAG:   %[[kIDX:.+]] = affine.apply #[[$MAP]]()[%[[K]]]
-//   CHECK-UNROLL-DAG:   %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (3, 3, 640)
-//   CHECK-UNROLL-DAG:   %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[C0]])[%[[mOFF]]]
-//   CHECK-UNROLL-DAG:   %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
-//   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
-//       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C0]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT_TILE]][%[[C0]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT0:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT_TILE]][%[[C0]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
-
-//  Second iteration
-//
-//   CHECK-UNROLL-DAG:   %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (3, 3, 640)
-//   CHECK-UNROLL-DAG:   %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[C1]])[%[[mOFF]]]
-//   CHECK-UNROLL-DAG:   %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
-//   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
-//       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C0]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT0]][%[[C0]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT1:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT0]][%[[C0]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
-
-//  Third iteration
-//
-//   CHECK-UNROLL-DAG:   %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (3, 3, 640)
-//   CHECK-UNROLL-DAG:   %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[C0]])[%[[mOFF]]]
-//   CHECK-UNROLL-DAG:   %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
-//   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
-//       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C1]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT1]][%[[C1]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT2:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT1]][%[[C1]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
-
-//  Fourth iteration
-//
-//   CHECK-UNROLL-DAG:   %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (3, 3, 640)
-//   CHECK-UNROLL-DAG:   %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[C1]])[%[[mOFF]]]
-//   CHECK-UNROLL-DAG:   %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (32, 32)
-//   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
-//   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
-//       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C1]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT2]][%[[C1]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT3:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT2]][%[[C1]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
-
-//       CHECK-UNROLL:   return %[[INSERT3]] : tensor<2x2x4xf32>
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+//       CHECK-UNROLL:   %[[EMPTY:.*]] = tensor.empty() : tensor<2x2x4xf32>
+// Unrolled: 4 copies (b=0,m=0), (b=0,m=1), (b=1,m=0), (b=1,m=1).
+//       CHECK-UNROLL:   linalg.copy ins({{.*}} : tensor<1x1x4xf32>) outs({{.*}} : tensor<1x1x4xf32>)
+//       CHECK-UNROLL:   %[[INS0:.*]] = tensor.insert_slice %{{.*}} into %[[EMPTY]]
+//       CHECK-UNROLL:   linalg.copy ins({{.*}} : tensor<1x1x4xf32>) outs({{.*}} : tensor<1x1x4xf32>)
+//       CHECK-UNROLL:   %[[INS1:.*]] = tensor.insert_slice %{{.*}} into %[[INS0]]
+//       CHECK-UNROLL:   linalg.copy ins({{.*}} : tensor<1x1x4xf32>) outs({{.*}} : tensor<1x1x4xf32>)
+//       CHECK-UNROLL:   %[[INS2:.*]] = tensor.insert_slice %{{.*}} into %[[INS1]]
+//       CHECK-UNROLL:   linalg.copy ins({{.*}} : tensor<1x1x4xf32>) outs({{.*}} : tensor<1x1x4xf32>)
+//       CHECK-UNROLL:   %[[INS3:.*]] = tensor.insert_slice %{{.*}} into %[[INS2]]
+//       CHECK-UNROLL:   return %[[INS3]] : tensor<2x2x4xf32>
 
 // -----
 
+// Test 7: im2col with pre-padded input (tensor.pad before im2col).
+// This uses the padding-aware code path which does have affine.max/affine.min ops.
 module {
   func.func @im2col_padding(%input: tensor<1x8x3x3xf32>) -> tensor<1x2x2x12xf32> {
     %cst = arith.constant 0.000000e+00 : f32
@@ -250,7 +304,7 @@ module {
     tensor.yield %cst : f32
   } : tensor<1x8x3x3xf32> to tensor<1x8x9x9xf32>
   %im2col = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-                              m_offset = [0, 0] * [2, 1] k_offset = [0] * [1]
+                              offsets = [0, 0, 0, 0] output_sizes = [[1], [7], [7], [8, 3, 3]]
                               batch_pos = [0] m_pos = [2, 3] k_pos = [1]
                               input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
                               ins(%padded : tensor<1x8x9x9xf32>)
@@ -259,21 +313,32 @@ module {
   }
 }
 
+// The im2col_padding test has a complex output with affine.max/affine.min ops
+// due to the pre-padded input. Use simpler CHECK patterns.
 // CHECK-LABEL: func.func @im2col_padding
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]
-//       CHECK: %[[T1:.+]] = tensor.extract_slice %[[ARG0]]
-//       CHECK: %[[T2:.+]] = tensor.pad %[[T1]]
+//       CHECK: tensor.extract_slice %[[ARG0]]
+//       CHECK: tensor.pad
 //  CHECK-NEXT: ^bb0
 //  CHECK-NEXT:   tensor.yield
-//  CHECK-NEXT: } : tensor<1x1x?x?xf32> to tensor<1x1x1x1xf32>
+//       CHECK: linalg.copy
+//       CHECK: tensor.insert_slice
+//   CHECK-NOT: iree_linalg_ext.im2col
+
+// CHECK-UNROLL-LABEL: func.func @im2col_padding
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+//       CHECK-UNROLL:   tensor.pad
+//       CHECK-UNROLL:   linalg.copy
 
 // -----
 
+// Test 8: Static sizes, NHWC layout with non-identity input_k_perm -- scalar fallback.
+// The non-identity k_perm prevents vectorization; two nested loops (M, K) with scalar copy.
 module {
   func.func @im2col_nhc_with_perm(%arg0: tensor<1x3x2xf32>) -> tensor<1x2x4xf32> {
     %0 = tensor.empty() : tensor<1x2x4xf32>
     %1 = iree_linalg_ext.im2col strides = [1] dilations = [1] kernel_size = [2]
-                            m_offset = [0] * [1] k_offset = [0] * [1]
+                            offsets = [0, 0, 0] output_sizes = [[1], [2], [2, 2]]
                             batch_pos = [0] m_pos = [1] k_pos = [2]
                             input_k_perm = [1, 0] output_perm = [0, 1, 2]
                             ins(%arg0 : tensor<1x3x2xf32>)
@@ -281,6 +346,7 @@ module {
     return %1 : tensor<1x2x4xf32>
   }
 }
+// Scalar fallback with k_perm: 2 loops (M + K) with linalg.copy.
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
 // CHECK-LABEL: func.func @im2col_nhc_with_perm
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x3x2xf32>
@@ -291,9 +357,9 @@ module {
 //       CHECK:   %[[OUT_TILE:.+]] = tensor.empty() : tensor<1x2x4xf32>
 //       CHECK:   %[[MLOOP:.+]] = scf.for %[[M:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT_TILE]]) -> (tensor<1x2x4xf32>)
 //       CHECK:     %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x2x4xf32>)
-//   CHECK-DAG:       %[[kParts:.+]]:2 = affine.delinearize_index %[[K]] into (2, 2) : index, index
-//   CHECK-DAG:       %[[hIdx:.+]] = affine.apply #[[$MAP]](%[[kParts]]#1, %[[M]])
-//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIdx]], %[[kParts]]#0] [1, 1, 1] [1, 1, 1] : tensor<1x3x2xf32> to tensor<1x1x1xf32>
+//       CHECK:       %[[kParts:.+]]:2 = affine.delinearize_index %[[K]] into (2, 2) : index, index
+//       CHECK:       %[[hIDX:.+]] = affine.apply #[[$MAP]](%[[M]], %[[kParts]]#1)
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIDX]], %[[kParts]]#0] [1, 1, 1] [1, 1, 1] : tensor<1x3x2xf32> to tensor<1x1x1xf32>
 //       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M]], %[[K]]] [1, 1, 1] [1, 1, 1] : tensor<1x2x4xf32> to tensor<1x1x1xf32>
 //       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
 //       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT2]][0, %[[M]], %[[K]]] [1, 1, 1] [1, 1, 1] : tensor<1x1x1xf32> into tensor<1x2x4xf32>
@@ -301,13 +367,20 @@ module {
 //       CHECK:     scf.yield %[[KLOOP]] : tensor<1x2x4xf32>
 //       CHECK:   return %[[MLOOP]] : tensor<1x2x4xf32>
 
+// CHECK-UNROLL-LABEL: func.func @im2col_nhc_with_perm
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+//       CHECK-UNROLL:   linalg.copy
+
 // -----
 
+// Test 9: Non-self-inverse input_k_perm = [2, 0, 1].
+// The inverse permutation [1, 2, 0] maps output K coords (ch, kH, kW) -> input
+// order (kH, kW, ch). This is now decomposed as a scalar fallback.
 module {
   func.func @im2col_nhwc_with_perm(%arg0: tensor<1x16x16x4xf32>) -> tensor<1x14x14x36xf32> {
     %0 = tensor.empty() : tensor<1x14x14x36xf32>
     %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-                            m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
+                            offsets = [0, 0, 0, 0] output_sizes = [[1], [14], [14], [4, 3, 3]]
                             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
                             input_k_perm = [2, 0, 1] output_perm = [0, 1, 2, 3]
                             ins(%arg0 : tensor<1x16x16x4xf32>)
@@ -315,40 +388,47 @@ module {
     return %1 : tensor<1x14x14x36xf32>
   }
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d0 * 14 + d1)>
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+// Scalar fallback with non-self-inverse kperm: loops over M0, M1, K.
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
 // CHECK-LABEL: func.func @im2col_nhwc_with_perm
-//  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
-//   CHECK-DAG: %[[C36:.+]] = arith.constant 36 : index
-//   CHECK-DAG: %[[C14:.+]] = arith.constant 14 : index
-//   CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-//   CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-//       CHECK: %[[OUT_TILE:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
-//       CHECK: %[[MLOOP0:.+]] = scf.for %[[M1:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT_TILE]]) -> (tensor<1x14x14x36xf32>)
-//       CHECK:   %[[MLOOP1:.+]] = scf.for %[[M2:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x14x14x36xf32>)
-//       CHECK:     %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C36]] step %[[C1]] iter_args(%[[OUT3:.+]] = %[[OUT2]]) -> (tensor<1x14x14x36xf32>)
-//   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[K]] into (4, 3, 3) : index, index, index
-//   CHECK-DAG:       %[[FLAT_M:.+]] = affine.apply #[[$MAP]](%[[M1]], %[[M2]])
-//   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[FLAT_M]] into (14, 14) : index, index
-//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0, %[[kParts]]#1)
-//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1, %[[kParts]]#2)
-//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIDX]], %[[wIDX]], %[[kParts]]#0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x16x16x4xf32> to tensor<1x1x1x1xf32>
-//       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT3]][0, %[[M1]], %[[M2]], %[[K]]]
-//       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x1xf32>)
-//       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT3]][0, %[[M1]], %[[M2]], %[[K]]]
-//       CHECK:     scf.yield %[[INSERT]] : tensor<1x14x14x36xf32>
-//       CHECK:   scf.yield %[[KLOOP]] : tensor<1x14x14x36xf32>
-//       CHECK: scf.yield %[[MLOOP1]] : tensor<1x14x14x36xf32>
-//       CHECK: return %[[MLOOP0]] : tensor<1x14x14x36xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
+//   CHECK-DAG:   %[[C36:.+]] = arith.constant 36 : index
+//   CHECK-DAG:   %[[C14:.+]] = arith.constant 14 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[OUT_TILE:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
+//       CHECK:   %[[MLOOP0:.+]] = scf.for %[[M0:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT0:.+]] = %[[OUT_TILE]]) -> (tensor<1x14x14x36xf32>)
+//       CHECK:     %[[MLOOP1:.+]] = scf.for %[[M1:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT0]]) -> (tensor<1x14x14x36xf32>)
+//       CHECK:       %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C36]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x14x14x36xf32>)
+//   CHECK-DAG:         %[[kParts:.+]]:3 = affine.delinearize_index %[[K]] into (4, 3, 3) : index, index, index
+//   CHECK-DAG:         %[[hIDX:.+]] = affine.apply #[[$MAP]](%[[M0]], %[[kParts]]#1)
+//   CHECK-DAG:         %[[wIDX:.+]] = affine.apply #[[$MAP]](%[[M1]], %[[kParts]]#2)
+//       CHECK:         %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIDX]], %[[wIDX]], %[[kParts]]#0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x16x16x4xf32> to tensor<1x1x1x1xf32>
+//       CHECK:         %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x14x14x36xf32> to tensor<1x1x1x1xf32>
+//       CHECK:         %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x1xf32>)
+//       CHECK:         %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x14x14x36xf32>
+//       CHECK:         scf.yield %[[INSERT]] : tensor<1x14x14x36xf32>
+//       CHECK:       scf.yield %[[KLOOP]] : tensor<1x14x14x36xf32>
+//       CHECK:     scf.yield %[[MLOOP1]] : tensor<1x14x14x36xf32>
+//       CHECK:   return %[[MLOOP0]] : tensor<1x14x14x36xf32>
+
+// CHECK-UNROLL-LABEL: func.func @im2col_nhwc_with_perm
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+//       CHECK-UNROLL:   linalg.copy
 
 // -----
 
+// Test 10: CHWN layout with batch dim as innermost.
+// Static sizes; three nested loops (M0, M1, K). Spatial coords via affine.apply.
+// The batch dim is innermost so extract_slice reads a 4-element slice (the full batch).
+// Because output_perm is [0,1,2,3] but batch_pos = [3], the output dimension order
+// differs from the input slice order, so a linalg.transpose is needed.
 module {
   func.func @im2col_chwn(%arg0: tensor<16x26x18x4xf32>, %arg1: index, %arg2: index, %arg3: index) -> tensor<4x2x2x2xf32> {
     %0 = tensor.empty() : tensor<4x2x2x2xf32>
     %1 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-            m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3] * [1]
+            offsets = [0, %arg1, %arg2, %arg3] output_sizes = [[4], [3], [3], [16, 24, 16]]
             batch_pos = [3] m_pos = [1, 2] k_pos = [0]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
             ins(%arg0 : tensor<16x26x18x4xf32>)
@@ -358,8 +438,7 @@ module {
 }
 
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * 3 + d1 + s0 * 3 + s1)>
-//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0] -> (d0 + d1 + s0)>
 // CHECK-LABEL: func.func @im2col_chwn
 //  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x4xf32>
 //  CHECK-SAME: %[[ARG1:[a-zA-Z0-9_]+]]: index
@@ -374,27 +453,33 @@ module {
 //       CHECK:     %[[kLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]])
 //   CHECK-DAG:       %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[K]])[%[[ARG3]]]
 //   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (16, 24, 16)
-//   CHECK-DAG:       %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[M0]], %[[M1]])[%[[ARG1]], %[[ARG2]]]
-//   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (3, 3)
-//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
-//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
-//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<16x26x18x4xf32> to tensor<1x1x1x4xf32>
-//       CHECK:       %[[INIT:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1] : tensor<4x2x2x2xf32> to tensor<4x1x1x1xf32>
-//       CHECK:       %[[TRANS:.+]] = linalg.transpose ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[INIT]] : tensor<4x1x1x1xf32>) permutation = [3, 1, 2, 0]
+//   CHECK-DAG:       affine.apply #[[$MAP1]](%[[kParts]]#1, %[[M0]])[%[[ARG1]]]
+//   CHECK-DAG:       affine.apply #[[$MAP1]](%[[kParts]]#2, %[[M1]])[%[[ARG2]]]
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, {{.*}}, {{.*}}, 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<16x26x18x4xf32> to tensor<1x1x1x4xf32>
+//       CHECK:       %[[DEST_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1] : tensor<4x2x2x2xf32> to tensor<4x1x1x1xf32>
+//       CHECK:       %[[TRANS:.+]] = linalg.transpose ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[DEST_SLICE]] : tensor<4x1x1x1xf32>) permutation = [3, 1, 2, 0]
 //       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] into %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1] : tensor<4x1x1x1xf32> into tensor<4x2x2x2xf32>
 //       CHECK:      scf.yield %[[INSERT]] : tensor<4x2x2x2xf32>
 //       CHECK:    scf.yield %[[kLOOP]] : tensor<4x2x2x2xf32>
 //       CHECK:  scf.yield %[[mLOOP1]] : tensor<4x2x2x2xf32>
 //       CHECK: return %[[mLOOP0:.+]] : tensor<4x2x2x2xf32>
 
+// CHECK-UNROLL-LABEL: func.func @im2col_chwn
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+
 // -----
 
+// Test 11: CHWN layout with output_perm that eliminates the batch transpose.
+// Static sizes; three nested loops (K, M0, M1) matching the permuted output.
+// Because output_perm = [3, 1, 2, 0], the batch and K positions are swapped
+// relative to the default [B, M0, M1, K]. No transpose is needed because
+// the output slice is arranged to match the input slice.
 module {
   func.func @im2col_chwn_output_perm(%arg0: tensor<16x26x18x4xf32>, %arg1: index, %arg2: index, %arg3: index) -> tensor<2x2x2x4xf32> {
     %0 = tensor.empty() : tensor<2x2x2x4xf32>
     %1 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-            m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3] * [1]
+            offsets = [0, %arg1, %arg2, %arg3] output_sizes = [[4], [3], [3], [16, 24, 16]]
             batch_pos = [3] m_pos = [1, 2] k_pos = [0]
             input_k_perm = [0, 1, 2] output_perm = [3, 1, 2, 0]
             ins(%arg0 : tensor<16x26x18x4xf32>)
@@ -404,8 +489,7 @@ module {
 }
 
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * 3 + d1 + s0 * 3 + s1)>
-//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0] -> (d0 + d1 + s0)>
 // CHECK-LABEL: func.func @im2col_chwn_output_perm
 //  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x4xf32>
 //  CHECK-SAME: %[[ARG1:[a-zA-Z0-9_]+]]: index
@@ -420,11 +504,9 @@ module {
 //       CHECK:     %[[LOOP2:.+]] = scf.for %[[IV2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG6:.+]] = %[[ARG5]])
 //   CHECK-DAG:       %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[IV0]])[%[[ARG3]]]
 //   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (16, 24, 16)
-//   CHECK-DAG:       %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[IV1]], %[[IV2]])[%[[ARG1]], %[[ARG2]]]
-//   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (3, 3)
-//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
-//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
-//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<16x26x18x4xf32> to tensor<1x1x1x4xf32>
+//   CHECK-DAG:       affine.apply #[[$MAP1]](%[[kParts]]#1, %[[IV1]])[%[[ARG1]]]
+//   CHECK-DAG:       affine.apply #[[$MAP1]](%[[kParts]]#2, %[[IV2]])[%[[ARG2]]]
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, {{.*}}, {{.*}}, 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<16x26x18x4xf32> to tensor<1x1x1x4xf32>
 //       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[ARG6]][%[[IV0]], %[[IV1]], %[[IV2]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x2x2x4xf32> to tensor<1x1x1x4xf32>
 //       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x4xf32>)
 //       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[ARG6]][%[[IV0]], %[[IV1]], %[[IV2]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<1x1x1x4xf32> into tensor<2x2x2x4xf32>
@@ -433,14 +515,20 @@ module {
 //       CHECK:   scf.yield %[[LOOP1]] : tensor<2x2x2x4xf32>
 //       CHECK: return %[[LOOP0]] : tensor<2x2x2x4xf32>
 
+// CHECK-UNROLL-LABEL: func.func @im2col_chwn_output_perm
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+
 // -----
 
+// Test 12: Expanded CHWN layout with output_perm and multi-element batch dims.
+// Five nested loops; the batch dims (batch_pos=[3,4]) are innermost in the input
+// but appear in loops corresponding to the permuted output positions.
 module {
   func.func @im2col_chwn_output_perm_expanded(%arg0: tensor<16x26x18x2x4xf32>, %arg1: index, %arg2: index, %arg3: index) -> tensor<2x2x2x2x2x4xf32> {
     %0 = tensor.empty() : tensor<2x2x2x2x2x4xf32>
     %1 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-            m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3, 0] * [2, 1]
+            offsets = [0, 0, %arg1, %arg2, %arg3, 0] output_sizes = [[2], [4], [3], [3], [16, 24], [16]]
             batch_pos = [3, 4] m_pos = [1, 2] k_pos = [0]
             input_k_perm = [0, 1, 2] output_perm = [4, 5, 2, 3, 0, 1]
             ins(%arg0 : tensor<16x26x18x2x4xf32>)
@@ -449,52 +537,42 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1)[s0] -> (d0 + d1 * 2 + s0 * 2)>
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * 3 + d1 + s0 * 3 + s1)>
-//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
 // CHECK-LABEL: func.func @im2col_chwn_output_perm_expanded
 //  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x2x4xf32>
-//  CHECK-SAME: %[[ARG1:[a-zA-Z0-9_]+]]: index
-//  CHECK-SAME: %[[ARG2:[a-zA-Z0-9_]+]]: index
-//  CHECK-SAME: %[[ARG3:[a-zA-Z0-9_]+]]: index
 //   CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
 //       CHECK: %[[INIT:.+]] = tensor.empty() : tensor<2x2x2x2x2x4xf32>
-//       CHECK: %[[LOOP0:.+]] = scf.for %[[IV0:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[INIT]])
-//       CHECK:   %[[LOOP1:.+]] = scf.for %[[IV1:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG4]])
-//       CHECK:     %[[LOOP2:.+]] = scf.for %[[IV2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG6:.+]] = %[[ARG5]])
-//       CHECK:       %[[LOOP3:.+]] = scf.for %[[IV3:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[ARG6]])
-//       CHECK:         %[[LOOP4:.+]] = scf.for %[[IV4:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG8:.+]] = %[[ARG7]])
-//   CHECK-DAG:           %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[IV1]], %[[IV0]])[%[[ARG3]]]
-//   CHECK-DAG:           %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (16, 24, 16)
-//   CHECK-DAG:           %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[IV2]], %[[IV3]])[%[[ARG1]], %[[ARG2]]]
-//   CHECK-DAG:           %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (3, 3)
-//   CHECK-DAG:           %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
-//   CHECK-DAG:           %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
-//       CHECK:           %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], %[[IV4]], 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1] : tensor<16x26x18x2x4xf32> to tensor<1x1x1x1x4xf32>
-//       CHECK:           %[[OUT_SLICE:.+]] = tensor.extract_slice %[[ARG8]][%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]], %[[IV4]], 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1] : tensor<2x2x2x2x2x4xf32> to tensor<1x1x1x1x4xf32>
-//       CHECK:           %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x1x4xf32>)
-//       CHECK:           %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[ARG8]][%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]], %[[IV4]], 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x4xf32> into tensor<2x2x2x2x2x4xf32>
-//       CHECK:           scf.yield %[[INSERT]] : tensor<2x2x2x2x2x4xf32>
+//       CHECK: %[[LOOP0:.+]] = scf.for {{.*}} = %[[C0]] to %[[C2]] step %[[C1]]
+//       CHECK:   %[[LOOP1:.+]] = scf.for {{.*}} = %[[C0]] to %[[C2]] step %[[C1]]
+//       CHECK:     %[[LOOP2:.+]] = scf.for {{.*}} = %[[C0]] to %[[C2]] step %[[C1]]
+//       CHECK:       %[[LOOP3:.+]] = scf.for {{.*}} = %[[C0]] to %[[C2]] step %[[C1]]
+//       CHECK:         %[[LOOP4:.+]] = scf.for {{.*}} = %[[C0]] to %[[C2]] step %[[C1]]
+//       CHECK:           affine.delinearize_index {{.*}} into (16, 24)
+//       CHECK:           %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]]{{.*}} [1, 1, 1, 1, 4] [1, 1, 1, 1, 1] : tensor<16x26x18x2x4xf32> to tensor<1x1x1x1x4xf32>
+//       CHECK:           linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1x4xf32>)
+//       CHECK:           tensor.insert_slice {{.*}} : tensor<1x1x1x1x4xf32> into tensor<2x2x2x2x2x4xf32>
+//       CHECK:           scf.yield {{.*}} : tensor<2x2x2x2x2x4xf32>
 //       CHECK:         scf.yield %[[LOOP4]] : tensor<2x2x2x2x2x4xf32>
 //       CHECK:       scf.yield %[[LOOP3]] : tensor<2x2x2x2x2x4xf32>
 //       CHECK:     scf.yield %[[LOOP2]] : tensor<2x2x2x2x2x4xf32>
 //       CHECK:   scf.yield %[[LOOP1]] : tensor<2x2x2x2x2x4xf32>
 //       CHECK: return %[[LOOP0]] : tensor<2x2x2x2x2x4xf32>
 
+// CHECK-UNROLL-LABEL: func.func @im2col_chwn_output_perm_expanded
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+
 // -----
 
-// Test im2col with multiple k_pos entries. This pattern arises in backward
-// weight convolutions where a spatial dimension with output size 1 is collapsed
-// into the K dimension. Here k_pos = [0, 2] means both input dim 0 and dim 2
-// contribute to the K index.
+// Test 13: Multiple k_pos entries (k_pos = [0, 2]).
+// Verify that both k_pos entries are used for the extract_slice offsets:
+// k_pos[0] = input dim 0 (C=16), k_pos[1] = input dim 2 (W=32).
 module {
   func.func @im2col_multiple_k_pos(%arg0: tensor<16x52x32x96xbf16>) -> tensor<3x24576x96xbf16> {
     %0 = tensor.empty() : tensor<3x24576x96xbf16>
     %1 = iree_linalg_ext.im2col
             strides = [2] dilations = [1] kernel_size = [48]
-            m_offset = [0] * [1] k_offset = [0] * [1]
+            offsets = [0, 0, 0] output_sizes = [[96], [3], [16, 48, 32]]
             batch_pos = [3] m_pos = [1] k_pos = [0, 2]
             input_k_perm = [0, 1, 2] output_perm = [1, 2, 0]
             ins(%arg0 : tensor<16x52x32x96xbf16>)
@@ -502,22 +580,26 @@ module {
     return %1 : tensor<3x24576x96xbf16>
   }
 }
-
-// Verify that both k_pos entries are used for the extract_slice offsets:
-// k_pos[0] = input dim 0 (C=16), k_pos[1] = input dim 2 (W=32).
 // CHECK-LABEL: func.func @im2col_multiple_k_pos
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x52x32x96xbf16>
 //       CHECK:       %[[kParts:.+]]:3 = affine.delinearize_index {{.*}} into (16, 48, 32)
 //       CHECK:       tensor.extract_slice %[[ARG0]][%[[kParts]]#0, {{.*}}, %[[kParts]]#2, 0]
+//   CHECK-NOT:   iree_linalg_ext.im2col
+
+// CHECK-UNROLL-LABEL: func.func @im2col_multiple_k_pos
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+//       CHECK-UNROLL:   tensor.extract_slice %[[ARG0:.+]][{{.*}}] {{.*}} : tensor<16x52x32x96xbf16>
 
 // -----
 
+// Test 14: CHWN rank-reduced output with dynamic sizes. The batch dim is innermost.
+// Nested M and K loops reading a 4-element batch slice.
 module {
   func.func @im2col_chwn_rank_reduce(%arg0: tensor<16x26x18x4xf32>, %arg1: index, %arg2: index, %m_size: index, %k_size: index) -> tensor<4x?x?xf32> {
     %0 = tensor.empty(%m_size, %k_size) : tensor<4x?x?xf32>
     %1 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-            m_offset = [%arg1] * [1] k_offset = [%arg2] * [1]
+            offsets = [0, %arg1, %arg2] output_sizes = [[4], [3, 3], [16, 24, 16]]
             batch_pos = [3] m_pos = [1, 2] k_pos = [0]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<16x26x18x4xf32>)
@@ -527,9 +609,59 @@ module {
 }
 
 // Verify that when the batch dimension is the innermost and generates rank-reduced output,
-// a 1d tensor slice is extracted and transpose is not needed.
+// a 4-element tensor slice is extracted, copied, and inserted.
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
 // CHECK-LABEL: func.func @im2col_chwn_rank_reduce
 //       CHECK:     %[[IN_SLICE:.+]] = tensor.extract_slice {{.*}} : tensor<16x26x18x4xf32> to tensor<4xf32>
-//       CHECK:     %[[OUT_SLICE:.+]] = tensor.extract_slice {{.*}} : tensor<4x?x?xf32> to tensor<4xf32>
-//       CHECK:     %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<4xf32>) outs(%[[OUT_SLICE]] : tensor<4xf32>)
-//       CHECK:     %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into {{.*}} : tensor<4xf32> into tensor<4x?x?xf32>
+//       CHECK:     linalg.copy ins(%[[IN_SLICE]]
+//       CHECK:     tensor.insert_slice {{.*}} : tensor<4xf32> into tensor<4x?x?xf32>
+
+// CHECK-UNROLL-LABEL: func.func @im2col_chwn_rank_reduce
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col
+//       CHECK-UNROLL:   scf.for
+//       CHECK-UNROLL:     scf.for
+//       CHECK-UNROLL:       linalg.copy
+
+// -----
+
+// Test 15: Backward-weight-style im2col with dilation=2 and expanded M output dims.
+// With 2 M output dims each having a single inner size, M coords are used
+// directly without delinearization. The spatial offsets include dilation factor.
+// Static sizes, non-padded: extract_slice + linalg.copy + insert_slice.
+module {
+  func.func @im2col_bwd_weight_dilation(%arg0: tensor<4x18x18x2xf32>, %m0: index, %m1: index, %k: index) -> tensor<3x3x4x2xf32> {
+    %0 = tensor.empty() : tensor<3x3x4x2xf32>
+    %1 = iree_linalg_ext.im2col
+            strides = [1, 1] dilations = [2, 2] kernel_size = [8, 8]
+            offsets = [0, %m0, %m1, %k] output_sizes = [[2], [3], [3], [4, 8, 8]]
+            batch_pos = [3] m_pos = [1, 2] k_pos = [0]
+            input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
+            ins(%arg0 : tensor<4x18x18x2xf32>)
+            outs(%0 : tensor<3x3x4x2xf32>) -> tensor<3x3x4x2xf32>
+    return %1 : tensor<3x3x4x2xf32>
+  }
+}
+// CHECK-LABEL: func.func @im2col_bwd_weight_dilation
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<4x18x18x2xf32>
+//  CHECK-SAME:     %[[M0:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[M1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[K:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
+//   CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
+//       CHECK:   %[[INIT:.+]] = tensor.empty() : tensor<3x3x4x2xf32>
+//       CHECK:   %[[LOOP0:.+]] = scf.for %[[IV0:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[A0:.+]] = %[[INIT]])
+//       CHECK:     %[[LOOP1:.+]] = scf.for %[[IV1:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[A1:.+]] = %[[A0]])
+//       CHECK:       %[[LOOP2:.+]] = scf.for %[[IV2:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[A2:.+]] = %[[A1]])
+//   CHECK-DAG:         affine.delinearize_index {{.*}} into (4, 8, 8)
+//       CHECK:         %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]]{{.*}} [1, 1, 1, 2] [1, 1, 1, 1] : tensor<4x18x18x2xf32> to tensor<1x1x1x2xf32>
+//       CHECK:         %[[DEST_SLICE:.+]] = tensor.extract_slice %[[A2]][%[[IV0]], %[[IV1]], %[[IV2]], 0] [1, 1, 1, 2] {{.*}} : tensor<3x3x4x2xf32> to tensor<1x1x1x2xf32>
+//       CHECK:         %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x2xf32>) outs(%[[DEST_SLICE]] : tensor<1x1x1x2xf32>)
+//       CHECK:         tensor.insert_slice %[[COPY]] into %[[A2]][%[[IV0]], %[[IV1]], %[[IV2]], 0] [1, 1, 1, 2] [1, 1, 1, 1] : tensor<1x1x1x2xf32> into tensor<3x3x4x2xf32>
+// Verify the im2col op is fully lowered to loops.
+//   CHECK-NOT:   iree_linalg_ext.im2col
+
+// CHECK-UNROLL-LABEL: func.func @im2col_bwd_weight_dilation
+//   CHECK-UNROLL-NOT:   iree_linalg_ext.im2col

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1319,7 +1319,7 @@ module attributes { transform.with_named_sequence } {
 func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [34] * [1] k_offset = [1000] * [1]
+           offsets = [0, 34, 1000] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
@@ -1334,8 +1334,8 @@ module attributes { transform.with_named_sequence } {
   }
 }
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0) -> (-d0 + 1024, 5)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0) -> (d0 + 1000)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 + 34)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0) -> (d0 + 34)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 + 1000)>
 // CHECK:      func.func @im2col(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32>
 // CHECK-DAG:    %[[C4:.+]] = arith.constant 4 : index
 // CHECK-DAG:    %[[C5:.+]] = arith.constant 5 : index
@@ -1352,17 +1352,15 @@ module attributes { transform.with_named_sequence } {
 // CHECK:            %[[RES2:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C5760]] step %[[C4]]
 // CHECK-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]]) -> (tensor<2x1024x5760xf32>)
 // CHECK-DAG:          %[[MSIZE:.+]] = affine.min #[[MAP]](%[[ARG3]])
-// CHECK-DAG:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], 0, 0, 0]
-// CHECK-SAME:           [1, 34, 34, 640] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x34x34x640xf32>
 // CHECK-DAG:          %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG1]], %[[ARG3]], %[[ARG5]]]
 // CHECK-SAME:           [1, %[[MSIZE]], 4] [1, 1, 1] : tensor<2x1024x5760xf32> to tensor<1x?x4xf32>
-// CHECK-DAG:          %[[KOFFSET:.+]] = affine.apply #[[MAP1]](%[[ARG5]])
-// CHECK-DAG:          %[[MOFFSET:.+]] = affine.apply #[[MAP2]](%[[ARG3]])
+// CHECK-DAG:          %[[MOFFSET:.+]] = affine.apply #[[MAP1]](%[[ARG3]])
+// CHECK-DAG:          %[[KOFFSET:.+]] = affine.apply #[[MAP2]](%[[ARG5]])
 // CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:           m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
+// CHECK-SAME:           offsets = [%[[ARG1]], %[[MOFFSET]], %[[KOFFSET]]] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
 // CHECK-SAME:           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
-// CHECK-SAME:           ins(%[[EXTRACTED_SLICE]] : tensor<1x34x34x640xf32>)
+// CHECK-SAME:           ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
 // CHECK-SAME:           outs(%[[EXTRACTED_SLICE_0]] : tensor<1x?x4xf32>) -> tensor<1x?x4xf32>
 // CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
 // CHECK-SAME:           [%[[ARG1]], %[[ARG3]], %[[ARG5]]] [1, %[[MSIZE]], 4] [1, 1, 1]
@@ -1377,7 +1375,7 @@ module attributes { transform.with_named_sequence } {
 func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-           m_offset = [42] * [1] k_offset = [7] * [1]
+           offsets = [0, 42, 7] output_sizes = [[2], [32, 32], [5, 2, 640]]
            batch_pos = [1] m_pos = [3, 2] k_pos = [0]
            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
            ins(%arg0 : tensor<640x2x101x172xf32>)
@@ -1393,8 +1391,8 @@ module attributes { transform.with_named_sequence } {
 }
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0) -> (-d0 + 1024, 9)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0) -> (-d0 + 5760, 7)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 + 7)>
-// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (d0 + 42)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 + 42)>
+// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (d0 + 7)>
 // CHECK:      func.func @im2col_transposed_m_pos(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<640x2x101x172xf32>) -> tensor<2x1024x5760xf32>
 // CHECK-DAG:    %[[C7:.+]] = arith.constant 7 : index
 // CHECK-DAG:    %[[C9:.+]] = arith.constant 9 : index
@@ -1412,17 +1410,15 @@ module attributes { transform.with_named_sequence } {
 // CHECK-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]]) -> (tensor<2x1024x5760xf32>)
 // CHECK-DAG:          %[[MSIZE:.+]] = affine.min #[[MAP]](%[[ARG3]])
 // CHECK-DAG:          %[[KSIZE:.+]] = affine.min #[[MAP1]](%[[ARG5]])
-// CHECK-DAG:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[ARG1]], 0, 0]
-// CHECK-SAME:           [640, 1, 101, 172] [1, 1, 1, 1] : tensor<640x2x101x172xf32> to tensor<640x1x101x172xf32>
 // CHECK-DAG:          %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG1]], %[[ARG3]], %[[ARG5]]]
 // CHECK-SAME:           [1, %[[MSIZE]], %[[KSIZE]]] [1, 1, 1] : tensor<2x1024x5760xf32> to tensor<1x?x?xf32>
-// CHECK-DAG:          %[[KOFFSET:.+]] = affine.apply #[[MAP2]](%[[ARG5]])
-// CHECK-DAG:          %[[MOFFSET:.+]] = affine.apply #[[MAP3]](%[[ARG3]])
+// CHECK-DAG:          %[[MOFFSET:.+]] = affine.apply #[[MAP2]](%[[ARG3]])
+// CHECK-DAG:          %[[KOFFSET:.+]] = affine.apply #[[MAP3]](%[[ARG5]])
 // CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
-// CHECK-SAME:           m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
+// CHECK-SAME:           offsets = [%[[ARG1]], %[[MOFFSET]], %[[KOFFSET]]] output_sizes = {{\[}}[2], [32, 32], [5, 2, 640]]
 // CHECK-SAME:           batch_pos = [1] m_pos = [3, 2] k_pos = [0]
 // CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
-// CHECK-SAME:           ins(%[[EXTRACTED_SLICE]] : tensor<640x1x101x172xf32>)
+// CHECK-SAME:           ins(%[[ARG0]] : tensor<640x2x101x172xf32>)
 // CHECK-SAME:           outs(%[[EXTRACTED_SLICE_0]] : tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
 // CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
 // CHECK-SAME:           [%[[ARG1]], %[[ARG3]], %[[ARG5]]] [1, %[[MSIZE]], %[[KSIZE]]] [1, 1, 1]
@@ -1438,7 +1434,7 @@ func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s
                           %mOffset: index, %kOffset: index) -> tensor<?x?x?xf32> {
   %0 = tensor.empty(%s0, %s1, %s2) : tensor<?x?x?xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-           m_offset = [%mOffset] * [1] k_offset = [%kOffset] * [1]
+           offsets = [0, %mOffset, %kOffset] output_sizes = [[2], [32, 32], [3, 3, 640]]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
            ins(%arg0 : tensor<?x?x?x?xf32>)
@@ -1458,11 +1454,9 @@ module attributes { transform.with_named_sequence } {
 // CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
 // CHECK:      func.func @im2col_dynamic(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?x?x?xf32>,
 // CHECK-SAME:   %[[S0:.+]]: index, %[[S1:.+]]: index, %[[S2:.+]]: index, %[[MOFF:.+]]: index, %[[KOFF:.+]]: index
-// CHECK-DAG:    %[[C3:.+]] = arith.constant 3 : index
 // CHECK-DAG:    %[[C5:.+]] = arith.constant 5 : index
 // CHECK-DAG:    %[[C7:.+]] = arith.constant 7 : index
 // CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
 // CHECK:        %[[D0:.+]] = tensor.empty(%[[S0]], %[[S1]], %[[S2]]) : tensor<?x?x?xf32>
 // CHECK:        %[[RES0:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[S0]] step %[[C2]]
@@ -1474,20 +1468,15 @@ module attributes { transform.with_named_sequence } {
 // CHECK-DAG:          %[[BSIZE:.+]] = affine.min #[[MAP]](%[[ARG1]])
 // CHECK-DAG:          %[[MSIZE:.+]] = affine.min #[[MAP1]](%[[ARG3]])
 // CHECK-DAG:          %[[KSIZE:.+]] = affine.min #[[MAP2]](%[[ARG5]])
-// CHECK-DAG:          %[[DIM1:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x?x?xf32>
-// CHECK-DAG:          %[[DIM2:.+]] = tensor.dim %[[ARG0]], %[[C2]] : tensor<?x?x?x?xf32>
-// CHECK-DAG:          %[[DIM3:.+]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xf32>
-// CHECK-DAG:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], 0, 0, 0]
-// CHECK-SAME:           [%[[BSIZE]], %[[DIM1]], %[[DIM2]], %[[DIM3]]] [1, 1, 1, 1] : tensor<?x?x?x?xf32> to tensor<?x?x?x?xf32>
 // CHECK-DAG:          %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG1]], %[[ARG3]], %[[ARG5]]]
 // CHECK-SAME:           [%[[BSIZE]], %[[MSIZE]], %[[KSIZE]]] [1, 1, 1] : tensor<?x?x?xf32> to tensor<?x?x?xf32>
 // CHECK-DAG:          %[[KOFFSET:.+]] = affine.apply #[[MAP3]](%[[ARG5]])[%[[KOFF]]]
 // CHECK-DAG:          %[[MOFFSET:.+]] = affine.apply #[[MAP3]](%[[ARG3]])[%[[MOFF]]]
 // CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:           m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
+// CHECK-SAME:           offsets = [%[[ARG1]], %[[MOFFSET]], %[[KOFFSET]]] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
 // CHECK-SAME:           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
-// CHECK-SAME:           ins(%[[EXTRACTED_SLICE]] : tensor<?x?x?x?xf32>)
+// CHECK-SAME:           ins(%[[ARG0]] : tensor<?x?x?x?xf32>)
 // CHECK-SAME:           outs(%[[EXTRACTED_SLICE_0]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
 // CHECK-SAME:           [%[[ARG1]], %[[ARG3]], %[[ARG5]]] [%[[BSIZE]], %[[MSIZE]], %[[KSIZE]]] [1, 1, 1]
@@ -1504,7 +1493,7 @@ module {
     %0 = tensor.empty() : tensor<2x32x32x1440x4xf32>
     %7 = iree_linalg_ext.im2col
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-            m_offset = [0, 0] * [%m_stride, 1] k_offset = [0, 0] * [4, 1]
+            offsets = [0, 0, 0, 0, 0] output_sizes = [[2], [32], [32], [3, 3], [640]]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
             input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
             ins(%arg0 : tensor<2x34x34x640xf32>)
@@ -1548,15 +1537,13 @@ module attributes { transform.with_named_sequence } {
 // CHECK-DAG:              %[[M0SIZE:.+]] = affine.min #[[MAP]](%[[ARG3]])
 // CHECK-DAG:              %[[M1SIZE:.+]] = affine.min #[[MAP1]](%[[ARG5]])
 // CHECK-DAG:              %[[K0SIZE:.+]] = affine.min #[[MAP2]](%[[ARG7]])
-// CHECK-DAG:              %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], 0, 0, 0]
-// CHECK-SAME:               [1, 34, 34, 640] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x34x34x640xf32>
 // CHECK-DAG:              %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG10]][%[[ARG1]], %[[ARG3]], %[[ARG5]], %[[ARG7]], %[[ARG9]]]
 // CHECK-SAME:               [1, %[[M0SIZE]], %[[M1SIZE]], %[[K0SIZE]], 2] [1, 1, 1, 1, 1] : tensor<2x32x32x1440x4xf32> to tensor<1x?x?x?x2xf32>
 // CHECK:                  %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:               m_offset = [%[[ARG3]], %[[ARG5]]] * [%[[M_STRIDE]], 1] k_offset = [%[[ARG7]], %[[ARG9]]] * [4, 1]
+// CHECK-SAME:               offsets = [%[[ARG1]], %[[ARG3]], %[[ARG5]], %[[ARG7]], %[[ARG9]]] output_sizes = {{\[}}[2], [32], [32], [3, 3], [640]]
 // CHECK-SAME:               batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:               input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
-// CHECK-SAME:               ins(%[[EXTRACTED_SLICE]] : tensor<1x34x34x640xf32>)
+// CHECK-SAME:               ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
 // CHECK-SAME:               outs(%[[EXTRACTED_SLICE_0]] : tensor<1x?x?x?x2xf32>) -> tensor<1x?x?x?x2xf32>
 // CHECK:                  %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG10]]
 // CHECK-SAME:               [%[[ARG1]], %[[ARG3]], %[[ARG5]], %[[ARG7]], %[[ARG9]]] [1, %[[M0SIZE]], %[[M1SIZE]], %[[K0SIZE]], 2] [1, 1, 1, 1, 1]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -615,7 +615,7 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   DenseMap<int64_t, AffineExpr> convToIgemmDimMap;
   for (auto [idx, expr] : llvm::enumerate(outputMap.getResults())) {
     auto convDimIdx = cast<AffineDimExpr>(expr).getPosition();
-    convToIgemmDimMap[convDimIdx] = getAffineDimExpr(idx, expr.getContext());
+    convToIgemmDimMap[convDimIdx] = getAffineDimExpr(idx, ctx);
   }
 
   // Lambda to remap conv dim indices to igemm dimensions.
@@ -690,9 +690,10 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
                                    : SmallVector<Value>({input, filter});
   igemmDetails.igemmOperands.push_back(output);
   SmallVector<int64_t> igemmLoopBounds;
-  igemmLoopBounds.insert(igemmLoopBounds.end(), outputShape.begin(),
-                         outputShape.begin() + numParallelDims);
-  SmallVector<utils::IteratorType> igemmLoopIterators(outputShape.size(),
+  for (auto [idx, expr] : llvm::enumerate(outputMap.getResults())) {
+    igemmLoopBounds.push_back(outputShape[idx]);
+  }
+  SmallVector<utils::IteratorType> igemmLoopIterators(numParallelDims,
                                                       parallel);
 
   for (auto iter : llvm::enumerate(filterIterators)) {


### PR DESCRIPTION
Replace the old m_offset/k_offset/m_strides/k_strides attributes with unified offsets and output_sizes (nested dynamic index list). This provides a single canonical representation for im2col output positions that supports delinearization-based indexing.

Key changes:
- New offsets and output_sizes attributes on Im2colOp (LinalgExtOps.td)
- Custom parser/printer for nested dynamic index lists
- Updated build(), verify(), getMixedOffsets/OutputSizes accessors
- Updated conv-to-im2col to emit new attributes
- Updated TilingInterfaceImpl for new attribute structure

This is part 1 of the im2col rewrite series. Padding support and direct vectorization will follow in subsequent commits.

### Benchmark Results ###

Two benchmark runs show that benchmarks are unchanged (none of the improvers/degraders appear in both runs, so they are likely just noise):
 - https://github.com/nod-ai/amd-shark-ai-reports/tree/main/boo/boo-custom-runs/2026-03-16_02-50_bb4e4e6dea609e48ed2384b2b4e662b476de21ac/comparison
 - https://github.com/nod-ai/amd-shark-ai-reports/tree/main/boo/boo-custom-runs/2026-03-16_19-19_bb4e4e6dea609e48ed2384b2b4e662b476de21ac/comparison

This PR is not expected to have performance impact, but it is a significant refactor, so these benchmarks are meant to show that there are no regressions.

Fixes https://github.com/iree-org/iree/issues/23786

ci-extra: test_torch