### PR TITLE
[GPUHeuristics] Improve MMA intrinsic selection and tiling for small-channel group backward convolutions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -526,22 +526,57 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                         remainingSubgroups, remainingTiles);
   }
 
-  // Leaving leftover factors unassigned generally works better than greedily
-  // assigning them, as it avoids overly aggressive tiling that reduces
-  // occupancy. However, for heavily imbalanced problems (4:1+ tile ratio),
-  // GCD fails for non-power-of-2 tile counts (e.g., 149 tiles for F=2376/16).
-  // In such cases, redirect remaining tiles to the starved dimension using
-  // min-based distribution. Only do this when both dimensions have enough
-  // tiles (>= 8) to avoid hurting small shapes like group convolutions.
+  // Determine whether to use min-based distribution for per-dimension tile
+  // assignment. Min-based is needed in two cases:
+  //
+  // 1) Degenerate schedule: GCD produced all-1 distributions because the tile
+  //    counts are small odd numbers (e.g., 3x3 filter dims) with GCD=1 against
+  //    power-of-2 seeds. Retry the collapsed distribution with min, then use
+  //    min for per-dimension assignment.
+  //
+  // 2) Imbalanced problems: One dimension has 4x+ more tiles than the other
+  //    (e.g., 149 vs 8 tiles). GCD fails for non-power-of-2 counts, so use
+  //    min to redirect remaining tiles to the dominant dimension. Only apply
+  //    when both dimensions have enough tiles (>= 8) to avoid hurting small
+  //    shapes.
+  bool isDegenerate = mSubgroupDistributed == 1 && nSubgroupDistributed == 1 &&
+                      mTileSizeDistributed == 1 && nTileSizeDistributed == 1 &&
+                      (remainingSubgroups > 1 || remainingTiles > 1);
+  bool mMultiDim = problem.mSizes.size() > 1;
+  bool nMultiDim = problem.nSizes.size() > 1;
+  bool hasMultiDim = mMultiDim || nMultiDim;
+  if (isDegenerate && hasMultiDim) {
+    LDBG() << "Degenerate GCD schedule, using min-based distribution";
+    remainingSubgroups = seeds.bestSubgroupCountPerWorkgroup;
+    remainingTiles = seeds.bestMNTileCountPerSubgroup;
+    // For single-dim M or N, only distribute if tiles >= 2x budget to avoid
+    // over-distributing (e.g., 8 subgroups for 9 tiles). Multi-dim can
+    // benefit even with fewer tiles since work spreads across sub-dims.
+    auto distributeMin = [](int64_t &totalTiles, int64_t &distributed,
+                            int64_t &budget, bool multiDim) {
+      if (multiDim || totalTiles >= 2 * budget) {
+        distributed *= distributeTilesUsingMin(totalTiles, budget);
+      }
+    };
+    distributeMin(mTotalTileToDistribute, mSubgroupDistributed,
+                  remainingSubgroups, mMultiDim);
+    distributeMin(mTotalTileToDistribute, mTileSizeDistributed, remainingTiles,
+                  mMultiDim);
+    distributeMin(nTotalTileToDistribute, nSubgroupDistributed,
+                  remainingSubgroups, nMultiDim);
+    distributeMin(nTotalTileToDistribute, nTileSizeDistributed, remainingTiles,
+                  nMultiDim);
+  }
+
+  // For heavily imbalanced problems (4:1+ tile ratio with both dims >= 8),
+  // redirect remaining tiles to the dominant dimension.
   constexpr int64_t kMinTileCountThreshold = 8;
   int64_t minMNTileCount =
       std::min(mTotalTileCounts.back(), nTotalTileCounts.back());
