### PR TITLE
[Tokenizer] Add encode ordinary mode (no special token matching)

### DIFF
--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -1691,9 +1691,11 @@ iree_tokenizer_encode_state_match_post_norm_special_tokens(
     iree_host_size_t* out_segment_limit) {
   *out_segment_limit = IREE_HOST_SIZE_MAX;
 
-  // Skip if no post-norm tokens configured.
+  // Skip if no post-norm tokens configured or matching disabled.
   if (iree_tokenizer_special_tokens_is_empty(
-          &tokenizer->special_tokens_post_norm)) {
+          &tokenizer->special_tokens_post_norm) ||
+      iree_any_bit_set(state->flags,
+                       IREE_TOKENIZER_ENCODE_FLAG_NO_SPECIAL_TOKEN_MATCHING)) {
     return IREE_TOKENIZER_POST_NORM_NO_MATCH;
   }
   // Skip if no unprocessed normalized output available.
@@ -2246,6 +2248,8 @@ static iree_status_t iree_tokenizer_encode_state_pump(
   // content itself serves as the "buffer" for reconstruction via get_partial().
   iree_host_size_t normalize_limit = IREE_HOST_SIZE_MAX;
   if (!iree_tokenizer_special_tokens_is_empty(&tokenizer->special_tokens) &&
+      !iree_any_bit_set(state->flags,
+                        IREE_TOKENIZER_ENCODE_FLAG_NO_SPECIAL_TOKEN_MATCHING) &&
       chunk->size > 0 && state->pending_special_token < 0) {
     // Continuing a partial match? Pass chunk directly to match().
     // Starting fresh? Check if first byte could start a special token.

--- a/runtime/src/iree/tokenizer/tokenizer.h
+++ b/runtime/src/iree/tokenizer/tokenizer.h
@@ -149,6 +149,11 @@ enum iree_tokenizer_encode_flag_bits_e {
   // to emit special tokens and assign type_ids to model-produced tokens.
   // When not set, no special tokens are inserted and type_ids are all 0.
   IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS = 1u << 2,
+  // Disable special token matching in input text. When set, sequences like
+  // <|endoftext|> are tokenized as ordinary text instead of being matched
+  // to special token IDs. Equivalent to tiktoken's encode_ordinary()
+  // (also known as encode(text, disallowed_special=())).
+  IREE_TOKENIZER_ENCODE_FLAG_NO_SPECIAL_TOKEN_MATCHING = 1u << 3,
 };
 typedef uint32_t iree_tokenizer_encode_flags_t;
 

--- a/runtime/src/iree/tokenizer/tools/huggingface_smoketest.py
+++ b/runtime/src/iree/tokenizer/tools/huggingface_smoketest.py
@@ -1473,6 +1473,10 @@ def main():
     model_results: list[ModelResult] = []
 
     for model_name, model_config in models:
+        # Skip tiktoken models — tested by tiktoken_smoketest.py instead.
+        if model_name.startswith("tiktoken/"):
+            continue
+
         description = model_config.get("description", "")
         xfail = model_config.get("xfail", False)
         test_count = len(model_config.get("tests", []))

--- a/runtime/src/iree/tokenizer/tools/tiktoken_smoketest.py
+++ b/runtime/src/iree/tokenizer/tools/tiktoken_smoketest.py
@@ -201,6 +201,7 @@ def run_iree_tokenize(
         f"--tokenizer={tokenizer_path}",
         "--json",
         "--special=false",
+        "--match_special=false",
         input_text,
     ]
 
@@ -241,6 +242,7 @@ def run_iree_tokenize_batch(
         "--json",
         "--batch",
         "--special=false",
+        "--match_special=false",
     ]
 
     # Batch mode is line-delimited on stdin, so inputs with newlines can't

--- a/tools/iree-tokenize-main.c
+++ b/tools/iree-tokenize-main.c
@@ -61,6 +61,9 @@ IREE_FLAG(bool, decode, false, "Decode mode: input is comma-separated IDs.");
 IREE_FLAG(bool, decode_special, false,
           "Include special tokens (BOS/EOS) in decode output.");
 IREE_FLAG(bool, special, true, "Add special tokens (BOS/EOS, CLS/SEP).");
+IREE_FLAG(bool, match_special, true,
+          "Match special tokens in input text. Set to false to treat sequences "
+          "like <|endoftext|> as ordinary text.");
 IREE_FLAG(bool, batch, false, "Batch mode: read lines from stdin.");
 IREE_FLAG(bool, stream, false, "Stream stdin continuously (not line-by-line).");
 IREE_FLAG(int32_t, max_length, 0, "Max output length (0 = unlimited).");
@@ -184,6 +187,9 @@ static iree_tokenizer_encode_flags_t iree_tooling_encode_flags(void) {
   iree_tokenizer_encode_flags_t flags =
       IREE_TOKENIZER_ENCODE_FLAG_AT_INPUT_START;
   if (FLAG_special) flags |= IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS;
+  if (!FLAG_match_special) {
+    flags |= IREE_TOKENIZER_ENCODE_FLAG_NO_SPECIAL_TOKEN_MATCHING;
+  }
   if (FLAG_offsets) flags |= IREE_TOKENIZER_ENCODE_FLAG_TRACK_OFFSETS;
   return flags;
 }


### PR DESCRIPTION
Add IREE_TOKENIZER_ENCODE_FLAG_NO_SPECIAL_TOKEN_MATCHING to skip special token recognition in input text. Equivalent to tiktoken's encode_ordinary(). Fixes 4/76 tiktoken smoketest failures. Also skips tiktoken models in the
HuggingFace smoketest (tested by the dedicated tiktoken smoketest instead).

**Test Results**:
- HuggingFace smoketest: 1667/1667 passed (tiktoken models skipped, tested separately)
- Tiktoken smoketest: 76/76 passed (all 4 special_token_endoftext tests now pass with --match_special)
