### PR TITLE
[CI] Move windows_x64_msvc to presubmit

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -119,7 +119,6 @@ CONTROL_JOB_REGEXES = frozenset(
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
         "linux_x64_clang_debug",
-        "windows_x64_msvc",
         "test_torch",
     ]
 )
@@ -188,7 +187,7 @@ PRESUBMIT_TOUCH_ONLY_JOBS = [
             "*win32*",
             "*windows*",
             "*msvc*",
-            ".github/worklflows/ci_windows_x64_msvc.yml",
+            ".github/workflows/ci_windows_x64_msvc.yml",
         ],
     ),
     (

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -486,12 +486,6 @@ runs.
     ci-extra: linux_arm64_clang
     ```
 
-* Opt in to the Windows compiler build and test workflow:
-
-    ``` text
-    ci-extra: windows_x64_msvc
-    ```
-
 * Opt in to the MacOS build and test workflows:
 
     ``` text


### PR DESCRIPTION
Moves `windows_x64_msvc` to presubmit (and fix a typo and update doc while we're here). This will help catch occasional msvc specific bugs that surface atm on postsubmit. 