### PR TITLE
[Codegen][GPU] Add iree_gpu.arg_compare operation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
@@ -379,6 +380,143 @@ LogicalResult CoalescedGatherDMAOp::verify() {
       return emitOpError("in_bounds array size (")
              << inBoundsAttr->size() << ") must match init rank (" << initRank
              << ")";
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ArgCompareOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ArgCompareOp::verify() {
+  VectorType inputValueType = getInputValueType();
+  auto initValueType = cast<VectorType>(getInitValue().getType());
+  auto initIndexType = cast<VectorType>(getInitIndex().getType());
+
+  int64_t inputRank = inputValueType.getRank();
+  int64_t initValueRank = initValueType.getRank();
+  int64_t initIndexRank = initIndexType.getRank();
+  int64_t dimension = getDimension();
+
+  if (dimension < 0 || dimension >= inputRank) {
+    return emitOpError("dimension ")
+           << dimension << " is out of range [0, " << inputRank << ")";
+  }
+
+  if (initValueRank != inputRank - 1) {
+    return emitOpError("init value rank (")
+           << initValueRank << ") must be input rank - 1 (" << (inputRank - 1)
+           << ")";
+  }
+
+  if (initIndexRank != inputRank - 1) {
+    return emitOpError("init index rank (")
+           << initIndexRank << ") must be input rank - 1 (" << (inputRank - 1)
+           << ")";
+  }
+
+  SmallVector<int64_t> expectedShape;
+  for (int64_t i = 0; i < inputRank; ++i) {
+    if (i != dimension) {
+      expectedShape.push_back(inputValueType.getDimSize(i));
+    }
+  }
+
+  ArrayRef<int64_t> initValueShape = initValueType.getShape();
+  if (expectedShape != initValueShape) {
+    return emitOpError("init value shape must match input shape with reduction "
+                       "dimension removed. ")
+           << "Expected: " << llvm::interleaved_array(expectedShape)
+           << ", but got: " << llvm::interleaved_array(initValueShape);
+  }
+
+  ArrayRef<int64_t> initIndexShape = initIndexType.getShape();
+  if (expectedShape != initIndexShape) {
+    return emitOpError("init index shape must match input shape with reduction "
+                       "dimension removed. ")
+           << "Expected: " << llvm::interleaved_array(expectedShape)
+           << ", but got: " << llvm::interleaved_array(initIndexShape);
+  }
+
+  // Note: Result type matching is enforced by ODS traits:
+  // - AllTypesMatch<["init_value", "result_value"]>
+  // - AllTypesMatch<["init_index", "result_index"]>
+  // - AllElementTypesMatch<["input_value", "init_value"]>
+
+  Type initIndexElementType = initIndexType.getElementType();
+  if (!isa<IntegerType, IndexType>(initIndexElementType)) {
+    return emitOpError(
+               "init index must have integer or index element type, but got ")
+           << initIndexElementType;
+  }
+
+  if (hasExplicitIndexInput()) {
+    VectorType inputIndexType = getInputIndexType();
+    ArrayRef<int64_t> inputIndexShape = inputIndexType.getShape();
+    ArrayRef<int64_t> inputValueShape = inputValueType.getShape();
+
+    if (inputIndexShape != inputValueShape) {
+      return emitOpError(
+                 "explicit-index mode: value and index inputs must have the "
+                 "same shape. ")
+             << "Value shape: " << llvm::interleaved_array(inputValueShape)
+             << ", index shape: " << llvm::interleaved_array(inputIndexShape);
+    }
+
+    Type inputIndexElementType = getInputIndexElementType();
+
+    if (!isa<IntegerType, IndexType>(inputIndexElementType)) {
+      return emitOpError("explicit-index mode: index input must have "
+                         "integer or index element type, but got ")
+             << inputIndexElementType;
+    }
+
+    if (inputIndexElementType != initIndexElementType) {
+      return emitOpError(
+                 "explicit-index mode: input and init index element types "
+                 "must match. ")
+             << "Input index type: " << inputIndexElementType
+             << ", init index type: " << initIndexElementType;
+    }
+
+    if (getIndexBase()) {
+      return emitOpError("index_base must not be used with explicit indices");
+    }
+  }
+
+  Block &block = getComparator().front();
+  if (block.getNumArguments() != 2) {
+    return emitOpError("comparator region must have exactly 2 arguments");
+  }
+
+  Type inputElementType = inputValueType.getElementType();
+  Type arg0Type = block.getArgument(0).getType();
+  Type arg1Type = block.getArgument(1).getType();
+
+  if (arg0Type != inputElementType || arg1Type != inputElementType) {
+    return emitOpError(
+               "comparator arguments must match input value element type. ")
+           << "Expected: " << inputElementType << ", but got: " << arg0Type
+           << " and " << arg1Type;
+  }
+
+  auto yieldOp = cast<GPU::YieldOp>(block.getTerminator());
+  if (yieldOp.getNumOperands() != 1) {
+    return emitOpError("comparator region must yield exactly one value");
+  }
+
+  Type yieldType = yieldOp.getOperand(0).getType();
+  if (!yieldType.isSignlessInteger(1)) {
+    return emitOpError("comparator region must yield i1, but got ")
+           << yieldType;
+  }
+
+  for (Operation &innerOp : block.getOperations()) {
+    if (!isPure(&innerOp)) {
+      return innerOp.emitOpError(
+          "comparator region must contain only pure operations");
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -172,7 +172,8 @@ def IREEGPU_ValueBarrierOp : Op<IREEGPU_Dialect, "value_barrier", [
 
 def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
     Pure, ReturnLike, Terminator,
-    HasParent<"::mlir::iree_compiler::IREE::GPU::BarrierRegionOp">]> {
+    ParentOneOf<["::mlir::iree_compiler::IREE::GPU::BarrierRegionOp",
+                 "::mlir::iree_compiler::IREE::GPU::ArgCompareOp"]>]> {
   let summary = [{Yield values from a iree_gpu region.}];
   let description = [{
      This operation is used to yield values from a within a region.
@@ -382,6 +383,116 @@ def IREEGPU_GlobalSubgroupBarrierOp : Op<IREEGPU_Dialect,
   let arguments = (ins);
   let results = (outs);
   let assemblyFormat = "attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// ArgCompareOp
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_ArgCompareOp : Op<IREEGPU_Dialect, "arg_compare", [
+  Pure,
+  SingleBlockImplicitTerminator<"iree_compiler::IREE::GPU::YieldOp">,
+  AttrSizedOperandSegments,
+  AllElementTypesMatch<["input_value", "init_value"]>,
+  AllTypesMatch<["init_value", "result_value"]>,
+  AllTypesMatch<["init_index", "result_index"]>
+]> {
+  let summary = "GPU-level arg reduction with custom comparator";
+
+  let description = [{
+    Performs arg reductions (argmax, argmin, etc.) at the GPU level. This
+    operation bridges iree_vector_ext.arg_compare and GPU-specific lowerings.
+
+    This operation works on vectors only. The operation reduces over the
+    specified dimension, tracking both the selected value and its corresponding
+    index. It supports:
+    - Implicit or explicit index modes
+    - Optional index_base for multi-phase reductions
+    - Custom comparator logic in the region
+
+    The comparator region takes two scalar values and returns i1 indicating
+    whether the first value should be selected over the second.
+
+    Example (implicit-index mode - argmax):
+    ```mlir
+    %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                   inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+    ^bb0(%lhs: f32, %rhs: f32):
+      %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+      iree_gpu.yield %cmp : i1
+    } -> vector<4xf32>, vector<4xi32>
+    ```
+
+    Example (explicit-index mode for multi-phase reductions):
+    ```mlir
+    %val, %idx = iree_gpu.arg_compare {1}(%vals, %idxs : vector<4x8xf32>, vector<4x8xi32>)
+                   inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+    ^bb0(%lhs: f32, %rhs: f32):
+      %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+      iree_gpu.yield %cmp : i1
+    } -> vector<4xf32>, vector<4xi32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyVectorOfAnyRank:$input_value,
+    Optional<AnyVectorOfAnyRank>:$input_index,
+    AnyVectorOfAnyRank:$init_value,
+    AnyVectorOfAnyRank:$init_index,
+    Optional<AnyType>:$index_base,
+    I64Attr:$dimension
+  );
+
+  let results = (outs
+    AnyVectorOfAnyRank:$result_value,
+    AnyVectorOfAnyRank:$result_index
+  );
+
+  let regions = (region SizedRegion<1>:$comparator);
+
+  let assemblyFormat = [{
+    `{` $dimension `}`
+    `(` $input_value (`,` $input_index^)? `:` type($input_value) (`,` type($input_index)^)? `)`
+    `inits` `(` $init_value `,` $init_index `:` type($init_value) `,` type($init_index) `)`
+    (`index_base` $index_base^ `:` type($index_base))?
+    attr-dict-with-keyword
+    $comparator
+    `->` type($result_value) `,` type($result_index)
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    bool hasExplicitIndexInput() {
+      return getInputIndex() != nullptr;
+    }
+
+    ::mlir::VectorType getInputValueType() {
+      return ::llvm::cast<::mlir::VectorType>(getInputValue().getType());
+    }
+
+    ::mlir::VectorType getInputIndexType() {
+      if (::mlir::Value idx = getInputIndex()) {
+        return ::llvm::cast<::mlir::VectorType>(idx.getType());
+      }
+      return nullptr;
+    }
+
+    ::mlir::Type getInputValueElementType() {
+      return getInputValueType().getElementType();
+    }
+
+    ::mlir::Type getInputIndexElementType() {
+      if (auto type = getInputIndexType()) {
+        return type.getElementType();
+      }
+      return nullptr;
+    }
+
+    int64_t getInputRank() {
+      return getInputValueType().getRank();
+    }
+  }];
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREEGPUOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -189,3 +189,232 @@ func.func @vector_multi_mma_with_permutation_of_wrong_size(%lhs: vector<2x3x4xf1
   } : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
   return %0 : vector<2x5x4xf32>
 }
+// -----
+
+func.func @arg_compare_dimension_out_of_range(%input: vector<4x8xf32>,
+                                               %init_val: vector<4xf32>,
+                                               %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{dimension 2 is out of range [0, 2)}}
+  %val, %idx = iree_gpu.arg_compare {2}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_negative_dimension(%input: vector<4x8xf32>,
+                                           %init_val: vector<4xf32>,
+                                           %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{dimension -1 is out of range [0, 2)}}
+  %val, %idx = iree_gpu.arg_compare {-1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_init_value_rank(%input: vector<4x8xf32>,
+                                              %init_val: vector<4x8xf32>,
+                                              %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{init value rank (2) must be input rank - 1 (1)}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4x8xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4x8xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_init_index_rank(%input: vector<4x8xf32>,
+                                              %init_val: vector<4xf32>,
+                                              %init_idx: vector<4x8xi32>) {
+  // expected-error @+1 {{init index rank (2) must be input rank - 1 (1)}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4x8xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4x8xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_init_value_shape(%input: vector<4x8xf32>,
+                                               %init_val: vector<8xf32>,
+                                               %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{init value shape must match input shape with reduction dimension removed. Expected: [4], but got: [8]}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<8xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<8xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_init_index_shape(%input: vector<4x8xf32>,
+                                               %init_val: vector<4xf32>,
+                                               %init_idx: vector<8xi32>) {
+  // expected-error @+1 {{init index shape must match input shape with reduction dimension removed. Expected: [4], but got: [8]}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<8xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<8xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_index_element_type(%input: vector<4x8xf32>,
+                                                 %init_val: vector<4xf32>,
+                                                 %init_idx: vector<4xf32>) {
+  // expected-error @+1 {{init index must have integer or index element type, but got 'f32'}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xf32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xf32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_shape_mismatch(%val: vector<2x4xf32>,
+                                                      %idx: vector<2x8xi32>,
+                                                      %init_val: vector<2xf32>,
+                                                      %init_idx: vector<2xi32>) {
+  // expected-error @+1 {{explicit-index mode: value and index inputs must have the same shape. Value shape: [2, 4], index shape: [2, 8]}}
+  %result_val, %result_idx = iree_gpu.arg_compare {1}(%val, %idx : vector<2x4xf32>, vector<2x8xi32>)
+                               inits(%init_val, %init_idx : vector<2xf32>, vector<2xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<2xf32>, vector<2xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_wrong_element_type(%val: vector<2x4xf32>,
+                                                          %idx: vector<2x4xf32>,
+                                                          %init_val: vector<2xf32>,
+                                                          %init_idx: vector<2xi32>) {
+  // expected-error @+1 {{explicit-index mode: index input must have integer or index element type, but got 'f32'}}
+  %result_val, %result_idx = iree_gpu.arg_compare {1}(%val, %idx : vector<2x4xf32>, vector<2x4xf32>)
+                               inits(%init_val, %init_idx : vector<2xf32>, vector<2xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<2xf32>, vector<2xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_explicit_index_type_mismatch(%val: vector<2x4xf32>,
+                                                     %idx: vector<2x4xi64>,
+                                                     %init_val: vector<2xf32>,
+                                                     %init_idx: vector<2xi32>) {
+  // expected-error @+1 {{explicit-index mode: input and init index element types must match. Input index type: 'i64', init index type: 'i32'}}
+  %result_val, %result_idx = iree_gpu.arg_compare {1}(%val, %idx : vector<2x4xf32>, vector<2x4xi64>)
+                               inits(%init_val, %init_idx : vector<2xf32>, vector<2xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<2xf32>, vector<2xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_index_base_with_explicit_index(%val: vector<2x4xf32>,
+                                                       %idx: vector<2x4xi32>,
+                                                       %init_val: vector<2xf32>,
+                                                       %init_idx: vector<2xi32>,
+                                                       %base: i32) {
+  // expected-error @+1 {{index_base must not be used with explicit indices}}
+  %result_val, %result_idx = iree_gpu.arg_compare {1}(%val, %idx : vector<2x4xf32>, vector<2x4xi32>)
+                               inits(%init_val, %init_idx : vector<2xf32>, vector<2xi32>)
+                               index_base %base : i32 {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<2xf32>, vector<2xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_num_comparator_args(%input: vector<4x8xf32>,
+                                                  %init_val: vector<4xf32>,
+                                                  %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{comparator region must have exactly 2 arguments}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32):
+    %c_true = arith.constant true
+    iree_gpu.yield %c_true : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_comparator_arg_type(%input: vector<4x8xf32>,
+                                                  %init_val: vector<4xf32>,
+                                                  %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{comparator arguments must match input value element type. Expected: 'f32', but got: 'i32' and 'i32'}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: i32, %rhs: i32):
+    %cmp = arith.cmpi slt, %lhs, %rhs : i32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_wrong_yield_type(%input: vector<4x8xf32>,
+                                        %init_val: vector<4xf32>,
+                                        %init_idx: vector<4xi32>) {
+  // expected-error @+1 {{comparator region must yield i1, but got 'f32'}}
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    iree_gpu.yield %lhs : f32
+  } -> vector<4xf32>, vector<4xi32>
+  return
+}
+
+// -----
+
+func.func @arg_compare_scalar_output_not_supported(%input: vector<8xf32>,
+                                                    %init_val: f32,
+                                                    %init_idx: i32) {
+  %val, %idx = iree_gpu.arg_compare {0}(%input : vector<8xf32>)
+                 // expected-error @+1 {{custom op 'iree_gpu.arg_compare' invalid kind of type specified}}
+                 inits(%init_val, %init_idx : f32, i32) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> f32, i32
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -197,3 +197,90 @@ func.func @coalesced_gather_dma_tensor_indices(%idx0: tensor<64xi32>, %source: t
 //       CHECK:   scf.forall
 //       CHECK:     scf.forall.in_parallel
 //       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : tensor<4096xf32>, tensor<64xi32>, tensor<64xf32>, index -> tensor<64xf32>
+
+// -----
+
+// CHECK-LABEL: func @arg_compare_implicit_index
+func.func @arg_compare_implicit_index(%input: vector<4x8xf32>,
+                                       %init_val: vector<4xf32>,
+                                       %init_idx: vector<4xi32>)
+                                       -> (vector<4xf32>, vector<4xi32>) {
+  // CHECK: iree_gpu.arg_compare{1} (%{{.+}} : vector<4x8xf32>)
+  // CHECK-SAME: inits(%{{.+}}, %{{.+}} : vector<4xf32>, vector<4xi32>)
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x8xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return %val, %idx : vector<4xf32>, vector<4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @arg_compare_explicit_index
+func.func @arg_compare_explicit_index(%val: vector<2x4xf32>,
+                                       %idx: vector<2x4xi32>,
+                                       %init_val: vector<2xf32>,
+                                       %init_idx: vector<2xi32>)
+                                       -> (vector<2xf32>, vector<2xi32>) {
+  // CHECK: iree_gpu.arg_compare{1} (%{{.+}}, %{{.+}} : vector<2x4xf32>, vector<2x4xi32>)
+  // CHECK-SAME: inits(%{{.+}}, %{{.+}} : vector<2xf32>, vector<2xi32>)
+  %result_val, %result_idx = iree_gpu.arg_compare {1}(%val, %idx : vector<2x4xf32>, vector<2x4xi32>)
+                               inits(%init_val, %init_idx : vector<2xf32>, vector<2xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf olt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<2xf32>, vector<2xi32>
+  return %result_val, %result_idx : vector<2xf32>, vector<2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @arg_compare_with_index_base
+func.func @arg_compare_with_index_base(%input: vector<2x8xf32>,
+                                        %init_val: vector<2xf32>,
+                                        %init_idx: vector<2xi32>,
+                                        %base: i32) -> (vector<2xf32>, vector<2xi32>) {
+  // CHECK: iree_gpu.arg_compare{1} (%{{.+}} : vector<2x8xf32>)
+  // CHECK-SAME: inits(%{{.+}}, %{{.+}} : vector<2xf32>, vector<2xi32>)
+  // CHECK-SAME: index_base %{{.+}} : i32
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<2x8xf32>)
+                 inits(%init_val, %init_idx : vector<2xf32>, vector<2xi32>)
+                 index_base %base : i32 {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<2xf32>, vector<2xi32>
+  return %val, %idx : vector<2xf32>, vector<2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @arg_compare_integer
+func.func @arg_compare_integer(%input: vector<4x16xi32>,
+                                %init_val: vector<4xi32>,
+                                %init_idx: vector<4xi32>) -> (vector<4xi32>, vector<4xi32>) {
+  %val, %idx = iree_gpu.arg_compare {1}(%input : vector<4x16xi32>)
+                 inits(%init_val, %init_idx : vector<4xi32>, vector<4xi32>) {
+  ^bb0(%lhs: i32, %rhs: i32):
+    %cmp = arith.cmpi slt, %lhs, %rhs : i32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xi32>, vector<4xi32>
+  return %val, %idx : vector<4xi32>, vector<4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @arg_compare_2d_dim0
+func.func @arg_compare_2d_dim0(%input: vector<8x4xf32>,
+                                %init_val: vector<4xf32>,
+                                %init_idx: vector<4xi32>) -> (vector<4xf32>, vector<4xi32>) {
+  %val, %idx = iree_gpu.arg_compare {0}(%input : vector<8x4xf32>)
+                 inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %cmp = arith.cmpf ogt, %lhs, %rhs : f32
+    iree_gpu.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return %val, %idx : vector<4xf32>, vector<4xi32>
+}


### PR DESCRIPTION
This PR adds the `iree_gpu.arg_compare` operation to represent the distributed form of `iree_vector_ext.arg_compare`.

The next step is to implement lowering for `iree_gpu.arg_compare` using DPP and rocdl::ballot instructions.

Note: I will continue extending arg_compare under the GPU dialect. For now, this change focuses on enabling it to flow through the vector distribute pipeline for ArgCompare.