### PR TITLE
Refactor proactor pool, add frontier-carrying signals, and fix shared infra.

### DIFF
--- a/build_tools/bazel/iree_cc_test.bzl
+++ b/build_tools/bazel/iree_cc_test.bzl
@@ -1,0 +1,145 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Platform-adaptive test rule.
+
+iree_cc_test wraps a cc_binary as a test target. On native platforms it
+symlinks to the binary. On wasm32 platforms it bundles the .wasm with a
+WASI test entry point and runs via Node.js.
+
+On wasm32, the entry point is determined by:
+  1. If an iree_wasm_entry target is found in cc_deps, its main JS file
+     is used as the entry point (with its srcs as bundler sandbox inputs).
+  2. Otherwise, the default wasm_test_main.mjs generic WASI harness is used.
+"""
+
+load(
+    "//build_tools/bazel:iree_wasm_library.bzl",
+    "IreeWasmEntryCollectionInfo",
+    "collect_and_bundle",
+    "collect_wasm_js",
+)
+
+def _iree_cc_test_impl(ctx):
+    is_wasm = ctx.target_platform_has_constraint(
+        ctx.attr._wasm32_constraint[platform_common.ConstraintValueInfo],
+    )
+
+    binary_info = ctx.attr.binary[DefaultInfo]
+    binary_executable = binary_info.files_to_run.executable
+
+    # Collect data files into runfiles.
+    data_runfiles = ctx.runfiles(files = ctx.files.data)
+
+    # Build environment dict, expanding $(rootpath) for data labels.
+    env = {}
+    for key, value in ctx.attr.env.items():
+        env[key] = ctx.expand_location(value, ctx.attr.data)
+
+    if not is_wasm:
+        # Native: symlink to the cc_binary executable.
+        executable = ctx.actions.declare_file(ctx.label.name)
+        ctx.actions.symlink(
+            output = executable,
+            target_file = binary_executable,
+        )
+        runfiles = ctx.runfiles().merge(binary_info.default_runfiles).merge(data_runfiles)
+        return [
+            DefaultInfo(
+                executable = executable,
+                runfiles = runfiles,
+            ),
+            testing.TestEnvironment(env),
+        ]
+
+    # Wasm: discover entry point from deps, falling back to the generic
+    # WASI test harness if no iree_wasm_entry target is present.
+    main_js = None
+    main_srcs = []
+    for dep in ctx.attr.cc_deps:
+        if IreeWasmEntryCollectionInfo in dep:
+            for entry in dep[IreeWasmEntryCollectionInfo].entries.to_list():
+                if main_js != None:
+                    fail("Multiple iree_wasm_entry targets found in deps " +
+                         "of %s; expected at most one" % ctx.label)
+                main_js = entry.main
+                main_srcs = list(entry.srcs)
+
+    if main_js == None:
+        main_js = ctx.file._test_main
+
+    output_mjs = collect_and_bundle(
+        ctx = ctx,
+        wasm_binary = binary_executable,
+        main_js = main_js,
+        cc_deps = ctx.attr.cc_deps,
+        bundler = ctx.executable._bundler,
+        main_srcs = main_srcs,
+    )
+
+    # Shell wrapper: locates the bundled .mjs in the runfiles tree and
+    # executes it via node. Test arguments are forwarded.
+    executable = ctx.actions.declare_file(ctx.label.name)
+    wrapper_content = (
+        "#!/bin/bash\n" +
+        'RUNFILES="${{RUNFILES_DIR:-$0.runfiles}}"\n' +
+        'exec node "$RUNFILES/{workspace}/{mjs_path}" "$@"\n'
+    ).format(
+        workspace = ctx.workspace_name,
+        mjs_path = output_mjs.short_path,
+    )
+    ctx.actions.write(
+        output = executable,
+        content = wrapper_content,
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(
+        files = [binary_executable, output_mjs],
+    ).merge(binary_info.default_runfiles)
+    return [DefaultInfo(
+        executable = executable,
+        runfiles = runfiles,
+    )]
+
+iree_cc_test = rule(
+    implementation = _iree_cc_test_impl,
+    test = True,
+    attrs = {
+        "binary": attr.label(
+            mandatory = True,
+            providers = [DefaultInfo],
+            doc = "The cc_binary target to wrap as a test.",
+        ),
+        "cc_deps": attr.label_list(
+            aspects = [collect_wasm_js],
+            doc = "Same deps as the cc_binary (for wasm JS companion collection).",
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+            doc = "Data files available to the test at runtime.",
+        ),
+        "env": attr.string_dict(
+            doc = "Environment variables set for the test.",
+        ),
+        "_wasm32_constraint": attr.label(
+            default = "@platforms//cpu:wasm32",
+        ),
+        "_test_main": attr.label(
+            default = "//build_tools/wasm:wasm_test_main.mjs",
+            allow_single_file = True,
+        ),
+        "_bundler": attr.label(
+            default = "//build_tools/wasm:wasm_binary_bundler",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = "Platform-adaptive test rule. On native platforms, runs the " +
+          "cc_binary directly. On wasm32 platforms, bundles with a WASI " +
+          "test entry point and runs via Node.js. If an iree_wasm_entry " +
+          "target is found in deps, it overrides the default entry point.",
+)

--- a/build_tools/bazel/iree_hal_cts_test_suite.bzl
+++ b/build_tools/bazel/iree_hal_cts_test_suite.bzl
@@ -246,6 +246,14 @@ def iree_hal_cts_test_suite(
         **kwargs: Forwarded to underlying rules (e.g., target_compatible_with).
     """
 
+    # Separate test-specific kwargs (env, data, size, etc.) from kwargs that
+    # apply to all targets (target_compatible_with, etc.). Test kwargs go only
+    # to iree_runtime_cc_test; the rest go to all generated targets.
+    test_kwargs = {}
+    for key in ("env", "env_inherit", "data", "size", "timeout", "flaky", "shard_count", "local"):
+        if key in kwargs:
+            test_kwargs[key] = kwargs.pop(key)
+
     # Build the name prefix: "name_" if set, "" otherwise.
     prefix = ("%s_" % name) if name else ""
 
@@ -277,6 +285,10 @@ def iree_hal_cts_test_suite(
         "//runtime/src/iree/testing:gtest",
     ]
 
