### PR TITLE
[Codegen] Move LLVMGPU pipelines to `#iree_gpu.pipeline<...>` attr

### DIFF
--- a/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
@@ -34,6 +34,15 @@ ireeGPUReorderWorkgroupsStrategyAttrGet(MlirContext mlirCtx, uint32_t value);
 MLIR_CAPI_EXPORTED uint32_t
 ireeGPUReorderWorkgroupsStrategyAttrGetValue(MlirAttribute attr);
 
+MLIR_CAPI_EXPORTED bool ireeAttributeIsAGPUPipelineAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirTypeID ireeGPUPipelineAttrGetTypeID(void);
+
+MLIR_CAPI_EXPORTED MlirAttribute ireeGPUPipelineAttrGet(MlirContext mlirCtx,
+                                                        uint32_t value);
+
+MLIR_CAPI_EXPORTED uint32_t ireeGPUPipelineAttrGetValue(MlirAttribute attr);
+
 MLIR_CAPI_EXPORTED
 bool ireeAttributeIsAGPUPipelineOptionsAttr(MlirAttribute attr);
 

--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -263,6 +263,27 @@ NB_MODULE(_ireeCompilerDialects, m) {
       });
 
   //===-------------------------------------------------------------------===//
+  // GPUPipelineAttr
+  //===-------------------------------------------------------------------===//
+
+  mlir_attribute_subclass(iree_gpu_module, "PipelineAttr",
+                          ireeAttributeIsAGPUPipelineAttr,
+                          ireeGPUPipelineAttrGetTypeID)
+      .def_classmethod(
+          "get",
+          [](const py::object &, uint32_t value, MlirContext ctx) {
+            return ireeGPUPipelineAttrGet(ctx, value);
+          },
+          "cls"_a, "value"_a, "ctx"_a = py::none(),
+          "Gets an #iree_gpu.pipeline from parameters.")
+      .def_property_readonly("raw_value", ireeGPUPipelineAttrGetValue)
+      .def_property_readonly("value", [](MlirAttribute self) -> py::object {
+        uint32_t rawValue = ireeGPUPipelineAttrGetValue(self);
+        return py::module_::import_(kGpuModuleImportPath)
+            .attr("LoweringPipeline")(rawValue);
+      });
+
+  //===-------------------------------------------------------------------===//
   // GPUPipelineOptionsAttr
   //===-------------------------------------------------------------------===//
 

