### PR TITLE
[Integrate] Integrate llvm-project@66395ad94c32

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -716,7 +716,6 @@ public:
         }
         llvm::TargetOptions opt;
         opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-        opt.NoNaNsFPMath = true;
         // Be extra cautious while this is less tested, and prevent unknown
         // fallbacks from global isel.
         //

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -31,7 +31,7 @@ builtin.module {
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readnone})
-//         CHECK:    rocdl.workgroup.dim.x
+//         CHECK:    llvm.call @__ockl_get_local_size({{.*}}) : (i32) -> (i64
 //         CHECK:    llvm.getelementptr inbounds|nuw %{{.*}} : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //       INDEX32:    llvm.getelementptr inbounds|nuw %{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, f32
 //         CHECK:    llvm.fadd
@@ -119,8 +119,8 @@ builtin.module attributes {} {
   }
 }
 // CHECK-LABEL: llvm.func @interface_wg_size
-//       CHECK:   %[[WGDIMX:.+]] = rocdl.workgroup.dim.x
-//       CHECK:   %[[WGDIMY:.+]] = rocdl.workgroup.dim.y
+//       CHECK:   llvm.call @__ockl_get_local_size({{.*}}) : (i32) -> (i64
+//       CHECK:   llvm.call @__ockl_get_local_size({{.*}}) : (i32) -> (i64
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_gather.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_gather.mlir
@@ -39,22 +39,25 @@ func.func @vector_gather(%arg0: memref<16x1082x1922xi8>, %index_vec: vector<16xi
 // CHECK-LABEL: func.func @vector_gather
 // CHECK-SAME:  %[[ARG0:.+]]: memref<16x1082x1922xi8>
 // CHECK-SAME:  %[[INDEX_VEC:.+]]: vector<16xindex>
-// CHECK-DAG:   %[[INIT:.+]] = arith.constant dense<0> : vector<16xi8>
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:       %[[INIT:.+]] = arith.constant dense<0> : vector<16xi8>
 
 // CHECK:       %[[IND0:.+]] = vector.extract %[[INDEX_VEC]][0] : index from vector<16xindex>
-// CHECK:       %[[LOAD0:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND0]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[DL0:.+]]:3 = affine.delinearize_index %[[IND0]] into (16, 1082, 1922)
+// CHECK:       %[[LOAD0:.+]] = vector.load %[[ARG0]][%[[DL0]]#0, %[[DL0]]#1, %[[DL0]]#2] : memref<16x1082x1922xi8>, vector<1xi8>
 // CHECK:       %[[EXTRACT0:.+]] = vector.extract %[[LOAD0]][0] : i8 from vector<1xi8>
 // CHECK:       %[[IND1:.+]] = vector.extract %[[INDEX_VEC]][1] : index from vector<16xindex>
-// CHECK:       %[[LOAD1:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND1]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[DL1:.+]]:3 = affine.delinearize_index %[[IND1]] into (16, 1082, 1922)
+// CHECK:       %[[LOAD1:.+]] = vector.load %[[ARG0]][%[[DL1]]#0, %[[DL1]]#1, %[[DL1]]#2] : memref<16x1082x1922xi8>, vector<1xi8>
 // CHECK:       %[[EXTRACT1:.+]] = vector.extract %[[LOAD1]][0] : i8 from vector<1xi8>
 // CHECK:       %[[IND2:.+]] = vector.extract %[[INDEX_VEC]][2] : index from vector<16xindex>
-// CHECK:       %[[LOAD2:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND2]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[DL2:.+]]:3 = affine.delinearize_index %[[IND2]] into (16, 1082, 1922)
+// CHECK:       %[[LOAD2:.+]] = vector.load %[[ARG0]][%[[DL2]]#0, %[[DL2]]#1, %[[DL2]]#2] : memref<16x1082x1922xi8>, vector<1xi8>
 // CHECK:       %[[EXTRACT2:.+]] = vector.extract %[[LOAD2]][0] : i8 from vector<1xi8>
 // CHECK:       %[[IND3:.+]] = vector.extract %[[INDEX_VEC]][3] : index from vector<16xindex>
-// CHECK:       %[[LOAD3:.+]] = vector.load %[[ARG0]][%[[C0]], %[[C0]], %[[IND3]]] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK:       %[[DL3:.+]]:3 = affine.delinearize_index %[[IND3]] into (16, 1082, 1922)
+// CHECK:       %[[LOAD3:.+]] = vector.load %[[ARG0]][%[[DL3]]#0, %[[DL3]]#1, %[[DL3]]#2] : memref<16x1082x1922xi8>, vector<1xi8>
 // CHECK:       %[[EXTRACT3:.+]] = vector.extract %[[LOAD3]][0] : i8 from vector<1xi8>
 // CHECK:       %[[VEC:.+]] = vector.from_elements %[[EXTRACT0]], %[[EXTRACT1]], %[[EXTRACT2]], %[[EXTRACT3]] : vector<4xi8>
 
 // CHECK:       vector.insert_strided_slice %[[VEC]], %[[INIT]] {offsets = [0], strides = [1]} : vector<4xi8> into vector<16xi8>
-// CHECK-COUNT-12: vector.load %[[ARG0]][%[[C0]], %[[C0]], %{{.*}}] : memref<16x1082x1922xi8>, vector<1xi8>
+// CHECK-COUNT-12: vector.load %[[ARG0]][%{{.+}}#0, %{{.+}}#1, %{{.+}}#2] : memref<16x1082x1922xi8>, vector<1xi8>

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -706,7 +706,7 @@ int64_t UninitializedAttr::getStorageSize() const {
 
 struct SizedStorageDenseElementsAttrModel
     : SizedStorageAttr::ExternalModel<SizedStorageDenseElementsAttrModel,
-                                      DenseIntOrFPElementsAttr> {
+                                      DenseTypedElementsAttr> {
   int64_t getStorageSize(Attribute baseAttr) const {
     auto attr = cast<ElementsAttr>(baseAttr);
     return IREE::Util::getRoundedPhysicalStorageSize(
@@ -743,7 +743,7 @@ struct SizedStorageStringAttrModel
 // byte buffers.
 struct SerializableDenseElementsAttrModel
     : SerializableAttrInterface::ExternalModel<
-          SerializableDenseElementsAttrModel, DenseIntOrFPElementsAttr> {
+          SerializableDenseElementsAttrModel, DenseTypedElementsAttr> {
   LogicalResult serializeToVector(Attribute baseAttr, Location loc,
                                   llvm::endianness endian,
                                   SmallVectorImpl<char> &buffer) const {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -502,7 +502,7 @@ static Attribute constFoldUnaryOp(Attribute rawOperand,
     }
     return DenseElementsAttr::get(operand.getType(), elementResult);
   } else if (auto operand = dyn_cast_if_present<ElementsAttr>(rawOperand)) {
-    return cast<DenseIntOrFPElementsAttr>(operand).mapValues(
+    return cast<DenseTypedElementsAttr>(operand).mapValues(
         cast<ShapedType>(operand.getType()).getElementType(),
         llvm::function_ref<ElementValueT(const ElementValueT &)>(
             [&](const ElementValueT &value) { return calculate(value); }));
@@ -526,7 +526,7 @@ constFoldFloatUnaryOp(Attribute rawOperand,
     }
     return DenseElementsAttr::get(operand.getType(), elementResult);
   } else if (auto operand = dyn_cast_if_present<ElementsAttr>(rawOperand)) {
-    return cast<DenseIntOrFPElementsAttr>(operand).mapValues(
+    return cast<DenseTypedElementsAttr>(operand).mapValues(
         cast<ShapedType>(operand.getType()).getElementType(),
         llvm::function_ref<APInt(const APFloat &)>([&](const APFloat &value) {
           return calculate(value).bitcastToAPInt();
@@ -1911,7 +1911,7 @@ static Attribute constFoldUnaryCmpOp(Attribute rawOperand,
     return IntegerAttr::get(boolType, calculate(operand.getValue()));
   } else if (auto operand = dyn_cast_if_present<ElementsAttr>(rawOperand)) {
     auto boolType = IntegerType::get(operand.getContext(), 32);
-    return cast<DenseIntOrFPElementsAttr>(operand).mapValues(
+    return cast<DenseTypedElementsAttr>(operand).mapValues(
         boolType,
         llvm::function_ref<APInt(const ElementValueT &)>(
             [&](const ElementValueT &value) { return calculate(value); }));


### PR DESCRIPTION
- Remove `opt.NoNaNsFPMath = true` from ROCMTarget.cpp (field removed upstream in #186285).
- Update convert_to_rocdl.mlir test: `rocdl.workgroup.dim.{x,y}` ops removed upstream (#186235), now lowered to `__ockl_get_local_size` library calls.
- Update vectorize_gather.mlir test: vector.gather lowering now uses
  affine.delinearize_index instead of flat index with constant zero
  base (upstream #184706).