### PR TITLE
Revert "[LLVMGPU] Add CombineSourceLayoutTransformation to TileAndFus…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -545,7 +545,6 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 5. Greedily fuse parallel loops and hoist from serial loops.
   funcPassManager.addPass(createGPUFuseAndHoistParallelLoopsPass());
-  funcPassManager.addPass(createCombineSourceLayoutTransformationPass());
   CombineResultLayoutTransformationPassOptions combineLayoutOptions;
   combineLayoutOptions.scope =
       IREE::Codegen::RelayoutCombinationScope::Workgroup;


### PR DESCRIPTION
…e pipeline (#23745)"

This reverts commit 71af3a5e41a8e265330bc693194c708cf6df4724.

Substantial degradation in `torch_models::llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json` from 208.7711642185847 <= 187` after the introduction of this pass. 