### PR TITLE
Move unrolling to common and use in CPU pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -170,6 +170,7 @@ iree_compiler_cc_library(
         "Transforms.cpp",
         "TypePropagation.cpp",
         "UnrollAnnotatedLoops.cpp",
+        "UnrollElementwiseOps.cpp",
         "UserConfig.cpp",
         "VectorLayoutAnalysis.cpp",
         "VectorTransferLowering.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -162,6 +162,7 @@ iree_cc_library(
     "Transforms.cpp"
     "TypePropagation.cpp"
     "UnrollAnnotatedLoops.cpp"
+    "UnrollElementwiseOps.cpp"
     "UserConfig.cpp"
     "VectorLayoutAnalysis.cpp"
     "VectorTransferLowering.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -175,6 +175,9 @@ struct ReshapeOps {
   tensor::CollapseShapeOp collapseShapeOp;
 };
 
+/// Populate patterns that unroll N-D elementwise ops on vectors to 1-D.
+void populateUnrollElementwiseOpsPatterns(RewritePatternSet &patterns);
+
 /// Populate patterns to remove optimization barriers.
 void populateRemoveOptimizationBarrierPatterns(RewritePatternSet &patterns);
 

--- a/compiler/src/iree/compiler/Codegen/Common/UnrollElementwiseOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/UnrollElementwiseOps.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The IREE Authors
+// Copyright 2026 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/Codegen/Common/UnrollElementwiseOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/UnrollElementwiseOps.cpp
@@ -1,0 +1,72 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+// Unrolls N-D elementwise vector operations to 1-D by iterating over all
+// leading dimensions and extracting/inserting 1-D subvectors.
+struct UnrollElementwiseOps final : RewritePattern {
+  UnrollElementwiseOps(MLIRContext *context, PatternBenefit benefit = 1)
+      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (!OpTrait::hasElementwiseMappableTraits(op) ||
+        op->getNumResults() != 1) {
+      return failure();
+    }
+
+    Location loc = op->getLoc();
+    VectorType dstVecTy = dyn_cast<VectorType>(op->getResult(0).getType());
+    if (!dstVecTy || dstVecTy.getRank() <= 1) {
+      return failure();
+    }
+    ArrayRef<int64_t> originalSize = dstVecTy.getShape();
+
+    Value result = ub::PoisonOp::create(rewriter, loc, dstVecTy);
+    auto subVecTy =
+        VectorType::get({originalSize.back()}, dstVecTy.getElementType());
+
+    SmallVector<int64_t> tileShape(dstVecTy.getRank() - 1, 1);
+    for (SmallVector<int64_t> offsets :
+         StaticTileOffsetRange(originalSize.drop_back(), tileShape)) {
+      SmallVector<Value> operands;
+      for (Value val : op->getOperands()) {
+        // Extract subvector if the operand is a vector. This is to handle
+        // things like arith.select which take a scalar conditional but are
+        // otherwise elementwise.
+        if (isa<VectorType>(val.getType())) {
+          val = vector::ExtractOp::create(rewriter, loc, val, offsets);
+        }
+        operands.push_back(val);
+      }
+
+      Operation *clonedOp = clone(rewriter, op, subVecTy, operands);
+      Value subResult = clonedOp->getResult(0);
+      result =
+          vector::InsertOp::create(rewriter, loc, subResult, result, offsets);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateUnrollElementwiseOpsPatterns(RewritePatternSet &patterns) {
+  patterns.add<UnrollElementwiseOps>(patterns.getContext());
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1027,6 +1027,7 @@ void ConvertToLLVMPass::runOnOperation() {
     RewritePatternSet vectorToLoopsPatterns(&getContext());
     populateVectorToSCFConversionPatterns(
         vectorToLoopsPatterns, VectorTransferToSCFOptions().enableFullUnroll());
+    populateUnrollElementwiseOpsPatterns(vectorToLoopsPatterns);
     if (failed(applyPatternsGreedily(getOperation(),
                                      std::move(vectorToLoopsPatterns)))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
@@ -15,7 +16,6 @@
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
@@ -507,54 +507,6 @@ private:
   }
 };
 
-struct UnrollElementwiseOps final : RewritePattern {
-  UnrollElementwiseOps(MLIRContext *context, PatternBenefit benefit = 1)
-      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    if (!OpTrait::hasElementwiseMappableTraits(op) ||
-        op->getNumResults() != 1) {
-      return failure();
-    }
-
-    Location loc = op->getLoc();
-    VectorType dstVecTy = dyn_cast<VectorType>(op->getResult(0).getType());
-    if (!dstVecTy || dstVecTy.getRank() <= 1) {
-      return failure();
-    }
-    ArrayRef<int64_t> originalSize = dstVecTy.getShape();
-
-    Value result = ub::PoisonOp::create(rewriter, loc, dstVecTy);
-    auto subVecTy =
-        VectorType::get({originalSize.back()}, dstVecTy.getElementType());
-
-    SmallVector<int64_t> tileShape(dstVecTy.getRank() - 1, 1);
-    for (SmallVector<int64_t> offsets :
-         StaticTileOffsetRange(originalSize.drop_back(), tileShape)) {
-      // Extract from each operand.
-      SmallVector<Value> operands;
-      for (Value val : op->getOperands()) {
-        // Extract subvector if the operand is a vector. This is to handle
-        // things like arith.select which take a scalar conditional but are
-        // otherwise elementwise.
-        if (isa<VectorType>(val.getType())) {
-          val = vector::ExtractOp::create(rewriter, loc, val, offsets);
-        }
-        operands.push_back(val);
-      }
-
-      Operation *clonedOp = clone(rewriter, op, subVecTy, operands);
-      Value subResult = clonedOp->getResult(0);
-      result =
-          vector::InsertOp::create(rewriter, loc, subResult, result, offsets);
-    }
-
-    rewriter.replaceOp(op, result);
-    return success();
-  }
-};
-
 struct LLVMGPUVectorLoweringPass final
     : impl::LLVMGPUVectorLoweringPassBase<LLVMGPUVectorLoweringPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -616,7 +568,7 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorMultiReductionUnrollingPatterns(
           contractLoweringPatterns,
           vector::VectorMultiReductionLowering::InnerReduction);
-      contractLoweringPatterns.add<UnrollElementwiseOps>(funcOp->getContext());
+      populateUnrollElementwiseOpsPatterns(contractLoweringPatterns);
       // Unroll transfer_gather ops to rank 1 and lower contiguous ones to
       // vector.transfer_read.
       IREE::VectorExt::populateVectorTransferGatherLoweringPatterns(


### PR DESCRIPTION
UnrollElementwiseOps is an pattern that we currently apply exclusively to the GPU pipeline.
This pattern takes arith elementwise operations with vector operands and unroll them in a rank reduction way until 1-D vector operations remain.

This PR partly addresses https://github.com/iree-org/iree/issues/23094.
By unrolling arith elementwise operations, the LLVM backend will not translate them into nested arrays of vectors.