### PR TITLE
[Codegen][Map] Add PackLayout distribution pattern for transfer_gather

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1114,6 +1114,7 @@ transform_dialect::TestGpuVectorDistribution::applyToOne(
   IREE::VectorExt::populateNestedLayoutDistributionPatterns(
       patterns, laneId, subgroupSize, workgroupSize);
   populateMapDistributeGenericPatterns(patterns, laneId);
+  populateMapDistributeMemoryPatterns(patterns, laneId);
   if (failed(distributeVectorOps(target, patterns, options))) {
     return emitDefaultDefiniteFailure(target);
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/BUILD.bazel
@@ -19,6 +19,7 @@ iree_compiler_cc_library(
     name = "MapTransforms",
     srcs = [
         "MapDistributeGenericOps.cpp",
+        "MapDistributeMemoryOps.cpp",
         "MapDistributionUtils.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
     "MapPatterns.h"
   SRCS
     "MapDistributeGenericOps.cpp"
+    "MapDistributeMemoryOps.cpp"
     "MapDistributionUtils.cpp"
   DEPS
     LLVMSupport

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/MapDistributeMemoryOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/MapDistributeMemoryOps.cpp
@@ -1,0 +1,238 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Map/Transforms/MapPatterns.h"
+
+#include "iree/compiler/Codegen/Dialect/Map/IR/IREEMapAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Map/IR/IntTuple.h"
+#include "iree/compiler/Codegen/Dialect/Map/Transforms/MapDistributionUtils.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/AffineMap.h"
+
+namespace mlir::iree_compiler {
+
+using IREE::Map::getSize;
+using IREE::Map::PackLayoutAttr;
+using IREE::VectorExt::DistributionSignature;
+using IREE::VectorExt::OpDistributionPattern;
+using IREE::VectorExt::TransferGatherOp;
+using IREE::VectorExt::VectorLayoutInterface;
+using VectorValue = TypedValue<VectorType>;
+
+namespace {
+
+/// Expand an AffineMap's dim references from the original vector rank to the
+/// distributed rank. A single original dim may become multiple distributed
+/// dims when a layout mode has multiple value leaves.
+///
+/// Example: origToDistDims = [[0, 1], [2]] (orig dim 0 → dist dims 0,1)
+///   (d0, d1) -> (d0, d1)  becomes  (d0, d1, d2) -> (d0, d1, d2)
+///   (d0, d1) -> (d1)      becomes  (d0, d1, d2) -> (d2)
+AffineMap expandDimsInMap(AffineMap map,
+                          ArrayRef<SmallVector<int64_t>> origToDistDims,
+                          int64_t distRank, int64_t numSymbols) {
+  MLIRContext *ctx = map.getContext();
+  SmallVector<AffineExpr> newResults;
+  for (AffineExpr expr : map.getResults()) {
+    if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
+      for (int64_t distDim : origToDistDims[dimExpr.getPosition()]) {
+        newResults.push_back(getAffineDimExpr(distDim, ctx));
+      }
+    } else {
+      assert(isa<AffineConstantExpr>(expr) && "expected dim or constant expr");
+      newResults.push_back(expr);
+    }
+  }
+  return AffineMap::get(distRank, numSymbols, newResults, ctx);
+}
+
+//===----------------------------------------------------------------------===//
+// TransferGather
+//===----------------------------------------------------------------------===//
+
+/// Distributes a transfer_gather under PackLayoutAttr by converting all
+/// source dimensions into gathered (symbol) accesses and distributing the index
+/// vectors:
+///
+///   - Contiguous dims (AffineDimExpr): replaced by a distributed vector.step
+///     which is marked for redistribution.
+///   - Gathered dims (AffineSymbolExpr): the existing index vec is distributed
+///     via getDistributed.
+///   - Broadcast dims (AffineConstantExpr): passed through unchanged.
+///
+/// The indexing maps are expanded from the original vector rank to the
+/// distributed rank (one original dim may become multiple distributed dims
+/// when a layout mode has multiple value leaves).
+///
+/// Example: layout ((4, 2), (4, 8)) : ((1, 0), (0, 4))
+///   Distributed shape: [2, 4]
+///
+///   // Before:
+///   transfer_gather %mem[%off0, %off1], %pad
+///     {indexing_maps = [(d0, d1) -> (d0, d1)]}
+///     : memref<8x32xf16>, vector<8x32xf16>
+///
+///   // After (pre-canonicalization):
+///   %s0 = vector.step : vector<8xindex>   // redistributed → [tid_off + 0, 1]
+///   %s1 = vector.step : vector<32xindex>  // redistributed → [tid_off + 0, 8,
+///   16, 24] transfer_gather %mem[%off0, %off1] [%s0, %s1], %pad
+///     {indexing_maps = [(d0, d1)[s0, s1] -> (s0, s1),
+///                       (d0, d1)[s0, s1] -> (d0),
+///                       (d0, d1)[s0, s1] -> (d1)]}
+///     : memref<8x32xf16>, vector<2x4xf16>
+struct MapDistributeTransferGather final
+    : OpDistributionPattern<TransferGatherOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  LogicalResult matchAndRewrite(TransferGatherOp gatherOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+    VectorValue result = gatherOp.getVector();
+    auto layout = dyn_cast<PackLayoutAttr>(signature[result]);
+    if (!layout) {
+      return rewriter.notifyMatchFailure(gatherOp, "not a PackLayout");
+    }
+    if (!isa<MemRefType>(gatherOp.getBase().getType())) {
+      return rewriter.notifyMatchFailure(gatherOp, "expects memrefs");
+    }
+
+    Location loc = gatherOp.getLoc();
+    MLIRContext *ctx = rewriter.getContext();
+    int64_t origRank = layout.getRank();
+    SmallVector<int64_t> distShape =
+        cast<VectorLayoutInterface>(layout).getDistributedShape();
+    int64_t distRank = distShape.size();
+
+    // origToDistDims[i] = list of distributed dim indices for original dim i.
+    SmallVector<LeafDimInfo> leafMap = getLeafDimMap(layout);
+    SmallVector<SmallVector<int64_t>> origToDistDims(origRank);
+    for (auto [distIdx, info] : llvm::enumerate(leafMap)) {
+      origToDistDims[info.origDim].push_back(distIdx);
+    }
+
+    SmallVector<AffineMap> origMaps = gatherOp.getIndexingMapsArray();
+    AffineMap origSourceMap = origMaps[0];
+    OperandRange origIndexVecs = gatherOp.getIndexVecs();
+    Value mask = gatherOp.getMask();
+
+    // Walk source map results and convert each to a gathered symbol.
+    SmallVector<AffineExpr> newSourceResults;
+    SmallVector<Value> newIndexVecs;
+    SmallVector<SmallVector<AffineExpr>> newIndexVecMapResults;
+    int64_t nextSymbol = 0;
+    SmallVector<int64_t> origDimToSymbol(origRank, -1);
+
+    for (auto [srcDim, expr] : llvm::enumerate(origSourceMap.getResults())) {
+      // Broadcast — pass through.
+      if (!isa<AffineDimExpr, AffineSymbolExpr>(expr)) {
+        newSourceResults.push_back(expr);
+        continue;
+      }
+
+      // Already-gathered dim — distribute the existing index vec.
+      if (auto symExpr = dyn_cast<AffineSymbolExpr>(expr)) {
+        int64_t origSym = symExpr.getPosition();
+        int64_t sym = nextSymbol++;
+        newSourceResults.push_back(getAffineSymbolExpr(sym, ctx));
+
+        Value origIdxVec = origIndexVecs[origSym];
+        if (auto vecVal = dyn_cast<VectorValue>(origIdxVec)) {
+          if (auto idxLayout = signature[vecVal]) {
+            newIndexVecs.push_back(getDistributed(rewriter, vecVal, idxLayout));
+          } else {
+            newIndexVecs.push_back(origIdxVec);
+          }
+        } else {
+          newIndexVecs.push_back(origIdxVec);
+        }
+
+        AffineMap expanded =
+            expandDimsInMap(origMaps[1 + origSym], origToDistDims, distRank,
+                            /*numSymbols=*/0);
+        newIndexVecMapResults.push_back(llvm::to_vector(expanded.getResults()));
+        continue;
+      }
+
+      // Contiguous dim — convert to gathered via a distributed step.
+      int64_t origDim = cast<AffineDimExpr>(expr).getPosition();
+
+      if (origDimToSymbol[origDim] >= 0) {
+        newSourceResults.push_back(
+            getAffineSymbolExpr(origDimToSymbol[origDim], ctx));
+        continue;
+      }
+
+      int64_t sym = nextSymbol++;
+      origDimToSymbol[origDim] = sym;
+      newSourceResults.push_back(getAffineSymbolExpr(sym, ctx));
+
+      // Create a step [0..dimSize) and mark it for redistribution with the
+      // projected layout for this dim. MapDistributeStep will resolve it
+      // into thread_offset + value_offsets.
+      int64_t dimSize = getSize(layout.getShapeMode(origDim));
+      auto stepType = VectorType::get({dimSize}, rewriter.getIndexType());
+      auto stepOp = vector::StepOp::create(rewriter, loc, stepType);
+
+      SmallVector<bool> droppedDims(origRank, true);
+      droppedDims[origDim] = false;
+      PackLayoutAttr projLayout = layout.project(droppedDims);
+      setSignatureForRedistribution(
+          rewriter, stepOp, /*inputLayouts=*/{},
+          /*outputLayouts=*/{cast<VectorLayoutInterface>(projLayout)});
+      newIndexVecs.push_back(getDistributed(rewriter, stepOp.getResult(),
+                                            VectorLayoutInterface(projLayout)));
+
+      SmallVector<AffineExpr> mapResults;
+      for (int64_t distDim : origToDistDims[origDim]) {
+        mapResults.push_back(getAffineDimExpr(distDim, ctx));
+      }
+      newIndexVecMapResults.push_back(std::move(mapResults));
+    }
+
+    int64_t totalSymbols = nextSymbol;
+
+    SmallVector<Attribute> allMapAttrs;
+    allMapAttrs.push_back(AffineMapAttr::get(
+        AffineMap::get(distRank, totalSymbols, newSourceResults, ctx)));
+    for (auto &mapResults : newIndexVecMapResults) {
+      allMapAttrs.push_back(AffineMapAttr::get(
+          AffineMap::get(distRank, totalSymbols, mapResults, ctx)));
+    }
+
+    Value newMask;
+    if (mask) {
+      auto maskVec = cast<VectorValue>(mask);
+      if (auto maskLayout = signature[maskVec]) {
+        newMask = getDistributed(rewriter, maskVec, maskLayout);
+      } else {
+        newMask = mask;
+      }
+      allMapAttrs.push_back(AffineMapAttr::get(expandDimsInMap(
+          origMaps.back(), origToDistDims, distRank, totalSymbols)));
+    }
+
+    Type elemType = result.getType().getElementType();
+    auto distVecType = VectorType::get(distShape, elemType);
+    auto newGather = TransferGatherOp::create(
+        rewriter, loc, distVecType, gatherOp.getBase(), gatherOp.getOffsets(),
+        newIndexVecs, rewriter.getArrayAttr(allMapAttrs), gatherOp.getPadding(),
+        newMask);
+
+    replaceOpWithDistributedValues(rewriter, gatherOp, newGather.getVector());
+    return success();
+  }
+};
+
+} // namespace
+
+void populateMapDistributeMemoryPatterns(RewritePatternSet &patterns,
+                                         Value threadId) {
+  patterns.add<MapDistributeTransferGather>(patterns.getContext());
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/MapPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/MapPatterns.h
@@ -17,5 +17,10 @@ namespace mlir::iree_compiler {
 void populateMapDistributeGenericPatterns(RewritePatternSet &patterns,
                                           Value threadId);
 
+/// Adds PackLayout-specific patterns for distributing memory ops
+/// (transfer_gather) using PackLayoutAttr.
+void populateMapDistributeMemoryPatterns(RewritePatternSet &patterns,
+                                         Value threadId);
+
 } // namespace mlir::iree_compiler
 #endif // IREE_COMPILER_CODEGEN_DIALECT_MAP_TRANSFORMS_MAPPATTERNS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/test/BUILD.bazel
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = [
         "map_distribute_generic_ops.mlir",
+        "map_distribute_memory_ops.mlir",
     ],
     cfg = "//compiler:lit.cfg.py",
     tools = [

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "map_distribute_generic_ops.mlir"
+    "map_distribute_memory_ops.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/test/map_distribute_memory_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/Transforms/test/map_distribute_memory_ops.mlir
@@ -1,0 +1,78 @@
+// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize --cse %s | FileCheck %s
+
+// 1D gather with a non-coalescable depth-3 layout and a mask.
+// Layout (2, 3, 4, 2):(12, 0, 3, 0) has interleaved thread/value leaves:
+//   Thread: (2, stride=12), (4, stride=3) → 8 threads
+//   Value:  (3, dataStride=8), (2, dataStride=1) → distributed shape [3, 2]
+// The two value leaves don't coalesce (3*1 ≠ 8).
+// After distribution: the step resolves to dense<[[0,1],[8,9],[16,17]]>,
+// the mask is distributed, and the thread offset is absorbed into the base.
+
+#layout_deep = #iree_map.pack_layout<((2, 3, 4, 2)) : ((12, 0, 3, 0))>
+
+// CHECK-LABEL: @transfer_gather_deep_masked
+// CHECK-DAG:   %[[OFFSETS:.*]] = arith.constant dense<{{\[\[}}0, 1], [8, 9], [16, 17]]> : vector<3x2xindex>
+// CHECK:       %[[MASK:.*]] = iree_vector_ext.to_simt %arg1 : vector<48xi1> -> vector<3x2xi1>
+// CHECK:       %[[GATHER:.*]] = iree_vector_ext.transfer_gather
+// CHECK-SAME:    [%[[OFFSETS]] : vector<3x2xindex>]
+// CHECK-SAME:    %[[MASK]]
+// CHECK-SAME:    memref<?xf16>, vector<3x2xf16>, vector<3x2xi1>
+// CHECK:       iree_vector_ext.to_simd %[[GATHER]] : vector<3x2xf16> -> vector<48xf16>
+func.func @transfer_gather_deep_masked(%mem: memref<?xf16>, %mask: vector<48xi1>) -> vector<48xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %mask_l = iree_vector_ext.to_layout %mask to layout(#layout_deep) : vector<48xi1>
+  %v = iree_vector_ext.transfer_gather %mem[%c0], %pad, %mask_l {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>]
+  } : memref<?xf16>, vector<48xf16>, vector<48xi1>
+  %vl = iree_vector_ext.to_layout %v to layout(#layout_deep) : vector<48xf16>
+  func.return %vl : vector<48xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// 2D gather: outer dim gathered via index vec, inner dim contiguous.
+// Layout: mode 0 = (4, 2):(1, 0), mode 1 = (8, 8):(8, 0) → 32 threads.
+// Distributed shape: [2, 8].
+// After distribution: the index vec is distributed via to_simt, the inner
+// contiguous dim becomes a step dense<[0,1,...,7]>.
+
+#layout_2d = #iree_map.pack_layout<((4, 2), (8, 8)) : ((1, 0), (8, 0))>
+#layout_idx = #iree_map.pack_layout<((4, 2)) : ((1, 0))>
+
+// CHECK-LABEL: @transfer_gather_indexed_outer
+// CHECK-DAG:   %[[INNER:.*]] = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7]> : vector<8xindex>
+// CHECK:       %[[IDX:.*]] = iree_vector_ext.to_simt %arg1 : vector<8xindex> -> vector<2xindex>
+// CHECK:       %[[GATHER:.*]] = iree_vector_ext.transfer_gather
+// CHECK-SAME:    [%[[IDX]], %[[INNER]] : vector<2xindex>, vector<8xindex>]
+// CHECK-SAME:    memref<?x64xf16>, vector<2x8xf16>
+// CHECK:       iree_vector_ext.to_simd %[[GATHER]] : vector<2x8xf16> -> vector<8x64xf16>
+func.func @transfer_gather_indexed_outer(%mem: memref<?x64xf16>, %idx: vector<8xindex>) -> vector<8x64xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %idx_l = iree_vector_ext.to_layout %idx to layout(#layout_idx) : vector<8xindex>
+  %v = iree_vector_ext.transfer_gather %mem[%c0, %c0]
+      [%idx_l : vector<8xindex>], %pad {
+    indexing_maps = [affine_map<(d0, d1)[s0] -> (s0, d1)>,
+                     affine_map<(d0, d1)[s0] -> (d0)>]
+  } : memref<?x64xf16>, vector<8x64xf16>
+  %vl = iree_vector_ext.to_layout %v to layout(#layout_2d) : vector<8x64xf16>
+  func.return %vl : vector<8x64xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}


### PR DESCRIPTION
Add MapDistributeTransferGather which distributes transfer_gather ops under PackLayoutAttr.

Eventually, transfer_read would pre-process to transfer_gather before distribution and distribute as transfer_gather. They eventually canonicalize to an equivalent form after unrolling.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
