### PR TITLE
[compiler][nfc] Fix up file comments to match the filenames.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
@@ -3,13 +3,13 @@
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//===- BubbleUpOrdinalOpPass.cpp -----------------------------------------===//
+//===- BubbleUpOrdinalOp.cpp ----------------------------------------------===//
 //
 // The workgroup count computation when using slices needs the ordinal
 // annotation ops to be bubbled up as much as possible. This pass implements
 // patterns to bubble these operations up.
 //
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatches.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatches.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- BufferizeCopyOnlyDispatchesPassPass.cpp ----------------------------===//
+//===- BufferizeCopyOnlyDispatches.cpp ------------------------------------===//
 //
 // This pass converts dispatches that are copy only into a form where backends
 // can tile and distribute them appropriately.

--- a/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocView.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocView.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- BufferAllocViewCleanUpPass.cpp -------------------------------------===//
+//===- BufferAllocViewCleanUp.cpp -----------------------------------------===//
 //
 // This pass performs canonicalizations/cleanups related to HAL interface/buffer
 // allocations and views. We need a dedicated pass because patterns here involve

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRV.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRV.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- CovertToSPIRVPass.cpp - Performs the final SPIR-V conversion -------===//
+//===- CovertToSPIRV.cpp - Performs the final SPIR-V conversion -----------===//
 //
 // This file implements a pass to perform the final conversion to SPIR-V.
 // This pass converts remaining interface ops into SPIR-V global variables,


### PR DESCRIPTION
It is a follow-up of https://github.com/iree-org/iree/commit/6c6eb09cc032bf1bda385f93ac3c40ab6aa5f4ba that missed the update for the comments.

It also fixes the unaligned comment in `BubbleUpOrdinalOps.cpp`.