### PR TITLE
[nfc] Simplify op rewrite pattern inheriting constructor definitions.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
@@ -86,7 +86,7 @@ Value materializeEpsilon(Operation *op, FloatAttr epsilonAttr, FloatType fpType,
 
 struct UnfuseBatchNormInferencePattern final
     : OpRewritePattern<mlir::stablehlo::BatchNormInferenceOp> {
-  using OpRewritePattern ::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::BatchNormInferenceOp bnOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -1194,7 +1194,7 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
 /// Pattern to fold consumer relayout ops into a producer map_load.
 struct FoldConsumerRelayoutIntoMapLoadPattern
     : OpRewritePattern<IREE::LinalgExt::MapLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapLoadOp mapLoadOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -622,7 +622,7 @@ protected:
 /// Pattern to convert tensor.pad fusion cases directly without requiring
 /// warp-mapped forall parent.
 struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
@@ -677,7 +677,7 @@ struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
 
 struct ConvertGatherToCoalescedDMA
     : OpRewritePattern<IREE::LinalgExt::GatherOp> {
-  using OpRewritePattern<IREE::LinalgExt::GatherOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::GatherOp gatherOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -155,7 +155,7 @@ namespace {
 /// optimizations that update offsets.
 struct ConvertMemRefExtractMetadataToIREECodegen
     : OpRewritePattern<memref::ExtractStridedMetadataOp> {
-  using OpRewritePattern<memref::ExtractStridedMetadataOp>::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(memref::ExtractStridedMetadataOp op,
                                 PatternRewriter &rewriter) const override {
     if (!getSourceInterfaceBinding(op.getSource())) {
@@ -281,8 +281,7 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
 /// ResolveExtractMetadataFromHalInterfaceBindingSubspan).
 struct ConvertIREECodegenExtractMetadataToMemRef
     : OpRewritePattern<IREE::Codegen::ExtractStridedMetadataOp> {
-  using OpRewritePattern<
-      IREE::Codegen::ExtractStridedMetadataOp>::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Codegen::ExtractStridedMetadataOp op,
                                 PatternRewriter &rewriter) const override {
     // GUARD: Don't convert back to memref if source is still from HAL binding.

--- a/compiler/src/iree/compiler/Codegen/Common/IREEInjectAssumeAlignment.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEInjectAssumeAlignment.cpp
@@ -19,8 +19,7 @@ namespace mlir::iree_compiler {
 namespace {
 struct InjectAssumeAlignmentForSubspanOp
     : OpRewritePattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpRewritePattern<
-      IREE::HAL::InterfaceBindingSubspanOp>::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op,
                                 PatternRewriter &rewriter) const override;
 };

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -314,8 +314,7 @@ static Value generateEncodingTransferOps(RewriterBase &rewriter, Value src,
 /// materializing the encoding.
 struct DecomposeMismatchEncodingTensorLoadOp
     : OpRewritePattern<IREE::TensorExt::DispatchTensorLoadOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorLoadOp>::OpRewritePattern;
+  using Base::Base;
 
   DecomposeMismatchEncodingTensorLoadOp(
       MaterializeEncodingTypeConverter &converter, MLIRContext *ctx,
@@ -381,8 +380,7 @@ private:
 /// materializing the encoding.
 struct DecomposeMismatchEncodingTensorStoreOp
     : OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+  using Base::Base;
 
   DecomposeMismatchEncodingTensorStoreOp(
       MaterializeEncodingTypeConverter &converter, MLIRContext *ctx,

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorMasking.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorMasking.cpp
@@ -157,7 +157,7 @@ projectMaskToOperand(ImplicitLocOpBuilder &builder, Value iterMask,
 //
 template <typename ConcreteType, typename InnerOpType>
 struct UnwrapMaskedOpPattern : OpRewritePattern<vector::MaskOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   using Base = UnwrapMaskedOpPattern;
 
   LogicalResult matchAndRewrite(vector::MaskOp maskOp,

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -278,8 +278,7 @@ struct FoldExpandShapeIntoInterfaceTensorLoad
 ///       tensor<864xf32>
 struct FoldExpandShapeIntoInterfaceTensorStore
     : OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -397,8 +396,7 @@ static void transformOverReassociation(
 /// is possible)
 struct FoldCollapseShapeIntoInterfaceTensorStoreFullSlice
     : OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -616,8 +614,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStoreFullSlice
 /// - For constants: divisible if value % innerDimProduct == 0
 struct FoldCollapseShapeIntoInterfaceTensorStore
     : OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -1004,8 +1001,7 @@ struct FoldInnerBitcastIntoInterfaceTensorLoad
 
 struct FoldInnerBitcastIntoInterfaceTensorStore
     : OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/LowerTransferGatherOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/LowerTransferGatherOps.cpp
@@ -101,7 +101,7 @@ static Value extractVecSlice(OpBuilder &b, Location loc, Value vec,
 /// Unrolls dim 0 of a transfer_gather, reducing vector rank by 1 each
 /// application. Stops at rank 1.
 struct UnrollTransferGatherDim : OpRewritePattern<TransferGatherOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(TransferGatherOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -80,7 +80,7 @@ namespace {
 // =>
 // %2 = hal.tensor.transients %0 : tensor<?xf32>{%dim} from %storage2
 struct FoldConsecutiveTransientsOps : OpRewritePattern<TensorTransientsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorTransientsOp op,
                                 PatternRewriter &rewriter) const override {
     // Check if the source is another transients op.

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2081,7 +2081,7 @@ namespace {
 
 struct FoldConsecutiveResourceTransientsOps
     : OpRewritePattern<ResourceTransientsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceTransientsOp op,
                                 PatternRewriter &rewriter) const override {
     auto resourceOp = op.getResource().getDefiningOp<ResourceTransientsOp>();

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -130,7 +130,7 @@ struct BitCastOfTensorCastStaticInfo final : OpRewritePattern<BitCastOp> {
 /// Replaces chains of two bitcast operations by a single bitcast operation.
 /// bitcast(bitcast(x : A -> B) : B -> C) -> bitcast(x : A -> C).
 struct ChainedBitCast final : OpRewritePattern<BitCastOp> {
-  using OpRewritePattern<BitCastOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -49,8 +49,7 @@ struct FoldTensorLoadWithExtractSlice
 /// `iree_tensor_ext.dispatch.tensor.store` operations.
 struct FoldInsertSliceWithTensorStoreOp
     : OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern<
-      IREE::TensorExt::DispatchTensorStoreOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp dispatchTensorStoreOp,

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -861,7 +861,7 @@ static bool inSingleBlockSCFRegion(Operation *op) {
 // patterns that are always applied.
 struct ConvertSCFUnreachableToTerminatorOp
     : OpRewritePattern<SCFUnreachableOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(SCFUnreachableOp op,
                                 PatternRewriter &rewriter) const override {
     // Only handle if the parent region is not an SCF operation.
@@ -907,7 +907,7 @@ struct ConvertSCFUnreachableToTerminatorOp
 // erasing subsequent operations and creating poison values.
 struct SimplifySCFUnreachableInSCFRegionOp
     : OpRewritePattern<SCFUnreachableOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(SCFUnreachableOp op,
                                 PatternRewriter &rewriter) const override {
     // Only handle if the parent region is in an SCF operation.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
@@ -601,7 +601,7 @@ struct MergeIndexSwitchPattern : OpRewritePattern<scf::IndexSwitchOp> {
 //  // to indicate that the opposite of `%cond` is true.
 //  "some.op"() : () -> ()
 struct SimplifyIfWithUnreachablePattern : OpRewritePattern<scf::IfOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::IfOp ifOp,
                                 PatternRewriter &rewriter) const override {
     // Check if either region contains an unreachable indicator.
@@ -668,7 +668,7 @@ struct SimplifyIfWithUnreachablePattern : OpRewritePattern<scf::IfOp> {
 
 // Simplifies scf.while when the body contains unreachable.
 struct SimplifyWhileWithUnreachablePattern : OpRewritePattern<scf::WhileOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::WhileOp whileOp,
                                 PatternRewriter &rewriter) const override {
     // Check if the after region (loop body) is unreachable.
@@ -713,7 +713,7 @@ struct SimplifyWhileWithUnreachablePattern : OpRewritePattern<scf::WhileOp> {
 // Simplifies scf.index_switch when cases contain unreachable.
 struct SimplifyIndexSwitchWithUnreachablePattern
     : OpRewritePattern<scf::IndexSwitchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::IndexSwitchOp switchOp,
                                 PatternRewriter &rewriter) const override {
     // Collect which cases are unreachable.
@@ -801,7 +801,7 @@ struct SimplifyIndexSwitchWithUnreachablePattern
 
 // Simplifies scf.for when the body contains unreachable.
 struct SimplifyForWithUnreachablePattern : OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
     // Check if the loop body ends with unreachable.
@@ -833,7 +833,7 @@ struct SimplifyForWithUnreachablePattern : OpRewritePattern<scf::ForOp> {
 // Simplifies unconditional branches to blocks that are unreachable.
 // This is likely to happen via other patterns but we preserve this for defense.
 struct SimplifyBranchToUnreachablePattern : OpRewritePattern<cf::BranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(cf::BranchOp branchOp,
                                 PatternRewriter &rewriter) const override {
     // Check if the destination block contains an unreachable indicator (_and_
@@ -863,7 +863,7 @@ struct SimplifyBranchToUnreachablePattern : OpRewritePattern<cf::BranchOp> {
 //   └─────────────────┴─────────────────┴──────────────────────┘
 struct SimplifyCondBranchToUnreachablePattern
     : OpRewritePattern<cf::CondBranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(cf::CondBranchOp condBr,
                                 PatternRewriter &rewriter) const override {
     // Check if either destination only contains an unreachable indicator and

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -383,7 +383,7 @@ struct BubbleExpandThroughConcat final
 /// bitcast(expand_shape(x)).
 struct BubbleExpandThroughBitCast final
     : OpRewritePattern<tensor::ExpandShapeOp> {
-  using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {
@@ -485,7 +485,7 @@ struct BubbleExpandThroughBitCast final
 /// collapse_shape(bitcast(x)).
 struct SinkCollapseThroughBitCast final
     : OpRewritePattern<IREE::TensorExt::BitCastOp> {
-  using OpRewritePattern<IREE::TensorExt::BitCastOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/FoldReshapesIntoTensorBarriers.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldReshapesIntoTensorBarriers.cpp
@@ -59,7 +59,7 @@ struct MoveReshapeAboveBarrierStart : RewritePattern {
 // Move tensor.expand_shape/collapse_shape below compute_barrier.end
 struct MoveReshapeBelowBarrierEnd
     : OpRewritePattern<IREE::TensorExt::ComputeBarrierEndOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::TensorExt::ComputeBarrierEndOp barrierEndOp,

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -597,7 +597,7 @@ private:
 // Sinks a transpose through a tensor.pad.
 class SinkTransposeThroughPad : public OpRewritePattern<tensor::PadOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::PadOp padOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -107,7 +107,7 @@ struct ConvertHwcfToFhwc : OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
 
 /// Transpose the generic form filter layout of `CHWF` or `CFHW` to `FHWC`.
 struct ConvertGenericFilterToFhwc : OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -450,8 +450,6 @@ namespace {
 
 struct ConvertLinalgConvNchwFchw : OpRewritePattern<linalg::Conv2DNchwFchwOp> {
   using Base::Base;
-  ConvertLinalgConvNchwFchw(MLIRContext *context, PatternBenefit benefit = 2)
-      : OpRewritePattern<linalg::Conv2DNchwFchwOp>(context, benefit) {}
 
   LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwOp convOp,
                                 PatternRewriter &rewriter) const override {
@@ -519,9 +517,6 @@ class GeneralizeOuterUnitDimsPackOp final
     : public OpRewritePattern<linalg::PackOp> {
 public:
   using Base::Base;
-  GeneralizeOuterUnitDimsPackOp(MLIRContext *context,
-                                PatternBenefit benefit = 2)
-      : OpRewritePattern<linalg::PackOp>(context, benefit) {}
 
   LogicalResult matchAndRewrite(linalg::PackOp packOp,
                                 PatternRewriter &rewriter) const override {
@@ -603,9 +598,6 @@ class GeneralizeOuterUnitDimsUnPackOp final
     : public OpRewritePattern<linalg::UnPackOp> {
 public:
   using Base::Base;
-  GeneralizeOuterUnitDimsUnPackOp(MLIRContext *context,
-                                  PatternBenefit benefit = 2)
-      : OpRewritePattern<linalg::UnPackOp>(context, benefit) {}
 
   LogicalResult matchAndRewrite(linalg::UnPackOp unpackOp,
                                 PatternRewriter &rewriter) const override {
@@ -670,7 +662,7 @@ public:
     {
       RewritePatternSet patterns(context);
       if (tilingFactor <= 0) {
-        patterns.insert<ConvertLinalgConvNchwFchw>(context);
+        patterns.insert<ConvertLinalgConvNchwFchw>(context, /*benefit=*/2);
       }
       patterns.insert<ConvertLinalgConvOp>(context, tilingFactor);
       if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
@@ -714,8 +706,8 @@ public:
     // effectively.
     {
       RewritePatternSet patterns(context);
-      patterns.insert<GeneralizeOuterUnitDimsPackOp>(context);
-      patterns.insert<GeneralizeOuterUnitDimsUnPackOp>(context);
+      patterns.insert<GeneralizeOuterUnitDimsPackOp>(context, /*benefit=*/2);
+      patterns.insert<GeneralizeOuterUnitDimsUnPackOp>(context, /*benefit=*/2);
       if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
         return signalPassFailure();
       }


### PR DESCRIPTION
The revision uses the `Base` type alias and deletes custom constructor that is only about `benefit`. The caller should decide the `benefit` when they add patterns.

Note that `using Base::Base` doesn't work for template classes with dependent base classes (e.g., OpRewritePattern<T> where T is a template parameter) due to C++ dependent name lookup rules.