### PR TITLE
[DMA][Swizzle] Enable LDS DMA with swizzling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -148,8 +148,7 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 ///
 /// The gather_to_lds instruction requires:
 ///   - Source indices: per-lane divergent (each lane reads from different loc)
-///   - Destination indices: per-lane divergent (each lane writes to distinct
-///     LDS location)
+///   - Destination indices: subgroup-uniform (all lanes write to same LDS base)
 ///
 /// Index computation rules for each dimension:
 ///
@@ -160,7 +159,7 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 ///
 /// Where:
 ///   - srcDimOffset: position with lane offset (divergent per lane)
-///   - dstDimOffset: position with lane offset (divergent per lane)
+///   - dstDimOffset: position without lane offset (uniform across subgroup)
 ///   - indices[dim]: index memref mapping dest positions to source positions
 static std::pair<SmallVector<Value>, SmallVector<Value>>
 generateGatherIndices(OpBuilder &rewriter, Location loc,
@@ -408,10 +407,9 @@ private:
           SmallVector<Value> srcDimOffsets(outerDimOffsets);
           llvm::append_range(srcDimOffsets, srcDelinearize.getResults());
 
-          // Destination indices: include lane offset (divergent per lane) so
-          // each lane writes to its own distinct LDS location.
+          // Destination indices: no lane offset (subgroup-uniform).
           auto dstDelinearize = affine::AffineDelinearizeIndexOp::create(
-              rewriter, loc, srcLinearOffset, basis, /*hasOuterBound=*/true);
+              rewriter, loc, linearOffsetVal, basis, /*hasOuterBound=*/true);
 
           SmallVector<Value> dstDimOffsets(outerDimOffsets);
           llvm::append_range(dstDimOffsets, dstDelinearize.getResults());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -144,6 +145,31 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
   return segments;
 }
 
+/// Trace a memref value through reshape/subview ops to find a SwizzleHintOp.
+/// Returns the swizzle attribute if found, std::nullopt otherwise.
+static std::optional<IREE::Codegen::SwizzleAttrInterface>
+getDestSwizzleAttr(Value dest) {
+  while (true) {
+    if (auto expandOp = dest.getDefiningOp<memref::ExpandShapeOp>()) {
+      dest = expandOp.getSrc();
+      continue;
+    }
+    if (auto collapseOp = dest.getDefiningOp<memref::CollapseShapeOp>()) {
+      dest = collapseOp.getSrc();
+      continue;
+    }
+    if (auto subviewOp = dest.getDefiningOp<memref::SubViewOp>()) {
+      dest = subviewOp.getSource();
+      continue;
+    }
+    break;
+  }
+  if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
+    return hintOp.getSwizzle();
+  }
+  return std::nullopt;
+}
+
 /// Generates source and destination indices for a GatherToLDS operation.
 ///
 /// The gather_to_lds instruction requires:
@@ -222,6 +248,8 @@ struct LowerCoalescedGatherDMAPattern final
 
     Value source = dmaOp.getSource();
     Value dest = dmaOp.getInit();
+    std::optional<IREE::Codegen::SwizzleAttrInterface> destSwizzle =
+        getDestSwizzleAttr(dest);
 
     auto sourceType = cast<MemRefType>(source.getType());
     auto destType = cast<MemRefType>(dest.getType());
@@ -320,7 +348,7 @@ struct LowerCoalescedGatherDMAPattern final
 
     emitTransfers(rewriter, loc, source, dest, destShape, numLinearDims,
                   elementType, indices, segments, segmentLaneOffsets,
-                  dmaOp.getInBounds());
+                  dmaOp.getInBounds(), destSwizzle);
 
     rewriter.eraseOp(dmaOp);
     return success();
@@ -349,12 +377,12 @@ private:
   ///   - Lane 16: srcLinearOffset = 0 + 16*4 = 64
   ///   - delinearize(64, [16, 64]) → [1, 0] (for source)
   ///   - delinearize(0, [16, 64])  → [0, 0] (for destination, uniform)
