### PR TITLE
[GlobalOptimization] Fix MSVC issue in DemoteContractionInputs

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputs.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputs.cpp
@@ -145,11 +145,6 @@ class DemoteContractionInputsPass
           DemoteContractionInputsPass> {
 public:
   using Base::Base;
-  explicit DemoteContractionInputsPass(
-      const DemoteContractionInputsPassOptions &operation) {
-    this->demoteType = operation.demoteType;
-    this->demoteOperation = operation.demoteOperation;
-  }
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();


### PR DESCRIPTION
Remove the explicit constructor taking `const DemoteContractionInputsPassOptions &` which was redundant with the inherited Base constructor (via `using Base::Base`).

The tablegen-generated PassBase already provides a constructor taking `DemoteContractionInputsPassOptions` by value that initializes all option fields. The explicit by-const-ref overload created an ambiguity (C2668) on MSVC when `std::make_unique` forwarded an rvalue; both the inherited by-value constructor and the explicit by-const-ref constructor were equally viable candidates.

Assisted by: Claude 

ci_extra: windows_x64_msvc