### PR TITLE
Fix hip_allocator_test segfault: provide proactor pool for device creation.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/hip/BUILD.bazel
@@ -131,7 +131,9 @@ iree_runtime_cc_test(
     ],
     deps = [
         ":dynamic_symbols",
+        "//runtime/src/iree/async/util:proactor_pool",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading:numa",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/hip/registration",
         "//runtime/src/iree/testing:gtest",

--- a/runtime/src/iree/hal/drivers/hip/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/hip/BUILD.bazel
@@ -133,7 +133,7 @@ iree_runtime_cc_test(
         ":dynamic_symbols",
         "//runtime/src/iree/async/util:proactor_pool",
         "//runtime/src/iree/base",
-        "//runtime/src/iree/base/threading:numa",
+        "//runtime/src/iree/base/threading",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/hip/registration",
         "//runtime/src/iree/testing:gtest",

--- a/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
@@ -128,7 +128,7 @@ iree_cc_test(
     ::dynamic_symbols
     iree::async::util::proactor_pool
     iree::base
-    iree::base::threading::numa
+    iree::base::threading
     iree::hal
     iree::hal::drivers::hip::registration
     iree::testing::gtest

--- a/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
@@ -126,7 +126,9 @@ iree_cc_test(
     "hip_allocator_test.cc"
   DEPS
     ::dynamic_symbols
+    iree::async::util::proactor_pool
     iree::base
+    iree::base::threading::numa
     iree::hal
     iree::hal::drivers::hip::registration
     iree::testing::gtest

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
@@ -22,7 +22,9 @@
 // Without the fix the pointer is still registered and the call returns
 // hipSuccess instead.
 
+#include "iree/async/util/proactor_pool.h"
 #include "iree/base/api.h"
+#include "iree/base/threading/numa.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
 #include "iree/hal/drivers/hip/registration/driver_module.h"
@@ -61,8 +63,15 @@ class HipAllocatorTest : public ::testing::Test {
       GTEST_SKIP() << "HIP driver not available";
     }
 
-    const iree_hal_device_create_params_t create_params =
+    status = iree_async_proactor_pool_create(
+        iree_numa_node_count(), /*node_ids=*/NULL,
+        iree_async_proactor_pool_options_default(), iree_allocator_system(),
+        &proactor_pool_);
+    ASSERT_TRUE(iree_status_is_ok(status));
+
+    iree_hal_device_create_params_t create_params =
         iree_hal_device_create_params_default();
+    create_params.proactor_pool = proactor_pool_;
     status = iree_hal_driver_create_default_device(
         driver_, &create_params, iree_allocator_system(), &device_);
     if (!iree_status_is_ok(status)) {
@@ -76,6 +85,8 @@ class HipAllocatorTest : public ::testing::Test {
     device_ = nullptr;
     iree_hal_driver_release(driver_);
     driver_ = nullptr;
+    iree_async_proactor_pool_release(proactor_pool_);
+    proactor_pool_ = nullptr;
     if (syms_initialized_) {
       iree_hal_hip_dynamic_symbols_deinitialize(&syms_);
       syms_initialized_ = false;
@@ -84,6 +95,7 @@ class HipAllocatorTest : public ::testing::Test {
 
   iree_hal_hip_dynamic_symbols_t syms_ = {};
   bool syms_initialized_ = false;
+  iree_async_proactor_pool_t* proactor_pool_ = nullptr;
   iree_hal_driver_t* driver_ = nullptr;
   iree_hal_device_t* device_ = nullptr;
 };


### PR DESCRIPTION
The HAL semaphore unification (d7f5abaf) made proactor_pool a required field in iree_hal_device_create_params_t. All CTS backends and other test fixtures were updated, but hip_allocator_test was missed — it creates devices directly rather than through the shared backend infrastructure. The NULL proactor_pool caused a segfault on iree_async_proactor_pool_retain(NULL) during device creation.