### PR TITLE
Integrate llvm-project@9d3d0d7bb692

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_conv2d.mlir
@@ -1,7 +1,4 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
-// Test the same patterns on generic convolution ops by first generalizing the
-// named ops. This ensures decomposition works on both named and generic convs.
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(linalg-generalize-named-ops,iree-codegen-decompose-convolution-to-lower-dim-ops))" --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0, 0, 0, 0], [1, 1, 1, 4, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
 module {


### PR DESCRIPTION
New revert:

- https://github.com/llvm/llvm-project/commit/479aeee2238c (adds SSAF frontend integration to
  clang but missing Bazel BUILD overlay, breaks linux_x64_bazel)

Other points of interest:

- https://github.com/llvm/llvm-project/commit/dfd5b85d0bb1 replaces per-layout convolution
  downscaling patterns with a single structure-aware
  `downscaleSizeOneWindowedConvolution`. The second RUN line in
  `decompose_conv2d.mlir` that tested generalize->decompose now produces
  `linalg.generic` instead of `linalg.depthwise_conv_1d_nwc_wc`. Removed
  the second RUN line per upstream guidance.