### PR TITLE
[CI] Add auto run generate_exports.py to pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Initializing llvm-project submodule
+        run: git submodule update --init --depth=1 third_party/llvm-project
       - name: Setting up python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       - name: Running pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,6 +126,6 @@ repos:
         name: Regenerate CAPI export files
         entry: compiler/src/iree/compiler/API/generate_exports.py
         language: python
-        files: '^compiler/bindings/python/'
+        files: '^compiler/bindings/c/iree/compiler/.*\.h$'
 
     # TODO(scotttodd): mypy type checking for Python (https://mypy-lang.org/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,4 +122,10 @@ repos:
         language: fail
         files: "BUILD$"
 
+      - id: generate_capi_exports
+        name: Regenerate CAPI export files
+        entry: compiler/src/iree/compiler/API/generate_exports.py
+        language: python
+        files: '^compiler/bindings/python/'
+
     # TODO(scotttodd): mypy type checking for Python (https://mypy-lang.org/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,5 +127,6 @@ repos:
         entry: compiler/src/iree/compiler/API/generate_exports.py
         language: python
         files: '^compiler/bindings/c/iree/compiler/.*\.h$'
+        pass_filenames: false
 
     # TODO(scotttodd): mypy type checking for Python (https://mypy-lang.org/)


### PR DESCRIPTION
It is easy to forget updating C API exports when adding new Python bindings.
This change adds a pre-commit hook that runs `generate_exports.py` whenever header files under compiler/bindings/c/iree/compiler/ are modified.