### PR TITLE
[LLVMGPU] Remove special bufferization pipeline for VectorDistribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -725,15 +725,6 @@ static LogicalResult gpuVectorCopyFn(OpBuilder &builder, Location loc,
   return success();
 }
 
-static void addVectorBufferizePasses(OpPassManager &funcPassManager) {
-  funcPassManager.addPass(createROCDLConfigureBufferInstructionsPass());
-  BufferizationOptions::AllocationFn allocationFn = gpuAllocationFn;
-  BufferizationOptions::MemCpyFn memcpyFn = gpuCopyFn;
-  addIREEComprehensiveBufferizePasses(funcPassManager, allocationFn, memcpyFn);
-  funcPassManager.addPass(createCanonicalizerPass());
-  funcPassManager.addPass(createCSEPass());
-}
-
 void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
                                         const GPUPipelineOptions &options,
                                         bool forROCDL) {
@@ -835,7 +826,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
   // Tensor -> Memref
-  addVectorBufferizePasses(funcPassManager);
+  addGPUBufferizePasses(funcPassManager);
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());


### PR DESCRIPTION
Reuse the TileAndFuse pipeline. VectorDistribute always allocates it's own workgroup memory in GPUVectorAlloc pass. Any memref.copy created by bufferization is either a no-op or a bug. Usually bufferization will generate noop copies from scf.forall parallel insert_slice stuff, but we shouldn't barrier on them as they are noops.

ci-extra: test_torch