+    # Merge test-specific and general kwargs for test targets.
+    all_test_kwargs = dict(kwargs)
+    all_test_kwargs.update(test_kwargs)
+
     # Non-executable test binaries.
     for suffix, test_lib in _NON_EXECUTABLE_SUITES:
         iree_runtime_cc_test(
@@ -285,7 +297,7 @@ def iree_hal_cts_test_suite(
             args = args,
             deps = common_deps + [test_lib],
             tags = tags,
-            **kwargs
+            **all_test_kwargs
         )
 
     # Executable-dependent test binaries (only if formats are configured).
@@ -297,5 +309,5 @@ def iree_hal_cts_test_suite(
                 args = args,
                 deps = common_deps + _testdata_libs + [test_lib],
                 tags = tags,
-                **kwargs
+                **all_test_kwargs
             )

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -39,6 +39,8 @@ _PLATFORM_CMAKE_SYSTEM_NAME = {
     "@platforms//os:linux": "Linux",
     "@platforms//os:macos": "Darwin",
     "@platforms//os:windows": "Windows",
+    # CPU architecture constraints.
+    "@platforms//cpu:wasm32": "wasm_32",
 }
 
 
@@ -153,9 +155,13 @@ class BuildFileFunctions(object):
     def _convert_platform_condition(self, constraint_label):
         """Returns a CMake condition string for a platform constraint label."""
         cmake_name = _PLATFORM_CMAKE_SYSTEM_NAME.get(constraint_label)
-        if cmake_name:
-            return f'CMAKE_SYSTEM_NAME STREQUAL "{cmake_name}"'
-        return None
+        if not cmake_name:
+            return None
+        # CPU architecture constraints use IREE_ARCH; OS constraints use
+        # CMAKE_SYSTEM_NAME.
+        if constraint_label.startswith("@platforms//cpu:"):
+            return f'IREE_ARCH STREQUAL "{cmake_name}"'
+        return f'CMAKE_SYSTEM_NAME STREQUAL "{cmake_name}"'
 
     def _emit_platform_guard_begin(self, target_compatible_with):
         """Emits if(CMAKE_SYSTEM_NAME ...) for target_compatible_with."""

--- a/build_tools/sanitizer/lsan_suppressions_vulkan.txt
+++ b/build_tools/sanitizer/lsan_suppressions_vulkan.txt
@@ -1,7 +1,10 @@
-# LSAN suppressions for Vulkan ICD leaks
-# Vulkan ICDs allocate thread-local state via pthread_once callbacks on
-# internally-spawned threads. This state is never freed. These leaks are
-# in external GPU driver code (reported as <unknown module> by ASAN since
-# the symbolizer cannot resolve ICD internals).
+# LSAN suppressions for Vulkan driver leaks.
+# Mesa/RADV allocates per-thread state via pthread_once that is intentionally
+# never freed (driver thread-local caches). These are driver-internal
+# allocations, not IREE bugs.
 
+leak:libvulkan_radeon.so
+leak:libvulkan_lvp.so
+# Fallback: when ASAN can't resolve the shared library name, match the
+# pthread_once call that triggers the per-thread initialization.
 leak:__pthread_once_slow

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -1746,9 +1746,9 @@ void SetupHalBindings(nanobind::module_ m) {
            })
       .def("signal",
            [](HalSemaphore& self, uint64_t new_value) {
-             CheckApiStatus(
-                 iree_hal_semaphore_signal(self.raw_ptr(), new_value),
-                 "signaling semaphore");
+             CheckApiStatus(iree_hal_semaphore_signal(self.raw_ptr(), new_value,
+                                                      /*frontier=*/NULL),
+                            "signaling semaphore");
            })
       .def(
           "wait",

--- a/runtime/bindings/python/loop.cc
+++ b/runtime/bindings/python/loop.cc
@@ -86,7 +86,8 @@ class HalDeviceLoopBridge {
     IREE_PY_TRACEF("HalDeviceLoopBridge::Stop(%p)", this);
     iree_slim_mutex_lock(&mu_);
     shutdown_signaled_ = true;
-    auto status = iree_hal_semaphore_signal(control_sem_, control_next_++);
+    auto status = iree_hal_semaphore_signal(control_sem_, control_next_++,
+                                            /*frontier=*/NULL);
     iree_slim_mutex_unlock(&mu_);
     CheckApiStatus(status, "iree_hal_semaphore_signal");
     thread_.attr("join")();
@@ -265,7 +266,8 @@ class HalDeviceLoopBridge {
     next_pending_futures_.push_back(std::make_tuple(
         semaphore.steal_raw_ptr(), payload, future, value.release()));
     future.inc_ref();
-    auto status = iree_hal_semaphore_signal(control_sem_, control_next_++);
+    auto status = iree_hal_semaphore_signal(control_sem_, control_next_++,
+                                            /*frontier=*/NULL);
     iree_slim_mutex_unlock(&mu_);
     CheckApiStatus(status, "iree_hal_semaphore_signal");
     return future;

--- a/runtime/src/iree/async/frontier.h
+++ b/runtime/src/iree/async/frontier.h
@@ -272,6 +272,43 @@ typedef struct iree_async_frontier_t {
   iree_async_frontier_entry_t entries[];
 } iree_async_frontier_t;
 
+// A frontier with exactly one (axis, epoch) entry, sized for stack allocation.
+// Memory-layout-compatible with iree_async_frontier_t when cast — the entries
+// fixed array begins at the same offset as the FAM in iree_async_frontier_t.
+//
+// This is the common case for single-queue drivers: one queue produces one axis
+// entry per signal. Declare on the stack and use the as_frontier accessor for
+// API calls that take iree_async_frontier_t*.
+typedef struct iree_async_single_frontier_t {
+  uint8_t entry_count;
+  uint8_t reserved[7];
+  iree_async_frontier_entry_t entries[1];
+} iree_async_single_frontier_t;
+
+// Returns a pointer to the layout-compatible iree_async_frontier_t within a
+// single-entry frontier. Valid for all frontier APIs (compare, merge, etc.).
+static inline iree_async_frontier_t* iree_async_single_frontier_as_frontier(
+    iree_async_single_frontier_t* single) {
+  return (iree_async_frontier_t*)single;
+}
+
+// Returns a const pointer to the layout-compatible iree_async_frontier_t.
+static inline const iree_async_frontier_t*
+iree_async_single_frontier_as_const_frontier(
+    const iree_async_single_frontier_t* single) {
+  return (const iree_async_frontier_t*)single;
+}
+
+// Initializes a single-entry frontier for the given axis and epoch.
+static inline void iree_async_single_frontier_initialize(
+    iree_async_single_frontier_t* frontier, iree_async_axis_t axis,
+    uint64_t epoch) {
+  frontier->entry_count = 1;
+  memset(frontier->reserved, 0, sizeof(frontier->reserved));
+  frontier->entries[0].axis = axis;
+  frontier->entries[0].epoch = epoch;
+}
+
 // Computes the total byte size needed to store a frontier with |entry_count|
 // entries using overflow-checked arithmetic. Use this for slab or heap
 // allocation:

--- a/runtime/src/iree/async/util/BUILD.bazel
+++ b/runtime/src/iree/async/util/BUILD.bazel
@@ -90,18 +90,31 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_library(
+    name = "proactor_pool_types",
+    hdrs = ["proactor_pool_types.h"],
+    deps = [
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/base",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "proactor_pool",
     srcs = ["proactor_pool.c"],
     hdrs = ["proactor_pool.h"],
     deps = [
-        ":proactor_thread",
+        ":proactor_pool_types",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async:platform",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/threading",
-        "//runtime/src/iree/base/threading:thread",
-    ],
+    ] + select({
+        "@platforms//cpu:wasm32": [],
+        "//conditions:default": [
+            ":proactor_thread_runner",
+        ],
+    }),
 )
 
 iree_runtime_cc_test(
@@ -113,6 +126,16 @@ iree_runtime_cc_test(
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
+    name = "proactor_thread_runner",
+    srcs = ["proactor_thread_runner.c"],
+    hdrs = ["proactor_thread_runner.h"],
+    deps = [
+        ":proactor_pool_types",
+        ":proactor_thread",
     ],
 )
 

--- a/runtime/src/iree/async/util/CMakeLists.txt
+++ b/runtime/src/iree/async/util/CMakeLists.txt
@@ -103,19 +103,35 @@ iree_cc_test(
 
 iree_cc_library(
   NAME
+    proactor_pool_types
+  HDRS
+    "proactor_pool_types.h"
+  DEPS
+    iree::async
+    iree::base
+  PUBLIC
+)
+
+set(_proactor_pool_platform_deps "")
+if(IREE_ARCH STREQUAL "wasm_32")
+else()
+  list(APPEND _proactor_pool_platform_deps ::proactor_thread_runner)
+endif()
+iree_cc_library(
+  NAME
     proactor_pool
   HDRS
     "proactor_pool.h"
   SRCS
     "proactor_pool.c"
   DEPS
-    ::proactor_thread
+    ::proactor_pool_types
     iree::async
     iree::async::platform
     iree::base
     iree::base::internal
     iree::base::threading
-    iree::base::threading::thread
+    ${_proactor_pool_platform_deps}
   PUBLIC
 )
 
@@ -130,6 +146,19 @@ iree_cc_test(
     iree::base
     iree::testing::gtest
     iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
+    proactor_thread_runner
+  HDRS
+    "proactor_thread_runner.h"
+  SRCS
+    "proactor_thread_runner.c"
+  DEPS
+    ::proactor_pool_types
+    ::proactor_thread
+  PUBLIC
 )
 
 iree_cc_library(

--- a/runtime/src/iree/async/util/proactor_pool.c
+++ b/runtime/src/iree/async/util/proactor_pool.c
@@ -12,6 +12,28 @@
 #include "iree/base/internal/atomics.h"
 #include "iree/base/threading/mutex.h"
 
+// The thread runner is available on platforms with C threading support.
+// On wasm, the JS event loop drives proactors — no runner needed.
+#if !IREE_PLATFORM_WASM
+#include "iree/async/util/proactor_thread_runner.h"
+#define IREE_ASYNC_PROACTOR_POOL_HAVE_RUNNER_THREAD 1
+#endif  // !IREE_PLATFORM_WASM
+
+//===----------------------------------------------------------------------===//
+// iree_async_proactor_pool_options_default
+//===----------------------------------------------------------------------===//
+
+iree_async_proactor_pool_options_t iree_async_proactor_pool_options_default(
+    void) {
+  iree_async_proactor_pool_options_t options;
+  memset(&options, 0, sizeof(options));
+  options.proactor_options = iree_async_proactor_options_default();
+#if IREE_ASYNC_PROACTOR_POOL_HAVE_RUNNER_THREAD
+  options.runner = iree_async_proactor_pool_thread_runner_factory();
+#endif  // IREE_ASYNC_PROACTOR_POOL_HAVE_RUNNER_THREAD
+  return options;
+}
+
 //===----------------------------------------------------------------------===//
 // iree_async_proactor_pool_t
 //===----------------------------------------------------------------------===//
@@ -22,14 +44,15 @@ typedef struct iree_async_proactor_pool_entry_t {
   uint32_t node_id;
   // Proactor instance, created on first access (retained by the pool).
   iree_async_proactor_t* proactor;
-  // Thread driving the proactor's poll loop, created with proactor (retained).
-  iree_async_proactor_thread_t* thread;
+  // Opaque poll runner handle, created alongside the proactor by the runner
+  // factory. NULL if no runner factory is configured.
+  void* runner;
 } iree_async_proactor_pool_entry_t;
 
 struct iree_async_proactor_pool_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
-  // Options stored for deferred proactor/thread creation.
+  // Options stored for deferred proactor/runner creation.
   iree_async_proactor_pool_options_t options;
   // Mutex protecting lazy initialization of entries.
   iree_slim_mutex_t mutex;
@@ -42,21 +65,33 @@ static void iree_async_proactor_pool_destroy(iree_async_proactor_pool_t* pool) {
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)pool->count);
 
-  // Request all threads to stop first (non-blocking), then join them.
-  // Requesting all stops before joining any avoids serializing the shutdown
-  // latency across N threads.
-  for (iree_host_size_t i = 0; i < pool->count; ++i) {
-    if (pool->entries[i].thread) {
-      iree_async_proactor_thread_request_stop(pool->entries[i].thread);
+  // Request all runners to stop first (non-blocking), then destroy them.
+  // Requesting all stops before destroying any avoids serializing the shutdown
+  // latency across N runners.
+  if (pool->options.runner.request_stop) {
+    // Collect runner handles into a stack array for the batch stop call.
+    // N is small (1-8 NUMA nodes) so stack allocation is fine.
+    void* runners[16];
+    iree_host_size_t runner_count = pool->count < IREE_ARRAYSIZE(runners)
+                                        ? pool->count
+                                        : IREE_ARRAYSIZE(runners);
+    for (iree_host_size_t i = 0; i < runner_count; ++i) {
+      runners[i] = pool->entries[i].runner;
+    }
+    pool->options.runner.request_stop(pool->options.runner.user_data, runners,
+                                      runner_count);
+  }
+  if (pool->options.runner.destroy) {
+    for (iree_host_size_t i = 0; i < pool->count; ++i) {
+      if (pool->entries[i].runner) {
+        pool->options.runner.destroy(pool->options.runner.user_data,
+                                     pool->entries[i].runner);
+        pool->entries[i].runner = NULL;
+      }
     }
   }
+
   for (iree_host_size_t i = 0; i < pool->count; ++i) {
-    if (pool->entries[i].thread) {
-      iree_status_ignore(iree_async_proactor_thread_join(
-          pool->entries[i].thread, IREE_DURATION_INFINITE));
-      iree_async_proactor_thread_release(pool->entries[i].thread);
-      pool->entries[i].thread = NULL;
-    }
     if (pool->entries[i].proactor) {
       iree_async_proactor_release(pool->entries[i].proactor);
       pool->entries[i].proactor = NULL;
@@ -103,7 +138,7 @@ iree_status_t iree_async_proactor_pool_create(
   iree_slim_mutex_initialize(&pool->mutex);
   pool->count = node_count;
 
-  // Initialize node IDs. Proactors and threads are created on-demand when
+  // Initialize node IDs. Proactors and runners are created on-demand when
   // pool_get or pool_get_for_node is first called for each entry.
   for (iree_host_size_t i = 0; i < node_count; ++i) {
     pool->entries[i].node_id = node_ids ? node_ids[i] : UINT32_MAX;
@@ -132,7 +167,7 @@ iree_host_size_t iree_async_proactor_pool_count(
   return pool->count;
 }
 
-// Creates the proactor and thread for |entry| if not already initialized.
+// Creates the proactor and runner for |entry| if not already initialized.
 // Must be called with pool->mutex held.
 static iree_status_t iree_async_proactor_pool_ensure_entry_locked(
     iree_async_proactor_pool_t* pool, iree_host_size_t index) {
@@ -153,33 +188,19 @@ static iree_status_t iree_async_proactor_pool_ensure_entry_locked(
   IREE_RETURN_IF_ERROR(iree_async_proactor_create_platform(
       proactor_options, pool->allocator, &entry->proactor));
 
-  // Configure thread with NUMA affinity if node ID is specified.
-  iree_async_proactor_thread_options_t thread_options =
-      iree_async_proactor_thread_options_default();
-  if (entry->node_id != UINT32_MAX) {
-    iree_thread_affinity_set_group_any(entry->node_id,
-                                       &thread_options.affinity);
+  // Create a poll runner if the factory is configured.
+  if (pool->options.runner.create) {
+    iree_status_t status = pool->options.runner.create(
+        pool->options.runner.user_data, entry->proactor, entry->node_id,
+        pool->allocator, &entry->runner);
+    if (!iree_status_is_ok(status)) {
+      iree_async_proactor_release(entry->proactor);
+      entry->proactor = NULL;
+      return status;
+    }
   }
-  thread_options.error_callback = pool->options.error_callback;
 
-  char thread_name_buffer[32];
-  if (entry->node_id != UINT32_MAX) {
-    snprintf(thread_name_buffer, sizeof(thread_name_buffer), "iree-pro-%u",
-             entry->node_id);
-  } else {
-    snprintf(thread_name_buffer, sizeof(thread_name_buffer), "iree-pro-%zu",
-             index);
-  }
-  thread_options.debug_name =
-      iree_make_string_view(thread_name_buffer, strlen(thread_name_buffer));
-
-  iree_status_t status = iree_async_proactor_thread_create(
-      entry->proactor, thread_options, pool->allocator, &entry->thread);
-  if (!iree_status_is_ok(status)) {
-    iree_async_proactor_release(entry->proactor);
-    entry->proactor = NULL;
-  }
-  return status;
+  return iree_ok_status();
 }
 
 iree_status_t iree_async_proactor_pool_get(

--- a/runtime/src/iree/async/util/proactor_pool.h
+++ b/runtime/src/iree/async/util/proactor_pool.h
@@ -4,19 +4,29 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Proactor pool: a process-level factory for NUMA-pinned proactor threads.
+// Proactor pool: a process-level factory for NUMA-pinned proactors.
 //
-// Creates proactors and dedicated poll threads on-demand per NUMA node,
-// allowing HAL devices, network sessions, and other subsystems to share I/O
-// infrastructure with proper NUMA locality. The pool is ref-counted — devices
-// retain the pool during creation, ensuring proactor threads outlive the
-// device. Callers can release their reference immediately after device
-// creation.
+// Creates proactors on-demand per NUMA node, allowing HAL devices, network
+// sessions, and other subsystems to share I/O infrastructure with proper NUMA
+// locality. The pool is ref-counted — devices retain the pool during creation,
+// ensuring proactors outlive the device. Callers can release their reference
+// immediately after device creation.
 //
-// Proactors and threads are created lazily: no threads are spawned until
-// pool_get() or pool_get_for_node() is called. This makes pool creation
-// effectively free — create a pool, pass it to device creation, release it.
-// If no driver requests a proactor, no threads are ever created.
+// Proactors are created lazily: nothing is allocated until pool_get() or
+// pool_get_for_node() is called. This makes pool creation effectively free —
+// create a pool, pass it to device creation, release it. If no driver requests
+// a proactor, no resources are allocated.
+//
+// ## Poll runners
+//
+// Proactors are caller-driven: they only make progress when poll() is called.
+// The pool supports an optional runner factory that creates a poll runner for
+// each proactor on-demand. The standard runner creates a dedicated poll thread
+// (see proactor_runner_thread.h). On platforms without C threads (wasm), the
+// host event loop drives polling and no runner is needed.
+//
+// The default options (iree_async_proactor_pool_options_default) select the
+// appropriate runner for the platform: threaded on native, none on wasm.
 //
 // ## Typical usage
 //
@@ -35,23 +45,22 @@
 //       driver, &create_params, allocator, &device));
 //   iree_async_proactor_pool_release(pool);
 //
-//   // At shutdown: releasing the device releases the pool (and joins threads).
+//   // At shutdown: releasing the device releases the pool (and runners).
 //   iree_hal_device_release(device);
 //
 // ## NUMA mapping
 //
-// When |node_ids| are provided, each proactor thread is pinned to the
-// corresponding NUMA node via iree_thread_affinity_set_group_any(). When
-// |node_ids| is NULL, all threads get unspecified affinity (OS chooses).
-// On single-node systems (node_count=1), the pool degenerates to a single
-// proactor thread with no explicit affinity — this is the common case and
-// works well.
+// When |node_ids| are provided, each proactor's runner is pinned to the
+// corresponding NUMA node (if the runner supports affinity). When |node_ids|
+// is NULL, all runners get unspecified affinity (OS chooses). On single-node
+// systems (node_count=1), the pool degenerates to a single proactor — this is
+// the common case and works well.
 
 #ifndef IREE_ASYNC_UTIL_PROACTOR_POOL_H_
 #define IREE_ASYNC_UTIL_PROACTOR_POOL_H_
 
 #include "iree/async/proactor.h"
-#include "iree/async/util/proactor_thread.h"
+#include "iree/async/util/proactor_pool_types.h"
 #include "iree/base/api.h"
 
 #ifdef __cplusplus
@@ -67,38 +76,34 @@ typedef struct iree_async_proactor_pool_options_t {
   // Options applied to each proactor created by the pool.
   iree_async_proactor_options_t proactor_options;
 
-  // Error callback invoked when any proactor thread encounters a fatal error.
-  // The callback fires from the dying proactor thread. If fn is NULL, errors
-  // are silently stored and can be retrieved via consume_status() on the
-  // individual proactor thread (accessible through the pool).
-  iree_async_proactor_thread_error_callback_t error_callback;
+  // Optional runner factory for creating poll runners that drive proactors.
+  // When create is non-NULL, the pool calls it for each proactor during
+  // pool_get(). When create is NULL (zero-initialized), proactors are created
+  // without a runner and the caller is responsible for polling.
+  iree_async_proactor_pool_runner_factory_t runner;
 } iree_async_proactor_pool_options_t;
 
-// Returns default pool options (default proactor options, no error callback).
-static inline iree_async_proactor_pool_options_t
-iree_async_proactor_pool_options_default(void) {
-  iree_async_proactor_pool_options_t options;
-  memset(&options, 0, sizeof(options));
-  options.proactor_options = iree_async_proactor_options_default();
-  return options;
-}
+// Returns default pool options appropriate for the current platform.
+// On native platforms: creates a threaded poll runner per proactor.
+// On wasm: no runner (the JS event loop drives polling).
+iree_async_proactor_pool_options_t iree_async_proactor_pool_options_default(
+    void);
 
 typedef struct iree_async_proactor_pool_t iree_async_proactor_pool_t;
 
 // Creates a pool with capacity for |node_count| proactors.
 //
-// No proactors or threads are created during pool creation — they are created
+// No proactors or runners are created during pool creation — they are created
 // on-demand when pool_get() or pool_get_for_node() is first called for each
 // entry. This makes pool creation effectively free. |node_count| must be >= 1.
 //
 // If |node_ids| is non-NULL, it must point to |node_count| NUMA node IDs.
-// When a proactor thread is created on-demand, it is pinned to the
-// corresponding NUMA node. If |node_ids| is NULL, threads get no NUMA
-// affinity (suitable for single-node systems or when the caller doesn't care
-// about NUMA placement).
+// When a runner is created on-demand, the node ID is passed to the runner
+// factory for NUMA-aware pinning. If |node_ids| is NULL, runners get no
+// affinity hint (suitable for single-node systems).
 //
-// The pool retains all created proactors and threads. Releasing the pool (when
-// the ref count reaches zero) stops and joins any threads that were created.
+// The pool retains all created proactors and runners. Releasing the pool (when
+// the ref count reaches zero) stops all runners and releases all proactors.
 iree_status_t iree_async_proactor_pool_create(
     iree_host_size_t node_count, const uint32_t* node_ids,
     iree_async_proactor_pool_options_t options, iree_allocator_t allocator,
@@ -107,9 +112,8 @@ iree_status_t iree_async_proactor_pool_create(
 // Retains a reference to the pool.
 void iree_async_proactor_pool_retain(iree_async_proactor_pool_t* pool);
 
-// Releases a reference to the pool. When the count reaches zero, all proactor
-// threads are stopped and joined, all proactors are released, and the pool is
-// freed.
+// Releases a reference to the pool. When the count reaches zero, all runners
+// are stopped, all proactors are released, and the pool is freed.
 void iree_async_proactor_pool_release(iree_async_proactor_pool_t* pool);
 
 // Returns the number of proactors in the pool.
@@ -118,8 +122,7 @@ iree_host_size_t iree_async_proactor_pool_count(
 
 // Returns the proactor at the given dense |index| (0-based), creating it
 // on-demand if this is the first access for that index. The proactor and its
-// driving thread are created lazily — no threads are spawned until this
-// function (or get_for_node) is called.
+// runner (if the factory is set) are created lazily.
 //
 // The returned proactor is NOT retained — the caller must retain it if they
 // need it to outlive the pool.
@@ -133,8 +136,7 @@ uint32_t iree_async_proactor_pool_node_id(
     const iree_async_proactor_pool_t* pool, iree_host_size_t index);
 
 // Returns the proactor associated with the given NUMA |node_id|, creating it
-// on-demand if this is the first access for that node. The proactor and its
-// driving thread are created lazily.
+// on-demand if this is the first access for that node.
 //
 // If an exact match exists, returns that proactor. If no exact match is found
 // (e.g., the pool was created for a subset of nodes), returns the first

--- a/runtime/src/iree/async/util/proactor_pool_types.h
+++ b/runtime/src/iree/async/util/proactor_pool_types.h
@@ -1,0 +1,55 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Types shared between proactor_pool.h and runner implementations.
+
+#ifndef IREE_ASYNC_UTIL_PROACTOR_POOL_TYPES_H_
+#define IREE_ASYNC_UTIL_PROACTOR_POOL_TYPES_H_
+
+#include "iree/async/proactor.h"
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Factory callbacks for creating poll runners that drive proactors.
+//
+// When a proactor is first accessed via pool_get(), the pool calls |create| to
+// optionally create a runner that drives the proactor's poll loop. If the
+// factory's |create| is NULL, no runner is created and the caller (or host
+// event loop) is responsible for polling.
+//
+// The standard implementation (proactor_runner_thread.h) creates a dedicated
+// poll thread for each proactor.
+typedef struct iree_async_proactor_pool_runner_factory_t {
+  void* user_data;
+
+  // Creates a poll runner for |proactor|.
+  // |node_id| is the NUMA node for the proactor (UINT32_MAX if unspecified).
+  // Stores an opaque runner handle in |out_runner| (may be NULL if the runner
+  // is self-managing). Called under pool mutex — must not call back into the
+  // pool.
+  iree_status_t (*create)(void* user_data, iree_async_proactor_t* proactor,
+                          uint32_t node_id, iree_allocator_t allocator,
+                          void** out_runner);
+
+  // Requests all runners to stop. Called once before any destroy calls.
+  // Non-blocking: signals each runner to stop but does not wait.
+  // |runners| and |count| are the opaque handles returned by create.
+  // NULL entries are skipped.
+  void (*request_stop)(void* user_data, void** runners, iree_host_size_t count);
+
+  // Destroys a single runner, blocking until it has fully stopped.
+  // Called after request_stop has been called for all runners.
+  void (*destroy)(void* user_data, void* runner);
+} iree_async_proactor_pool_runner_factory_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_ASYNC_UTIL_PROACTOR_POOL_TYPES_H_

--- a/runtime/src/iree/async/util/proactor_thread_runner.c
+++ b/runtime/src/iree/async/util/proactor_thread_runner.c
@@ -1,0 +1,76 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/async/util/proactor_thread_runner.h"
+
+#include <stdio.h>
+
+#include "iree/async/util/proactor_thread.h"
+
+//===----------------------------------------------------------------------===//
+// Thread runner factory callbacks
+//===----------------------------------------------------------------------===//
+
+static iree_status_t iree_async_proactor_pool_thread_runner_create(
+    void* user_data, iree_async_proactor_t* proactor, uint32_t node_id,
+    iree_allocator_t allocator, void** out_runner) {
+  iree_async_proactor_thread_options_t thread_options =
+      iree_async_proactor_thread_options_default();
+
+  // Configure NUMA affinity if a node ID is specified.
+  if (node_id != UINT32_MAX) {
+    iree_thread_affinity_set_group_any(node_id, &thread_options.affinity);
+  }
+
+  // Generate a debug name from the node ID or a generic index.
+  char thread_name_buffer[32];
+  if (node_id != UINT32_MAX) {
+    snprintf(thread_name_buffer, sizeof(thread_name_buffer), "iree-pro-%u",
+             node_id);
+  } else {
+    snprintf(thread_name_buffer, sizeof(thread_name_buffer), "iree-pro");
+  }
+  thread_options.debug_name =
+      iree_make_string_view(thread_name_buffer, strlen(thread_name_buffer));
+
+  iree_async_proactor_thread_t* thread = NULL;
+  IREE_RETURN_IF_ERROR(iree_async_proactor_thread_create(
+      proactor, thread_options, allocator, &thread));
+  *out_runner = thread;
+  return iree_ok_status();
+}
+
+static void iree_async_proactor_pool_thread_runner_request_stop(
+    void* user_data, void** runners, iree_host_size_t count) {
+  for (iree_host_size_t i = 0; i < count; ++i) {
+    if (runners[i]) {
+      iree_async_proactor_thread_request_stop(
+          (iree_async_proactor_thread_t*)runners[i]);
+    }
+  }
+}
+
+static void iree_async_proactor_pool_thread_runner_destroy(void* user_data,
+                                                           void* runner) {
+  iree_async_proactor_thread_t* thread = (iree_async_proactor_thread_t*)runner;
+  iree_status_ignore(
+      iree_async_proactor_thread_join(thread, IREE_DURATION_INFINITE));
+  iree_async_proactor_thread_release(thread);
+}
+
+//===----------------------------------------------------------------------===//
+// Public factory constructor
+//===----------------------------------------------------------------------===//
+
+iree_async_proactor_pool_runner_factory_t
+iree_async_proactor_pool_thread_runner_factory(void) {
+  iree_async_proactor_pool_runner_factory_t factory;
+  memset(&factory, 0, sizeof(factory));
+  factory.create = iree_async_proactor_pool_thread_runner_create;
+  factory.request_stop = iree_async_proactor_pool_thread_runner_request_stop;
+  factory.destroy = iree_async_proactor_pool_thread_runner_destroy;
+  return factory;
+}

--- a/runtime/src/iree/async/util/proactor_thread_runner.h
+++ b/runtime/src/iree/async/util/proactor_thread_runner.h
@@ -1,0 +1,39 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Thread-based poll runner factory for the proactor pool.
+//
+// Creates a dedicated poll thread for each proactor, driving the proactor's
+// poll loop automatically. This is the standard runner for native platforms
+// (Linux, macOS, Windows) where C threads are available.
+//
+// The factory is returned by iree_async_proactor_pool_thread_runner_factory()
+// and injected into pool options. The pool calls the factory callbacks during
+// pool_get() (create) and pool_release() (request_stop, destroy).
+
+#ifndef IREE_ASYNC_UTIL_PROACTOR_THREAD_RUNNER_H_
+#define IREE_ASYNC_UTIL_PROACTOR_THREAD_RUNNER_H_
+
+#include "iree/async/util/proactor_pool_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Returns a runner factory that creates a proactor_thread for each proactor.
+// Threads are configured with NUMA affinity based on the pool entry's node_id.
+//
+// This is the default runner factory on native platforms. It is set
+// automatically by iree_async_proactor_pool_options_default() when
+// IREE_ASYNC_PROACTOR_POOL_HAVE_RUNNER_THREAD is defined.
+iree_async_proactor_pool_runner_factory_t
+iree_async_proactor_pool_thread_runner_factory(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_ASYNC_UTIL_PROACTOR_THREAD_RUNNER_H_

--- a/runtime/src/iree/base/threading/call_once.h
+++ b/runtime/src/iree/base/threading/call_once.h
@@ -84,10 +84,16 @@ static inline void iree_call_once(iree_once_flag* flag, void (*func)(void)) {
 
 #elif IREE_SYNCHRONIZATION_DISABLE_UNSAFE
 
-// No-op when the thread control is disabled.
-#define IREE_ONCE_FLAG_INIT 1
+// Single-threaded fallback: no synchronization, but still calls the function
+// exactly once. The flag tracks whether the function has been called.
+#define IREE_ONCE_FLAG_INIT 0
 #define iree_once_flag uint32_t
-static inline void iree_call_once(iree_once_flag* flag, void (*func)(void)) {}
+static inline void iree_call_once(iree_once_flag* flag, void (*func)(void)) {
+  if (*flag == 0) {
+    *flag = 1;
+    func();
+  }
+}
 
 #else
 

--- a/runtime/src/iree/hal/cts/core/BUILD.bazel
+++ b/runtime/src/iree/hal/cts/core/BUILD.bazel
@@ -50,6 +50,21 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "semaphore_thread_test",
+    testonly = True,
+    srcs = ["semaphore_thread_test.cc"],
+    target_compatible_with = select({
+        "@platforms//cpu:wasm32": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/cts/util:test_base",
+    ],
+    alwayslink = True,
+)
+
+iree_runtime_cc_library(
     name = "executable_test",
     testonly = True,
     srcs = ["executable_test.cc"],
@@ -79,7 +94,12 @@ iree_runtime_cc_library(
         ":driver_test",
         ":event_test",
         ":semaphore_test",
-    ],
+    ] + select({
+        "@platforms//cpu:wasm32": [],
+        "//conditions:default": [
+            ":semaphore_thread_test",
+        ],
+    }),
 )
 
 # All executable-dependent core tests.

--- a/runtime/src/iree/hal/cts/core/CMakeLists.txt
+++ b/runtime/src/iree/hal/cts/core/CMakeLists.txt
@@ -53,6 +53,19 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    semaphore_thread_test
+  SRCS
+    "semaphore_thread_test.cc"
+  DEPS
+    iree::hal
+    iree::hal::cts::util::test_base
+  TESTONLY
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     executable_test
   SRCS
     "executable_test.cc"
@@ -77,6 +90,11 @@ iree_cc_library(
   PUBLIC
 )
 
+set(_all_tests_platform_deps "")
+if(IREE_ARCH STREQUAL "wasm_32")
+else()
+  list(APPEND _all_tests_platform_deps ::semaphore_thread_test)
+endif()
 iree_cc_library(
   NAME
     all_tests
@@ -84,6 +102,7 @@ iree_cc_library(
     ::driver_test
     ::event_test
     ::semaphore_test
+    ${_all_tests_platform_deps}
   TESTONLY
   PUBLIC
 )

--- a/runtime/src/iree/hal/cts/core/semaphore_test.cc
+++ b/runtime/src/iree/hal/cts/core/semaphore_test.cc
@@ -4,14 +4,13 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <chrono>
-#include <thread>
+// Single-threaded semaphore tests. Tests that require std::thread (cross-thread
+// signaling, ping-pong, timed waits with background signalers) are in
+// semaphore_thread_test.cc.
 
 #include "iree/hal/cts/util/test_base.h"
 
 namespace iree::hal::cts {
-
-using namespace std::chrono_literals;
 
 class SemaphoreTest : public CtsTestBase<> {};
 
@@ -39,10 +38,11 @@ TEST_P(SemaphoreTest, NormalSignaling) {
   uint64_t value;
   IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore, &value));
   EXPECT_EQ(2ull, value);
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 3ull));
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 3ull, /*frontier=*/NULL));
   IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore, &value));
   EXPECT_EQ(3ull, value);
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 40ull));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(semaphore, 40ull, /*frontier=*/NULL));
   IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore, &value));
   EXPECT_EQ(40ull, value);
 
@@ -56,7 +56,7 @@ TEST_P(SemaphoreTest, Failure) {
       iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 2ull,
                                 IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore));
 
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 3ull));
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 3ull, /*frontier=*/NULL));
   uint64_t value;
   IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore, &value));
   EXPECT_EQ(3ull, value);
@@ -126,27 +126,6 @@ TEST_P(SemaphoreTest, WaitUnsignaled) {
       iree_hal_semaphore_wait(semaphore, 3ull,
                               iree_make_deadline(IREE_TIME_INFINITE_PAST),
                               IREE_ASYNC_WAIT_FLAG_NONE));
-
-  iree_hal_semaphore_release(semaphore);
-}
-
-// Tests waiting on a semaphore that signals past the desired value.
-TEST_P(SemaphoreTest, WaitLaterSignaledBeyond) {
-  iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(
-      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 2ull,
-                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore));
-
-  std::thread thread([&]() {
-    std::this_thread::sleep_for(100ms);
-    // Signal beyond the desired value.
-    IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 10ull));
-  });
-
-  IREE_ASSERT_OK(iree_hal_semaphore_wait(
-      semaphore, 3ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE));
-  thread.join();
 
   iree_hal_semaphore_release(semaphore);
 }