-  bool useMinForM = minMNTileCount >= kMinTileCountThreshold &&
-                    mTotalTileCounts.back() >= 4 * nTotalTileCounts.back();
-  bool useMinForN = minMNTileCount >= kMinTileCountThreshold &&
-                    nTotalTileCounts.back() >= 4 * mTotalTileCounts.back();
-
-  // Redirect remaining tiles to the starved (dominant) dimension.
+  bool imbalancedM = minMNTileCount >= kMinTileCountThreshold &&
+                     mTotalTileCounts.back() >= 4 * nTotalTileCounts.back();
+  bool imbalancedN = minMNTileCount >= kMinTileCountThreshold &&
+                     nTotalTileCounts.back() >= 4 * mTotalTileCounts.back();
   auto redirectRemainingTiles = [&](bool condition, int64_t totalTiles,
                                     int64_t &tileSizeDistributed) {
     if (!condition || remainingTiles <= 1) {
@@ -553,9 +588,9 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
       tileSizeDistributed = newTile;
     }
   };
-  redirectRemainingTiles(useMinForM, mTotalTileToDistribute,
+  redirectRemainingTiles(imbalancedM, mTotalTileToDistribute,
                          mTileSizeDistributed);
-  redirectRemainingTiles(useMinForN, nTotalTileToDistribute,
+  redirectRemainingTiles(imbalancedN, nTotalTileToDistribute,
                          nTileSizeDistributed);
 
   LDBG() << "Leftover factors: subgroups: " << remainingSubgroups
@@ -566,15 +601,26 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
          << ", N: " << nTileSizeDistributed;
 
   // Distribute collapsed counts to per-dimension M and N (inner -> outer).
-  // Use min-based distribution for the dominant dimension in imbalanced
-  // problems, since GCD fails for non-power-of-2 tile counts.
+  // Use min-based distribution when GCD fails for that dimension: either
+  // from a degenerate multi-dim schedule or an imbalanced problem.
+  bool useMinForM = (isDegenerate && mMultiDim) || imbalancedM;
+  bool useMinForN = (isDegenerate && nMultiDim) || imbalancedN;
   auto distributeToDims = [](MutableArrayRef<int64_t> tileCounts,
                              MutableArrayRef<int64_t> subgroupCounts,
                              MutableArrayRef<int64_t> tileSizes,
                              int64_t &subgroupBudget, int64_t &tileBudget,
                              bool useMin) {
-    int64_t (*distribute)(int64_t &, int64_t &) =
-        useMin ? distributeTilesUsingMin : distributeTilesUsingGCD;
+    auto distribute = [useMin](int64_t &tiles, int64_t &budget) -> int64_t {
+      if (!useMin) {
+        return distributeTilesUsingGCD(tiles, budget);
+      }
+      // Skip min-based distribution when tiles/budget < 2 (e.g., 9/8 = 1) to
+      // avoid over-distributing.
+      if (tiles > budget && tiles / budget < 2) {
+        return 1;
+      }
+      return distributeTilesUsingMin(tiles, budget);
+    };
     for (size_t e = tileCounts.size(), i = e - 1; i < e; --i) {
       subgroupCounts[i] = distribute(tileCounts[i], subgroupBudget);
       tileSizes[i] = distribute(tileCounts[i], tileBudget);
@@ -599,19 +645,52 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                         mTileSizes,        nTileSizes,       kTileSizes};
 }
 
+/// Compute the M*N utilization of an intrinsic for a given problem, measuring
+/// the fraction of the intrinsic's M*N tile occupied by real data vs padding.
+/// Returns a value in (0.0, 1.0]. A value < 1.0 indicates padding is needed.
+static double computeMNUtilization(const GPUMatmulShapeType &problem,
+                                   const GPUIntrinsicType &intrinsic) {
+  double mUtil = std::min(problem.mSizes.back(), intrinsic.mSizes.back()) /
+                 static_cast<double>(intrinsic.mSizes.back());
+  double nUtil = std::min(problem.nSizes.back(), intrinsic.nSizes.back()) /
+                 static_cast<double>(intrinsic.nSizes.back());
+  return mUtil * nUtil;
+}
+
 /// Compare the MMA intrinsics by following precedence rules:
-///   1) k-alignment. We prefer intrinsics that can evenly divide the K
+///   1) M*N utilization. When one intrinsic has significantly better (>= 2x)
+///   M*N utilization, prefer it regardless of other rules. This avoids
+///   choosing an intrinsic that wastes most of its compute on M/N padding
+///   (e.g., 32x32 = 6.25% util vs 16x16 = 25% for an 8x8 problem).
+///   2) K-alignment. We prefer intrinsics that can evenly divide the K
 ///   dimension of the problem.
-///   2) M/N-alignment. We prefer intrinsics that can evenly divide the M
+///   3) M/N-alignment. We prefer intrinsics that can evenly divide the M
 ///   and N dimensions of the problem.
-///   3) Intrinsic with larger gemm input size.
-///   4) Intrinsic with larger K size.
+///   4) Intrinsic with larger gemm input size.
+///   5) Intrinsic with larger K size.
 ///
 /// This function acts as a comparison function object for std::sort, which
 /// returns true if the lhs is ordered before rhs.
 static bool compareIntrinsics(const GPUMatmulShapeType &problem,
                               const GPUIntrinsicType &lhs,
                               const GPUIntrinsicType &rhs) {
+  // When both M and N need padding, prefer the intrinsic with better M*N
+  // utilization. This targets grouped convolutions where per-group channels
+  // are small (e.g., 8x8 problem: 16x16 at 25% util >> 32x32 at 6.25%).
+  // Only applies when both dims are smaller than the larger intrinsic's tile;
+  // when only one dim is small, the larger intrinsic still helps on the big
+  // dim.
+  double lhsUtil = computeMNUtilization(problem, lhs);
+  double rhsUtil = computeMNUtilization(problem, rhs);
+  bool bothDimsNeedPadding =
+      problem.mSizes.back() < std::max(lhs.mSizes.back(), rhs.mSizes.back()) &&
+      problem.nSizes.back() < std::max(lhs.nSizes.back(), rhs.nSizes.back());
+  bool hasUtilAdvantage =
+      std::max(lhsUtil, rhsUtil) >= 2.0 * std::min(lhsUtil, rhsUtil);
+  if (bothDimsNeedPadding && hasUtilAdvantage) {
+    return lhsUtil > rhsUtil;
+  }
+
   // Prefer K-aligned intrinsics.
   int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
   int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
@@ -642,6 +721,29 @@ static bool compareIntrinsics(const GPUMatmulShapeType &problem,
             ShapedType::getNumElements(intrinsic.nSizes)) *
            ShapedType::getNumElements(intrinsic.kSizes);
   };
+
+  // When both dims need padding with equal utilization, prefer smaller M*N
+  // tile (less waste per instruction). For same-M*N intrinsics differing
+  // only in K (e.g., 16x16x16 vs 16x16x32), prefer smaller K at moderate
+  // utilization (>= 10%); at very low utilization, let later rules pick
+  // larger K for better throughput.
+  if (bothDimsNeedPadding && lhsUtil == rhsUtil) {
+    int64_t lhsMN = ShapedType::getNumElements(lhs.mSizes) *
+                    ShapedType::getNumElements(lhs.nSizes);
+    int64_t rhsMN = ShapedType::getNumElements(rhs.mSizes) *
+                    ShapedType::getNumElements(rhs.nSizes);
+    if (lhsMN != rhsMN) {
+      return lhsMN < rhsMN;
+    }
+    // lhsUtil == rhsUtil here, so checking one suffices.
+    if (lhsUtil >= 0.10) {
+      int64_t lhsCompute = intrinsicCompute(lhs);
+      int64_t rhsCompute = intrinsicCompute(rhs);
+      if (lhsCompute != rhsCompute) {
+        return lhsCompute < rhsCompute;
+      }
+    }
+  }
 
   // For compute-bound GEMMs, maximize compute throughput first, then
   // minimize operand VGPR pressure among equal-compute intrinsics.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -47,6 +47,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   os << "kTileSizes: " << schedule.kTileSizes << ", ";
   os << "mSubgroupCounts: " << schedule.mSubgroupCounts << ", ";
   os << "nSubgroupCounts: " << schedule.nSubgroupCounts;
+  if (!schedule.workgroupBatchSizes.empty()) {
+    os << ", workgroupBatchSizes: " << schedule.workgroupBatchSizes;
+  }
   return os;
 }
 
@@ -932,6 +935,29 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     GPUMMASchedule schedule =
         getOptimalMMASchedule(problem, intrinsic, localSeeds);
 
+    // Compute batch tile sizes. When both M and N need padding (problem size
+    // < intrinsic size), tile batch dims up to 4 to give each workgroup more
+    // useful work and amortize dispatch overhead. The intrinsic M/N sizes are
+    // fixed per intrinsic, so the batch tiles don't change during schedule
+    // fitting.
+    bool needsMNPadding = problem.mSizes.back() < schedule.getTotalMSize() &&
+                          problem.nSizes.back() < schedule.getTotalNSize();
+    SmallVector<int64_t, 2> wgBatchSizes;
+    for (int64_t batchSize : problem.batchSizes) {
+      int64_t batchTile = 1;
+      if (needsMNPadding && !ShapedType::isDynamic(batchSize)) {
+        for (int64_t t = 4; t >= 2; t /= 2) {
+          if (batchSize % t == 0) {
+            batchTile = t;
+            break;
+          }
+        }
+      }
+      wgBatchSizes.push_back(batchTile);
+    }
+    schedule.workgroupBatchSizes = wgBatchSizes;
+    int64_t totalBatchTile = schedule.getTotalWorkgroupBatchSize();
+
     LDBG() << "Chosen MMA schedule:\n" << schedule;
 
     auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
@@ -959,9 +985,13 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
             schedule, resultBitwidth, problem.numHorizontallyFusedOps);
       }
 
