### PR TITLE
Reapply "[GPUHeuristics] Further tune `LargeGemm` perf (#23652)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -689,64 +689,125 @@ sortMMAIntrinsics(GPUMatmulShapeType problem,
   return sortedIntrinsics;
 }
 
-static int64_t adjustSeedsForWgpCount(const GPUMatmulShapeType &problem,
-                                      const GPUIntrinsicType &intrinsic,
-                                      std::optional<int64_t> wgpCount,
-                                      int64_t bestSubgroupCountPerWorkgroup,
-                                      int64_t bestMNTileCountPerSubgroup,
-                                      int64_t splitReductionTripCnt) {
-  if (!wgpCount.has_value()) {
-    LDBG() << "WGP count is not available,"
-           << "Skipping adjustment of seeds for workgroup count.";
-    return bestMNTileCountPerSubgroup;
+static int64_t computeEstimatedWorkgroupCount(const GPUMMAHeuristicSeeds &seeds,
+                                              const GPUMatmulShapeType &problem,
+                                              const GPUIntrinsicType &intrinsic,
+                                              int64_t splitReductionTripCnt) {
+  int64_t mSize = ShapedType::getNumElements(problem.mSizes);
+  int64_t nSize = ShapedType::getNumElements(problem.nSizes);
+  int64_t mnTileSizePerSubgroup = seeds.bestMNTileCountPerSubgroup *
+                                  intrinsic.mSizes[0] * intrinsic.nSizes[0];
+  int64_t workgroupSize =
+      mnTileSizePerSubgroup * seeds.bestSubgroupCountPerWorkgroup;
+  assert(workgroupSize > 0 && "workgroup size must be positive");
+  int64_t numWorkgroups = mSize * nSize / workgroupSize;
+  if (splitReductionTripCnt > 1) {
+    numWorkgroups *= splitReductionTripCnt;
+  }
+  return numWorkgroups;
+}
+
+/// Adjust M*N tile-count (bestMNTileCountPerSubgroup) seeds based on target
+/// hardware and problem characteristics. Three independent adjustments, applied
+/// in order:
+/// 1. Baseline (all targets): reduces bestMNTileCountPerSubgroup until the
+///    estimated workgroup count fills all CUs.
+/// 2. Tile-count boost (when boostMNTileCountPerSubgroup is set): for GEMMs
+///    with balanced K, boosts tile count to the architecture-specific target.
+/// 3. Utilization guard (when minUtilizationThreshold is set): halves tile
+///    count until GPU utilization meets the threshold.
+static void adjustSeedsForTarget(GPUMMAHeuristicSeeds &seeds,
+                                 const GPUMatmulShapeType &problem,
+                                 const GPUIntrinsicType &intrinsic,
+                                 IREE::GPU::TargetAttr target,
+                                 int64_t splitReductionTripCnt) {
+  IREE::GPU::TargetChipAttr chip = target ? target.getChip() : nullptr;
+  int64_t wgpCount = chip ? chip.getWgpCount() : 0;
+  if (wgpCount == 0) {
+    LDBG() << "WGP count unavailable, skipping seed adjustment.";
+    return;
   }
 
   if (!problem.gemmSize || problem.gemmSize == GemmSizeKind::SmallGemm) {
     LDBG() << "Arithmetic intensity is too low, "
            << "skipping adjustment of seeds for workgroup count.";
-    return bestMNTileCountPerSubgroup;
+    return;
   }
-  int64_t mSize = ShapedType::getNumElements(problem.mSizes);
-  int64_t nSize = ShapedType::getNumElements(problem.nSizes);
-  auto computeWorkgroupCount = [&] {
-    // Compute the number of workgroups needed to cover the problem size.
-    // This number tends to be lower than actual workgroup count, since:
-    // 1) It assumes tile and subgroup seeds are all allocated.
-    // 2) It assumes shared memory usage does not exceed hardware limits.
-    int64_t mnTileSizePerSubgroup =
-        bestMNTileCountPerSubgroup * intrinsic.mSizes[0] * intrinsic.nSizes[0];
-    int64_t workgroupSize =
-        mnTileSizePerSubgroup * bestSubgroupCountPerWorkgroup;
-    int64_t numWorkgroups = mSize * nSize / workgroupSize;
-    // Account for split reduction distribution to avoid decreasing
-    // `bestMNTileCountPerSubgroup` when parallelism is sufficient.
-    if (splitReductionTripCnt > 1) {
-      numWorkgroups *= splitReductionTripCnt;
-    }
-    return numWorkgroups;
-  };
-  int64_t numWorkgroups = computeWorkgroupCount();
+
+  // Baseline for all architectures: reduce MNT until workgroups fill CUs.
+  int64_t numWorkgroups = computeEstimatedWorkgroupCount(
+      seeds, problem, intrinsic, splitReductionTripCnt);
   LDBG() << "Estimated number of workgroups: " << numWorkgroups
          << ", WGP count: " << wgpCount;
 
   while (numWorkgroups < wgpCount) {
-    if (bestMNTileCountPerSubgroup <= 1) {
+    if (seeds.bestMNTileCountPerSubgroup <= 1) {
       LDBG() << "Cannot decrease tile size further, "
                 "bestMNTileCountPerSubgroup is already 1.";
       break;
     }
-    bestMNTileCountPerSubgroup /= 2;
+    seeds.bestMNTileCountPerSubgroup /= 2;
     LDBG() << "Decreasing bestMNTileCountPerSubgroup to "
-           << bestMNTileCountPerSubgroup;
-    numWorkgroups = computeWorkgroupCount();
+           << seeds.bestMNTileCountPerSubgroup;
+    numWorkgroups = computeEstimatedWorkgroupCount(seeds, problem, intrinsic,
+                                                   splitReductionTripCnt);
   }
-  return bestMNTileCountPerSubgroup;
+
+  // For GEMMs with balanced K dimensions (K <= max(M, N)), boost MNT to the
+  // architecture-specific target to improve per-workgroup compute density
+  // (more output elements per workgroup). The workload benefits from wider M*N
+  // tiles rather than deeper K unrolling.
+  if (seeds.boostMNTileCountPerSubgroup) {
+    int64_t boostMNT = *seeds.boostMNTileCountPerSubgroup;
+    int64_t mSize = ShapedType::getNumElements(problem.mSizes);
+    int64_t nSize = ShapedType::getNumElements(problem.nSizes);
+    int64_t kSize = ShapedType::getNumElements(problem.kSizes);
+    int64_t boostedWGSize = boostMNT * intrinsic.mSizes[0] *
+                            intrinsic.nSizes[0] *
+                            seeds.bestSubgroupCountPerWorkgroup;
+    bool kDominated = kSize > std::max(mSize, nSize);
+    bool enoughOutput = mSize * nSize >= 2 * wgpCount * boostedWGSize;
+    if (!kDominated && enoughOutput) {
+      seeds.bestMNTileCountPerSubgroup =
+          std::max(seeds.bestMNTileCountPerSubgroup, boostMNT);
+      LDBG() << "Boosting MNT to " << seeds.bestMNTileCountPerSubgroup
+             << " for balanced large gemm";
+    }
+  }
+
+  // When a utilization threshold is set and workgroup count barely exceeds a
+  // wave boundary, the last wave has most CUs idle. For example, 260
+  // workgroups on 256 CUs gives 2 waves but only 50.8% utilization. Halve
+  // MNT until utilization meets the threshold.
+  if (seeds.minUtilizationThreshold) {
+    double threshold = *seeds.minUtilizationThreshold;
+    numWorkgroups = computeEstimatedWorkgroupCount(seeds, problem, intrinsic,
+                                                   splitReductionTripCnt);
+    auto computeUtilization = [&]() -> double {
+      int64_t waves = llvm::divideCeil(numWorkgroups, wgpCount);
+      if (waves == 0) {
+        return 0.0;
+      }
+      return static_cast<double>(numWorkgroups) / (waves * wgpCount);
+    };
+
+    while (computeUtilization() < threshold) {
+      if (seeds.bestMNTileCountPerSubgroup <= 1) {
+        break;
+      }
+      seeds.bestMNTileCountPerSubgroup /= 2;
+      numWorkgroups = computeEstimatedWorkgroupCount(seeds, problem, intrinsic,
+                                                     splitReductionTripCnt);
+      LDBG() << "Low utilization, decreasing MNT to "
+             << seeds.bestMNTileCountPerSubgroup;
+    }
+  }
 }
 
 FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMatmulShapeType &problem, ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
-    int64_t subgroupSize, std::optional<int64_t> wgpCount, Location loc,
+    int64_t subgroupSize, IREE::GPU::TargetAttr target, Location loc,
     bool transposedLhs, bool transposedRhs, bool canUpcastAcc,
     bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned,
     bool doCPromotion, int64_t splitReductionTripCnt) {
@@ -764,9 +825,8 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     // more than once in a row, and we want to keep the original seeds intact
     // for the next call.
     GPUMMAHeuristicSeeds localSeeds = seeds;
-    localSeeds.bestMNTileCountPerSubgroup = adjustSeedsForWgpCount(
-        problem, intrinsic, wgpCount, seeds.bestSubgroupCountPerWorkgroup,
-        seeds.bestMNTileCountPerSubgroup, splitReductionTripCnt);
+    adjustSeedsForTarget(localSeeds, problem, intrinsic, target,
+                         splitReductionTripCnt);
     GPUMMASchedule schedule =
         getOptimalMMASchedule(problem, intrinsic, localSeeds);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -12,6 +12,10 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "mlir/IR/Types.h"
 
+namespace mlir::iree_compiler::IREE::GPU {
+class TargetAttr;
+} // namespace mlir::iree_compiler::IREE::GPU
+
 namespace mlir::iree_compiler {
 
 enum class GemmSizeKind : int {
@@ -83,6 +87,21 @@ struct GPUMMAHeuristicSeeds {
   // equivalent to `bestKTileCountPerSubgroup * bestIntrinsic.kSize`, for
   // some chosen intrinsic `bestIntrinsic`.
   int64_t bestKElementCountPerSubgroup = 0;
+  // Optional minimum GPU utilization threshold for seed adjustment. When set,
+  // adjustSeedsForTarget will boost MNT for balanced large GEMMs and then
+  // halve MNT until utilization meets this threshold. GPU utilization is
+  // defined as numWorkgroups / (numWaves * numCUs), where numWaves =
+  // ceil(numWorkgroups / numCUs). A threshold of 0.50 means at least 50% of
+  // CU-slots in the last wave must be occupied.
+  std::optional<double> minUtilizationThreshold = std::nullopt;
+  // Optional MN tile count boost target for GEMMs with balanced K (i.e.,
+  // K <= max(M, N)). When set, adjustSeedsForTarget will boost
+  // bestMNTileCountPerSubgroup to at least this value, provided the output
+  // tensor is large enough to keep the GPU busy at the boosted tile size. A
+  // higher value increases per-workgroup compute density (more output elements
+  // per workgroup), which can improve performance when the GPU has enough work
+  // to stay saturated.
+  std::optional<int64_t> boostMNTileCountPerSubgroup = std::nullopt;
 };
 
 struct GPUMMASchedule {
@@ -159,13 +178,15 @@ struct GPUMMASchedule {
 
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
+/// When |target| is provided, architecture-specific seed adjustments (e.g.,
+/// utilization-aware MNT tuning for CDNA4) are applied per-intrinsic.
 /// When |doCPromotion| is true, the accumulator uses shared memory. This can be
 /// due to padding requirements or because the operation has an existing
 /// accumulator that needs to be loaded from global memory (matmul_accumulate).
 FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMatmulShapeType &problem, ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
-    int64_t subgroupSize, std::optional<int64_t> cuCount, Location loc,
+    int64_t subgroupSize, IREE::GPU::TargetAttr target, Location loc,
     bool transposedLhs = false, bool transposedRhs = false,
     bool canUpcastAcc = false, bool useDirectLoad = false,
     int64_t prefetchNumStages = 0, bool mustBeAligned = true,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AMDGPUUtils",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FunctionInterfaces",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
     "ReductionConfigUtils.cpp"
   DEPS
     LLVMSupport
+    MLIRAMDGPUUtils
     MLIRAnalysis
     MLIRFunctionInterfaces
     MLIRIR

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -388,15 +388,10 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
 
-  std::optional<int64_t> wgpCount = std::nullopt;
-  if (TargetChipAttr chip = target.getChip()) {
-    wgpCount = chip.getWgpCount();
-  }
-
   // First try to find a schedule with an exactly matching intrinsic.
   std::optional<GPUMMASchedule> schedule = deduceMMASchedule(
       problem, intrinsics, seeds, maxSharedMemoryBytes, targetSubgroupSize,
-      wgpCount, loc, transposedLhs, transposedRhs, /*canUpcastAcc=*/false,
+      target, loc, transposedLhs, transposedRhs, /*canUpcastAcc=*/false,
       useDirectLoad, prefetchNumStages, /*mustBeAligned=*/mustBeAligned,
       doCPromotion, splitReductionTripCnt);
   return schedule;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -1284,6 +1284,36 @@ static constexpr ArchSeedSet kDefaultSeeds = {
     },
 };
 
+/// CDNA4 seeds use the default values plus utilization-aware MNT tuning.
+/// The boostMNTileCountPerSubgroup of 32 was empirically determined by
+/// benchmarking large GEMM shapes (e.g. 4096x4096x4096) on MI350 to balance
+/// per-workgroup compute density against register pressure and occupancy.
+/// TODO: Link to iree-org/iree discussion with full benchmarking methodology.
+static constexpr ArchSeedSet kCDNA4Seeds = {
+    /*gemm=*/{
+        /*SmallGemm=*/     {2, 2,  4, 2 * kCacheLineSizeBits},
+        /*MediumGemm=*/    {4, 8,  4, 2 * kCacheLineSizeBits},
+        /*LargeGemm=*/     {4, 16, 2, kCacheLineSizeBits / 2,
+                            /*minUtilizationThreshold=*/0.50,
+                            /*boostMNTileCountPerSubgroup=*/32},
+        /*VeryLargeGemm=*/ {4, 16, 2, kCacheLineSizeBits / 2,
+                            /*minUtilizationThreshold=*/0.50,
+                            /*boostMNTileCountPerSubgroup=*/32},
+    },
+    /*scaledGemm=*/{
+        /*SmallGemm=*/     {2, 2,  4, 2 * kCacheLineSizeBits},
+        /*MediumGemm=*/    {8, 32, 4, kCacheLineSizeBits / 2},
+        /*LargeGemm=*/     {8, 32, 2, kCacheLineSizeBits / 2},
+        /*VeryLargeGemm=*/ {8, 32, 2, kCacheLineSizeBits / 2},
+    },
+    /*conv=*/{
+        /*SmallGemm=*/     {2, 2,  4, kCacheLineSizeBits},
+        /*MediumGemm=*/    {8, 4,  4, 2 * kCacheLineSizeBits},
+        /*LargeGemm=*/     {8, 8,  2, kCacheLineSizeBits / 2},
+        /*VeryLargeGemm=*/ {8, 8,  2, kCacheLineSizeBits / 2},
+    },
+};
+
 /// RDNA4 seeds (tuned based on RX 9070 XT benchmarking data).
 static constexpr ArchSeedSet kRDNA4Seeds = {
     /*gemm=*/{
@@ -1315,11 +1345,17 @@ const ArchSeedSet &getArchSeedSet(TargetAttr target) {
   }
 
   StringRef arch = target.getArch();
+  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(arch);
+  // CDNA4 is gfx950 (major=9, minor=5).
+  bool isCDNA4 = succeeded(chipset) && chipset->majorVersion == 9 &&
+                 chipset->minorVersion == 5;
   // RDNA4 is gfx1200/gfx1201 (major=12, minor=0). Note: gfx1250 (minor=5)
   // is a separate experimental target and should not use RDNA4 seeds.
-  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(arch);
   bool isRDNA4 = succeeded(chipset) && chipset->majorVersion == 12 &&
                  chipset->minorVersion == 0;
+  if (isCDNA4 || arch == "cdna4") {
+    return kCDNA4Seeds;
+  }
   if (isRDNA4 || arch == "rdna4") {
     return kRDNA4Seeds;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -134,6 +134,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:ConfigUtils",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:KnownTargets",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -177,6 +177,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::ConfigUtils
+    iree::compiler::Codegen::Dialect::GPU::TargetUtils::KnownTargets
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
@@ -333,25 +334,25 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // https://github.com/iree-org/iree/discussions/21506.
   // This is already implemented in KernelConfig.cpp in tileAndFuse pipeline
   // and should be ported to here once its perf results are verified.
+  const auto &archGemmSeeds = getArchSeedSet(target).gemm[0];
   GPUMMAHeuristicSeeds seeds{/*bestSubgroupCountPerWorkgroup=*/4,
                              /*bestMNTileCountPerSubgroup=*/8,
-                             /*bestKTileCountPerSubgroup=*/2};
+                             /*bestKTileCountPerSubgroup=*/2,
+                             /*bestKElementCountPerSubgroup=*/0,
+                             archGemmSeeds.minUtilizationThreshold,
+                             archGemmSeeds.boostMNTileCountPerSubgroup};
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
 
-  std::optional<int64_t> wgpCount = std::nullopt;
-  if (IREE::GPU::TargetChipAttr chip = target.getChip()) {
-    wgpCount = chip.getWgpCount();
-  }
   // First try to find a schedule with an exactly matching intrinsic.
   FailureOr<GPUMMASchedule> schedule =
       deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                        targetSubgroupSize, wgpCount, op.getLoc());
+                        targetSubgroupSize, target, op.getLoc());
   if (failed(schedule)) {
     // Then try again by allowing upcasting accumulator.
     schedule =
         deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                          targetSubgroupSize, wgpCount, op.getLoc(),
+                          targetSubgroupSize, target, op.getLoc(),
                           /*transposedLhs*/ false, /*transposedRhs*/ false,
                           /*canUpcastAcc=*/true);
   }
@@ -572,17 +573,24 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // https://github.com/iree-org/iree/discussions/21506.
   // This is already implemented in KernelConfig.cpp in tileAndFuse pipeline
   // and should be ported to here once its perf results are verified.
+  const auto &defaultGemmSeeds = getArchSeedSet(target).gemm[0];
   if (problem.mSizes[0] * problem.nSizes[0] <= clGPUMatmulCThreshold) {
     // For matmuls with small M*N size, we want to distribute M*N onto more
     // workgroups to fill the GPU. Use a smaller bestMNTileCountPerSubgroup
     // and a larger bestKTileCountPerSubgroup.
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/4,
-             /*bestKTileCountPerSubgroup=*/8};
+             /*bestKTileCountPerSubgroup=*/8,
+             /*bestKElementCountPerSubgroup=*/0,
+             defaultGemmSeeds.minUtilizationThreshold,
+             defaultGemmSeeds.boostMNTileCountPerSubgroup};
   } else {
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/8,
-             /*bestKTileCountPerSubgroup=*/4};
+             /*bestKTileCountPerSubgroup=*/4,
+             /*bestKElementCountPerSubgroup=*/0,
+             defaultGemmSeeds.minUtilizationThreshold,
+             defaultGemmSeeds.boostMNTileCountPerSubgroup};
   }
   // Scale the seed by number of contractions of horizontally fused case.
   seeds.bestMNTileCountPerSubgroup /= op.getNumDpsInputs() - 1;
@@ -600,20 +608,15 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   bool transposedRhs =
       nDim != cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
 
-  std::optional<int64_t> wgpCount = std::nullopt;
-  if (IREE::GPU::TargetChipAttr chip = target.getChip()) {
-    wgpCount = chip.getWgpCount();
-  }
-
   // First try to find a schedule with an exactly matching intrinsic.
   std::optional<GPUMMASchedule> schedule =
       deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                        targetSubgroupSize, wgpCount, op.getLoc());