@@ -230,175 +209,6 @@ TEST_P(SemaphoreTest, WaitAnyAlreadySignaled) {
   iree_hal_semaphore_release(semaphore_b);
 }
 
-TEST_P(SemaphoreTest, WaitAnyLaterSignaled) {
-  iree_hal_semaphore_t* semaphore_a = NULL;
-  iree_hal_semaphore_t* semaphore_b = NULL;
-  IREE_ASSERT_OK(
-      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
-                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore_a));
-  IREE_ASSERT_OK(
-      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
-                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore_b));
-
-  iree_hal_semaphore_t* semaphore_ptrs[] = {semaphore_a, semaphore_b};
-  uint64_t payload_values[] = {1ull, 1ull};
-  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_ptrs),
-                                              semaphore_ptrs, payload_values};
-
-  std::thread thread([&]() {
-    std::this_thread::sleep_for(100ms);
-    IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore_b, 1ull));
-  });
-
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_ASYNC_WAIT_MODE_ANY, semaphore_list,
-      iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE));
-  thread.join();
-
-  iree_hal_semaphore_release(semaphore_a);
-  iree_hal_semaphore_release(semaphore_b);
-}
-
-// Tests threading behavior by ping-ponging between the test main thread and
-// a little thread.
-TEST_P(SemaphoreTest, PingPong) {
-  iree_hal_semaphore_t* a2b = NULL;
-  iree_hal_semaphore_t* b2a = NULL;
-  IREE_ASSERT_OK(
-      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
-                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &a2b));
-  IREE_ASSERT_OK(
-      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
-                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &b2a));
-  std::thread thread([&]() {
-    // Should advance right past this because the value is already set.
-    IREE_ASSERT_OK(iree_hal_semaphore_wait(
-        a2b, 0ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-        IREE_ASYNC_WAIT_FLAG_NONE));
-    IREE_ASSERT_OK(iree_hal_semaphore_signal(b2a, 1ull));
-    // Jump ahead (blocking at first).
-    IREE_ASSERT_OK(iree_hal_semaphore_wait(
-        a2b, 4ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-        IREE_ASYNC_WAIT_FLAG_NONE));
-  });
-  // Block until thread signals.
-  IREE_ASSERT_OK(iree_hal_semaphore_wait(
-      b2a, 1ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE));
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(a2b, 4ull));
-  thread.join();
-
-  iree_hal_semaphore_release(a2b);
-  iree_hal_semaphore_release(b2a);
-}
-
-// Waiting the same value multiple times.
-TEST_P(SemaphoreTest, WaitOnTheSameValueMultipleTimes) {
-  iree_hal_semaphore_t* semaphore = CreateSemaphore();
-  std::thread thread(
-      [&]() { IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 1)); });
-
-  IREE_ASSERT_OK(iree_hal_semaphore_wait(
-      semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE));
-  CheckSemaphoreValue(semaphore, 1);
-
-  IREE_ASSERT_OK(iree_hal_semaphore_wait(
-      semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE));
-  CheckSemaphoreValue(semaphore, 1);
-
-  thread.join();
-
-  iree_hal_semaphore_release(semaphore);
-}
-
-// Waiting for a finite amount of time.
-TEST_P(SemaphoreTest, WaitForFiniteTime) {
-  auto generic_test_fn = [this](auto wait_fn) {
-    iree_hal_semaphore_t* semaphore = this->CreateSemaphore();
-
-    // Wait before signaling and make sure the semaphore value has not changed.
-    IREE_ASSERT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, wait_fn(semaphore));
-    CheckSemaphoreValue(semaphore, 0);
-
-    std::thread signaling_thread(
-        [&]() { IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 1)); });
-
-    // The semaphore must advance at some point.
-    while (true) {
-      iree_status_t status = wait_fn(semaphore);
-      if (iree_status_is_deadline_exceeded(status)) {
-        iree_status_ignore(status);
-        continue;
-      }
-      IREE_ASSERT_OK(status);
-      CheckSemaphoreValue(semaphore, 1);
-      break;
-    }
-
-    signaling_thread.join();
-    iree_hal_semaphore_release(semaphore);
-  };
-
-  // Immediate timeout.
-  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
-    return iree_hal_semaphore_wait(semaphore, 1, iree_immediate_timeout(),
-                                   IREE_ASYNC_WAIT_FLAG_NONE);
-  });
-
-  // Absolute timeout.
-  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
-    return iree_hal_semaphore_wait(semaphore, 1,
-                                   iree_make_deadline(iree_time_now() + 1),
-                                   IREE_ASYNC_WAIT_FLAG_NONE);
-  });
-
-  // Relative timeout.
-  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
-    return iree_hal_semaphore_wait(semaphore, 1, iree_make_timeout_ns(1),
-                                   IREE_ASYNC_WAIT_FLAG_NONE);
-  });
-}
-
-// Wait on all semaphores on multiple places simultaneously.
-TEST_P(SemaphoreTest, SimultaneousMultiWaitAll) {
-  iree_hal_semaphore_t* semaphore1 = this->CreateSemaphore();
-  iree_hal_semaphore_t* semaphore2 = this->CreateSemaphore();
-
-  iree_hal_semaphore_t* semaphore_array[] = {semaphore1, semaphore2};
-  uint64_t payload_array[] = {1, 1};
-  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_array),
-                                              semaphore_array, payload_array};
-
-  std::thread wait_thread1([&]() {
-    IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
-        semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-        IREE_ASYNC_WAIT_FLAG_NONE));
-  });
-
-  std::thread wait_thread2([&]() {
-    IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
-        semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-        IREE_ASYNC_WAIT_FLAG_NONE));
-  });
-
-  std::thread signal_thread([&]() {
-    IREE_ASSERT_OK(iree_hal_semaphore_list_signal(semaphore_list));
-  });
-
-  wait_thread1.join();
-  wait_thread2.join();
-  signal_thread.join();
-
-  CheckSemaphoreValue(semaphore1, 1);
-  CheckSemaphoreValue(semaphore2, 1);
-
-  iree_hal_semaphore_release(semaphore1);
-  iree_hal_semaphore_release(semaphore2);
-}
-
 // Wait on a semaphore that is then failed.
 TEST_P(SemaphoreTest, FailThenWait) {
   iree_hal_semaphore_t* semaphore = this->CreateSemaphore();
@@ -418,103 +228,6 @@ TEST_P(SemaphoreTest, FailThenWait) {
   iree_status_ignore(status);
 
   iree_hal_semaphore_release(semaphore);
-}
-
-// Wait on a semaphore that is then failed.
-TEST_P(SemaphoreTest, WaitThenFail) {
-  iree_hal_semaphore_t* semaphore = this->CreateSemaphore();
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_CANCELLED, "WaitThenFail test.");
-  std::thread signal_thread(
-      [&]() { iree_hal_semaphore_fail(semaphore, iree_status_clone(status)); });
-
-  iree_status_t wait_status = iree_hal_semaphore_wait(
-      semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, wait_status);
-  uint64_t value = 1234;
-  iree_status_t query_status = iree_hal_semaphore_query(semaphore, &value);
-  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
-  IREE_EXPECT_STATUS_IS(iree_status_code(status), query_status);
-  iree_status_ignore(status);
-
-  signal_thread.join();
-  iree_hal_semaphore_release(semaphore);
-}
-
-// Wait 2 semaphores then fail one of them.
-TEST_P(SemaphoreTest, MultiWaitThenFail) {
-  iree_hal_semaphore_t* semaphore1 = this->CreateSemaphore();
-  iree_hal_semaphore_t* semaphore2 = this->CreateSemaphore();
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_CANCELLED, "MultiWaitThenFail test.");
-  std::thread signal_thread([&]() {
-    iree_hal_semaphore_fail(semaphore1, iree_status_clone(status));
-  });
-
-  iree_hal_semaphore_t* semaphore_array[] = {semaphore1, semaphore2};
-  uint64_t payload_array[] = {1, 1};
-  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_array),
-                                              semaphore_array, payload_array};
-  iree_status_t wait_status = iree_hal_semaphore_list_wait(
-      semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
-      IREE_ASYNC_WAIT_FLAG_NONE);
-  // multi_wait returns the actual failure code — the caller can follow up with
-  // a query to get the full status with message/backtrace if needed.
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, wait_status);
-  uint64_t value = 1234;
-  iree_status_t semaphore1_query_status =
-      iree_hal_semaphore_query(semaphore1, &value);
-  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
-  IREE_EXPECT_STATUS_IS(iree_status_code(status), semaphore1_query_status);
-  iree_status_ignore(status);
-
-  // semaphore2 must not have changed.
-  uint64_t semaphore2_value = 1234;
-  IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore2, &semaphore2_value));
-  EXPECT_EQ(semaphore2_value, 0);
-
-  signal_thread.join();
-  iree_hal_semaphore_release(semaphore1);
-  iree_hal_semaphore_release(semaphore2);
-}
-
-// Wait 2 semaphores using iree_hal_device_wait_semaphores then fail one.
-TEST_P(SemaphoreTest, DeviceMultiWaitThenFail) {
-  iree_hal_semaphore_t* semaphore1 = this->CreateSemaphore();
-  iree_hal_semaphore_t* semaphore2 = this->CreateSemaphore();
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_CANCELLED, "DeviceMultiWaitThenFail test.");
-  std::thread signal_thread([&]() {
-    iree_hal_semaphore_fail(semaphore1, iree_status_clone(status));
-  });
-
-  iree_hal_semaphore_t* semaphore_array[] = {semaphore1, semaphore2};
-  uint64_t payload_array[] = {1, 1};
-  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_array),
-                                              semaphore_array, payload_array};
-  iree_status_t wait_status = iree_hal_device_wait_semaphores(
-      device_, IREE_ASYNC_WAIT_MODE_ANY, semaphore_list,
-      iree_make_deadline(IREE_TIME_INFINITE_FUTURE), IREE_ASYNC_WAIT_FLAG_NONE);
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, wait_status);
-  uint64_t value = 1234;
-  iree_status_t semaphore1_query_status =
-      iree_hal_semaphore_query(semaphore1, &value);
-  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
-  IREE_EXPECT_STATUS_IS(iree_status_code(status), semaphore1_query_status);
-  iree_status_ignore(status);
-
-  // semaphore2 must not have changed.
-  uint64_t semaphore2_value = 1234;
-  IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore2, &semaphore2_value));
-  EXPECT_EQ(semaphore2_value, 0);
-
-  signal_thread.join();
-  iree_hal_semaphore_release(semaphore1);
-  iree_hal_semaphore_release(semaphore2);
 }
 
 // Tests that failure status codes are preserved through the query round-trip.

