### PR TITLE
[VectorExt] IndexedVectorOpInterface for transfer_gather/scatter

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -668,11 +668,11 @@ struct DistributeTransferGather final
     ValueRange indices = gatherOp.getOffsets();
     SmallVector<int64_t> strides(rank, 1);
 
-    // getPermutationMap inverts the source map, mapping gathered (symbol) and
-    // broadcast (constant) dims to constant 0. This is correct here because
+    // getBasePermutationMap inverts the source map, mapping gathered (symbol)
+    // and broadcast (constant) dims to constant 0. This is correct here because
     // getTransferIndicesFromNestedLayout treats constant-0 dims as broadcast,
     // leaving the original base offset unchanged for gathered dimensions.
-    AffineMap permMap = gatherOp.getPermutationMap();
+    AffineMap permMap = gatherOp.getBasePermutationMap();
 
     std::vector<StaticTileOffsetRange::IteratorTy> allMaskOffsets;
     if (mask) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/BUILD.bazel
@@ -18,6 +18,7 @@ exports_files([
     "VectorExtBase.td",
     "VectorExtOps.td",
     "VectorExtInterfaces.td",
+    "VectorExtOpInterfaces.td",
 ])
 
 iree_td_library(
@@ -28,6 +29,7 @@ iree_td_library(
             "VectorExtAttrs.td",
             "VectorExtBase.td",
             "VectorExtInterfaces.td",
+            "VectorExtOpInterfaces.td",
             "VectorExtOps.td",
         ],
         include = ["*.td"],
@@ -64,6 +66,8 @@ iree_compiler_cc_library(
         "VectorExtEnums.cpp.inc",
         "VectorExtAttrInterfaces.h.inc",
         "VectorExtAttrInterfaces.cpp.inc",
+        "VectorExtOpInterfaces.h.inc",
+        "VectorExtOpInterfaces.cpp.inc",
         "VectorExtOps.h.inc",
         "VectorExtOps.cpp.inc",
     ],
@@ -72,6 +76,7 @@ iree_compiler_cc_library(
         ":IREEVectorExtDialectGen",
         ":IREEVectorExtEnumsGen",
         ":IREEVectorExtInterfacesGen",
+        ":IREEVectorExtOpInterfacesGen",
         ":IREEVectorExtOpsGen",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Utils",
@@ -164,6 +169,23 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "VectorExtInterfaces.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "IREEVectorExtOpInterfacesGen",
+    tbl_outs = [
+        (
+            ["--gen-op-interface-decls"],
+            "VectorExtOpInterfaces.h.inc",
+        ),
+        (
+            ["--gen-op-interface-defs"],
+            "VectorExtOpInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "VectorExtOpInterfaces.td",
     deps = [":td_files"],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/CMakeLists.txt
@@ -26,6 +26,8 @@ iree_cc_library(
     "VectorExtDialect.h.inc"
     "VectorExtEnums.cpp.inc"
     "VectorExtEnums.h.inc"
+    "VectorExtOpInterfaces.cpp.inc"
+    "VectorExtOpInterfaces.h.inc"
     "VectorExtOps.cpp.inc"
     "VectorExtOps.h.inc"
   SRCS
@@ -37,6 +39,7 @@ iree_cc_library(
     ::IREEVectorExtDialectGen
     ::IREEVectorExtEnumsGen
     ::IREEVectorExtInterfacesGen
+    ::IREEVectorExtOpInterfacesGen
     ::IREEVectorExtOpsGen
     LLVMSupport
     MLIRAffineDialect
@@ -91,6 +94,16 @@ iree_tablegen_library(
   OUTS
     --gen-attr-interface-decls VectorExtAttrInterfaces.h.inc
     --gen-attr-interface-defs VectorExtAttrInterfaces.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    IREEVectorExtOpInterfacesGen
+  TD_FILE
+    "VectorExtOpInterfaces.td"
+  OUTS
+    --gen-op-interface-decls VectorExtOpInterfaces.h.inc
+    --gen-op-interface-defs VectorExtOpInterfaces.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.cpp
@@ -19,6 +19,7 @@ using namespace mlir;
 using namespace mlir::iree_compiler::IREE::VectorExt;
 
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrInterfaces.cpp.inc"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOpInterfaces.cpp.inc"
 
 namespace mlir::iree_compiler::IREE::VectorExt {
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.h
@@ -15,4 +15,12 @@
 /// Include the generated interface declarations.
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrInterfaces.h.inc"
 
+// Manual declaration; defined in VectorExtOps.cpp, called from generated
+// interface verify.
+namespace mlir::iree_compiler::IREE::VectorExt::detail {
+LogicalResult verifyIndexedVectorOpInterface(::mlir::Operation *op);
+} // namespace mlir::iree_compiler::IREE::VectorExt::detail
+
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOpInterfaces.h.inc"
+
 #endif // IREE_DIALECTS_DIALECT_VECTOREXT_INTERFACES_H

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOpInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOpInterfaces.td
@@ -1,0 +1,139 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECT_VECTOREXT_OP_INTERFACES
+#define IREE_DIALECT_VECTOREXT_OP_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def IndexedVectorOpInterface : OpInterface<"IndexedVectorOpInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::VectorExt";
+
+  let description = [{
+    Interface for ops that access a shaped base (memref or tensor) using an
+    affine indexing map whose symbols are bound to index vectors. This covers
+    the common structure shared by `transfer_gather` (read) and
+    `transfer_scatter` (write).
+
+    An implementing op has:
+    - A **base** shaped operand (source for reads, destination for writes).
+    - A **vector** value (the result for reads, an operand for writes).
+    - Zero or more **index vectors** that provide gathered/scattered indices.
+    - An **indexing_maps** attribute describing how the vector iteration space
+      maps to the base dimensions and to each index vector.
+    - An optional **mask** vector.
+
+    The `indexing_maps` attribute is an array of affine maps. Every map has
+    `numDims = vector rank` and `numSymbols = number of index vecs`:
+
+    - Map 0 (base map): `(vector_dims)[symbols] -> (base_dims)`.
+      A dim expr means the base dimension is contiguous (iterated in lockstep
+      with the vector dimension). A symbol expr means the base dimension is
+      gathered/scattered (looked up via the corresponding index vector).
+      A constant 0 means the base dimension is broadcast.
+    - Maps 1..N (index vec maps): `(vector_dims)[symbols] -> (index_vec_dims)`.
+      Describes how each index vector is indexed from the vector iteration
+      space. Only dim exprs are allowed.
+    - Optional last map (mask map): present only when a mask operand is
+      provided. Only dim exprs are allowed.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*description=*/"Get the base shaped operand (source for gather, dest for scatter).",
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getBase"
+    >,
+    InterfaceMethod<
+      /*description=*/"Get the index vector operands.",
+      /*retTy=*/"::mlir::Operation::operand_range",
+      /*methodName=*/"getIndexVecs"
+    >,
+    InterfaceMethod<
+      /*description=*/"Get the optional mask operand.",
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getMask"
+    >,
+    InterfaceMethod<
+      /*description=*/"Get the indexing maps attribute.",
+      /*retTy=*/"::mlir::ArrayAttr",
+      /*methodName=*/"getIndexingMaps"
+    >,
+    InterfaceMethod<
+      /*description=*/"Get the vector value (result for gather, operand for scatter).",
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getVector"
+    >,
+  ];
+
+  let verify = [{
+    return detail::verifyIndexedVectorOpInterface($_op);
+  }];
+
+  let extraSharedClassDeclaration = [{
+    /// Return the vector type.
+    VectorType getVectorType() {
+      return cast<VectorType>($_op.getVector().getType());
+    }
+
+    /// Return indexing maps as a vector of AffineMap.
+    SmallVector<AffineMap> getIndexingMapsArray() {
+      return llvm::to_vector(
+          $_op.getIndexingMaps().template getAsValueRange<AffineMapAttr>());
+    }
+
+    /// Return the indexing map for the base operand (first map).
+    AffineMap getBaseIndexingMap() {
+      return cast<AffineMapAttr>($_op.getIndexingMaps()[0]).getValue();
+    }
+
+    /// Return the indexing maps for each index vector.
+    SmallVector<AffineMap> getIndexVecIndexingMaps() {
+      SmallVector<AffineMap> maps = $_op.getIndexingMapsArray();
+      return SmallVector<AffineMap>(
+          maps.begin() + 1, maps.begin() + 1 + $_op.getIndexVecs().size());
+    }
+
+    /// Return the mask indexing map, if a mask is present.
+    std::optional<AffineMap> getMaskIndexingMap() {
+      if (!$_op.getMask()) {
+        return std::nullopt;
+      }
+      ArrayAttr maps = $_op.getIndexingMaps();
+      return cast<AffineMapAttr>(maps[maps.size() - 1]).getValue();
+    }
+
+    /// Invert the base indexing map to get a permutation map suitable for
+    /// vector.transfer_read/write. The base map is
+    /// (vector_dims)[symbols] -> (base_dims). This returns
+    /// (base_dims) -> (vector_dims), where non-dim results (gathered/scattered
+    /// symbols, broadcast constants) become constant 0.
+    /// Note: conceptually the same as inverseAndBroadcastProjectedPermutation,
+    /// but that utility asserts symbol-free maps. Our base map has symbols for
+    /// gathered/scattered dims, which we treat identically to broadcast (map to
+    /// constant 0 in the inverse).
+    AffineMap getBasePermutationMap() {
+      AffineMap baseMap = $_op.getBaseIndexingMap();
+      MLIRContext *ctx = $_op->getContext();
+      SmallVector<AffineExpr> exprs(baseMap.getNumDims(),
+                                    getAffineConstantExpr(0, ctx));
+      for (auto [i, expr] : llvm::enumerate(baseMap.getResults())) {
+        if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
+          exprs[dimExpr.getPosition()] = getAffineDimExpr(i, ctx);
+        }
+      }
+      return AffineMap::get(baseMap.getNumResults(), /*symbolCount=*/0,
+                            exprs, ctx);
+    }
+
+    /// Return true if the base operand has tensor semantics.
+    bool hasTensorSemantics() {
+      return isa<RankedTensorType>($_op.getBase().getType());
+    }
+  }];
+}
+
+#endif // IREE_DIALECT_VECTOREXT_OP_INTERFACES

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -68,12 +68,15 @@ void TransferGatherOp::getEffects(
   }
 }
 
-// Shared verifier for TransferGatherOp and TransferScatterOp.
+LogicalResult
+mlir::iree_compiler::IREE::VectorExt::detail::verifyIndexedVectorOpInterface(
+    Operation *operation) {
+  auto op = cast<IndexedVectorOpInterface>(operation);
+  VectorType vectorType = op.getVectorType();
+  OperandRange indexVecs = op.getIndexVecs();
+  Value mask = op.getMask();
+  SmallVector<AffineMap> indexingMaps = op.getIndexingMapsArray();
 
-static LogicalResult
-verifyTransferGatherScatterLikeOp(Operation *op, VectorType vectorType,
-                                  OperandRange indexVecs, Value mask,
-                                  ArrayRef<AffineMap> indexingMaps) {
   // Check that we have the correct number of indexing maps.
   int64_t expectedNumIndexingMaps =
       /*baseIndexingMap=*/1 + /*indexVecIndexingMaps=*/indexVecs.size() +
@@ -143,7 +146,7 @@ verifyTransferGatherScatterLikeOp(Operation *op, VectorType vectorType,
         cast<VectorType>(indexVecs[i].getType()).getShape();
     if (ArrayRef<int64_t>(expectedShape) != actualShape) {
       return op->emitOpError(
-                 "Mismatched vector shape for index vec at position ")
+                 "mismatched vector shape for index vec at position ")
              << i << ". Expected: [" << expectedShape << "]" << ", got: ["
              << actualShape << "]";
     }
@@ -163,19 +166,13 @@ verifyTransferGatherScatterLikeOp(Operation *op, VectorType vectorType,
     }
     ArrayRef<int64_t> actualShape = cast<VectorType>(mask.getType()).getShape();
     if (ArrayRef<int64_t>(expectedShape) != actualShape) {
-      return op->emitOpError("Mismatched mask shape")
+      return op->emitOpError("mismatched mask shape")
              << ". Expected: [" << expectedShape << "]" << ", got: ["
              << actualShape << "]";
     }
   }
 
   return success();
-}
-
-LogicalResult TransferGatherOp::verify() {
-  return verifyTransferGatherScatterLikeOp(
-      getOperation(), getVector().getType(), getIndexVecs(), getMask(),
-      getIndexingMapsArray());
 }
 
 // Fold and canonicalization helpers.
@@ -638,7 +635,7 @@ struct FoldContiguousGatherToTransferRead final
       return failure();
     }
 
-    AffineMap permutationMap = op.getPermutationMap();
+    AffineMap permutationMap = op.getBasePermutationMap();
 
     Value mask = op.getMask();
     if (mask) {
@@ -700,13 +697,7 @@ void TransferScatterOp::getEffects(
 }
 
 LogicalResult TransferScatterOp::verify() {
-  if (failed(verifyTransferGatherScatterLikeOp(getOperation(), getVectorType(),
-                                               getIndexVecs(), getMask(),
-                                               getIndexingMapsArray()))) {
-    return failure();
-  }
-
-  // Verify result type matches base type for tensor semantics.
+  // Scatter-specific checks.
   if (hasTensorSemantics()) {
     if (!getResult()) {
       return emitOpError("expected result for tensor operand");

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -118,23 +118,34 @@ mlir::iree_compiler::IREE::VectorExt::detail::verifyIndexedVectorOpInterface(
     }
   }
 
-  // Extra verification for index vecs.
+  // Build the expected shape from a dim-only affine map by resolving each dim
+  // expression against the vector shape. Returns failure if any non-dim
+  // expression is found.
   ArrayRef<int64_t> vectorShape = vectorType.getShape();
-  ArrayRef<AffineMap> vectorIndexingMaps =
-      ArrayRef(indexingMaps).slice(1, indexSyms);
-  for (auto [i, map] : llvm::enumerate(vectorIndexingMaps)) {
-    SmallVector<int64_t> expectedShape;
+  auto getExpectedShape =
+      [&](AffineMap map) -> FailureOr<SmallVector<int64_t>> {
+    SmallVector<int64_t> shape;
     for (AffineExpr expr : map.getResults()) {
       if (auto dim = dyn_cast<AffineDimExpr>(expr)) {
-        expectedShape.push_back(vectorShape[dim.getPosition()]);
+        shape.push_back(vectorShape[dim.getPosition()]);
       } else {
-        return op->emitOpError(
-            "expected vector indexing maps to not have any symbols");
+        return failure();
       }
+    }
+    return shape;
+  };
+
+  // Verify index vec shapes against their indexing maps.
+  ArrayRef<AffineMap> vecMaps = ArrayRef(indexingMaps).slice(1, indexSyms);
+  for (auto [i, map] : llvm::enumerate(vecMaps)) {
+    FailureOr<SmallVector<int64_t>> expectedShape = getExpectedShape(map);
+    if (failed(expectedShape)) {
+      return op->emitOpError(
+          "expected index vec indexing maps to only have dim exprs");
     }
     // Scalar index: map must have 0 results and type must be plain index.
     if (isa<IndexType>(indexVecs[i].getType())) {
-      if (!expectedShape.empty()) {
+      if (!expectedShape->empty()) {
         return op->emitOpError(
                    "expected empty indexing map for scalar index vec "
                    "at position ")
@@ -144,30 +155,26 @@ mlir::iree_compiler::IREE::VectorExt::detail::verifyIndexedVectorOpInterface(
     }
     ArrayRef<int64_t> actualShape =
         cast<VectorType>(indexVecs[i].getType()).getShape();
-    if (ArrayRef<int64_t>(expectedShape) != actualShape) {
+    if (ArrayRef<int64_t>(*expectedShape) != actualShape) {
       return op->emitOpError(
                  "mismatched vector shape for index vec at position ")
-             << i << ". Expected: [" << expectedShape << "]" << ", got: ["
+             << i << ". Expected: [" << *expectedShape << "]" << ", got: ["
              << actualShape << "]";
     }
   }
 
-  // Extra verification for mask.
+  // Verify mask shape against its indexing map.
   if (mask) {
     AffineMap maskMap = indexingMaps.back();
-    SmallVector<int64_t> expectedShape;
-    for (AffineExpr expr : maskMap.getResults()) {
-      if (auto dim = dyn_cast<AffineDimExpr>(expr)) {
-        expectedShape.push_back(vectorShape[dim.getPosition()]);
-      } else {
-        return op->emitOpError(
-            "expected mask indexing map to not have any symbols");
-      }
+    FailureOr<SmallVector<int64_t>> expectedShape = getExpectedShape(maskMap);
+    if (failed(expectedShape)) {
+      return op->emitOpError(
+          "expected mask indexing map to only have dim exprs");
     }
     ArrayRef<int64_t> actualShape = cast<VectorType>(mask.getType()).getShape();
-    if (ArrayRef<int64_t>(expectedShape) != actualShape) {
+    if (ArrayRef<int64_t>(*expectedShape) != actualShape) {
       return op->emitOpError("mismatched mask shape")
-             << ". Expected: [" << expectedShape << "]" << ", got: ["
+             << ". Expected: [" << *expectedShape << "]" << ", got: ["
              << actualShape << "]";
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -11,6 +11,7 @@ include "mlir/Interfaces/VectorInterfaces.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtBase.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td"
+include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOpInterfaces.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -111,6 +112,7 @@ def IREEVectorExt_ToSIMTOp : IREEVectorExt_PureOp<"to_simt",
 def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+    IndexedVectorOpInterface,
     AttrSizedOperandSegments,
     TypesMatchWith<"padding type must match source element type",
                    "base", "padding", "getElementTypeOrSelf($_self)">
@@ -170,56 +172,16 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
     ```
   }];
 
-  let extraClassDeclaration = [{
-    SmallVector<AffineMap> getIndexingMapsArray() {
-      return llvm::to_vector(getIndexingMaps().getAsValueRange<AffineMapAttr>());
-    }
-
-    AffineMap getSourceIndexingMap() {
-      return getIndexingMapsArray().front();
-    }
-
-    SmallVector<AffineMap> getIndexVecIndexingMaps() {
-      auto maps = getIndexingMapsArray();
-      return SmallVector<AffineMap>(
-          maps.begin() + 1, maps.begin() + 1 + getIndexVecs().size());
-    }
-
-    std::optional<AffineMap> getMaskIndexingMap() {
-      if (!getMask()) return std::nullopt;
-      return getIndexingMapsArray().back();
-    }
-
-    /// Invert the source indexing map to get a permutation map suitable for
-    /// vector.transfer_read. The source map is
-    /// (vector_dims)[symbols] -> (source_dims). This returns
-    /// (source_dims) -> (vector_dims), where non-dim results (gathered
-    /// symbols, broadcast constants) become constant 0.
-    AffineMap getPermutationMap() {
-      AffineMap sourceMap = getSourceIndexingMap();
-      MLIRContext *ctx = getContext();
-      SmallVector<AffineExpr> exprs(sourceMap.getNumDims(),
-                                    getAffineConstantExpr(0, ctx));
-      for (auto [i, expr] : llvm::enumerate(sourceMap.getResults())) {
-        if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
-          exprs[dimExpr.getPosition()] = getAffineDimExpr(i, ctx);
-        }
-      }
-      return AffineMap::get(sourceMap.getNumResults(), /*symbolCount=*/0,
-                            exprs, ctx);
-    }
-  }];
-
   let assemblyFormat = "$base `[` $offsets `]` (`[` $index_vecs^ `:` type($index_vecs) `]`)? `,` $padding (`,` $mask^)? attr-dict `:` type($base) `,` type($vector) (`,` type($mask)^)?";
 
   let hasCanonicalizer = 1;
   let hasFolder = 1;
-  let hasVerifier = 1;
 }
 
 def IREEVectorExt_TransferScatterOp : IREEVectorExt_PureOp<"transfer_scatter", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+    IndexedVectorOpInterface,
     AttrSizedOperandSegments,
     AllElementTypesMatch<["base", "vector"]>
   ]> {
@@ -272,58 +234,6 @@ def IREEVectorExt_TransferScatterOp : IREEVectorExt_PureOp<"transfer_scatter", [
     `transfer_gather`. See `transfer_gather` documentation for details. The
     only difference is that Map 0 describes the destination indexing rather
     than the source indexing.
-  }];
-
-  let extraClassDeclaration = [{
-    SmallVector<AffineMap> getIndexingMapsArray() {
-      return llvm::to_vector(getIndexingMaps().getAsValueRange<AffineMapAttr>());
-    }
-
-    AffineMap getDestIndexingMap() {
-      return getIndexingMapsArray().front();
-    }
-
-    SmallVector<AffineMap> getIndexVecIndexingMaps() {
-      auto maps = getIndexingMapsArray();
-      return SmallVector<AffineMap>(
-          maps.begin() + 1, maps.begin() + 1 + getIndexVecs().size());
-    }
-
-    std::optional<AffineMap> getMaskIndexingMap() {
-      if (!getMask()) return std::nullopt;
-      return getIndexingMapsArray().back();
-    }
-
-    VectorType getVectorType() {
-      return getVector().getType();
-    }
-
-    ShapedType getBaseType() {
-      return cast<ShapedType>(getBase().getType());
-    }
-
-    bool hasTensorSemantics() {
-      return isa<RankedTensorType>(getBase().getType());
-    }
-
-    /// Invert the dest indexing map to get a permutation map suitable for
-    /// vector.transfer_write. The dest map is
-    /// (vector_dims)[symbols] -> (dest_dims). This returns
-    /// (dest_dims) -> (vector_dims), where non-dim results (scattered
-    /// symbols, broadcast constants) become constant 0.
-    AffineMap getPermutationMap() {
-      AffineMap destMap = getDestIndexingMap();
-      MLIRContext *ctx = getContext();
-      SmallVector<AffineExpr> exprs(destMap.getNumDims(),
-                                    getAffineConstantExpr(0, ctx));
-      for (auto [i, expr] : llvm::enumerate(destMap.getResults())) {
-        if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
-          exprs[dimExpr.getPosition()] = getAffineDimExpr(i, ctx);
-        }
-      }
-      return AffineMap::get(destMap.getNumResults(), /*symbolCount=*/0,
-                            exprs, ctx);
-    }
   }];
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -73,7 +73,7 @@ func.func @index_vec_shape_mismatch(%indices: vector<128x64xindex>,
   %cst0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
 
-  // expected-error @+1 {{'iree_vector_ext.transfer_gather' op Mismatched vector shape for index vec at position 0. Expected: [64, 128], got: [128, 64]}}
+  // expected-error @+1 {{'iree_vector_ext.transfer_gather' op mismatched vector shape for index vec at position 0. Expected: [64, 128], got: [128, 64]}}
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0]
   [%indices : vector<128x64xindex>], %cst0 {
     indexing_maps = [affine_map<(d0, d1)[s0] -> (d0, s0)>,
@@ -110,7 +110,7 @@ func.func @scatter_index_vec_shape_mismatch(%indices: vector<128x64xindex>,
 
   %c0 = arith.constant 0 : index
 
-  // expected-error @+1 {{'iree_vector_ext.transfer_scatter' op Mismatched vector shape for index vec at position 0. Expected: [64, 128], got: [128, 64]}}
+  // expected-error @+1 {{'iree_vector_ext.transfer_scatter' op mismatched vector shape for index vec at position 0. Expected: [64, 128], got: [128, 64]}}
   %out = iree_vector_ext.transfer_scatter %vector into %dest[%c0, %c0]
   [%indices : vector<128x64xindex>] {
     indexing_maps = [affine_map<(d0, d1)[s0] -> (d0, s0)>,


### PR DESCRIPTION
These ops are very similar to each other, this patches moves their shared infrastructure to an interface.