+                        targetSubgroupSize, target, op.getLoc());
   if (!schedule) {
     // Then try again by allowing upcasting accumulator.
     schedule =
         deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                          targetSubgroupSize, wgpCount, op.getLoc(),
+                          targetSubgroupSize, target, op.getLoc(),
                           transposedLhs, transposedRhs, /*canUpcastAcc=*/true);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -21,6 +21,11 @@
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-3
 
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=mi355x@hip \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=MI355X
+
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
 #rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
 #scale_m = affine_map<(M, N, Ko, Kb) -> (M, Ko)>
@@ -380,3 +385,110 @@ func.func @matmul_f16_compute_bound(
 // CHECK-REMARKS-DIRECT-LOAD-3: [Analysis] SharedMemoryUsage
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Category:deduceMMASchedule
 // CHECK-REMARKS-DIRECT-LOAD-3-SAME: Remark=98304
+
+// -----
+
+// MI355X-specific (CDNA4) heuristic tests: MI355X targets gfx950 with chip
+// info (wgpCount=256), enabling utilization-aware MNT boosting for balanced
+// large GEMMs. These tests verify that the boosted config differs from bare
+// gfx950 (which has no chip info).
+
+// LargeGemm — symmetric (4096x4096x4096)
+// Balanced K (K == M == N), so MNT gets boosted to 32.
+func.func @matmul_large_symmetric_f16(
+    %arg0: tensor<4096x4096xf16>,
+    %arg1: tensor<4096x4096xf16>) -> tensor<4096x4096xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<4096x4096xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+  %result = linalg.matmul ins(%arg0, %arg1 : tensor<4096x4096xf16>, tensor<4096x4096xf16>)
+                          outs(%fill : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+  return %result : tensor<4096x4096xf32>
+}
+
+// MI355X-LABEL: func.func @matmul_large_symmetric_f16
+//  MI355X-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  MI355X-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64
+//       MI355X:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  MI355X-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
+//  MI355X-SAME:     promote_operands = [0, 1]
+//  MI355X-SAME:     reduction = [0, 0, 1]
+//  MI355X-SAME:     subgroup = [4, 8, 0]
+//  MI355X-SAME:     workgroup = [128, 256, 0]
+
+// -----
+
+// LargeGemm — tall-M (21760x3840x3840)
+// Balanced K (K == N < M), MNT boost applies.
+func.func @matmul_large_tall_m_f16(
+    %arg0: tensor<21760x3840xf16>,
+    %arg1: tensor<3840x3840xf16>) -> tensor<21760x3840xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<21760x3840xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<21760x3840xf32>) -> tensor<21760x3840xf32>
+  %result = linalg.matmul ins(%arg0, %arg1 : tensor<21760x3840xf16>, tensor<3840x3840xf16>)
+                          outs(%fill : tensor<21760x3840xf32>) -> tensor<21760x3840xf32>
+  return %result : tensor<21760x3840xf32>
+}
+
+// MI355X-LABEL: func.func @matmul_large_tall_m_f16
+//  MI355X-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  MI355X-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64
+//       MI355X:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  MI355X-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
+//  MI355X-SAME:     promote_operands = [0, 1]
+//  MI355X-SAME:     reduction = [0, 0, 1]
+//  MI355X-SAME:     subgroup = [4, 8, 0]
+//  MI355X-SAME:     workgroup = [128, 256, 0]
+
+// -----
+
+// LargeGemm — wide-N (4096x8192x2048)
+// Balanced K (K < max(M, N)), MNT boost applies.
+func.func @matmul_large_wide_n_f16(
+    %arg0: tensor<4096x2048xf16>,
+    %arg1: tensor<2048x8192xf16>) -> tensor<4096x8192xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<4096x8192xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4096x8192xf32>) -> tensor<4096x8192xf32>
+  %result = linalg.matmul ins(%arg0, %arg1 : tensor<4096x2048xf16>, tensor<2048x8192xf16>)
+                          outs(%fill : tensor<4096x8192xf32>) -> tensor<4096x8192xf32>
+  return %result : tensor<4096x8192xf32>
+}
+
+// MI355X-LABEL: func.func @matmul_large_wide_n_f16
+//  MI355X-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  MI355X-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64
+//       MI355X:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  MI355X-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
+//  MI355X-SAME:     promote_operands = [0, 1]
+//  MI355X-SAME:     reduction = [0, 0, 1]
+//  MI355X-SAME:     subgroup = [4, 8, 0]
+//  MI355X-SAME:     workgroup = [128, 256, 0]
+
+// -----
+
+// LargeGemm — very tall-M with large K (150000x4096x16384)
+// K > max(M, N) so K-dominated — MNT boost does NOT apply.
+// Requires padding since 150000 is not a multiple of tile size.
+func.func @matmul_large_very_tall_m_f16(
+    %arg0: tensor<150000x16384xf16>,
+    %arg1: tensor<16384x4096xf16>) -> tensor<150000x4096xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<150000x4096xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<150000x4096xf32>) -> tensor<150000x4096xf32>
+  %result = linalg.matmul ins(%arg0, %arg1 : tensor<150000x16384xf16>, tensor<16384x4096xf16>)
+                          outs(%fill : tensor<150000x4096xf32>) -> tensor<150000x4096xf32>
+  return %result : tensor<150000x4096xf32>
+}
+
+// MI355X-LABEL: func.func @matmul_large_very_tall_m_f16
+//  MI355X-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  MI355X-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64
+//       MI355X:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  MI355X-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
+//  MI355X-SAME:     padding = [128, 256, 32]
+//  MI355X-SAME:     promote_operands = [0, 1]
+//  MI355X-SAME:     reduction = [0, 0, 1]
+//  MI355X-SAME:     subgroup = [4, 8, 0]
+//  MI355X-SAME:     workgroup = [128, 256, 0]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -964,7 +964,7 @@ setCooperativeMatrixConfig(IREE::GPU::TargetAttr target, linalg::LinalgOp op,
 
   FailureOr<GPUMMASchedule> schedule = deduceMMASchedule(
       problem, intrinsics, seeds, sharedMemoryLimitInBytes, subgroupSize,
-      /*cuCount=*/std::nullopt, op.getLoc(), transposedLhs, transposedRhs);
+      /*target=*/nullptr, op.getLoc(), transposedLhs, transposedRhs);
   if (failed(schedule)) {
     return failure();
   }