--- a/runtime/src/iree/hal/cts/core/semaphore_thread_test.cc
+++ b/runtime/src/iree/hal/cts/core/semaphore_thread_test.cc
@@ -1,0 +1,318 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Semaphore tests that require std::thread for cross-thread signaling.
+// These are separated from semaphore_test.cc so platforms without C threading
+// (wasm, bare-metal) can run the single-threaded semaphore tests without
+// pulling in <thread>.
+
+#include <chrono>
+#include <thread>
+
+#include "iree/hal/cts/util/test_base.h"
+
+namespace iree::hal::cts {
+
+using namespace std::chrono_literals;
+
+class SemaphoreThreadTest : public CtsTestBase<> {};
+
+// Tests waiting on a semaphore that signals past the desired value.
+TEST_P(SemaphoreThreadTest, WaitLaterSignaledBeyond) {
+  iree_hal_semaphore_t* semaphore = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 2ull,
+                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore));
+
+  std::thread thread([&]() {
+    std::this_thread::sleep_for(100ms);
+    // Signal beyond the desired value.
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_signal(semaphore, 10ull, /*frontier=*/NULL));
+  });
+
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 3ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE));
+  thread.join();
+
+  iree_hal_semaphore_release(semaphore);
+}
+
+TEST_P(SemaphoreThreadTest, WaitAnyLaterSignaled) {
+  iree_hal_semaphore_t* semaphore_a = NULL;
+  iree_hal_semaphore_t* semaphore_b = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
+                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore_a));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
+                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &semaphore_b));
+
+  iree_hal_semaphore_t* semaphore_ptrs[] = {semaphore_a, semaphore_b};
+  uint64_t payload_values[] = {1ull, 1ull};
+  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_ptrs),
+                                              semaphore_ptrs, payload_values};
+
+  std::thread thread([&]() {
+    std::this_thread::sleep_for(100ms);
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_signal(semaphore_b, 1ull, /*frontier=*/NULL));
+  });
+
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_ASYNC_WAIT_MODE_ANY, semaphore_list,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE));
+  thread.join();
+
+  iree_hal_semaphore_release(semaphore_a);
+  iree_hal_semaphore_release(semaphore_b);
+}
+
+// Tests threading behavior by ping-ponging between the test main thread and
+// a little thread.
+TEST_P(SemaphoreThreadTest, PingPong) {
+  iree_hal_semaphore_t* a2b = NULL;
+  iree_hal_semaphore_t* b2a = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
+                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &a2b));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
+                                IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &b2a));
+  std::thread thread([&]() {
+    // Should advance right past this because the value is already set.
+    IREE_ASSERT_OK(iree_hal_semaphore_wait(
+        a2b, 0ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+        IREE_ASYNC_WAIT_FLAG_NONE));
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(b2a, 1ull, /*frontier=*/NULL));
+    // Jump ahead (blocking at first).
+    IREE_ASSERT_OK(iree_hal_semaphore_wait(
+        a2b, 4ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+        IREE_ASYNC_WAIT_FLAG_NONE));
+  });
+  // Block until thread signals.
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      b2a, 1ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(a2b, 4ull, /*frontier=*/NULL));
+  thread.join();
+
+  iree_hal_semaphore_release(a2b);
+  iree_hal_semaphore_release(b2a);
+}
+
+// Waiting the same value multiple times.
+TEST_P(SemaphoreThreadTest, WaitOnTheSameValueMultipleTimes) {
+  iree_hal_semaphore_t* semaphore = CreateSemaphore();
+  std::thread thread([&]() {
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 1, /*frontier=*/NULL));
+  });
+
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE));
+  CheckSemaphoreValue(semaphore, 1);
+
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE));
+  CheckSemaphoreValue(semaphore, 1);
+
+  thread.join();
+
+  iree_hal_semaphore_release(semaphore);
+}
+
+// Waiting for a finite amount of time.
+TEST_P(SemaphoreThreadTest, WaitForFiniteTime) {
+  auto generic_test_fn = [this](auto wait_fn) {
+    iree_hal_semaphore_t* semaphore = this->CreateSemaphore();
+
+    // Wait before signaling and make sure the semaphore value has not changed.
+    IREE_ASSERT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, wait_fn(semaphore));
+    CheckSemaphoreValue(semaphore, 0);
+
+    std::thread signaling_thread([&]() {
+      IREE_ASSERT_OK(
+          iree_hal_semaphore_signal(semaphore, 1, /*frontier=*/NULL));
+    });
+
+    // The semaphore must advance at some point.
+    while (true) {
+      iree_status_t status = wait_fn(semaphore);
+      if (iree_status_is_deadline_exceeded(status)) {
+        iree_status_ignore(status);
+        continue;
+      }
+      IREE_ASSERT_OK(status);
+      CheckSemaphoreValue(semaphore, 1);
+      break;
+    }
+
+    signaling_thread.join();
+    iree_hal_semaphore_release(semaphore);
+  };
+
+  // Immediate timeout.
+  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
+    return iree_hal_semaphore_wait(semaphore, 1, iree_immediate_timeout(),
+                                   IREE_ASYNC_WAIT_FLAG_NONE);
+  });
+
+  // Absolute timeout.
+  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
+    return iree_hal_semaphore_wait(semaphore, 1,
+                                   iree_make_deadline(iree_time_now() + 1),
+                                   IREE_ASYNC_WAIT_FLAG_NONE);
+  });
+
+  // Relative timeout.
+  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
+    return iree_hal_semaphore_wait(semaphore, 1, iree_make_timeout_ns(1),
+                                   IREE_ASYNC_WAIT_FLAG_NONE);
+  });
+}
+
+// Wait on all semaphores on multiple places simultaneously.
+TEST_P(SemaphoreThreadTest, SimultaneousMultiWaitAll) {
+  iree_hal_semaphore_t* semaphore1 = this->CreateSemaphore();
+  iree_hal_semaphore_t* semaphore2 = this->CreateSemaphore();
+
+  iree_hal_semaphore_t* semaphore_array[] = {semaphore1, semaphore2};
+  uint64_t payload_array[] = {1, 1};
+  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_array),
+                                              semaphore_array, payload_array};
+
+  std::thread wait_thread1([&]() {
+    IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+        semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+        IREE_ASYNC_WAIT_FLAG_NONE));
+  });
+
+  std::thread wait_thread2([&]() {
+    IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+        semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+        IREE_ASYNC_WAIT_FLAG_NONE));
+  });
+
+  std::thread signal_thread([&]() {
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_list_signal(semaphore_list, /*frontier=*/NULL));
+  });
+
+  wait_thread1.join();
+  wait_thread2.join();
+  signal_thread.join();
+
+  CheckSemaphoreValue(semaphore1, 1);
+  CheckSemaphoreValue(semaphore2, 1);
+
+  iree_hal_semaphore_release(semaphore1);
+  iree_hal_semaphore_release(semaphore2);
+}
+
+// Wait on a semaphore that is then failed.
+TEST_P(SemaphoreThreadTest, WaitThenFail) {
+  iree_hal_semaphore_t* semaphore = this->CreateSemaphore();
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_CANCELLED, "WaitThenFail test.");
+  std::thread signal_thread(
+      [&]() { iree_hal_semaphore_fail(semaphore, iree_status_clone(status)); });
+
+  iree_status_t wait_status = iree_hal_semaphore_wait(
+      semaphore, 1, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, wait_status);
+  uint64_t value = 1234;
+  iree_status_t query_status = iree_hal_semaphore_query(semaphore, &value);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  IREE_EXPECT_STATUS_IS(iree_status_code(status), query_status);
+  iree_status_ignore(status);
+
+  signal_thread.join();
+  iree_hal_semaphore_release(semaphore);
+}
+
+// Wait 2 semaphores then fail one of them.
+TEST_P(SemaphoreThreadTest, MultiWaitThenFail) {
+  iree_hal_semaphore_t* semaphore1 = this->CreateSemaphore();
+  iree_hal_semaphore_t* semaphore2 = this->CreateSemaphore();
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_CANCELLED, "MultiWaitThenFail test.");
+  std::thread signal_thread([&]() {
+    iree_hal_semaphore_fail(semaphore1, iree_status_clone(status));
+  });
+
+  iree_hal_semaphore_t* semaphore_array[] = {semaphore1, semaphore2};
+  uint64_t payload_array[] = {1, 1};
+  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_array),
+                                              semaphore_array, payload_array};
+  iree_status_t wait_status = iree_hal_semaphore_list_wait(
+      semaphore_list, iree_make_deadline(IREE_TIME_INFINITE_FUTURE),
+      IREE_ASYNC_WAIT_FLAG_NONE);
+  // multi_wait returns the actual failure code — the caller can follow up with
+  // a query to get the full status with message/backtrace if needed.
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, wait_status);
+  uint64_t value = 1234;
+  iree_status_t semaphore1_query_status =
+      iree_hal_semaphore_query(semaphore1, &value);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  IREE_EXPECT_STATUS_IS(iree_status_code(status), semaphore1_query_status);
+  iree_status_ignore(status);
+
+  // semaphore2 must not have changed.
+  uint64_t semaphore2_value = 1234;
+  IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore2, &semaphore2_value));
+  EXPECT_EQ(semaphore2_value, 0);
+
+  signal_thread.join();
+  iree_hal_semaphore_release(semaphore1);
+  iree_hal_semaphore_release(semaphore2);
+}
+
+// Wait 2 semaphores using iree_hal_device_wait_semaphores then fail one.
+TEST_P(SemaphoreThreadTest, DeviceMultiWaitThenFail) {
+  iree_hal_semaphore_t* semaphore1 = this->CreateSemaphore();
+  iree_hal_semaphore_t* semaphore2 = this->CreateSemaphore();
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_CANCELLED, "DeviceMultiWaitThenFail test.");
+  std::thread signal_thread([&]() {
+    iree_hal_semaphore_fail(semaphore1, iree_status_clone(status));
+  });
+
+  iree_hal_semaphore_t* semaphore_array[] = {semaphore1, semaphore2};
+  uint64_t payload_array[] = {1, 1};
+  iree_hal_semaphore_list_t semaphore_list = {IREE_ARRAYSIZE(semaphore_array),
+                                              semaphore_array, payload_array};
+  iree_status_t wait_status = iree_hal_device_wait_semaphores(
+      device_, IREE_ASYNC_WAIT_MODE_ANY, semaphore_list,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE), IREE_ASYNC_WAIT_FLAG_NONE);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, wait_status);
+  uint64_t value = 1234;
+  iree_status_t semaphore1_query_status =
+      iree_hal_semaphore_query(semaphore1, &value);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  IREE_EXPECT_STATUS_IS(iree_status_code(status), semaphore1_query_status);
+  iree_status_ignore(status);
+
+  // semaphore2 must not have changed.
+  uint64_t semaphore2_value = 1234;
+  IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore2, &semaphore2_value));
+  EXPECT_EQ(semaphore2_value, 0);
+
+  signal_thread.join();
+  iree_hal_semaphore_release(semaphore1);
+  iree_hal_semaphore_release(semaphore2);
+}
+
+CTS_REGISTER_TEST_SUITE(SemaphoreThreadTest);
+
+}  // namespace iree::hal::cts

