### PR TITLE
[GPUHeuristics] Fix RDNA4 conv heuristic seeds to resolve regressions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -1330,9 +1330,9 @@ static constexpr ArchSeedSet kRDNA4Seeds = {
     },
     /*conv=*/{
         /*SmallGemm=*/     {2, 2,  4, kCacheLineSizeBits},
-        /*MediumGemm=*/    {4, 4,  4, kCacheLineSizeBits},
-        /*LargeGemm=*/     {4, 8,  4, kCacheLineSizeBits},
-        /*VeryLargeGemm=*/ {4, 8,  4, kCacheLineSizeBits},
+        /*MediumGemm=*/    {8, 4,  4, kCacheLineSizeBits},
+        /*LargeGemm=*/     {8, 8,  4, kCacheLineSizeBits},
+        /*VeryLargeGemm=*/ {8, 8,  4, kCacheLineSizeBits},
     },
 };
 
@@ -1346,16 +1346,18 @@ const ArchSeedSet &getArchSeedSet(TargetAttr target) {
 
   StringRef arch = target.getArch();
   FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(arch);
+
   // CDNA4 is gfx950 (major=9, minor=5).
   bool isCDNA4 = succeeded(chipset) && chipset->majorVersion == 9 &&
                  chipset->minorVersion == 5;
-  // RDNA4 is gfx1200/gfx1201 (major=12, minor=0). Note: gfx1250 (minor=5)
-  // is a separate experimental target and should not use RDNA4 seeds.
-  bool isRDNA4 = succeeded(chipset) && chipset->majorVersion == 12 &&
-                 chipset->minorVersion == 0;
   if (isCDNA4 || arch == "cdna4") {
     return kCDNA4Seeds;
   }
+
+  // RDNA4 is gfx1200/gfx1201 (major=12, minor<=1). Note: gfx1250 (minor=50)
+  // is a separate experimental target and should not use RDNA4 seeds.
+  bool isRDNA4 = succeeded(chipset) && chipset->majorVersion == 12 &&
+                 chipset->minorVersion <= 1;
   if (isRDNA4 || arch == "rdna4") {
     return kRDNA4Seeds;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx1201.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx1201.mlir
@@ -2,7 +2,7 @@
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
 // RUN:   | FileCheck %s --check-prefix=GEMM
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx1201 \
-// RUN:   --iree-codegen-llvmgpu-use-igemm=false --iree-codegen-llvmgpu-use-direct-convolution=true \
+// RUN:   --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-use-direct-convolution=false \
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
 // RUN:   | FileCheck %s --check-prefix=CONV
 
@@ -97,13 +97,15 @@ func.func @conv_small_f16(%arg0: tensor<1x18x18x16xf16>, %arg1: tensor<32x3x3x16
 
 // CONV-LABEL: func.func @conv_small_f16
 //  CONV-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
-//  CONV-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
+//  CONV-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 32
+//  CONV-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
+//  CONV-SAME:   use_igemm_convolution = true
 //       CONV:   linalg.conv_2d_nhwc_fhwc {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CONV-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
 //  CONV-SAME:     promote_operands = [0, 1]
-//  CONV-SAME:     reduction = [0, 0, 0, 0, 1, 1, 1]
-//  CONV-SAME:     subgroup = [1, 2, 1, 1, 0, 0, 0]
-//  CONV-SAME:     workgroup = [1, 4, 16, 32, 0, 0, 0]
+//  CONV-SAME:     reduction = [0, 0, 0, 0, 1]
+//  CONV-SAME:     subgroup = [1, 2, 1, 1, 0]
+//  CONV-SAME:     workgroup = [1, 8, 16, 32, 0]
 
 // -----
 
@@ -123,13 +125,15 @@ func.func @conv_medium_f16(%arg0: tensor<2x66x66x128xf16>, %arg1: tensor<128x3x3
 
 // CONV-LABEL: func.func @conv_medium_f16
 //  CONV-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
-//  CONV-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
+//  CONV-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 32
+//  CONV-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
+//  CONV-SAME:   use_igemm_convolution = true
 //       CONV:   linalg.conv_2d_nhwc_fhwc {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CONV-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
 //  CONV-SAME:     promote_operands = [0, 1]
-//  CONV-SAME:     reduction = [0, 0, 0, 0, 1, 1, 4]
-//  CONV-SAME:     subgroup = [1, 1, 2, 2, 0, 0, 0]
-//  CONV-SAME:     workgroup = [1, 1, 64, 64, 0, 0, 0]
+//  CONV-SAME:     reduction = [0, 0, 0, 0, 4]
+//  CONV-SAME:     subgroup = [1, 2, 1, 2, 0]
+//  CONV-SAME:     workgroup = [1, 2, 64, 64, 0]
 
 // -----
 
@@ -149,10 +153,12 @@ func.func @conv_large_f16(%arg0: tensor<16x50x34x576xf16>, %arg1: tensor<576x3x3
 
 // CONV-LABEL: func.func @conv_large_f16
 //  CONV-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
-//  CONV-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 32
+//  CONV-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 32
+//  CONV-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false
+//  CONV-SAME:   use_igemm_convolution = true
 //       CONV:   linalg.conv_2d_nhwc_fhwc {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CONV-SAME:     mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
 //  CONV-SAME:     promote_operands = [0, 1]
-//  CONV-SAME:     reduction = [0, 0, 0, 0, 1, 1, 4]
-//  CONV-SAME:     subgroup = [1, 2, 1, 2, 0, 0, 0]
-//  CONV-SAME:     workgroup = [1, 2, 32, 64, 0, 0, 0]
+//  CONV-SAME:     reduction = [0, 0, 0, 0, 4]
+//  CONV-SAME:     subgroup = [1, 2, 1, 4, 0]
+//  CONV-SAME:     workgroup = [1, 4, 32, 128, 0]


### PR DESCRIPTION
After the previous RDNA4 seed tuning commit, several medium/large-sized convolution shapes showed significant regressions. To fix the issue, increase conv subgroupCount seed from 4 to 8. This change will bring back the performance upto 2x faster, while not introduce new regressions.

Also update the convolution tests to use IGEMM path with use_igemm=true.