### PR DESCRIPTION
Here is previous commit message.
---
* Adds additional, optional utilization rate as a guard in the heuristic seeds.
* Tunes `LargeGemm` MMA schedule heuristic seeds from sg=4/MNT=16 to sg=8/MNT=32 and upgrades the workgroup count adjustment guard to be utilization-aware.
* Inflate LargeGemm heuristic seeds for gfx950 (sg=8, MNT=32) to better utilize CDNA4 compute resources. This is based on tuner results.
* Benchmarked on 75 LargeGemm bf16 shapes from mi355x: +7.0% geomean improvement with 28 shapes improved (up to 30%) and no regressions >5%.

Here are some `LargeGemm`s representative results: | M×N×K | Change |
  |---|---|
  | 150000×4096×16384 | **+11%** |
  | 150000×16384×4096 | **+10%** |
  | 150000×2048×8192 | **+12%** |
  | 150000×4096×2268 | **+10%** |
  | 21760×3840×3840 | **+30%** |
  | 16640×3840×3840 | **+26%** |
  | 11520×3840×3840 | **+17%** |
  | 6400×3840×3840 | **+13%** |
  | 24576×2048×1536 | **+10%** |
  | 4096×8192×2048 | **+6%** |
  | 3840×3840×4352 | neutral |
  | 4096×16384×150000 (large-K) | neutral |
  | 2268×4096×150000 | neutral |

---------