### PR TITLE
[DMA] Fix DMA `tensor.empty` tracing through swizzle promotion ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -70,8 +70,35 @@ static tensor::PadOp traceToTensorPad(Value source) {
   return source.getDefiningOp<tensor::PadOp>();
 }
 
-/// Check if a value traces back to tensor.empty (possibly through forall args).
+/// Trace through swizzle promotion ops (swizzle_hint, expand_shape,
+/// collapse_shape) to find the underlying value. These ops are inserted by
+/// swizzle promotion and don't affect whether the tensor traces to empty.
+static Value traceThroughSwizzleOps(Value value) {
+  while (true) {
+    if (auto expandOp = value.getDefiningOp<tensor::ExpandShapeOp>()) {
+      value = expandOp.getSrc();
+      continue;
+    }
+    if (auto collapseOp = value.getDefiningOp<tensor::CollapseShapeOp>()) {
+      value = collapseOp.getSrc();
+      continue;
+    }
+    if (auto swizzleOp = value.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
+      value = swizzleOp.getOperand();
+      continue;
+    }
+    break;
+  }
+  return value;
+}
+
+/// Check if a value traces back to tensor.empty, possibly through swizzle
+/// promotion ops (swizzle_hint, expand_shape, collapse_shape) and/or forall
+/// block arguments.
 static bool tracesToTensorEmpty(Value value) {
+  // Trace through swizzle promotion ops first.
+  value = traceThroughSwizzleOps(value);
+
   // Direct tensor.empty.
   if (value.getDefiningOp<tensor::EmptyOp>()) {
     return true;
@@ -105,7 +132,9 @@ static bool tracesToTensorEmpty(Value value) {
     return false;
   }
 
-  Value initValue = forallOp.getOutputs()[sharedOutIndex];
+  // Trace through swizzle ops on the forall init value as well.
+  Value initValue =
+      traceThroughSwizzleOps(forallOp.getOutputs()[sharedOutIndex]);
   return initValue.getDefiningOp<tensor::EmptyOp>() != nullptr;
 }
 
@@ -259,18 +288,14 @@ static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
     return false;
   }
 
-  // The pre-check runs before tiling, so the output is directly a
-  // tensor.empty() (not yet inside forall block args). A simple defining op
-  // check suffices here, unlike tracesToTensorEmpty used post-tiling.
-  // TODO: If the pass pipeline changes such that copies are already inside
-  // forall ops at pre-check time, switch to tracesToTensorEmpty here to avoid
-  // undercounting availableElements (currently safe but conservative).
+  // The pre-check runs before tiling but after promotion, so the output may
+  // have swizzle promotion ops (swizzle_hint, expand_shape) between it and
+  // tensor.empty. Use tracesToTensorEmpty to handle both cases.
   int64_t availableElements = innermostDim;
   Value output = copyOp.getOutputs()[0];
-  if (output.getDefiningOp<tensor::EmptyOp>()) {
-    if (llvm::none_of(shape, ShapedType::isDynamic)) {
-      availableElements = ShapedType::getNumElements(shape);
-    }
+  if (tracesToTensorEmpty(output) &&
+      llvm::none_of(shape, ShapedType::isDynamic)) {
+    availableElements = ShapedType::getNumElements(shape);
   }
 
   return getDMAAlignedSubgroupSize(funcOp, outputType.getElementType(),
@@ -1011,16 +1036,14 @@ private:
     }
 
     // Determine how many elements are available for coalesced access.
-    // For CopyOp with tensor.empty() output, we can linearize all dimensions.
-    // Otherwise, we can only use the innermost dimension.
+    // For CopyOp with output tracing to tensor.empty() (possibly through
+    // swizzle promotion ops), we can linearize all dimensions.
     int64_t availableElements = innermostDim;
     if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
       Value output = copyOp.getOutputs()[0];
-      if (output.getDefiningOp<tensor::EmptyOp>()) {
-        // Can linearize all dimensions - compute total static elements.
-        if (llvm::none_of(shape, ShapedType::isDynamic)) {
-          availableElements = ShapedType::getNumElements(shape);
-        }
+      if (tracesToTensorEmpty(output) &&
+          llvm::none_of(shape, ShapedType::isDynamic)) {
+        availableElements = ShapedType::getNumElements(shape);
       }
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -777,3 +777,52 @@ func.func @copy_from_dispatch_tensor_load(%init: tensor<64x512xbf16>) -> tensor<
 
   return %result : tensor<64x512xbf16>
 }
+
+// -----
+
+// Test: Small innermost dimension with swizzle_hint + expand_shape output CAN
+// be linearized. When the copy output traces through expand_shape and
+// swizzle_hint back to tensor.empty(), we can use total elements for the
+// alignment check, enabling coalesced DMA even when innermost dim alone is
+// too small.
+
+#gpu_target_swizzle_linearize = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32]
+>>
+
+#exec_target_swizzle_linearize = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_swizzle_linearize}>
+#translation_swizzle_linearize = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @copy_swizzle_hint_linearized
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<128x16xf32>
+func.func @copy_swizzle_hint_linearized(%source: tensor<128x16xf32>) -> tensor<128x16xf32>
+  attributes {hal.executable.target = #exec_target_swizzle_linearize, translation_info = #translation_swizzle_linearize} {
+  // Swizzle promotion creates: tensor.empty -> swizzle_hint -> expand_shape
+  %empty = tensor.empty() : tensor<2048xf32>
+  %swizzled = iree_codegen.swizzle_hint %empty[#iree_codegen.xor_shuffle<128, 16>] : tensor<2048xf32>
+  %expanded = tensor.expand_shape %swizzled [[0, 1]] output_shape [128, 16]
+      : tensor<2048xf32> into tensor<128x16xf32>
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%source : tensor<128x16xf32>)
+    outs(%expanded : tensor<128x16xf32>) -> tensor<128x16xf32>
+
+  // Innermost dimension (16) < minElementsPerTransfer (64), but since output
+  // traces through swizzle_hint to tensor.empty(), we use total elements (2048)
+  // for the check, which passes. DMA should be applied.
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<2048xf32>
+  // CHECK: %[[SWIZZLE:.+]] = iree_codegen.swizzle_hint %[[EMPTY]]
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SWIZZLE]]
+
+  // Warp-level forall should be created (not rejected due to alignment).
+  // CHECK: scf.forall
+  // CHECK:   scf.forall
+  // CHECK:     iree_gpu.coalesced_gather_dma
+  // CHECK-NOT: linalg.copy
+
+  return %result : tensor<128x16xf32>
+}


### PR DESCRIPTION
Part of enabling DMA with XOR Swizzle. And the issue is documented as barrier 1 in: https://hackmd.io/@ZFjpPhi8Q5ug3nawAd1acw/BytFfEkcWx

* Fix `tracesToTensorEmpty` to trace through swizzle promotion ops when checking if a copy output traces back to `tensor.empty`.
* Without this fix, DMA pre-check and the coalesced DMA conversion both fail to linearize across all dimensions when swizzle promotion inserts ops between the copy output and `tensor.empty()`.
* Add `traceThroughSwizzleOps` helper and use `tracesToTensorEmpty` uniformly in both the pre-check (`isCopyDMAConvertible`) and the conversion pattern.
* Add relevant tests.