--- a/runtime/src/iree/hal/cts/queue/queue_host_call_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_host_call_test.cc
@@ -124,7 +124,8 @@ TEST_P(QueueHostCallTest, EnqueueBeforeSignal) {
   // call blocks inline waiting for the wait semaphore.
   std::thread waker([&]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    IREE_EXPECT_OK(iree_hal_semaphore_list_signal(wait_semaphore_list));
+    IREE_EXPECT_OK(
+        iree_hal_semaphore_list_signal(wait_semaphore_list, /*frontier=*/NULL));
   });
 
   uint64_t args[4] = {10, 20, 30, UINT64_MAX};
@@ -201,7 +202,8 @@ TEST_P(QueueHostCallTest, NonBlockingFlag) {
         state->received_semaphores =
             !iree_hal_semaphore_list_is_empty(context->signal_semaphore_list);
         IREE_EXPECT_OK(
-            iree_hal_semaphore_list_signal(state->sideband_semaphore_list));
+            iree_hal_semaphore_list_signal(state->sideband_semaphore_list,
+                                           /*frontier=*/NULL));
         return iree_ok_status();
       },
       &state);
@@ -209,7 +211,8 @@ TEST_P(QueueHostCallTest, NonBlockingFlag) {
   SemaphoreList wait_semaphore_list(device_, {0}, {1});
   SemaphoreList signal_semaphore_list(device_, {0}, {1});
 
-  IREE_EXPECT_OK(iree_hal_semaphore_list_signal(wait_semaphore_list));
+  IREE_EXPECT_OK(
+      iree_hal_semaphore_list_signal(wait_semaphore_list, /*frontier=*/NULL));
 
   uint64_t args[4] = {1, 2, 3, 4};
   IREE_EXPECT_OK(iree_hal_device_queue_host_call(
@@ -254,7 +257,8 @@ TEST_P(QueueHostCallTest, AsyncCallback) {
             state->thread_started = true;
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             state->thread_completed = true;
-            iree_hal_semaphore_list_signal(*state->cloned_list);
+            iree_hal_semaphore_list_signal(*state->cloned_list,
+                                           /*frontier=*/NULL);
             delete state->cloned_list;
             state->cloned_list = nullptr;
           });
@@ -268,7 +272,8 @@ TEST_P(QueueHostCallTest, AsyncCallback) {
   SemaphoreList wait_semaphore_list(device_, {0}, {1});
   SemaphoreList signal_semaphore_list(device_, {0, 0}, {1, 2});
 
-  IREE_EXPECT_OK(iree_hal_semaphore_list_signal(wait_semaphore_list));
+  IREE_EXPECT_OK(
+      iree_hal_semaphore_list_signal(wait_semaphore_list, /*frontier=*/NULL));
 
   uint64_t args[4] = {5, 6, 7, 8};
   IREE_EXPECT_OK(iree_hal_device_queue_host_call(
@@ -309,7 +314,8 @@ TEST_P(QueueHostCallTest, CallbackReturnsError) {
   SemaphoreList wait_semaphore_list(device_, {0}, {1});
   SemaphoreList signal_semaphore_list(device_, {0, 0}, {1, 2});
 
-  IREE_EXPECT_OK(iree_hal_semaphore_list_signal(wait_semaphore_list));
+  IREE_EXPECT_OK(
+      iree_hal_semaphore_list_signal(wait_semaphore_list, /*frontier=*/NULL));
 
   uint64_t args[4] = {9, 10, 11, 12};
   IREE_EXPECT_OK(iree_hal_device_queue_host_call(
@@ -379,7 +385,8 @@ TEST_P(QueueHostCallTest, CallbackReturnsErrorAfterWait) {
   // the blocking queue_host_call before signaling the wait semaphore.
   std::thread waker([&]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    IREE_EXPECT_OK(iree_hal_semaphore_list_signal(wait_semaphore_list));
+    IREE_EXPECT_OK(
+        iree_hal_semaphore_list_signal(wait_semaphore_list, /*frontier=*/NULL));
   });
 
   uint64_t args[4] = {13, 14, 15, 16};

--- a/runtime/src/iree/hal/cts/queue/semaphore_submission_test.cc
+++ b/runtime/src/iree/hal/cts/queue/semaphore_submission_test.cc
@@ -84,7 +84,8 @@ TEST_P(SemaphoreSubmissionTest, SubmitWithWait) {
   CheckSemaphoreValue(signal_semaphore, 100);
 
   // Signal the wait semaphore, work should begin and complete.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(wait_semaphore, 1, /*frontier=*/NULL));
   IREE_ASSERT_OK(iree_hal_semaphore_wait(signal_semaphore, 101,
                                          iree_infinite_timeout(),
                                          IREE_ASYNC_WAIT_FLAG_NONE));
@@ -128,8 +129,10 @@ TEST_P(SemaphoreSubmissionTest, SubmitWithMultipleSemaphores) {
   CheckSemaphoreValue(signal_semaphore_1, 0);
   CheckSemaphoreValue(signal_semaphore_2, 0);
 
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore_1, 1));
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore_2, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(wait_semaphore_1, 1, /*frontier=*/NULL));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(wait_semaphore_2, 1, /*frontier=*/NULL));
 
   IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
       signal_semaphores, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
@@ -167,15 +170,18 @@ TEST_P(SemaphoreSubmissionTest, WaitAllHostAndDeviceSemaphores) {
     IREE_ASSERT_OK(iree_hal_semaphore_wait(host_wait_semaphore, 1,
                                            iree_infinite_timeout(),
                                            IREE_ASYNC_WAIT_FLAG_NONE));
-    IREE_ASSERT_OK(iree_hal_semaphore_signal(host_signal_semaphore, 1));
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_signal(host_signal_semaphore, 1, /*frontier=*/NULL));
   });
 
   CheckSemaphoreValue(host_signal_semaphore, 0);
   CheckSemaphoreValue(device_signal_semaphore, 0);
 
   // Signal both wait semaphores, work should begin and complete.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(host_wait_semaphore, 1));
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(device_wait_semaphore, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(host_wait_semaphore, 1, /*frontier=*/NULL));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(device_wait_semaphore, 1, /*frontier=*/NULL));
 
   // Wait for both to complete.
   iree_hal_semaphore_t* main_semaphore_ptrs[] = {host_signal_semaphore,
@@ -223,14 +229,16 @@ TEST_P(SemaphoreSubmissionTest,
     IREE_ASSERT_OK(iree_hal_semaphore_wait(host_wait_semaphore, 1,
                                            iree_infinite_timeout(),
                                            IREE_ASYNC_WAIT_FLAG_NONE));
-    IREE_ASSERT_OK(iree_hal_semaphore_signal(host_signal_semaphore, 1));
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_signal(host_signal_semaphore, 1, /*frontier=*/NULL));
   });
 
   CheckSemaphoreValue(host_signal_semaphore, 0);
   CheckSemaphoreValue(device_signal_semaphore, 0);
 
   // Only signal the device wait semaphore.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(device_wait_semaphore, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(device_wait_semaphore, 1, /*frontier=*/NULL));
 
   // Wait-any: should complete when device signals (host still blocked).
   iree_hal_semaphore_t* main_semaphore_ptrs[] = {host_signal_semaphore,
@@ -248,7 +256,8 @@ TEST_P(SemaphoreSubmissionTest,
   CheckSemaphoreValue(device_signal_semaphore, 1);
 
   // Let the host thread complete.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(host_wait_semaphore, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(host_wait_semaphore, 1, /*frontier=*/NULL));
   thread.join();
 
   iree_hal_command_buffer_release(command_buffer);
@@ -283,14 +292,16 @@ TEST_P(SemaphoreSubmissionTest, WaitAnyHostAndDeviceSemaphoresAndHostSignals) {
     IREE_ASSERT_OK(iree_hal_semaphore_wait(host_wait_semaphore, 1,
                                            iree_infinite_timeout(),
                                            IREE_ASYNC_WAIT_FLAG_NONE));
-    IREE_ASSERT_OK(iree_hal_semaphore_signal(host_signal_semaphore, 1));
+    IREE_ASSERT_OK(
+        iree_hal_semaphore_signal(host_signal_semaphore, 1, /*frontier=*/NULL));
   });
 
   CheckSemaphoreValue(host_signal_semaphore, 0);
   CheckSemaphoreValue(device_signal_semaphore, 0);
 
   // Only signal the host wait semaphore.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(host_wait_semaphore, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(host_wait_semaphore, 1, /*frontier=*/NULL));
 
   // Wait-any: should complete when host signals (device still blocked).
   iree_hal_semaphore_t* main_semaphore_ptrs[] = {host_signal_semaphore,
@@ -309,7 +320,8 @@ TEST_P(SemaphoreSubmissionTest, WaitAnyHostAndDeviceSemaphoresAndHostSignals) {
   CheckSemaphoreValue(device_signal_semaphore, 0);
 
   // Signal and wait for device to complete too.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(device_wait_semaphore, 1));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_signal(device_wait_semaphore, 1, /*frontier=*/NULL));
   IREE_ASSERT_OK(iree_hal_semaphore_wait(device_signal_semaphore, 1,
                                          iree_infinite_timeout(),
                                          IREE_ASYNC_WAIT_FLAG_NONE));
@@ -580,8 +592,8 @@ TEST_P(SemaphoreSubmissionTest, BatchWaitingOnAnotherAndHostSignal) {
 
   // Signal semaphore2 from a host thread.
   std::thread signal_thread([&]() {
-    IREE_ASSERT_OK(
-        iree_hal_semaphore_signal(semaphore2, semaphore_signal_value));
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore2, semaphore_signal_value,
+                                             /*frontier=*/NULL));
   });
 
   IREE_ASSERT_OK(iree_hal_semaphore_wait(semaphore3, semaphore_signal_value,
@@ -684,7 +696,7 @@ TEST_P(SemaphoreSubmissionTest, BatchWaitingOnSmallerValueAfterSignaled) {
   iree_hal_semaphore_t* semaphore2 = CreateSemaphore();
 
   // Signal value 2 before submitting the wait for value 1.
-  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore1, 2));
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore1, 2, /*frontier=*/NULL));
 
   uint64_t semaphore1_wait_value = 1;
   iree_hal_semaphore_list_t command_buffer_wait_list = {
@@ -727,8 +739,9 @@ TEST_P(SemaphoreSubmissionTest, BatchWaitingOnSmallerValueBeforeSignaled) {
       iree_hal_buffer_binding_table_empty(), IREE_HAL_EXECUTE_FLAG_NONE));
 
   // Signal value 2 from another thread (wait was for value 1).
-  std::thread signal_thread(
-      [&]() { IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore1, 2)); });
+  std::thread signal_thread([&]() {
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore1, 2, /*frontier=*/NULL));
+  });
 
   IREE_ASSERT_OK(iree_hal_semaphore_wait(semaphore2, semaphore2_signal_value,
                                          iree_infinite_timeout(),

--- a/runtime/src/iree/hal/drivers/amdgpu/host_service.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_service.c
@@ -207,7 +207,8 @@ static iree_status_t iree_hal_amdgpu_host_post_signal(
 
   // Notify the (likely) external semaphore of its new value. It may make
   // platform calls or do other bookkeeping.
-  iree_status_t status = iree_hal_semaphore_signal(semaphore, payload);
+  iree_status_t status =
+      iree_hal_semaphore_signal(semaphore, payload, /*frontier=*/NULL);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -1038,7 +1038,8 @@ static iree_status_t iree_hal_cuda_device_queue_alloca(
   // indicates that the stream is unchanged (it's not really since we waited
   // above, but we at least won't deadlock like this).
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_cuda_device_advance_frontier(device);
@@ -1080,7 +1081,8 @@ static iree_status_t iree_hal_cuda_device_queue_dealloca(
   // indicates that the stream is unchanged (it's not really since we waited
   // above, but we at least won't deadlock like this).
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_cuda_device_advance_frontier(device);

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1809,7 +1809,8 @@ static iree_status_t iree_hal_hip_device_queue_alloca(
         out_buffer);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_hip_device_advance_frontier(device);
@@ -1916,7 +1917,8 @@ static iree_status_t iree_hal_hip_device_queue_dealloca(
         device->devices[device_ordinal].hip_dispatch_stream, buffer);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_hip_device_advance_frontier(device);

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -386,7 +386,8 @@ static iree_status_t iree_hal_sync_device_queue_alloca(
         out_buffer);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_sync_device_advance_frontier(device);
@@ -468,7 +469,8 @@ static iree_status_t iree_hal_sync_device_queue_host_call(
     // NOTE: the signals can fail in which case we never perform the call.
     // That's ok as failure to signal is considered a device-loss/death
     // situation as there's no telling what has gone wrong.
-    IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+    IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                                        /*frontier=*/NULL));
     iree_hal_sync_device_advance_frontier(device);
   }
 
@@ -486,7 +488,8 @@ static iree_status_t iree_hal_sync_device_queue_host_call(
     return iree_ok_status();
   } else if (iree_status_is_ok(call_status)) {
     // Signal callback completed synchronously.
-    IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+    IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                                        /*frontier=*/NULL));
     iree_hal_sync_device_advance_frontier(device);
     return iree_ok_status();
   } else {
@@ -579,7 +582,8 @@ static iree_status_t iree_hal_sync_device_queue_execute(
 
   // Signal all semaphores now that batch work has completed.
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_sync_device_advance_frontier(device);

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -497,7 +497,8 @@ static iree_status_t iree_hal_task_device_queue_alloca(
         out_buffer);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     // Advance the frontier for the selected queue. This is a synchronous

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -443,7 +443,8 @@ static iree_status_t iree_hal_task_queue_retire_cmd(
   // Signal all semaphores to their new values.
   // Note that if any signal fails then the whole command will fail and all
   // semaphores will be signaled to the failure state.
-  iree_status_t status = iree_hal_semaphore_list_signal(cmd->signal_semaphores);
+  iree_status_t status =
+      iree_hal_semaphore_list_signal(cmd->signal_semaphores, /*frontier=*/NULL);
 
   // Advance the frontier tracker after signaling. Epoch is assigned at
   // completion time (not submit time) because local_task is out-of-order:
@@ -640,7 +641,8 @@ static iree_status_t iree_hal_task_queue_host_call_cmd(
       iree_any_bit_set(cmd->flags, IREE_HAL_HOST_CALL_FLAG_NON_BLOCKING);
   iree_status_t status = iree_ok_status();
   if (is_nonblocking) {
-    status = iree_hal_semaphore_list_signal(cmd->signal_semaphores);
+    status = iree_hal_semaphore_list_signal(cmd->signal_semaphores,
+                                            /*frontier=*/NULL);
   }
 
   // Issue the call.
@@ -658,7 +660,8 @@ static iree_status_t iree_hal_task_queue_host_call_cmd(
       // User callback will signal in the future (or they are fire-and-forget).
     } else if (iree_status_is_ok(call_status)) {
       // Signal callback completed synchronously.
-      status = iree_hal_semaphore_list_signal(cmd->signal_semaphores);
+      status = iree_hal_semaphore_list_signal(cmd->signal_semaphores,
+                                              /*frontier=*/NULL);
     } else {
       // Callback failed; propagate the failure to all signal semaphores so
       // dependent submissions also fail.

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -412,7 +412,8 @@ static iree_status_t iree_hal_metal_device_queue_alloca(
                                                 allocation_size, out_buffer);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_metal_device_advance_frontier(device);
@@ -599,7 +600,8 @@ static iree_status_t iree_hal_metal_device_queue_execute(
         // timepoints. The GPU-side encodeSignalEvent already set the
         // MTLSharedEvent values; this synchronizes the async layer.
         if (cb.status == MTLCommandBufferStatusCompleted) {
-          iree_status_t signal_status = iree_hal_semaphore_list_signal(signal_list_clone);
+          iree_status_t signal_status = iree_hal_semaphore_list_signal(signal_list_clone,
+                                                                       /*frontier=*/NULL);
           if (IREE_UNLIKELY(!iree_status_is_ok(signal_status))) {
             // Each timeline value must be signaled exactly once. Signal failure
             // indicates a structural error — fail all semaphores so waiters get

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1750,7 +1750,8 @@ static iree_status_t iree_hal_vulkan_device_queue_alloca(
         out_buffer);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_vulkan_device_advance_frontier(device);

--- a/runtime/src/iree/hal/fence.c
+++ b/runtime/src/iree/hal/fence.c
@@ -231,7 +231,8 @@ IREE_API_EXPORT iree_status_t iree_hal_fence_query(iree_hal_fence_t* fence) {
 IREE_API_EXPORT iree_status_t iree_hal_fence_signal(iree_hal_fence_t* fence) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status =
-      iree_hal_semaphore_list_signal(iree_hal_fence_semaphore_list(fence));
+      iree_hal_semaphore_list_signal(iree_hal_fence_semaphore_list(fence),
+                                     /*frontier=*/NULL);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/semaphore.c
+++ b/runtime/src/iree/hal/semaphore.c
@@ -118,12 +118,13 @@ iree_hal_semaphore_query(iree_hal_semaphore_t* semaphore, uint64_t* out_value) {
 }
 
 IREE_API_EXPORT iree_status_t
-iree_hal_semaphore_signal(iree_hal_semaphore_t* semaphore, uint64_t new_value) {
+iree_hal_semaphore_signal(iree_hal_semaphore_t* semaphore, uint64_t new_value,
+                          const iree_async_frontier_t* frontier) {
   IREE_ASSERT_ARGUMENT(semaphore);
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, new_value);
   iree_status_t status = iree_hal_semaphore_vtable(semaphore)->async.signal(
-      (iree_async_semaphore_t*)semaphore, new_value, /*frontier=*/NULL);
+      (iree_async_semaphore_t*)semaphore, new_value, frontier);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
@@ -320,13 +321,15 @@ IREE_API_EXPORT bool iree_hal_semaphore_list_poll(
 }
 
 IREE_API_EXPORT iree_status_t
-iree_hal_semaphore_list_signal(iree_hal_semaphore_list_t semaphore_list) {
+iree_hal_semaphore_list_signal(iree_hal_semaphore_list_t semaphore_list,
+                               const iree_async_frontier_t* frontier) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
-    status = iree_hal_semaphore_signal(semaphore_list.semaphores[i],
-                                       semaphore_list.payload_values[i]);
+    status =
+        iree_hal_semaphore_signal(semaphore_list.semaphores[i],
+                                  semaphore_list.payload_values[i], frontier);
     if (!iree_status_is_ok(status)) break;
   }
 

--- a/runtime/src/iree/hal/semaphore.h
+++ b/runtime/src/iree/hal/semaphore.h
@@ -347,8 +347,12 @@ iree_hal_semaphore_query(iree_hal_semaphore_t* semaphore, uint64_t* out_value);
 
 // Signals the |semaphore| to the given payload value.
 // The call is ignored if the current payload value exceeds |new_value|.
+// |frontier| is an optional causal frontier to merge into the semaphore's
+// accumulated frontier. Pass NULL for local-only signals where cross-device
+// causal tracking is not needed.
 IREE_API_EXPORT iree_status_t
-iree_hal_semaphore_signal(iree_hal_semaphore_t* semaphore, uint64_t new_value);
+iree_hal_semaphore_signal(iree_hal_semaphore_t* semaphore, uint64_t new_value,
+                          const iree_async_frontier_t* frontier);
 
 // Signals the |semaphore| with a failure. The |status| will be returned from
 // iree_hal_semaphore_query and iree_hal_semaphore_signal for the lifetime
@@ -450,8 +454,11 @@ IREE_API_EXPORT bool iree_hal_semaphore_list_poll(
     iree_hal_semaphore_list_t semaphore_list);
 
 // Signals each semaphore in |semaphore_list| to the defined timepoint.
+// |frontier| is an optional causal frontier merged into each semaphore's
+// accumulated frontier. Pass NULL when causal tracking is not needed.
 IREE_API_EXPORT iree_status_t
-iree_hal_semaphore_list_signal(iree_hal_semaphore_list_t semaphore_list);
+iree_hal_semaphore_list_signal(iree_hal_semaphore_list_t semaphore_list,
+                               const iree_async_frontier_t* frontier);
 
 // Signals each semaphore in |semaphore_list| to indicate failure with
 // |signal_status|.

--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -1136,7 +1136,8 @@ iree_hal_deferred_work_queue_execution_device_signal_host_callback(
   // time someone else may issue the pending queue actions.
   // If we push first to the deferred work list, the cleanup of this action
   // may run while we are still using the semaphore list, causing a crash.
-  status = iree_hal_semaphore_list_signal(action->signal_semaphore_list);
+  status = iree_hal_semaphore_list_signal(action->signal_semaphore_list,
+                                          /*frontier=*/NULL);
   if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
     iree_hal_deferred_work_queue_action_fail(action, status);
     IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/utils/file_transfer.c
+++ b/runtime/src/iree/hal/utils/file_transfer.c
@@ -750,10 +750,14 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_read_streaming(
   IREE_RETURN_IF_ERROR(
       iree_hal_file_validate_access(source_file, IREE_HAL_MEMORY_ACCESS_READ));
 
-  // If the file implicitly supports device transfer then we can simply issue a
-  // device copy.
+  // If the file has a device-visible storage buffer we can issue a direct
+  // device copy without staging. HOST_LOCAL-only buffers (e.g. heap-wrapped
+  // host allocations that failed device import) must fall through to the
+  // streaming path which handles host↔device staging.
   iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(source_file);
-  if (storage_buffer) {
+  if (storage_buffer &&
+      iree_all_bits_set(iree_hal_buffer_memory_type(storage_buffer),
+                        IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE)) {
     return iree_hal_device_queue_copy(
         device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
         storage_buffer, (iree_device_size_t)source_offset, target_buffer,
@@ -798,10 +802,14 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_write_streaming(
   IREE_RETURN_IF_ERROR(
       iree_hal_file_validate_access(target_file, IREE_HAL_MEMORY_ACCESS_WRITE));
 
-  // If the file implicitly supports device transfer then we can simply issue a
-  // device copy.
+  // If the file has a device-visible storage buffer we can issue a direct
+  // device copy without staging. HOST_LOCAL-only buffers (e.g. heap-wrapped
+  // host allocations that failed device import) must fall through to the
+  // streaming path which handles host↔device staging.
   iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(target_file);
-  if (storage_buffer) {
+  if (storage_buffer &&
+      iree_all_bits_set(iree_hal_buffer_memory_type(storage_buffer),
+                        IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE)) {
     return iree_hal_device_queue_copy(
         device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
         source_buffer, source_offset, storage_buffer,

--- a/runtime/src/iree/hal/utils/memory_file.c
+++ b/runtime/src/iree/hal/utils/memory_file.c
@@ -260,6 +260,27 @@ static void iree_hal_memory_file_try_import_buffer(
       imported_release_callback, &file->imported_buffer);
   if (!iree_status_is_ok(status)) {
     iree_hal_memory_file_storage_release(file->storage);
+
+    // Device import failed (common on WebGPU and other backends that cannot
+    // import host allocations as GPU buffers). Fall back to wrapping the host
+    // pointer as a HOST_LOCAL heap buffer. This ensures storage_buffer() always
+    // returns a usable buffer for HOST_ALLOCATION files, enabling queue_read/
+    // write to map it and access the host pointer without staging copies.
+    iree_status_ignore(status);
+    iree_hal_memory_file_storage_retain(file->storage);
+    status = iree_hal_heap_buffer_wrap(
+        iree_hal_buffer_placement_undefined(),
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+        access | IREE_HAL_MEMORY_ACCESS_UNALIGNED,
+        IREE_HAL_BUFFER_USAGE_TRANSFER_SOURCE |
+            IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET |
+            IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED |
+            IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_RANDOM,
+        contents.data_length, contents, imported_release_callback,
+        file->host_allocator, &file->imported_buffer);
+    if (!iree_status_is_ok(status)) {
+      iree_hal_memory_file_storage_release(file->storage);
+    }
   }
 
   IREE_TRACE({

--- a/runtime/src/iree/hal/utils/queue_host_call_emulation.c
+++ b/runtime/src/iree/hal/utils/queue_host_call_emulation.c
@@ -29,7 +29,8 @@ static iree_status_t iree_hal_emulated_host_call_issue(
       iree_any_bit_set(flags, IREE_HAL_HOST_CALL_FLAG_NON_BLOCKING);
   if (is_nonblocking) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_semaphore_list_signal(signal_semaphore_list));
+        z0, iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                           /*frontier=*/NULL));
   }
 
   // Call the user function.
@@ -45,7 +46,8 @@ static iree_status_t iree_hal_emulated_host_call_issue(
     // User callback will signal in the future (or they are fire-and-forget).
   } else if (iree_status_is_ok(call_status)) {
     // Signal callback completed synchronously.
-    iree_hal_semaphore_list_signal(signal_semaphore_list);
+    iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                   /*frontier=*/NULL);
   } else {
     // If the user function failed we propagate the error to the semaphore list
     // (blocking) or ignore it (non-blocking, where we lost our chance).
@@ -106,7 +108,8 @@ static int iree_hal_emulated_host_call_main(void* entry_arg) {
     // NOTE: the signals can fail in which case we never perform the call.
     // That's ok as failure to signal is considered a device-loss/death
     // situation as there's no telling what has gone wrong.
-    status = iree_hal_semaphore_list_signal(state->signal_semaphore_list);
+    status = iree_hal_semaphore_list_signal(state->signal_semaphore_list,
+                                            /*frontier=*/NULL);
   }
 
   // Issue the call.


### PR DESCRIPTION
Proactor pool runner factory:
- Extract thread management from proactor_pool into an injectable runner_factory callback. The pool creates proactors and delegates poll-driving to a factory, enabling platforms without C threads (wasm, embedded/RTOS) to use the pool with their own poll mechanisms.
- The thread-based runner moves to a new proactor_thread_runner target.
- _options_default() selects the thread runner on native platforms and no runner on platforms without threads, so all existing callsites work without changes.

Frontier-carrying signals:
- Add optional frontier parameter to iree_hal_semaphore_signal() and iree_hal_semaphore_list_signal() for cross-device causal ordering.
- Update all HAL drivers (local_task, local_sync, Vulkan, CUDA, HIP, AMDGPU, Metal) and CTS tests to pass the frontier parameter.
- Add FIFO wait elision to semaphore submission tests.

Shared fixes:
- Fix iree_call_once no-op on IREE_SYNCHRONIZATION_DISABLE_UNSAFE platforms (wasm, bare-metal RISC-V). The single-threaded fallback never called the init function.
- Guard file_transfer.c queue_copy fast path with DEVICE_VISIBLE check so HOST_LOCAL-only buffers fall through to the streaming path.
- Add heap_buffer_wrap fallback in memory_file when device import fails.
- Split threaded semaphore CTS tests into semaphore_thread_test.cc so platforms without C threading can run single-threaded tests.