### PR TITLE
[Tokenizer] Fix silent output truncation in encode/decode finalize

### DIFF
--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -2898,6 +2898,18 @@ iree_status_t iree_tokenizer_encode_state_finalize(
       &state->postprocessor, output, total_tokens);
 
   *out_token_count = total_tokens;
+
+  // Detect output buffer overflow: if any pipeline stage still has pending
+  // data after finalize completed all its work, the output buffer was too
+  // small. has_pending checks all stages: postprocessor, model, segments,
+  // ring buffer, normalizer, and special token state.
+  if (iree_tokenizer_encode_state_has_pending(state)) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "encode finalize: output buffer full "
+                            "(wrote %" PRIhsz " of %" PRIhsz " capacity)",
+                            total_tokens, output.capacity);
+  }
+
   return iree_ok_status();
 }
 
@@ -3518,6 +3530,17 @@ iree_status_t iree_tokenizer_decode_state_finalize(
           iree_tokenizer_decode_flush_pending_as_replacement(
               state, (uint8_t*)text_output.data, 0, text_output.size);
       *out_text_length = flushed;
+      // Defensive: if pending bytes remain after flush, the output buffer was
+      // too small for the replacement characters. Each pending byte emits one
+      // U+FFFD (3 bytes UTF-8). Only reachable with byte_fallback decoders
+      // (SentencePiece-based tokenizers) when the last fed tokens form an
+      // incomplete UTF-8 sequence and the output buffer is very small
+      // (edge case).
+      if (state->byte_fallback_pending_count > 0) {
+        return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "decode finalize: output buffer too small "
+                                "for pending byte fallback replacements");
+      }
     }
     return iree_ok_status();
   }

--- a/runtime/src/iree/tokenizer/tokenizer_decode_test.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_decode_test.cc
@@ -1250,6 +1250,81 @@ TEST_F(TokenizerDecodeTest, ByteFallbackInvalidContinuation) {
   iree_tokenizer_free(tokenizer);
 }
 
+//===----------------------------------------------------------------------===//
+// Output Buffer Overflow Detection
+//
+// Verifies that decode functions return IREE_STATUS_RESOURCE_EXHAUSTED when the
+// output buffer is too small, rather than silently truncating.
+//===----------------------------------------------------------------------===//
+
+class TokenizerDecodeOverflowTest : public ::testing::Test {};
+
+// Batch decode with output buffer too small for the decoded text.
+// "Hello" = 5 bytes, but buffer only holds 1.
+TEST_F(TokenizerDecodeOverflowTest, BatchDecodeOutputBufferTooSmall) {
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "Hello");
+  vocab_builder.AddToken(1, "world");
+  ScopedVocab vocab = vocab_builder.Build();
+
+  iree_tokenizer_t* tokenizer = BuildByteLevelTokenizer(vocab.release());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // Buffer size = 1, but "Helloworld" needs 10 bytes.
+  int32_t token_ids[] = {0, 1};
+  iree_tokenizer_token_id_list_t tokens = {2, token_ids};
+  char output[1];
+  iree_host_size_t text_length = 0;
+  iree_status_t status = iree_tokenizer_decode(
+      tokenizer, tokens, IREE_TOKENIZER_DECODE_FLAG_NONE,
+      iree_make_mutable_string_view(output, sizeof(output)),
+      iree_allocator_system(), &text_length);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Defensive: byte_fallback finalize with partial flush.
+// Feed <0xF0> + <0x9F> (2 bytes of a 4-byte UTF-8 sequence). Finalize emits
+// one U+FFFD per pending byte (2 * 3 = 6 bytes needed). Buffer of 5 bytes
+// fits one U+FFFD (3 bytes) but not the second, triggering RESOURCE_EXHAUSTED.
+TEST_F(TokenizerDecodeOverflowTest,
+       FinalizePreDecodedByteFallbackPartialFlush) {
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "<0xF0>", IREE_TOKENIZER_TOKEN_ATTR_BYTE);
+  vocab_builder.AddToken(1, "<0x9F>", IREE_TOKENIZER_TOKEN_ATTR_BYTE);
+  ScopedVocab vocab = vocab_builder.Build();
+
+  iree_tokenizer_t* tokenizer = BuildByteFallbackTokenizer(vocab.release());
+  ASSERT_NE(tokenizer, nullptr);
+
+  IREE_ASSERT_OK_AND_ASSIGN(auto state_storage,
+                            DecodeStateStorage::Allocate(tokenizer));
+  auto* state = state_storage.state();
+
+  // Feed both byte tokens — accumulates 2 bytes in fallback buffer.
+  int32_t token_ids[] = {0, 1};
+  iree_tokenizer_token_id_list_t tokens = {2, token_ids};
+  char feed_output[256];
+  iree_host_size_t tokens_consumed = 0;
+  iree_host_size_t text_written = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_feed(
+      state, tokens,
+      iree_make_mutable_string_view(feed_output, sizeof(feed_output)),
+      &tokens_consumed, &text_written));
+
+  // Finalize with 5 bytes — fits one U+FFFD (3 bytes) but not two (6 bytes).
+  char finalize_output[5];
+  iree_host_size_t finalize_written = 0;
+  iree_status_t status = iree_tokenizer_decode_state_finalize(
+      state, iree_make_mutable_string_view(finalize_output, 5),
+      &finalize_written);
+  EXPECT_EQ(finalize_written, 3u) << "Should have flushed one U+FFFD (3 bytes)";
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
+
+  iree_tokenizer_free(tokenizer);
+}
+
 }  // namespace
 }  // namespace tokenizer
 }  // namespace iree

