### PR TITLE
[Tokenizer] Fix deferred emission dropping back-to-back special tokens

### DIFF
--- a/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json_test.cc
+++ b/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json_test.cc
@@ -460,6 +460,94 @@ TEST_F(TokenizerJsonTest, AddedTokenRstripFlag) {
   iree_tokenizer_free(tokenizer);
 }
 
+// Verifies that back-to-back special tokens are both emitted. Previously,
+// when the pipeline had buffered content, the second match would overwrite
+// pending_special_token before the first was emitted, dropping it.
+TEST_F(TokenizerJsonTest, BackToBackSpecialTokens) {
+  iree_string_view_t json = IREE_SV(R"({
+    "model": {
+      "type": "BPE",
+      "vocab": {"hello": 1, "world": 2},
+      "merges": []
+    },
+    "added_tokens": [{
+      "id": 100,
+      "content": "<|user|>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }, {
+      "id": 101,
+      "content": "<|end|>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }, {
+      "id": 102,
+      "content": "<|assistant|>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }],
+    "pre_tokenizer": null
+  })");
+
+  iree_tokenizer_t* tokenizer = nullptr;
+  IREE_ASSERT_OK(
+      iree_tokenizer_from_huggingface_json(json, allocator_, &tokenizer));
+  ASSERT_NE(tokenizer, nullptr);
+
+  auto encode = [&](const char* text) -> std::vector<int32_t> {
+    std::vector<int32_t> tokens(64);
+    iree_host_size_t token_count = 0;
+    IREE_CHECK_OK(
+        iree_tokenizer_encode(tokenizer, iree_make_cstring_view(text),
+                              IREE_TOKENIZER_ENCODE_FLAG_NONE,
+                              iree_tokenizer_make_token_output(
+                                  tokens.data(), NULL, NULL, tokens.size()),
+                              allocator_, &token_count));
+    tokens.resize(token_count);
+    return tokens;
+  };
+
+  // Two special tokens with no text between them.
+  {
+    auto tokens = encode("<|end|><|assistant|>");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], 101);  // <|end|>
+    EXPECT_EQ(tokens[1], 102);  // <|assistant|>
+  }
+
+  // Text, then two back-to-back special tokens, then more text.
+  {
+    auto tokens = encode("<|user|>hello<|end|><|assistant|>world<|end|>");
+    ASSERT_EQ(tokens.size(), 6u);
+    EXPECT_EQ(tokens[0], 100);  // <|user|>
+    EXPECT_EQ(tokens[1], 1);    // hello
+    EXPECT_EQ(tokens[2], 101);  // <|end|>
+    EXPECT_EQ(tokens[3], 102);  // <|assistant|>
+    EXPECT_EQ(tokens[4], 2);    // world
+    EXPECT_EQ(tokens[5], 101);  // <|end|>
+  }
+
+  // Three back-to-back special tokens.
+  {
+    auto tokens = encode("<|end|><|user|><|assistant|>");
+    ASSERT_EQ(tokens.size(), 3u);
+    EXPECT_EQ(tokens[0], 101);  // <|end|>
+    EXPECT_EQ(tokens[1], 100);  // <|user|>
+    EXPECT_EQ(tokens[2], 102);  // <|assistant|>
+  }
+
+  iree_tokenizer_free(tokenizer);
+}
+
 TEST_F(TokenizerJsonTest, AddedTokenSingleWordFlag) {
   // The single_word flag means the token only matches when surrounded by
   // word boundaries (whitespace or punctuation).

--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -2246,7 +2246,7 @@ static iree_status_t iree_tokenizer_encode_state_pump(
   // content itself serves as the "buffer" for reconstruction via get_partial().
   iree_host_size_t normalize_limit = IREE_HOST_SIZE_MAX;
   if (!iree_tokenizer_special_tokens_is_empty(&tokenizer->special_tokens) &&
-      chunk->size > 0) {
+      chunk->size > 0 && state->pending_special_token < 0) {
     // Continuing a partial match? Pass chunk directly to match().
     // Starting fresh? Check if first byte could start a special token.
     bool should_match = state->special_token_match.match_position > 0;


### PR DESCRIPTION
## Summary

When text preceded back-to-back special tokens (e.g. <|user|>Hi<|end|><|assistant|>), the first was dropped because matching continued while a deferred token was pending, overwriting the single pending_special_token slot. This breaks every multi-turn chat prompt. Add the missing pending < 0 guard to skip matching until the deferred token is emitted.

## Test results

### HuggingFace smoketest (`huggingface_smoketest.py`)

**1667/1667** tokenization comparisons pass across ~80 HuggingFace models (0 mismatches).

76 additional tests fail to **load** (not tokenization mismatches) — these are tiktoken models listed in the HF smoketest that aren't valid HuggingFace model identifiers. They're tested by the dedicated tiktoken smoketest instead. This is fixed in https://github.com/iree-org/iree/pull/23830.

### Tiktoken smoketest (`tiktoken_smoketest.py`)

**72/76** tokenization comparisons pass across 4 tiktoken encodings (cl100k_base, o200k_base, r50k_base, p50k_base).

4 failures — **identical between upstream and this PR** (pre-existing, same as `fix-tokenizer-added-tokens` branch):

| Encoding | Failing test | Cause |
|----------|-------------|-------|
| cl100k_base | `special_token_endoftext` | IREE matches `<\|endoftext\|>` as special token; tiktoken's `encode_ordinary` treats it as literal text |
| o200k_base | `special_token_endoftext` | Same |
| r50k_base | `special_token_endoftext` | Same |
| p50k_base | `special_token_endoftext` | Same |

Root cause: the IREE tokenizer has no "encode ordinary" mode (equivalent to tiktoken's `disallowed_special=()`). Fixed in: https://github.com/iree-org/iree/pull/23830.