-  void emitTransfers(PatternRewriter &rewriter, Location loc, Value source,
-                     Value dest, ArrayRef<int64_t> destShape,
-                     int64_t numLinearDims, Type elementType,
-                     OperandRange indices, ArrayRef<TransferSegment> segments,
-                     ArrayRef<Value> segmentLaneOffsets,
-                     std::optional<ArrayAttr> inBoundsAttr) const {
+  void emitTransfers(
+      PatternRewriter &rewriter, Location loc, Value source, Value dest,
+      ArrayRef<int64_t> destShape, int64_t numLinearDims, Type elementType,
+      OperandRange indices, ArrayRef<TransferSegment> segments,
+      ArrayRef<Value> segmentLaneOffsets, std::optional<ArrayAttr> inBoundsAttr,
+      std::optional<IREE::Codegen::SwizzleAttrInterface> destSwizzle) const {
     int64_t destRank = destShape.size();
     int64_t numOuterDims = destRank - numLinearDims;
     LDBG() << "Emitting transfers: " << numOuterDims << " outer dims, "
@@ -401,6 +429,14 @@ private:
           // Source indices: add lane offset before delinearization (divergent).
           Value srcLinearOffset =
               arith::AddIOp::create(rewriter, loc, linearOffsetVal, laneOffset);
+          // Apply inverse source swizzle when destination has XOR swizzle.
+          // XOR swizzle is self-inverse, so swizzle(swizzle(x)) = x.
+          if (destSwizzle) {
+            srcLinearOffset = getValueOrCreateConstantIndexOp(
+                rewriter, loc,
+                destSwizzle->swizzleOffset(rewriter, loc, srcLinearOffset,
+                                           dest));
+          }
           auto srcDelinearize = affine::AffineDelinearizeIndexOp::create(
               rewriter, loc, srcLinearOffset, basis, /*hasOuterBound=*/true);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -148,7 +148,8 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 ///
 /// The gather_to_lds instruction requires:
 ///   - Source indices: per-lane divergent (each lane reads from different loc)
-///   - Destination indices: subgroup-uniform (all lanes write to same LDS base)
+///   - Destination indices: per-lane divergent (each lane writes to distinct
+///     LDS location)
 ///
 /// Index computation rules for each dimension:
 ///
@@ -159,7 +160,7 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 ///
 /// Where:
 ///   - srcDimOffset: position with lane offset (divergent per lane)
-///   - dstDimOffset: position without lane offset (uniform across subgroup)
+///   - dstDimOffset: position with lane offset (divergent per lane)
 ///   - indices[dim]: index memref mapping dest positions to source positions
 static std::pair<SmallVector<Value>, SmallVector<Value>>
 generateGatherIndices(OpBuilder &rewriter, Location loc,
@@ -407,9 +408,10 @@ private:
           SmallVector<Value> srcDimOffsets(outerDimOffsets);
           llvm::append_range(srcDimOffsets, srcDelinearize.getResults());
 
-          // Destination indices: no lane offset (subgroup-uniform).
+          // Destination indices: include lane offset (divergent per lane) so
+          // each lane writes to its own distinct LDS location.
           auto dstDelinearize = affine::AffineDelinearizeIndexOp::create(
-              rewriter, loc, linearOffsetVal, basis, /*hasOuterBound=*/true);
+              rewriter, loc, srcLinearOffset, basis, /*hasOuterBound=*/true);
 
           SmallVector<Value> dstDimOffsets(outerDimOffsets);
           llvm::append_range(dstDimOffsets, dstDelinearize.getResults());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -31,6 +31,7 @@
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
@@ -145,24 +146,12 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
   return segments;
 }
 
-/// Trace a memref value through reshape/subview ops to find a SwizzleHintOp.
+/// Trace a memref value through view-like ops to find a SwizzleHintOp.
 /// Returns the swizzle attribute if found, std::nullopt otherwise.
 static std::optional<IREE::Codegen::SwizzleAttrInterface>
 getDestSwizzleAttr(Value dest) {
-  while (true) {
-    if (auto expandOp = dest.getDefiningOp<memref::ExpandShapeOp>()) {
-      dest = expandOp.getSrc();
-      continue;
-    }
-    if (auto collapseOp = dest.getDefiningOp<memref::CollapseShapeOp>()) {
-      dest = collapseOp.getSrc();
-      continue;
-    }
-    if (auto subviewOp = dest.getDefiningOp<memref::SubViewOp>()) {
-      dest = subviewOp.getSource();
-      continue;
-    }
-    break;
+  while (auto viewOp = dest.getDefiningOp<mlir::ViewLikeOpInterface>()) {
+    dest = viewOp.getViewSource();
   }
   if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
     return hintOp.getSwizzle();
@@ -369,8 +358,13 @@ private:
   ///   - Source indices: per-lane divergent (include lane offset)
   ///   - Destination indices: subgroup-uniform (exclude lane offset)
   ///
+  /// When a destination swizzle is present (e.g., XOR swizzle for LDS bank
+  /// conflict avoidance), an inverse swizzle is applied to the source indices.
+  /// The destination writes linearly into LDS, and the swizzled source read
+  /// pattern ensures data arrives in the correct swizzled layout.
+  ///
   /// We generate two delinearizations:
-  ///   1. With lane offset: for source index computation (divergent)
+  ///   1. With lane offset (and optional inverse swizzle): for source indices
   ///   2. Without lane offset: for destination index computation (uniform)
   ///
   /// Example: shape [16, 64] with 32 lanes, 4 elements/lane:

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -853,42 +853,32 @@ struct GPUConvertToCoalescedDMAPass final
     FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
 
-    // Pre-check: decide whether all linalg.copy ops should be DMA-converted.
-    // Only activate when at least one copy already has use_global_load_dma
-    // (indicating DMA intent from upstream config, e.g. --iree-llvmgpu-use-
-    // direct-load). Collect all promoted copies (use_global_load_dma or
-    // derived_thread_config). If ALL are DMA-convertible, upgrade them all to
-    // use_global_load_dma. If ANY fails, downgrade them all to
-    // derived_thread_config.
+    // Pre-check: verify that all copies marked with use_global_load_dma are
+    // actually DMA-convertible. If any DMA-marked copy fails the check,
+    // downgrade ALL DMA-marked copies to derived_thread_config.
+    // Copies already marked with derived_thread_config are left unchanged —
+    // they should not be upgraded to use_global_load_dma because they may
+    // have shapes (e.g. scale operands) that are too small for DMA after
+    // per-warp tiling, leading to incorrect thread distribution.
     // Note: GatherOps are excluded — they come from input IR (not from
     // GPUPromoteMatmulOperands) and are handled independently by
     // ConvertGatherToCoalescedDMA.
-    SmallVector<linalg::CopyOp> promotedCopies;
-    bool hasDMAIntent = false;
+    SmallVector<linalg::CopyOp> dmaCopies;
     funcOp->walk([&](linalg::CopyOp copyOp) {
       if (getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp)) {
-        hasDMAIntent = true;
-        promotedCopies.push_back(copyOp);
-      } else if (getLoweringConfig<IREE::GPU::DerivedThreadConfigAttr>(
-                     copyOp)) {
-        promotedCopies.push_back(copyOp);
+        dmaCopies.push_back(copyOp);
       }
     });
 
-    if (hasDMAIntent) {
-      bool allConvertible = llvm::all_of(promotedCopies, isCopyDMAConvertible);
-      LLVM_DEBUG({
-        if (!allConvertible) {
-          llvm::dbgs() << "DMA pre-check: not all copies convertible, "
-                       << "downgrading " << promotedCopies.size()
+    if (!dmaCopies.empty()) {
+      bool allConvertible = llvm::all_of(dmaCopies, isCopyDMAConvertible);
+      if (!allConvertible) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "DMA pre-check: not all DMA copies convertible, "
+                       << "downgrading " << dmaCopies.size()
                        << " copies to derived_thread_config\n";
-        }
-      });
-      for (linalg::CopyOp copyOp : promotedCopies) {
-        if (allConvertible) {
-          setLoweringConfig(copyOp,
-                            IREE::GPU::UseGlobalLoadDMAAttr::get(context));
-        } else {
+        });
+        for (linalg::CopyOp copyOp : dmaCopies) {
           setLoweringConfig(copyOp,
                             IREE::GPU::DerivedThreadConfigAttr::get(context));
         }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1604,7 +1604,7 @@ func.func @no_lower_oob_without_fat_raw_buffer(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_swizzle = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_swizzle = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // CHECK-LABEL: func.func @lower_dma_with_dest_swizzle
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -19,7 +19,8 @@
 // Test: 4x128 memref with 32 lanes.
 //   - Elements per lane = 128 / 32 = 4 (each lane reads 4 contiguous f32s)
 //   - Source offset = divergent (includes lane_id * 4)
-//   - Dest offset = uniform (excludes lane offset, subgroup-uniform for gather_to_lds)
+//   - Dest offset = divergent (includes lane offset, same as source)
+//   - Both src and dst delinearize use the same srcLinearOffset (addi result)
 //   - Loop iterations = 4 (one gather_to_lds per row)
 //
 // CHECK-LABEL: func.func @lower_coalesced_gather_dma_multiple
@@ -38,32 +39,32 @@ func.func @lower_coalesced_gather_dma_multiple(
     // CHECK: %[[C4:.+]] = arith.constant 4 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src gets + lane_offset, dst is uniform
+    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 128
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (4, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN128]]#0, %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     //
     // Transfer 3: linearOffset = 256
     // CHECK: %[[C256:.+]] = arith.constant 256 : index
     // CHECK: %[[SRC_LIN256:.+]] = arith.addi %[[C256]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (4, 128)
-    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[C256]] into (4, 128)
+    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN256]]#0, %[[SRC_DELIN256]]#1], %[[DST]][%[[DST_DELIN256]]#0, %[[DST_DELIN256]]#1] : vector<4xf32>
     //
     // Transfer 4: linearOffset = 384
     // CHECK: %[[C384:.+]] = arith.constant 384 : index
     // CHECK: %[[SRC_LIN384:.+]] = arith.addi %[[C384]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN384:.+]]:2 = affine.delinearize_index %[[SRC_LIN384]] into (4, 128)
-    // CHECK: %[[DST_DELIN384:.+]]:2 = affine.delinearize_index %[[C384]] into (4, 128)
+    // CHECK: %[[DST_DELIN384:.+]]:2 = affine.delinearize_index %[[SRC_LIN384]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN384]]#0, %[[SRC_DELIN384]]#1], %[[DST]][%[[DST_DELIN384]]#0, %[[DST_DELIN384]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
@@ -91,7 +92,7 @@ func.func @lower_coalesced_gather_dma_multiple(
 // Test: 2x64 memref with 32 lanes.
 //   - Elements per lane = 64 / 32 = 2 (each lane reads 2 contiguous f16s)
 //   - Source offset = divergent (lane_id * 2)
-//   - Dest offset = uniform (subgroup-uniform for gather_to_lds)
+//   - Dest offset = divergent (includes lane offset, same as source)
 //   - Loop iterations = 2 (one gather_to_lds per row)
 //
 // CHECK-LABEL: func.func @lower_coalesced_copy_dma_basic
@@ -110,18 +111,18 @@ func.func @lower_coalesced_copy_dma_basic(
     // CHECK: %[[C2:.+]] = arith.constant 2 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C2]]
     //
-    // Transfer 1: linearOffset = 0, src gets +lane_offset, dst is uniform
+    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<2xf16>
     //
     // Transfer 2: linearOffset = 64
     // CHECK: %[[C64:.+]] = arith.constant 64 : index
     // CHECK: %[[SRC_LIN64:.+]] = arith.addi %[[C64]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN64:.+]]:2 = affine.delinearize_index %[[SRC_LIN64]] into (2, 64)
-    // CHECK: %[[DST_DELIN64:.+]]:2 = affine.delinearize_index %[[C64]] into (2, 64)
+    // CHECK: %[[DST_DELIN64:.+]]:2 = affine.delinearize_index %[[SRC_LIN64]] into (2, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN64]]#0, %[[SRC_DELIN64]]#1], %[[DST]][%[[DST_DELIN64]]#0, %[[DST_DELIN64]]#1] : vector<2xf16>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x64xf16, #amdgpu.address_space<fat_raw_buffer>>, memref<2x64xf16, #gpu.address_space<workgroup>>, index
@@ -164,7 +165,7 @@ func.func @lower_coalesced_copy_dma_1d(
     // CHECK: %[[C0:[a-zA-Z0-9_]+]] = arith.constant 0
     // CHECK: %[[SRC_LIN:[a-zA-Z0-9_]+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN:[a-zA-Z0-9_]+]] = affine.delinearize_index %[[SRC_LIN]] into (128)
-    // CHECK: %[[DST_DELIN:[a-zA-Z0-9_]+]] = affine.delinearize_index %[[C0]] into (128)
+    // CHECK: %[[DST_DELIN:[a-zA-Z0-9_]+]] = affine.delinearize_index %[[SRC_LIN]] into (128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN]]], %[[DST]][%[[DST_DELIN]]] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<128xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<128xf32, #gpu.address_space<workgroup>>, index
@@ -208,11 +209,11 @@ func.func @lower_coalesced_copy_dma_single_row_2d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Single transfer: src gets +lane_offset, dst is uniform
+    // Single transfer: src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN:.+]]:2 = affine.delinearize_index %[[SRC_LIN]] into (1, 128)
-    // CHECK: %[[DST_DELIN:.+]]:2 = affine.delinearize_index %[[C0]] into (1, 128)
+    // CHECK: %[[DST_DELIN:.+]]:2 = affine.delinearize_index %[[SRC_LIN]] into (1, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN]]#0, %[[SRC_DELIN]]#1], %[[DST]][%[[DST_DELIN]]#0, %[[DST_DELIN]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -256,32 +257,32 @@ func.func @lower_coalesced_copy_dma_3d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src gets +lane_offset, dst is uniform
+    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:3 = affine.delinearize_index %[[SRC_LIN0]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:3 = affine.delinearize_index %[[C0]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:3 = affine.delinearize_index %[[SRC_LIN0]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1, %[[SRC_DELIN0]]#2], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1, %[[DST_DELIN0]]#2] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 128
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:3 = affine.delinearize_index %[[SRC_LIN128]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:3 = affine.delinearize_index %[[C128]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:3 = affine.delinearize_index %[[SRC_LIN128]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN128]]#0, %[[SRC_DELIN128]]#1, %[[SRC_DELIN128]]#2], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1, %[[DST_DELIN128]]#2] : vector<4xf32>
     //
     // Transfer 3: linearOffset = 256
     // CHECK: %[[C256:.+]] = arith.constant 256 : index
     // CHECK: %[[SRC_LIN256:.+]] = arith.addi %[[C256]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN256:.+]]:3 = affine.delinearize_index %[[SRC_LIN256]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN256:.+]]:3 = affine.delinearize_index %[[C256]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN256:.+]]:3 = affine.delinearize_index %[[SRC_LIN256]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN256]]#0, %[[SRC_DELIN256]]#1, %[[SRC_DELIN256]]#2], %[[DST]][%[[DST_DELIN256]]#0, %[[DST_DELIN256]]#1, %[[DST_DELIN256]]#2] : vector<4xf32>
     //
     // Transfer 4: linearOffset = 384
     // CHECK: %[[C384:.+]] = arith.constant 384 : index
     // CHECK: %[[SRC_LIN384:.+]] = arith.addi %[[C384]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN384:.+]]:3 = affine.delinearize_index %[[SRC_LIN384]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN384:.+]]:3 = affine.delinearize_index %[[C384]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN384:.+]]:3 = affine.delinearize_index %[[SRC_LIN384]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN384]]#0, %[[SRC_DELIN384]]#1, %[[SRC_DELIN384]]#2], %[[DST]][%[[DST_DELIN384]]#0, %[[DST_DELIN384]]#1, %[[DST_DELIN384]]#2] : vector<4xf32>
     //
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -328,18 +329,18 @@ func.func @lower_coalesced_copy_dma_wide_forall_2d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src gets +lane_offset, dst is uniform
+    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 1024)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 1024)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 1024)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 1024
     // CHECK: %[[C1024:.+]] = arith.constant 1024 : index
     // CHECK: %[[SRC_LIN1024:.+]] = arith.addi %[[C1024]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN1024:.+]]:2 = affine.delinearize_index %[[SRC_LIN1024]] into (2, 1024)
-    // CHECK: %[[DST_DELIN1024:.+]]:2 = affine.delinearize_index %[[C1024]] into (2, 1024)
+    // CHECK: %[[DST_DELIN1024:.+]]:2 = affine.delinearize_index %[[SRC_LIN1024]] into (2, 1024)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN1024]]#0, %[[SRC_DELIN1024]]#1], %[[DST]][%[[DST_DELIN1024]]#0, %[[DST_DELIN1024]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x1024xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2x1024xf32, #gpu.address_space<workgroup>>, index
@@ -386,7 +387,7 @@ func.func @lower_coalesced_gather_dma_with_indices(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 128)
     // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%[[SRC_DELIN0]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
@@ -394,7 +395,7 @@ func.func @lower_coalesced_gather_dma_with_indices(
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (2, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (2, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (2, 128)
     // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%[[SRC_DELIN128]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -439,11 +440,11 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src has lane offset, dst is uniform
+    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (3, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (3, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (3, 128)
     // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%[[SRC_DELIN0]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
@@ -451,7 +452,7 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (3, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (3, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (3, 128)
     // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%[[SRC_DELIN128]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     //
@@ -459,7 +460,7 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C256:.+]] = arith.constant 256 : index
     // CHECK: %[[SRC_LIN256:.+]] = arith.addi %[[C256]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (3, 128)
-    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[C256]] into (3, 128)
+    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (3, 128)
     // CHECK: %[[LOADED_ROW2:.+]] = memref.load %[[IDX]][%[[SRC_DELIN256]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW2]], %[[SRC_DELIN256]]#1], %[[DST]][%[[DST_DELIN256]]#0, %[[DST_DELIN256]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
@@ -750,18 +751,18 @@ func.func @lower_coalesced_dma_linearized_2_rows_per_transfer(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src has lane offset, dst is uniform
+    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 128
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 64)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (4, 64)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN128]]#0, %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -935,11 +936,11 @@ func.func @lower_coalesced_gather_dma_innermost_1d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: src has lane offset for index lookup, dst is uniform
+    // Transfer 1: src and dst both use srcLinearOffset (same value)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]] = affine.delinearize_index %[[SRC_LIN0]] into (256)
-    // CHECK: %[[DST_DELIN0:.+]] = affine.delinearize_index %[[C0]] into (256)
+    // CHECK: %[[DST_DELIN0:.+]] = affine.delinearize_index %[[SRC_LIN0]] into (256)
     // CHECK: %[[LOADED0:.+]] = memref.load %{{.+}}[%[[SRC_DELIN0]]]
     // CHECK: amdgpu.gather_to_lds %{{.+}}[%[[LOADED0]]], %{{.+}}[%[[DST_DELIN0]]]
     //
@@ -947,7 +948,7 @@ func.func @lower_coalesced_gather_dma_innermost_1d(
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]] = affine.delinearize_index %[[SRC_LIN128]] into (256)
-    // CHECK: %[[DST_DELIN128:.+]] = affine.delinearize_index %[[C128]] into (256)
+    // CHECK: %[[DST_DELIN128:.+]] = affine.delinearize_index %[[SRC_LIN128]] into (256)
     // CHECK: %[[LOADED128:.+]] = memref.load %{{.+}}[%[[SRC_DELIN128]]]
     // CHECK: amdgpu.gather_to_lds %{{.+}}[%[[LOADED128]]], %{{.+}}[%[[DST_DELIN128]]]
     //
@@ -1006,13 +1007,13 @@ func.func @lower_coalesced_dma_lane_offset_regression(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: src has lane_offset (divergent), dst is uniform
+    // Transfer 1: src and dst both use srcLinearOffset (same value, both divergent)
     // For lane 16: srcLinear = 0 + 64 = 64 → delinearize → (1, 0)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (16, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (16, 64)
-    // Source uses divergent indices, dest uses uniform indices
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (16, 64)
+    // Both src and dst use the same divergent linear offset
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2-8: similar pattern for remaining 896 elements
@@ -1074,7 +1075,7 @@ func.func @lower_coalesced_dma_with_in_bounds(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
     // No non-outermost OOB dims, so select is identity (false → original index).
     // CHECK: %[[FALSE0:.+]] = arith.constant false
     // CHECK: %[[C2:.+]] = arith.constant 2 : index
@@ -1139,7 +1140,7 @@ func.func @lower_coalesced_dma_4x64_tensor_pad_fusion(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
     // in_bounds = [false, true]: no non-outermost OOB dims, select is identity.
     // CHECK: %[[FALSE0:.+]] = arith.constant false
     // CHECK: %[[DIM0:.+]] = memref.dim %[[SRC]], %{{.+}}
@@ -1197,7 +1198,7 @@ func.func @gather_dma_non_outermost_oob_check(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 8)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 8)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 8)
     //
     // Bounds check: compare srcIndices[1] >= 6 (source dim 1 size)
     // CHECK: %[[FALSE:.+]] = arith.constant false
@@ -1257,7 +1258,7 @@ func.func @gather_dma_inner_dim_oob_64x62(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (64, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (64, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (64, 64)
     //
     // Bounds check: compare srcIndices[1] >= 62 (source inner dim size).
     // CHECK: %[[FALSE:.+]] = arith.constant false

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -19,8 +19,7 @@
 // Test: 4x128 memref with 32 lanes.
 //   - Elements per lane = 128 / 32 = 4 (each lane reads 4 contiguous f32s)
 //   - Source offset = divergent (includes lane_id * 4)
-//   - Dest offset = divergent (includes lane offset, same as source)
-//   - Both src and dst delinearize use the same srcLinearOffset (addi result)
+//   - Dest offset = uniform (excludes lane offset, subgroup-uniform for gather_to_lds)
 //   - Loop iterations = 4 (one gather_to_lds per row)
 //
 // CHECK-LABEL: func.func @lower_coalesced_gather_dma_multiple
@@ -39,32 +38,32 @@ func.func @lower_coalesced_gather_dma_multiple(
     // CHECK: %[[C4:.+]] = arith.constant 4 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
+    // Transfer 1: linearOffset = 0, src gets + lane_offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 128
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN128]]#0, %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     //
     // Transfer 3: linearOffset = 256
     // CHECK: %[[C256:.+]] = arith.constant 256 : index
     // CHECK: %[[SRC_LIN256:.+]] = arith.addi %[[C256]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (4, 128)
-    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (4, 128)
+    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[C256]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN256]]#0, %[[SRC_DELIN256]]#1], %[[DST]][%[[DST_DELIN256]]#0, %[[DST_DELIN256]]#1] : vector<4xf32>
     //
     // Transfer 4: linearOffset = 384
     // CHECK: %[[C384:.+]] = arith.constant 384 : index
     // CHECK: %[[SRC_LIN384:.+]] = arith.addi %[[C384]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN384:.+]]:2 = affine.delinearize_index %[[SRC_LIN384]] into (4, 128)
-    // CHECK: %[[DST_DELIN384:.+]]:2 = affine.delinearize_index %[[SRC_LIN384]] into (4, 128)
+    // CHECK: %[[DST_DELIN384:.+]]:2 = affine.delinearize_index %[[C384]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN384]]#0, %[[SRC_DELIN384]]#1], %[[DST]][%[[DST_DELIN384]]#0, %[[DST_DELIN384]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
@@ -92,7 +91,7 @@ func.func @lower_coalesced_gather_dma_multiple(
 // Test: 2x64 memref with 32 lanes.
 //   - Elements per lane = 64 / 32 = 2 (each lane reads 2 contiguous f16s)
 //   - Source offset = divergent (lane_id * 2)
-//   - Dest offset = divergent (includes lane offset, same as source)
+//   - Dest offset = uniform (subgroup-uniform for gather_to_lds)
 //   - Loop iterations = 2 (one gather_to_lds per row)
 //
 // CHECK-LABEL: func.func @lower_coalesced_copy_dma_basic
@@ -111,18 +110,18 @@ func.func @lower_coalesced_copy_dma_basic(
     // CHECK: %[[C2:.+]] = arith.constant 2 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C2]]
     //
-    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
+    // Transfer 1: linearOffset = 0, src gets +lane_offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<2xf16>
     //
     // Transfer 2: linearOffset = 64
     // CHECK: %[[C64:.+]] = arith.constant 64 : index
     // CHECK: %[[SRC_LIN64:.+]] = arith.addi %[[C64]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN64:.+]]:2 = affine.delinearize_index %[[SRC_LIN64]] into (2, 64)
-    // CHECK: %[[DST_DELIN64:.+]]:2 = affine.delinearize_index %[[SRC_LIN64]] into (2, 64)
+    // CHECK: %[[DST_DELIN64:.+]]:2 = affine.delinearize_index %[[C64]] into (2, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN64]]#0, %[[SRC_DELIN64]]#1], %[[DST]][%[[DST_DELIN64]]#0, %[[DST_DELIN64]]#1] : vector<2xf16>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x64xf16, #amdgpu.address_space<fat_raw_buffer>>, memref<2x64xf16, #gpu.address_space<workgroup>>, index
@@ -165,7 +164,7 @@ func.func @lower_coalesced_copy_dma_1d(
     // CHECK: %[[C0:[a-zA-Z0-9_]+]] = arith.constant 0
     // CHECK: %[[SRC_LIN:[a-zA-Z0-9_]+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN:[a-zA-Z0-9_]+]] = affine.delinearize_index %[[SRC_LIN]] into (128)
-    // CHECK: %[[DST_DELIN:[a-zA-Z0-9_]+]] = affine.delinearize_index %[[SRC_LIN]] into (128)
+    // CHECK: %[[DST_DELIN:[a-zA-Z0-9_]+]] = affine.delinearize_index %[[C0]] into (128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN]]], %[[DST]][%[[DST_DELIN]]] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<128xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<128xf32, #gpu.address_space<workgroup>>, index
@@ -209,11 +208,11 @@ func.func @lower_coalesced_copy_dma_single_row_2d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Single transfer: src and dst both use srcLinearOffset (same value)
+    // Single transfer: src gets +lane_offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN:.+]]:2 = affine.delinearize_index %[[SRC_LIN]] into (1, 128)
-    // CHECK: %[[DST_DELIN:.+]]:2 = affine.delinearize_index %[[SRC_LIN]] into (1, 128)
+    // CHECK: %[[DST_DELIN:.+]]:2 = affine.delinearize_index %[[C0]] into (1, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN]]#0, %[[SRC_DELIN]]#1], %[[DST]][%[[DST_DELIN]]#0, %[[DST_DELIN]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -257,32 +256,32 @@ func.func @lower_coalesced_copy_dma_3d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
+    // Transfer 1: linearOffset = 0, src gets +lane_offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:3 = affine.delinearize_index %[[SRC_LIN0]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:3 = affine.delinearize_index %[[SRC_LIN0]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:3 = affine.delinearize_index %[[C0]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1, %[[SRC_DELIN0]]#2], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1, %[[DST_DELIN0]]#2] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 128
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:3 = affine.delinearize_index %[[SRC_LIN128]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:3 = affine.delinearize_index %[[SRC_LIN128]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:3 = affine.delinearize_index %[[C128]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN128]]#0, %[[SRC_DELIN128]]#1, %[[SRC_DELIN128]]#2], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1, %[[DST_DELIN128]]#2] : vector<4xf32>
     //
     // Transfer 3: linearOffset = 256
     // CHECK: %[[C256:.+]] = arith.constant 256 : index
     // CHECK: %[[SRC_LIN256:.+]] = arith.addi %[[C256]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN256:.+]]:3 = affine.delinearize_index %[[SRC_LIN256]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN256:.+]]:3 = affine.delinearize_index %[[SRC_LIN256]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN256:.+]]:3 = affine.delinearize_index %[[C256]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN256]]#0, %[[SRC_DELIN256]]#1, %[[SRC_DELIN256]]#2], %[[DST]][%[[DST_DELIN256]]#0, %[[DST_DELIN256]]#1, %[[DST_DELIN256]]#2] : vector<4xf32>
     //
     // Transfer 4: linearOffset = 384
     // CHECK: %[[C384:.+]] = arith.constant 384 : index
     // CHECK: %[[SRC_LIN384:.+]] = arith.addi %[[C384]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN384:.+]]:3 = affine.delinearize_index %[[SRC_LIN384]] into (2, 2, 128)
-    // CHECK: %[[DST_DELIN384:.+]]:3 = affine.delinearize_index %[[SRC_LIN384]] into (2, 2, 128)
+    // CHECK: %[[DST_DELIN384:.+]]:3 = affine.delinearize_index %[[C384]] into (2, 2, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN384]]#0, %[[SRC_DELIN384]]#1, %[[SRC_DELIN384]]#2], %[[DST]][%[[DST_DELIN384]]#0, %[[DST_DELIN384]]#1, %[[DST_DELIN384]]#2] : vector<4xf32>
     //
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -329,18 +328,18 @@ func.func @lower_coalesced_copy_dma_wide_forall_2d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
+    // Transfer 1: linearOffset = 0, src gets +lane_offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 1024)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 1024)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 1024)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 1024
     // CHECK: %[[C1024:.+]] = arith.constant 1024 : index
     // CHECK: %[[SRC_LIN1024:.+]] = arith.addi %[[C1024]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN1024:.+]]:2 = affine.delinearize_index %[[SRC_LIN1024]] into (2, 1024)
-    // CHECK: %[[DST_DELIN1024:.+]]:2 = affine.delinearize_index %[[SRC_LIN1024]] into (2, 1024)
+    // CHECK: %[[DST_DELIN1024:.+]]:2 = affine.delinearize_index %[[C1024]] into (2, 1024)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN1024]]#0, %[[SRC_DELIN1024]]#1], %[[DST]][%[[DST_DELIN1024]]#0, %[[DST_DELIN1024]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x1024xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<2x1024xf32, #gpu.address_space<workgroup>>, index
@@ -387,7 +386,7 @@ func.func @lower_coalesced_gather_dma_with_indices(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (2, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (2, 128)
     // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%[[SRC_DELIN0]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
@@ -395,7 +394,7 @@ func.func @lower_coalesced_gather_dma_with_indices(
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (2, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (2, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (2, 128)
     // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%[[SRC_DELIN128]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -440,11 +439,11 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
+    // Transfer 1: linearOffset = 0, src has lane offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (3, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (3, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (3, 128)
     // CHECK: %[[LOADED_ROW0:.+]] = memref.load %[[IDX]][%[[SRC_DELIN0]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW0]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
@@ -452,7 +451,7 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (3, 128)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (3, 128)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (3, 128)
     // CHECK: %[[LOADED_ROW1:.+]] = memref.load %[[IDX]][%[[SRC_DELIN128]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW1]], %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     //
@@ -460,7 +459,7 @@ func.func @gather_iterates_over_dest_shape_not_source(
     // CHECK: %[[C256:.+]] = arith.constant 256 : index
     // CHECK: %[[SRC_LIN256:.+]] = arith.addi %[[C256]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (3, 128)
-    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[SRC_LIN256]] into (3, 128)
+    // CHECK: %[[DST_DELIN256:.+]]:2 = affine.delinearize_index %[[C256]] into (3, 128)
     // CHECK: %[[LOADED_ROW2:.+]] = memref.load %[[IDX]][%[[SRC_DELIN256]]#0]
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[LOADED_ROW2]], %[[SRC_DELIN256]]#1], %[[DST]][%[[DST_DELIN256]]#0, %[[DST_DELIN256]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
@@ -751,18 +750,18 @@ func.func @lower_coalesced_dma_linearized_2_rows_per_transfer(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: linearOffset = 0, src and dst both use srcLinearOffset (same value)
+    // Transfer 1: linearOffset = 0, src has lane offset, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2: linearOffset = 128
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 64)
-    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[SRC_LIN128]] into (4, 64)
+    // CHECK: %[[DST_DELIN128:.+]]:2 = affine.delinearize_index %[[C128]] into (4, 64)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN128]]#0, %[[SRC_DELIN128]]#1], %[[DST]][%[[DST_DELIN128]]#0, %[[DST_DELIN128]]#1] : vector<4xf32>
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -936,11 +935,11 @@ func.func @lower_coalesced_gather_dma_innermost_1d(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: src and dst both use srcLinearOffset (same value)
+    // Transfer 1: src has lane offset for index lookup, dst is uniform
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]] = affine.delinearize_index %[[SRC_LIN0]] into (256)
-    // CHECK: %[[DST_DELIN0:.+]] = affine.delinearize_index %[[SRC_LIN0]] into (256)
+    // CHECK: %[[DST_DELIN0:.+]] = affine.delinearize_index %[[C0]] into (256)
     // CHECK: %[[LOADED0:.+]] = memref.load %{{.+}}[%[[SRC_DELIN0]]]
     // CHECK: amdgpu.gather_to_lds %{{.+}}[%[[LOADED0]]], %{{.+}}[%[[DST_DELIN0]]]
     //
@@ -948,7 +947,7 @@ func.func @lower_coalesced_gather_dma_innermost_1d(
     // CHECK: %[[C128:.+]] = arith.constant 128 : index
     // CHECK: %[[SRC_LIN128:.+]] = arith.addi %[[C128]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN128:.+]] = affine.delinearize_index %[[SRC_LIN128]] into (256)
-    // CHECK: %[[DST_DELIN128:.+]] = affine.delinearize_index %[[SRC_LIN128]] into (256)
+    // CHECK: %[[DST_DELIN128:.+]] = affine.delinearize_index %[[C128]] into (256)
     // CHECK: %[[LOADED128:.+]] = memref.load %{{.+}}[%[[SRC_DELIN128]]]
     // CHECK: amdgpu.gather_to_lds %{{.+}}[%[[LOADED128]]], %{{.+}}[%[[DST_DELIN128]]]
     //
@@ -1007,13 +1006,13 @@ func.func @lower_coalesced_dma_lane_offset_regression(
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
     // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
-    // Transfer 1: src and dst both use srcLinearOffset (same value, both divergent)
+    // Transfer 1: src has lane_offset (divergent), dst is uniform
     // For lane 16: srcLinear = 0 + 64 = 64 → delinearize → (1, 0)
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (16, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (16, 64)
-    // Both src and dst use the same divergent linear offset
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (16, 64)
+    // Source uses divergent indices, dest uses uniform indices
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
     // Transfer 2-8: similar pattern for remaining 896 elements
@@ -1075,7 +1074,7 @@ func.func @lower_coalesced_dma_with_in_bounds(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
     // No non-outermost OOB dims, so select is identity (false → original index).
     // CHECK: %[[FALSE0:.+]] = arith.constant false
     // CHECK: %[[C2:.+]] = arith.constant 2 : index
@@ -1140,7 +1139,7 @@ func.func @lower_coalesced_dma_4x64_tensor_pad_fusion(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 64)
     // in_bounds = [false, true]: no non-outermost OOB dims, select is identity.
     // CHECK: %[[FALSE0:.+]] = arith.constant false
     // CHECK: %[[DIM0:.+]] = memref.dim %[[SRC]], %{{.+}}
@@ -1198,7 +1197,7 @@ func.func @gather_dma_non_outermost_oob_check(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 8)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 8)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 8)
     //
     // Bounds check: compare srcIndices[1] >= 6 (source dim 1 size)
     // CHECK: %[[FALSE:.+]] = arith.constant false
@@ -1258,7 +1257,7 @@ func.func @gather_dma_inner_dim_oob_64x62(
     // CHECK: %[[C0:.+]] = arith.constant 0 : index
     // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
     // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (64, 64)
-    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (64, 64)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (64, 64)
     //
     // Bounds check: compare srcIndices[1] >= 62 (source inner dim size).
     // CHECK: %[[FALSE:.+]] = arith.constant false

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1588,15 +1588,15 @@ func.func @no_lower_oob_without_fat_raw_buffer(
 // The destination traces through expand_shape -> swizzle_hint -> alloc.
 // Source indices should be swizzled, destination indices should be linear.
 //
-// Shape: 4x128 f32 dest. With 32 lanes, 128-bit DMA = 4 elements/lane.
-// 128 elements/transfer, 512 total = 4 transfers.
+// Shape: 4x128 f32 dest. With 64 lanes, 128-bit DMA = 4 elements/lane.
+// 256 elements/transfer, 512 total = 2 transfers.
 // XOR swizzle with row_width=128, access_width=16 permutes source offsets.
 
 #executable_target_rocm_hsaco_fb_swizzle = #hal.executable.target<"rocm",
   "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
   arch = "gfx950", features = "", wgp = <
     compute = fp32, storage = b32, subgroup = none, dot = none, mma = [],
-    subgroup_size_choices = [32, 32],
+    subgroup_size_choices = [64, 64],
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
@@ -1604,7 +1604,7 @@ func.func @no_lower_oob_without_fat_raw_buffer(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_swizzle = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_swizzle = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @lower_dma_with_dest_swizzle
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>
@@ -1620,8 +1620,8 @@ func.func @lower_dma_with_dest_swizzle(
       output_shape [4, 128]
       : memref<512xf32, #gpu.address_space<workgroup>>
       into memref<4x128xf32, #gpu.address_space<workgroup>>
-  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
-  scf.forall (%lane) in (32) {
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (64)
+  scf.forall (%lane) in (64) {
     // CHECK: %[[C4:.+]] = arith.constant 4 : index
     // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C4]]
     //
@@ -1641,8 +1641,8 @@ func.func @lower_dma_with_dest_swizzle(
     // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
     // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %{{.+}}[%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
     //
-    // Remaining 3 transfers also have XOR swizzle on source.
-    // CHECK-COUNT-3: amdgpu.gather_to_lds
+    // Remaining 1 transfer also has XOR swizzle on source.
+    // CHECK-COUNT-1: amdgpu.gather_to_lds
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1581,3 +1581,73 @@ func.func @no_lower_oob_without_fat_raw_buffer(
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return
 }
+
+// -----
+
+// Test: Inverse source swizzle when destination has swizzle_hint.
+// The destination traces through expand_shape -> swizzle_hint -> alloc.
+// Source indices should be swizzled, destination indices should be linear.
+//
+// Shape: 4x128 f32 dest. With 32 lanes, 128-bit DMA = 4 elements/lane.
+// 128 elements/transfer, 512 total = 4 transfers.
+// XOR swizzle with row_width=128, access_width=16 permutes source offsets.
+
+#executable_target_rocm_hsaco_fb_swizzle = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [],
+    subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_swizzle = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+// CHECK-LABEL: func.func @lower_dma_with_dest_swizzle
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>
+func.func @lower_dma_with_dest_swizzle(
+    %source: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_swizzle,
+    translation_info = #translation_swizzle} {
+  %alloc = memref.alloc() : memref<512xf32, #gpu.address_space<workgroup>>
+  %swizzled = iree_codegen.swizzle_hint %alloc[#iree_codegen.xor_shuffle<128, 16>]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+  %dest = memref.expand_shape %swizzled [[0, 1]]
+      output_shape [4, 128]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+      into memref<4x128xf32, #gpu.address_space<workgroup>>
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
+  scf.forall (%lane) in (32) {
+    // CHECK: %[[C4:.+]] = arith.constant 4 : index
+    // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C4]]
+    //
+    // Transfer 1: linearOffset = 0, source gets XOR-swizzled offset.
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
+    // XOR swizzle: extractCol, extractRow, xori, updateCol, diff, add.
+    // CHECK: %[[COL0:.+]] = affine.apply
+    // CHECK: %[[ROW0:.+]] = affine.apply
+    // CHECK: %[[XOR0:.+]] = arith.xori %[[ROW0]], %[[COL0]]
+    // CHECK: %[[UCOL0:.+]] = affine.apply
+    // CHECK: %[[DIFF0:.+]] = arith.subi %[[UCOL0]], %[[SRC_LIN0]]
+    // CHECK: %[[SWIZZLED0:.+]] = arith.addi %[[SRC_LIN0]], %[[DIFF0]]
+    // Source delinearized from swizzled offset.
+    // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SWIZZLED0]] into (4, 128)
+    // Destination delinearized from unswizzled offset (no xori).
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %{{.+}}[%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
+    //
+    // Remaining 3 transfers also have XOR swizzle on source.
+    // CHECK-COUNT-3: amdgpu.gather_to_lds
+    // CHECK-NOT: amdgpu.gather_to_lds
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)
+        : memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>,
+          memref<4x128xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#iree_gpu.lane_id<0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -232,8 +232,8 @@ static void resolveHintOp(RewriterBase &rewriter,
     // used as the destination (via expand_shape/collapse_shape/subview) of a
     // gather_to_lds, the swizzle is applied at the source-side in the DMA
     // lowering pass, so these ops just pass through the swizzled allocation.
-    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp,
-            memref::SubViewOp>(user)) {
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp, memref::SubViewOp>(
+            user)) {
       continue;
     }
     // Throw if we can't rewrite all users.

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/AffineExpr.h"
@@ -225,6 +226,14 @@ static void resolveHintOp(RewriterBase &rewriter,
         return;
       }
       gatherToLDSOps.push_back(gatherToLDSOp);
+      continue;
+    }
+    // Treat reshape/subview ops as transparent users. When a swizzle_hint is
+    // used as the destination (via expand_shape/collapse_shape/subview) of a
+    // gather_to_lds, the swizzle is applied at the source-side in the DMA
+    // lowering pass, so these ops just pass through the swizzled allocation.
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp,
+            memref::SubViewOp>(user)) {
       continue;
     }
     // Throw if we can't rewrite all users.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -930,11 +930,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
         context, baseAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs);
     if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
-      promotionArray =
-          useDirectLoad
-              ? SmallVector<Attribute>{useGlobalDma, useGlobalDma,
-                                       defaultConfigAttr, defaultConfigAttr}
-              : SmallVector<Attribute>{};
+      promotionArray = SmallVector<Attribute>{
+          baseAttr, baseAttr, defaultConfigAttr, defaultConfigAttr};
     } else {
       promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
                         defaultConfigAttr};

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -801,15 +801,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              lhsScaleType,
                              rhsScaleType};
 
-  // TODO(#22119): We don't use global load DMA for scaled matmuls, because
-  // compilation doesn't support it. Once this is fixed, we should use global
-  // load DMA here when possible.
   Location loc = operands[0].getLoc();
-  if (scaled && useDirectLoad) {
-    mlir::emitWarning(loc) << "direct load (global load DMA) is not yet "
-                              "supported for scaled matmuls, ignoring";
-    useDirectLoad = false;
-  }
 
   // Accumulator needs shared memory if:
   // - Padding requires C promotion, OR
@@ -927,18 +919,28 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   if (scaled) {
     promotionList.append({2, 3});
     auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
-    // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
-    FailureOr<Attribute> lhsSwizzleAttr =
-        getXorShuffleAttr(context, defaultConfigAttr, target, kind,
-                          schedule->kTileSizes, kMMAOperandLhs);
-    FailureOr<Attribute> rhsSwizzleAttr =
-        getXorShuffleAttr(context, defaultConfigAttr, target, kind,
-                          schedule->kTileSizes, kMMAOperandRhs);
-    if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
-      promotionArray = {};
-    } else {
-      promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
+    if (useDirectLoad) {
+      // Use DMA for LHS/RHS (operands 0,1) and thread-based copy for scale
+      // operands (2,3). Scale operands use a different mapping level than DMA
+      // copies, so mixing DMA for all operands would prevent loop fusion in
+      // GPUFuseAndHoistParallelLoops (see #22119).
+      Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+      promotionArray = {useGlobalDma, useGlobalDma, defaultConfigAttr,
                         defaultConfigAttr};
+    } else {
+      // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
+      FailureOr<Attribute> lhsSwizzleAttr =
+          getXorShuffleAttr(context, defaultConfigAttr, target, kind,
+                            schedule->kTileSizes, kMMAOperandLhs);
+      FailureOr<Attribute> rhsSwizzleAttr =
+          getXorShuffleAttr(context, defaultConfigAttr, target, kind,
+                            schedule->kTileSizes, kMMAOperandRhs);
+      if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
+        promotionArray = {};
+      } else {
+        promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
+                          defaultConfigAttr};
+      }
     }
   }
   if ((!mustBeAligned || couldNeedPadding) && cPromoteIfPadding) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -911,36 +911,33 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   // Use global load DMA attribute (subgroup sizes will be derived from
   // translation_info).
   SmallVector<Attribute> promotionArray;
-  if (useDirectLoad) {
-    Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+  auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
+  Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+  if (useDirectLoad && !scaled) {
     promotionArray = {useGlobalDma, useGlobalDma};
   }
   SmallVector<int64_t> promotionList = {0, 1};
   if (scaled) {
     promotionList.append({2, 3});
-    auto defaultConfigAttr = IREE::GPU::DerivedThreadConfigAttr::get(context);
-    if (useDirectLoad) {
-      // Use DMA for LHS/RHS (operands 0,1) and thread-based copy for scale
-      // operands (2,3). Scale operands use a different mapping level than DMA
-      // copies, so mixing DMA for all operands would prevent loop fusion in
-      // GPUFuseAndHoistParallelLoops (see #22119).
-      Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
-      promotionArray = {useGlobalDma, useGlobalDma, defaultConfigAttr,
-                        defaultConfigAttr};
+    // For data operands (0,1), use DMA config when useDirectLoad is set,
+    // otherwise use thread-based config. Both paths apply XOR swizzle for
+    // bank conflict avoidance. The DMA lowering pass applies inverse source
+    // swizzle to produce the correct swizzled layout in LDS.
+    // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
+    Attribute baseAttr = useDirectLoad ? useGlobalDma : defaultConfigAttr;
+    FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
+        context, baseAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs);
+    FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
+        context, baseAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs);
+    if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
+      promotionArray =
+          useDirectLoad
+              ? SmallVector<Attribute>{useGlobalDma, useGlobalDma,
+                                       defaultConfigAttr, defaultConfigAttr}
+              : SmallVector<Attribute>{};
     } else {
-      // TODO(#23329): Do not swizzle shapes that have no bank conflicts.
-      FailureOr<Attribute> lhsSwizzleAttr =
-          getXorShuffleAttr(context, defaultConfigAttr, target, kind,
-                            schedule->kTileSizes, kMMAOperandLhs);
-      FailureOr<Attribute> rhsSwizzleAttr =
-          getXorShuffleAttr(context, defaultConfigAttr, target, kind,
-                            schedule->kTileSizes, kMMAOperandRhs);
-      if (failed(lhsSwizzleAttr) || failed(rhsSwizzleAttr)) {
-        promotionArray = {};
-      } else {
-        promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
-                          defaultConfigAttr};
-      }
+      promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
+                        defaultConfigAttr};
     }
   }
   if ((!mustBeAligned || couldNeedPadding) && cPromoteIfPadding) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -40,6 +40,7 @@ iree_lit_test_suite(
             "pipeline_igemm_tile_and_fuse.mlir",
             "pipeline_igemm_tile_and_fuse_gfx950.mlir",
             "pipeline_lower_to_llvmgpu.mlir",
+            "pipeline_scaled_matmul_dma.mlir",
             "pipeline_scaled_truncation_gfx950.mlir",
             "pipeline_tile_and_fuse.mlir",
             "pipeline_tile_and_fuse_gfx950.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "pipeline_igemm_tile_and_fuse.mlir"
     "pipeline_igemm_tile_and_fuse_gfx950.mlir"
     "pipeline_lower_to_llvmgpu.mlir"
+    "pipeline_scaled_matmul_dma.mlir"
     "pipeline_scaled_truncation_gfx950.mlir"
     "pipeline_tile_and_fuse.mlir"
     "pipeline_tile_and_fuse_gfx950.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -23,6 +23,12 @@
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
+// RUN: | FileCheck %s --check-prefix=CHECK-DIRECT-LOAD
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
 // RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=3 \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-3
@@ -79,6 +85,10 @@ func.func @scaled_matmul(
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=104448
 
+// CHECK-DIRECT-LOAD-LABEL: func.func @scaled_matmul
+// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+
 // -----
 
 #lhs_map = affine_map<(B, M, N, Ko, Kb) -> (B, M, Ko, Kb)>
@@ -124,6 +134,10 @@ func.func @scaled_matmul_with_batch(
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=104448
+
+// CHECK-DIRECT-LOAD-LABEL: func.func @scaled_matmul_with_batch
+// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 
 // -----
 
@@ -199,6 +213,10 @@ func.func @scaled_matmul_with_dynamic_batch(
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=78336
 
+// CHECK-DIRECT-LOAD-LABEL: func.func @scaled_matmul_with_dynamic_batch
+// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+
 // -----
 
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
@@ -244,6 +262,10 @@ func.func @small_scaled_matmul(
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=6528
+
+// CHECK-DIRECT-LOAD-LABEL: func.func @small_scaled_matmul
+// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
 
 // -----
 
@@ -366,6 +388,10 @@ func.func @scaled_matmul_accumulate(
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=130816
 
+// CHECK-DIRECT-LOAD-LABEL: func.func @scaled_matmul_accumulate
+// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+
 // -----
 
 // Very large f16 matmul — compute-bound, so picks 32x32x16 (higher compute per
@@ -394,3 +420,7 @@ func.func @matmul_f16_compute_bound(
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=98304
+
+// CHECK-DIRECT-LOAD-LABEL: func.func @matmul_f16_compute_bound
+// CHECK-DIRECT-LOAD:       linalg.matmul {lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -65,18 +65,10 @@ func.func @scaled_matmul(
 //  CHECK-SAME:     subgroup = [4, 8, 0, 0]
 //  CHECK-SAME:     workgroup = [256, 256, 0, 0]
 
-// With --iree-llvmgpu-use-direct-load, LHS/RHS get use_global_load_dma while
-// scales keep derived_thread_config.
-// CHECK-DIRECT-LOAD-LABEL: func.func @scaled_matmul
-// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
-
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=34816
 
-// TODO(#22119): With direct-load, no cache swizzle on LHS/RHS so shared
-// memory increases. This needs to be addressed.
 // CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=69632

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -12,6 +12,12 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
 // RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
+// RUN: | FileCheck %s --check-prefix=CHECK-DIRECT-LOAD
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-2
 
@@ -53,17 +59,25 @@ func.func @scaled_matmul(
 //  CHECK-SAME:     subgroup = [4, 8, 0, 0]
 //  CHECK-SAME:     workgroup = [256, 256, 0, 0]
 
+// With --iree-llvmgpu-use-direct-load, LHS/RHS get use_global_load_dma while
+// scales keep derived_thread_config.
+// CHECK-DIRECT-LOAD-LABEL: func.func @scaled_matmul
+// CHECK-DIRECT-LOAD:       linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+
 // CHECK-REMARKS: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-SAME: Remark=34816
 
+// TODO(#22119): With direct-load, no cache swizzle on LHS/RHS so shared
+// memory increases. This needs to be addressed.
 // CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=34816
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=69632
 
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=34816
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=104448
 
 // -----
 
@@ -105,11 +119,11 @@ func.func @scaled_matmul_with_batch(
 
 // CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=34816
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=69632
 
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=34816
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=104448
 
 // -----
 
@@ -179,11 +193,11 @@ func.func @scaled_matmul_with_dynamic_batch(
 
 // CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=26112
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=52224
 
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=26112
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=78336
 
 // -----
 
@@ -225,11 +239,11 @@ func.func @small_scaled_matmul(
 
 // CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=2176
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=4352
 
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=2176
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=6528
 
 // -----
 
@@ -346,11 +360,11 @@ func.func @scaled_matmul_accumulate(
 
 // CHECK-REMARKS-DIRECT-LOAD-2: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-2-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=157184
+// CHECK-REMARKS-DIRECT-LOAD-2-SAME: Remark=109056
 
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
-// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=157184
+// CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=130816
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
@@ -2,9 +2,9 @@
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" %s | FileCheck %s
 
 // Test: Scaled matmul (f4E2M1FN * f4E2M1FN with f8E8M0FNU scales) compiles
-// through the full pipeline with DMA config. This validates that the pipeline
-// handles sub-byte types correctly, including the narrow type emulation for
-// gather_to_lds ops.
+// through the full pipeline with DMA + XOR swizzle config. This validates
+// that the pipeline handles DMA with inverse source swizzle for data
+// operands, including sub-byte type narrow type emulation.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer, ReadOnly>,
@@ -30,8 +30,8 @@
     acc_elem_type = f32>,
   promote_operands = [0, 1, 2, 3],
   promotion_types = [
-    #iree_gpu.use_global_load_dma,
-    #iree_gpu.use_global_load_dma,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<256, 32>>,
     #iree_gpu.derived_thread_config,
     #iree_gpu.derived_thread_config],
   reduction = [0, 0, 1, 1],
@@ -84,16 +84,13 @@ hal.executable public @main {
 }
 
 // Verify pipeline completes and produces scaled MFMA compute ops.
-// LHS/RHS are promoted to workgroup shared memory and scales use thread-based
-// copies. The compute uses 16x16x128 scaled MFMA instructions.
+// LHS/RHS are promoted to workgroup shared memory with XOR swizzle hints
+// and scales use thread-based copies. The compute uses 16x16x128 scaled
+// MFMA instructions.
 
 // CHECK-LABEL: func.func @scaled_matmul_dma
 //   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf8E8M0FNU, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf4E2M1FN, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall
 //       CHECK:     scf.for
-// TODO: The DMA config is set but the pipeline currently lowers LHS/RHS copies
-// via vector.transfer_read/write instead of amdgpu.gather_to_lds. Once the DMA
-// lowering path handles scaled matmul operands, add:
-//   COM: CHECK: amdgpu.gather_to_lds
 //       CHECK:       amdgpu.scaled_mfma 16x16x128

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
@@ -92,4 +92,8 @@ hal.executable public @main {
 //   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf4E2M1FN, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall
 //       CHECK:     scf.for
+// TODO: The DMA config is set but the pipeline currently lowers LHS/RHS copies
+// via vector.transfer_read/write instead of amdgpu.gather_to_lds. Once the DMA
+// lowering path handles scaled matmul operands, add:
+//   COM: CHECK: amdgpu.gather_to_lds
 //       CHECK:       amdgpu.scaled_mfma 16x16x128

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
@@ -1,0 +1,95 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" %s | FileCheck %s
+
+// Test: Scaled matmul (f4E2M1FN * f4E2M1FN with f8E8M0FNU scales) compiles
+// through the full pipeline with DMA config. This validates that the pipeline
+// handles sub-byte types correctly, including the narrow type emulation for
+// gather_to_lds ops.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#translation_info = #iree_codegen.translation_info<pipeline =
+  LLVMGPUTileAndFuse
+  workgroup_size = [512, 1, 1]
+  subgroup_size = 64,
+  {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      prefetch_num_stages = 2,
+      no_reduce_shared_memory_bank_conflicts = true>
+  }
+>
+#config = #iree_gpu.lowering_config<{
+  mma_kind = #iree_gpu.scaled_mma_layout<
+    intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+    lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN,
+    acc_elem_type = f32>,
+  promote_operands = [0, 1, 2, 3],
+  promotion_types = [
+    #iree_gpu.use_global_load_dma,
+    #iree_gpu.use_global_load_dma,
+    #iree_gpu.derived_thread_config,
+    #iree_gpu.derived_thread_config],
+  reduction = [0, 0, 1, 1],
+  subgroup = [4, 8, 0, 0],
+  workgroup = [256, 256, 0, 0]
+}>
+#lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
+#rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
+#scale_m = affine_map<(M, N, Ko, Kb) -> (M, Ko)>
+#scale_n = affine_map<(M, N, Ko, Kb) -> (N, Ko)>
+#out_map = affine_map<(M, N, Ko, Kb) -> (M, N)>
+hal.executable public @main {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @scaled_matmul_dma ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @scaled_matmul_dma()
+        attributes {translation_info = #translation_info} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512x32xf4E2M1FN>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512x32xf4E2M1FN>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf8E8M0FNU>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf8E8M0FNU>>
+        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+        %A = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [1024, 512, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512x32xf4E2M1FN>> -> tensor<1024x512x32xf4E2M1FN>
+        %B = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [1024, 512, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512x32xf4E2M1FN>> -> tensor<1024x512x32xf4E2M1FN>
+        %A_scales = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf8E8M0FNU>> -> tensor<1024x512xf8E8M0FNU>
+        %B_scales = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf8E8M0FNU>> -> tensor<1024x512xf8E8M0FNU>
+        %empty = tensor.empty() : tensor<1024x1024xf32>
+        %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+        %result = linalg.generic {
+          indexing_maps = [#lhs_map, #rhs_map, #scale_m, #scale_n, #out_map],
+          iterator_types = ["parallel", "parallel", "reduction", "reduction"]
+        } ins(%A, %B, %A_scales, %B_scales : tensor<1024x512x32xf4E2M1FN>, tensor<1024x512x32xf4E2M1FN>, tensor<1024x512xf8E8M0FNU>, tensor<1024x512xf8E8M0FNU>) outs(%fill : tensor<1024x1024xf32>) attrs = {lowering_config = #config} {
+        ^bb0(%a: f4E2M1FN, %b: f4E2M1FN, %a_scale: f8E8M0FNU, %b_scale: f8E8M0FNU, %out: f32):
+          %s1 = arith.scaling_extf %a, %a_scale : f4E2M1FN, f8E8M0FNU to f32
+          %s2 = arith.scaling_extf %b, %b_scale : f4E2M1FN, f8E8M0FNU to f32
+          %m = arith.mulf %s1, %s2 : f32
+          %r = arith.addf %out, %m : f32
+          linalg.yield %r : f32
+        } -> tensor<1024x1024xf32>
+        iree_tensor_ext.dispatch.tensor.store %result, %4, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1] : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+        return
+      }
+    }
+  }
+}
+
+// Verify pipeline completes and produces scaled MFMA compute ops.
+// LHS/RHS are promoted to workgroup shared memory and scales use thread-based
+// copies. The compute uses 16x16x128 scaled MFMA instructions.
+
+// CHECK-LABEL: func.func @scaled_matmul_dma
+//   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf8E8M0FNU, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf4E2M1FN, #gpu.address_space<workgroup>>
+//       CHECK:   scf.forall
+//       CHECK:     scf.for
+//       CHECK:       amdgpu.scaled_mfma 16x16x128

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_matmul_dma.mlir
@@ -14,7 +14,7 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation_info = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [512, 1, 1]
   subgroup_size = 64,
   {

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2637,6 +2637,7 @@ iree_generated_e2e_runner_test(
     "--mx_scale_type=f8E8M0FNU"
     "--mx_block_size=32"
     "--shapes=small"
+    "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2636,7 +2636,8 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--mx_scale_type=f8E8M0FNU"
     "--mx_block_size=32"
-    "--shapes=small"
+    "--shapes=custom_mnk"
+    "--mnk=64,64,64"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
   TEST_RUNNER

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2624,6 +2624,37 @@ iree_generated_e2e_runner_test(
     "requires-gpu-cdna4"
 )
 
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cdna4_mxfp4_dma
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=easy_large_static"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-llvmgpu-use-direct-load"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
 endif()
 
 

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2636,7 +2636,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--mx_scale_type=f8E8M0FNU"
     "--mx_block_size=32"
-    "--shapes=easy_large_static"
+    "--shapes=small"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test


### PR DESCRIPTION
* Add swizzle detection helper that traces destination memref through `expand_shape/collapse_shape/subview` to find `SwizzleHintOp`.
* Apply the swizzle attribute's offset transformation to source linear offsets in the `gather_to_lds` lowering.
* XOR swizzle is self-inverse, so applying it to source addresses produces the correct swizzled layout in LDS without violating `gather_to_lds`'s uniform-destination constraint.
* Add pipeline tests and E2E tests.