### PR TITLE
[Tokenizer] Fix rstrip flag: remove match rejection, add whitespace consumption

### DIFF
--- a/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json_test.cc
+++ b/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json_test.cc
@@ -433,8 +433,8 @@ TEST_F(TokenizerJsonTest, AddedTokenLstripFlag) {
 }
 
 TEST_F(TokenizerJsonTest, AddedTokenRstripFlag) {
-  // The rstrip flag means the token only matches when followed by whitespace
-  // or at the end of input.
+  // The rstrip flag indicates trailing whitespace should be stripped after
+  // matching (post-processing). It does not affect match eligibility.
   iree_string_view_t json = IREE_SV(R"({
     "model": {
       "type": "BPE",
@@ -543,6 +543,97 @@ TEST_F(TokenizerJsonTest, BackToBackSpecialTokens) {
     EXPECT_EQ(tokens[0], 101);  // <|end|>
     EXPECT_EQ(tokens[1], 100);  // <|user|>
     EXPECT_EQ(tokens[2], 102);  // <|assistant|>
+  }
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Verifies end-to-end rstrip behavior: the token matches regardless of what
+// follows, and trailing whitespace after the token is consumed (not passed to
+// BPE). See:
+// https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/tokenizer/added_vocabulary.rs
+TEST_F(TokenizerJsonTest, RstripTokenMatchAndWhitespaceConsumption) {
+  iree_string_view_t json = IREE_SV(R"({
+    "model": {
+      "type": "BPE",
+      "vocab": {"hello": 1, "world": 2},
+      "merges": []
+    },
+    "added_tokens": [{
+      "id": 100,
+      "content": "<|user|>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": true,
+      "normalized": false,
+      "special": true
+    }],
+    "pre_tokenizer": null
+  })");
+
+  iree_tokenizer_t* tokenizer = nullptr;
+  IREE_ASSERT_OK(
+      iree_tokenizer_from_huggingface_json(json, allocator_, &tokenizer));
+  ASSERT_NE(tokenizer, nullptr);
+
+  auto encode = [&](const char* text) -> std::vector<int32_t> {
+    std::vector<int32_t> tokens(64);
+    iree_host_size_t token_count = 0;
+    IREE_CHECK_OK(
+        iree_tokenizer_encode(tokenizer, iree_make_cstring_view(text),
+                              IREE_TOKENIZER_ENCODE_FLAG_NONE,
+                              iree_tokenizer_make_token_output(
+                                  tokens.data(), NULL, NULL, tokens.size()),
+                              allocator_, &token_count));
+    tokens.resize(token_count);
+    return tokens;
+  };
+
+  // rstrip token followed by text (no whitespace): token must match.
+  {
+    auto tokens = encode("<|user|>hello");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|>
+    EXPECT_EQ(tokens[1], 1);    // hello
+  }
+
+  // rstrip token followed by space + text: whitespace must be consumed.
+  {
+    auto tokens = encode("<|user|> hello");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|>
+    EXPECT_EQ(tokens[1], 1);    // hello (space consumed by rstrip)
+  }
+
+  // rstrip token followed by multiple spaces + text.
+  {
+    auto tokens = encode("<|user|>   hello");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|>
+    EXPECT_EQ(tokens[1], 1);    // hello (spaces consumed by rstrip)
+  }
+
+  // rstrip token followed by tab + text.
+  {
+    auto tokens = encode("<|user|>\thello");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|>
+    EXPECT_EQ(tokens[1], 1);    // hello (tab consumed by rstrip)
+  }
+
+  // rstrip token followed by newline + text.
+  {
+    auto tokens = encode("<|user|>\nhello");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|>
+    EXPECT_EQ(tokens[1], 1);    // hello (newline consumed by rstrip)
+  }
+
+  // rstrip token followed by only whitespace (no text after).
+  {
+    auto tokens = encode("<|user|>   ");
+    ASSERT_EQ(tokens.size(), 1u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|> (whitespace consumed, nothing left)
   }
 
   iree_tokenizer_free(tokenizer);

--- a/runtime/src/iree/tokenizer/special_tokens.c
+++ b/runtime/src/iree/tokenizer/special_tokens.c
@@ -421,17 +421,6 @@ static bool iree_tokenizer_special_tokens_flags_allow_match(
     }
   }
 
-  // rstrip: Must be followed by whitespace or end of input.
-  if (iree_any_bit_set(flags, IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_RSTRIP)) {
-    if (!at_end) {
-      // rstrip specifically checks for whitespace.
-      bool next_is_whitespace = (next_byte <= 0x20);
-      if (!next_is_whitespace) {
-        return false;
-      }
-    }
-  }
-
   // single_word: Must be a complete word (word boundaries on both sides).
   if (iree_any_bit_set(flags, IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_SINGLE_WORD)) {
     // Check left boundary.
@@ -519,6 +508,7 @@ iree_tokenizer_special_tokens_match(
           // Match accepted!
           *out_length = new_bytes_consumed;
           *out_id = special_tokens->ids[i];
+          state->matched_flags = special_tokens->flags[i];
           state->match_position = 0;
           return IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED;
         }
@@ -584,6 +574,7 @@ iree_tokenizer_special_tokens_match(
                 special_tokens, i, state, next_byte, at_end)) {
           *out_length = token_length;
           *out_id = special_tokens->ids[i];
+          state->matched_flags = special_tokens->flags[i];
           return IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED;
         }
         // Flags rejected - continue scanning for other tokens.

--- a/runtime/src/iree/tokenizer/special_tokens.h
+++ b/runtime/src/iree/tokenizer/special_tokens.h
@@ -52,7 +52,9 @@ enum iree_tokenizer_special_token_flag_bits_e {
   IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_NONE = 0u,
   // Match only if preceded by whitespace or start of input.
   IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_LSTRIP = 1u << 0,
-  // Match only if followed by whitespace or end of input.
+  // Strip trailing whitespace after the matched token (post-processing).
+  // This is NOT a match condition — the token always matches regardless of
+  // what follows. Matches HuggingFace AddedToken.rstrip semantics.
   IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_RSTRIP = 1u << 1,
   // Match only whole words (both lstrip AND rstrip semantics + word boundary).
   IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_SINGLE_WORD = 1u << 2,
@@ -324,6 +326,11 @@ typedef struct iree_tokenizer_special_tokens_encode_state_t {
   // 0 = start of input (no previous byte). Stored as value+1 so 0 is unset.
   uint8_t prev_byte_plus_one;
 
+  // Flags of the last successfully matched token. Set when match() returns
+  // MATCHED. Callers use this for post-processing (e.g. rstrip whitespace
+  // consumption).
+  iree_tokenizer_special_token_flags_t matched_flags;
+
   // True if this is the start of input (before any bytes have been processed).
   bool at_start_of_input;
 } iree_tokenizer_special_tokens_encode_state_t;
@@ -335,6 +342,7 @@ static inline void iree_tokenizer_special_tokens_encode_state_initialize(
   out_state->partial_token_index = 0;
   out_state->drain_position = 0;
   out_state->prev_byte_plus_one = 0;  // No previous byte yet.
+  out_state->matched_flags = IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_NONE;
   out_state->at_start_of_input = true;
 }
 

--- a/runtime/src/iree/tokenizer/special_tokens_test.cc
+++ b/runtime/src/iree/tokenizer/special_tokens_test.cc
@@ -682,23 +682,29 @@ TEST_F(SpecialTokensFlagsTest, RstripMatchesBeforeWhitespace) {
             IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
 }
 
-TEST_F(SpecialTokensFlagsTest, RstripRejectsBeforeNonWhitespace) {
+TEST_F(SpecialTokensFlagsTest, RstripMatchesBeforeNonWhitespace) {
   BuildWithFlags("<|special|>", 100, IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_RSTRIP);
 
-  // Before letter, rstrip should NOT allow match.
+  // rstrip is a post-processing directive (strip trailing whitespace after the
+  // token), NOT a match condition. Tokens with rstrip always match regardless
+  // of what follows.
   ResetState();
-  EXPECT_EQ(TryMatch(IREE_SV("<|special|>abc")),
-            IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
+  iree_host_size_t length = 0;
+  EXPECT_EQ(TryMatch(IREE_SV("<|special|>abc"), &length),
+            IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
+  EXPECT_EQ(length, 11u);
 
   // Before digit.
   ResetState();
-  EXPECT_EQ(TryMatch(IREE_SV("<|special|>123")),
-            IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
+  EXPECT_EQ(TryMatch(IREE_SV("<|special|>123"), &length),
+            IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
+  EXPECT_EQ(length, 11u);
 
   // Before punctuation.
   ResetState();
-  EXPECT_EQ(TryMatch(IREE_SV("<|special|>!")),
-            IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
+  EXPECT_EQ(TryMatch(IREE_SV("<|special|>!"), &length),
+            IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
+  EXPECT_EQ(length, 11u);
 }
 
 //===----------------------------------------------------------------------===//
@@ -768,11 +774,11 @@ TEST_F(SpecialTokensFlagsTest, LstripAndRstripCombined) {
   EXPECT_EQ(TryMatch(IREE_SV("<|special|> ")),
             IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
 
-  // After space, before letter - rstrip fails.
+  // After space, before letter - rstrip is post-processing only, still matches.
   ResetState();
   ConsumeBytes(IREE_SV(" "));
   EXPECT_EQ(TryMatch(IREE_SV("<|special|>abc")),
-            IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
+            IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
 }
 
 TEST_F(SpecialTokensFlagsTest, NoFlagsMatchesAnywhere) {
@@ -844,14 +850,15 @@ TEST_F(SpecialTokensFlagsTest, RstripStreamingChecksNextByte) {
   result = TryMatch(IREE_SV("cial|> "));
   EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
 
-  // Scenario 3: Stream token with letter after (should NOT match).
+  // Scenario 3: Stream token with letter after - rstrip is post-processing
+  // only, so token still matches regardless of what follows.
   ResetState();
   result = TryMatch(IREE_SV("<|spe"));
   EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_NEED_MORE);
 
-  // Complete with letter after - should NOT match.
+  // Complete with letter after - rstrip does not reject, still matches.
   result = TryMatch(IREE_SV("cial|>abc"));
-  EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
+  EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
 }
 
 TEST_F(SpecialTokensFlagsTest, SingleWordStreamingChecksBothBoundaries) {
@@ -902,7 +909,8 @@ TEST_F(SpecialTokensFlagsTest, StreamingByteByByteWithFlags) {
   result = TryMatch(IREE_SV("C "));  // Complete with trailing space.
   EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
 
-  // Same but no trailing whitespace at end - should NOT match.
+  // Same but with non-whitespace after - rstrip is post-processing only,
+  // so the token still matches. Only lstrip is a match condition.
   ResetState();
   ConsumeBytes(IREE_SV(" "));
 
@@ -913,7 +921,7 @@ TEST_F(SpecialTokensFlagsTest, StreamingByteByByteWithFlags) {
   EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_NEED_MORE);
 
   result = TryMatch(IREE_SV("Cx"));  // Complete with 'x' after.
-  EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_NO_MATCH);
+  EXPECT_EQ(result, IREE_TOKENIZER_SPECIAL_TOKENS_MATCHED);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -1639,10 +1639,22 @@ static iree_host_size_t iree_tokenizer_strip_lstrip_whitespace(
     flags = special_tokens->flags[check_state->partial_token_index];
   }
 
-  // If LSTRIP is set, strip trailing whitespace from the safe prefix.
+  // If LSTRIP is set, strip trailing Unicode whitespace from the safe prefix.
   if (iree_any_bit_set(flags, IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_LSTRIP)) {
-    while (safe > 0 && (uint8_t)input.data[safe - 1] <= 0x20) {
-      --safe;
+    while (safe > 0) {
+      // Walk back over UTF-8 continuation bytes (10xxxxxx) to find the
+      // leading byte. ASCII bytes (0xxxxxxx) don't match the continuation
+      // pattern, so the loop is a no-op for single-byte characters.
+      iree_host_size_t start = safe - 1;
+      while (start > 0 && ((uint8_t)input.data[start] & 0xC0) == 0x80) {
+        --start;
+      }
+      iree_host_size_t pos = 0;
+      iree_string_view_t tail =
+          iree_make_string_view(input.data + start, safe - start);
+      uint32_t codepoint = iree_unicode_utf8_decode(tail, &pos);
+      if (!iree_unicode_is_whitespace(codepoint)) break;
+      safe = start;
     }
   }
 
@@ -2324,6 +2336,20 @@ static iree_status_t iree_tokenizer_encode_state_pump(
         chunk->data += match_length;
         chunk->size -= match_length;
         *out_made_progress = true;
+
+        // rstrip: consume trailing Unicode whitespace after the matched token.
+        if (iree_any_bit_set(state->special_token_match.matched_flags,
+                             IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_RSTRIP)) {
+          while (chunk->size > 0) {
+            iree_host_size_t pos = 0;
+            iree_string_view_t remaining =
+                iree_make_string_view(chunk->data, chunk->size);
+            uint32_t codepoint = iree_unicode_utf8_decode(remaining, &pos);
+            if (!iree_unicode_is_whitespace(codepoint)) break;
+            chunk->data += pos;
+            chunk->size -= pos;
+          }
+        }
 
         // Check if pipeline has content that must be emitted first.
         bool pipeline_has_content =


### PR DESCRIPTION
## Summary

`flags_allow_match()` treated `rstrip=true` as a match condition, rejecting tokens not followed by whitespace or end of input. Per [HuggingFace's implementation(https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/tokenizer/added_vocabulary.rs), `rstrip` is a post-processing directive that consumes trailing whitespace after the match, not a match gate. This caused special tokens like `<|user|>` in Phi-4-mini to fall through to BPE subword tokenization when followed by text.

**Example** (Phi-4-mini-instruct, token `<|user|>` has `rstrip=true`):

Input: "<|user|>Hello"
Before fix:  [27, 91, 1428, 91, 29, 13225]  ← <|user|> split into subwords
After fix:   [200021, 13225]                  ← matches HuggingFace output



## Changes

- Remove the rstrip rejection branch from `flags_allow_match()` in `special_tokens.c`
- Add rstrip whitespace consumption in `tokenizer.c` after a successful match
- Add `matched_flags` field to encode state to propagate flags to the caller

## Test results

### HuggingFace smoketest (`huggingface_smoketest.py`)

**1667/1667** tokenization comparisons pass across ~80 HuggingFace models (0 mismatches).

76 additional tests fail to **load** (not tokenization mismatches) — these are tiktoken models listed in the HF smoketest that aren't valid HuggingFace model identifiers. They're tested by the dedicated tiktoken smoketest instead.

### Tiktoken smoketest (`tiktoken_smoketest.py`)

**72/76** tokenization comparisons pass across 4 tiktoken encodings (cl100k_base, o200k_base, r50k_base, p50k_base).

4 failures — **identical between upstream and this PR** (pre-existing):

| Encoding | Failing test | Cause |
|----------|-------------|-------|
| cl100k_base | `special_token_endoftext` | IREE matches `<\|endoftext\|>` as special token; tiktoken's `encode_ordinary` treats it as literal text |
| o200k_base | `special_token_endoftext` | Same |
| r50k_base | `special_token_endoftext` | Same |
| p50k_base | `special_token_endoftext` | Same |

Root cause: the IREE tokenizer has no "encode ordinary" mode (equivalent to tiktoken's `disallowed_special=()`).