### PR TITLE
Rewrite local_sync queue operations as direct inline implementations.

### DIFF
--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -148,6 +148,16 @@ iree_runtime_cc_test(
     ],
 )
 
+cc_binary_benchmark(
+    name = "atomic_slist_benchmark",
+    srcs = ["atomic_slist_benchmark.cc"],
+    deps = [
+        ":atomic_slist",
+        "//runtime/src/iree/testing:benchmark_main",
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
 iree_runtime_cc_library(
     name = "atomic_freelist",
     hdrs = ["atomic_freelist.h"],

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -146,6 +146,18 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_binary_benchmark(
+  NAME
+    atomic_slist_benchmark
+  SRCS
+    "atomic_slist_benchmark.cc"
+  DEPS
+    ::atomic_slist
+    benchmark
+    iree::testing::benchmark_main
+  TESTONLY
+)
+
 iree_cc_library(
   NAME
     atomic_freelist

--- a/runtime/src/iree/base/internal/atomic_slist.c
+++ b/runtime/src/iree/base/internal/atomic_slist.c
@@ -10,9 +10,17 @@
 
 #include "iree/base/attributes.h"
 
-// TODO(benvanik): add TSAN annotations when switched to atomics:
-// https://github.com/gcc-mirror/gcc/blob/master/libsanitizer/include/sanitizer/tsan_interface_atomic.h
-// https://reviews.llvm.org/D18500
+// Loads the head pointer with the given memory ordering.
+static inline iree_atomic_slist_entry_t* iree_atomic_slist_load_head(
+    iree_atomic_slist_t* list, iree_memory_order_t order) {
+  return (iree_atomic_slist_entry_t*)iree_atomic_load(&list->head, order);
+}
+
+// Stores the head pointer with release ordering (publishes prior writes).
+static inline void iree_atomic_slist_store_head(
+    iree_atomic_slist_t* list, iree_atomic_slist_entry_t* value) {
+  iree_atomic_store(&list->head, (intptr_t)value, iree_memory_order_release);
+}
 
 void iree_atomic_slist_initialize(iree_atomic_slist_t* out_list) {
   memset(out_list, 0, sizeof(*out_list));
@@ -20,7 +28,6 @@ void iree_atomic_slist_initialize(iree_atomic_slist_t* out_list) {
 }
 
 void iree_atomic_slist_deinitialize(iree_atomic_slist_t* list) {
-  // TODO(benvanik): assert empty.
   iree_slim_mutex_deinitialize(&list->mutex);
   memset(list, 0, sizeof(*list));
 }
@@ -30,37 +37,44 @@ void iree_atomic_slist_concat(iree_atomic_slist_t* list,
                               iree_atomic_slist_entry_t* tail) {
   if (IREE_UNLIKELY(!head)) return;
   iree_slim_mutex_lock(&list->mutex);
-  tail->next = list->head;
-  list->head = head;
+  tail->next = iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, head);
   iree_slim_mutex_unlock(&list->mutex);
 }
 
 void iree_atomic_slist_push(iree_atomic_slist_t* list,
                             iree_atomic_slist_entry_t* entry) {
   iree_slim_mutex_lock(&list->mutex);
-  iree_atomic_slist_push_unsafe(list, entry);
+  entry->next = iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, entry);
   iree_slim_mutex_unlock(&list->mutex);
 }
 
 void iree_atomic_slist_push_unsafe(iree_atomic_slist_t* list,
                                    iree_atomic_slist_entry_t* entry) {
-  // NOTE: no lock is held here and no atomic operation will be used when this
-  // is actually made atomic.
-  entry->next = list->head;
-  list->head = entry;
+  entry->next = iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, entry);
 }
 
 void iree_atomic_slist_discard(iree_atomic_slist_t* list) {
   iree_slim_mutex_lock(&list->mutex);
-  list->head = NULL;
+  iree_atomic_slist_store_head(list, NULL);
   iree_slim_mutex_unlock(&list->mutex);
 }
 
 iree_atomic_slist_entry_t* iree_atomic_slist_pop(iree_atomic_slist_t* list) {
+  // Fast path: check if the list is empty without taking the mutex.
+  // The relaxed load is safe because we re-check under the mutex if non-NULL.
+  // False negatives (read NULL when an entry was just pushed) are benign —
+  // the entry will be seen on the next pop call.
+  if (!iree_atomic_slist_load_head(list, iree_memory_order_relaxed)) {
+    return NULL;
+  }
   iree_slim_mutex_lock(&list->mutex);
-  iree_atomic_slist_entry_t* entry = list->head;
+  iree_atomic_slist_entry_t* entry =
+      iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
   if (entry != NULL) {
-    list->head = entry->next;
+    iree_atomic_slist_store_head(list, entry->next);
     entry->next = NULL;
   }
   iree_slim_mutex_unlock(&list->mutex);
@@ -71,19 +85,19 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
                              iree_atomic_slist_flush_order_t flush_order,
                              iree_atomic_slist_entry_t** out_head,
                              iree_atomic_slist_entry_t** out_tail) {
-  // Exchange list head with NULL to steal the entire list. The list will be in
-  // the native LIFO order of the slist.
+  // Fast path: check if the list is empty without taking the mutex.
+  if (!iree_atomic_slist_load_head(list, iree_memory_order_relaxed)) {
+    return false;
+  }
   iree_slim_mutex_lock(&list->mutex);
-  iree_atomic_slist_entry_t* head = list->head;
-  list->head = NULL;
+  iree_atomic_slist_entry_t* head =
+      iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, NULL);
   iree_slim_mutex_unlock(&list->mutex);
   if (!head) return false;
 
   switch (flush_order) {
     case IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO: {
-      // List is already in native LIFO order. If the user wants a tail we have
-      // to scan for it, though, which we really only want to do when required
-      // as it's a linked list pointer walk.
       *out_head = head;
       if (out_tail) {
         iree_atomic_slist_entry_t* p = head;
@@ -93,9 +107,6 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
       break;
     }
     case IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_FIFO: {
-      // Reverse the list in a single scan. list_head is our tail, so scan
-      // forward to find our head. Since we have to walk the whole list anyway
-      // we can cheaply give both the head and tail to the caller.
       iree_atomic_slist_entry_t* tail = head;
       if (out_tail) *out_tail = tail;
       iree_atomic_slist_entry_t* p = head;

--- a/runtime/src/iree/base/internal/atomic_slist.h
+++ b/runtime/src/iree/base/internal/atomic_slist.h
@@ -78,9 +78,10 @@ typedef struct iree_atomic_slist_entry_t {
 // etc. That said, the Windows Interlocked* variants don't seem to. Having a
 // single heavily tested implementation seems more worthwhile than several.
 typedef iree_alignas(iree_max_align_t) struct {
-  // TODO(benvanik): spend some time golfing this. Unblocking myself for now :)
   iree_slim_mutex_t mutex;
-  iree_atomic_slist_entry_t* head;
+  // Atomic head pointer: relaxed loads enable fast-path empty checks
+  // without taking the mutex. All mutations still hold the mutex.
+  iree_atomic_intptr_t head;
 } iree_atomic_slist_t;
 
 // Initializes an slist handle to an empty list.

--- a/runtime/src/iree/base/internal/atomic_slist_benchmark.cc
+++ b/runtime/src/iree/base/internal/atomic_slist_benchmark.cc
@@ -1,0 +1,440 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Benchmarks for iree_atomic_slist_t characterizing single-threaded operation
+// costs and multi-threaded contention behavior.
+//
+// Single-threaded baselines measure the raw cost of each operation in
+// isolation. Multi-threaded benchmarks use Google Benchmark's ->Threads(N)
+// to measure how operations scale under contention with increasing thread
+// counts on the same list.
+//
+// Key scenarios:
+//   - Push/pop/flush round-trip cost (uncontended)
+//   - Fast-path empty check cost (pop/flush on empty list)
+//   - Batch push then pop/flush throughput
+//   - Write-write contention (N threads pushing)
+//   - Mixed contention (N threads doing push+pop)
+//   - Producer/consumer (N-1 pushers, 1 popper or flusher)
+//   - Empty fast-path under contention (N threads popping/flushing empty)
+//
+// Run with:
+//   iree-bazel-run //runtime/src/iree/base/internal:atomic_slist_benchmark
+// Filter:
+//   --benchmark_filter='Contention'
+
+#include <algorithm>
+#include <thread>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "iree/base/internal/atomic_slist.h"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Test entry type
+//===----------------------------------------------------------------------===//
+
+struct bench_entry_t {
+  int value;
+  iree_atomic_slist_intrusive_ptr_t slist_next;
+};
+IREE_TYPED_ATOMIC_SLIST_WRAPPER(bench, bench_entry_t,
+                                offsetof(bench_entry_t, slist_next));
+
+// Returns the number of hardware threads, clamped to at least 1.
+static int HardwareConcurrency() {
+  int count = static_cast<int>(std::thread::hardware_concurrency());
+  return count > 0 ? count : 1;
+}
+
+// Skips benchmarks that request more threads than the machine has cores.
+// Running N threads on M << N cores produces meaningless contention noise.
+static bool ShouldSkipThreadCount(benchmark::State& state) {
+  if (state.threads() > HardwareConcurrency()) {
+    state.SkipWithMessage("thread count exceeds available cores");
+    return true;
+  }
+  return false;
+}
+
+// Thread counts to sweep for contention benchmarks. Powers of two up to 256,
+// filtered at runtime by ShouldSkipThreadCount.
+static void ThreadRange(::benchmark::Benchmark* benchmark) {
+  for (int threads = 1; threads <= 256; threads *= 2) {
+    benchmark->Threads(threads);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Single-threaded baselines
+//===----------------------------------------------------------------------===//
+
+// Push then pop a single entry. Measures the uncontended round-trip cost
+// through the mutex (lock, store head, unlock) x2.
+void BM_PushPop(benchmark::State& state) {
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+  bench_entry_t entry = {42, nullptr};
+
+  for (auto _ : state) {
+    bench_slist_push(&list, &entry);
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushPop);
+
+// Pop from an empty list. Measures the fast-path relaxed load cost: should
+// return without ever touching the mutex.
+void BM_PopEmpty(benchmark::State& state) {
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PopEmpty);
+
+// Flush from an empty list. Same fast-path as pop: relaxed load of NULL head
+// returns immediately without locking.
+void BM_FlushEmpty(benchmark::State& state) {
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    bench_entry_t* head = nullptr;
+    bool flushed = bench_slist_flush(
+        &list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head, nullptr);
+    benchmark::DoNotOptimize(flushed);
+  }
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_FlushEmpty);
+
+// Push N entries then pop them all one at a time. Measures throughput of
+// sequential pop draining a populated list (N mutex acquisitions).
+// The final pop hits the fast-path empty check.
+void BM_PushNPopN(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    for (int i = 0; i < count; ++i) {
+      bench_slist_push(&list, &entries[i]);
+    }
+    for (int i = 0; i < count; ++i) {
+      bench_entry_t* popped = bench_slist_pop(&list);
+      benchmark::DoNotOptimize(popped);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * count * 2);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushNPopN)->Arg(1)->Arg(4)->Arg(16)->Arg(64)->Arg(256)->Arg(1024);
+
+// Push N entries then flush them all at once (LIFO order). Measures the
+// amortized cost: one mutex acquisition drains the entire list. The flush
+// walks the list to find the tail only when out_tail is requested.
+void BM_PushNFlushLIFO(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    for (int i = 0; i < count; ++i) {
+      bench_slist_push(&list, &entries[i]);
+    }
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    benchmark::DoNotOptimize(head);
+  }
+  state.SetItemsProcessed(state.iterations() * count);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushNFlushLIFO)
+    ->Arg(1)
+    ->Arg(4)
+    ->Arg(16)
+    ->Arg(64)
+    ->Arg(256)
+    ->Arg(1024);
+
+// Push N entries then flush them all at once (FIFO order). FIFO flush
+// reverses the list in-place, touching every entry's next pointer. This
+// shows the cost delta between LIFO (O(1) without tail) and FIFO (O(N)
+// reversal).
+void BM_PushNFlushFIFO(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    for (int i = 0; i < count; ++i) {
+      bench_slist_push(&list, &entries[i]);
+    }
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_FIFO,
+                      &head, nullptr);
+    benchmark::DoNotOptimize(head);
+  }
+  state.SetItemsProcessed(state.iterations() * count);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushNFlushFIFO)
+    ->Arg(1)
+    ->Arg(4)
+    ->Arg(16)
+    ->Arg(64)
+    ->Arg(256)
+    ->Arg(1024);
+
+// Concat a chain of N entries at once. Measures the cost of a single mutex
+// acquisition to prepend an entire chain (O(1) regardless of chain length).
+void BM_Concat(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    // Build chain: link entries[0] -> entries[1] -> ... -> entries[N-1].
+    for (int i = 0; i < count - 1; ++i) {
+      bench_slist_set_next(&entries[i], &entries[i + 1]);
+    }
+    bench_slist_set_next(&entries[count - 1], nullptr);
+
+    bench_slist_concat(&list, &entries[0], &entries[count - 1]);
+
+    // Drain so the list is empty for the next iteration.
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    benchmark::DoNotOptimize(head);
+  }
+  state.SetItemsProcessed(state.iterations() * count);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_Concat)->Arg(1)->Arg(4)->Arg(16)->Arg(64)->Arg(256)->Arg(1024);
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded contention: write-write
+//===----------------------------------------------------------------------===//
+
+// N threads all pushing to the same list. Measures mutex contention on the
+// write path. Each thread pushes its own entry (no data sharing beyond the
+// list head). After each iteration, entries accumulate in the list; a barrier
+// and flush between iterations would add noise, so we accept the growing list
+// and report per-operation throughput.
+void BM_ContentionPush(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  // Shared list, initialized once by thread 0.
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  // Each thread gets its own entry to push (no false sharing between entries).
+  bench_entry_t entry = {static_cast<int>(state.thread_index()), nullptr};
+
+  for (auto _ : state) {
+    bench_slist_push(&list, &entry);
+  }
+
+  // Thread 0 cleans up.
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ContentionPush)->Apply(ThreadRange)->UseRealTime();
+
+// N threads each doing push-then-pop cycles on the same list. Measures
+// mixed read-write contention. Each thread pushes its own entry then
+// immediately pops (which may get its own entry back, or another thread's —
+// that's fine, we're measuring contention cost not correctness).
+void BM_ContentionPushPop(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  bench_entry_t entry = {static_cast<int>(state.thread_index()), nullptr};
+
+  for (auto _ : state) {
+    bench_slist_push(&list, &entry);
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ContentionPushPop)->Apply(ThreadRange)->UseRealTime();
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded contention: empty fast-path
+//===----------------------------------------------------------------------===//
+
+// N threads all popping from an empty list. This is the critical benchmark
+// for the fast-path empty check: with the relaxed load, threads should never
+// touch the mutex and should scale perfectly. Without it, every pop would
+// contend on the mutex even though the list is always empty.
+void BM_PopEmptyContention(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  for (auto _ : state) {
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  if (state.thread_index() == 0) {
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_PopEmptyContention)->Apply(ThreadRange)->UseRealTime();
+
+// N threads all flushing an empty list. Same fast-path test as PopEmpty
+// but for the flush path.
+void BM_FlushEmptyContention(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  for (auto _ : state) {
+    bench_entry_t* head = nullptr;
+    bool flushed = bench_slist_flush(
+        &list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head, nullptr);
+    benchmark::DoNotOptimize(flushed);
+  }
+
+  if (state.thread_index() == 0) {
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_FlushEmptyContention)->Apply(ThreadRange)->UseRealTime();
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded contention: producer/consumer
+//===----------------------------------------------------------------------===//
+
+// (N-1) producers pushing, 1 consumer popping. Simulates the typical
+// pattern where worker threads produce results into a shared collection
+// list and a coordinator drains them one at a time. The consumer (thread 0)
+// may frequently see an empty list, exercising the fast-path.
+//
+// For the single-thread case, the one thread does push+pop (no point in
+// having zero producers or zero consumers).
+void BM_ProducerConsumerPop(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  bench_entry_t entry = {static_cast<int>(state.thread_index()), nullptr};
+  const bool is_consumer = (state.thread_index() == 0);
+
+  for (auto _ : state) {
+    if (state.threads() == 1 || !is_consumer) {
+      bench_slist_push(&list, &entry);
+    }
+    if (state.threads() == 1 || is_consumer) {
+      bench_entry_t* popped = bench_slist_pop(&list);
+      benchmark::DoNotOptimize(popped);
+    }
+  }
+
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ProducerConsumerPop)->Apply(ThreadRange)->UseRealTime();
+
+// (N-1) producers pushing, 1 consumer flushing. Simulates the pattern where
+// a coordinator periodically drains the entire list in one shot. This is the
+// typical pattern for work-stealing schedulers and batch processing: the
+// flush amortizes mutex cost across all accumulated entries.
+void BM_ProducerConsumerFlush(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  bench_entry_t entry = {static_cast<int>(state.thread_index()), nullptr};
+  const bool is_consumer = (state.thread_index() == 0);
+
+  for (auto _ : state) {
+    if (state.threads() == 1 || !is_consumer) {
+      bench_slist_push(&list, &entry);
+    }
+    if (state.threads() == 1 || is_consumer) {
+      bench_entry_t* head = nullptr;
+      bool flushed = bench_slist_flush(
+          &list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head,
+          nullptr);
+      benchmark::DoNotOptimize(flushed);
+    }
+  }
+
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ProducerConsumerFlush)->Apply(ThreadRange)->UseRealTime();
+
+}  // namespace

--- a/runtime/src/iree/hal/drivers/cuda/timepoint_pool.c
+++ b/runtime/src/iree/hal/drivers/cuda/timepoint_pool.c
@@ -218,9 +218,16 @@ iree_status_t iree_hal_cuda_timepoint_pool_acquire_device_signal(
       z0, iree_hal_cuda_event_pool_acquire(timepoint_pool->device_event_pool,
                                            timepoint_count, device_events));
 
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_cuda_timepoint_pool_acquire_internal(
-              timepoint_pool, timepoint_count, out_timepoints));
+  iree_status_t status = iree_hal_cuda_timepoint_pool_acquire_internal(
+      timepoint_pool, timepoint_count, out_timepoints);
+  if (!iree_status_is_ok(status)) {
+    // Release already-acquired events back to the pool before returning.
+    for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
+      iree_hal_cuda_event_release(device_events[i]);
+    }
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
   for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
     out_timepoints[i]->kind = IREE_HAL_CUDA_TIMEPOINT_KIND_DEVICE_SIGNAL;
     out_timepoints[i]->timepoint.device_signal = device_events[i];
@@ -244,9 +251,16 @@ iree_status_t iree_hal_cuda_timepoint_pool_acquire_device_wait(
       z0, iree_hal_cuda_event_pool_acquire(timepoint_pool->device_event_pool,
                                            timepoint_count, device_events));
 
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_cuda_timepoint_pool_acquire_internal(
-              timepoint_pool, timepoint_count, out_timepoints));
+  iree_status_t status = iree_hal_cuda_timepoint_pool_acquire_internal(
+      timepoint_pool, timepoint_count, out_timepoints);
+  if (!iree_status_is_ok(status)) {
+    // Release already-acquired events back to the pool before returning.
+    for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
+      iree_hal_cuda_event_release(device_events[i]);
+    }
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
   for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
     out_timepoints[i]->kind = IREE_HAL_CUDA_TIMEPOINT_KIND_DEVICE_WAIT;
     out_timepoints[i]->timepoint.device_wait = device_events[i];

--- a/runtime/src/iree/hal/drivers/local_sync/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_sync/BUILD.bazel
@@ -38,7 +38,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/local",
         "//runtime/src/iree/hal/local:executable_environment",
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
-        "//runtime/src/iree/hal/utils:file_transfer",
         "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:queue_emulation",
     ],

--- a/runtime/src/iree/hal/drivers/local_sync/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_sync/BUILD.bazel
@@ -37,8 +37,8 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/local",
         "//runtime/src/iree/hal/local:executable_environment",
+        "//runtime/src/iree/hal/local:inline_dispatch",
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:files",
-        "//runtime/src/iree/hal/utils:queue_emulation",
     ],
 )

--- a/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
@@ -34,9 +34,9 @@ iree_cc_library(
     iree::hal
     iree::hal::local
     iree::hal::local::executable_environment
+    iree::hal::local::inline_dispatch
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::files
-    iree::hal::utils::queue_emulation
   PUBLIC
 )
 

--- a/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
@@ -35,7 +35,6 @@ iree_cc_library(
     iree::hal::local
     iree::hal::local::executable_environment
     iree::hal::utils::deferred_command_buffer
-    iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::queue_emulation
   PUBLIC

--- a/runtime/src/iree/hal/drivers/local_sync/cts/backends.cc
+++ b/runtime/src/iree/hal/drivers/local_sync/cts/backends.cc
@@ -77,7 +77,24 @@ static iree_status_t CreateLocalSyncDevice(iree_hal_driver_t** out_driver,
 static bool local_sync_registered_ =
     (CtsRegistry::RegisterBackend({
          "local_sync",
-         {"local_sync", CreateLocalSyncDevice},
+         {"local_sync",
+          CreateLocalSyncDevice,
+          /*executable_format=*/nullptr,
+          /*executable_data=*/nullptr,
+          RecordingMode::kDirect,
+          /*unsupported_tests=*/
+          {
+              {"QueueAllocaTest.BufferMetadata",
+               "sync driver uses heap allocation, no ASYNCHRONOUS placement"},
+              {"QueueAllocaTest.DeallocaReleasesMemory",
+               "sync driver dealloca is a barrier, heap buffers stay valid"},
+          },
+          /*expected_failures=*/
+          {
+              {"QueueAllocaTest.AllocaWithWaitSemaphores",
+               "background thread signaling deadlocks sync queue wait "
+               "(sync driver blocks on semaphore wait in queue_alloca)"},
+          }},
          {"events", "file_io", "host_calls", "mapping", "indirect"},
      }),
      true);

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -526,6 +526,109 @@ static iree_status_t iree_hal_sync_device_queue_write(
   return status;
 }
 
+static iree_status_t iree_hal_sync_device_queue_fill(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, const void* pattern,
+    iree_host_size_t pattern_length, iree_hal_fill_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_buffer_map_fill(target_buffer, target_offset, length,
+                                      pattern, pattern_length);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_sync_device_advance_frontier(device);
+  } else {
+    iree_hal_semaphore_list_fail(signal_semaphore_list,
+                                 iree_status_clone(status));
+    if (device->frontier_tracker) {
+      iree_async_frontier_tracker_fail_axis(
+          device->frontier_tracker, device->axis,
+          iree_status_from_code(iree_status_code(status)));
+    }
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_sync_device_queue_update(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    const void* source_buffer, iree_host_size_t source_offset,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, iree_hal_update_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_buffer_map_write(
+        target_buffer, target_offset,
+        (const uint8_t*)source_buffer + source_offset, length);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_sync_device_advance_frontier(device);
+  } else {
+    iree_hal_semaphore_list_fail(signal_semaphore_list,
+                                 iree_status_clone(status));
+    if (device->frontier_tracker) {
+      iree_async_frontier_tracker_fail_axis(
+          device->frontier_tracker, device->axis,
+          iree_status_from_code(iree_status_code(status)));
+    }
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_sync_device_queue_copy(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, iree_hal_copy_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+  if (iree_status_is_ok(status)) {
+    iree_hal_buffer_mapping_t source_mapping = {{0}};
+    status = iree_hal_buffer_map_range(
+        source_buffer, IREE_HAL_MAPPING_MODE_SCOPED,
+        IREE_HAL_MEMORY_ACCESS_READ, source_offset, length, &source_mapping);
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_buffer_map_write(target_buffer, target_offset,
+                                         source_mapping.contents.data,
+                                         source_mapping.contents.data_length);
+      status = iree_status_join(status,
+                                iree_hal_buffer_unmap_range(&source_mapping));
+    }
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_sync_device_advance_frontier(device);
+  } else {
+    iree_hal_semaphore_list_fail(signal_semaphore_list,
+                                 iree_status_clone(status));
+    if (device->frontier_tracker) {
+      iree_async_frontier_tracker_fail_axis(
+          device->frontier_tracker, device->axis,
+          iree_status_from_code(iree_status_code(status)));
+    }
+  }
+  return status;
+}
+
 static iree_status_t iree_hal_sync_device_queue_host_call(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -731,9 +834,9 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
         iree_hal_sync_device_query_semaphore_compatibility,
     .queue_alloca = iree_hal_sync_device_queue_alloca,
     .queue_dealloca = iree_hal_sync_device_queue_dealloca,
-    .queue_fill = iree_hal_device_queue_emulated_fill,
-    .queue_update = iree_hal_device_queue_emulated_update,
-    .queue_copy = iree_hal_device_queue_emulated_copy,
+    .queue_fill = iree_hal_sync_device_queue_fill,
+    .queue_update = iree_hal_sync_device_queue_update,
+    .queue_copy = iree_hal_sync_device_queue_copy,
     .queue_read = iree_hal_sync_device_queue_read,
     .queue_write = iree_hal_sync_device_queue_write,
     .queue_host_call = iree_hal_sync_device_queue_host_call,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -22,7 +22,6 @@
 #include "iree/hal/local/local_executable_cache.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
 #include "iree/hal/utils/file_registry.h"
-#include "iree/hal/utils/file_transfer.h"
 #include "iree/hal/utils/queue_emulation.h"
 
 typedef struct iree_hal_sync_device_t {
@@ -421,14 +420,57 @@ static iree_status_t iree_hal_sync_device_queue_read(
     iree_hal_file_t* source_file, uint64_t source_offset,
     iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
     iree_device_size_t length, iree_hal_read_flags_t flags) {
-  iree_hal_file_transfer_options_t options = {
-      .chunk_count = IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
-      .chunk_size = IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
-  };
-  return iree_hal_device_queue_read_streaming(
-      base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
-      source_file, source_offset, target_buffer, target_offset, length, flags,
-      options);
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_file_validate_access(source_file, IREE_HAL_MEMORY_ACCESS_READ));
+  if (length == 0) {
+    return iree_hal_device_queue_barrier(
+        base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+        IREE_HAL_EXECUTE_FLAG_NONE);
+  }
+  uint64_t file_length = iree_hal_file_length(source_file);
+  if (file_length > 0 && source_offset + length > file_length) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "read range [%" PRIu64 ", %" PRIu64 ") exceeds file length %" PRIu64,
+        source_offset, source_offset + (uint64_t)length, file_length);
+  }
+
+  // Memory file fast path: route to queue_copy via the storage buffer.
+  iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(source_file);
+  if (storage_buffer) {
+    return iree_hal_device_queue_copy(
+        base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+        storage_buffer, (iree_device_size_t)source_offset, target_buffer,
+        target_offset, length, IREE_HAL_COPY_FLAG_NONE);
+  }
+
+  // Synchronous I/O: wait, read, signal.
+  if (!iree_hal_file_supports_synchronous_io(source_file)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "file does not support synchronous I/O");
+  }
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_file_read(source_file, source_offset, target_buffer,
+                                target_offset, length);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_sync_device_advance_frontier(device);
+  } else {
+    iree_hal_semaphore_list_fail(signal_semaphore_list,
+                                 iree_status_clone(status));
+    if (device->frontier_tracker) {
+      iree_async_frontier_tracker_fail_axis(
+          device->frontier_tracker, device->axis,
+          iree_status_from_code(iree_status_code(status)));
+    }
+  }
+  return status;
 }
 
 static iree_status_t iree_hal_sync_device_queue_write(
@@ -438,14 +480,50 @@ static iree_status_t iree_hal_sync_device_queue_write(
     iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
     iree_hal_file_t* target_file, uint64_t target_offset,
     iree_device_size_t length, iree_hal_write_flags_t flags) {
-  iree_hal_file_transfer_options_t options = {
-      .chunk_count = IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
-      .chunk_size = IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
-  };
-  return iree_hal_device_queue_write_streaming(
-      base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
-      source_buffer, source_offset, target_file, target_offset, length, flags,
-      options);
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_file_validate_access(target_file, IREE_HAL_MEMORY_ACCESS_WRITE));
+  if (length == 0) {
+    return iree_hal_device_queue_barrier(
+        base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+        IREE_HAL_EXECUTE_FLAG_NONE);
+  }
+
+  // Memory file fast path: route to queue_copy via the storage buffer.
+  iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(target_file);
+  if (storage_buffer) {
+    return iree_hal_device_queue_copy(
+        base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+        source_buffer, source_offset, storage_buffer,
+        (iree_device_size_t)target_offset, length, IREE_HAL_COPY_FLAG_NONE);
+  }
+
+  // Synchronous I/O: wait, write, signal.
+  if (!iree_hal_file_supports_synchronous_io(target_file)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "file does not support synchronous I/O");
+  }
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_file_write(target_file, target_offset, source_buffer,
+                                 source_offset, length);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_sync_device_advance_frontier(device);
+  } else {
+    iree_hal_semaphore_list_fail(signal_semaphore_list,
+                                 iree_status_clone(status));
+    if (device->frontier_tracker) {
+      iree_async_frontier_tracker_fail_axis(
+          device->frontier_tracker, device->axis,
+          iree_status_from_code(iree_status_code(status)));
+    }
+  }
+  return status;
 }
 
 static iree_status_t iree_hal_sync_device_queue_host_call(

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -19,10 +19,10 @@
 #include "iree/hal/drivers/local_sync/sync_semaphore.h"
 #include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/inline_command_buffer.h"
+#include "iree/hal/local/inline_dispatch.h"
 #include "iree/hal/local/local_executable_cache.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
 #include "iree/hal/utils/file_registry.h"
-#include "iree/hal/utils/queue_emulation.h"
 
 typedef struct iree_hal_sync_device_t {
   iree_hal_resource_t resource;
@@ -629,6 +629,40 @@ static iree_status_t iree_hal_sync_device_queue_copy(
   return status;
 }
 
+static iree_status_t iree_hal_sync_device_queue_dispatch(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_executable_t* executable,
+    iree_hal_executable_export_ordinal_t export_ordinal,
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const iree_hal_buffer_ref_list_t bindings,
+    iree_hal_dispatch_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_local_executable_dispatch_inline(
+        executable, export_ordinal, config, constants, bindings.values,
+        bindings.count, flags);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_sync_device_advance_frontier(device);
+  } else {
+    iree_hal_semaphore_list_fail(signal_semaphore_list,
+                                 iree_status_clone(status));
+    if (device->frontier_tracker) {
+      iree_async_frontier_tracker_fail_axis(
+          device->frontier_tracker, device->axis,
+          iree_status_from_code(iree_status_code(status)));
+    }
+  }
+  return status;
+}
+
 static iree_status_t iree_hal_sync_device_queue_host_call(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -840,7 +874,7 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .queue_read = iree_hal_sync_device_queue_read,
     .queue_write = iree_hal_sync_device_queue_write,
     .queue_host_call = iree_hal_sync_device_queue_host_call,
-    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
+    .queue_dispatch = iree_hal_sync_device_queue_dispatch,
     .queue_execute = iree_hal_sync_device_queue_execute,
     .queue_flush = iree_hal_sync_device_queue_flush,
     .profiling_begin = iree_hal_sync_device_profiling_begin,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -369,21 +369,20 @@ iree_hal_sync_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
-static iree_status_t iree_hal_sync_device_queue_alloca(
-    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
-    const iree_hal_semaphore_list_t wait_semaphore_list,
-    const iree_hal_semaphore_list_t signal_semaphore_list,
-    iree_hal_allocator_pool_t pool, iree_hal_buffer_params_t params,
-    iree_device_size_t allocation_size, iree_hal_alloca_flags_t flags,
-    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
-  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-  iree_status_t status = iree_hal_semaphore_list_wait(
+// Waits for all semaphore dependencies before a queue operation body.
+static inline iree_status_t iree_hal_sync_device_queue_op_begin(
+    iree_hal_sync_device_t* device,
+    const iree_hal_semaphore_list_t wait_semaphore_list) {
+  return iree_hal_semaphore_list_wait(
       wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_allocator_allocate_buffer(
-        iree_hal_device_allocator(base_device), params, allocation_size,
-        out_buffer);
-  }
+}
+
+// Signals semaphores after a queue operation body completes (or fails them on
+// error) and advances the frontier tracker.
+static inline iree_status_t iree_hal_sync_device_queue_op_end(
+    iree_hal_sync_device_t* device,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_status_t status) {
   if (iree_status_is_ok(status)) {
     status = iree_hal_semaphore_list_signal(signal_semaphore_list);
   }
@@ -401,16 +400,91 @@ static iree_status_t iree_hal_sync_device_queue_alloca(
   return status;
 }
 
+static iree_status_t iree_hal_sync_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_t pool, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size, iree_hal_alloca_flags_t flags,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status =
+      iree_hal_allocator_allocate_buffer(iree_hal_device_allocator(base_device),
+                                         params, allocation_size, out_buffer);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
+}
+
 static iree_status_t iree_hal_sync_device_queue_dealloca(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer, iree_hal_dealloca_flags_t flags) {
-  // TODO(benvanik): queue-ordered allocations.
-  IREE_RETURN_IF_ERROR(iree_hal_device_queue_barrier(
-      base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
-      IREE_HAL_EXECUTE_FLAG_NONE));
-  return iree_ok_status();
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           iree_ok_status());
+}
+
+static iree_status_t iree_hal_sync_device_queue_fill(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, const void* pattern,
+    iree_host_size_t pattern_length, iree_hal_fill_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status = iree_hal_buffer_map_fill(
+      target_buffer, target_offset, length, pattern, pattern_length);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
+}
+
+static iree_status_t iree_hal_sync_device_queue_update(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    const void* source_buffer, iree_host_size_t source_offset,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, iree_hal_update_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status = iree_hal_buffer_map_write(
+      target_buffer, target_offset,
+      (const uint8_t*)source_buffer + source_offset, length);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
+}
+
+static iree_status_t iree_hal_sync_device_queue_copy(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, iree_hal_copy_flags_t flags) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_hal_buffer_mapping_t source_mapping = {{0}};
+  iree_status_t status = iree_hal_buffer_map_range(
+      source_buffer, IREE_HAL_MAPPING_MODE_SCOPED, IREE_HAL_MEMORY_ACCESS_READ,
+      source_offset, length, &source_mapping);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_buffer_map_write(target_buffer, target_offset,
+                                       source_mapping.contents.data,
+                                       source_mapping.contents.data_length);
+    status =
+        iree_status_join(status, iree_hal_buffer_unmap_range(&source_mapping));
+  }
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
 }
 
 static iree_status_t iree_hal_sync_device_queue_read(
@@ -420,7 +494,6 @@ static iree_status_t iree_hal_sync_device_queue_read(
     iree_hal_file_t* source_file, uint64_t source_offset,
     iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
     iree_device_size_t length, iree_hal_read_flags_t flags) {
-  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   IREE_RETURN_IF_ERROR(
       iree_hal_file_validate_access(source_file, IREE_HAL_MEMORY_ACCESS_READ));
   if (length == 0) {
@@ -435,7 +508,6 @@ static iree_status_t iree_hal_sync_device_queue_read(
         "read range [%" PRIu64 ", %" PRIu64 ") exceeds file length %" PRIu64,
         source_offset, source_offset + (uint64_t)length, file_length);
   }
-
   // Memory file fast path: route to queue_copy via the storage buffer.
   iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(source_file);
   if (storage_buffer) {
@@ -444,33 +516,17 @@ static iree_status_t iree_hal_sync_device_queue_read(
         storage_buffer, (iree_device_size_t)source_offset, target_buffer,
         target_offset, length, IREE_HAL_COPY_FLAG_NONE);
   }
-
-  // Synchronous I/O: wait, read, signal.
   if (!iree_hal_file_supports_synchronous_io(source_file)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "file does not support synchronous I/O");
   }
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_file_read(source_file, source_offset, target_buffer,
-                                target_offset, length);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-  return status;
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status = iree_hal_file_read(
+      source_file, source_offset, target_buffer, target_offset, length);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
 }
 
 static iree_status_t iree_hal_sync_device_queue_write(
@@ -480,7 +536,6 @@ static iree_status_t iree_hal_sync_device_queue_write(
     iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
     iree_hal_file_t* target_file, uint64_t target_offset,
     iree_device_size_t length, iree_hal_write_flags_t flags) {
-  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   IREE_RETURN_IF_ERROR(
       iree_hal_file_validate_access(target_file, IREE_HAL_MEMORY_ACCESS_WRITE));
   if (length == 0) {
@@ -488,7 +543,6 @@ static iree_status_t iree_hal_sync_device_queue_write(
         base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
         IREE_HAL_EXECUTE_FLAG_NONE);
   }
-
   // Memory file fast path: route to queue_copy via the storage buffer.
   iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(target_file);
   if (storage_buffer) {
@@ -497,136 +551,17 @@ static iree_status_t iree_hal_sync_device_queue_write(
         source_buffer, source_offset, storage_buffer,
         (iree_device_size_t)target_offset, length, IREE_HAL_COPY_FLAG_NONE);
   }
-
-  // Synchronous I/O: wait, write, signal.
   if (!iree_hal_file_supports_synchronous_io(target_file)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "file does not support synchronous I/O");
   }
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_file_write(target_file, target_offset, source_buffer,
-                                 source_offset, length);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-  return status;
-}
-
-static iree_status_t iree_hal_sync_device_queue_fill(
-    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
-    const iree_hal_semaphore_list_t wait_semaphore_list,
-    const iree_hal_semaphore_list_t signal_semaphore_list,
-    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
-    iree_device_size_t length, const void* pattern,
-    iree_host_size_t pattern_length, iree_hal_fill_flags_t flags) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_map_fill(target_buffer, target_offset, length,
-                                      pattern, pattern_length);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-  return status;
-}
-
-static iree_status_t iree_hal_sync_device_queue_update(
-    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
-    const iree_hal_semaphore_list_t wait_semaphore_list,
-    const iree_hal_semaphore_list_t signal_semaphore_list,
-    const void* source_buffer, iree_host_size_t source_offset,
-    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
-    iree_device_size_t length, iree_hal_update_flags_t flags) {
-  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_map_write(
-        target_buffer, target_offset,
-        (const uint8_t*)source_buffer + source_offset, length);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-  return status;
-}
-
-static iree_status_t iree_hal_sync_device_queue_copy(
-    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
-    const iree_hal_semaphore_list_t wait_semaphore_list,
-    const iree_hal_semaphore_list_t signal_semaphore_list,
-    iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
-    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
-    iree_device_size_t length, iree_hal_copy_flags_t flags) {
-  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    iree_hal_buffer_mapping_t source_mapping = {{0}};
-    status = iree_hal_buffer_map_range(
-        source_buffer, IREE_HAL_MAPPING_MODE_SCOPED,
-        IREE_HAL_MEMORY_ACCESS_READ, source_offset, length, &source_mapping);
-    if (iree_status_is_ok(status)) {
-      status = iree_hal_buffer_map_write(target_buffer, target_offset,
-                                         source_mapping.contents.data,
-                                         source_mapping.contents.data_length);
-      status = iree_status_join(status,
-                                iree_hal_buffer_unmap_range(&source_mapping));
-    }
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-  return status;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status = iree_hal_file_write(
+      target_file, target_offset, source_buffer, source_offset, length);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
 }
 
 static iree_status_t iree_hal_sync_device_queue_dispatch(
@@ -639,28 +574,13 @@ static iree_status_t iree_hal_sync_device_queue_dispatch(
     const iree_hal_buffer_ref_list_t bindings,
     iree_hal_dispatch_flags_t flags) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_local_executable_dispatch_inline(
-        executable, export_ordinal, config, constants, bindings.values,
-        bindings.count, flags);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-  return status;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status = iree_hal_local_executable_dispatch_inline(
+      executable, export_ordinal, config, constants, bindings.values,
+      bindings.count, flags);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
 }
 
 static iree_status_t iree_hal_sync_device_queue_host_call(
@@ -780,37 +700,12 @@ static iree_status_t iree_hal_sync_device_queue_execute(
     iree_hal_buffer_binding_table_t binding_table,
     iree_hal_execute_flags_t flags) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
-
-  // Wait for semaphores to be signaled before performing any work.
-  iree_status_t status = iree_hal_semaphore_list_wait(
-      wait_semaphore_list, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
-
-  // Run all deferred command buffers - any we could have run inline we already
-  // did during recording.
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_sync_device_apply_deferred_command_buffer(
-        device, command_buffer, binding_table);
-  }
-
-  // Signal all semaphores now that batch work has completed.
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_signal(signal_semaphore_list);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_sync_device_advance_frontier(device);
-  } else {
-    // Fail all signal semaphores so downstream waiters see the error instead
-    // of hanging indefinitely.
-    iree_hal_semaphore_list_fail(signal_semaphore_list,
-                                 iree_status_clone(status));
-    if (device->frontier_tracker) {
-      iree_async_frontier_tracker_fail_axis(
-          device->frontier_tracker, device->axis,
-          iree_status_from_code(iree_status_code(status)));
-    }
-  }
-
-  return status;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_sync_device_queue_op_begin(device, wait_semaphore_list));
+  iree_status_t status = iree_hal_sync_device_apply_deferred_command_buffer(
+      device, command_buffer, binding_table);
+  return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
+                                           status);
 }
 
 static iree_status_t iree_hal_sync_device_queue_flush(

--- a/runtime/src/iree/hal/local/BUILD.bazel
+++ b/runtime/src/iree/hal/local/BUILD.bazel
@@ -127,6 +127,17 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "inline_dispatch",
+    srcs = ["inline_dispatch.c"],
+    hdrs = ["inline_dispatch.h"],
+    deps = [
+        ":local",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "local",
     srcs = [
         "inline_command_buffer.c",

--- a/runtime/src/iree/hal/local/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/CMakeLists.txt
@@ -144,6 +144,20 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    inline_dispatch
+  HDRS
+    "inline_dispatch.h"
+  SRCS
+    "inline_dispatch.c"
+  DEPS
+    ::local
+    iree::base
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     local
   HDRS
     "executable_loader.h"

--- a/runtime/src/iree/hal/local/inline_dispatch.c
+++ b/runtime/src/iree/hal/local/inline_dispatch.c
@@ -1,0 +1,76 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/local/inline_dispatch.h"
+
+#include "iree/hal/local/local_executable.h"
+
+iree_status_t iree_hal_local_executable_dispatch_inline(
+    iree_hal_executable_t* executable,
+    iree_hal_executable_export_ordinal_t export_ordinal,
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const iree_hal_buffer_ref_t* bindings, iree_host_size_t binding_count,
+    iree_hal_dispatch_flags_t flags) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Stack-allocate mapping and pointer arrays for the bindings.
+  iree_hal_buffer_mapping_t* mappings = NULL;
+  void** binding_ptrs = NULL;
+  size_t* binding_lengths = NULL;
+  if (binding_count > 0) {
+    mappings = (iree_hal_buffer_mapping_t*)iree_alloca(binding_count *
+                                                       sizeof(*mappings));
+    memset(mappings, 0, binding_count * sizeof(*mappings));
+    binding_ptrs = (void**)iree_alloca(binding_count * sizeof(*binding_ptrs));
+    binding_lengths =
+        (size_t*)iree_alloca(binding_count * sizeof(*binding_lengths));
+  }
+
+  // Map all binding buffers.
+  iree_status_t status = iree_ok_status();
+  iree_host_size_t mapped_count = 0;
+  for (iree_host_size_t i = 0; i < binding_count && iree_status_is_ok(status);
+       ++i) {
+    status = iree_hal_buffer_map_range(
+        bindings[i].buffer, IREE_HAL_MAPPING_MODE_SCOPED,
+        IREE_HAL_MEMORY_ACCESS_ANY, bindings[i].offset, bindings[i].length,
+        &mappings[i]);
+    if (iree_status_is_ok(status)) {
+      binding_ptrs[i] = mappings[i].contents.data;
+      binding_lengths[i] = mappings[i].contents.data_length;
+      ++mapped_count;
+    }
+  }
+
+  // Execute all workgroups inline.
+  if (iree_status_is_ok(status)) {
+    iree_hal_executable_dispatch_state_v0_t dispatch_state = {
+        .workgroup_size_x = config.workgroup_size[0],
+        .workgroup_size_y = config.workgroup_size[1],
+        .workgroup_size_z = (uint16_t)config.workgroup_size[2],
+        .constant_count = (uint16_t)(constants.data_length / sizeof(uint32_t)),
+        .workgroup_count_x = config.workgroup_count[0],
+        .workgroup_count_y = config.workgroup_count[1],
+        .workgroup_count_z = (uint16_t)config.workgroup_count[2],
+        .max_concurrency = 1,
+        .binding_count = (uint8_t)binding_count,
+        .constants = (const uint32_t*)constants.data,
+        .binding_ptrs = binding_ptrs,
+        .binding_lengths = binding_lengths,
+    };
+    status = iree_hal_local_executable_issue_dispatch_inline(
+        iree_hal_local_executable_cast(executable), export_ordinal,
+        &dispatch_state, /*processor_id=*/0, iree_byte_span_empty());
+  }
+
+  // Unmap all binding buffers (even on failure — mappings hold refs).
+  for (iree_host_size_t i = 0; i < mapped_count; ++i) {
+    iree_status_ignore(iree_hal_buffer_unmap_range(&mappings[i]));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/runtime/src/iree/hal/local/inline_dispatch.h
+++ b/runtime/src/iree/hal/local/inline_dispatch.h
@@ -1,0 +1,45 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Inline single-threaded dispatch for CPU executables.
+//
+// Executes a dispatch synchronously on the calling thread without command
+// buffer intermediation. Maps binding buffers, populates the executable
+// dispatch state, iterates all workgroups, and unmaps.
+//
+// Used by local_sync for queue_dispatch and by local_task for inline
+// dispatches (ALLOW_INLINE_EXECUTION with budget-1 processes).
+
+#ifndef IREE_HAL_LOCAL_INLINE_DISPATCH_H_
+#define IREE_HAL_LOCAL_INLINE_DISPATCH_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Executes a dispatch inline on the calling thread.
+//
+// Maps all binding buffers with SCOPED lifetime, populates the executable's
+// dispatch state, iterates all workgroups via issue_dispatch_inline, and
+// unmaps. Returns the dispatch status (first workgroup failure).
+//
+// The executable must be a local executable (iree_hal_local_executable_t).
+// Binding buffers must support host-visible mapping.
+iree_status_t iree_hal_local_executable_dispatch_inline(
+    iree_hal_executable_t* executable,
+    iree_hal_executable_export_ordinal_t export_ordinal,
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const iree_hal_buffer_ref_t* bindings, iree_host_size_t binding_count,
+    iree_hal_dispatch_flags_t flags);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_HAL_LOCAL_INLINE_DISPATCH_H_

--- a/runtime/src/iree/hal/utils/fd_file.c
+++ b/runtime/src/iree/hal/utils/fd_file.c
@@ -270,38 +270,35 @@ IREE_API_EXPORT iree_status_t iree_hal_fd_file_from_handle(
   file->fd = fd;
   file->length = length;
 
-  // If a proactor is provided, duplicate the fd and import it for async I/O.
-  // The duplicate is owned by the proactor-managed async file and closed when
-  // the async file is released.
+  // If a proactor is provided, attempt to duplicate the fd and import it for
+  // async I/O. The duplicate is owned by the proactor-managed async file and
+  // closed when the async file is released.
   //
-  // Currently only supported on platforms with native fd async primitives
-  // (POSIX). Windows IOCP requires HANDLE-based import with ReOpenFile to
-  // obtain a FILE_FLAG_OVERLAPPED handle, which needs the original share mode
-  // and access rights threaded through the import API.
-  iree_status_t status = iree_ok_status();
+  // If async import fails (unsupported fd type, platform limitations, etc.) the
+  // file degrades to synchronous-only mode: all reads/writes go through
+  // pread/pwrite instead of the proactor. This is always correct — async I/O is
+  // a performance optimization, not a correctness requirement.
 #if defined(IREE_ASYNC_HAVE_FD)
   if (proactor) {
     iree_async_primitive_t async_primitive = iree_async_primitive_from_fd(fd);
     iree_async_primitive_t dup_primitive;
-    status = iree_async_primitive_dup(async_primitive, &dup_primitive);
-    if (iree_status_is_ok(status)) {
-      status =
+    iree_status_t import_status =
+        iree_async_primitive_dup(async_primitive, &dup_primitive);
+    if (iree_status_is_ok(import_status)) {
+      import_status =
           iree_async_file_import(proactor, dup_primitive, &file->async_file);
-      if (!iree_status_is_ok(status)) {
+      if (!iree_status_is_ok(import_status)) {
         iree_async_primitive_close(&dup_primitive);
       }
     }
+    // Async import failure is non-fatal: degrade to sync-only mode.
+    iree_status_ignore(import_status);
   }
 #endif  // IREE_ASYNC_HAVE_FD
 
-  if (iree_status_is_ok(status)) {
-    *out_file = (iree_hal_file_t*)file;
-  } else {
-    iree_io_file_handle_release(file->handle);
-    iree_allocator_free(host_allocator, file);
-  }
+  *out_file = (iree_hal_file_t*)file;
   IREE_TRACE_ZONE_END(z0);
-  return status;
+  return iree_ok_status();
 }
 
 static void iree_hal_fd_file_destroy(iree_hal_file_t* IREE_RESTRICT base_file) {

--- a/runtime/src/iree/hal/utils/fd_file.c
+++ b/runtime/src/iree/hal/utils/fd_file.c
@@ -65,6 +65,10 @@ static iree_status_t iree_hal_platform_fd_pread(
         "file descriptor is not backed by a valid Win32 HANDLE");
   }
 
+  // Cap at INT32_MAX to prevent silent DWORD truncation for >4GB requests.
+  // Callers retry for the remaining bytes via out_bytes_read.
+  if (count > INT32_MAX) count = INT32_MAX;
+
   DWORD bytes_read = 0;
   OVERLAPPED overlapped = {0};
   overlapped.Offset = (DWORD)(offset & 0xFFFFFFFFu);
@@ -90,6 +94,10 @@ static iree_status_t iree_hal_platform_fd_pwrite(
         IREE_STATUS_INVALID_ARGUMENT,
         "file descriptor is not backed by a valid Win32 HANDLE");
   }
+
+  // Cap at INT32_MAX to prevent silent DWORD truncation for >4GB requests.
+  // Callers retry for the remaining bytes via out_bytes_written.
+  if (count > INT32_MAX) count = INT32_MAX;
 
   DWORD bytes_written = 0;
   OVERLAPPED overlapped = {0};
@@ -134,6 +142,9 @@ static iree_status_t iree_hal_platform_fd_pread(
     iree_host_size_t* out_bytes_read) {
   IREE_ASSERT_ARGUMENT(out_bytes_read);
   *out_bytes_read = 0;
+  // Cap at INT_MAX: some kernels return -EINVAL for counts exceeding this.
+  // Callers retry for the remaining bytes via out_bytes_read.
+  if (count > INT_MAX) count = INT_MAX;
   ssize_t bytes_read = pread(fd, buffer, (size_t)count, (off_t)offset);
   if (bytes_read > 0) {
     *out_bytes_read = (iree_host_size_t)bytes_read;
@@ -152,6 +163,9 @@ static iree_status_t iree_hal_platform_fd_pwrite(
     iree_host_size_t* out_bytes_written) {
   IREE_ASSERT_ARGUMENT(out_bytes_written);
   *out_bytes_written = 0;
+  // Cap at INT_MAX: some kernels return -EINVAL for counts exceeding this.
+  // Callers retry for the remaining bytes via out_bytes_written.
+  if (count > INT_MAX) count = INT_MAX;
   ssize_t bytes_written = pwrite(fd, buffer, (size_t)count, (off_t)offset);
   if (bytes_written > 0) {
     *out_bytes_written = (iree_host_size_t)bytes_written;

--- a/runtime/src/iree/hal/utils/memory_file.c
+++ b/runtime/src/iree/hal/utils/memory_file.c
@@ -219,8 +219,11 @@ static void iree_hal_memory_file_try_import_buffer(
     iree_hal_allocator_t* device_allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  const bool is_aligned = iree_host_size_has_alignment(
+      (uintptr_t)contents.data, IREE_HAL_HEAP_BUFFER_ALIGNMENT);
   iree_hal_buffer_params_t staging_buffer_params = {
-      .access = access | IREE_HAL_MEMORY_ACCESS_DISCARD,
+      .access = access | IREE_HAL_MEMORY_ACCESS_DISCARD |
+                (!is_aligned ? IREE_HAL_MEMORY_ACCESS_UNALIGNED : 0),
       .queue_affinity = queue_affinity,
       .type = IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_HOST |
               IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,

--- a/runtime/src/iree/task/topology_sysfs.c
+++ b/runtime/src/iree/task/topology_sysfs.c
@@ -323,29 +323,40 @@ iree_task_topology_node_id_t iree_task_topology_query_current_node(void) {
 // Constructive sharing mask utilities
 //===----------------------------------------------------------------------===//
 
-// Context for building processor bitmask from CPU list.
+// Context for building a topology group mask directly from a CPU list.
+// For each CPU range in the list, we scan the topology's groups to find which
+// ones have a processor_index in the range, and set their bit in group_mask.
+// This avoids the intermediate cpu_set_t (limited to CPU_SETSIZE=1024) and
+// works for arbitrary processor IDs.
 typedef struct {
-  cpu_set_t processor_mask;
-} iree_sysfs_processor_mask_context_t;
+  const iree_task_topology_t* topology;
+  iree_task_topology_group_mask_t group_mask;
+} iree_sysfs_sharing_context_t;
 
-// Callback to accumulate processor IDs into a bitmask.
-static bool iree_sysfs_accumulate_processor_mask(uint32_t start_cpu,
+// Callback for iree_sysfs_parse_cpu_list that maps CPU ranges to group indices.
+// O(ranges_in_list x group_count) per group — both are small.
+static bool iree_sysfs_accumulate_sharing_groups(uint32_t start_cpu,
                                                  uint32_t end_cpu,
                                                  void* user_data) {
-  iree_sysfs_processor_mask_context_t* ctx =
-      (iree_sysfs_processor_mask_context_t*)user_data;
-  for (uint32_t cpu = start_cpu; cpu < end_cpu; ++cpu) {
-    CPU_SET(cpu, &ctx->processor_mask);
+  iree_sysfs_sharing_context_t* ctx = (iree_sysfs_sharing_context_t*)user_data;
+  for (iree_host_size_t i = 0; i < ctx->topology->group_count; ++i) {
+    uint32_t processor = ctx->topology->groups[i].processor_index;
+    if (processor >= start_cpu && processor < end_cpu) {
+      iree_task_affinity_set_set_index(&ctx->group_mask,
+                                       ctx->topology->groups[i].group_index);
+    }
   }
   return true;  // Continue enumeration.
 }
 
-// Reads shared_cpu_list for a given cache index into processor bitmask.
+// Reads shared_cpu_list for a given cache index and builds a group mask
+// directly from the topology (no intermediate cpu_set_t).
 // Returns true if successful, false if the file doesn't exist or can't be
 // parsed.
-static bool iree_sysfs_read_cache_shared_cpu_list(uint32_t processor,
-                                                  uint32_t cache_index,
-                                                  cpu_set_t* out_mask) {
+static bool iree_sysfs_read_cache_shared_cpu_list(
+    uint32_t processor, uint32_t cache_index,
+    const iree_task_topology_t* topology,
+    iree_task_topology_group_mask_t* out_group_mask) {
   char path[256];
   iree_snprintf(path, sizeof(path),
                 "%s/cpu/cpu%u/cache/index%u/shared_cpu_list",
@@ -360,27 +371,28 @@ static bool iree_sysfs_read_cache_shared_cpu_list(uint32_t processor,
     return false;
   }
 
-  // Parse CPU list into bitmask.
-  iree_sysfs_processor_mask_context_t ctx;
-  CPU_ZERO(&ctx.processor_mask);
+  // Parse CPU list directly into group mask.
+  iree_sysfs_sharing_context_t ctx = {
+      .topology = topology,
+      .group_mask = iree_task_affinity_set_empty(),
+  };
   status =
       iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
-                                iree_sysfs_accumulate_processor_mask, &ctx);
-  const bool valid_bitmask = iree_status_is_ok(status);
+                                iree_sysfs_accumulate_sharing_groups, &ctx);
+  const bool valid = iree_status_is_ok(status);
   iree_status_ignore(status);
-  *out_mask = ctx.processor_mask;
-  return valid_bitmask;
+  *out_group_mask = ctx.group_mask;
+  return valid;
 }
 
-// Finds the best cache level for constructive sharing.
-// Prefers L3 Data/Unified, falls back to L2 Data/Unified.
-// Populates |out_mask| with processors sharing that cache level.
+// Finds the best cache level for constructive sharing and returns the group
+// mask directly. Prefers L3 Data/Unified, falls back to L2 Data/Unified.
 // Returns true if a mask was found, false otherwise.
-static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
-                                               cpu_set_t* out_mask) {
-  cpu_set_t l3_mask, l2_mask;
-  CPU_ZERO(&l3_mask);
-  CPU_ZERO(&l2_mask);
+static bool iree_sysfs_find_sharing_cache_mask(
+    uint32_t processor, const iree_task_topology_t* topology,
+    iree_task_topology_group_mask_t* out_group_mask) {
+  iree_task_topology_group_mask_t l3_mask = iree_task_affinity_set_empty();
+  iree_task_topology_group_mask_t l2_mask = iree_task_affinity_set_empty();
   bool found_l3 = false;
   bool found_l2 = false;
 
@@ -400,8 +412,8 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
       continue;
     }
 
-    cpu_set_t shared_mask;
-    if (iree_sysfs_read_cache_shared_cpu_list(processor, cache_index,
+    iree_task_topology_group_mask_t shared_mask;
+    if (iree_sysfs_read_cache_shared_cpu_list(processor, cache_index, topology,
                                               &shared_mask)) {
       if (cache.level == 3) {
         l3_mask = shared_mask;
@@ -416,10 +428,10 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
 
   // Prefer L3, fall back to L2.
   if (found_l3) {
-    *out_mask = l3_mask;
+    *out_group_mask = l3_mask;
     return true;
   } else if (found_l2) {
-    *out_mask = l2_mask;
+    *out_group_mask = l2_mask;
     return true;
   }
   return false;
@@ -429,30 +441,19 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
 // We parse shared_cpu_list from cache/index*/shared_cpu_list to determine
 // which processors share cache levels. We prefer L3 cache sharing, falling
 // back to L2 if L3 is not available.
+//
+// The group mask is built directly from the CPU list without an intermediate
+// cpu_set_t, so there is no limit on processor IDs (unlike glibc's
+// CPU_SETSIZE=1024 which overflows on machines with >1024 logical CPUs).
 iree_status_t iree_task_topology_fixup_constructive_sharing_masks(
     iree_task_topology_t* topology) {
-  // O(n^2), but n is always <= 64 (and often <= 8).
   for (iree_host_size_t i = 0; i < topology->group_count; ++i) {
     iree_task_topology_group_t* group = &topology->groups[i];
-    uint32_t processor = group->processor_index;
 
-    // Find processors that share L3 (or L2 as fallback) cache.
-    cpu_set_t processor_sharing_mask;
-    const bool has_sharing_mask =
-        iree_sysfs_find_sharing_cache_mask(processor, &processor_sharing_mask);
-
-    // Convert processor bitmask to group bitmask.
-    // Only processors in the topology can contribute to the group mask.
-    iree_task_topology_group_mask_t group_mask = 0;
-    if (has_sharing_mask) {
-      for (iree_host_size_t j = 0; j < topology->group_count; ++j) {
-        const iree_task_topology_group_t* other_group = &topology->groups[j];
-        uint32_t other_processor = other_group->processor_index;
-        if (CPU_ISSET(other_processor, &processor_sharing_mask)) {
-          group_mask |= 1ull << other_group->group_index;
-        }
-      }
-    }
+    // Find groups that share L3 (or L2 as fallback) cache with this group.
+    iree_task_topology_group_mask_t group_mask = iree_task_affinity_set_empty();
+    iree_sysfs_find_sharing_cache_mask(group->processor_index, topology,
+                                       &group_mask);
 
     group->constructive_sharing_mask = group_mask;
   }
@@ -525,6 +526,115 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
 // Cache domain enumeration
 //===----------------------------------------------------------------------===//
 
+// Context for building a processor bitmask from a CPU list.
+// Used by the cache domain enumeration path which needs cpu_set_t for domain
+// grouping. Note: cpu_set_t is limited to CPU_SETSIZE (glibc 1024) — this is
+// acceptable for domain enumeration since IREE_TASK_TOPOLOGY_MAX_GROUP_COUNT
+// bounds the number of cores we enumerate, but processor IDs themselves could
+// exceed 1024 on large machines. The constructive sharing mask path above
+// avoids cpu_set_t entirely.
+typedef struct {
+  cpu_set_t processor_mask;
+} iree_sysfs_processor_mask_context_t;
+
+// Callback to accumulate processor IDs into a cpu_set_t bitmask.
+static bool iree_sysfs_accumulate_processor_mask(uint32_t start_cpu,
+                                                 uint32_t end_cpu,
+                                                 void* user_data) {
+  iree_sysfs_processor_mask_context_t* ctx =
+      (iree_sysfs_processor_mask_context_t*)user_data;
+  for (uint32_t cpu = start_cpu; cpu < end_cpu; ++cpu) {
+    if (cpu < CPU_SETSIZE) {
+      CPU_SET(cpu, &ctx->processor_mask);
+    }
+  }
+  return true;  // Continue enumeration.
+}
+
+// Reads shared_cpu_list for a given cache index into a processor bitmask.
+// Returns true if successful, false if the file doesn't exist or can't be
+// parsed.
+static bool iree_sysfs_read_cache_shared_processor_mask(uint32_t processor,
+                                                        uint32_t cache_index,
+                                                        cpu_set_t* out_mask) {
+  char path[256];
+  iree_snprintf(path, sizeof(path),
+                "%s/cpu/cpu%u/cache/index%u/shared_cpu_list",
+                iree_sysfs_get_root_path(), processor, cache_index);
+
+  char buffer[256];
+  iree_host_size_t length = 0;
+  iree_status_t status =
+      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return false;
+  }
+
+  // Parse CPU list into bitmask.
+  iree_sysfs_processor_mask_context_t ctx;
+  CPU_ZERO(&ctx.processor_mask);
+  status =
+      iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
+                                iree_sysfs_accumulate_processor_mask, &ctx);
+  const bool valid_bitmask = iree_status_is_ok(status);
+  iree_status_ignore(status);
+  *out_mask = ctx.processor_mask;
+  return valid_bitmask;
+}
+
+// Finds the best cache level for domain grouping and returns a processor mask.
+// Prefers L3 Data/Unified, falls back to L2 Data/Unified.
+// Returns true if a mask was found, false otherwise.
+static bool iree_sysfs_find_sharing_processor_mask(uint32_t processor,
+                                                   cpu_set_t* out_mask) {
+  cpu_set_t l3_mask, l2_mask;
+  CPU_ZERO(&l3_mask);
+  CPU_ZERO(&l2_mask);
+  bool found_l3 = false;
+  bool found_l2 = false;
+
+  // Scan cache indices looking for L3 (preferred) and L2 (fallback).
+  for (uint32_t cache_index = 0; cache_index < IREE_SYSFS_MAX_CACHE_INDICES;
+       ++cache_index) {
+    iree_sysfs_cache_info_t cache = {0};
+    iree_status_t status =
+        iree_sysfs_query_cache_level(processor, cache_index, &cache);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      break;  // No more cache levels.
+    }
+
+    // Only consider Data or Unified caches.
+    if (!cache.is_data_cache) {
+      continue;
+    }
+
+    cpu_set_t shared_mask;
+    if (iree_sysfs_read_cache_shared_processor_mask(processor, cache_index,
+                                                    &shared_mask)) {
+      if (cache.level == 3) {
+        l3_mask = shared_mask;
+        found_l3 = true;
+        break;  // L3 is best, use it immediately.
+      } else if (cache.level == 2) {
+        l2_mask = shared_mask;
+        found_l2 = true;
+      }
+    }
+  }
+
+  // Prefer L3, fall back to L2.
+  if (found_l3) {
+    *out_mask = l3_mask;
+    return true;
+  } else if (found_l2) {
+    *out_mask = l2_mask;
+    return true;
+  }
+  return false;
+}
+
 // Cache domain descriptor grouping cores that share L3 cache.
 typedef struct {
   // All cores in this domain.
@@ -548,7 +658,7 @@ static iree_host_size_t iree_sysfs_enumerate_cache_domains(
     cpu_set_t sharing_mask;
     CPU_ZERO(&sharing_mask);
     const bool has_mask =
-        iree_sysfs_find_sharing_cache_mask(processor, &sharing_mask);
+        iree_sysfs_find_sharing_processor_mask(processor, &sharing_mask);
 
     // If no cache info available, put all cores in one domain.
     if (!has_mask) {

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -65,8 +65,9 @@ iree_status_t iree_task_worker_initialize(
       iree_max(IREE_TASK_WORKER_MIN_STACK_SIZE, stack_size);
 
   // NOTE: if the thread creation fails we'll bail here and let the caller
-  // cleanup by calling deinitialize (which is safe because we zero init
-  // everything).
+  // cleanup by calling deinitialize. The guard in deinitialize checks
+  // worker->executor (set above) to distinguish initialized workers from
+  // never-initialized ones in the same allocation.
   iree_status_t status = iree_thread_create(
       iree_task_worker_thread_entry, out_worker, thread_params,
       executor->allocator, &out_worker->thread);
@@ -126,10 +127,18 @@ void iree_task_worker_await_exit(iree_task_worker_t* worker) {
 }
 
 void iree_task_worker_deinitialize(iree_task_worker_t* worker) {
+  // Skip workers that were never initialized. Their memory is zero-filled
+  // from iree_allocator_malloc but notifications were never initialized —
+  // calling iree_notification_deinitialize on them would operate on a
+  // never-initialized pthread_mutex_t (undefined behavior on non-glibc).
+  // worker->executor is set at the start of iree_task_worker_initialize,
+  // before notification init, so NULL means initialize was never called.
+  if (!worker->executor) return;
+
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Must have called request_exit/await_exit, OR thread creation failed during
-  // initialization.
+  // initialization (thread is NULL but notifications are initialized).
   IREE_ASSERT_TRUE(!worker->thread || iree_task_worker_is_zombie(worker));
 
   iree_thread_release(worker->thread);


### PR DESCRIPTION
The local_sync driver is the synchronous, single-threaded HAL backend — every queue operation blocks the calling thread until completion. Despite this, it was routing operations through heavyweight abstractions designed for async backends:

- **File I/O** went through the streaming file transfer machinery (`file_transfer.h`): staging buffer allocation, transfer worker management, chunked semaphore chains. This caused `FdFileReadRangeValidation` to deadlock because the error path got tangled in semaphore signaling.

- **Fill, update, copy** went through queue emulation (`queue_emulation.h`): each operation created a one-shot command buffer, recorded a single command, called `queue_execute` to replay it, then destroyed the command buffer.

- **Dispatch** similarly created a throwaway command buffer for each dispatch call.

All of this is unnecessary overhead for a driver that executes everything inline. The fix: replace every queue operation with the same three-line pattern:

```c
IREE_RETURN_IF_ERROR(queue_op_begin(device, wait_semaphores));
iree_status_t status = do_the_thing();
return queue_op_end(device, signal_semaphores, status);
```

`queue_op_begin` waits on semaphores. `queue_op_end` signals on success, fails on error, and advances the frontier tracker. Both are `static inline` helpers — the compiler eliminates them entirely.

### What changed

- **queue_read/write**: Direct `iree_hal_file_read`/`write` calls with range validation (fixes the deadlock). Memory files still fast-path through `queue_copy` via the storage buffer.

- **queue_fill/update/copy**: Direct `iree_hal_buffer_map_fill`, `map_write`, and map-source + `map_write` respectively. No command buffers.

- **queue_dispatch**: New shared utility `iree_hal_local_executable_dispatch_inline` in `hal/local/` that maps bindings, populates the dispatch state, and iterates all workgroups. ~75 lines that replace the command buffer round-trip. Available for local_task's inline dispatch path as a future simplification.

- **begin/end factoring**: The 15-line wait/signal/fail/frontier pattern that was copy-pasted across 9 queue operations is now two inline helpers. The simplest operations (dealloca) are three lines of body.

### Result

local_sync has zero dependency on `file_transfer.h` and `queue_emulation.h`. Net deletion of ~105 lines while adding file I/O support, range validation, inline dispatch, and fixing a deadlock. The driver is now a clear, readable expression of "wait, do the thing, signal" — which is all a synchronous driver should be.