### PR TITLE
Integrate llvm/llvm-project@eabcfcee0803

### DIFF
--- a/compiler/plugins/input/TOSA/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/Passes.cpp
@@ -54,11 +54,11 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   tosaToLinalgNamedOptions.preferConv2DKernelLayoutHWCF = true;
   tosa::TosaValidationOptions tosaValidationOptions;
   tosa::TosaAttachTargetOptions tosaTargetOptions;
-  tosaTargetOptions.extensions = {"dynamic"};
+  tosaTargetOptions.extensions = {"dynamic", "doubleround"};
   tosaTargetOptions.profiles = {"pro_int", "pro_fp"};
-  passManager.addPass(tosa::createTosaAttachTarget(tosaTargetOptions));
   tosa::addTosaToLinalgPasses(passManager, TosaToLinalgOptions(),
-                              tosaToLinalgNamedOptions, tosaValidationOptions);
+                              tosaToLinalgNamedOptions, tosaValidationOptions,
+                              tosaTargetOptions);
   passManager.addNestedPass<func::FuncOp>(
       iree_compiler::createConverti48Toi64Pass());
 


### PR DESCRIPTION
Carrying reverts:

- https://github.com/llvm/llvm-project/commit/429e9717e232 (adds MLIRAsmParser dep to ArithUtils
in CMake but missing Bazel overlay port, breaks linux_x64_bazel)
- llvm/llvm-project@a1a714b8b87e (Make getMutableSuccessorOperands overridable on ReturnLike ops, breaks torch-mlir build — three ops define custom getMutableSuccessorOperands but DeclareOpInterfaceMethods no longer generates the declaration since the method now has a default). Fix requires change in torch-mlir as well; temporary revert for now and will add back later.

Other points of interest:

- llvm/llvm-project@4f6379069eb2 added a createTosaAttachTarget pass inside addTosaToLinalgPasses with a default that only declares the "doubleround" extension. This overwrites IREE's earlier createTosaAttachTarget that declared the "dynamic" extension, causing tosa.table with variable table values to be rejected by validation.

- Fix by passing IREE's target options (with both "dynamic" and "doubleround" extensions) through the new attachTargetOptions parameter and removing the now-redundant standalone createTosaAttachTarget call.

assisted by:claude 