--- a/runtime/src/iree/tokenizer/tokenizer_encode_test.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_encode_test.cc
@@ -599,6 +599,8 @@ TEST_F(TokenizerUTF8Test, MultiCallFinalizeWithSmallCapacity) {
   }
 
   // Finalize with capacity=1, collecting tokens one at a time.
+  // Each call that produces a token returns RESOURCE_EXHAUSTED if more tokens
+  // are pending. The final call returns OK when everything is drained.
   std::vector<iree_tokenizer_token_id_t> tokens;
   iree_tokenizer_token_id_t single_token;
 
@@ -606,12 +608,17 @@ TEST_F(TokenizerUTF8Test, MultiCallFinalizeWithSmallCapacity) {
   const int max_iterations = 100;
   while (iterations++ < max_iterations) {
     bool has_pending = iree_tokenizer_encode_state_has_pending(state);
-    IREE_ASSERT_OK(iree_tokenizer_encode_state_finalize(
+    iree_status_t status = iree_tokenizer_encode_state_finalize(
         state, iree_tokenizer_make_token_output(&single_token, NULL, NULL, 1),
-        &token_count));
+        &token_count);
     if (token_count > 0) {
       tokens.push_back(single_token);
     }
+    if (iree_status_is_resource_exhausted(status)) {
+      iree_status_free(status);
+      continue;  // More pending — keep draining.
+    }
+    IREE_ASSERT_OK(status);
     if (!has_pending && token_count == 0) break;
   }
 
@@ -2021,16 +2028,22 @@ TEST_F(TokenizerPartialSegmentTest, OutputBufferExhaustion) {
   }
   ASSERT_LT(iterations, 1000) << "Feed loop should terminate";
 
-  // Finalize with small capacity too.
+  // Finalize with small capacity too. Each call that fills the buffer returns
+  // RESOURCE_EXHAUSTED if more tokens are pending.
   int finalize_iterations = 0;
   while (finalize_iterations++ < 100) {
     iree_host_size_t token_count = 0;
-    IREE_ASSERT_OK(iree_tokenizer_encode_state_finalize(
+    iree_status_t status = iree_tokenizer_encode_state_finalize(
         state, iree_tokenizer_make_token_output(batch, NULL, NULL, 10),
-        &token_count));
+        &token_count);
     for (iree_host_size_t i = 0; i < token_count; ++i) {
       all_tokens.push_back(batch[i]);
     }
+    if (iree_status_is_resource_exhausted(status)) {
+      iree_status_free(status);
+      continue;  // More pending — keep draining.
+    }
+    IREE_ASSERT_OK(status);
     if (token_count == 0 && !iree_tokenizer_encode_state_has_pending(state)) {
       break;
     }
@@ -3128,9 +3141,7 @@ TEST_F(TokenizerSpecialTokenStreamingTest, FinalizeDoesNotSilentlyDropPartial) {
   } else {
     // Error path: finalize returned RESOURCE_EXHAUSTED because ring was full.
     // This is acceptable - it's NOT a silent failure.
-    EXPECT_TRUE(iree_status_is_resource_exhausted(status))
-        << "Expected RESOURCE_EXHAUSTED if finalize can't write partial";
-    iree_status_free(status);
+    IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
 
     // State should still have pending (partial not dropped).
     EXPECT_TRUE(iree_tokenizer_encode_state_has_pending(state))
@@ -6233,6 +6244,118 @@ TEST_F(TokenizerPartialSegmentTest, UnigramMultipleSpecialTokensSmallBuffer) {
   }
   EXPECT_EQ(special_count, 20u)
       << "expected 20 </s> special tokens in output, got " << special_count;
+
+  iree_tokenizer_free(tokenizer);
+}
+
+//===----------------------------------------------------------------------===//
+// Output Buffer Overflow Detection
+//
+// Verifies that encode functions return IREE_STATUS_RESOURCE_EXHAUSTED when the
+// output buffer is too small, rather than silently truncating.
+//===----------------------------------------------------------------------===//
+
+class TokenizerEncodeOverflowTest : public ::testing::Test {};
+
+// Batch encode with output capacity too small for the input text.
+// "abcde" produces 5 tokens with single-char BPE, but buffer only holds 2.
+TEST_F(TokenizerEncodeOverflowTest, BatchEncodeOutputBufferTooSmall) {
+  ScopedVocabBuilder vocab_builder;
+  for (int i = 0; i < 26; ++i) {
+    char token_str[2] = {(char)('a' + i), '\0'};
+    vocab_builder.AddToken(i, token_str);
+  }
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // Output buffer capacity = 2, but "abcde" needs 5 tokens.
+  std::vector<iree_tokenizer_token_id_t> token_ids(2);
+  iree_host_size_t token_count = 0;
+  iree_status_t status =
+      iree_tokenizer_encode(tokenizer, iree_make_cstring_view("abcde"),
+                            IREE_TOKENIZER_ENCODE_FLAG_NONE,
+                            iree_tokenizer_make_token_output(
+                                token_ids.data(), NULL, NULL, token_ids.size()),
+                            iree_allocator_system(), &token_count);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Batch encode with ADD_SPECIAL_TOKENS where buffer fits the text tokens
+// but not the prefix/suffix special tokens.
+// "ab" → BPE [0, 1], with BOS(100)+EOS(200) → needs 4 slots, buffer has 2.
+TEST_F(TokenizerEncodeOverflowTest,
+       BatchEncodeOutputBufferTooSmallForSpecialTokens) {
+  iree_tokenizer_postprocessor_t postprocessor = {};
+  postprocessor.single.prefix_count = 1;
+  postprocessor.single.suffix_count = 1;
+  postprocessor.single.token_ids[0] = 100;  // BOS prefix
+  postprocessor.single.token_ids[1] = 200;  // EOS suffix
+
+  iree_tokenizer_t* tokenizer = BuildTokenizerWithPostprocessor(postprocessor);
+  ASSERT_NE(tokenizer, nullptr);
+
+  // Buffer capacity = 2 (enough for "ab" model tokens, but not BOS+EOS).
+  std::vector<iree_tokenizer_token_id_t> token_ids(2);
+  iree_host_size_t token_count = 0;
+  iree_status_t status =
+      iree_tokenizer_encode(tokenizer, iree_make_cstring_view("ab"),
+                            IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+                            iree_tokenizer_make_token_output(
+                                token_ids.data(), NULL, NULL, token_ids.size()),
+                            iree_allocator_system(), &token_count);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Streaming encode finalize with insufficient capacity for suffix.
+// Feed "ab" (produces [BOS, 0, 1]), then finalize with capacity 0 for EOS.
+TEST_F(TokenizerEncodeOverflowTest, FinalizeOutputBufferTooSmallForSuffix) {
+  iree_tokenizer_postprocessor_t postprocessor = {};
+  postprocessor.single.prefix_count = 1;
+  postprocessor.single.suffix_count = 1;
+  postprocessor.single.token_ids[0] = 100;  // BOS prefix
+  postprocessor.single.token_ids[1] = 200;  // EOS suffix
+
+  iree_tokenizer_t* tokenizer = BuildTokenizerWithPostprocessor(postprocessor);
+  ASSERT_NE(tokenizer, nullptr);
+
+  {
+    IREE_ASSERT_OK_AND_ASSIGN(
+        auto state_storage, testing::EncodeStateStorage::Allocate(
+                                tokenizer, /*transform_buffer_capacity=*/1024,
+                                /*offset_run_capacity=*/0,
+                                IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS));
+    auto* state = state_storage.state();
+
+    // Feed "ab" with enough capacity for BOS + 'a' + 'b' = 3 tokens.
+    std::vector<iree_tokenizer_token_id_t> tokens(3);
+    iree_host_size_t bytes_consumed = 0;
+    iree_host_size_t tokens_written = 0;
+    IREE_ASSERT_OK(iree_tokenizer_encode_state_feed(
+        state, iree_make_cstring_view("ab"),
+        iree_tokenizer_make_token_output(tokens.data(), NULL, NULL,
+                                         tokens.size()),
+        &bytes_consumed, &tokens_written));
+
+    // Finalize with capacity 0 — not enough room for EOS suffix.
+    iree_tokenizer_token_id_t dummy_token;
+    iree_host_size_t finalize_count = 0;
+    iree_status_t status = iree_tokenizer_encode_state_finalize(
+        state, iree_tokenizer_make_token_output(&dummy_token, NULL, NULL, 0),
+        &finalize_count);
+    IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
+  }  // state_storage destroyed before tokenizer
 
   iree_tokenizer_free(tokenizer);
 }


### PR DESCRIPTION
## Summary

Return RESOURCE_EXHAUSTED instead of silently truncating when the output buffer is too small, matching the documented API contract in tokenizer.h.

## Test results

### HuggingFace smoketest (`huggingface_smoketest.py`)

**1667/1667** tokenization comparisons pass across ~80 HuggingFace models (0 mismatches).

76 additional tests fail to **load** (not tokenization mismatches) — these are tiktoken models listed in the HF smoketest that aren't valid HuggingFace model identifiers. They're tested by the dedicated tiktoken smoketest instead. These tests are removed from the HF smoketest in https://github.com/iree-org/iree/pull/23830.

### Tiktoken smoketest (`tiktoken_smoketest.py`)

**72/76** tokenization comparisons pass across 4 tiktoken encodings (cl100k_base, o200k_base, r50k_base, p50k_base).

4 failures — **identical between upstream and this PR** (pre-existing, same as `fix-tokenizer-added-tokens` branch):

| Encoding | Failing test | Cause |
|----------|-------------|-------|
| cl100k_base | `special_token_endoftext` | IREE matches `<\|endoftext\|>` as special token; tiktoken's `encode_ordinary` treats it as literal text |
| o200k_base | `special_token_endoftext` | Same |
| r50k_base | `special_token_endoftext` | Same |
| p50k_base | `special_token_endoftext` | Same |

Root cause: the IREE tokenizer has no "encode ordinary" mode (equivalent to tiktoken's `disallowed_special=()`). Fixed in https://github.com/iree-org/iree/pull/23830.