### PR TITLE
[GPU] Fix RDNA3 WMMA f16/bf16 accumulator layout

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -453,7 +453,10 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
       return {/*outer=*/{1, 1}, /*thread=*/{1, 16}, /*tstrides=*/{0, 1},
               /*element=*/{16, 1}};
     case kMMAOperandAcc:
-      return {/*outer=*/{16, 1}, /*thread=*/{1, 16}, /*tstrides=*/{0, 1},
+      // RDNA3 WMMA f16/bf16 output uses vector<16xf16> but only 8 values are
+      // valid (at even indices with subwordOffset=0). The actual lane mapping
+      // is the same as the f32 accumulator: 2 thread groups in M, 16 in N.
+      return {/*outer=*/{8, 1}, /*thread=*/{2, 16}, /*tstrides=*/{16, 1},
               /*element=*/{1, 1}};
     }
   case MMAIntrinsic::WMMAR4_F32_16x16x16_F16:
@@ -801,6 +804,42 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
     // major result.
     if (colMajor) {
       std::swap(lhs, rhs);
+    }
+    // RDNA3 WMMA f16/bf16: the accumulator layout is outer={8,1} (8 logical
+    // elements per lane), but the hardware instruction operates on 8 VGPRs
+    // (vector<16xf16>) with valid values at even indices (opsel=0). We widen
+    // the accumulator to vector<16xf16> here so the LLVM backend gets the
+    // native type and generates correct code in reduction loops.
+    //
+    // TODO: This per-instruction interleave/deinterleave does not cancel
+    // between consecutive WMMAs in K-reduction loops, adding ~6 v_mov_b16
+    // per WMMA (~2x v_mov count on a 256x256x256 f16 matmul).
+    // Potential alternatives:
+    //   1. Handle the type mismatch at the layout level (carry vector<16xf16>
+    //      through the loop, convert only at boundaries) — similar to the
+    //      VDMFMA accumulator approach.
+    //   2. Paired-WMMA virtual intrinsic using opsel=0/opsel=1 to write both
+    //      even and odd result slots, getting a bigger effective tile.
+    bool isRDNA3HalfAcc =
+        (intrinsic == MMAIntrinsic::WMMAR3_F16_16x16x16_F16 ||
+         intrinsic == MMAIntrinsic::WMMAR3_BF16_16x16x16_BF16);
+    if (isRDNA3HalfAcc) {
+      Type elemTy = cast<VectorType>(acc.getType()).getElementType();
+      auto halfVecTy = VectorType::get({8}, elemTy);
+      auto hwVecTy = VectorType::get({16}, elemTy);
+      // Interleave 8 -> 16: place elements at even indices, zeros at odd.
+      Value zero = arith::ConstantOp::create(
+          builder, loc,
+          SplatElementsAttr::get(halfVecTy, builder.getZeroAttr(elemTy)));
+      Value hwAcc = vector::InterleaveOp::create(builder, loc, acc, zero);
+      Value hwResult =
+          amdgpu::WMMAOp::create(builder, loc, hwVecTy, layout.mSize,
+                                 layout.nSize, layout.kSize, lhs, rhs, hwAcc)
+              .getResult();
+      // Deinterleave 16 -> 8: extract even indices (the valid results).
+      auto deinterleave =
+          vector::DeinterleaveOp::create(builder, loc, hwResult);
+      return deinterleave.getRes1();
     }
     return amdgpu::WMMAOp::create(builder, loc, resultType, layout.mSize,
                                   layout.nSize, layout.kSize, lhs, rhs, acc)

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -349,30 +349,32 @@ func.func @distribute_I32_32x32x16_I8(%lhs: tensor<32x16xi8>, %rhs: tensor<16x32
  affine_map<() -> ()>,
  affine_map<() -> ()>
 ]