--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -626,14 +626,14 @@ def test_get_iree_constraints_op():
         module {
             iree_codegen.smt.constraints
                 target = <set = 0>,
-                pipeline = LLVMGPUVectorDistribute,
+                pipeline = #iree_gpu.pipeline<VectorDistribute>,
                 knobs = {}
                 dims() {
                 }
             func.func @main() -> () {
                 iree_codegen.smt.constraints
                     target = #iree_codegen.root_op<set = 1>,
-                    pipeline = LLVMGPUVectorDistribute,
+                    pipeline = #iree_gpu.pipeline<VectorDistribute>,
                     knobs = {}
                     dims() {
                     }
@@ -642,7 +642,7 @@ def test_get_iree_constraints_op():
             func.func @test() -> () {
                 iree_codegen.smt.constraints
                     target = #iree_codegen.root_op<set = 0>,
-                    pipeline = LLVMGPUVectorDistribute,
+                    pipeline = #iree_gpu.pipeline<VectorDistribute>,
                     knobs = {}
                     dims() {
                     }

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -89,17 +89,23 @@ def run(fn):
 @run
 def codegen_dispatch_lowering_pass_pipeline():
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
+        iree_codegen.DispatchLoweringPassPipeline.CPUDefault
     )
     assert pipeline_attr is not None
-    assert (
-        pipeline_attr.value
-        == iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
-    )
+    assert pipeline_attr.value == iree_codegen.DispatchLoweringPassPipeline.CPUDefault
     assert pipeline_attr.raw_value == int(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
+        iree_codegen.DispatchLoweringPassPipeline.CPUDefault
     )
-    assert "LLVMGPUTileAndFuse" in str(pipeline_attr)
+    assert "CPUDefault" in str(pipeline_attr)
+
+
+@run
+def gpu_pipeline_attr():
+    pipeline_attr = iree_gpu.PipelineAttr.get(iree_gpu.LoweringPipeline.TileAndFuse)
+    assert pipeline_attr is not None
+    assert pipeline_attr.value == iree_gpu.LoweringPipeline.TileAndFuse
+    assert pipeline_attr.raw_value == int(iree_gpu.LoweringPipeline.TileAndFuse)
+    assert "TileAndFuse" in str(pipeline_attr)
 
 
 @run

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
@@ -67,7 +67,7 @@ pdl.pattern @annotate_matmul_like_f8E4M3FNUZ_medium_expanded : benefit(1) {
         workgroup = [1, 128, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -158,7 +158,7 @@ pdl.pattern @annotate_matmul_like_f8E4M3FNUZ_large_expanded : benefit(2) {
         workgroup = [1, 256, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -242,7 +242,7 @@ pdl.pattern @annotate_matmul_like_f16_large : benefit(1) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -330,7 +330,7 @@ pdl.pattern @annotate_matmul_like_f16_medium_expanded : benefit(1) {
         workgroup = [1, 128, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
         }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -418,7 +418,7 @@ pdl.pattern @annotate_matmul_like_f16_large_expanded : benefit(2) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -502,7 +502,7 @@ pdl.pattern @annotate_matmul_like_bf16_large : benefit(1) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -594,7 +594,7 @@ pdl.pattern @annotate_matmul_like_bf16_medium_expanded : benefit(1) {
         workgroup = [1, 128, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
         }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -676,7 +676,7 @@ pdl.pattern @annotate_matmul_like_bf16_large_expanded : benefit(2) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -733,7 +733,7 @@ pdl.pattern @annotate_inner_tiled_f8E4M3FNUZ_medium : benefit(1) {
         workgroup = [1, 1, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -790,7 +790,7 @@ pdl.pattern @annotate_inner_tiled_f8E4M3FNUZ_large : benefit(2) {
         workgroup = [1, 1, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -847,7 +847,7 @@ pdl.pattern @annotate_inner_tiled_f16_large : benefit(1) {
         workgroup = [1, 1, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx950.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx950.mlir
@@ -67,7 +67,7 @@ pdl.pattern @annotate_matmul_like_f8E4M3FN_medium_expanded : benefit(1) {
         workgroup = [1, 128, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -158,7 +158,7 @@ pdl.pattern @annotate_matmul_like_f8E4M3FN_large_expanded : benefit(2) {
         workgroup = [1, 256, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -242,7 +242,7 @@ pdl.pattern @annotate_matmul_like_f16_large : benefit(1) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -332,7 +332,7 @@ pdl.pattern @annotate_matmul_like_f16_medium_expanded : benefit(1) {
         workgroup = [1, 128, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
         }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -420,7 +420,7 @@ pdl.pattern @annotate_matmul_like_f16_large_expanded : benefit(2) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -504,7 +504,7 @@ pdl.pattern @annotate_matmul_like_bf16_large : benefit(1) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -596,7 +596,7 @@ pdl.pattern @annotate_matmul_like_bf16_medium_expanded : benefit(1) {
         workgroup = [1, 128, 256, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
         }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -678,7 +678,7 @@ pdl.pattern @annotate_matmul_like_bf16_large_expanded : benefit(2) {
     %config = pdl.attribute = #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 256, 256, 0],
                                                    workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>}>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory
@@ -746,7 +746,7 @@ pdl.pattern @annotate_dt_scaled_matmul_like_f4E2M1FN_medium : benefit(1) {
         workgroup = [1, 1, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy uses the maximum amount of possible shared memory on
         // all gfx9 architectures so shared memory padding to reduce bank
@@ -804,7 +804,7 @@ pdl.pattern @annotate_inner_tiled_f8E4M3FN_large : benefit(2) {
         workgroup = [1, 1, 0],
         workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 32>
       }>,
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
         workgroup_size = [512, 1, 1] subgroup_size = 64,
         // This strategy manually prefetches and eliminates bank conflicts on LDS
         // by using swizzling (rotate_rows). Therefore, we disable prefetch_shared_memory

--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -71,7 +71,7 @@ transform.named_sequence
   // required for exp/exp2.
   %config = transform.param.constant #iree_codegen.compilation_info<
           lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 0], reduction=[0, 0, 0, 0, 0, 64], promote_operands = [1, 2]}>,
-          translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+          translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                                             workgroup_size = [256]
                                                             subgroup_size = 64 ,
             {llvm_func_attrs = { "amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign" }}>>
@@ -110,7 +110,7 @@ transform.named_sequence
                                                  subgroup_basis = [[2, 2, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 64],
                                                  workgroup = [64, 128, 0]}>,
-    translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
       workgroup_size = [256, 1, 1] subgroup_size = 64,
       {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2>}>
   > -> !transform.any_param

--- a/compiler/plugins/target/ROCM/test/enable_tensor_ukernels.mlir
+++ b/compiler/plugins/target/ROCM/test/enable_tensor_ukernels.mlir
@@ -44,7 +44,7 @@ hal.executable public @main {
     }
   }
 }
-// CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+// CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 // CHECK:      func.func @matmul_f8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK:        linalg.generic

--- a/compiler/plugins/target/ROCM/test/lowering_strategy_from_tuning_spec.mlir
+++ b/compiler/plugins/target/ROCM/test/lowering_strategy_from_tuning_spec.mlir
@@ -13,7 +13,7 @@
 
 // Make sure we can apply the lowering strategy from the specified tuning spec.
 
-// CHECK:      #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64>
+// CHECK:      #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64>
 // CHECK:      func.func @matmul_transpose_b
 // CHECK-SAME:   translation_info = #translation
 // CHECK:        linalg.generic

--- a/compiler/plugins/target/ROCM/test/tuning_spec_mmt_tile_and_fuse.mlir
+++ b/compiler/plugins/target/ROCM/test/tuning_spec_mmt_tile_and_fuse.mlir
@@ -16,7 +16,7 @@ transform.named_sequence @match_mmt(%matmul: !transform.any_op {transform.readon
                                                   reduction = [0, 0, 4],
                                                   thread = [8, 4],
                                                   promote_operands = [0, 1]}>,
-    translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+    translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
       workgroup_size = [128, 1, 1] subgroup_size = 64>
   > -> !transform.any_param
  transform.yield %matmul, %config : !transform.any_op, !transform.any_param

--- a/compiler/plugins/target/ROCM/test/ukernel_pipeline_transform.mlir
+++ b/compiler/plugins/target/ROCM/test/ukernel_pipeline_transform.mlir
@@ -41,7 +41,7 @@ func.func @argmax_1d_f16i64() attributes {
   return
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDefault workgroup_size = [32, 1, 1]>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Default> workgroup_size = [32, 1, 1]>
 //       CHECK: func.func @argmax_1d_f16i64()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f16i64"
@@ -89,7 +89,7 @@ func.func @argmax_2d_f32i64() attributes {
   return
 }
 
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDefault workgroup_size = [32, 1, 1]>
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Default> workgroup_size = [32, 1, 1]>
 //      CHECK: func.func @argmax_2d_f32i64
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   %[[SUBVIEW:.*]] = memref.subview{{.*}} memref<16x?xf32
@@ -139,7 +139,7 @@ func.func @no_ukernel_argmax_1d_f16i64() attributes {
   return
 }
 
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [1, 1, 1]>
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Distribute> workgroup_size = [1, 1, 1]>
 //      CHECK: func.func @no_ukernel_argmax_1d_f16i64()
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //  CHECK-NOT:   iree_codegen.ukernel.generic
@@ -196,7 +196,7 @@ func.func @argmax_1d_bf16i64() attributes {
   return
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDefault workgroup_size = [32, 1, 1]>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Default> workgroup_size = [32, 1, 1]>
 //       CHECK: func.func @argmax_1d_bf16i64()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_bf16i64"
@@ -244,7 +244,7 @@ func.func @not_neg_inf_init_argmax_1d() attributes {
   return
 }
 
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [1, 1, 1]>
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Distribute> workgroup_size = [1, 1, 1]>
 //      CHECK: func.func @not_neg_inf_init_argmax_1d()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]
 //  CHECK-NOT:   iree_codegen.ukernel.generic

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -132,6 +132,33 @@ uint32_t ireeGPUReorderWorkgroupsStrategyAttrGetValue(MlirAttribute attr) {
           .getValue());
 }
 
+bool ireeAttributeIsAGPUPipelineAttr(MlirAttribute attr) {
+  return llvm::isa<mlir::iree_compiler::IREE::GPU::PipelineAttr>(unwrap(attr));
+}
+
+MlirTypeID ireeGPUPipelineAttrGetTypeID() {
+  return wrap(mlir::iree_compiler::IREE::GPU::PipelineAttr::getTypeID());
+}
+
+static_assert(
+    std::is_same_v<uint32_t,
+                   std::underlying_type_t<
+                       mlir::iree_compiler::IREE::GPU::LoweringPipeline>>,
+    "Enum type changed");
+
+MlirAttribute ireeGPUPipelineAttrGet(MlirContext mlirCtx, uint32_t value) {
+  mlir::MLIRContext *ctx = unwrap(mlirCtx);
+  return wrap(mlir::iree_compiler::IREE::GPU::PipelineAttr::get(
+      ctx,
+      static_cast<mlir::iree_compiler::IREE::GPU::LoweringPipeline>(value)));
+}
+
+uint32_t ireeGPUPipelineAttrGetValue(MlirAttribute attr) {
+  return static_cast<uint32_t>(
+      llvm::cast<mlir::iree_compiler::IREE::GPU::PipelineAttr>(unwrap(attr))
+          .getValue());
+}
+
 bool ireeAttributeIsAGPUMMAIntrinsicAttr(MlirAttribute attr) {
   return llvm::isa<mlir::iree_compiler::IREE::GPU::MMAIntrinsicAttr>(
       unwrap(attr));

--- a/compiler/src/iree/compiler/API/api_exports.def
+++ b/compiler/src/iree/compiler/API/api_exports.def
@@ -8,6 +8,7 @@ EXPORTS
   ireeAttributeIsAGPULoweringConfigAttr
   ireeAttributeIsAGPUMMAAttr
   ireeAttributeIsAGPUMMAIntrinsicAttr
+  ireeAttributeIsAGPUPipelineAttr
   ireeAttributeIsAGPUPipelineOptionsAttr
   ireeAttributeIsAGPUReorderWorkgroupsStrategyAttr
   ireeAttributeIsAGPUVirtualMMAAttr
@@ -104,6 +105,9 @@ EXPORTS
   ireeGPUMMAIntrinsicAttrGet
   ireeGPUMMAIntrinsicAttrGetTypeID
   ireeGPUMMAIntrinsicAttrGetValue
+  ireeGPUPipelineAttrGet
+  ireeGPUPipelineAttrGetTypeID
+  ireeGPUPipelineAttrGetValue
   ireeGPUPipelineOptionsAttrGet
   ireeGPUPipelineOptionsAttrGetNoReduceSharedMemoryBankConflicts
   ireeGPUPipelineOptionsAttrGetPrefetchNumStages

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -13,8 +13,8 @@
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_64 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_64 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: 4x128 memref with 32 lanes.
 //   - Elements per lane = 128 / 32 = 4 (each lane reads 4 contiguous f32s)
@@ -86,7 +86,7 @@ func.func @lower_coalesced_gather_dma_multiple(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: 2x64 memref with 32 lanes.
 //   - Elements per lane = 64 / 32 = 2 (each lane reads 2 contiguous f16s)
@@ -142,7 +142,7 @@ func.func @lower_coalesced_copy_dma_basic(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: 1D memref with 128 elements and 32 lanes.
 //   * Elements per lane = 128 / 32 = 4 (each lane reads 4 contiguous f32s)
@@ -185,7 +185,7 @@ func.func @lower_coalesced_copy_dma_1d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: Single-row 2D memref (1x128) with 32 lanes.
 // This verifies that a 2D memref with only 1 row produces a single transfer,
@@ -234,7 +234,7 @@ func.func @lower_coalesced_copy_dma_single_row_2d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: 3D memref with shape 2x2x128 and 32 lanes.
 //   * Elements per lane = 128 / 32 = 4
@@ -303,7 +303,7 @@ func.func @lower_coalesced_copy_dma_3d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_256_wide = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 256>
+#translation_256_wide = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 256>
 
 // Test: Wide forall with 256 lanes, 2D memref 2x1024.
 //   * subgroup_size = 256
@@ -360,7 +360,7 @@ func.func @lower_coalesced_copy_dma_wide_forall_2d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test gather 2D with indices.
 // Source indices use srcDimOffset (with lane offset) for index lookup.
@@ -416,7 +416,7 @@ func.func @lower_coalesced_gather_dma_with_indices(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: Verify iteration uses destShape, not sourceShape.
 // If code iterated over sourceShape, would generate 256 ops.
@@ -482,7 +482,7 @@ func.func @gather_iterates_over_dest_shape_not_source(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: N-transfer mode for wide innermost dimension.
 // When innermostDimSize > subgroupSize * elementsPerLane, multiple
@@ -538,7 +538,7 @@ func.func @lower_coalesced_dma_multiple_transfers_1d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: N-transfer mode for 2D memref with wide innermost dimension.
 //   - Shape: 2x256, innermostDimSize = 256
@@ -592,7 +592,7 @@ func.func @lower_coalesced_dma_multiple_transfers_2d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: Mixed DMA sizes within the same row.
 // When innermost dimension isn't evenly divisible by the largest DMA size,
@@ -653,7 +653,7 @@ func.func @lower_coalesced_dma_mixed_sizes_1d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: Mixed DMA sizes with 2D contiguous memref (linearized path).
 // Since the destination is fully contiguous, the linearized transfer path is
@@ -719,7 +719,7 @@ func.func @lower_coalesced_dma_mixed_sizes_2d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test: Linearized transfer spanning 2 rows per transfer.
 // When destination is fully contiguous, the entire memref is treated as a 1D
@@ -783,7 +783,7 @@ func.func @lower_coalesced_dma_linearized_2_rows_per_transfer(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128, 32]>>}>
 
-#translation_3d = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_3d = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test with 3D shape where only innermost 2 dims are contiguous.
 // Dest shape: <2x4x32xf32> with strided<[256, 32, 1]>
@@ -850,7 +850,7 @@ func.func @lower_3d_partial_contiguous(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128, 32]>>}>
 
-#translation_3d_mixed = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_3d_mixed = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test with 3D shape where innermost 2 dims require mixed DMA sizes.
 // Dest shape: <2x5x32xf32> with strided<[256, 32, 1]>
@@ -909,7 +909,7 @@ func.func @lower_3d_partial_contiguous_mixed_dma(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test gather with indices on the innermost (only) dimension.
 // This tests true per-element gather where each lane loads its own index.
@@ -989,7 +989,7 @@ func.func @lower_coalesced_gather_dma_innermost_1d(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // CHECK-LABEL: func.func @lower_coalesced_dma_lane_offset_regression
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<16x64xf32, #amdgpu.address_space<fat_raw_buffer>>
@@ -1044,7 +1044,7 @@ func.func @lower_coalesced_dma_lane_offset_regression(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // CHECK-LABEL: func.func @lower_coalesced_dma_with_in_bounds
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<2x128xf32, #amdgpu.address_space<fat_raw_buffer>>
@@ -1117,7 +1117,7 @@ func.func @lower_coalesced_dma_with_in_bounds(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_64_unaligned = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_64_unaligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @lower_coalesced_dma_4x64_tensor_pad_fusion
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<?x64xf32, strided<[64, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
@@ -1177,7 +1177,7 @@ func.func @lower_coalesced_dma_4x64_tensor_pad_fusion(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_32_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32_pad = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // CHECK-LABEL: func.func @gather_dma_non_outermost_oob_check
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x6xf32, #amdgpu.address_space<fat_raw_buffer>>
@@ -1236,7 +1236,7 @@ func.func @gather_dma_non_outermost_oob_check(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_64_inner_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_64_inner_pad = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @gather_dma_inner_dim_oob_64x62
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<64x62xf32, #amdgpu.address_space<fat_raw_buffer>>
@@ -1300,7 +1300,7 @@ func.func @gather_dma_inner_dim_oob_64x62(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 func.func @fallback_1d_basic(
     %source: memref<48xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1354,7 +1354,7 @@ func.func @fallback_1d_basic(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 func.func @fallback_2d_basic(
     %source: memref<3x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1406,7 +1406,7 @@ func.func @fallback_2d_basic(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 func.func @fallback_gather_with_indices(
     %source: memref<1024x16xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1455,7 +1455,7 @@ func.func @fallback_gather_with_indices(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 func.func @fallback_non_outermost_oob(
     %source: memref<4x12xf32, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1513,7 +1513,7 @@ func.func @fallback_non_outermost_oob(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [128]>>}>
 
-#translation_32_outer = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_32_outer = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 func.func @fallback_with_outer_dims(
     %source: memref<2x8xf32, strided<[64, 1]>, #amdgpu.address_space<fat_raw_buffer>>,
@@ -1566,7 +1566,7 @@ func.func @fallback_with_outer_dims(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation_64 = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation_64 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 
 func.func @no_lower_oob_without_fat_raw_buffer(
     %source: memref<2x128xf32>,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
@@ -5,7 +5,7 @@
 module {
   func.func @inferred_add_tensor(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>, %5: tensor<64x256xf32>) -> tensor<64x256xf32>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [16, 32, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [16, 32, 1] subgroup_size = 64>
       } {
     %6 = linalg.generic {
       indexing_maps = [#map, #map, #map],
@@ -32,7 +32,7 @@ module {
 module {
   func.func @inferred_dynamic(%3: tensor<?x?xf32>, %4: tensor<?x?xf32>, %5: tensor<?x?xf32>) -> tensor<?x?xf32>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [16, 32, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [16, 32, 1] subgroup_size = 64>
       } {
     %6 = linalg.generic {
       indexing_maps = [#map, #map, #map],
@@ -62,7 +62,7 @@ module {
 module {
   func.func @inferred_small_inner_dim(%3: tensor<8x2xf32>, %4: tensor<8x2xf32>, %5: tensor<8x2xf32>) -> tensor<8x2xf32>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [16, 32, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [16, 32, 1] subgroup_size = 64>
       } {
     %6 = linalg.generic {
       indexing_maps = [#map, #map, #map],
@@ -87,7 +87,7 @@ module {
 module {
   func.func @inferred_small_inner_dim_fill_vector_sizes(%0: tensor<4x16x8x4x16x2x4xf16>, %1: tensor<4x16x8x4x16x2x4xf16>) -> tensor<4x16x8x4x16x2x4xf16>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
       } {
     %2 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
         ins(%0 : tensor<4x16x8x4x16x2x4xf16>)
@@ -108,7 +108,7 @@ module {
   func.func @inferred_small_inner_dim_dont_fill_non_contiguous(
     %0: tensor<4x16x4x4xf16>, %1: tensor<4x16x4x4xf16>) -> tensor<4x16x4x4xf16>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
       } {
     %2 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
         ins(%0 : tensor<4x16x4x4xf16>)
@@ -128,7 +128,7 @@ module {
 module {
   func.func @inferred_unaligned(%0: tensor<70xf16>, %1: tensor<70xf16>) -> tensor<70xf16>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
       } {
     %2 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
         ins(%0 : tensor<70xf16>)
@@ -148,7 +148,7 @@ module {
 module {
   func.func @inferred_smaller_load(%0: tensor<128xf16>, %1: tensor<128xf16>) -> tensor<128xf16>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
       } {
     %2 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
         ins(%0 : tensor<128xf16>)
@@ -169,7 +169,7 @@ module {
 module {
   func.func @inferred_im2col(%2: tensor<2x34x34x128xf16>, %3: tensor<2x128x8xf16>) -> tensor<2x128x8xf16>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [16, 32, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [16, 32, 1] subgroup_size = 64>
       } {
     %4 = iree_linalg_ext.im2col {lowering_config = #config}
       strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
@@ -194,7 +194,7 @@ module {
 module {
   func.func @inferred_im2col_batch_last(%2: tensor<16x26x18x32xbf16>, %3: tensor<32x1x1x32xbf16>) -> tensor<32x1x1x32xbf16>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
       } {
     %4 = iree_linalg_ext.im2col {lowering_config = #config}
       strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
@@ -218,7 +218,7 @@ module {
 #config = #iree_gpu.derived_thread_config
 func.func @scatter(%arg0: tensor<3x32x16xf32>, %arg1: tensor<3x1xi32>, %arg2: tensor<3x32x16xf32>) -> tensor<3x32x16xf32>
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
       } {
   %1 = iree_linalg_ext.scatter {lowering_config = #config} dimension_map = [0] unique_indices(true)
     ins(%arg0, %arg1 : tensor<3x32x16xf32>, tensor<3x1xi32>) outs(%arg2 : tensor<3x32x16xf32>) {
@@ -238,7 +238,7 @@ func.func @scatter(%arg0: tensor<3x32x16xf32>, %arg1: tensor<3x1xi32>, %arg2: te
 #config = #iree_gpu.derived_thread_config
 func.func @map_store(%arg0: tensor<2x32xf32>, %arg1: tensor<64x256xf32>) -> tensor<64x256xf32>
     attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [16, 32] subgroup_size = 64>
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [16, 32] subgroup_size = 64>
     } {
   %true = arith.constant true
   %1 = iree_linalg_ext.map_store {lowering_config = #config} %arg0 into %arg1 {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -390,7 +390,7 @@ module {
 func.func @distribute_multi_result_generic(
   %arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4xf32>, %arg2: tensor<3x4xf32>) -> (tensor<3x4x5xf32>, tensor<3x4x5xf32>)
       attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32, {}>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32, {}>
       } {
   %empty = tensor.empty() : tensor<3x4x5xf32>
   %0:2 = linalg.generic {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -9,7 +9,7 @@
 >>
 
 #exec_target_copy = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_copy}>
-#translation_copy = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 512, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_copy = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 512, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x512xf32>
@@ -58,7 +58,7 @@ func.func @copy(%source: tensor<64x512xf32>, %init: tensor<64x512xf32>) -> tenso
 >>
 
 #exec_target_gather = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_gather}>
-#translation_gather = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1024, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_gather = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1024, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @gather
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x512xf32>
@@ -112,7 +112,7 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
 >>
 
 #exec_target_small_inner = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_small_inner}>
-#translation_small_inner = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_small_inner = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_small_innermost_dim
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x32xf32>
@@ -149,7 +149,7 @@ func.func @copy_small_innermost_dim(%source: tensor<64x32xf32>, %init: tensor<64
 >>
 
 #exec_target_not_aligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_not_aligned}>
-#translation_not_aligned = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_not_aligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_not_aligned_to_dma
 // CHECK-SAME:    %[[SRC_BUF:[a-zA-Z0-9]+]]: memref<320xbf16, #amdgpu.address_space<fat_raw_buffer>>
@@ -185,7 +185,7 @@ func.func @copy_not_aligned_to_dma(%source_buffer: memref<320xbf16, #amdgpu.addr
 >>
 
 #exec_target_contiguous = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_contiguous}>
-#translation_contiguous = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_contiguous = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_prefer_contiguous_subview
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x128xf32>
@@ -245,7 +245,7 @@ func.func @copy_prefer_contiguous_subview(%source: tensor<64x128xf32>, %init: te
 >>
 
 #exec_target_linearize = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_linearize}>
-#translation_linearize = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation_linearize = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @copy_small_innermost_linearized
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<128x16xf32>
@@ -305,7 +305,7 @@ func.func @copy_small_innermost_linearized(%source: tensor<128x16xf32>) -> tenso
 >>
 
 #exec_target_1d = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_1d}>
-#translation_1d = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation_1d = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @copy_1d_tensor
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<2048xf32>
@@ -367,7 +367,7 @@ func.func @copy_1d_tensor(%source: tensor<2048xf32>) -> tensor<2048xf32>
 >>
 
 #exec_target_no_linearize = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_no_linearize}>
-#translation_no_linearize = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation_no_linearize = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @copy_small_innermost_no_linearize
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<128x16xf32>
@@ -404,7 +404,7 @@ func.func @copy_small_innermost_no_linearize(%source: tensor<128x16xf32>, %dest:
 >>
 
 #exec_target_extract_input = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_extract_input}>
-#translation_extract_input = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation_extract_input = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @copy_with_extract_slice_input
 // CHECK-SAME:    %[[LARGE_SRC:[a-zA-Z0-9]+]]: tensor<256x128xf32>
@@ -460,7 +460,7 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
 >>
 
 #exec_target_pad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad}>
-#translation_pad = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_pad = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_with_tensor_pad_fusion
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<121x64xf32>
@@ -513,7 +513,7 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
 >>
 
 #exec_target_pad_multi_warp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_multi_warp}>
-#translation_pad_multi_warp = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_pad_multi_warp = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_with_tensor_pad_fusion_multi_warp
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<121x64xf32>
@@ -579,7 +579,7 @@ func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %
 >>
 
 #exec_target_pad_unaligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_unaligned}>
-#translation_pad_unaligned = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_pad_unaligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_with_tensor_pad_unaligned_row
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<65x121xf16>
@@ -628,7 +628,7 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
 >>
 
 #exec_target_fat_raw = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_fat_raw}>
-#translation_fat_raw = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_fat_raw = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_from_fat_raw_buffer
 // CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<64x512xbf16, #amdgpu.address_space<fat_raw_buffer>>
@@ -670,7 +670,7 @@ func.func @copy_from_fat_raw_buffer(
 >>
 
 #exec_target_fat_raw_small = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_fat_raw_small}>
-#translation_fat_raw_small = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_fat_raw_small = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_from_fat_raw_buffer_small
 // CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<4x256xbf16, #amdgpu.address_space<fat_raw_buffer>>
@@ -712,7 +712,7 @@ func.func @copy_from_fat_raw_buffer_small(
 >>
 
 #exec_target_storage_buf = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_storage_buf}>
-#translation_storage_buf = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_storage_buf = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_from_non_fat_raw_buffer
 // CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<64x512xbf16, #hal.descriptor_type<storage_buffer>>
@@ -756,7 +756,7 @@ func.func @copy_from_non_fat_raw_buffer(
 >>
 
 #exec_target_dtl = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_dtl}>
-#translation_dtl = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_dtl = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_from_dispatch_tensor_load
 func.func @copy_from_dispatch_tensor_load(%init: tensor<64x512xbf16>) -> tensor<64x512xbf16>
@@ -795,7 +795,7 @@ func.func @copy_from_dispatch_tensor_load(%init: tensor<64x512xbf16>) -> tensor<
 >>
 
 #exec_target_swizzle_linearize = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_swizzle_linearize}>
-#translation_swizzle_linearize = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation_swizzle_linearize = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: func.func @copy_swizzle_hint_linearized
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<128x16xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute.mlir
@@ -8,7 +8,7 @@
 #map = affine_map<()[s0] -> (s0 * 256)>
 #map1 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 #map2 = affine_map<(d0) -> (d0 * 4)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [64, 1, 1]>
 func.func @add_tensor() attributes {translation_info = #translation} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -53,7 +53,7 @@ func.func @add_tensor() attributes {translation_info = #translation} {
 #map = affine_map<()[s0] -> (s0 * 256)>
 #map1 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 #map2 = affine_map<(d0) -> (d0 * 4)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1]>
 func.func @add_tensor_lane_id() attributes {translation_info = #translation} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_forall.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt %s --split-input-file --mlir-print-local-scope \
 // RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-distribute-forall, canonicalize, cse))" | FileCheck %s
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_thread_forall(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {
@@ -27,7 +27,7 @@ func.func @distribute_thread_forall(%out : memref<?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_warp_forall(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {
@@ -54,7 +54,7 @@ func.func @distribute_warp_forall(%out : memref<?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_lane_forall(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {
@@ -71,7 +71,7 @@ func.func @distribute_lane_forall(%out : memref<?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_thread_forall_drop_for_loop(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {
@@ -92,7 +92,7 @@ func.func @distribute_thread_forall_drop_for_loop(%out : memref<?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_thread_forall_single_thread(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {
@@ -116,7 +116,7 @@ func.func @distribute_thread_forall_single_thread(%out : memref<?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_thread_forall_overhang(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {
@@ -140,7 +140,7 @@ func.func @distribute_thread_forall_overhang(%out : memref<?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 func.func @distribute_thread_forall_multi_dim(%out : memref<?x?x?xi32>)
     attributes {translation_info = #translation_info} {
@@ -167,7 +167,7 @@ func.func @distribute_thread_forall_multi_dim(%out : memref<?x?x?xi32>)
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [7, 1, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [7, 1, 1] subgroup_size = 32>
 
 func.func @distribute_thread_forall_small_workgroup(%out : memref<?xi32>)
     attributes {translation_info = #translation_info} {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_scf_for.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_scf_for.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-distribute-scf-for))" --mlir-print-local-scope %s | FileCheck %s
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-distribute-scf-for{use-block-dims=false}))" --mlir-print-local-scope %s | FileCheck --check-prefix=NO-BLOCK-DIM %s
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [64, 1, 1]>
 func.func @distribute_to_x(%lb : index, %ub : index, %step: index, %output: memref<?xf32>)
   attributes {translation_info = #translation} {
   %zero = arith.constant 0.0 : f32
@@ -31,7 +31,7 @@ func.func @distribute_to_x(%lb : index, %ub : index, %step: index, %output: memr
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [1, 64, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [1, 64, 1]>
 func.func @distribute_to_y(%lb : index, %ub : index, %step: index, %output: memref<?xf32>)
   attributes {translation_info = #translation} {
   %zero = arith.constant 0.0 : f32
@@ -52,7 +52,7 @@ func.func @distribute_to_y(%lb : index, %ub : index, %step: index, %output: memr
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [1, 1, 64]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [1, 1, 64]>
 func.func @distribute_to_z(%lb : index, %ub : index, %step: index, %output: memref<?xf32>)
   attributes {translation_info = #translation} {
   %zero = arith.constant 0.0 : f32

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-fuse-and-hoist-parallel-loops))' --split-input-file --verify-diagnostics | FileCheck %s
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #map = affine_map<(d0) -> (d0 * 2)>
 #map1 = affine_map<(d0) -> (d0 * 4)>
@@ -65,7 +65,7 @@ func.func @forall_fuse_then_hoist(%3: tensor<128x128xf16>, %4: tensor<128x128xf1
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #map = affine_map<(d0) -> (d0 * 2)>
 #map1 = affine_map<(d0) -> (d0 * 4)>
@@ -118,7 +118,7 @@ func.func @forall_fuse_then_hoist_mixed_mappings(%3: tensor<128x128xf16>, %5: te
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #map = affine_map<(d0) -> (d0 * 2)>
 #map1 = affine_map<(d0) -> (d0 * 4)>
@@ -380,7 +380,7 @@ func.func @no_fuse_forall_without_workgroup_size(%arg0: tensor<128x128xf32>) -> 
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64>
 #map = affine_map<(d0) -> (d0 * 2)>
 #map1 = affine_map<(d0) -> (d0 * 16)>
 func.func @no_fuse_forall_workgroup_size_mismatch(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32>
@@ -414,7 +414,7 @@ func.func @no_fuse_forall_workgroup_size_mismatch(%arg0: tensor<128x128xf32>) ->
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 #map1 = affine_map<(d0) -> (d0 * 16)>
 func.func @fuse_direct_forall_use(%arg0: tensor<128x128xf32>, %arg1: tensor<16x16xf32>) -> tensor<128x128xf32>
   attributes {translation_info = #translation_info} {
@@ -449,7 +449,7 @@ func.func @fuse_direct_forall_use(%arg0: tensor<128x128xf32>, %arg1: tensor<16x1
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 func.func @forall_hoist_unit_loop_with_fill(%3: tensor<1x128xf16>, %4: tensor<128x1xf16>) -> tensor<1x1xf32>
     attributes {translation_info = #translation_info} {
@@ -947,7 +947,7 @@ func.func @fuse_pad_dest(%arg0: tensor<128xf16>, %arg1: index) -> tensor<128xf16
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 func.func @no_swap_same_block_expand_slice(%arg0: tensor<64xf16>) -> tensor<4x4xf16>
     attributes {translation_info = #translation_info} {
   %expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [8, 8]
@@ -966,7 +966,7 @@ func.func @no_swap_same_block_expand_slice(%arg0: tensor<64xf16>) -> tensor<4x4x
 
 // Check that when fusing two separate producer foralls (each with different swizzle hints)
 // into a consumer, each producer creates a bufferization.alloc_tensor with its correct swizzle.
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1024, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [1024, 1, 1] subgroup_size = 64>
 func.func @swizzle_with_fusion(%arg0: tensor<128x128xf16>, %arg1: tensor<128x128xf16>) -> tensor<128x128xf16>
     attributes {translation_info = #translation_info} {
   %empty1 = tensor.empty() : tensor<128x128xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_greedily_distribute_to_threads.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_greedily_distribute_to_threads.mlir
@@ -5,7 +5,7 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 func.func @simple_generic(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>, %5: tensor<64x256xf32>) -> tensor<64x256xf32>
     attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
     } {
   %6 = linalg.generic {
     indexing_maps = [#map, #map, #map],
@@ -29,7 +29,7 @@ func.func @simple_generic(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>, %5: te
 #map = affine_map<(d0, d1) -> (d0, d1)>
 func.func @fuse_destination(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>) -> tensor<64x64xf32>
     attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
     } {
   %empty = tensor.empty() : tensor<64x64xf32>
   %cst = arith.constant 0.0 : f32
@@ -50,7 +50,7 @@ func.func @fuse_destination(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>) -> ten
 
 func.func @in_nested_region(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>, %5: tensor<64x64xf32>) -> tensor<64x64xf32>
     attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
     } {
   %c8 = arith.constant 8 : index
   %c64 = arith.constant 64 : index
@@ -77,7 +77,7 @@ func.func @in_nested_region(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>, %5: te
 
 func.func @do_not_redistribute_in_forall(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>, %5: tensor<64x64xf32>) -> tensor<64x64xf32>
     attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
     } {
   %c8 = arith.constant 8 : index
   %c64 = arith.constant 64 : index
@@ -132,7 +132,7 @@ func.func @do_not_redistribute_in_forall(%3: tensor<64x64xf32>, %4: tensor<64x64
 
 func.func @multiple_use_tilable_op(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>) -> (tensor<64x256xf32>, tensor<256x64xf32>)
     attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
     } {
   %add_empty = tensor.empty() : tensor<64x256xf32>
   %6 = linalg.add

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_coalesced_dma_to_global_loads.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_coalesced_dma_to_global_loads.mlir
@@ -15,7 +15,7 @@
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 
 // CHECK-LABEL: func.func @lower_coalesced_gather_dma_multiple
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>
@@ -55,7 +55,7 @@ func.func @lower_coalesced_gather_dma_multiple(
     max_load_instruction_bits = 128, simds_per_wgp = 4,
     vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // Test case for coalesced DMA without explicit indices (copy operation)
 // CHECK-LABEL: func.func @lower_coalesced_copy_dma_basic

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
@@ -28,7 +28,7 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
     %c500 = arith.constant 500 : index
     %c1 = arith.constant 1 : index
     hal.return %c250, %c500, %c1 : index, index, index
-  } attributes {subgroup_size = 64 : index, translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>, workgroup_size = [64 : index, 16 : index, 1 : index]}
+  } attributes {subgroup_size = 64 : index, translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>, workgroup_size = [64 : index, 16 : index, 1 : index]}
   builtin.module {
     func.func @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16() {
       %c128 = arith.constant 128 : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tensor_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tensor_alloc.mlir
@@ -230,7 +230,7 @@ func.func @weight_dequant_matmul() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @conv() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+func.func @conv() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x34x34x1280xf16>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tensor_tile.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tensor_tile.mlir
@@ -8,7 +8,7 @@
 #config = #iree_codegen.lowering_config<tile_sizes = [[1, 256]]>
 #map = affine_map<()[s0] -> (s0 * 256)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [64, 1, 1]>
 module {
   func.func @add_tensor() attributes {translation_info = #translation} {
     %c0 = arith.constant 0 : index
@@ -64,7 +64,7 @@ module {
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 #map2 = affine_map<(d0, d1) -> (d0)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [64, 1, 1]>
 module {
   func.func @reduction() attributes {translation_info = #translation} {
     %c0 = arith.constant 0 : index
@@ -120,7 +120,7 @@ module {
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [64, 1, 1]>
 module {
   func.func @reduction_broadcast() attributes {translation_info = #translation} {
     %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_verify_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_verify_distribution.mlir
@@ -10,7 +10,7 @@ func.func @incomplete_funcop() {
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 func.func @unmapped_forall() attributes {translation_info = #translation} {
   // expected-error @+1 {{requires a mapping attribute}}
   scf.forall (%arg0) in (32) {
@@ -20,7 +20,7 @@ func.func @unmapped_forall() attributes {translation_info = #translation} {
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 func.func @lane_forall_no_warp_parent() attributes {translation_info = #translation} {
   // expected-error @+1 {{lane distributed scf.forall must have a parent subgroup distributed loop}}
   scf.forall (%arg0) in (32) {
@@ -32,7 +32,7 @@ func.func @lane_forall_no_warp_parent() attributes {translation_info = #translat
 
 // Writes inside thread-mapped foralls should pass verification.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 func.func @thread_forall_write_ok(%buf: memref<64xf32, #gpu.address_space<workgroup>>)
     attributes {translation_info = #translation} {
   scf.forall (%tid) in (64) {
@@ -46,7 +46,7 @@ func.func @thread_forall_write_ok(%buf: memref<64xf32, #gpu.address_space<workgr
 
 // Writes outside any distributed context should fail.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 func.func @undistributed_write(%buf: memref<64xf32, #gpu.address_space<workgroup>>)
     attributes {translation_info = #translation} {
   %c0 = arith.constant 0 : index
@@ -60,7 +60,7 @@ func.func @undistributed_write(%buf: memref<64xf32, #gpu.address_space<workgroup
 
 // Writes inside pcf.generic should pass verification.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64>
 func.func @pcf_generic_write_ok(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
     attributes {translation_info = #translation} {
   pcf.generic scope(#iree_gpu.subgroup_scope)
@@ -80,7 +80,7 @@ func.func @pcf_generic_write_ok(%buf: memref<256xf16, #gpu.address_space<workgro
 
 // Writes inside lane-scoped pcf.loop should pass verification.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64>
 func.func @pcf_loop_lane_scope_write_ok(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
     attributes {translation_info = #translation} {
   %c4 = arith.constant 4 : index
@@ -97,7 +97,7 @@ func.func @pcf_loop_lane_scope_write_ok(%buf: memref<256xf16, #gpu.address_space
 
 // Writes inside subgroup-scoped pcf.generic (without lane nesting) should fail.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64>
 func.func @pcf_subgroup_scope_write_fail(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
     attributes {translation_info = #translation} {
   pcf.generic scope(#iree_gpu.subgroup_scope)
@@ -114,7 +114,7 @@ func.func @pcf_subgroup_scope_write_fail(%buf: memref<256xf16, #gpu.address_spac
 
 // Write outside pcf.generic (but pcf.generic exists elsewhere) should fail.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64>
 func.func @write_outside_pcf_generic(%buf: memref<256xf16, #gpu.address_space<workgroup>>)
     attributes {translation_info = #translation} {
   pcf.generic scope(#iree_gpu.subgroup_scope)

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_constraints_to_smt.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_constraints_to_smt.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: iree_codegen.smt.constraints
 // CHECK-SAME:    target = <set = 0>
-// CHECK-SAME:    pipeline = LLVMGPUVectorDistribute
+// CHECK-SAME:    pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 // CHECK:         smt.solver() : () -> ()
 
@@ -32,7 +32,7 @@
 
 iree_codegen.smt.constraints
     target = <set = 0>,
-    pipeline = LLVMGPUVectorDistribute,
+    pipeline = #iree_gpu.pipeline<VectorDistribute>,
     knobs = {wg_m = #iree_codegen.smt.int_knob<"wg_m">,
              mma_idx = #iree_codegen.smt.int_knob<"mma_idx">}
     dims() {

--- a/compiler/src/iree/compiler/Codegen/Common/test/convolution_to_igemm.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convolution_to_igemm.mlir
@@ -105,7 +105,7 @@ func.func @fold_with_buffer_load_store(
 
 // -----
 
-func.func @conv_with_lowering_config() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>} {
+func.func @conv_with_lowering_config() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x34x34x128xf32>>

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -1,13 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-codegen-strip-compilation-info %s | FileCheck %s
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
 func.func @main() attributes {translation_info = #translation_info} {
   return
 }
 
 // CHECK-LABEL: func.func @main
 // CHECK-NOT:   iree_codegen.translation_info
-// CHECK-NOT:   LLVMGPUVectorDistribute
+// CHECK-NOT:   #iree_gpu.pipeline<VectorDistribute>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -1243,7 +1243,7 @@ func.func @multi_fusable_users(%arg0: tensor<?x65536x32xf16>, %arg1: index, %arg
 
 // -----
 func.func @matmul_transposed_reordering_static_on(%arg0 : tensor<8192x4096xf16>,%arg1 : tensor<128256x4096xf16>) -> tensor<8192x128256xf32>
-attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64,
+attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64,
 {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>} {
   %cst = arith.constant 0.000000e+00 : f32
   %5 = tensor.empty() : tensor<8192x128256xf32>
@@ -1272,7 +1272,7 @@ attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPU
 //   CHECK: {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
 func.func @matmul_transposed_reordering_static_no_reordering(%arg0 : tensor<8192x4096xf16>,%arg1 : tensor<128256x4096xf16>) -> tensor<8192x128256xf32>
-attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64,
+attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64,
 {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>} {
   %cst = arith.constant 0.000000e+00 : f32
   %5 = tensor.empty() : tensor<8192x128256xf32>
@@ -1300,7 +1300,7 @@ attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPU
 //   CHECK: {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
 func.func @matmul_transposed_reordering_static_off(%arg0 : tensor<128256x4096xf16>,%arg1 : tensor<8192x4096xf16>) -> tensor<128256x8192xf32>
-attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64,
+attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64,
 {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>} {
   %cst = arith.constant 0.000000e+00 : f32
   %7 = tensor.empty() : tensor<128256x8192xf32>
@@ -1329,7 +1329,7 @@ attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPU
 
 
 func.func @matmul_transposed_reordering_dynamic(%arg0 : tensor<?x256x4096xf16>,%arg1 : tensor<8192x4096xf16>) -> tensor<?x256x8192xf32>
-attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64,
+attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64,
 {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -112,7 +112,10 @@ ArrayAttr ExportConfigAttr::getWorkgroupSizeIndexArray() {
 // iree_codegen.pass_pipeline
 //===----------------------------------------------------------------------===//
 
-LogicalResult PassPipelineAttr::buildPipeline(OpPassManager &pm) const {
+LogicalResult
+PassPipelineAttr::buildPipeline(OpPassManager &pm,
+                                const CodegenPipelineOptions *options) const {
+  // Textual pipelines ignore options.
   if (failed(parsePassPipeline(getPipeline(), pm))) {
     return failure();
   }
@@ -184,7 +187,8 @@ LogicalResult TranslationInfoAttr::verify(
              << "transform dialect codegen spec requires pass pipeline : "
              << stringifyEnum(tdPassPipeline);
     }
-  } else if (!isa<PipelineAttrInterface>(passPipeline)) {
+  } else if (!passPipeline
+                  .hasPromiseOrImplementsInterface<PipelineAttrInterface>()) {
     return emitError()
            << "pass pipeline must be a DispatchLoweringPassPipelineAttr or "
               "implement PipelineAttrInterface";

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -32,21 +32,6 @@ def CPU_DataTiling
 def CPU_LinalgExtTileAndVectorize
     : I32EnumAttrCase<"CPULinalgExtTileAndVectorize", 6>;
 
-def LLVMGPU_Default
-    : I32EnumAttrCase<"LLVMGPUDefault", 100>;
-def LLVMGPU_BaseLowering
-    : I32EnumAttrCase<"LLVMGPUBaseLowering", 101>;
-def LLVMGPU_SimpleDistribute
-    : I32EnumAttrCase<"LLVMGPUDistribute", 102>;
-def LLVMGPU_Vectorize
-    : I32EnumAttrCase<"LLVMGPUVectorize", 103>;
-def LLVMGPU_VectorDistribute
-    : I32EnumAttrCase<"LLVMGPUVectorDistribute", 104>;
-def LLVMGPU_WinogradVectorize
-    : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 105>;
-def LLVMGPU_TileAndFuse
-    : I32EnumAttrCase<"LLVMGPUTileAndFuse", 106>;
-
 def SPIRV_BaseLowering
     : I32EnumAttrCase<"SPIRVBaseLowering", 200>;
 def SPIRV_BaseDistribute
@@ -81,11 +66,6 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     CPU_ConvTileAndDecomposeExpert,
     CPU_Mmt4dTilingExpert, CPU_BufferOpsTileAndVectorize,
     CPU_DataTiling, CPU_LinalgExtTileAndVectorize,
-
-    // LLVMGPU CodeGen pipelines
-    LLVMGPU_Default, LLVMGPU_BaseLowering, LLVMGPU_SimpleDistribute,
-    LLVMGPU_Vectorize, LLVMGPU_VectorDistribute,
-    LLVMGPU_WinogradVectorize, LLVMGPU_TileAndFuse,
 
     // SPIR-V CodeGen pipelines
     SPIRV_BaseLowering, SPIRV_BaseDistribute, SPIRV_BaseVectorize,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h
@@ -18,6 +18,10 @@
 
 #include "llvm/ADT/STLExtras.h"
 
+namespace mlir::iree_compiler {
+struct CodegenPipelineOptions;
+} // namespace mlir::iree_compiler
+
 // clang-format off
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h.inc"

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -765,9 +765,8 @@ def IREECodegen_PipelineAttrInterface :
       /*desc=*/[{
         Populates the given pass manager with a pass pipeline.
 
-        The options parameter carries backend-specific pipeline options
-        (e.g., GPU bank conflict reduction, CPU vectorization flags).
-        May be null when no backend options are available.
+        The options parameter carries backend-specific codegen options.
+        May be null when no options are available.
       }],
       /*retTy=*/"::mlir::LogicalResult",
       /*methodName=*/"buildPipeline",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -764,10 +764,15 @@ def IREECodegen_PipelineAttrInterface :
     InterfaceMethod<
       /*desc=*/[{
         Populates the given pass manager with a pass pipeline.
+
+        The options parameter carries backend-specific pipeline options
+        (e.g., GPU bank conflict reduction, CPU vectorization flags).
+        May be null when no backend options are available.
       }],
       /*retTy=*/"::mlir::LogicalResult",
       /*methodName=*/"buildPipeline",
-      /*args=*/(ins "::mlir::OpPassManager &":$pm)
+      /*args=*/(ins "::mlir::OpPassManager &":$pm,
+                    "const ::mlir::iree_compiler::CodegenPipelineOptions *":$options)
     >
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -654,7 +654,7 @@ def IREECodegen_ConstraintsOp :
     Example:
     ```mlir
     // The matmul is marked: {root_op = #iree_codegen.root_op<set = 0>}
-    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+    iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
      knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
      dims(%M, %N, %K) {
     ^bb0(%m: !smt.int, %n: !smt.int, %k: !smt.int):

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -116,7 +116,7 @@ func.func private @workgroup_scope_attr_linearize() attributes {
 
 // Test constraints op with knobs and dims.
 func.func @constraints_op(%arg0: index, %arg1: index) {
-  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
    knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
    dims(%arg0, %arg1) {
   ^bb0(%m: !smt.int, %n: !smt.int):
@@ -128,7 +128,7 @@ func.func @constraints_op(%arg0: index, %arg1: index) {
 // CHECK-LABEL: func.func @constraints_op(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[N:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK:     knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
 // CHECK:     dims(%[[M]], %[[N]])
 // CHECK:    ^bb0(%{{.*}}: !smt.int, %{{.*}}: !smt.int):
@@ -139,7 +139,7 @@ func.func @constraints_op(%arg0: index, %arg1: index) {
 
 // Test constraints op with nested knobs (multiple dict groups) and SMT body.
 func.func @constraints_op_with_smt_body(%arg0: index, %arg1: index) {
-  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
    knobs = {reduction = [#iree_codegen.smt.int_knob<"red_k">], workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
    dims(%arg0, %arg1) {
   ^bb0(%m: !smt.int, %n: !smt.int):
@@ -155,7 +155,7 @@ func.func @constraints_op_with_smt_body(%arg0: index, %arg1: index) {
 // CHECK-LABEL: func.func @constraints_op_with_smt_body(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[N:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK:     knobs = {reduction = [#iree_codegen.smt.int_knob<"red_k">], workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
 // CHECK:     dims(%[[M]], %[[N]])
 // CHECK:    ^bb0(%{{.*}}: !smt.int, %{{.*}}: !smt.int):
@@ -188,7 +188,7 @@ func.func @assert_static_message(%arg0: index) {
 
 // Test assert op with format string args.
 func.func @assert_with_format_args(%arg0: index) {
-  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUVectorDistribute,
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
    knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]}
    dims(%arg0) {
   ^bb0(%m: !smt.int):
@@ -224,7 +224,7 @@ func.func @constraints_op_empty_dims() {
 
 // Test constraints op with extra attributes (placed before the body).
 func.func @constraints_op_with_attrs(%arg0: index) {
-  iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUTileAndFuse,
+  iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
    knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">]}
    dims(%arg0) attributes {some_tag = "hello"} {
   ^bb0(%m: !smt.int):
@@ -233,7 +233,7 @@ func.func @constraints_op_with_attrs(%arg0: index) {
 }
 // CHECK-LABEL: func.func @constraints_op_with_attrs(
 // CHECK-SAME:    %[[M:[a-zA-Z0-9_]+]]: index
-// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = LLVMGPUTileAndFuse,
+// CHECK:    iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
 // CHECK:     knobs = {workgroup = [#iree_codegen.smt.int_knob<"wg_m">]}
 // CHECK:     dims(%[[M]]) attributes {some_tag = "hello"}
 // CHECK:    ^bb0(%{{.*}}: !smt.int):

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/BUILD.bazel
@@ -15,14 +15,17 @@ package(
 iree_compiler_cc_library(
     name = "ExternalModels",
     srcs = [
+        "GPUPipelineExternalModels.cpp",
         "GPUScopeExternalModels.cpp",
         "Interfaces.cpp",
     ],
     hdrs = [
+        "GPUPipelineExternalModels.h",
         "GPUScopeExternalModels.h",
         "Interfaces.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",
@@ -30,5 +33,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/CMakeLists.txt
@@ -14,9 +14,11 @@ iree_cc_library(
   NAME
     ExternalModels
   HDRS
+    "GPUPipelineExternalModels.h"
     "GPUScopeExternalModels.h"
     "Interfaces.h"
   SRCS
+    "GPUPipelineExternalModels.cpp"
     "GPUScopeExternalModels.cpp"
     "Interfaces.cpp"
   DEPS
@@ -24,6 +26,8 @@ iree_cc_library(
     MLIRArithDialect
     MLIRGPUDialect
     MLIRIR
+    MLIRPass
+    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Dialect::PCF::Transforms

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.cpp
@@ -1,0 +1,46 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+/// Global builder callback registered by the LLVMGPU backend.
+static GPUPipelineBuilder globalGPUPipelineBuilder = nullptr;
+
+void registerGPUPipelineBuilder(GPUPipelineBuilder builder) {
+  assert((!globalGPUPipelineBuilder || globalGPUPipelineBuilder == builder) &&
+         "GPU pipeline builder already registered with a different callback");
+  globalGPUPipelineBuilder = builder;
+}
+
+namespace {
+
+struct GPUPipelineExternalModel final
+    : Codegen::PipelineAttrInterface::ExternalModel<GPUPipelineExternalModel,
+                                                    PipelineAttr> {
+  LogicalResult buildPipeline(Attribute attr, OpPassManager &pm,
+                              const CodegenPipelineOptions *options) const {
+    assert(globalGPUPipelineBuilder &&
+           "no GPU pipeline builder registered; ensure "
+           "registerCodegenLLVMGPUPasses() was called");
+    return globalGPUPipelineBuilder(attr, pm, options);
+  }
+};
+
+} // namespace
+
+void registerGPUPipelineExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, IREEGPUDialect *dialect) {
+    PipelineAttr::attachInterface<GPUPipelineExternalModel>(*ctx);
+  });
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.cpp
@@ -12,13 +12,16 @@
 
 namespace mlir::iree_compiler::IREE::GPU {
 
-/// Global builder callback registered by the LLVMGPU backend.
-static GPUPipelineBuilder globalGPUPipelineBuilder = nullptr;
+static GPUPipelineBuilder &getGPUPipelineBuilder() {
+  static GPUPipelineBuilder builder = nullptr;
+  return builder;
+}
 
 void registerGPUPipelineBuilder(GPUPipelineBuilder builder) {
-  assert((!globalGPUPipelineBuilder || globalGPUPipelineBuilder == builder) &&
+  GPUPipelineBuilder &current = getGPUPipelineBuilder();
+  assert((!current || current == builder) &&
          "GPU pipeline builder already registered with a different callback");
-  globalGPUPipelineBuilder = builder;
+  current = builder;
 }
 
 namespace {
@@ -28,10 +31,10 @@ struct GPUPipelineExternalModel final
                                                     PipelineAttr> {
   LogicalResult buildPipeline(Attribute attr, OpPassManager &pm,
                               const CodegenPipelineOptions *options) const {
-    assert(globalGPUPipelineBuilder &&
-           "no GPU pipeline builder registered; ensure "
-           "registerCodegenLLVMGPUPasses() was called");
-    return globalGPUPipelineBuilder(attr, pm, options);
+    GPUPipelineBuilder builder = getGPUPipelineBuilder();
+    assert(builder && "no GPU pipeline builder registered; ensure "
+                      "registerCodegenLLVMGPUPasses() was called");
+    return builder(attr, pm, options);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_EXTERNALINTERFACES_GPUPIPELINEEXTERNALMODELS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_GPU_EXTERNALINTERFACES_GPUPIPELINEEXTERNALMODELS_H_
+
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir::iree_compiler {
+struct CodegenPipelineOptions;
+} // namespace mlir::iree_compiler
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+/// Callback type for GPU pipeline builders. Returns success if the pipeline
+/// was handled.
+using GPUPipelineBuilder =
+    LogicalResult (*)(Attribute pipelineAttr, OpPassManager &pm,
+                      const CodegenPipelineOptions *options);
+
+/// Registers a GPU pipeline builder callback. Called from the LLVMGPU backend
+/// at pass registration time. The callback is invoked by the
+/// PipelineAttrInterface external model on GPU::PipelineAttr.
+void registerGPUPipelineBuilder(GPUPipelineBuilder builder);
+
+/// Registers the external model attaching PipelineAttrInterface to
+/// GPU::PipelineAttr.
+void registerGPUPipelineExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler::IREE::GPU
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_EXTERNALINTERFACES_GPUPIPELINEEXTERNALMODELS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/Interfaces.cpp
@@ -6,11 +6,13 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/Interfaces.h"
 
+#include "iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.h"
 #include "iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUScopeExternalModels.h"
 
 namespace mlir::iree_compiler {
 
 void registerIREEGPUExternalInterfaces(DialectRegistry &registry) {
+  IREE::GPU::registerGPUPipelineExternalModels(registry);
   IREE::GPU::registerGPUScopeExternalModels(registry);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2470,13 +2470,9 @@ int64_t LaneIdAttr::getRelativeIndex() const { return getDim(); }
 // GPU Pipeline Attribute
 //===----------------------------------------------------------------------===//
 
-LogicalResult PipelineAttr::buildPipeline(OpPassManager &pm) const {
-  // GPU pipeline construction requires target-specific context (pipeline
-  // options, forROCDL flag) that PipelineAttrInterface::buildPipeline does not
-  // provide. LLVMGPULowerExecutableTarget dispatches on GPU::PipelineAttr
-  // directly before the generic PipelineAttrInterface path.
-  return failure();
-}
+// PipelineAttrInterface is implemented via an external model registered
+// from GPUPipelineExternalModels.cpp. The builder callback is set by the
+// LLVMGPU backend in registerCodegenLLVMGPUPasses().
 
 //===----------------------------------------------------------------------===//
 // GPU Pipeline Options

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -39,7 +39,6 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
-#include "mlir/Pass/PassManager.h"
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2470,10 +2470,6 @@ int64_t LaneIdAttr::getRelativeIndex() const { return getDim(); }
 // GPU Pipeline Attribute
 //===----------------------------------------------------------------------===//
 
-// PipelineAttrInterface is implemented via an external model registered
-// from GPUPipelineExternalModels.cpp. The builder callback is set by the
-// LLVMGPU backend in registerCodegenLLVMGPUPasses().
-
 //===----------------------------------------------------------------------===//
 // GPU Pipeline Options
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -39,6 +39,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Pass/PassManager.h"
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
@@ -2464,6 +2465,18 @@ int64_t LaneIdAttr::getMappingId() const { return getDim(); }
 bool LaneIdAttr::isLinearMapping() const { return true; }
 
 int64_t LaneIdAttr::getRelativeIndex() const { return getDim(); }
+
+//===----------------------------------------------------------------------===//
+// GPU Pipeline Attribute
+//===----------------------------------------------------------------------===//
+
+LogicalResult PipelineAttr::buildPipeline(OpPassManager &pm) const {
+  // GPU pipeline construction requires target-specific context (pipeline
+  // options, forROCDL flag) that PipelineAttrInterface::buildPipeline does not
+  // provide. LLVMGPULowerExecutableTarget dispatches on GPU::PipelineAttr
+  // directly before the generic PipelineAttrInterface path.
+  return failure();
+}
 
 //===----------------------------------------------------------------------===//
 // GPU Pipeline Options

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -819,7 +819,8 @@ def IREEGPU_PipelineAttr : AttrDef<IREEGPU_Dialect, "Pipeline"> {
   let summary = "LLVMGPU lowering pipeline identifier.";
   let description = [{
     Identifies an LLVMGPU lowering pipeline. PipelineAttrInterface is
-    attached via an external model registered from the LLVMGPU backend.
+    attached via an external model (GPUPipelineExternalModels.cpp). The
+    builder callback is registered by registerCodegenLLVMGPUPasses().
   }];
   let parameters = (ins
     EnumParameter<IREEGPU_LoweringPipeline>:$value

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -811,6 +811,26 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 }
 
 //===----------------------------------------------------------------------===//
+// GPU Pipeline Attribute
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_PipelineAttr : AttrDef<IREEGPU_Dialect, "Pipeline", [
+  DeclareAttrInterfaceMethods<IREECodegen_PipelineAttrInterface, [
+    "buildPipeline"]>
+]> {
+  let mnemonic = "pipeline";
+  let summary = "LLVMGPU lowering pipeline identifier.";
+  let description = [{
+    Identifies an LLVMGPU lowering pipeline. Implements PipelineAttrInterface
+    so it can be stored in TranslationInfoAttr pipeline fields.
+  }];
+  let parameters = (ins
+    EnumParameter<IREEGPU_LoweringPipeline>:$value
+  );
+  let assemblyFormat = "`<` $value `>`";
+}
+
+//===----------------------------------------------------------------------===//
 // GPU Target Attributes
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -814,15 +814,12 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 // GPU Pipeline Attribute
 //===----------------------------------------------------------------------===//
 
-def IREEGPU_PipelineAttr : AttrDef<IREEGPU_Dialect, "Pipeline", [
-  DeclareAttrInterfaceMethods<IREECodegen_PipelineAttrInterface, [
-    "buildPipeline"]>
-]> {
+def IREEGPU_PipelineAttr : AttrDef<IREEGPU_Dialect, "Pipeline"> {
   let mnemonic = "pipeline";
   let summary = "LLVMGPU lowering pipeline identifier.";
   let description = [{
-    Identifies an LLVMGPU lowering pipeline. Implements PipelineAttrInterface
-    so it can be stored in TranslationInfoAttr pipeline fields.
+    Identifies an LLVMGPU lowering pipeline. PipelineAttrInterface is
+    attached via an external model registered from the LLVMGPU backend.
   }];
   let parameters = (ins
     EnumParameter<IREEGPU_LoweringPipeline>:$value

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.cpp.inc"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
@@ -24,6 +25,7 @@ void IREEGPUDialect::initialize() {
   // Promised interface declarations for interfaces implemented externally.
   declarePromisedInterface<PCF::ScopeAttrInterface, SubgroupScopeAttr>();
   declarePromisedInterface<PCF::ScopeAttrInterface, LaneScopeAttr>();
+  declarePromisedInterface<Codegen::PipelineAttrInterface, PipelineAttr>();
 }
 
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -462,4 +462,24 @@ def IREEGPU_ReorderWorkgroupsStrategy : IREEGPU_I32PipelineEnumAttr<"ReorderWork
     ]> {
 }
 
+//===----------------------------------------------------------------------===//
+// GPU Lowering Pipelines
+//===----------------------------------------------------------------------===//
+
+// LLVMGPU pipelines.
+def IREEGPU_LP_Default : I32EnumAttrCase<"Default", 0>;
+def IREEGPU_LP_BaseLowering : I32EnumAttrCase<"BaseLowering", 1>;
+def IREEGPU_LP_Distribute : I32EnumAttrCase<"Distribute", 2>;
+def IREEGPU_LP_Vectorize : I32EnumAttrCase<"Vectorize", 3>;
+def IREEGPU_LP_VectorDistribute : I32EnumAttrCase<"VectorDistribute", 4>;
+def IREEGPU_LP_WinogradVectorize : I32EnumAttrCase<"WinogradVectorize", 5>;
+def IREEGPU_LP_TileAndFuse : I32EnumAttrCase<"TileAndFuse", 6>;
+
+def IREEGPU_LoweringPipeline : IREEGPU_I32EnumAttr<"LoweringPipeline",
+    "LLVMGPU lowering pipeline identifier", [
+      IREEGPU_LP_Default, IREEGPU_LP_BaseLowering, IREEGPU_LP_Distribute,
+      IREEGPU_LP_Vectorize, IREEGPU_LP_VectorDistribute,
+      IREEGPU_LP_WinogradVectorize, IREEGPU_LP_TileAndFuse
+    ]>;
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -234,3 +234,18 @@ module {
 }
 // CHECK-LABEL: func @test_swizzle_hint_promotion
 //  CHECK-SAME:   promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>]
+
+module {
+  func.func @test_pipeline_attrs() attributes {
+      vd = #iree_gpu.pipeline<VectorDistribute>,
+      taf = #iree_gpu.pipeline<TileAndFuse>,
+      base = #iree_gpu.pipeline<BaseLowering>,
+      def = #iree_gpu.pipeline<Default>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_pipeline_attrs
+//  CHECK-SAME:   base = #iree_gpu.pipeline<BaseLowering>
+//  CHECK-SAME:   def = #iree_gpu.pipeline<Default>
+//  CHECK-SAME:   taf = #iree_gpu.pipeline<TileAndFuse>
+//  CHECK-SAME:   vd = #iree_gpu.pipeline<VectorDistribute>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -47,6 +47,17 @@ namespace mlir::iree_compiler::IREE::GPU {
 constexpr int64_t kCacheLineSizeBits = 128 * 8;
 constexpr int64_t kPreferredCopyNumBits = 128;
 
+/// Helper to build a TranslationInfoAttr with a GPU pipeline.
+static IREE::Codegen::TranslationInfoAttr
+getGPUTranslationInfo(MLIRContext *ctx, LoweringPipeline pipeline,
+                      ArrayRef<int64_t> workgroupSize = {},
+                      std::optional<int64_t> subgroupSize = std::nullopt,
+                      DictionaryAttr pipelineConfig = {}) {
+  return IREE::Codegen::TranslationInfoAttr::get(
+      ctx, PipelineAttr::get(ctx, pipeline), SymbolRefAttr(), workgroupSize,
+      subgroupSize.value_or(0), pipelineConfig);
+}
+
 //===----------------------------------------------------------------------===//
 // Lowering Config Selection
 //===----------------------------------------------------------------------===//
@@ -124,11 +135,10 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
       IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName(), pipelineOptions);
   auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
 
-  // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 static std::optional<ComputeBitwidths> getComputeBitwidthForType(Type type) {
@@ -1083,11 +1093,10 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
       DictionaryAttr::get(linalgOp->getContext(), pipelineAttrs);
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
 
-  // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 LogicalResult
@@ -1169,11 +1178,10 @@ setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
       DictionaryAttr::get(linalgOp->getContext(), pipelineAttrs);
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
 
-  // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 /// Helper to identify contraction like operations for operand promotiong.
@@ -1653,11 +1661,10 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
   LDBG() << "Selected tile and fuse lowering config: " << loweringConfig
          << "\n";
 
-  // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      {flatWorkgroupSize, 1, 1}, subgroupSize, DictionaryAttr());
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            {flatWorkgroupSize, 1, 1}, subgroupSize));
 }
 
 LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
@@ -1759,11 +1766,10 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
   LDBG() << "Selected tile and fuse lowering config: " << loweringConfig
          << "\n";
 
-  // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, scatter, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      {flatWorkgroupSize, 1, 1}, flatWorkgroupSize, DictionaryAttr());
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            {flatWorkgroupSize, 1, 1}, flatWorkgroupSize));
 }
 
 LogicalResult setDirectConvolutionLoweringConfig(
@@ -2030,8 +2036,8 @@ LogicalResult setDirectConvolutionLoweringConfig(
 
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
-      Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse, workgroupSize,
-      targetSubgroupSize, pipelineConfig);
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 //====---------------------------------------------------------------------===//
@@ -2063,8 +2069,8 @@ LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
         createLoweringConfig(int64_t{0}, int64_t{0});
     return setOpConfigAndEntryPointFnTranslation(
         entryPoint, op, loweringConfig,
-        IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-        {1, 1, 1}, subgroupSize, DictionaryAttr());
+        getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                              {1, 1, 1}, subgroupSize));
   }
 
   unsigned numLoops = cast<ShapedType>(op->getResult(0).getType()).getRank();
@@ -2109,8 +2115,8 @@ LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
       createLoweringConfig(workgroupTileSizes, threadTileSizes);
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      workgroupSize, subgroupSize, DictionaryAttr());
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            workgroupSize, subgroupSize));
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
@@ -27,8 +27,6 @@ constexpr unsigned kVectorDistributeReductionSizeToTargetIfDynamic = (1 << 31);
 
 namespace mlir::iree_compiler::IREE::GPU {
 
-using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
-
 namespace {
 
 bool isROCmBackend(IREE::GPU::TargetAttr target) {
@@ -819,8 +817,8 @@ LogicalResult setReductionConfig(IREE::GPU::TargetAttr target,
   auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
 
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-      context, CodeGenPipeline::LLVMGPUVectorDistribute, SymbolRefAttr(),
-      {workgroupSize, 1, 1}, subgroupSize, pipelineConfig);
+      context, PipelineAttr::get(context, LoweringPipeline::VectorDistribute),
+      SymbolRefAttr(), {workgroupSize, 1, 1}, subgroupSize, pipelineConfig);
 
   if (shouldSetTunerAttributes()) {
     setRootOpInfo(op);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -572,7 +572,7 @@ func.func @distribute_WMMA_F32_16x16x128_F8E4M3FN(%lhs: tensor<16x128xf8E4M3FN>,
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<1x1x4x16xf32>, %rhs: tensor<1x1x4x16xf32>, %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -607,7 +607,7 @@ func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<1x1x4x16xf32>, %rhs: t
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_1x1x1_tensor_multi_mma_permuted(%lhs: tensor<1x1x16x4xf32>, %rhs: tensor<1x1x16x4xf32>, %acc: tensor<1x1x4x4x16xf32>) -> tensor<1x1x4x4x16xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -643,7 +643,7 @@ func.func @data_tiled_1x1x1_tensor_multi_mma_permuted(%lhs: tensor<1x1x16x4xf32>
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_2x2x4_tensor_multi_mma_unrolled(%lhs: tensor<1x1x2x4x16x4xf32>, %rhs: tensor<1x1x2x4x16x4xf32>, %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -680,7 +680,7 @@ func.func @data_tiled_2x2x4_tensor_multi_mma_unrolled(%lhs: tensor<1x1x2x4x16x4x
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_2x2x4_tensor_multi_mma_interleave_m_and_k(%lhs: tensor<1x1x4x16x2x4xf32>, %rhs: tensor<1x1x2x4x16x4xf32>, %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -717,7 +717,7 @@ func.func @data_tiled_2x2x4_tensor_multi_mma_interleave_m_and_k(%lhs: tensor<1x1
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_2x2x4_tensor_multi_mma_interleave_m_only(%lhs: tensor<1x1x4x4x16x2xf32>, %rhs: tensor<1x1x2x4x4x16xf32>, %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -754,7 +754,7 @@ func.func @data_tiled_2x2x4_tensor_multi_mma_interleave_m_only(%lhs: tensor<1x1x
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_2x2x4_tensor_multi_mma_unrolled_to_subgroups(%lhs: tensor<1x1x2x4x16x4xf32>, %rhs: tensor<1x1x2x4x16x4xf32>, %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -800,7 +800,7 @@ func.func @data_tiled_scaled_2x2x4_tensor_multi_mma_unrolled_to_subgroups(
     %lhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>,
     %lhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>, %rhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>,
     %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
@@ -852,7 +852,7 @@ func.func @data_tiled_scaled_2x2x4_tensor_multi_mma_unrolled(
     %lhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>,
     %lhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>, %rhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>,
     %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
@@ -900,7 +900,7 @@ func.func @data_tiled_scaled_2x2x4_tensor_interleave_m_n_and_k(
     %lhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>,
     %lhs_scales: tensor<1x1x4x16x2x4xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16x2x4xf8E8M0FNU>,
     %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
-    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
@@ -943,7 +943,7 @@ func.func @data_tiled_scaled_2x2x4_tensor_interleave_m_n_and_k(
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @data_tiled_tensor_multi_mma_subgroups_k_2(%lhs: tensor<1x1x2x4x16xf32>, %rhs: tensor<1x1x2x4x16xf32>, %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
-      attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64>} {
+      attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -984,7 +984,7 @@ func.func @data_tiled_scaled_1x1x1_tensor_multi_mma(
     %lhs: tensor<1x1x1x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x4x16x32xf4E2M1FN>,
     %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
     %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
-    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
@@ -1032,7 +1032,7 @@ func.func @data_tiled_scaled_multi_mma_subgroups_m_and_k(
     %lhs: tensor<1x1x1x2x2x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x2x4x16x32xf4E2M1FN>,
     %lhs_scales: tensor<1x1x2x2x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x2x4x16xf8E8M0FNU>,
     %acc: tensor<1x1x2x4x16x4xf32>) -> tensor<1x1x2x4x16x4xf32>
-    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -174,7 +174,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   Attribute pipelineAttr = translationInfo.getPassPipeline();
   if (auto customPipeline =
           dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr)) {
-    if (failed(customPipeline.buildPipeline(passManager))) {
+    if (failed(customPipeline.buildPipeline(passManager,
+                                            /*options=*/nullptr))) {
       funcOp.emitOpError("failed to build custom pass pipeline");
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -132,6 +132,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common/GPU:CommonGPUPasses",
         "//compiler/src/iree/compiler/Codegen/Common/GPU:GPUHeuristics",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces:ExternalModels",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:ConfigUtils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -175,6 +175,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common::GPU::GPUHeuristics
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::GPU::ExternalInterfaces::ExternalModels
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::ConfigUtils
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -150,7 +150,18 @@ static llvm::cl::opt<std::optional<uint64_t>, /*ExternalStorage=*/false,
 
 namespace {
 
-using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
+using GPUPipeline = IREE::GPU::LoweringPipeline;
+
+/// Helper to build a TranslationInfoAttr with a GPU pipeline.
+static IREE::Codegen::TranslationInfoAttr
+getGPUTranslationInfo(MLIRContext *ctx, GPUPipeline pipeline,
+                      ArrayRef<int64_t> workgroupSize = {},
+                      std::optional<int64_t> subgroupSize = std::nullopt,
+                      DictionaryAttr pipelineConfig = {}) {
+  return IREE::Codegen::TranslationInfoAttr::get(
+      ctx, IREE::GPU::PipelineAttr::get(ctx, pipeline), SymbolRefAttr(),
+      workgroupSize, subgroupSize.value_or(0), pipelineConfig);
+}
 
 // Threshold used to determine whether a matmul dimension is 'very skinny'.
 constexpr int64_t kVerySkinnyDimThreshold = 4;
@@ -171,13 +182,15 @@ static bool isROCmBackend(IREE::GPU::TargetAttr target) {
   return target.getArch().starts_with("gfx");
 }
 
-static bool needsLoweringConfigPropagation(
-    IREE::Codegen::DispatchLoweringPassPipeline pipeline) {
-  using Pipeline = IREE::Codegen::DispatchLoweringPassPipeline;
+static bool needsLoweringConfigPropagation(Attribute pipelineAttr) {
+  auto gpuPipeline = dyn_cast_if_present<IREE::GPU::PipelineAttr>(pipelineAttr);
+  if (!gpuPipeline) {
+    return true;
+  }
   // Pipelines that do not need propagation of lowering config.
-  Pipeline supportedPipelines[] = {Pipeline::LLVMGPUTileAndFuse,
-                                   Pipeline::LLVMGPUVectorDistribute};
-  return !llvm::is_contained(supportedPipelines, pipeline);
+  GPUPipeline noPropagatePipelines[] = {GPUPipeline::TileAndFuse,
+                                        GPUPipeline::VectorDistribute};
+  return !llvm::is_contained(noPropagatePipelines, gpuPipeline.getValue());
 }
 
 //====---------------------------------------------------------------------===//
@@ -431,8 +444,9 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   auto pipelineConfig = DictionaryAttr::get(context, pipelineAttrs);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUVectorDistribute,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
+      entryPoint, op, loweringConfig,
+      getGPUTranslationInfo(context, GPUPipeline::VectorDistribute,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 [[maybe_unused]] static void
@@ -591,8 +605,6 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   LDBG() << "Matmul Vector Distribution Config";
 
-  auto pipeline = CodeGenPipeline::LLVMGPUVectorDistribute;
-
   // Infer if lhs or rhs is transposed to help generate better schedule.
   SmallVector<AffineMap> maps = op.getIndexingMapsArray();
   bool transposedLhs =
@@ -704,8 +716,9 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   auto pipelineConfig = DictionaryAttr::get(context, pipelineAttrs);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, loweringConfig, pipeline, workgroupSize,
-      targetSubgroupSize, pipelineConfig);
+      entryPoint, op, loweringConfig,
+      getGPUTranslationInfo(context, GPUPipeline::VectorDistribute,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 /// Sets attention specific pipeline attributes.
@@ -1045,8 +1058,9 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   op.setDecompositionConfigAttr(decompositionConfigDict);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUVectorDistribute,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
+      entryPoint, op, loweringConfig,
+      getGPUTranslationInfo(context, GPUPipeline::VectorDistribute,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 struct AttentionReductionHeuristicSeeds {
@@ -1324,10 +1338,9 @@ static LogicalResult setAttentionReductionConfig(
   auto pipelineConfig = DictionaryAttr::get(context, pipelineAttrs);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUVectorDistribute,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
-
-  return success();
+      entryPoint, op, loweringConfig,
+      getGPUTranslationInfo(context, GPUPipeline::VectorDistribute,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 static LogicalResult
@@ -1499,7 +1512,7 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
                                             ArrayRef<int64_t> workgroupSize,
                                             ArrayRef<int32_t> subgroupSizes,
                                             unsigned softwarePipelineDepth,
-                                            CodeGenPipeline pipeline) {
+                                            GPUPipeline pipeline) {
     TileSizesListType tileSizes;
     unsigned numParallelLoops = op.getNumParallelLoops();
     unsigned numReductionLoops = op.getNumReductionLoops();
@@ -1525,11 +1538,10 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
       subgroupSize = subgroupSizes.front();
     }
 
-    // For the LLVMGPUTileAndFuse pipeline, we need to split tile sizes
+    // For the TileAndFuse pipeline, we need to split tile sizes
     // for workgroup, thread, and reduction.
-    if (pipeline == CodeGenPipeline::LLVMGPUTileAndFuse) {
-
-      MLIRContext *context = op.getContext();
+    MLIRContext *context = op.getContext();
+    if (pipeline == GPUPipeline::TileAndFuse) {
       Builder b(context);
 
       SmallVector<int64_t> threadTileSizes(numParallelLoops + numReductionLoops,
@@ -1568,8 +1580,9 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
       auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
 
       return setOpConfigAndEntryPointFnTranslation(
-          entryPoint, op, loweringConfig, pipeline, workgroupSize, subgroupSize,
-          pipelineConfig);
+          entryPoint, op, loweringConfig,
+          getGPUTranslationInfo(context, pipeline, workgroupSize, subgroupSize,
+                                pipelineConfig));
     }
 
     // Other pipeline (MatmulTensorCore) expect the reduction tile size to be in
@@ -1577,10 +1590,13 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
     workgroupTileSizes[numParallelLoops + numReductionLoops - 1] = tileK;
     tileSizes.emplace_back(std::move(workgroupTileSizes));
 
+    auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
     return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, pipeline, workgroupSize, subgroupSize,
-        getSoftwarePipeliningAttrDict(op->getContext(), softwarePipelineDepth,
-                                      /*softwarePipelineStoreStage=*/1));
+        entryPoint, op, config,
+        getGPUTranslationInfo(context, pipeline, workgroupSize, subgroupSize,
+                              getSoftwarePipeliningAttrDict(
+                                  op->getContext(), softwarePipelineDepth,
+                                  /*softwarePipelineStoreStage=*/1)));
   };
   // Infer the MxN size of the matmul based on operands and indexing maps.
   auto lhsShape =
@@ -1625,7 +1641,7 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
       return setMatmulConfig(
           sizeN, sizeM, 4, {sizeM, sizeN, 1},
           target.getWgp().getSubgroupSizeChoices().asArrayRef(),
-          softwarePipelineDepthSimt, CodeGenPipeline::LLVMGPUTileAndFuse);
+          softwarePipelineDepthSimt, GPUPipeline::TileAndFuse);
     }
 
     // SIMT matmul case. Query the best configuration.
@@ -1639,7 +1655,7 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
             config.tileSize[0], config.tileSize[1], config.tileSize[2],
             config.workgroupSize,
             target.getWgp().getSubgroupSizeChoices().asArrayRef(),
-            softwarePipelineDepthSimt, CodeGenPipeline::LLVMGPUTileAndFuse);
+            softwarePipelineDepthSimt, GPUPipeline::TileAndFuse);
       }
     }
   }
@@ -1664,8 +1680,7 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
                                              config.workgroupSize[2]};
   return setMatmulConfig(tileX, tileY, tileK, workgroupSize,
                          target.getWgp().getSubgroupSizeChoices().asArrayRef(),
-                         softwarePipelineDepthSimt,
-                         CodeGenPipeline::LLVMGPUTileAndFuse);
+                         softwarePipelineDepthSimt, GPUPipeline::TileAndFuse);
 }
 
 //====---------------------------------------------------------------------===//
@@ -1675,6 +1690,7 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
 static LogicalResult setFftConfig(IREE::GPU::TargetAttr target,
                                   mlir::FunctionOpInterface entryPoint,
                                   IREE::LinalgExt::FftOp op) {
+  MLIRContext *context = op.getContext();
   auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
   auto partitionedLoops =
       interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
@@ -1698,9 +1714,10 @@ static LogicalResult setFftConfig(IREE::GPU::TargetAttr target,
     }
   }
   TileSizesListType tileSizes = {workgroupTileSize};
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, CodeGenPipeline::LLVMGPUDistribute,
-      workgroupSize);
+      entryPoint, op, config,
+      getGPUTranslationInfo(context, GPUPipeline::Distribute, workgroupSize));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1715,7 +1732,7 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
                       IREE::LinalgExt::WinogradFilterTransformOp,
                       IREE::LinalgExt::WinogradOutputTransformOp>::value,
       "expected winograd transform op");
-  auto pipeline = CodeGenPipeline::LLVMGPUWinogradVectorize;
+  MLIRContext *context = op.getContext();
   TileSizesListType tileSizes;
   std::array<int64_t, 3> workgroupSize = {32, 4, 4};
   int64_t iterationRank = op.getIterationDomainRank();
@@ -1734,8 +1751,11 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
   tileSizes.push_back(workgroupTileSizes);
   SmallVector<int64_t> threadTileSizes(iterationRank, 1);
   tileSizes.push_back(threadTileSizes);
-  return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
-                                               pipeline, workgroupSize);
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, config,
+      getGPUTranslationInfo(context, GPUPipeline::WinogradVectorize,
+                            workgroupSize));
 }
 
 //====---------------------------------------------------------------------===//
@@ -1745,15 +1765,17 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
 static LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
                                    mlir::FunctionOpInterface entryPoint,
                                    Operation *op) {
+  MLIRContext *context = op->getContext();
   TileSizesListType tileSizes;
   auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
   auto partitionedLoops =
       interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
   if (partitionedLoops.empty()) {
     tileSizes.push_back({});
+    auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
     return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, CodeGenPipeline::LLVMGPUDistribute,
-        {1, 1, 1});
+        entryPoint, op, config,
+        getGPUTranslationInfo(context, GPUPipeline::Distribute, {1, 1, 1}));
   }
   size_t numLoops = partitionedLoops.back() + 1;
   // To get peak occupancy we need a workgroup size of at least two warps
@@ -1777,9 +1799,10 @@ static LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
     }
   }
   tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, CodeGenPipeline::LLVMGPUDistribute,
-      workgroupSize);
+      entryPoint, op, config,
+      getGPUTranslationInfo(context, GPUPipeline::Distribute, workgroupSize));
 }
 
 //====---------------------------------------------------------------------===//
@@ -1790,14 +1813,17 @@ static LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
 static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
                                           mlir::FunctionOpInterface entryPoint,
                                           Operation *op) {
-  CodeGenPipeline passPipeline = CodeGenPipeline::LLVMGPUDistribute;
+  MLIRContext *context = op->getContext();
+  GPUPipeline passPipeline = GPUPipeline::Distribute;
   TileSizesListType tileSizes;
   auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
   auto partitionedLoops = interfaceOp.getPartitionableLoops(std::nullopt);
   if (partitionedLoops.empty()) {
     tileSizes.push_back({});
-    return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
-                                                 passPipeline, {1, 1, 1});
+    auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
+    return setOpConfigAndEntryPointFnTranslation(
+        entryPoint, op, config,
+        getGPUTranslationInfo(context, passPipeline, {1, 1, 1}));
   }
 
   const int preferredSubgroupSize = target.getPreferredSubgroupSize();
@@ -1883,7 +1909,7 @@ static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
                    [](AffineMap m) { return !m.isProjectedPermutation(); })) {
     vectorSize = 1;
   } else {
-    passPipeline = CodeGenPipeline::LLVMGPUVectorize;
+    passPipeline = GPUPipeline::Vectorize;
   }
 
   int64_t id = 0;
@@ -1912,9 +1938,11 @@ static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
     workgroupTileSizes.append(linalgOp.getNumReductionLoops(), 4);
   }
   tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
-  return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
-                                               passPipeline, workgroupSize,
-                                               preferredSubgroupSize);
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, config,
+      getGPUTranslationInfo(context, passPipeline, workgroupSize,
+                            preferredSubgroupSize));
 }
 
 /// Returns true if it's MatVec like i.e., either the bound of M or N dim = 1,
@@ -2047,11 +2075,10 @@ static LogicalResult setTransposeConfig(IREE::GPU::TargetAttr target,
                       pipelineOptions)});
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
 
-  // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, linalgOp, loweringConfig,
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      workgroupSize, targetSubgroupSize, pipelineConfig);
+      getGPUTranslationInfo(linalgOp.getContext(), GPUPipeline::TileAndFuse,
+                            workgroupSize, targetSubgroupSize, pipelineConfig));
 }
 
 //====---------------------------------------------------------------------===//
@@ -2118,8 +2145,9 @@ static LogicalResult setArgmaxUkernelConfig(
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
   if (failed(setOpConfigAndEntryPointFnTranslation(
-          entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUDefault,
-          workgroupSize))) {
+          entryPoint, op, loweringConfig,
+          getGPUTranslationInfo(context, GPUPipeline::Default,
+                                workgroupSize)))) {
     return failure();
   }
   return success();
@@ -2203,6 +2231,7 @@ static bool distributeToSquare(const int64_t oh, const int64_t ow,
 static LogicalResult setConvolutionConfig(
     IREE::GPU::TargetAttr target, mlir::FunctionOpInterface entryPointFn,
     linalg::LinalgOp linalgOp, const int64_t bestTilingFactor) {
+  MLIRContext *context = linalgOp.getContext();
   if (!isa<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp>(linalgOp)) {
     return failure();
   }
@@ -2283,7 +2312,6 @@ static LogicalResult setConvolutionConfig(
       }
     }
   }
-  auto pipeline = CodeGenPipeline::LLVMGPUVectorize;
   TileSizesListType tileSizes;
   // Add reduction tile sizes.
   if (isNCHW) {
@@ -2297,8 +2325,10 @@ static LogicalResult setConvolutionConfig(
   SmallVector<int64_t> windowTileSizes(4, 0);
   windowTileSizes[ohIndex] = 1;
   tileSizes.push_back(windowTileSizes);
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, linalgOp, tileSizes, pipeline, workgroupSize);
+      entryPointFn, linalgOp, config,
+      getGPUTranslationInfo(context, GPUPipeline::Vectorize, workgroupSize));
 }
 
 //====---------------------------------------------------------------------===//
@@ -2477,9 +2507,8 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
       auto isOne = [](Value value) { return matchPattern(value, m_One()); };
       if (llvm::all_of(retOp.getOperands(), isOne)) {
         SmallVector<int64_t, 3> workgroupSize = {1, 1, 1};
-        auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-            funcOp.getContext(), CodeGenPipeline::LLVMGPUBaseLowering,
-            workgroupSize);
+        auto translationInfo = getGPUTranslationInfo(
+            funcOp.getContext(), GPUPipeline::BaseLowering, workgroupSize);
         if (failed(setTranslationInfo(funcOp, translationInfo))) {
           return failure();
         }
@@ -2492,8 +2521,7 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
   if (IREE::Codegen::TranslationInfoAttr translationInfo =
           getTranslationInfo(funcOp)) {
     // Currently some ROCDL requires propagation of user lowering configs.
-    if (needsLoweringConfigPropagation(
-            translationInfo.getDispatchLoweringPassPipeline())) {
+    if (needsLoweringConfigPropagation(translationInfo.getPassPipeline())) {
       for (Operation *op : computeOps) {
         if (getLoweringConfig(op)) {
           propagateLoweringConfig(op, computeOps);
@@ -2579,7 +2607,7 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
   if (!rootOperation) {
     // No root operation found, set it to none.
     auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-        funcOp.getContext(), CodeGenPipeline::None);
+        funcOp.getContext(), IREE::Codegen::DispatchLoweringPassPipeline::None);
     if (failed(setTranslationInfo(funcOp, translationInfo))) {
       return failure();
     }
@@ -2593,8 +2621,7 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
   if (IREE::Codegen::TranslationInfoAttr translationInfo =
           getTranslationInfo(funcOp)) {
     // Currently some ROCDL requires propagation of user lowering configs.
-    if (!needsLoweringConfigPropagation(
-            translationInfo.getDispatchLoweringPassPipeline())) {
+    if (!needsLoweringConfigPropagation(translationInfo.getPassPipeline())) {
       return success();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
@@ -33,6 +34,7 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
 
 namespace {
+
 /// Lowers an hal.executable.variant operation to scalar/native-vector
 /// code. Invokes different compilation pipeline to
 /// - first lower to scalar/native-vector code
@@ -85,49 +87,28 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
   }
   OpPassManager &pipeline = maybePipeline.value();
 
-  IREE::GPU::GPUPipelineOptions pipelineOptions =
-      IREE::GPU::getPipelineOptions(funcOp, translationInfo);
-
   Attribute pipelineAttr = translationInfo.getPassPipeline();
 
-  // Check for GPU pipeline attribute (#iree_gpu.pipeline<...>).
-  if (auto gpuPipeline = dyn_cast<IREE::GPU::PipelineAttr>(pipelineAttr)) {
-    switch (gpuPipeline.getValue()) {
-    case IREE::GPU::LoweringPipeline::Default:
-      addGPUDefaultPassPipeline(pipeline, pipelineOptions);
-      break;
-    case IREE::GPU::LoweringPipeline::BaseLowering:
-      addGPUBaseLoweringPassPipeline(pipeline);
-      break;
-    case IREE::GPU::LoweringPipeline::Distribute:
-      addGPUSimpleDistributePassPipeline(pipeline);
-      break;
-    case IREE::GPU::LoweringPipeline::Vectorize:
-      addGPUVectorizationPassPipeline(pipeline);
-      break;
-    case IREE::GPU::LoweringPipeline::WinogradVectorize:
-      addGPUWinogradVectorizePassPipeline(pipeline);
-      break;
-    case IREE::GPU::LoweringPipeline::VectorDistribute:
-      addGPUVectorDistributePassPipeline(pipeline, pipelineOptions, forROCDL);
-      break;
-    case IREE::GPU::LoweringPipeline::TileAndFuse:
-      addGPUTileAndFusePassPipeline(pipeline, pipelineOptions, forROCDL);
-      break;
+  // Check for PipelineAttrInterface first (covers GPU::PipelineAttr via
+  // external model and any custom pipeline attrs).
+  auto pipelineIface =
+      dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr);
+
+  if (!pipelineIface) {
+    // Not an interface implementor -- check for the legacy None pipeline.
+    if (translationInfo.getDispatchLoweringPassPipeline() ==
+        IREE::Codegen::DispatchLoweringPassPipeline::None) {
+      return;
     }
-  } else if (auto customPipeline =
-                 dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr)) {
-    // Check for a custom pipeline via PipelineAttrInterface.
-    if (failed(customPipeline.buildPipeline(pipeline))) {
-      funcOp.emitOpError("failed to build custom pass pipeline");
-      return signalPassFailure();
-    }
-  } else if (translationInfo.getDispatchLoweringPassPipeline() ==
-             IREE::Codegen::DispatchLoweringPassPipeline::None) {
-    // No pipeline specified, nothing to do.
-    return;
-  } else {
-    funcOp.emitOpError("unsupported pipeline on GPU target.");
+    funcOp.emitOpError("unsupported pipeline on GPU target");
+    return signalPassFailure();
+  }
+  IREE::GPU::GPUPipelineOptions pipelineOptions =
+      IREE::GPU::getPipelineOptions(funcOp, translationInfo);
+  GPUCodegenPipelineOptions gpuOpts(pipelineOptions, forROCDL);
+
+  if (failed(pipelineIface.buildPipeline(pipeline, &gpuOpts))) {
+    funcOp.emitOpError("failed to build pass pipeline");
     return signalPassFailure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
@@ -87,44 +88,47 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
   IREE::GPU::GPUPipelineOptions pipelineOptions =
       IREE::GPU::getPipelineOptions(funcOp, translationInfo);
 
-  // Check for a custom pipeline via PipelineAttrInterface.
   Attribute pipelineAttr = translationInfo.getPassPipeline();
-  if (auto customPipeline =
-          dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr)) {
+
+  // Check for GPU pipeline attribute (#iree_gpu.pipeline<...>).
+  if (auto gpuPipeline = dyn_cast<IREE::GPU::PipelineAttr>(pipelineAttr)) {
+    switch (gpuPipeline.getValue()) {
+    case IREE::GPU::LoweringPipeline::Default:
+      addGPUDefaultPassPipeline(pipeline, pipelineOptions);
+      break;
+    case IREE::GPU::LoweringPipeline::BaseLowering:
+      addGPUBaseLoweringPassPipeline(pipeline);
+      break;
+    case IREE::GPU::LoweringPipeline::Distribute:
+      addGPUSimpleDistributePassPipeline(pipeline);
+      break;
+    case IREE::GPU::LoweringPipeline::Vectorize:
+      addGPUVectorizationPassPipeline(pipeline);
+      break;
+    case IREE::GPU::LoweringPipeline::WinogradVectorize:
+      addGPUWinogradVectorizePassPipeline(pipeline);
+      break;
+    case IREE::GPU::LoweringPipeline::VectorDistribute:
+      addGPUVectorDistributePassPipeline(pipeline, pipelineOptions, forROCDL);
+      break;
+    case IREE::GPU::LoweringPipeline::TileAndFuse:
+      addGPUTileAndFusePassPipeline(pipeline, pipelineOptions, forROCDL);
+      break;
+    }
+  } else if (auto customPipeline =
+                 dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr)) {
+    // Check for a custom pipeline via PipelineAttrInterface.
     if (failed(customPipeline.buildPipeline(pipeline))) {
       funcOp.emitOpError("failed to build custom pass pipeline");
       return signalPassFailure();
     }
-  } else {
-    switch (translationInfo.getDispatchLoweringPassPipeline()) {
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDefault:
-      addGPUDefaultPassPipeline(pipeline, pipelineOptions);
-      break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUBaseLowering:
-      addGPUBaseLoweringPassPipeline(pipeline);
-      break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute:
-      addGPUSimpleDistributePassPipeline(pipeline);
-      break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorize:
-      addGPUVectorizationPassPipeline(pipeline);
-      break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUWinogradVectorize:
-      addGPUWinogradVectorizePassPipeline(pipeline);
-      break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorDistribute:
-      addGPUVectorDistributePassPipeline(pipeline, pipelineOptions, forROCDL);
-      break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse:
-      addGPUTileAndFusePassPipeline(pipeline, pipelineOptions, forROCDL);
-      break;
+  } else if (translationInfo.getDispatchLoweringPassPipeline() ==
+             IREE::Codegen::DispatchLoweringPassPipeline::None) {
     // No pipeline specified, nothing to do.
-    case IREE::Codegen::DispatchLoweringPassPipeline::None:
-      return;
-    default:
-      funcOp.emitOpError("unsupported pipeline on GPU target.");
-      return signalPassFailure();
-    }
+    return;
+  } else {
+    funcOp.emitOpError("unsupported pipeline on GPU target.");
+    return signalPassFailure();
   }
 
   if (failed(runPipeline(pipeline, funcOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "mlir/Pass/Pass.h"
@@ -48,8 +49,10 @@ static LogicalResult verifyLoweringConfiguration(
       return success();
     }
 
-    if (translationInfo.getDispatchLoweringPassPipeline() ==
-        IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorDistribute) {
+    auto gpuPipeline =
+        dyn_cast<IREE::GPU::PipelineAttr>(translationInfo.getPassPipeline());
+    if (gpuPipeline && gpuPipeline.getValue() ==
+                           IREE::GPU::LoweringPipeline::VectorDistribute) {
       return verifyLLVMGPUVectorDistributePipeline(op, loweringConfig);
     }
     return success();
@@ -89,9 +92,11 @@ void LLVMGPUSelectLoweringStrategyPass::runOnOperation() {
       return;
     }
 
-    // Custom pipelines via PipelineAttrInterface skip enum-based verification.
-    if (isa<IREE::Codegen::PipelineAttrInterface>(
-            translationInfo.getPassPipeline())) {
+    // Custom pipelines via PipelineAttrInterface skip enum-based verification
+    // (GPU::PipelineAttr is handled above via verifyLoweringConfiguration).
+    Attribute passPipeline = translationInfo.getPassPipeline();
+    if (isa<IREE::Codegen::PipelineAttrInterface>(passPipeline) &&
+        !isa<IREE::GPU::PipelineAttr>(passPipeline)) {
       continue;
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -13,6 +13,8 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/GPU/ExternalInterfaces/GPUPipelineExternalModels.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
@@ -1192,7 +1194,52 @@ namespace common {
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
 } // namespace common
 
+/// GPU pipeline builder callback. Dispatches GPU::PipelineAttr to the
+/// appropriate pass pipeline construction function.
+static LogicalResult buildGPUPipeline(Attribute attr, OpPassManager &pm,
+                                      const CodegenPipelineOptions *options) {
+  auto pipelineAttr = cast<IREE::GPU::PipelineAttr>(attr);
+  const auto *gpuOpts =
+      llvm::dyn_cast_if_present<GPUCodegenPipelineOptions>(options);
+  switch (pipelineAttr.getValue()) {
+  case IREE::GPU::LoweringPipeline::BaseLowering:
+    addGPUBaseLoweringPassPipeline(pm);
+    return success();
+  case IREE::GPU::LoweringPipeline::Distribute:
+    addGPUSimpleDistributePassPipeline(pm);
+    return success();
+  case IREE::GPU::LoweringPipeline::Vectorize:
+    addGPUVectorizationPassPipeline(pm);
+    return success();
+  case IREE::GPU::LoweringPipeline::WinogradVectorize:
+    addGPUWinogradVectorizePassPipeline(pm);
+    return success();
+  case IREE::GPU::LoweringPipeline::Default:
+    if (!gpuOpts) {
+      return failure();
+    }
+    addGPUDefaultPassPipeline(pm, gpuOpts->options);
+    return success();
+  case IREE::GPU::LoweringPipeline::VectorDistribute:
+    if (!gpuOpts) {
+      return failure();
+    }
+    addGPUVectorDistributePassPipeline(pm, gpuOpts->options, gpuOpts->forROCDL);
+    return success();
+  case IREE::GPU::LoweringPipeline::TileAndFuse:
+    if (!gpuOpts) {
+      return failure();
+    }
+    addGPUTileAndFusePassPipeline(pm, gpuOpts->options, gpuOpts->forROCDL);
+    return success();
+  }
+  return failure();
+}
+
 void registerCodegenLLVMGPUPasses() {
+  // Register GPU pipeline builder for the PipelineAttrInterface external model.
+  IREE::GPU::registerGPUPipelineBuilder(buildGPUPipeline);
+
   // Generated.
   common::registerPasses();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1199,8 +1199,7 @@ namespace common {
 static LogicalResult buildGPUPipeline(Attribute attr, OpPassManager &pm,
                                       const CodegenPipelineOptions *options) {
   auto pipelineAttr = cast<IREE::GPU::PipelineAttr>(attr);
-  const auto *gpuOpts =
-      llvm::dyn_cast_if_present<GPUCodegenPipelineOptions>(options);
+  const auto *gpuOpts = dyn_cast_if_present<GPUCodegenPipelineOptions>(options);
   switch (pipelineAttr.getValue()) {
   case IREE::GPU::LoweringPipeline::BaseLowering:
     addGPUBaseLoweringPassPipeline(pm);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -18,6 +18,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "iree/compiler/Codegen/Utils/CodegenOptions.h"
+#include "iree/compiler/Codegen/Utils/CodegenPipelineOptions.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Pass/Pass.h"
 
@@ -78,6 +79,21 @@ void buildLLVMGPUCodegenConfigurationPassPipeline(
 /// the module within the IREE::HAL::ExecutableOp.
 void buildLLVMGPUCodegenPassPipeline(OpPassManager &variantPassManagery,
                                      bool useROCM, bool preserveDebugInfo);
+
+/// Wraps GPUPipelineOptions and forROCDL for passing through
+/// PipelineAttrInterface::buildPipeline.
+struct GPUCodegenPipelineOptions final : CodegenPipelineOptions {
+  GPUCodegenPipelineOptions(const GPUPipelineOptions &options, bool forROCDL)
+      : CodegenPipelineOptions(TypeID::get<GPUCodegenPipelineOptions>()),
+        options(options), forROCDL(forROCDL) {}
+
+  static bool classof(const CodegenPipelineOptions *opts) {
+    return opts->getTypeID() == TypeID::get<GPUCodegenPipelineOptions>();
+  }
+
+  GPUPipelineOptions options;
+  bool forROCDL = false;
+};
 
 /// Verify configuration set for the LLVMGPUVectorDistribute pass pipeline.
 LogicalResult verifyLLVMGPUVectorDistributePipeline(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_tile_and_fuse_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_tile_and_fuse_sm80.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=sm_80 \
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
-// Test that sm_80 selects LLVMGPUTileAndFuse with NV_MMA_SYNC intrinsics by default.
+// Test that sm_80 selects #iree_gpu.pipeline<TileAndFuse> with NV_MMA_SYNC intrinsics by default.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -24,7 +24,7 @@ func.func @matmul_256x256x256_f16_f32() {
 }
 
 // CHECK-LABEL: func.func @matmul_256x256x256_f16_f32(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 32
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 32
 
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F32_16x8x16_F16>
@@ -58,7 +58,7 @@ func.func @matmul_256x256x256_f16_f16() {
 }
 
 // CHECK-LABEL: func.func @matmul_256x256x256_f16_f16(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 32
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 32
 
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F16_16x8x16_F16>
@@ -86,7 +86,7 @@ func.func @matmul_accumulate_256x256x256_f16_f32() {
 }
 
 // CHECK-LABEL: func.func @matmul_accumulate_256x256x256_f16_f32(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 32
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 32
 
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     convert_acc_gemm

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_vector_distribute_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_vector_distribute_sm80.mlir
@@ -3,7 +3,7 @@
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
 // Test that sm_80 selects NV_MMA_SYNC intrinsics for matmul operations.
-// With --iree-codegen-llvmgpu-use-vector-distribution, it should select LLVMGPUVectorDistribute.
+// With --iree-codegen-llvmgpu-use-vector-distribution, it should select #iree_gpu.pipeline<VectorDistribute>.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -25,7 +25,7 @@ func.func @matmul_256x256x256_f16_f32() {
   return
 }
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // Verify that the matmul gets NV_MMA_SYNC_F32 intrinsic.
 // CHECK-LABEL: func.func @matmul_256x256x256_f16_f32()
 // CHECK:       linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
@@ -55,7 +55,7 @@ func.func @matmul_256x256x256_f16_f16() {
   return
 }
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // Verify that the f16 output matmul gets NV_MMA_SYNC_F16 intrinsic.
 // CHECK-LABEL: func.func @matmul_256x256x256_f16_f16()
 // CHECK:       linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_sm80.mlir
@@ -23,7 +23,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_tile_and_fuse_mma_sync()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 32>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 32>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -86,7 +86,7 @@ hal.executable public @main_f16 {
     }
     builtin.module {
       func.func @matmul_tile_and_fuse_mma_sync_f16()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 32>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 32>} {
         %cst = arith.constant 0.000000e+00 : f16
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout_f16) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_vector_distribute_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_vector_distribute_sm80.mlir
@@ -6,7 +6,7 @@
 // Test matmul lowering with NV_MMA_SYNC intrinsics produces nvgpu.mma.sync operations.
 
 #config = #iree_gpu.lowering_config<{workgroup = [32, 16, 0], reduction = [0, 0, 32], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F32_16x8x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 1, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 1, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -53,7 +53,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 // Test with F16 accumulator
 
 #config_f16 = #iree_gpu.lowering_config<{workgroup = [32, 16, 0], reduction = [0, 0, 32], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F16_16x8x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation_f16 = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 1, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation_f16 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 1, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout_f16 = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
@@ -17,7 +17,7 @@ func.func @conv_nhwc_fhwc(%arg0: tensor<16x50x34x576xf16>, %arg1: tensor<576x3x3
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_fhwc
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -39,7 +39,7 @@ func.func @conv_nhwc_named_dynamic(%arg0: tensor<16x?x34x576xf16>, %arg1: tensor
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_named_dynamic
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -69,7 +69,7 @@ func.func @conv_nhwc_fhwc_unaligned(%arg0: tensor<16x26x19x287xf16>, %arg1: tens
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_fhwc_unaligned
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -100,7 +100,7 @@ func.func @group_conv_hwgc_gfhwc_unaligned(%arg0: tensor<61x93x16x56xbf16>, %arg
 }
 
 // CHECK-LABEL: func.func @group_conv_hwgc_gfhwc_unaligned
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -130,7 +130,7 @@ func.func @conv_nhwc_fhc_two_batch_dims(%arg0: tensor<16x50x32x576xf16>, %arg1: 
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_fhc_two_batch_dims
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -153,7 +153,7 @@ func.func @conv_nchw_named(%3: tensor<2x128x34x34xf32>, %4: tensor<64x128x3x3xf3
 }
 
 // CHECK-LABEL: func.func @conv_nchw_named
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -183,7 +183,7 @@ func.func @conv_chwn_fhwn(%arg0: tensor<16x26x18x144xf16>, %arg1: tensor<16x24x1
 }
 
 // CHECK-LABEL: func.func @conv_chwn_fhwn
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -16,7 +16,7 @@ func.func @nhwc_conv_mfma(%3: tensor<2x34x34x128xf32>, %4: tensor<3x3x128x64xf32
 }
 
 // CHECK-LABEL: func.func @nhwc_conv_mfma
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -43,7 +43,7 @@ func.func @nchw_conv_mfma(%3: tensor<2x128x34x34xf32>, %4: tensor<64x128x3x3xf32
 }
 
 // CHECK-LABEL: func.func @nchw_conv_mfma
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -70,7 +70,7 @@ func.func @nhwc_conv_unaligned_mfma(%3: tensor<2x33x33x128xf32>, %4: tensor<3x3x
 }
 
 // CHECK-LABEL: func.func @nhwc_conv_unaligned_mfma
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -102,7 +102,7 @@ func.func @nchw_conv_unaligned_mfma(%3: tensor<2x128x34x34xf32>, %4: tensor<63x1
 }
 
 // CHECK-LABEL: func.func @nchw_conv_unaligned_mfma
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -141,7 +141,7 @@ func.func @conv_nhwc_fhwc_unaligned_channel(%arg0: tensor<16x26x19x287xf16>, %ar
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_fhwc_unaligned_channel
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -180,7 +180,7 @@ func.func @conv_chwn_chwf_unaligned_batch(%arg0: tensor<16x193x129x40xbf16>, %ar
 }
 
 // CHECK-LABEL: func.func @conv_chwn_chwf_unaligned_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -212,7 +212,7 @@ func.func @group_conv_hwgc_gfhwc_unaligned(%arg0: tensor<61x93x16x55xbf16>, %arg
 }
 
 // CHECK-LABEL: func.func @group_conv_hwgc_gfhwc_unaligned
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
@@ -252,7 +252,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_filter_5x1_unaligned
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_reduction_transposed_output.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_reduction_transposed_output.mlir
@@ -5,13 +5,13 @@
 // RUN:   | FileCheck %s
 
 // Verify that reductions fused with multi-output generics that have transposed
-// outputs select LLVMGPUVectorDistribute and attach lowering configs to the
+// outputs select #iree_gpu.pipeline<VectorDistribute> and attach lowering configs to the
 // parallel op with the transposed output.
 
 // 2D case: reduction over dim 1, elementwise with (d0, d1) -> (d1, d0) output.
 
 // CHECK-LABEL: func.func @reduction_2d_transposed_output
-//  CHECK-SAME:   pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME:   pipeline = #iree_gpu.pipeline<VectorDistribute>
 //       CHECK:   linalg.generic {{.*}} iterator_types = ["parallel", "reduction"]
 //  CHECK-SAME:     lowering_config
 //       CHECK:   linalg.generic {{.*}} iterator_types = ["parallel", "parallel"]
@@ -58,7 +58,7 @@ func.func @reduction_2d_transposed_output(
 // 3D case: reduction over dim 2, elementwise with (d0, d1, d2) -> (d0, d2, d1) output.
 
 // CHECK-LABEL: func.func @reduction_3d_transposed_output
-//  CHECK-SAME:   pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME:   pipeline = #iree_gpu.pipeline<VectorDistribute>
 //       CHECK:   linalg.generic {{.*}} iterator_types = ["parallel", "parallel", "reduction"]
 //  CHECK-SAME:     lowering_config
 //       CHECK:   linalg.generic {{.*}} iterator_types = ["parallel", "parallel", "parallel"]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -29,7 +29,7 @@ func.func @expanded_matmul_transpose_b(%lhs: tensor<2x64x2048xf16>, %rhs: tensor
 }
 
 // CHECK-LABEL: func.func @expanded_matmul_transpose_b(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
 
 // Verify that the fill does not have the lowering config propagated to it.
@@ -66,7 +66,7 @@ func.func @multi_dim_mma_schedule(%lhs: tensor<10x32x128x16xf16>, %rhs: tensor<4
 }
 
 // CHECK-LABEL: func.func @multi_dim_mma_schedule(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
@@ -103,7 +103,7 @@ func.func @dynamic_multi_dim_mma_schedule(%lhs: tensor<?x6x16x?x16xf16>, %rhs: t
 }
 
 // CHECK-LABEL: func.func @dynamic_multi_dim_mma_schedule(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
@@ -124,7 +124,7 @@ func.func @mfma_matmul_1024x1024x1024(%lhs: tensor<1024x1024xf16>, %rhs: tensor<
 }
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
 
 // Verify that the fill does not have the lowering config propagated to it.
@@ -185,7 +185,7 @@ func.func @mfma_matmul_k_aligned_intrinsic(%lhs: tensor<1024x360xf16>, %rhs: ten
 }
 
 // CHECK-LABEL: func.func @mfma_matmul_k_aligned_intrinsic(
-// CHECK:         pipeline = LLVMGPUTileAndFuse
+// CHECK:         pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK:         linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:    mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
 
@@ -218,7 +218,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @conv_nhwc(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 3, 4]
 //  CHECK-SAME:     thread = [1, 1, 1, 1, 0, 0, 0]
@@ -233,7 +233,7 @@ func.func @matmul_dynamic_M(%arg0: tensor<?x256xf32>, %arg1: tensor<256x256xf32>
 }
 
 // CHECK-LABEL: func.func @matmul_dynamic_M(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     promote_operands = [0, 1]
 //  CHECK-SAME:     reduction = [0, 0, 4]
@@ -253,7 +253,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @elementwise_dynamic_dim(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.add {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 4]
 //  CHECK-SAME:     workgroup = [1, 256]
@@ -267,7 +267,7 @@ func.func @elementwise_unaligned(%11: tensor<180x180xf16>, %12: tensor<180x180xf
 }
 
 // CHECK-LABEL: func.func @elementwise_unaligned(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // -----
 
@@ -280,7 +280,7 @@ func.func @elementwise_large_rank(%11: tensor<3x5x7x11x13x17x19x23xf16>, %12: te
 // Verify that a lowering config is set on large rank tensors with unaligned
 // shapes.
 // CHECK-LABEL: func.func @elementwise_large_rank(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // -----
 
@@ -304,7 +304,7 @@ func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32(
 }
 
 // CHECK-LABEL: func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     reduction = [0, 0, 1]
@@ -321,7 +321,7 @@ func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x8x577xf32>, %r
 }
 
 // CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul(
-// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64
 // CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
 // CHECK:         linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:     reduction = [0, 0, 0, 1]
@@ -344,7 +344,7 @@ func.func @unaligned_matmul_with_two_reduce_dim(%arg0: tensor<196x9x4xf32>, %arg
 }
 
 // CHECK-LABEL: func.func @unaligned_matmul_with_two_reduce_dim(
-// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64
 // CHECK:       linalg.generic
 // CHECK-SAME:  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
 // CHECK-SAME:  padding = [64, 1, 16, 4]
@@ -369,7 +369,7 @@ func.func @aligned_dynamic_matmul_with_two_reduce_dim(%arg0: tensor<192x?x16xf32
 }
 
 // CHECK-LABEL: func.func @aligned_dynamic_matmul_with_two_reduce_dim(
-// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64
 // CHECK:       linalg.generic
 // CHECK-SAME:  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
 // CHECK-SAME:  promote_operands = [0, 1]
@@ -393,7 +393,7 @@ func.func @unaligned_dynamic_matmul_with_two_reduce_dim(%arg0: tensor<196x?x4xf3
 }
 
 // CHECK-LABEL: func.func @unaligned_dynamic_matmul_with_two_reduce_dim(
-// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK:       linalg.generic
 // CHECK-SAME:  promote_operands = [0, 1]
 // CHECK-SAME:  reduction = [0, 4, 0, 4],
@@ -418,7 +418,7 @@ func.func @unaligned_to_intrinsic_batched_matmul_tiling_check(%lhs : tensor<12x5
 // schedule with nTileSize of 16 while in reality it should be 8.
 
 // CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul_tiling_check(
-// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 // CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
 // CHECK:         linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:      padding = [1, 64, 128, 4]
@@ -441,7 +441,7 @@ func.func @unaligned_matmul_nn_layout(%lhs : tensor<513x513xf16>, %rhs : tensor<
 // benefit from relaxed padding policy.
 
 // CHECK-LABEL: func.func @unaligned_matmul_nn_layout(
-// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 // CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
 // CHECK:         linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
@@ -466,7 +466,7 @@ func.func @large_scatter(%arg0: tensor<3x2048x2048xf32>,
 }
 
 // CHECK-LABEL: func.func @large_scatter(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 4]
@@ -487,7 +487,7 @@ func.func @small_scatter(%arg0: tensor<3x32x16xf32>,
 }
 
 // CHECK-LABEL: func.func @small_scatter(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 4]
@@ -508,7 +508,7 @@ func.func @smaller_scatter(%arg0: tensor<3x4x16xf32>,
 }
 
 // CHECK-LABEL: func.func @smaller_scatter(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 4]
@@ -529,7 +529,7 @@ func.func @only_scattered_dim(%arg0: tensor<48xf32>,
 }
 
 // CHECK-LABEL: func.func @only_scattered_dim(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [128, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Distribute> workgroup_size = [128, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_codegen.lowering_config
 //  CHECK-SAME:     tile_sizes = {{\[}}[128]]
@@ -549,7 +549,7 @@ func.func @dynamic_scatter(%arg0: tensor<3x32x?xf32>,
 }
 
 // CHECK-LABEL: func.func @dynamic_scatter(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 4]
@@ -573,7 +573,7 @@ func.func @elementwise_scatter(%arg0: tensor<3x2048x2048xf32>,
 }
 
 // CHECK-LABEL: func.func @elementwise_scatter(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg.add {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 4]
@@ -638,7 +638,7 @@ func.func @set_encoding_gpu(%0 : tensor<1234x567xi8>) -> tensor<10x9x8x4x4x4x2x8
 }
 
 // CHECK-LABEL: func.func @set_encoding_gpu(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 1, 1, 1, 1, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 8, 4, 4, 4, 2, 8]
@@ -666,7 +666,7 @@ func.func @unset_encoding_gpu(%arg0: tensor<10x5x4x8x2x4x16x4xi32>) -> tensor<12
 }
 
 // CHECK-LABEL: func.func @unset_encoding_gpu(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 1, 1, 1, 1, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 4, 8, 4, 4, 16, 2]
@@ -692,7 +692,7 @@ func.func @pack_dynamic_producer(%arg0: tensor<?x?xi8>, %d0: index, %d1: index, 
 }
 
 // CHECK-LABEL: func.func @pack_dynamic_producer(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [1, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1]
 //  CHECK-SAME:     workgroup = [32, 32]
@@ -718,7 +718,7 @@ func.func @pack_full_tile(%arg0: tensor<32x32xi8>) -> tensor<1x1x32x32xi8> {
 }
 
 // CHECK-LABEL: func.func @pack_full_tile(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 4]
 //  CHECK-SAME:     workgroup = [32, 32]
@@ -744,7 +744,7 @@ func.func @pack_dynamic_tile(%arg0: tensor<32x32xi8>, %d0: index, %d1: index, %t
 }
 
 // CHECK-LABEL: func.func @pack_dynamic_tile(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 4]
 //  CHECK-SAME:     workgroup = [8, 32]
@@ -763,7 +763,7 @@ func.func @single_pack(%arg0: tensor<100x250xi32>) -> tensor<16x4x16x32xi32> {
 }
 
 // CHECK-LABEL: func.func @single_pack(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.pack {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 4]
 //  CHECK-SAME:     workgroup = [1, 1, 16, 32]
@@ -789,7 +789,7 @@ func.func @unpack_pack(%arg0: tensor<8x4x32x32xi32>) -> tensor<16x4x16x32xi32> {
 }
 
 // CHECK-LABEL: func.func @unpack_pack(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.pack {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 4]
 //  CHECK-SAME:     workgroup = [2, 1, 16, 32]
@@ -811,7 +811,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @erf(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 8]
 //  CHECK-SAME:     workgroup = [1, 1, 512]
@@ -829,7 +829,7 @@ func.func @map_store(%arg0: tensor<100x250xi32>) -> tensor<100x250xi32> {
 }
 
 // CHECK-LABEL: func.func @map_store(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   iree_linalg_ext.map_store {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1]
 //  CHECK-SAME:     workgroup = [1, 64]
@@ -848,7 +848,7 @@ func.func @small_reduction(%arg0 : tensor<2x?xf32>, %arg1 : tensor<?xf32>, %arg2
   return %0 : tensor<?xf32>
 }
 // CHECK-LABEL: @small_reduction(
-// CHECK-SAME:     #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK-SAME:     #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 
 // -----
 
@@ -871,7 +871,7 @@ func.func @fully_dyn_elementwise(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
 }
 
 // CHECK-LABEL: func.func @fully_dyn_elementwise(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1]
 //  CHECK-SAME:     workgroup = [1, 64]
@@ -899,7 +899,7 @@ func.func @dyn_parallel_reduction(%arg0: tensor<?x32xf32>) -> tensor<?xf32> {
 }
 
 // CHECK-LABEL: func.func @dyn_parallel_reduction(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     reduction = [0, 4]
 //  CHECK-SAME:     thread = [1, 0]
@@ -935,7 +935,7 @@ func.func @multi_result_index_generic_with_scatterfusion(%arg0: tensor<4x?x32x8x
 }
 
 // CHECK-LABEL: func.func @multi_result_index_generic_with_scatterfusion(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 4]
 //  CHECK-SAME:     workgroup = [1, 1, 32, 8]
@@ -976,7 +976,7 @@ func.func @producer_broadcasted(%arg0: tensor<4xi64>, %arg1: tensor<4xi64>) -> t
 }
 
 // CHECK-LABEL: func.func @producer_broadcasted(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //       CHECK:     thread = [1, 1]
 //  CHECK-SAME:     workgroup = [4, 16]
@@ -1018,7 +1018,7 @@ func.func @producer_broadcasted_and_stored_to_buffer(%arg0: tensor<4xi64>, %arg1
 }
 
 // CHECK-LABEL: func.func @producer_broadcasted_and_stored_to_buffer(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //       CHECK:     reduction = [0, 4]
 //  CHECK-SAME:     thread = [1, 0]
@@ -1063,7 +1063,7 @@ func.func @producer_broadcasted_and_stored_to_buffer2(%arg0: tensor<4xi64>, %arg
 }
 
 // CHECK-LABEL: func.func @producer_broadcasted_and_stored_to_buffer2(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //       CHECK:     reduction = [0, 4]
 //  CHECK-SAME:     thread = [1, 0]
@@ -1138,7 +1138,7 @@ func.func @mixed_precision_matmul_f32xbf16(%lhs: tensor<16x64xf32>, %rhs: tensor
 }
 
 // CHECK-LABEL: func.func @mixed_precision_matmul_f32xbf16(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 //   CHECK-NOT:     mma_kind
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx1201.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx1201.mlir
@@ -22,7 +22,7 @@ func.func @matmul_small_f16(%arg0: tensor<64x1280xf16>, %arg1: tensor<1280x1280x
 }
 
 // GEMM-LABEL: func.func @matmul_small_f16
-//  GEMM-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  GEMM-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //  GEMM-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
 //       GEMM:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  GEMM-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
@@ -46,7 +46,7 @@ func.func @matmul_medium_f16(%arg0: tensor<2048x1280xf16>, %arg1: tensor<1280x12
 }
 
 // GEMM-LABEL: func.func @matmul_medium_f16
-//  GEMM-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  GEMM-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //  GEMM-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
 //       GEMM:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  GEMM-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
@@ -70,7 +70,7 @@ func.func @matmul_large_f16(%arg0: tensor<4096x4096xf16>, %arg1: tensor<4096x409
 }
 
 // GEMM-LABEL: func.func @matmul_large_f16
-//  GEMM-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  GEMM-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //  GEMM-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 32
 //       GEMM:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  GEMM-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
@@ -96,7 +96,7 @@ func.func @conv_small_f16(%arg0: tensor<1x18x18x16xf16>, %arg1: tensor<32x3x3x16
 }
 
 // CONV-LABEL: func.func @conv_small_f16
-//  CONV-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CONV-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //  CONV-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
 //       CONV:   linalg.conv_2d_nhwc_fhwc {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CONV-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
@@ -122,7 +122,7 @@ func.func @conv_medium_f16(%arg0: tensor<2x66x66x128xf16>, %arg1: tensor<128x3x3
 }
 
 // CONV-LABEL: func.func @conv_medium_f16
-//  CONV-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CONV-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //  CONV-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
 //       CONV:   linalg.conv_2d_nhwc_fhwc {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CONV-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
@@ -148,7 +148,7 @@ func.func @conv_large_f16(%arg0: tensor<16x50x34x576xf16>, %arg1: tensor<576x3x3
 }
 
 // CONV-LABEL: func.func @conv_large_f16
-//  CONV-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CONV-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //  CONV-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
 //       CONV:   linalg.conv_2d_nhwc_fhwc {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CONV-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -43,7 +43,7 @@ func.func @scaled_matmul(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
@@ -89,7 +89,7 @@ func.func @scaled_matmul_with_batch(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_with_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
@@ -135,7 +135,7 @@ func.func @scaled_matmul_with_dynamic_red_dim(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_with_dynamic_red_dim
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //   CHECK-NOT:     mma_kind
 
@@ -163,7 +163,7 @@ func.func @scaled_matmul_with_dynamic_batch(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_with_dynamic_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
@@ -209,7 +209,7 @@ func.func @small_scaled_matmul(
 }
 
 // CHECK-LABEL: func.func @small_scaled_matmul
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
@@ -253,7 +253,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @data_tiled_scaled_mma_inner_tiled
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     promote_operands = [0, 1]
@@ -289,7 +289,7 @@ func.func @data_tiled_scaled_mma_inner_tiled_with_copy(
 }
 
 // CHECK-LABEL: func.func @data_tiled_scaled_mma_inner_tiled_with_copy
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
 //       CHECK:   linalg.copy
 //   CHECK-NOT:   lowering_config
@@ -331,7 +331,7 @@ func.func @scaled_matmul_accumulate(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_accumulate
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [512, 1, 1] subgroup_size = 64
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
@@ -365,7 +365,7 @@ func.func @matmul_f16_compute_bound(
   return %0 : tensor<16384x16384xf32>
 }
 // CHECK-LABEL: func.func @matmul_f16_compute_bound
-// CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK:   lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME: mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16>
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -9,10 +9,10 @@
 
 // Check that applying the `no_reduce_shared_memory_bank_conflicts` pipeline option attribute disables shared memory padding.
 
-// OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>
 
-// OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>
 #config = #iree_gpu.lowering_config<{workgroup = [128, 128, 0], reduction = [0, 0, 32], promote_operands = [0, 1],
                                     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -44,7 +44,7 @@ hal.executable public @main_0_dispatch_0 {
       // OPT-IN:         } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64, {
           gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>  // Disable the 'reduceSharedMemoryBankConflicts' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f32
@@ -81,10 +81,10 @@ hal.executable public @main_0_dispatch_0 {
 
 // Check that applying the `reorder_workgroups_strategy = <Transpose>` pipeline option attribute enables workgroup reordering.
 
-// OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <Transpose>>
 
-// OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <Transpose>>
 #config = #iree_gpu.lowering_config<{workgroup = [128, 128, 0], reduction = [0, 0, 32], promote_operands = [0, 1],
                                     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -115,7 +115,7 @@ hal.executable public @main_0_dispatch_0 {
       // OPT-IN:          scf.for
       // OPT-IN:         } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64, {
           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <Transpose>>  // enable the 'reorderWorkgroups' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f32
@@ -151,7 +151,7 @@ hal.executable public @main_0_dispatch_0 {
 // -----
 // Check that applying the `reorder_workgroups_strategy = <None>` pipeline option disables workgroup reordering.
 
-// OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <None>>
 #config = #iree_gpu.lowering_config<{workgroup = [128, 128, 0], reduction = [0, 0, 32], promote_operands = [0, 1],
                                     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -175,7 +175,7 @@ hal.executable public @main_0_dispatch_0 {
       // OPT-OUT:          scf.for
       // OPT-OUT:         } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 2, 1] subgroup_size = 64, {
           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <None>>  // Disable the 'reorderWorkgroups' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx1100.mlir
@@ -6,7 +6,7 @@
 // to be migrated to the rocdl heuristics, but for now is just physically
 // located here.
 
-// WMMA:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// WMMA:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // WMMA-SAME: workgroup_size = [128, 1, 1]
 // WMMA-SAME: subgroup_size = 32
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -7,7 +7,7 @@
 // to be migrated to the rocdl heuristics, but for now is just physically
 // located here.
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -46,7 +46,7 @@ func.func @expanded_matmul_transpose_b() {
 
 // -----
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -106,11 +106,11 @@ func.func @matmul_256x256x256() attributes {hal.executable.target = #executable_
 
 // Check that we do not use the distribute pipeline if there are no supported
 // intrinsics.
-//       CHECK-NOT: iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//       CHECK-NOT: iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 // -----
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -141,7 +141,7 @@ func.func @mfma_matmul_1024x1024x1024() {
 
 // -----
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -191,7 +191,7 @@ func.func @conv_nchwc() {
 
 // -----
 
-//       CHECK: iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//       CHECK: iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -232,7 +232,7 @@ func.func @matmul_dynamic_dim() {
 
 // -----
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-NOT:   prefetch_num_stages = 2
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
@@ -277,7 +277,7 @@ func.func @attention_20x4096x64x4096x64() {
 
 // -----
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-NOT:   prefetch_num_stages = 2
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64_f8()
@@ -323,7 +323,7 @@ func.func @attention_20x4096x64x4096x64_f8() {
 
 // -----
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-NOT:   prefetch_num_stages = 2
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
@@ -371,7 +371,7 @@ func.func @attention_large_head_dim_shared_mem() {
 
 // -----
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-LABEL: func.func @attention_20x64x4096x64_f8()
 
 // Test that the config logic can handle a missing M dimension.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -7,7 +7,7 @@
 // to be migrated to the rocdl heuristics, but for now is just physically
 // located here.
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -46,7 +46,7 @@ func.func @expanded_matmul_transpose_b() {
 
 // -----
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -77,7 +77,7 @@ func.func @conv_nhwc() {
 
 // -----
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -108,7 +108,7 @@ func.func @mfma_matmul_1024x1024x1024() {
 
 // -----
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -187,11 +187,11 @@ func.func @matmul_dynamic_dim() {
   return
 }
 // Check that we have unhandled dynamic dimension.
-//       CHECK-NOT: iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//       CHECK-NOT: iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 // -----
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-NOT:   prefetch_num_stages = 2
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
@@ -235,7 +235,7 @@ func.func @attention_20x4096x64x4096x64() {
 
 // -----
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-NOT:   prefetch_num_stages = 2
 // CHECK:       iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
 
@@ -289,7 +289,7 @@ func.func @attention_large_head_dim_shared_mem() {
 // and the QK matmul used MFMA_F32_32x32x64_F8E4M3FN. Vector distribution failed
 // to distribute these layouts to threads.
 
-//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+//       CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64
 // CHECK:       iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
 // CHECK-LABEL: func.func @attention_check_mma_accs_compatible
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -2,7 +2,7 @@
 // RUN:   --iree-codegen-llvmgpu-use-igemm=false \
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-SAME: iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -80,7 +80,7 @@ func.func @reduction_with_no_consumer() {
     iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [2, 32], strides = [1, 1] : tensor<2x32xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32xf32>>
     return
 }
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 // CHECK-LABEL: func.func @reduction_with_no_consumer
 // CHECK:           lowering_config = #iree_gpu.lowering_config
@@ -245,7 +245,7 @@ func.func @nhwc_layernorm_small_channel() {
 // to satisfy the constraint from the parallel operations' last parallel
 // dim (3).
 
-// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 
 // CHECK-LABEL: func.func @nhwc_layernorm_small_channel
 // CHECK:       linalg.generic {{.*}} iterator_types = ["parallel", "reduction", "reduction"]{{.*}} thread = [0, 1, 1]
@@ -276,7 +276,7 @@ func.func @test_dyn_reduction(%arg0: !iree_tensor_ext.dispatch.tensor<readwrite:
   iree_tensor_ext.dispatch.tensor.store %5, %arg0, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<128x128xf32>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //       CHECK: func.func @test_dyn_reduction
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -316,7 +316,7 @@ func.func @test_multiple_stores(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
   iree_tensor_ext.dispatch.tensor.store %5, %arg4, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : tensor<4x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [1024, 1, 1] subgroup_size = 64
 //       CHECK: func.func @test_multiple_stores
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -362,7 +362,7 @@ func.func @test_gather_config(%arg0: !iree_tensor_ext.dispatch.tensor<readonly:t
   iree_tensor_ext.dispatch.tensor.store %3, %arg2, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
   return
 }
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //      CHECK: func.func @test_gather_config
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.generic
@@ -407,7 +407,7 @@ func.func @split_reduction_config(%arg0 : tensor<?x131072xf32>,
       : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%1}
   return
 }
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //      CHECK: func @split_reduction_config
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
@@ -452,7 +452,7 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
   iree_codegen.store_to_buffer %12, %expand_shape : tensor<?x4xf32> into memref<?x4xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [512, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @test_store_to_buffer
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -507,7 +507,7 @@ func.func @batch_matvec_f16_f32() {
   return
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @batch_matvec_f16_f32
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs = {lowering_config = #iree_gpu.lowering_config<{

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx950.mlir
@@ -2,7 +2,7 @@
 // RUN:   --iree-codegen-llvmgpu-use-igemm=false \
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
-// Check that skinny scaled matmuls are sent down the LLVMGPUVectorDistribute pipeline.
+// Check that skinny scaled matmuls are sent down the #iree_gpu.pipeline<VectorDistribute> pipeline.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -46,5 +46,5 @@ func.func @skinny_scaled_matmul() {
   iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [4, 1024], sizes = [4, 1024], strides = [1, 1] : tensor<4x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1024xf32>>
   return
 }
-//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//       CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @skinny_scaled_matmul

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_direct_conv_tile_and_fuse.mlir
@@ -7,7 +7,7 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [512, 1, 1]
   subgroup_size = 64,
   {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -7,7 +7,7 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -91,7 +91,7 @@ hal.executable private @main {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -168,7 +168,7 @@ hal.executable private @main {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -241,7 +241,7 @@ hal.executable private @main {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse_gfx950.mlir
@@ -7,7 +7,7 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -69,7 +69,7 @@ hal.executable private @conv_nhwc_f16 {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation_unaligned = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -132,7 +132,7 @@ hal.executable private @conv_nhwc_unaligned_f16 {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #translation_backward = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -20,7 +20,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -98,7 +98,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_mfma()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 2, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 2, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -176,7 +176,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_wmmar3()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -258,7 +258,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_mfma_16x16x4()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 2, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 2, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : !aeltype
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280x!eltype>>
@@ -319,7 +319,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_mfma_16x16x32_f8()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 2, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 2, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : !aeltype
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280x!eltype>>
@@ -380,7 +380,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_mfma_32x32x16_i8()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 2, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 2, 1] subgroup_size = 64>} {
         %cst = arith.constant 0 : !aeltype
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280x!eltype>>
@@ -441,7 +441,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_wmmar3_f16_16x16x16_f16()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>} {
         %cst = arith.constant 0.000000e+00 : !aeltype
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280x!eltype>>
@@ -484,7 +484,7 @@ hal.executable public @main {
   workgroup = [1, 1, 4, 8, 0, 0, 0]
 }>
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [8, 4, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [8, 4, 1] subgroup_size = 32>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
@@ -547,7 +547,7 @@ hal.executable public @main {
   promote_operands = [0, 1]
 }>
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [8, 4, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [8, 4, 1] subgroup_size = 32>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
@@ -619,7 +619,7 @@ hal.executable public @main {
   #hal.pipeline.binding<storage_buffer, Indirect>
 ]>
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 2, 1] subgroup_size = 32>
 
 #lowering_config = #iree_gpu.lowering_config<{
   mma_kind = #iree_gpu.mma_layout<WMMAR3_I32_16x16x16_I8>,
@@ -685,7 +685,7 @@ hal.executable public @main {
   thread = [1, 1], workgroup = [1, 1]
 }>
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
@@ -737,7 +737,7 @@ hal.executable public @main {
   flags = Indirect
 >
 #translation_info = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -867,7 +867,7 @@ hal.executable public @main {
   thread = [1, 4, 0],
   workgroup = [1, 128, 0]
 }>
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 hal.executable public @main {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
@@ -938,7 +938,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @small_matvec()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x10xf32>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x1xf32>>
@@ -989,7 +989,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @elemwise_reduction_elemwise() attributes {
-        translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+        translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
       } {
         %cst_3 = arith.constant 3.0 : f32
         %cst_4 = arith.constant 4.0 : f32
@@ -1103,7 +1103,7 @@ hal.executable public @main {
     }
     builtin.module {
       func.func @matmul_transpose_b_promote_result()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 2, 1] subgroup_size = 64>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 2, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -1180,7 +1180,7 @@ hal.executable public @main {
   workgroup = [1, 16, 64, 0]
 }>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -1251,7 +1251,7 @@ hal.executable public @main {
   workgroup = [1, 16, 64, 0]
 }>
 #translation = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -1308,7 +1308,7 @@ hal.executable public @main {
   thread = [1, 1, 1, 4], workgroup = [1, 1, 16, 32]
 }>
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
@@ -1350,7 +1350,7 @@ hal.executable public @main {
 
 // -----
 
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 #lowering_config = #iree_gpu.lowering_config<{
   thread = [1, 4], workgroup = [1, 256]
 }>
@@ -1397,7 +1397,7 @@ hal.executable public @main {
 
 
 // -----
-#translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 #lowering_config = #iree_gpu.lowering_config<{thread = [1, 1, 1, 4], workgroup = [1, 1, 32, 8]}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -10,7 +10,7 @@
   flags = Indirect
 >
 #translation_info = #iree_codegen.translation_info<pipeline =
-  LLVMGPUTileAndFuse
+  #iree_gpu.pipeline<TileAndFuse>
   workgroup_size = [256, 1, 1]
   subgroup_size = 64,
   {
@@ -173,7 +173,7 @@ hal.executable public @matmul_transpose_b_f16 {
     }
     builtin.module {
       func.func @matmul_transpose_b_f16()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout_f16_transb) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -243,7 +243,7 @@ hal.executable public @matmul_transpose_b_i8 {
     }
     builtin.module {
       func.func @matmul_transpose_b_i8()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0 : i32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout_i8_transb) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xi8>>
@@ -314,7 +314,7 @@ hal.executable public @matmul_f16 {
     }
     builtin.module {
       func.func @matmul_f16()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout_f16) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf16>>
@@ -379,7 +379,7 @@ hal.executable public @matmul_i8 {
     }
     builtin.module {
       func.func @matmul_i8()
-        attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0 : i32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout_i8) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xi8>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_dynamic_shapes_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_dynamic_shapes_gfx942.mlir
@@ -14,7 +14,7 @@ hal.executable private @kernel {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @kernel() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>} {
+      func.func @kernel() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [512, 1, 1] subgroup_size = 64, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>} {
         %cst = arith.constant 0.0721687824 : f32
         %c32 = arith.constant 32 : index
         %cst_0 = arith.constant 0xFF800000 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -4,7 +4,7 @@
 // RUN:   %s | FileCheck %s
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -50,7 +50,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], mma_kind = #iree_gpu.mma_layout<WMMAR3_F16_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -102,7 +102,7 @@ hal.executable private @matvec_dispatch_0 {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
@@ -150,7 +150,7 @@ hal.executable private @matvec_dispatch_0 {
 #map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
 #map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 32, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 32, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>
 module {
   hal.executable public @attention {
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -9,7 +9,7 @@
 // RUN:   %s | FileCheck %s --check-prefix=MEMORY
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -54,7 +54,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -95,7 +95,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -173,7 +173,7 @@ hal.executable @matmul_multiple_k {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @matmul_multiple_k() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+      func.func @matmul_multiple_k() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>>
@@ -212,7 +212,7 @@ hal.executable @matmul_multiple_k {
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 16, n = 16, k = 32)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -257,7 +257,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic i8, i8 -> i32 matmul.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -302,7 +302,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 32, n = 32, k = 16)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -347,7 +347,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic i8, i8 -> i32 matmul_transpose_b.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -397,7 +397,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 128, 0, 0, 0], reduction = [0, 0, 0, 0, 1, 1, 32], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -439,7 +439,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 64, 1, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 2, 1], [0, 1, 2, 3, 4]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -513,7 +513,7 @@ hal.executable public @main_dispatch_expanded_matmul {
 //       but rather is an example of a matmul shape from a model that broke our compilation heuristic.
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 16, 128, 0], reduction = [0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 4, 1], [0, 1, 2, 3]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -566,7 +566,7 @@ hal.executable public @contract_schedule_considering_read_layout {
 // (intrinsic with shape, m = 32, n = 32, k = 16)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -627,7 +627,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // (intrinsic with shape m = 16, n = 16, k = 32)
 
 #config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -674,7 +674,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // This test ensures we can generate correct instructions from V(Virtual) MFMAs that has only different read layouts.
 
 #config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -751,7 +751,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
                                                     #hal.pipeline.binding<storage_buffer>,
                                                     #hal.pipeline.binding<storage_buffer>,
                                                     #hal.pipeline.binding<storage_buffer>]>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
 #config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 64], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 128, 0]}>
 
 hal.executable public @matmul_gather_rhs {
@@ -813,7 +813,7 @@ hal.executable public @matmul_gather_rhs {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 64, 0, 0, 64], reduction = [0, 0, 0, 64, 0], promote_operands = [0, 1, 2]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -885,7 +885,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 0, 0, 64], reduction = [0, 0, 0, 0, 64, 0], promote_operands = [0, 1, 2]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -952,7 +952,7 @@ hal.executable private @attention_multiple_m_transpose {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 64], reduction = [0, 0, 0, 0, 32, 0], promote_operands = [0, 1, 2]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -1025,7 +1025,7 @@ hal.executable private @attention_mfma_32x32x8 {
 !ROWRED_SK= tensor<1x4x16xf32>
 
 #config = #iree_gpu.lowering_config<{ workgroup = [1, 1, 16, 0, 0, 0], reduction = [0, 0, 0, 0, 0, 32],promote_operands = [0, 1, 2] }>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -1104,7 +1104,7 @@ hal.executable private @online_attention_split_k2 {
 #map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
 #map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>]>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {}>
 
 #qk_config = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, promote_operands = [0, 1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]]}>}
 #pv_config = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, promote_operands = [1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 5]]}>}
@@ -1174,7 +1174,7 @@ hal.executable private @matvec_dispatch_0 {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
@@ -1207,7 +1207,7 @@ hal.executable private @matvec_dispatch_0 {
 // -----
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
@@ -8,7 +8,7 @@
 // RUN:   %s | FileCheck %s --check-prefix=MEMORY
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -58,7 +58,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -104,7 +104,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 64, 0], reduction = [0, 0, 0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -186,7 +186,7 @@ hal.executable @matmul_multiple_k {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @matmul_multiple_k() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+      func.func @matmul_multiple_k() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>>
@@ -231,7 +231,7 @@ hal.executable @matmul_multiple_k {
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 16, n = 16, k = 128)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 1024], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x128_F8E4M3FN>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -282,7 +282,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic i8, i8 -> i32 matmul.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 512], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -333,7 +333,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 32, n = 32, k = 64)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 1024], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x64_F8E4M3FN>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -384,7 +384,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic i8, i8 -> i32 matmul_transpose_b.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 512], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -439,7 +439,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 64, 0, 0, 64], reduction = [0, 0, 0, 128, 0], promote_operands = [0, 1, 2]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -518,7 +518,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 64], reduction = [0, 0, 0, 0, 64, 0], promote_operands = [0, 1, 2]}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -598,7 +598,7 @@ hal.executable private @matvec_dispatch_0 {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -9,7 +9,7 @@
                                       subgroup_basis = [[1, 1, 1], [0, 1, 2]],
                                       lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
-#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
                                                workgroup_size = [64, 1, 1]
                                                subgroup_size = 64, {}>
 
@@ -66,7 +66,7 @@ hal.executable private @matvec_fp16 {
                                       subgroup_basis = [[1, 4, 1], [0, 1, 2]],
                                       lane_basis = [[1, 1, 64], [0, 1, 2]]}
 >
-#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
                                                workgroup_size = [256, 1, 1]
                                                subgroup_size = 64, {}>
 
@@ -124,7 +124,7 @@ hal.executable private @matvec_fp16_parallel_subgroup {
                                       lane_basis = [[1, 1, 64], [0, 1, 2]],
                                       promote_operands = [1]}
 >
-#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
                                                workgroup_size = [256, 1, 1]
                                                subgroup_size = 64, {}>
 
@@ -202,7 +202,7 @@ hal.executable private @matvec_fp16_promote_rhs {
                                         thread         = [0, 0, 4, 4],
                                         promote_operands = [1]}>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [256, 1, 1]
                                               subgroup_size = 64>
 
@@ -296,7 +296,7 @@ hal.executable private @attention_20x1x64x4096x64 {
                                         thread         = [0, 0, 4, 4],
                                         promote_operands = [1]}>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [256, 1, 1]
                                               subgroup_size = 64>
 
@@ -379,7 +379,7 @@ hal.executable private @attention_20x1x64x4096x64 {
                                       subgroup_basis = [[1, 1, 2], [0, 1, 2]],
                                       lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
-#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
                                                workgroup_size = [128, 1, 1]
                                                subgroup_size = 64, {}>
 
@@ -437,7 +437,7 @@ hal.executable private @matvec_fp16 {
                                       subgroup_basis = [[1, 1, 1], [0, 1, 2]],
                                       lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
-#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
                                                workgroup_size = [64, 1, 1]
                                                subgroup_size = 64, {}>
 
@@ -494,7 +494,7 @@ hal.executable private @matvec_fp16_unaligned {
 
 /// Paged attention reduction distribution to multiple subgroups.
 /// Distribute 8x32 reduction dims across 4 subbroups with 2x32 threads shape per subgroup.
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
 #pv_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], lane_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
 #qk_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], lane_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
 #attention_lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 0, 0, 0, 8, 0], workgroup = [1, 1, 1, 0, 0, 0, 0]}>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_complex_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_complex_matmul.mlir
@@ -6,10 +6,10 @@
 // RUN:   | FileCheck %s
 
 // Verify that complex element types do not crash the MMA heuristics and get
-// routed to a working pipeline (LLVMGPUTileAndFuse via the SIMT contraction
+// routed to a working pipeline (#iree_gpu.pipeline<TileAndFuse> via the SIMT contraction
 // config, not the MMA-based matmul config).
 
-//      CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-LABEL: func.func @complex_batch_matmul
 //      CHECK:   linalg.{{fill|generic}}
 //      CHECK:   lowering_config = #iree_gpu.lowering_config
@@ -31,7 +31,7 @@ func.func @complex_batch_matmul(%arg0: !TA, %arg1: !TB, %arg2: !DTC) {
 
 // -----
 
-//      CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-LABEL: func.func @complex_matmul
 //      CHECK:   linalg.{{fill|generic}}
 //      CHECK:   lowering_config = #iree_gpu.lowering_config

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
@@ -33,7 +33,7 @@ func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
   return %1 : tensor<384x128xf32>
 }
 //      CHECK: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128, 0]]>
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64,
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64,
 // CHECK-LABEL: func @custom_op
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   iree_linalg_ext.custom_op
@@ -46,7 +46,7 @@ func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
 // -----
 
 func.func @custom_op_preset_config(%arg0: tensor<384x512xf32>, %arg1: tensor<512x128xf32>, %arg2: tensor<128xf32>) -> tensor<384x128xf32>
-  attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse>} {
+  attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>>} {
   %cst = arith.constant 0.000000e+00 : f32
   %0 = tensor.empty() : tensor<384x128xf32>
   %1 = iree_linalg_ext.custom_op{
@@ -77,7 +77,7 @@ func.func @custom_op_preset_config(%arg0: tensor<384x512xf32>, %arg1: tensor<512
   return %1 : tensor<384x128xf32>
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[24, 32]]>
-//  CHECK-DAG: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse>
+//  CHECK-DAG: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>>
 //      CHECK: func @custom_op_preset_config(
 // CHECK-SAME:     translation_info = #[[TRANSLATION_INFO]]
 //      CHECK:   iree_linalg_ext.custom_op

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_gather_like_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_gather_like_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
 
-// CHECK:   LLVMGPUTileAndFuse
+// CHECK:   #iree_gpu.pipeline<TileAndFuse>
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 func.func @elementwise_broadcast(%3: tensor<128256x4096xf16>, %4: tensor<1024xi64>) -> tensor<1024x4096xf16> {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
@@ -69,7 +69,7 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 }
 // CHECK-LABEL: func @fused_contraction_1
 //  CHECK-SAME:     translation_info = #iree_codegen.translation_info
-//  CHECK-SAME:         pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME:         pipeline = #iree_gpu.pipeline<VectorDistribute>
 //  CHECK-SAME:         workgroup_size = [256, 1, 1]
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   linalg.generic
@@ -120,7 +120,7 @@ func.func @fused_contraction_2(%arg0: tensor<4096x640xf32>,
 }
 // CHECK-LABEL: func @fused_contraction_2
 //  CHECK-SAME:     translation_info = #iree_codegen.translation_info
-//  CHECK-SAME:         pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME:         pipeline = #iree_gpu.pipeline<VectorDistribute>
 //  CHECK-SAME:         workgroup_size = [256, 1, 1]
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   linalg.generic
@@ -185,7 +185,7 @@ func.func @fused_contraction_3(%arg0 : tensor<2x4096x640xi8>,
 }
 // CHECK-LABEL: func @fused_contraction_3
 //  CHECK-SAME:     translation_info = #iree_codegen.translation_info
-//  CHECK-SAME:         pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME:         pipeline = #iree_gpu.pipeline<VectorDistribute>
 //  CHECK-SAME:         workgroup_size = [256, 1, 1]
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   linalg.generic
@@ -271,7 +271,7 @@ func.func @fused_contraction_4(%arg0: tensor<2x4096x640xf16>,
 }
 // CHECK-LABEL: func @fused_contraction_4
 //  CHECK-SAME:     translation_info = #iree_codegen.translation_info
-//  CHECK-SAME:         pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME:         pipeline = #iree_gpu.pipeline<VectorDistribute>
 //  CHECK-SAME:         workgroup_size = [256, 1, 1]
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   linalg.generic

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
@@ -13,7 +13,7 @@
 !TC = tensor<32x32xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x32xf32>>
 
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {
 func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   // Sanity check that generalize/specialize works.
@@ -33,7 +33,7 @@ func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !TB = tensor<4096x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {
 func.func @matmul_4096_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK: {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
@@ -49,7 +49,7 @@ func.func @matmul_4096_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC
 !TB = tensor<32x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {
 func.func @matmul_4096_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK:  #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
@@ -66,7 +66,7 @@ func.func @matmul_4096_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) 
 !TB = tensor<1x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 64
 // CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 func.func @matmul_4096_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
@@ -87,7 +87,7 @@ func.func @matmul_4096_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !TB = tensor<32x32xf32>
 !TC = tensor<?x32xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x32xf32>>
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64>
 func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index) {
   // CHECK:       #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 4], thread = [1, 1, 0], workgroup = [1, 64, 0]}>
@@ -98,7 +98,7 @@ func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %ar
 
 // -----
 
-//      CHECK:         #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//      CHECK:         #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-SAME:         workgroup_size = [1024, 1, 1] subgroup_size = 64,
 // CHECK-SAME:         {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 !TA = tensor<?x4096xf32>
@@ -115,7 +115,7 @@ func.func @matmul_DYN_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC,
 
 // -----
 
-// CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+// CHECK:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 // CHECK:    #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 4], thread = [1, 4, 0], workgroup = [1, 256, 0]}
 !TA = tensor<?x32xf32>
 !TB = tensor<32x4096xf32>
@@ -129,7 +129,7 @@ func.func @matmul_DYN_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %
 
 // -----
 
-// CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+// CHECK:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 // CHECK:    #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 1], thread = [1, 4, 0], workgroup = [1, 256, 0]}
 !TA = tensor<?x1xf32>
 !TB = tensor<1x4096xf32>
@@ -152,7 +152,7 @@ func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %a
 !TC = tensor<32x32xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x32xf32>>
 
-//      CHECK:    #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:    #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:    workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 func.func @matmul_32_32_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
    // CHECK:     #iree_gpu.lowering_config<{reduction = [0, 0, 1], thread = [1, 8, 0], workgroup = [64, 128, 1]}
@@ -167,7 +167,7 @@ func.func @matmul_32_32_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !TB = tensor<?x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:         #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//      CHECK:         #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
 // CHECK-SAME:         workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
    // CHECK:      #iree_gpu.lowering_config<{reduction = [0, 0, 1], thread = [1, 8, 0], workgroup = [64, 128, 1]}
@@ -182,7 +182,7 @@ func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC)
 // Dynamic all
 // ============================================================================
 
-//     CHECK:      LLVMGPUVectorDistribute
+//     CHECK:      #iree_gpu.pipeline<VectorDistribute>
 // CHECK-SAME:     workgroup_size = [1024, 1, 1] subgroup_size = 64,
 
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -24,8 +24,8 @@ func.func @static_batch_matvec() {
 }
 
 
-// CHECK:     LLVMGPUVectorDistribute
-// CDNA3:     LLVMGPUVectorDistribute
+// CHECK:     #iree_gpu.pipeline<VectorDistribute>
+// CDNA3:     #iree_gpu.pipeline<VectorDistribute>
 
 // -----
 
@@ -69,7 +69,7 @@ func.func @dynamic_batch_generic_matvec() {
 }
 
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @dynamic_batch_generic_matvec()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -79,7 +79,7 @@ func.func @dynamic_batch_generic_matvec() {
 //  CHECK-SAME:               thread = [0, 0, 0, 8],
 //  CHECK-SAME:               workgroup = [1, 1, 1, 0]
 
-// CDNA3: LLVMGPUVectorDistribute
+// CDNA3: #iree_gpu.pipeline<VectorDistribute>
 
 // -----
 
@@ -114,7 +114,7 @@ func.func @vmt1() attributes {hal.executable.target = #executable_target_rocm_hs
   return
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @vmt1()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -158,7 +158,7 @@ func.func @matvec_like_no_m_dim() attributes {hal.executable.target = #executabl
   return
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @matvec_like_no_m_dim()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -201,7 +201,7 @@ func.func @matvec_unit_n_dim() attributes {hal.executable.target = #executable_t
   return
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @matvec_unit_n_dim()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -246,7 +246,7 @@ func.func @vmt2() attributes {hal.executable.target = #executable_target_rocm_hs
   return
 }
 
-//   CDNA3-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//   CDNA3-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [32, 1, 1] subgroup_size = 32
 // CDNA3-LABEL: func.func @vmt2()
 //  CDNA3-SAME:     translation_info = #[[$TRANSLATION]]
 //       CDNA3:   linalg.generic
@@ -306,7 +306,7 @@ func.func @i4_dequant_matvec() {
 
 // TODO: We should process multiple rows per subgroup.
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //       CHECK: func.func @i4_dequant_matvec()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -353,7 +353,7 @@ func.func @skinny_mmt_lhs_is_vector() {
 //  CHECK-DAG: #[[$MA:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 //  CHECK-DAG: #[[$MB:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 //  CHECK-DAG: #[[$MC:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-//      CHECK: pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //      CHECK: linalg.fill
 //      CHECK: linalg.matmul
 // CHECK-SAME: indexing_maps = [#[[$MA]], #[[$MB]], #[[$MC]]]
@@ -396,7 +396,7 @@ func.func @skinny_mmt_lhs_is_matrix() {
   return
 }
 
-//      CHECK: pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //      CHECK: linalg.fill
 //      CHECK: linalg.matmul
 // CHECK-SAME: indexing_maps
@@ -438,7 +438,7 @@ func.func @not_vmt() {
   return
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 //       CHECK: func.func @not_vmt()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -486,10 +486,10 @@ func.func @not_vmt() {
     return
   }
 
-//      CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//      CHECK:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-SAME:   workgroup_size = [512, 1, 1] subgroup_size = 64
 
-//      CDNA:   #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//      CDNA:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CDNA-SAME:   workgroup_size = [512, 1, 1] subgroup_size = 64
 
 
@@ -557,5 +557,5 @@ func.func @test_dyn_reduction() {
   return
 }
 
-//      CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//      CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-SAME: workgroup_size = [64, 1, 1] subgroup_size = 64,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_root_op_attribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_root_op_attribute.mlir
@@ -20,7 +20,7 @@ func.func @matvec(%matrix: tensor<32000x4096xf16>, %vector: tensor<4096xf16>, %i
   return
 }
 
-// CHECK: #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK: #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-LABEL: func.func @matvec
 // CHECK: linalg.matvec
 // CHECK-SAME: lowering_config = #iree_gpu.lowering_config
@@ -43,7 +43,7 @@ func.func @reduction_sum(%input: tensor<2x32x128x4096xf32>, %init: tensor<2x32xf
   return
 }
 
-// CHECK: #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK: #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
 // CHECK-LABEL: func.func @reduction_sum
 // CHECK: %{{.*}} = linalg.generic
 // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction", "reduction"]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_sort.mlir
@@ -11,7 +11,7 @@ func.func @sort1D(%1: tensor<4xi32>) -> tensor<4xi32> {
 }
 
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1, 1, 1] subgroup_size = 32>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [1, 1, 1] subgroup_size = 32>
 //       CHECK: func.func @sort1D(
 //       CHECK:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.sort {
@@ -28,7 +28,7 @@ func.func @sort2D_static_shape(%1: tensor<2000x30000xi32>) -> tensor<2000x30000x
   return %2 : tensor<2000x30000xi32>
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 //       CHECK: func.func @sort2D_static_shape(
 //       CHECK:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.sort {
@@ -44,7 +44,7 @@ func.func @sort3D_dynamic_shape(%4: index, %6: tensor<?x2x4xi32>) -> tensor<?x2x
   return %7 : tensor<?x2x4xi32>
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 //       CHECK: func.func @sort3D_dynamic_shape(
 //       CHECK:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.sort {
@@ -60,7 +60,7 @@ func.func @sort5D_static_shape(%1: tensor<4x100x100x200x300xi32>) -> tensor<4x10
   return %2 : tensor<4x100x100x200x300xi32>
 }
 
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 //   CHECK-DAG: func.func @sort5D_static_shape(
 //       CHECK:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.sort {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
@@ -7,7 +7,7 @@ func.func @winograd_filter_transform(%2: tensor<3x3x64x128xf32>) -> tensor<8x8x6
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 16], [1, 1]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWinogradVectorize workgroup_size = [16, 32, 1]>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<WinogradVectorize> workgroup_size = [16, 32, 1]>
 //       CHECK: func.func @winograd_filter_transform(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.filter_transform
@@ -22,7 +22,7 @@ func.func @winograd_input_transform(%2: tensor<2x34x34x128xf16>) -> tensor<8x8x2
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32], [1, 1, 1, 1]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<WinogradVectorize> workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_input_transform(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.input_transform
@@ -37,7 +37,7 @@ func.func @winograd_output_transform(%2: tensor<8x8x2x6x6x128xf16>) -> tensor<2x
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32], [1, 1, 1, 1]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<WinogradVectorize> workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.output_transform

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-llvmgpu-configure-tensor-layouts, canonicalize, cse))' %s | FileCheck %s
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -50,7 +50,7 @@ func.func @matmul_96x64x16_mfma(%lhs: tensor<96x16xf16>,
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -100,7 +100,7 @@ func.func @matmul_96x64x16_wmmar3(%lhs: tensor<96x16xf16>,
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -150,7 +150,7 @@ func.func @matmul_96x64x16_wmmar4(%lhs: tensor<96x16xf16>,
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [32, 1, 1]
                                               subgroup_size = 32>
 
@@ -199,7 +199,7 @@ func.func @matmul_96x64x32_wmma_gfx1250(%lhs: tensor<96x32xf16>,
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -249,7 +249,7 @@ func.func @matmul_128x64x16_multi_subgroup(%lhs: tensor<128x16xf16>,
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -271,7 +271,7 @@ func.func @linalg_copy(%in : tensor<16x16x16xf16>) -> tensor<16x16x16xf16>
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -314,7 +314,7 @@ func.func @gather_like(%base : tensor<16384x16x32x128xf16>,
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -338,7 +338,7 @@ func.func @dynamic_infer_sizes(%in : tensor<4x32x?x128xf16>) -> tensor<1x1x?x128
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
@@ -373,7 +373,7 @@ func.func @dynamic_infer_sizes_lowering_config(%in : tensor<4x32x?x128xf16>) -> 
 // Verify that the batch tile for a dimension that requires ceil division
 // (63 / 8 = 8, not 7) is computed correctly.
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
                                               workgroup_size = [512, 1, 1]
                                               subgroup_size = 64>
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -9,7 +9,7 @@
 #map = affine_map<()[s0] -> (s0 * 2)>
 #map1 = affine_map<()[s0] -> (s0 * 256)>
 #map2 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
 func.func @dot_dispatch_0() attributes {translation_info = #translation} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -77,7 +77,7 @@ func.func @dot_dispatch_0() attributes {translation_info = #translation} {
 #map2 = affine_map<(d0, d1, d2)[s0] -> (d0 * 32768 + s0 + d1 * 1024 + d2)>
 #map3 = affine_map<(d0, d1, d2)[s0] -> (d0 * 65536 + s0 + d1 * 64 + d2)>
 #map4 = affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [8, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [8, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
 func.func @batch_matmul_func() attributes {translation_info = #translation} {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -143,7 +143,7 @@ func.func @batch_matmul_func() attributes {translation_info = #translation} {
 #map = affine_map<()[s0] -> (s0 * 2)>
 #map1 = affine_map<()[s0] -> (s0 * 32)>
 #map2 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
 func.func @dot_dispatch_0() attributes {translation_info = #translation} {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -209,7 +209,7 @@ func.func @dot_dispatch_0() attributes {translation_info = #translation} {
 #config = #iree_codegen.lowering_config<tile_sizes = [[]]>
 #map = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0) -> ()>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [1, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [1, 1, 1]>
 func.func @predict_dispatch_153() attributes {translation_info = #translation} {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0x7FC00000 : f32
@@ -248,7 +248,7 @@ func.func @predict_dispatch_153() attributes {translation_info = #translation} {
 #map1 = affine_map<(d0) -> (256, -d0 + 56)>
 #map2 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 200704 + s0 + d1 * 3136 + d2 * 56 + d3)>
 #map3 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 64 + s0 + d1 + d2 + d3)>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Vectorize> workgroup_size = [64, 1, 1]>
 module {
   func.func @conv_dispatch() attributes {translation_info = #translation} {
     %c56 = arith.constant 56 : index
@@ -302,7 +302,7 @@ module {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_codegen.lowering_config<tile_sizes = [[0, 1, 2, 256, 4]]>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
 #map = affine_map<()[s0] -> (s0 * 2)>
 #map1 = affine_map<()[s0] -> (s0 * 256)>
 #map2 = affine_map<(d0)[s0] -> (-d0 + s0, 2)>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
@@ -22,6 +22,6 @@ func.func @forward_dispatch_0_generic_320x320x3x3() {
   iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [320, 320, 3, 3], strides = [1, 1, 1, 1] : tensor<320x320x3x3xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<320x320x3x3xf32>>
   return
 }
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
 //      CHECK: func.func @forward_dispatch_0_generic_320x320x3x3()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pipeline_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pipeline_coalesced_dma.mlir
@@ -22,7 +22,7 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: hal.executable public @coalesced_dma_to_lds
 hal.executable public @coalesced_dma_to_lds {
@@ -88,7 +88,7 @@ hal.executable public @coalesced_dma_to_lds {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: hal.executable public @coalesced_dma_matmul_operand
 hal.executable public @coalesced_dma_matmul_operand {
@@ -153,7 +153,7 @@ hal.executable public @coalesced_dma_matmul_operand {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: hal.executable public @coalesced_dma_f16
 hal.executable public @coalesced_dma_f16 {
@@ -220,7 +220,7 @@ hal.executable public @coalesced_dma_f16 {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: hal.executable public @coalesced_dma_multi_transfer
 hal.executable public @coalesced_dma_multi_transfer {
@@ -304,7 +304,7 @@ hal.executable public @coalesced_dma_multi_transfer {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // CHECK-LABEL: hal.executable public @coalesced_dma_multi_transfer_128bit
 hal.executable public @coalesced_dma_multi_transfer_128bit {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -34,7 +34,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 }
 }
 
-//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 32
+//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @warp_reduction_dispatch()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
 //     CHECK-DAG:    %[[CST_ACC:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x1xf32>
@@ -100,7 +100,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 }
 }
 
-//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 32
+//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @warp_reduction_broadcast_dispatch()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
 //         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1xf32>) {
@@ -141,7 +141,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 }
 }
 
-//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 32
+//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [1024, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @softmax()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
 //         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1xf32>) {
@@ -199,7 +199,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 }
 }
 
-//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//         CHECK: #[[TRANSLATION_INFO:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [32, 1, 1] subgroup_size = 32
 //         CHECK:  func.func @softmax_singlesubgroup()
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
 //         CHECK:    scf.for {{.*}} -> (vector<1x1x1x1x1x1x1x1x1xf32>) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -36,7 +36,7 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
 }
 }
 
-//         RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//         RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [32, 1, 1] subgroup_size = 32
 //         RDNA3: func.func @group_reduction_1d()
 //    RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
 //         RDNA3:        gpu.subgroup_reduce add {{.*}} cluster(size = 32) : (f32) -> f32
@@ -76,7 +76,7 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
 
 // On CDNA, we prefer wave64 with subgroup size of 64.
 
-//        CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//        CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //        CHECK: func.func @group_reduction_1d
 //        CHECK:     gpu.subgroup_reduce add {{.*}} cluster(size = 64) : (f32) -> f32
 
@@ -132,7 +132,7 @@ hal.executable private @i4_dequant_matvec {
   }
 }
 
-//        RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//        RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [32, 1, 1] subgroup_size = 32
 //        RDNA3: func.func @i4_dequant_matvec()
 //   RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
 //     RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
@@ -200,7 +200,7 @@ hal.executable private @i4_dequant_matvec {
   }
 }
 
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //      CHECK: func.func @i4_dequant_matvec()
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 
@@ -246,7 +246,7 @@ hal.executable private @matvec_fp16 {
 // write 8 results at the end.
 // TODO(kuhar): We should reduce the number of `gpu.shuffles` performed.
 
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //          CHECK: func.func @matvec_fp16()
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
@@ -299,7 +299,7 @@ hal.executable private @matvec_fp16 {
 // Multi-row matvec with wave32.
 // TODO(kuhar): We should reduce the number of `gpu.shuffles` performed.
 
-//          RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//          RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [32, 1, 1] subgroup_size = 32
 //          RDNA3: func.func @matvec_fp16()
 //     RDNA3-SAME:     translation_info = #[[$TRANSLATION]]
 //      RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
@@ -378,7 +378,7 @@ hal.executable public @multi_reduction {
 
 // Check that all loops are singly nested.
 //
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [960, 1, 1] subgroup_size = 64
+//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [960, 1, 1] subgroup_size = 64
 //          CHECK: func.func @multi_reduction()
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir
@@ -16,7 +16,7 @@ func.func @softmax() {
   return
 }
 
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 32
+//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [1024, 1, 1] subgroup_size = 32
 //    CHECK-LABEL: func.func @softmax
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //     CHECK:    gpu.subgroup_reduce maxnumf {{.*}} cluster(size = 32) : (f32) -> f32
@@ -25,7 +25,7 @@ func.func @softmax() {
 
 // On CDNA, we prefer wave64 with subgroup size 64.
 
-//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
+//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [1024, 1, 1] subgroup_size = 64
 //          CDNA3: func.func @softmax
 //     CDNA3-SAME:      translation_info = #[[$TRANSLATION]]
 //     CDNA3:    gpu.subgroup_reduce maxnumf {{.*}} cluster(size = 64) : (f32) -> f32
@@ -49,7 +49,7 @@ func.func @softmax_singlesubgroup() {
   return
 }
 
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [32, 1, 1] subgroup_size = 32
 //    CHECK-LABEL: func.func @softmax_singlesubgroup
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //     CHECK:    gpu.subgroup_reduce maxnumf {{.*}} cluster(size = 32) : (f32) -> f32
@@ -57,7 +57,7 @@ func.func @softmax_singlesubgroup() {
 
 // On CDNA, we prefer wave64 with subgroup size 64.
 
-//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64
 //          CDNA3: func.func @softmax_singlesubgroup
 //     CDNA3-SAME:      translation_info = #[[$TRANSLATION]]
 //     CDNA3:    gpu.subgroup_reduce maxnumf {{.*}} cluster(size = 64) : (f32) -> f32
@@ -90,7 +90,7 @@ func.func @dynamic_softmax() {
 }
 
 // Verify that LLVMVectorDistribute is used for dynamic softmax.
-// CHECK: LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 32
+// CHECK: #iree_gpu.pipeline<VectorDistribute> workgroup_size = [1024, 1, 1] subgroup_size = 32
 //    CHECK-LABEL: func.func @dynamic_softmax
 //     CHECK:    gpu.subgroup_reduce maxnumf {{.*}} cluster(size = 32) : (f16) -> f16
 //     CHECK:    gpu.subgroup_reduce add {{.*}} cluster(size = 32) : (f16) -> f16

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_load_to_transpose_load.mlir
@@ -433,7 +433,7 @@ func.func @transform_unroll_f16_8x1() -> vector<8x1xf16> {
 // Test: 3-element delinearize_index from thread_id gets hints with correct group sizes
 // With workgroup_size = [128, 1, 1], thread_id x gets lane_increment<128>
 // For basis (2, 4, 16): result #0 gets lane_constant<64>, result #1 gets lane_constant<16>, result #2 gets lane_increment<16>
-#translation_128 = #iree_codegen.translation_info<pipeline = LLVMGPUDefault workgroup_size = [128, 1, 1]>
+#translation_128 = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Default> workgroup_size = [128, 1, 1]>
 // CHECK-LABEL: func.func @preprocess_delinearize_3d
 // CHECK: amdgpu.transpose_load
 // CHECK: vector.shape_cast

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/sort_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/sort_pipeline_test.mlir
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [1, 1, 1] subgroup_size = 32>
 #lowering_config = #iree_gpu.lowering_config<{thread = [0], workgroup = [0]}>
 module {
   func.func @sort1D() attributes {translation_info = #translation} {
@@ -26,7 +26,7 @@ module {
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 #lowering_config = #iree_gpu.lowering_config<{thread = [1], workgroup = [1]}>
 module {
   func.func @sort2D_static_shape() attributes {translation_info = #translation} {
@@ -52,7 +52,7 @@ module {
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 32>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 32>
 #lowering_config = #iree_gpu.lowering_config<{thread = [1, 1], workgroup = [1, 2]}>
 module {
   func.func @sort3D_dynamic_shape() attributes {translation_info = #translation} {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTarget.cpp
@@ -84,7 +84,8 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
   Attribute pipelineAttr = translationInfo.getPassPipeline();
   if (auto customPipeline =
           dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr)) {
-    if (failed(customPipeline.buildPipeline(pipeline))) {
+    if (failed(customPipeline.buildPipeline(pipeline,
+                                            /*options=*/nullptr))) {
       funcOp.emitOpError("failed to build custom pass pipeline");
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -18,6 +18,7 @@ iree_compiler_cc_library(
     name = "Utils",
     srcs = [
         "CPUUtils.cpp",
+        "CodegenPipelineOptions.cpp",
         "EncodingUtils.cpp",
         "GPUUtils.cpp",
         "LinalgOpInfo.cpp",
@@ -27,6 +28,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "CPUUtils.h",
+        "CodegenPipelineOptions.h",
         "EncodingUtils.h",
         "GPUUtils.h",
         "LinalgOpInfo.h",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
     Utils
   HDRS
     "CPUUtils.h"
+    "CodegenPipelineOptions.h"
     "EncodingUtils.h"
     "GPUUtils.h"
     "LinalgOpInfo.h"
@@ -23,6 +24,7 @@ iree_cc_library(
     "Utils.h"
   SRCS
     "CPUUtils.cpp"
+    "CodegenPipelineOptions.cpp"
     "EncodingUtils.cpp"
     "GPUUtils.cpp"
     "LinalgOpInfo.cpp"

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenPipelineOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenPipelineOptions.cpp
@@ -1,0 +1,16 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Utils/CodegenPipelineOptions.h"
+
+namespace mlir::iree_compiler {
+
+// Out-of-line definition to anchor the vtable in this TU.
+// See
+// https://llvm.org/docs/CodingStandards.html#provide-a-virtual-method-anchor-for-classes-in-headers.
+CodegenPipelineOptions::~CodegenPipelineOptions() = default;
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenPipelineOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenPipelineOptions.h
@@ -1,0 +1,28 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_UTILS_CODEGENPIPELINEOPTIONS_H_
+#define IREE_COMPILER_CODEGEN_UTILS_CODEGENPIPELINEOPTIONS_H_
+
+#include "mlir/Support/TypeID.h"
+
+namespace mlir::iree_compiler {
+
+/// Polymorphic base for per-pipeline codegen options passed through
+/// PipelineAttrInterface::buildPipeline. Supports llvm::isa/cast/dyn_cast.
+struct CodegenPipelineOptions {
+  explicit CodegenPipelineOptions(TypeID typeID) : typeID(typeID) {}
+  virtual ~CodegenPipelineOptions();
+
+  TypeID getTypeID() const { return typeID; }
+
+private:
+  TypeID typeID;
+};
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_UTILS_CODEGENPIPELINEOPTIONS_H_

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenPipelineOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenPipelineOptions.h
@@ -14,10 +14,12 @@ namespace mlir::iree_compiler {
 /// Polymorphic base for per-pipeline codegen options passed through
 /// PipelineAttrInterface::buildPipeline. Supports llvm::isa/cast/dyn_cast.
 struct CodegenPipelineOptions {
-  explicit CodegenPipelineOptions(TypeID typeID) : typeID(typeID) {}
   virtual ~CodegenPipelineOptions();
 
   TypeID getTypeID() const { return typeID; }
+
+protected:
+  explicit CodegenPipelineOptions(TypeID typeID) : typeID(typeID) {}
 
 private:
   TypeID typeID;

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerExecutableTarget.cpp
@@ -74,7 +74,8 @@ void VMVXLowerExecutableTargetPass::runOnOperation() {
   Attribute pipelineAttr = translationInfo.getPassPipeline();
   if (auto customPipeline =
           dyn_cast<IREE::Codegen::PipelineAttrInterface>(pipelineAttr)) {
-    if (failed(customPipeline.buildPipeline(pipeline))) {
+    if (failed(customPipeline.buildPipeline(pipeline,
+                                            /*options=*/nullptr))) {
       funcOp.emitOpError("failed to build custom pass pipeline");
       return signalPassFailure();
     }

--- a/tests/e2e/matmul/compilation_info.py
+++ b/tests/e2e/matmul/compilation_info.py
@@ -80,7 +80,7 @@ class IREEGPUCompilationInfo(CompilationInfo):
         if self.subgroup_size is not None:
             subgroup_size_str = f"subgroup_size = {self.subgroup_size}"
 
-        if compiler_pipeline == "LLVMGPUTileAndFuse":
+        if compiler_pipeline == "#iree_gpu.pipeline<TileAndFuse>":
             # Add convert_acc_gemm for NVIDIA mma.sync intrinsics
             convert_acc_gemm = ""
             if self.mma_schedule.intrinsic.startswith("NV_MMA_SYNC"):
@@ -418,7 +418,7 @@ def get_rocm_test_compilation_infos(
             IREEGPUCompilationInfo(
                 workgroup_tile=workgroup_tile,
                 reduction_tile=reduction_tile,
-                dispatch_lowering_pass_pipeline="LLVMGPUVectorDistribute",
+                dispatch_lowering_pass_pipeline="#iree_gpu.pipeline<VectorDistribute>",
                 workgroup_size=workgroup_size,
                 mma_schedule=schedule,
                 subgroup_size=subgroup_size,
@@ -439,9 +439,9 @@ def get_cuda_test_compilation_infos(
 
     # Determine the pipeline based on compilation_info_id
     if compilation_info_id == CompilationInfoId.LLVMGPUVectorDistributeCUDA:
-        pipeline = "LLVMGPUVectorDistribute"
+        pipeline = "#iree_gpu.pipeline<VectorDistribute>"
     elif compilation_info_id == CompilationInfoId.LLVMGPUTileAndFuseCUDA:
-        pipeline = "LLVMGPUTileAndFuse"
+        pipeline = "#iree_gpu.pipeline<TileAndFuse>"
     else:
         raise ValueError("Unknown pipeline for CUDA")
 

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -36,7 +36,11 @@ def generate_function_name(
 
     info = ""
     if compilation_info:
-        info = f"_for_{compilation_info.dispatch_lowering_pass_pipeline}"
+        pipeline_name = compilation_info.dispatch_lowering_pass_pipeline
+        # Strip #iree_gpu.pipeline<...> wrapper for use in identifiers.
+        if pipeline_name.startswith("#iree_gpu.pipeline<"):
+            pipeline_name = pipeline_name[len("#iree_gpu.pipeline<") : -1]
+        info = f"_for_{pipeline_name}"
 
     matmul_kind = "matmul_accumulate" if accumulate else "matmul"
 

--- a/tests/e2e/matmul/generate_code_mx.py
+++ b/tests/e2e/matmul/generate_code_mx.py
@@ -37,7 +37,11 @@ def generate_function_name_mx(
 
     info = ""
     if compilation_info:
-        info = f"_for_{compilation_info.dispatch_lowering_pass_pipeline}"
+        pipeline_name = compilation_info.dispatch_lowering_pass_pipeline
+        # Strip #iree_gpu.pipeline<...> wrapper for use in identifiers.
+        if pipeline_name.startswith("#iree_gpu.pipeline<"):
+            pipeline_name = pipeline_name[len("#iree_gpu.pipeline<") : -1]
+        info = f"_for_{pipeline_name}"
 
     matmul_kind = "matmul_accumulate" if accumulate else "matmul"
 


### PR DESCRIPTION
Replace LLVMGPU entries in the global `DispatchLoweringPassPipeline` enum with a dedicated `#iree_gpu.pipeline<...>` attribute backed by a new `IREE::GPU::LoweringPipeline` enum.

The overall goal is to enable pipeline-specific constraint generation -- I want to be able to attach an (external) interface to gpu pipelines.

The global enum carried target backend-specific pipelines that belong in their respective dialect. This moves the seven LLVMGPU pipelines into `iree_gpu`, with `PipelineAttrInterface` so they integrate with `TranslationInfoAttr` and `ConstraintsOp`.

I plan to move the remaining pipelines in follow up PRs, to keep each PR as small as feasible.

Issue: https://github.com/iree-org/iree/issues/23535