+      // Batch tiling multiplies the promoted operand sizes: each batch slice
+      // uses separate shared memory, so total usage scales linearly.
+      sharedMemoryUsed *= totalBatchTile;
+
       LDBG() << "Available Shared Memory: " << sharedMemLimitInBytes << " bytes"
              << "Predicted Shared Memory Used by Schedule: " << sharedMemoryUsed
-             << " bytes";
+             << " bytes (batch tile factor: " << totalBatchTile << ")";
 
       bool isValid = isAligned && sharedMemoryUsed <= sharedMemLimitInBytes;
       if (isValid) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -936,24 +936,16 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
         getOptimalMMASchedule(problem, intrinsic, localSeeds);
 
     // Compute batch tile sizes. When both M and N need padding (problem size
-    // < intrinsic size), tile batch dims up to 4 to give each workgroup more
-    // useful work and amortize dispatch overhead. The intrinsic M/N sizes are
-    // fixed per intrinsic, so the batch tiles don't change during schedule
-    // fitting.
-    bool needsMNPadding = problem.mSizes.back() < schedule.getTotalMSize() &&
-                          problem.nSizes.back() < schedule.getTotalNSize();
-    SmallVector<int64_t, 2> wgBatchSizes;
-    for (int64_t batchSize : problem.batchSizes) {
-      int64_t batchTile = 1;
-      if (needsMNPadding && !ShapedType::isDynamic(batchSize)) {
-        for (int64_t t = 4; t >= 2; t /= 2) {
-          if (batchSize % t == 0) {
-            batchTile = t;
-            break;
-          }
-        }
+    // < intrinsic size), tile the static innermost batch dim up to 4 to give
+    // each workgroup more useful work and amortize dispatch overhead.
+    SmallVector<int64_t, 2> wgBatchSizes(problem.batchSizes.size(), 1);
+    if (!problem.batchSizes.empty()) {
+      int64_t innerBatch = problem.batchSizes.back();
+      bool needsMNPadding = problem.mSizes.back() < schedule.getTotalMSize() &&
+                            problem.nSizes.back() < schedule.getTotalNSize();
+      if (needsMNPadding && innerBatch % 2 == 0) {
+        wgBatchSizes.back() = (innerBatch % 4 == 0) ? 4 : 2;
       }
-      wgBatchSizes.push_back(batchTile);
     }
     schedule.workgroupBatchSizes = wgBatchSizes;
     int64_t totalBatchTile = schedule.getTotalWorkgroupBatchSize();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -127,7 +127,7 @@ struct GPUMMASchedule {
 
   // Workgroup-level batch tile sizes. Defaults to all 1s. When both M and
   // N sizes are smaller than the intrinsic sizes and must be padded up to
-  // them, tiling batch elements per workgroup may helpamortize the
+  // them, tiling batch elements per workgroup may help amortize the
   // padding overhead.
   SmallVector<int64_t, 2> workgroupBatchSizes;
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -125,6 +125,12 @@ struct GPUMMASchedule {
   SmallVector<int64_t, 2> nTileSizes; // N tile sizes per subgroup.
   SmallVector<int64_t, 2> kTileSizes; // K tile sizes.
 
+  // Workgroup-level batch tile sizes. Defaults to all 1s. When both M and
+  // N sizes are smaller than the intrinsic sizes and must be padded up to
+  // them, tiling batch elements per workgroup may helpamortize the
+  // padding overhead.
+  SmallVector<int64_t, 2> workgroupBatchSizes;
+
   // Constructor for multi M, N, K dim schedules.
   GPUMMASchedule(IREE::Codegen::InnerTileDescAttrInterface kind,
                  ArrayRef<int64_t> mIntrinsicSizes,
@@ -165,6 +171,12 @@ struct GPUMMASchedule {
   }
   int64_t getTotalNSubgroupCount() const {
     return llvm::product_of(nSubgroupCounts);
+  }
+
+  // Total workgroup batch tile factor (product of all batch tile sizes).
+  int64_t getTotalWorkgroupBatchSize() const {
+    return workgroupBatchSizes.empty() ? 1
+                                       : llvm::product_of(workgroupBatchSizes);
   }
 
   // Check if all schedule dimensions are single-element.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -842,9 +842,24 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   SmallVector<int64_t> workgroupTileSizes(bounds.size(), 0);
   SmallVector<int64_t> reductionTileSizes(bounds.size(), 0);
   SmallVector<int64_t> subgroupTileSizes(bounds.size(), 0);
-  // Tile all batch dimensions with unit size.
+
+  // Tile batch dimensions. Normally each workgroup handles one batch element.
+  // When both M and N need padding (e.g., grouped convolutions with small
+  // per-group channels), tile batch up to 4 to give each workgroup more
+  // useful work and amortize dispatch overhead.
+  bool needsMNPadding = problem.mSizes.back() < schedule->getTotalMSize() &&
+                        problem.nSizes.back() < schedule->getTotalNSize();
   for (int64_t batch : contractionB) {
-    workgroupTileSizes[batch] = 1;
+    int64_t batchTile = 1;
+    if (needsMNPadding && !ShapedType::isDynamic(bounds[batch])) {
+      for (int64_t t = 4; t >= 2; t /= 2) {
+        if (bounds[batch] % t == 0) {
+          batchTile = t;
+          break;
+        }
+      }
+    }
+    workgroupTileSizes[batch] = batchTile;
   }
 
   // Tile all m, n, k and k_b dimensions to 1 except the innermost. Unit dims

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -786,14 +786,10 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   // Intentionally padded GEMM proved to be beneficial for performance for
   // the following layouts: 1) [M, K] x [K, N] 2) [M, K] x [N, K]
   // Therefore we disallow padding only when LHS is transposed.
-  // Include all batch dims (static and dynamic) so the heuristic can compute
-  // per-dimension batch tile sizes aligned with contractionB indices.
-  auto allBatchBounds = llvm::map_to_vector(
-      contractionB, [&](int64_t dim) { return bounds[dim]; });
   GPUMatmulShapeType problem{getDimBounds(mDims, transposedLhs),
                              getDimBounds(nDims, transposedLhs),
                              getDimBoundsNoPad(kDims),
-                             allBatchBounds,
+                             getDimBoundsNoPad(batchDims),
                              lhsElemType,
                              rhsElemType,
                              initElemType,
@@ -851,8 +847,14 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   // N sizes are smaller than the intrinsic sizes and must be padded up to
   // them, tiling batch elements per workgroup may help amortize the
   // padding overhead.
-  for (auto [i, batch] : llvm::enumerate(contractionB)) {
-    workgroupTileSizes[batch] = schedule->workgroupBatchSizes[i];
+  int64_t staticBatchIdx = 0;
+  for (unsigned batch : contractionB) {
+    if (ShapedType::isDynamic(bounds[batch])) {
+      workgroupTileSizes[batch] = 1;
+    } else {
+      workgroupTileSizes[batch] =
+          schedule->workgroupBatchSizes[staticBatchIdx++];
+    }
   }
 
   // Tile all m, n, k and k_b dimensions to 1 except the innermost. Unit dims

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -786,10 +786,14 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   // Intentionally padded GEMM proved to be beneficial for performance for
   // the following layouts: 1) [M, K] x [K, N] 2) [M, K] x [N, K]
   // Therefore we disallow padding only when LHS is transposed.
+  // Include all batch dims (static and dynamic) so the heuristic can compute
+  // per-dimension batch tile sizes aligned with contractionB indices.
+  auto allBatchBounds = llvm::map_to_vector(
+      contractionB, [&](int64_t dim) { return bounds[dim]; });
   GPUMatmulShapeType problem{getDimBounds(mDims, transposedLhs),
                              getDimBounds(nDims, transposedLhs),
                              getDimBoundsNoPad(kDims),
-                             getDimBoundsNoPad(batchDims),
+                             allBatchBounds,
                              lhsElemType,
                              rhsElemType,
                              initElemType,
@@ -843,23 +847,12 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   SmallVector<int64_t> reductionTileSizes(bounds.size(), 0);
   SmallVector<int64_t> subgroupTileSizes(bounds.size(), 0);
 
-  // Tile batch dimensions. Normally each workgroup handles one batch element.
-  // When both M and N need padding (e.g., grouped convolutions with small
-  // per-group channels), tile batch up to 4 to give each workgroup more
-  // useful work and amortize dispatch overhead.
-  bool needsMNPadding = problem.mSizes.back() < schedule->getTotalMSize() &&
-                        problem.nSizes.back() < schedule->getTotalNSize();
-  for (int64_t batch : contractionB) {
-    int64_t batchTile = 1;
-    if (needsMNPadding && !ShapedType::isDynamic(bounds[batch])) {
-      for (int64_t t = 4; t >= 2; t /= 2) {
-        if (bounds[batch] % t == 0) {
-          batchTile = t;
-          break;
-        }
-      }
-    }
-    workgroupTileSizes[batch] = batchTile;
+  // Use the batch tile sizes computed by the heuristic. When both M and
+  // N sizes are smaller than the intrinsic sizes and must be padded up to
+  // them, tiling batch elements per workgroup may help amortize the
+  // padding overhead.
+  for (auto [i, batch] : llvm::enumerate(contractionB)) {
+    workgroupTileSizes[batch] = schedule->workgroupBatchSizes[i];
   }
 
   // Tile all m, n, k and k_b dimensions to 1 except the innermost. Unit dims

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
@@ -183,7 +183,7 @@ func.func @conv_chwn_fhwn(%arg0: tensor<16x26x18x144xf16>, %arg1: tensor<16x24x1
 }
 
 // CHECK-LABEL: func.func @conv_chwn_fhwn
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [192, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
@@ -193,4 +193,4 @@ func.func @conv_chwn_fhwn(%arg0: tensor<16x26x18x144xf16>, %arg1: tensor<16x24x1
 //  CHECK-SAME:     promote_operands = [0, 1]
 //  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 1]
 //  CHECK-SAME:     subgroup = [1, 1, 1, 1, 0, 0, 0]
-//  CHECK-SAME:     workgroup = [16, 1, 1, 16, 0, 0, 0]
+//  CHECK-SAME:     workgroup = [16, 1, 3, 16, 0, 0, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -180,19 +180,25 @@ func.func @conv_chwn_chwf_unaligned_batch(%arg0: tensor<16x193x129x40xbf16>, %ar
 }
 
 // CHECK-LABEL: func.func @conv_chwn_chwf_unaligned_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [192, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>
-//  CHECK-SAME:     padding = [16, 1, 1, 16, 128]
-//  CHECK-SAME:     promote_operands = [0, 1]
-//  CHECK-SAME:     reduction = [0, 0, 0, 0, 8]
-//  CHECK-SAME:     subgroup = [1, 1, 1, 1, 0]
-//  CHECK-SAME:     workgroup = [16, 1, 1, 16, 0]
+// GFX942-SAME:     padding = [16, 1, 2, 48, 128]
+// GFX942-SAME:     promote_operands = [0, 1]
+// GFX942-SAME:     reduction = [0, 0, 0, 0, 8]
+// GFX942-SAME:     subgroup = [1, 1, 2, 1, 0]
+// GFX942-SAME:     workgroup = [16, 1, 2, 48, 0]
 
-// PAD-CONV-GFX942:     padding_conv =  [0, 0, 0, 16, 0, 0, 0]
+// MI300X-SAME:     padding = [16, 1, 1, 48, 128]
+// MI300X-SAME:     promote_operands = [0, 1]
+// MI300X-SAME:     reduction = [0, 0, 0, 0, 8]
+// MI300X-SAME:     subgroup = [1, 1, 1, 1, 0]
+// MI300X-SAME:     workgroup = [16, 1, 1, 48, 0]
+
+// PAD-CONV-GFX942:     padding_conv = [0, 0, 0, 48, 0, 0, 0]
 
 // -----
 
@@ -290,7 +296,7 @@ func.func @conv_chwn_chwf_aligned_batch(%arg0: tensor<2x192x128x48xbf16>, %arg1:
 }
 
 //         CHECK-LABEL:  func.func @conv_chwn_chwf_aligned_batch
-//     PAD-CONV-GFX942:     padding = [16, 1, 1, 16, 16]
+//     PAD-CONV-GFX942:     padding = [16, 1, 2, 48, 16]
 // PAD-CONV-GFX942-NOT:     padding_conv
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -26,6 +26,10 @@
 // RUN: --iree-codegen-llvmgpu-use-igemm=false \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=MI355X
 
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=IGEMM
+
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
 #rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
 #scale_m = affine_map<(M, N, Ko, Kb) -> (M, Ko)>
@@ -492,3 +496,48 @@ func.func @matmul_large_very_tall_m_f16(
 //  MI355X-SAME:     reduction = [0, 0, 1]
 //  MI355X-SAME:     subgroup = [4, 8, 0]
 //  MI355X-SAME:     workgroup = [128, 256, 0]
+
+// -----
+
+// Small M*N matmul: M=8, N=8, K=5000. Both M and N need padding.
+// Without the M*N utilization rule, this picks MFMA_F32_32x32x8_F16
+// (6.25% util). With it, picks MFMA_F32_16x16x16_F16 (25% util, 4x better).
+func.func @small_mn_matmul(%lhs: tensor<8x5000xf16>, %rhs: tensor<5000x8xf16>, %out: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs : tensor<8x5000xf16>, tensor<5000x8xf16>) outs(%out : tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %result : tensor<8x8xf32>
+}
+// CHECK-LABEL: func.func @small_mn_matmul
+// CHECK:         linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:      padding = [16, 16, 16]
+// CHECK-SAME:      subgroup = [1, 1, 0]
+// CHECK-SAME:      workgroup = [16, 16, 0]
+
+// -----
+
+// Small-channel grouped convolution (weight backward): 32 groups, 8 in/out channels per group.
+// With old heuristics, this picks MFMA_F32_32x32x8_F16 with workgroup = [1, 16, 1, 1, 16, 0].
+// Now it picks MFMA_F32_16x16x16_F16 (less wasted compute per instruction for 8x8 per-group channels),
+// distributes the N=3 filter dim, and increases batch tile from 1 to 4.
+#map_gc = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d2 + d6, d3 + d7, d0, d4)>
+#map_gc1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d6, d7, d0, d1)>
+#map_gc2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>
+func.func @group_conv_small_channels(%arg0: tensor<32x102x102x32x8xf16>, %arg1: tensor<32x100x100x32x8xf16>, %arg2: tensor<32x8x3x3x8xf32>) -> tensor<32x8x3x3x8xf32> {
+  %0 = linalg.generic {indexing_maps = [#map_gc, #map_gc1, #map_gc2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<32x102x102x32x8xf16>, tensor<32x100x100x32x8xf16>) outs(%arg2 : tensor<32x8x3x3x8xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<32x8x3x3x8xf32>
+  return %0 : tensor<32x8x3x3x8xf32>
+}
+// IGEMM-LABEL: func.func @group_conv_small_channels
+// IGEMM:         linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+// IGEMM-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// IGEMM-SAME:      padding = [4, 16, 1, 3, 16, 128]
+// IGEMM-SAME:      promote_operands = [0, 1]
+// IGEMM-SAME:      reduction = [0, 0, 0, 0, 0, 8]
+// IGEMM-SAME:      subgroup = [0, 1, 1, 1, 1, 0]
+// IGEMM-SAME:      workgroup = [4, 16, 1, 3, 16, 0]


### PR DESCRIPTION
Three changes to improve performance of grouped convolutions with small per-group channel counts (e.g., 32 groups with 8 input/output channels):

1. MMA intrinsic selection: Add MN utilization check as the highest-priority rule. When one intrinsic has >= 2x better MN utilization, prefer it regardless of K-alignment. This avoids selecting 32x32 intrinsics (6.25% util) over 16x16 intrinsics (25% util) for problems with small M/N dimensions. For same MN intrinsics differing only in K (e.g., 16x16x16 vs 16x16x32), use a 10% utilization threshold: at moderate util prefer smaller compute; at very low util let later rules pick the larger-K intrinsic for better K throughput.

2. Degenerate schedule fallback: When GCD-based distribution produces all-1 subgroup/tile counts (because tile counts are small odd numbers like 3x3 with GCD=1 against power-of-2 seeds), fall back to min-based distribution. This ensures the schedule assigns meaningful work to subgroups for small filter spatial dimensions.

3. Batch dimension tiling: When the inner M and N dimensions both require padding (smaller than the intrinsic tile), increase the batch tile size from 1 to up to 4. This gives each workgroup more useful work to amortize dispatch and memory access overhead, which is critical for grouped convolutions where the per-group computation is very small.

Benchmark results on MI355X:
  - Top improvements (group backward weight convolutions, g=32): 
  3.94x (2466 -> 627 us)  g=32, 256, 200x200, 3x3, stride 2 
  3.51x (1929 -> 550 us)  g=32, 256, 100x100, 3x3
  1.94x (370 -> 191 us)   g=32, 512, 50x50, 3x3
  - No significant regressions.
 
Similar performance improvements are also observed on RDNA4 and Mi300x.