-func.func @distribute_WMMAR3_F16_16x16x16_F16(%lhs: tensor<16x16xf16>, %rhs: tensor<16x16xf16>, %acc: tensor<16x8x2xf16>) -> tensor<16x8x2xf16> {
+func.func @distribute_WMMAR3_F16_16x16x16_F16(%lhs: tensor<16x16xf16>, %rhs: tensor<16x16xf16>, %acc: tensor<8x2x16xf16>) -> tensor<8x2x16xf16> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [],
     kind = #iree_gpu.mma_layout<WMMAR3_F16_16x16x16_F16>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>
-  } : tensor<16x16xf16>, tensor<16x16xf16> into tensor<16x8x2xf16>
-  return %0 : tensor<16x8x2xf16>
+  } : tensor<16x16xf16>, tensor<16x16xf16> into tensor<8x2x16xf16>
+  return %0 : tensor<8x2x16xf16>
 }
 
 // CHECK-LABEL: func @distribute_WMMAR3_F16_16x16x16_F16
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<16x16xf16>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<16x16xf16>
-//       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<16x8x2xf16>)
-//   CHECK-DAG:     %[[ID:.+]]:2 = affine.delinearize_index %[[LANEID]] into (16)
-//   CHECK-DAG:     %[[ROW:.+]] = iree_codegen.index_hint %[[ID]]#1(#iree_gpu.lane_increment<16, aligned>) : index
-//   CHECK-DAG:     %[[COL:.+]] = iree_codegen.index_hint %c0(#iree_gpu.lane_constant<16>) : index
-//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[ROW]], 0] [1, 16]
-//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, %[[ROW]]] [16, 1]
-//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, %[[COL]], %[[ROW]]] [16, 1, 1]
+//       CHECK:   scf.forall (%[[LANEID:.+]]) in (32) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<8x2x16xf16>)
+//   CHECK-DAG:     %[[LHS_ID:.+]]:2 = affine.delinearize_index %[[LANEID]] into (16)
+//   CHECK-DAG:     %[[LHS_ROW:.+]] = iree_codegen.index_hint %[[LHS_ID]]#1(#iree_gpu.lane_increment<16, aligned>) : index
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[LHS_ROW]], 0] [1, 16]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][{{.*}}, %[[LHS_ROW]]] [16, 1]
+//   CHECK-DAG:     %[[ACC_ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 16)
+//   CHECK-DAG:     %[[ACC_TROW:.+]] = iree_codegen.index_hint %[[ACC_ID]]#1(#iree_gpu.lane_constant<16>) : index
+//   CHECK-DAG:     %[[ACC_TCOL:.+]] = iree_codegen.index_hint %[[ACC_ID]]#2(#iree_gpu.lane_increment<16, aligned>) : index
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, %[[ACC_TROW]], %[[ACC_TCOL]]] [8, 1, 1]
 //       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]]) outs(%[[ACC_SLICE]])
 //  CHECK-SAME:       kind = #iree_gpu.mma_layout<WMMAR3_F16_16x16x16_F16>
-//  CHECK-SAME:       : tensor<1x16xf16>, tensor<16x1xf16> into tensor<16x1x1xf16>
-//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, %[[COL]], %[[ROW]]] [16, 1, 1]
+//  CHECK-SAME:       : tensor<1x16xf16>, tensor<16x1xf16> into tensor<8x1x1xf16>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, %[[ACC_TROW]], %[[ACC_TCOL]]] [8, 1, 1]
 //       CHECK:   mapping = [#iree_gpu.lane_id<0>]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/expand_undistributed_inner_tiles.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/expand_undistributed_inner_tiles.mlir
