### PR TITLE
Unroll vectors at SCF boundary

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -137,6 +137,7 @@ iree_compiler_cc_library(
         "MaterializeVectorMasking.cpp",
         "MathTransform.cpp",
         "MemrefCopyToLinalg.cpp",
+        "NDTo1DVectorUnrolling.cpp",
         "NormalizeLoopBounds.cpp",
         "OptimizeTensorInsertExtractSlices.cpp",
         "OptimizeVectorTransfer.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -129,6 +129,7 @@ iree_cc_library(
     "MaterializeVectorMasking.cpp"
     "MathTransform.cpp"
     "MemrefCopyToLinalg.cpp"
+    "NDTo1DVectorUnrolling.cpp"
     "NormalizeLoopBounds.cpp"
     "OptimizeTensorInsertExtractSlices.cpp"
     "OptimizeVectorTransfer.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/NDTo1DVectorUnrolling.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/NDTo1DVectorUnrolling.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===- NDTo1DVectorUnrolling.cpp ------------------------------------------===//
+//
+// Unrolls ND static vector types into multiple 1D vectors at SCF region
+// boundaries using 1:N type conversion. Each ND vector is decomposed into
+// slices along the innermost dimension.
+//
+// Example: vector<4x8xf32> -> vector<8xf32> x4
+//
+//   Before:
+//     %0 = scf.for ... iter_args(%arg = %init) -> vector<4x8xf32> {
+//       scf.yield %arg : vector<4x8xf32>
+//     }
+//
+//   After:
+//     %e0 = vector.extract %init[0] : vector<8xf32> from vector<4x8xf32>
+//     %e1 = vector.extract %init[1] : vector<8xf32> from vector<4x8xf32>
+//     %e2 = vector.extract %init[2] : vector<8xf32> from vector<4x8xf32>
+//     %e3 = vector.extract %init[3] : vector<8xf32> from vector<4x8xf32>
+//     %0:4 = scf.for ... iter_args(%a0 = %e0, %a1 = %e1, %a2 = %e2,
+//                                   %a3 = %e3)
+//         -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+//       scf.yield %a0, %a1, %a2, %a3 : vector<8xf32>, ...
+//     }
+//     %p = ub.poison : vector<4x8xf32>
+//     %i0 = vector.insert %0#0, %p [0] : vector<8xf32> into vector<4x8xf32>
+//     ...
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_NDTO1DVECTORUNROLLINGPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+struct UnrollVectorTypeConverter final : public TypeConverter {
+  UnrollVectorTypeConverter() {
+    addConversion([](Type type) -> std::optional<Type> { return type; });
+
+    addConversion([](VectorType type, SmallVectorImpl<Type> &types)
+                      -> std::optional<LogicalResult> {
+      if (type.getRank() <= 1) {
+        types.push_back(type);
+        return success();
+      }
+      assert(type.hasStaticShape() &&
+             "expected static shape for ND to 1D vector unrolling");
+      int64_t innerDim = type.getShape().back();
+      int64_t num1DVectors = type.getNumElements() / innerDim;
+      Type innerDimVector = VectorType::get({innerDim}, type.getElementType());
+      types.append(num1DVectors, innerDimVector);
+      return success();
+    });
+
+    addSourceMaterialization([](OpBuilder &builder, VectorType targetType,
+                                ValueRange inputs, Location loc) -> Value {
+      Value result = ub::PoisonOp::create(builder, loc, targetType);
+      SmallVector<int64_t> iteratorSpace(targetType.getShape().drop_back());
+      for (auto [input, idx] : llvm::zip_equal(
+               inputs, StaticTileOffsetRange(
+                           iteratorSpace,
+                           SmallVector<int64_t>(iteratorSpace.size(), 1)))) {
+        result = vector::InsertOp::create(builder, loc, input, result, idx);
+      }
+      return result;
+    });
+
+    addTargetMaterialization([](OpBuilder &builder, TypeRange targetTypes,
+                                ValueRange sources, Location loc,
+                                Type originalType) -> SmallVector<Value> {
+      assert(sources.size() == 1 && "expected single source value");
+      Value source = sources[0];
+      SmallVector<Value> results;
+      VectorType originalTypeVec = cast<VectorType>(originalType);
+      SmallVector<int64_t> iteratorSpace(
+          originalTypeVec.getShape().drop_back());
+      for (SmallVector<int64_t> idx : StaticTileOffsetRange(
+               iteratorSpace, SmallVector<int64_t>(iteratorSpace.size(), 1))) {
+        results.push_back(vector::ExtractOp::create(builder, loc, source, idx));
+      }
+      return results;
+    });
+  }
+};
+
+struct NDTo1DVectorUnrollingPass final
+    : impl::NDTo1DVectorUnrollingPassBase<NDTo1DVectorUnrollingPass> {
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+
+    UnrollVectorTypeConverter typeConverter;
+    ConversionTarget target(*ctx);
+
+    scf::populateSCFStructuralTypeConversionTarget(typeConverter, target);
+    scf::populateSCFStructuralTypeConversions(typeConverter, patterns);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -884,6 +884,27 @@ def MemrefCopyToLinalgPass :
   let summary = "Convert memref.copy to linalg op";
 }
 
+def NDTo1DVectorUnrollingPass : Pass<"iree-codegen-nd-to-1d-vector-unrolling"> {
+  let summary =
+      "Unroll ND vectors into multiple 1D vectors at SCF region boundaries.";
+  let description = [{
+    Uses 1:N type conversion to decompose ND vector values into flat
+    collections of 1D vectors sliced along the innermost dimension. The
+    conversion is applied at SCF region boundaries (e.g., `scf.for` iter_args
+    and `scf.yield` operands), so that each ND vector carried across a region
+    interface is replaced by the corresponding set of 1D vectors.
+
+    For example, a `vector<4x8xf32>` is decomposed into four `vector<8xf32>`
+    values. Source materializations re-assemble the ND vector with
+    `vector.insert`, and target materializations extract 1D slices with
+    `vector.extract`.
+  }];
+  let dependentDialects = [
+    "::mlir::ub::UBDialect",
+    "::mlir::vector::VectorDialect",
+  ];
+}
+
 def NormalizeLoopBoundsPass :
     Pass<"iree-codegen-normalize-loop-bounds", ""> {
   let summary = "Normalize the loop bounds of `scf.for` and `scf.forall`";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -102,6 +102,7 @@ iree_lit_test_suite(
             "materialize_user_configs.mlir",
             "materialize_vector_masking.mlir",
             "math_transform.mlir",
+            "nd_to_1d_vector_unrolling.mlir",
             "normalize_loop_bounds.mlir",
             "optimize_tensor_insert_extract_slices.mlir",
             "pad_dynamic_alloc.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -97,6 +97,7 @@ iree_lit_test_suite(
     "materialize_user_configs.mlir"
     "materialize_vector_masking.mlir"
     "math_transform.mlir"
+    "nd_to_1d_vector_unrolling.mlir"
     "normalize_loop_bounds.mlir"
     "optimize_tensor_insert_extract_slices.mlir"
     "pad_dynamic_alloc.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/nd_to_1d_vector_unrolling.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/nd_to_1d_vector_unrolling.mlir
@@ -1,0 +1,80 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-codegen-nd-to-1d-vector-unrolling)" --split-input-file %s | FileCheck %s
+
+func.func @for_2d_vector(%init : vector<4x8xf32>, %lb : index, %ub : index, %step : index) -> vector<4x8xf32> {
+  %result = scf.for %iv = %lb to %ub step %step iter_args(%arg = %init) -> vector<4x8xf32> {
+    scf.yield %arg : vector<4x8xf32>
+  }
+  return %result : vector<4x8xf32>
+}
+
+// CHECK-LABEL: func.func @for_2d_vector
+// CHECK-SAME:    %[[INIT:.+]]: vector<4x8xf32>
+// CHECK-DAG:   %[[E0:.+]] = vector.extract %[[INIT]][0] : vector<8xf32> from vector<4x8xf32>
+// CHECK-DAG:   %[[E1:.+]] = vector.extract %[[INIT]][1] : vector<8xf32> from vector<4x8xf32>
+// CHECK-DAG:   %[[E2:.+]] = vector.extract %[[INIT]][2] : vector<8xf32> from vector<4x8xf32>
+// CHECK-DAG:   %[[E3:.+]] = vector.extract %[[INIT]][3] : vector<8xf32> from vector<4x8xf32>
+// CHECK:       %[[FOR:.+]]:4 = scf.for {{.+}} iter_args(%[[A0:.+]] = %[[E0]], %[[A1:.+]] = %[[E1]], %[[A2:.+]] = %[[E2]], %[[A3:.+]] = %[[E3]])
+// CHECK-SAME:    -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>)
+// CHECK:         scf.yield %[[A0]], %[[A1]], %[[A2]], %[[A3]] : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>
+// CHECK:       %[[POISON:.+]] = ub.poison : vector<4x8xf32>
+// CHECK:       %[[I0:.+]] = vector.insert %[[FOR]]#0, %[[POISON]] [0] : vector<8xf32> into vector<4x8xf32>
+// CHECK:       %[[I1:.+]] = vector.insert %[[FOR]]#1, %[[I0]] [1] : vector<8xf32> into vector<4x8xf32>
+// CHECK:       %[[I2:.+]] = vector.insert %[[FOR]]#2, %[[I1]] [2] : vector<8xf32> into vector<4x8xf32>
+// CHECK:       %[[I3:.+]] = vector.insert %[[FOR]]#3, %[[I2]] [3] : vector<8xf32> into vector<4x8xf32>
+// CHECK:       return %[[I3]] : vector<4x8xf32>
+
+// -----
+
+func.func @for_3d_vector(%init : vector<2x3x4xf32>, %lb : index, %ub : index, %step : index) -> vector<2x3x4xf32> {
+  %result = scf.for %iv = %lb to %ub step %step iter_args(%arg = %init) -> vector<2x3x4xf32> {
+    scf.yield %arg : vector<2x3x4xf32>
+  }
+  return %result : vector<2x3x4xf32>
+}
+
+// CHECK-LABEL: func.func @for_3d_vector
+// CHECK-SAME:    %[[INIT:.+]]: vector<2x3x4xf32>
+// CHECK-DAG:   vector.extract %[[INIT]][0, 0] : vector<4xf32> from vector<2x3x4xf32>
+// CHECK-DAG:   vector.extract %[[INIT]][0, 1] : vector<4xf32> from vector<2x3x4xf32>
+// CHECK-DAG:   vector.extract %[[INIT]][0, 2] : vector<4xf32> from vector<2x3x4xf32>
+// CHECK-DAG:   vector.extract %[[INIT]][1, 0] : vector<4xf32> from vector<2x3x4xf32>
+// CHECK-DAG:   vector.extract %[[INIT]][1, 1] : vector<4xf32> from vector<2x3x4xf32>
+// CHECK-DAG:   vector.extract %[[INIT]][1, 2] : vector<4xf32> from vector<2x3x4xf32>
+// CHECK:       %{{.+}}:6 = scf.for
+// CHECK-SAME:    -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
+// CHECK:       ub.poison : vector<2x3x4xf32>
+// CHECK-COUNT-6: vector.insert {{.+}} : vector<4xf32> into vector<2x3x4xf32>
+
+// -----
+
+func.func @nounroll_1d_vector(%init : vector<8xf32>, %lb : index, %ub : index, %step : index) -> vector<8xf32> {
+  %result = scf.for %iv = %lb to %ub step %step iter_args(%arg = %init) -> vector<8xf32> {
+    scf.yield %arg : vector<8xf32>
+  }
+  return %result : vector<8xf32>
+}
+
+// CHECK-LABEL: func.func @nounroll_1d_vector
+// CHECK-SAME:    %[[INIT:.+]]: vector<8xf32>
+// CHECK:       %[[FOR:.+]] = scf.for {{.+}} iter_args(%[[ARG:.+]] = %[[INIT]]) -> (vector<8xf32>)
+// CHECK:         scf.yield %[[ARG]] : vector<8xf32>
+// CHECK:       return %[[FOR]] : vector<8xf32>
+// CHECK-NOT:   ub.poison
+// CHECK-NOT:   vector.extract
+// CHECK-NOT:   vector.insert
+
+// -----
+
+func.func @for_mixed_iter_args(%v : vector<2x4xf32>, %s : f32, %lb : index, %ub : index, %step : index) -> (vector<2x4xf32>, f32) {
+  %result:2 = scf.for %iv = %lb to %ub step %step iter_args(%varg = %v, %sarg = %s) -> (vector<2x4xf32>, f32) {
+    scf.yield %varg, %sarg : vector<2x4xf32>, f32
+  }
+  return %result#0, %result#1 : vector<2x4xf32>, f32
+}
+
+// CHECK-LABEL: func.func @for_mixed_iter_args
+// CHECK-SAME:    %[[V:.+]]: vector<2x4xf32>, %[[S:.+]]: f32
+// CHECK-DAG:   %[[E0:.+]] = vector.extract %[[V]][0] : vector<4xf32> from vector<2x4xf32>
+// CHECK-DAG:   %[[E1:.+]] = vector.extract %[[V]][1] : vector<4xf32> from vector<2x4xf32>
+// CHECK:       %{{.+}}:3 = scf.for {{.+}} iter_args(%{{.+}} = %[[E0]], %{{.+}} = %[[E1]], %{{.+}} = %[[S]])
+// CHECK-SAME:    -> (vector<4xf32>, vector<4xf32>, f32)

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -577,6 +577,7 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
                 cpuOpts.failOnOutOfBoundsStackAllocation});
       })
       // SCF -> CF
+      .addPass(createNDTo1DVectorUnrollingPass)
       .addPass(createSCFToControlFlowPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)


### PR DESCRIPTION
Unroll basic blocks at SCF boundary.
It adds the NDTo1VectorUnrolling pass.
This pass will unroll N-dim vectors in 1-dim vectors when passed as parameters or returned from SCF operations. This allows SCF operations to be lowered to LLVM without nested arrays of vectors.

Originally from here: https://github.com/iree-org/iree/pull/22156