### PR TITLE
[Codegen][ROCm] Fix crash in complex matmul configuration logic

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -269,6 +269,11 @@ getContractionHeuristicSeeds(IREE::GPU::TargetAttr target,
   const ArchSeedSet &archSeeds = getArchSeedSet(target);
   assert(problem.gemmSize.has_value() && "GemmSizeKind must be set");
 
+  // MMA heuristics only apply to int/float element types.
+  if (!problem.aType.isIntOrFloat()) {
+    return std::nullopt;
+  }
+
   // Pick the right category, index by GemmSizeKind, then convert the stored
   // K-element bits to an actual element count.
   const GPUMMAHeuristicSeeds *table =
@@ -376,8 +381,10 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
   LDBG() << "This config is " << *problem.gemmSize;
   std::optional<GPUMMAHeuristicSeeds> maybeSeeds =
       getContractionHeuristicSeeds(target, problem, isGemm, scaled);
-  assert(maybeSeeds.has_value() && "expected seeds to be found");
-  GPUMMAHeuristicSeeds seeds = maybeSeeds.value();
+  if (!maybeSeeds) {
+    return std::nullopt;
+  }
+  GPUMMAHeuristicSeeds seeds = *maybeSeeds;
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
 
@@ -1092,6 +1099,14 @@ setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
   if (!linalgOp ||
       (!linalg::isaContractionOpInterface(linalgOp) &&
        !IREE::LinalgExt::isaScaledContractionOpInterface(linalgOp))) {
+    return failure();
+  }
+
+  // The MMA lowering path does not support complex element types. Bail so
+  // the contraction falls through to a SIMT-based pipeline.
+  if (llvm::any_of(linalgOp->getOperands(), [](Value v) {
+        return isa<ComplexType>(getElementTypeOrSelf(v.getType()));
+      })) {
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "amdgpu_emulate_narrow_type.mlir",
             "assign_constant_ordinals.mlir",
             "cast_address_space_function.mlir",
+            "config_complex_matmul.mlir",
             "config_custom_op.mlir",
             "config_gather_like_ops.mlir",
             "config_horizontally_fused_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "amdgpu_emulate_narrow_type.mlir"
     "assign_constant_ordinals.mlir"
     "cast_address_space_function.mlir"
+    "config_complex_matmul.mlir"
     "config_custom_op.mlir"
     "config_gather_like_ops.mlir"
     "config_horizontally_fused_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_complex_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_complex_matmul.mlir
@@ -1,0 +1,52 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 \
+// RUN:   --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s \
+// RUN:   | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 \
+// RUN:   --pass-pipeline='builtin.module(linalg-generalize-named-ops,iree-llvmgpu-select-lowering-strategy)' %s \
+// RUN:   | FileCheck %s
+
+// Verify that complex element types do not crash the MMA heuristics and get
+// routed to a working pipeline (LLVMGPUTileAndFuse via the SIMT contraction
+// config, not the MMA-based matmul config).
+
+//      CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK-LABEL: func.func @complex_batch_matmul
+//      CHECK:   linalg.{{fill|generic}}
+//      CHECK:   lowering_config = #iree_gpu.lowering_config
+//  CHECK-NOT:   mma_kind
+
+!TA = tensor<17x96x153xcomplex<f32>>
+!TB = tensor<17x153x16xcomplex<f32>>
+!TC = tensor<17x96x16xcomplex<f32>>
+!DTC = !iree_tensor_ext.dispatch.tensor<writeonly:tensor<17x96x16xcomplex<f32>>>
+
+func.func @complex_batch_matmul(%arg0: !TA, %arg1: !TB, %arg2: !DTC) {
+  %zero = complex.constant [0.0 : f32, 0.0 : f32] : complex<f32>
+  %init = tensor.empty() : tensor<17x96x16xcomplex<f32>>
+  %filled = linalg.fill ins(%zero : complex<f32>) outs(%init : !TC) -> !TC
+  %bmm = linalg.batch_matmul ins(%arg0, %arg1 : !TA, !TB) outs(%filled : !TC) -> !TC
+  iree_tensor_ext.dispatch.tensor.store %bmm, %arg2, offsets = [0, 0, 0], sizes = [17, 96, 16], strides = [1, 1, 1] : !TC -> !DTC
+  return
+}
+
+// -----
+
+//      CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK-LABEL: func.func @complex_matmul
+//      CHECK:   linalg.{{fill|generic}}
+//      CHECK:   lowering_config = #iree_gpu.lowering_config
+//  CHECK-NOT:   mma_kind
+
+!MA = tensor<64x128xcomplex<f32>>
+!MB = tensor<128x32xcomplex<f32>>
+!MC = tensor<64x32xcomplex<f32>>
+!DMC = !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x32xcomplex<f32>>>
+
+func.func @complex_matmul(%arg0: !MA, %arg1: !MB, %arg2: !DMC) {
+  %zero = complex.constant [0.0 : f32, 0.0 : f32] : complex<f32>
+  %init = tensor.empty() : tensor<64x32xcomplex<f32>>
+  %filled = linalg.fill ins(%zero : complex<f32>) outs(%init : !MC) -> !MC
+  %mm = linalg.matmul ins(%arg0, %arg1 : !MA, !MB) outs(%filled : !MC) -> !MC
+  iree_tensor_ext.dispatch.tensor.store %mm, %arg2, offsets = [0, 0], sizes = [64, 32], strides = [1, 1] : !MC -> !DMC
+  return
+}


### PR DESCRIPTION
`getContractionHeuristicSeeds` called `problem.aType.getIntOrFloatBitWidth()` unconditionally, but aType can be `complex<f32>` from complex batch matmul dispatches.

Route complex contractions to the SIMT-based setContractConfig fallback instead. This fixes a crash on a proprietary model.

I checked the numerics against numpy and cpu and rocm is as accurate as cpu.