@@ -320,9 +320,9 @@ func.func @concretize_WMMAR3_F16_16x16x16_F16(%lhs: tensor<16x16xf16>, %rhs: ten
 // CHECK-INPUTS:        %[[MMA:.+]] = iree_codegen.inner_tiled
 // CHECK-INPUTS:        return %[[MMA]]
 
-// CHECK-OUTPUTS:        %[[EXPANDED_ACC:.+]] = tensor.expand_shape %[[ACC]] {{\[}}[0, 1], [2]] output_shape [16, 1, 16]
+// CHECK-OUTPUTS:        %[[EXPANDED_ACC:.+]] = tensor.expand_shape %[[ACC]] {{\[}}[0, 1], [2]] output_shape [8, 2, 16]
 // CHECK-OUTPUTS:        %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[EXPANDED_ACC]])
-// CHECK-OUTPUTS-SAME:     : tensor<16x16xf16>, tensor<16x16xf16> into tensor<16x1x16xf16>
+// CHECK-OUTPUTS-SAME:     : tensor<16x16xf16>, tensor<16x16xf16> into tensor<8x2x16xf16>
 // CHECK-OUTPUTS:        %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MMA]] {{\[}}[0, 1], [2]]
 // CHECK-OUTPUTS:        return %[[COLLAPSED]]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -471,7 +471,7 @@ hal.executable public @main {
 //   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
-//       CHECK:     scf.for %{{.*}} = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x16x1x1xf16>)
+//       CHECK:     scf.for %{{.*}} = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x8x1x1xf16>)
 // CHECK-COUNT-8:     amdgpu.wmma {{.*}} : vector<16xf16>, vector<16xf16>, vector<16xf16>
 //       CHECK:       scf.yield
 //       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -83,13 +83,18 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f16_f16
-//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args({{.*}}) -> (vector<2x2x16x1x1x1xf16>)
+//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args({{.*}}) -> (vector<2x2x8x1x1x1xf16>)
 // Each subgroup handles 2 * 2 tiles, and for each tile we accumulate 8 times
-// along the K dimension. So in total 32 wmma ops.
-// CHECK-COUNT-32:     amdgpu.wmma {{.*}} : vector<16xf16>, vector<16xf16>, vector<16xf16>
-//          CHECK:     scf.yield %{{.+}} : vector<2x2x16x1x1x1xf16>
-//  Since each subgroup handles 2 * 2 tiles, and for each tile, each lane holds 4 values.
-//  we will have 32 writes. We cannot do contiguous writes since the outputs columns has interleaved
+// along the K dimension. So in total 32 wmma ops. Each wmma op is bracketed by
+// an interleave (8→16, placing acc elements at even indices) and a deinterleave
+// (16→8, extracting results from even indices) for the f16 accumulator layout.
+//          CHECK:     vector.interleave {{.*}} : vector<8xf16> -> vector<16xf16>
+//          CHECK:     amdgpu.wmma {{.*}} : vector<16xf16>, vector<16xf16>, vector<16xf16>
+//          CHECK:     vector.deinterleave {{.*}} : vector<16xf16> -> vector<8xf16>
+// CHECK-COUNT-31:     amdgpu.wmma {{.*}} : vector<16xf16>, vector<16xf16>, vector<16xf16>
+//          CHECK:     scf.yield %{{.+}} : vector<2x2x8x1x1x1xf16>
+//  Since each subgroup handles 2 * 2 tiles, and for each tile, each lane holds 8 values.
+//  We will have 32 writes. We cannot do contiguous writes since the outputs columns has interleaved
 //  thread ids.
 //  CHECK-COUNT-32:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<1x1xf16>, memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
 

--- a/tests/e2e/rocm_specific/CMakeLists.txt
+++ b/tests/e2e/rocm_specific/CMakeLists.txt
@@ -11,3 +11,19 @@
 iree_add_all_subdirs()
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+# Regression test for RDNA3 WMMA f16/bf16 accumulator layout bug.
+if(IREE_ROCM_TEST_TARGET_CHIP MATCHES "^gfx1[12]")
+  iree_check_single_backend_test_suite(
+    NAME
+      check_rocm_hip_wmma_matmul_f16
+    SRCS
+      "wmma_matmul_f16.mlir"
+    TARGET_BACKEND
+      "rocm"
+    DRIVER
+      "hip"
+    LABELS
+      "requires-gpu-rdna3"
+  )
+endif()

--- a/tests/e2e/rocm_specific/wmma_matmul_f16.mlir
+++ b/tests/e2e/rocm_specific/wmma_matmul_f16.mlir
@@ -1,0 +1,122 @@
+// Test RDNA3 WMMA f16/bf16 accumulator correctness for matmul.
+//
+// Regression test for a bug where WMMAR3_F16_16x16x16_F16 accumulator layout
+// on gfx1100 (RDNA3) was incorrect: outer={16,1} claimed 16 valid elements per
+// lane but v_wmma_f16_16x16x16_f16 only produces 8 valid results at even
+// indices. The fix changes the layout to outer={8,1}, thread={2,16}.
+// See amdgpu.wmma op docs in AMDGPUOps.td for the gfx11 subwordOffset layout.
+//
+// Uses LHS * I = LHS (matmul with identity) so each output element has a
+// unique expected value. LHS values are unique per element (row and column
+// dependent) to catch both row-swap and column-permutation bugs.
+//
+// The optimization_barrier prevents fusion of data generation with the matmul,
+// ensuring the matmul gets its own dispatch and triggers the WMMA codegen path
+// via vector distribution on gfx1100.
+
+func.func @wmma_matmul_f16_identity() {
+  // Build LHS with unique values: element [i,j] = (i * 128 + j) / 16384.
+  // Range [0, ~1.0] stays within f16 precision.
+  %empty_lhs = tensor.empty() : tensor<128x128xf16>
+  %c128 = arith.constant 128.0 : f32
+  %c16384 = arith.constant 16384.0 : f32
+  %lhs_gen = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } outs(%empty_lhs : tensor<128x128xf16>) {
+  ^bb0(%out: f16):
+    %i = linalg.index 0 : index
+    %j = linalg.index 1 : index
+    %i_i32 = arith.index_cast %i : index to i32
+    %j_i32 = arith.index_cast %j : index to i32
+    %i_f32 = arith.sitofp %i_i32 : i32 to f32
+    %j_f32 = arith.sitofp %j_i32 : i32 to f32
+    %row = arith.mulf %i_f32, %c128 : f32
+    %linear = arith.addf %row, %j_f32 : f32
+    %val_f32 = arith.divf %linear, %c16384 : f32
+    %val = arith.truncf %val_f32 : f32 to f16
+    linalg.yield %val : f16
+  } -> tensor<128x128xf16>
+
+  // Build 128x128 identity matrix.
+  %empty_rhs = tensor.empty() : tensor<128x128xf16>
+  %zero_f16 = arith.constant 0.0 : f16
+  %one_f16 = arith.constant 1.0 : f16
+  %rhs_gen = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } outs(%empty_rhs : tensor<128x128xf16>) {
+  ^bb0(%out: f16):
+    %r = linalg.index 0 : index
+    %c = linalg.index 1 : index
+    %eq = arith.cmpi eq, %r, %c : index
+    %val = arith.select %eq, %one_f16, %zero_f16 : f16
+    linalg.yield %val : f16
+  } -> tensor<128x128xf16>
+
+  // Prevent fusion of data generation with the matmul so the matmul gets
+  // its own dispatch and the WMMA codegen path is selected.
+  %lhs = util.optimization_barrier %lhs_gen : tensor<128x128xf16>
+  %rhs = util.optimization_barrier %rhs_gen : tensor<128x128xf16>
+
+  // Matmul: LHS * I = LHS
+  %cst = arith.constant 0.0 : f16
+  %empty_out = tensor.empty() : tensor<128x128xf16>
+  %fill = linalg.fill ins(%cst : f16) outs(%empty_out : tensor<128x128xf16>) -> tensor<128x128xf16>
+  %result = linalg.matmul ins(%lhs, %rhs : tensor<128x128xf16>, tensor<128x128xf16>)
+    outs(%fill : tensor<128x128xf16>) -> tensor<128x128xf16>
+
+  check.expect_almost_eq(%result, %lhs) : tensor<128x128xf16>
+  return
+}
+
+func.func @wmma_matmul_bf16_identity() {
+  // Same test for bf16 to cover WMMAR3_BF16_16x16x16_BF16.
+  %empty_lhs = tensor.empty() : tensor<128x128xbf16>
+  %c128 = arith.constant 128.0 : f32
+  %c16384 = arith.constant 16384.0 : f32
+  %lhs_gen = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } outs(%empty_lhs : tensor<128x128xbf16>) {
+  ^bb0(%out: bf16):
+    %i = linalg.index 0 : index
+    %j = linalg.index 1 : index
+    %i_i32 = arith.index_cast %i : index to i32
+    %j_i32 = arith.index_cast %j : index to i32
+    %i_f32 = arith.sitofp %i_i32 : i32 to f32
+    %j_f32 = arith.sitofp %j_i32 : i32 to f32
+    %row = arith.mulf %i_f32, %c128 : f32
+    %linear = arith.addf %row, %j_f32 : f32
+    %val_f32 = arith.divf %linear, %c16384 : f32
+    %val = arith.truncf %val_f32 : f32 to bf16
+    linalg.yield %val : bf16
+  } -> tensor<128x128xbf16>
+
+  %empty_rhs = tensor.empty() : tensor<128x128xbf16>
+  %zero_bf16 = arith.constant 0.0 : bf16
+  %one_bf16 = arith.constant 1.0 : bf16
+  %rhs_gen = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } outs(%empty_rhs : tensor<128x128xbf16>) {
+  ^bb0(%out: bf16):
+    %r = linalg.index 0 : index
+    %c = linalg.index 1 : index
+    %eq = arith.cmpi eq, %r, %c : index
+    %val = arith.select %eq, %one_bf16, %zero_bf16 : bf16
+    linalg.yield %val : bf16
+  } -> tensor<128x128xbf16>
+
+  %lhs = util.optimization_barrier %lhs_gen : tensor<128x128xbf16>
+  %rhs = util.optimization_barrier %rhs_gen : tensor<128x128xbf16>
+
+  %cst = arith.constant 0.0 : bf16
+  %empty_out = tensor.empty() : tensor<128x128xbf16>
+  %fill = linalg.fill ins(%cst : bf16) outs(%empty_out : tensor<128x128xbf16>) -> tensor<128x128xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs : tensor<128x128xbf16>, tensor<128x128xbf16>)
+    outs(%fill : tensor<128x128xbf16>) -> tensor<128x128xbf16>
+
+  check.expect_almost_eq(%result, %lhs) : tensor<128x128xbf16>
+  return
+}


### PR DESCRIPTION
The WMMAR3_F16_16x16x16_F16 (and BF16) accumulator layout on gfx1100 was incorrect: outer={16,1} assumed 16 valid elements per lane, but v_wmma_f16_16x16x16_f16 only produces 8 valid results at even indices. Fix the layout to outer={8,1}, thread={2,16} and add interleave/ deinterleave shuffles in createMmaOp to widen to the hardware's native vector<16xf16> type.