### PR TITLE
[LLVMGPU] Handle decomposed masks in ROCDLBufferInstructionsOptimization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -138,6 +138,7 @@ iree_compiler_cc_library(
         "MathTransform.cpp",
         "MemrefCopyToLinalg.cpp",
         "NormalizeLoopBounds.cpp",
+        "OptimizeComparisonOps.cpp",
         "OptimizeTensorInsertExtractSlices.cpp",
         "OptimizeVectorTransfer.cpp",
         "PadDynamicAlloc.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -130,6 +130,7 @@ iree_cc_library(
     "MathTransform.cpp"
     "MemrefCopyToLinalg.cpp"
     "NormalizeLoopBounds.cpp"
+    "OptimizeComparisonOps.cpp"
     "OptimizeTensorInsertExtractSlices.cpp"
     "OptimizeVectorTransfer.cpp"
     "PadDynamicAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeComparisonOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeComparisonOps.cpp
@@ -1,0 +1,293 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h"
+
+#include "llvm/Support/DebugLog.h"
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+
+#include <limits>
+
+#define DEBUG_TYPE "iree-codegen-optimize-comparison-ops"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_OPTIMIZECOMPARISONOPSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+using P = arith::CmpIPredicate;
+
+/// Normalize a comparison so the broadcast operand is on the RHS.
+/// Returns the (possibly flipped) predicate, the vector operand, and the
+/// broadcast source scalar. Returns std::nullopt if neither operand is a
+/// broadcast of a scalar.
+static std::optional<std::tuple<arith::CmpIPredicate, Value, Value>>
+normalizeBroadcastOperands(arith::CmpIOp cmpOp) {
+  Value lhs = cmpOp.getLhs();
+  Value rhs = cmpOp.getRhs();
+  arith::CmpIPredicate pred = cmpOp.getPredicate();
+
+  // Try RHS broadcast first.
+  if (auto bc = rhs.getDefiningOp<vector::BroadcastOp>()) {
+    if (bc.getSource().getType().isIntOrIndex()) {
+      return std::make_tuple(pred, lhs, bc.getSource());
+    }
+  }
+  // Try LHS broadcast -- swap operands so broadcast is on the RHS.
+  // Swapping operands flips the comparison direction:
+  //   lt(a,b) = gt(b,a), le(a,b) = ge(b,a), etc.
+  if (auto bc = lhs.getDefiningOp<vector::BroadcastOp>()) {
+    if (bc.getSource().getType().isIntOrIndex()) {
+      P swapped;
+      switch (pred) {
+      case P::eq:
+        swapped = P::eq;
+        break;
+      case P::ne:
+        swapped = P::ne;
+        break;
+      case P::slt:
+        swapped = P::sgt;
+        break;
+      case P::sle:
+        swapped = P::sge;
+        break;
+      case P::sgt:
+        swapped = P::slt;
+        break;
+      case P::sge:
+        swapped = P::sle;
+        break;
+      case P::ult:
+        swapped = P::ugt;
+        break;
+      case P::ule:
+        swapped = P::uge;
+        break;
+      case P::ugt:
+        swapped = P::ult;
+        break;
+      case P::uge:
+        swapped = P::ule;
+        break;
+      default:
+        assert(false && "unexpected CmpIPredicate");
+      }
+      return std::make_tuple(swapped, rhs, bc.getSource());
+    }
+  }
+  return std::nullopt;
+}
+
+/// Return true if the predicate is strict (< or >, not <= or >=).
+static bool isStrictPredicate(arith::CmpIPredicate pred) {
+  return pred == P::slt || pred == P::sgt || pred == P::ult || pred == P::ugt;
+}
+
+/// Return true if the predicate is a less-than variant (lt or le).
+static bool isLessThanPredicate(arith::CmpIPredicate pred) {
+  return pred == P::slt || pred == P::sle || pred == P::ult || pred == P::ule;
+}
+
+/// Try to simplify a vector cmpi to a scalar comparison broadcast using
+/// divisibility analysis. When the broadcast scalar's divisibility guarantees
+/// that the comparison result is the same for all vector lanes, rewrite to a
+/// scalar comparison broadcast.
+// TODO(Max191): Consider moving this into the upstream OptimizeIntArithmetic /
+// int-range-optimizations pass if it ever runs after vector lowering (or after
+// vector flattening/unrolling). Currently this must run post-vector-lowering
+// to see the 1-D mask computations.
+static void simplifyDivisibleCmpI(IRRewriter &rewriter, arith::CmpIOp cmpOp,
+                                  DataFlowSolver &solver) {
+  auto resultType = dyn_cast<VectorType>(cmpOp.getResult().getType());
+  if (!resultType) {
+    return;
+  }
+
+  auto normalized = normalizeBroadcastOperands(cmpOp);
+  if (!normalized) {
+    return;
+  }
+  auto [pred, vectorVal, broadcastSource] = *normalized;
+
+  // Get range of the vector operand (signed — divisibility analysis is
+  // signed, and eq/ne are signedness-agnostic).
+  auto *vecRangeLattice =
+      solver.lookupState<dataflow::IntegerValueRangeLattice>(vectorVal);
+  if (!vecRangeLattice || vecRangeLattice->getValue().isUninitialized()) {
+    return;
+  }
+  const ConstantIntRanges &vecRange = vecRangeLattice->getValue().getValue();
+
+  auto *divLattice = solver.lookupState<IREE::Util::IntegerDivisibilityLattice>(
+      broadcastSource);
+  if (!divLattice || divLattice->getValue().isUninitialized()) {
+    return;
+  }
+  int64_t sdiv = divLattice->getValue().getValue().sdiv();
+  if (sdiv <= 0) {
+    return;
+  }
+
+  int64_t vecMinS = vecRange.smin().getSExtValue();
+  int64_t vecMaxS = vecRange.smax().getSExtValue();
+
+  LDBG() << "Divisibility cmpi analysis (pred="
+         << arith::stringifyCmpIPredicate(pred) << "):";
+  LDBG() << "  scalar sdiv=" << sdiv << " vecRange=[" << vecMinS << ", "
+         << vecMaxS << "]";
+
+  auto floorDiv = [](int64_t a, int64_t d) -> int64_t {
+    int64_t q = a / d;
+    // Adjust for negative values: if remainder is nonzero and a is negative,
+    // C++ truncation went toward zero but we need toward -inf.
+    if (a % d != 0 && a < 0) {
+      q -= 1;
+    }
+    return q;
+  };
+
+  // eq/ne: if no multiple of sdiv falls within [vecMin, vecMax], then no
+  // vector element can ever equal the scalar, so eq is always false and ne
+  // is always true.
+  if (pred == P::eq || pred == P::ne) {
+    // Guard: vecMinS - 1 must not underflow.
+    if (vecMinS == std::numeric_limits<int64_t>::min()) {
+      return;
+    }
+    // "No multiple in [vecMin, vecMax]" iff floor((vecMin-1)/sdiv) ==
+    // floor(vecMax/sdiv).
+    if (floorDiv(vecMinS - 1, sdiv) != floorDiv(vecMaxS, sdiv)) {
+      return;
+    }
+    LDBG() << "  -> No multiple of sdiv in vector range. Folding to constant.";
+    Location loc = cmpOp.getLoc();
+    rewriter.setInsertionPoint(cmpOp);
+    bool value = (pred == P::ne);
+    auto constAttr = DenseElementsAttr::get(resultType, value);
+    auto constOp = arith::ConstantOp::create(rewriter, loc, constAttr);
+    rewriter.replaceOp(cmpOp, constOp);
+    return;
+  }
+
+  // The divisibility analysis (sdiv) is only valid for signed integers —
+  // unsigned overflow/underflow breaks the modular arithmetic assumptions.
+  bool isUnsigned =
+      (pred == P::ult || pred == P::ule || pred == P::ugt || pred == P::uge);
+  if (isUnsigned) {
+    return;
+  }
+
+  bool isLessThan = isLessThanPredicate(pred);
+  bool isStrict = isStrictPredicate(pred);
+
+  // Check that the vector range lies within a single bucket of size sdiv.
+  // The condition is that the vector's full range does not span any multiple
+  // of sdiv that would cause different vector elements to fall on different
+  // sides of the comparison. The exact interval to check depends on whether
+  // the predicate is strict:
+  //   slt/sge (strict == lessThan): no multiple of sdiv in [vecMin+1, vecMax]
+  //     → floor(vecMin / sdiv) == floor(vecMax / sdiv)
+  //   sle/sgt (strict != lessThan): no multiple of sdiv in [vecMin, vecMax-1]
+  //     → floor((vecMin-1) / sdiv) == floor((vecMax-1) / sdiv)
+  bool needsAdjust = (isStrict != isLessThan);
+  if (needsAdjust) {
+    // Guard: vecMinS - 1 must not underflow.
+    if (vecMinS == std::numeric_limits<int64_t>::min()) {
+      return;
+    }
+    if (floorDiv(vecMinS - 1, sdiv) != floorDiv(vecMaxS - 1, sdiv)) {
+      LDBG() << "  -> Vector range spans multiple buckets. Skipping.";
+      return;
+    }
+  } else {
+    if (floorDiv(vecMinS, sdiv) != floorDiv(vecMaxS, sdiv)) {
+      LDBG() << "  -> Vector range spans multiple buckets. Skipping.";
+      return;
+    }
+  }
+
+  // The threshold distinguishes all-true from all-false:
+  //   slt/sge: all-true boundary at vecMax+1 (strict comparison on vec)
+  //   sle/sgt: all-true boundary at vecMax (non-strict includes vecMax)
+  int64_t threshold;
+  if (needsAdjust) {
+    threshold = vecMaxS;
+  } else {
+    if (vecMaxS == std::numeric_limits<int64_t>::max()) {
+      return;
+    }
+    threshold = vecMaxS + 1;
+  }
+
+  LDBG() << "  threshold=" << threshold;
+  LDBG() << "  -> Uniform. Rewriting to scalar comparison.";
+
+  Location loc = cmpOp.getLoc();
+  rewriter.setInsertionPoint(cmpOp);
+
+  // Emitted predicate:
+  //   slt/sle (lessThan): broadcast(scalar sge threshold)
+  //   sge/sgt (not lessThan): broadcast(scalar slt threshold)
+  arith::CmpIPredicate scalarPred =
+      isLessThan ? arith::CmpIPredicate::sge : arith::CmpIPredicate::slt;
+
+  Value thresholdVal;
+  if (broadcastSource.getType().isIndex()) {
+    thresholdVal = arith::ConstantIndexOp::create(rewriter, loc, threshold);
+  } else {
+    thresholdVal = arith::ConstantIntOp::create(
+        rewriter, loc, threshold,
+        broadcastSource.getType().getIntOrFloatBitWidth());
+  }
+
+  Value scalarCmp = arith::CmpIOp::create(rewriter, loc, scalarPred,
+                                          broadcastSource, thresholdVal);
+  auto broadcast =
+      vector::BroadcastOp::create(rewriter, loc, resultType, scalarCmp);
+  rewriter.replaceOp(cmpOp, broadcast);
+}
+
+//===----------------------------------------------------------------------===//
+// Pass definition
+//===----------------------------------------------------------------------===//
+
+struct OptimizeComparisonOpsPass final
+    : impl::OptimizeComparisonOpsPassBase<OptimizeComparisonOpsPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    FunctionOpInterface funcOp = getOperation();
+
+    // Setup dataflow analyses.
+    DataFlowSolver solver;
+    solver.load<dataflow::SparseConstantPropagation>();
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::IntegerRangeAnalysis>();
+    solver.load<IREE::Util::IntegerDivisibilityAnalysis>();
+    if (failed(solver.initializeAndRun(funcOp))) {
+      return signalPassFailure();
+    }
+
+    IRRewriter rewriter(context);
+
+    // Collect cmpi ops first since simplification may replace them.
+    SmallVector<arith::CmpIOp> cmpOps;
+    funcOp.walk([&](arith::CmpIOp op) { cmpOps.push_back(op); });
+    for (arith::CmpIOp cmpOp : cmpOps) {
+      simplifyDivisibleCmpI(rewriter, cmpOp, solver);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -899,6 +899,20 @@ def NormalizeLoopBoundsPass :
   ];
 }
 
+def OptimizeComparisonOpsPass
+    : InterfacePass<"iree-codegen-optimize-comparison-ops",
+                    "mlir::FunctionOpInterface"> {
+  let summary = "Simplify uniform vector comparisons to scalar broadcasts "
+                "using divisibility analysis";
+  let description = [{
+    Simplifies vector arith.cmpi operations where one operand is a broadcast of
+    a scalar. Uses integer divisibility analysis to determine if the comparison
+    result is uniform across all vector lanes, and rewrites to a scalar
+    comparison broadcast when possible.
+  }];
+  let dependentDialects = ["arith::ArithDialect", "vector::VectorDialect"];
+}
+
 def OptimizeVectorTransferPass :
     InterfacePass<"iree-codegen-optimize-vector-transfer", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -103,6 +103,7 @@ iree_lit_test_suite(
             "materialize_vector_masking.mlir",
             "math_transform.mlir",
             "normalize_loop_bounds.mlir",
+            "optimize_comparison_ops.mlir",
             "optimize_tensor_insert_extract_slices.mlir",
             "pad_dynamic_alloc.mlir",
             "patch_func_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -98,6 +98,7 @@ iree_lit_test_suite(
     "materialize_vector_masking.mlir"
     "math_transform.mlir"
     "normalize_loop_bounds.mlir"
+    "optimize_comparison_ops.mlir"
     "optimize_tensor_insert_extract_slices.mlir"
     "pad_dynamic_alloc.mlir"
     "patch_func_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_comparison_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_comparison_ops.mlir
@@ -1,0 +1,305 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-optimize-comparison-ops, canonicalize, cse))" %s \
+// RUN:   | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Ordered predicates: normal + swapped operands
+//
+// All tests use offset vec [1..4] with sdiv=8 so that both standard
+// (slt/sge) and adjusted (sle/sgt) bucket checks pass, including after
+// normalization flips the predicate for swapped operands.
+//   Standard check: floor(1/8)=0 == floor(4/8)=0, threshold=5
+//   Adjusted check: floor(0/8)=0 == floor(3/8)=0, threshold=4
+//===----------------------------------------------------------------------===//
+
+// slt normal → sge(scalar, 5). Swapped slt(bcast, vec) → sgt(vec, bcast)
+// which uses adjusted check → slt(scalar, 4).
+
+func.func @simplify_slt(%arg0 : index) -> (vector<4xi1>, vector<4xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %c1 = arith.constant 1 : index
+  %step = vector.step : vector<4xindex>
+  %offset = vector.broadcast %c1 : index to vector<4xindex>
+  %vec = arith.addi %step, %offset : vector<4xindex>
+  %bcast = vector.broadcast %bound : index to vector<4xindex>
+  %normal = arith.cmpi slt, %vec, %bcast : vector<4xindex>
+  %swapped = arith.cmpi slt, %bcast, %vec : vector<4xindex>
+  return %normal, %swapped : vector<4xi1>, vector<4xi1>
+}
+
+// CHECK-LABEL: @simplify_slt
+//   CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
+//   CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+//       CHECK: %[[BOUND:.+]] = util.assume.int
+//       CHECK: %[[CMP1:.+]] = arith.cmpi sge, %[[BOUND]], %[[C5]] : index
+//       CHECK: %[[B1:.+]] = vector.broadcast %[[CMP1]] : i1 to vector<4xi1>
+//       CHECK: %[[CMP2:.+]] = arith.cmpi slt, %[[BOUND]], %[[C4]] : index
+//       CHECK: %[[B2:.+]] = vector.broadcast %[[CMP2]] : i1 to vector<4xi1>
+//       CHECK: return %[[B1]], %[[B2]]
+
+// -----
+
+// sge normal → slt(scalar, 5). Swapped sge(bcast, vec) → sle(vec, bcast)
+// which uses adjusted check → sge(scalar, 4).
+
+func.func @simplify_sge(%arg0 : index) -> (vector<4xi1>, vector<4xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %c1 = arith.constant 1 : index
+  %step = vector.step : vector<4xindex>
+  %offset = vector.broadcast %c1 : index to vector<4xindex>
+  %vec = arith.addi %step, %offset : vector<4xindex>
+  %bcast = vector.broadcast %bound : index to vector<4xindex>
+  %normal = arith.cmpi sge, %vec, %bcast : vector<4xindex>
+  %swapped = arith.cmpi sge, %bcast, %vec : vector<4xindex>
+  return %normal, %swapped : vector<4xi1>, vector<4xi1>
+}
+
+// CHECK-LABEL: @simplify_sge
+//   CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
+//   CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+//       CHECK: %[[BOUND:.+]] = util.assume.int
+//       CHECK: %[[CMP1:.+]] = arith.cmpi slt, %[[BOUND]], %[[C5]] : index
+//       CHECK: %[[B1:.+]] = vector.broadcast %[[CMP1]] : i1 to vector<4xi1>
+//       CHECK: %[[CMP2:.+]] = arith.cmpi sge, %[[BOUND]], %[[C4]] : index
+//       CHECK: %[[B2:.+]] = vector.broadcast %[[CMP2]] : i1 to vector<4xi1>
+//       CHECK: return %[[B1]], %[[B2]]
+
+// -----
+
+// sle normal → sge(scalar, 4). Swapped sle(bcast, vec) → sge(vec, bcast)
+// which uses standard check → slt(scalar, 5).
+
+func.func @simplify_sle(%arg0 : index) -> (vector<4xi1>, vector<4xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %c1 = arith.constant 1 : index
+  %step = vector.step : vector<4xindex>
+  %offset = vector.broadcast %c1 : index to vector<4xindex>
+  %vec = arith.addi %step, %offset : vector<4xindex>
+  %bcast = vector.broadcast %bound : index to vector<4xindex>
+  %normal = arith.cmpi sle, %vec, %bcast : vector<4xindex>
+  %swapped = arith.cmpi sle, %bcast, %vec : vector<4xindex>
+  return %normal, %swapped : vector<4xi1>, vector<4xi1>
+}
+
+// CHECK-LABEL: @simplify_sle
+//   CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+//   CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
+//       CHECK: %[[BOUND:.+]] = util.assume.int
+//       CHECK: %[[CMP1:.+]] = arith.cmpi sge, %[[BOUND]], %[[C4]] : index
+//       CHECK: %[[B1:.+]] = vector.broadcast %[[CMP1]] : i1 to vector<4xi1>
+//       CHECK: %[[CMP2:.+]] = arith.cmpi slt, %[[BOUND]], %[[C5]] : index
+//       CHECK: %[[B2:.+]] = vector.broadcast %[[CMP2]] : i1 to vector<4xi1>
+//       CHECK: return %[[B1]], %[[B2]]
+
+// -----
+
+// sgt normal → slt(scalar, 4). Swapped sgt(bcast, vec) → slt(vec, bcast)
+// which uses standard check → sge(scalar, 5).
+
+func.func @simplify_sgt(%arg0 : index) -> (vector<4xi1>, vector<4xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %c1 = arith.constant 1 : index
+  %step = vector.step : vector<4xindex>
+  %offset = vector.broadcast %c1 : index to vector<4xindex>
+  %vec = arith.addi %step, %offset : vector<4xindex>
+  %bcast = vector.broadcast %bound : index to vector<4xindex>
+  %normal = arith.cmpi sgt, %vec, %bcast : vector<4xindex>
+  %swapped = arith.cmpi sgt, %bcast, %vec : vector<4xindex>
+  return %normal, %swapped : vector<4xi1>, vector<4xi1>
+}
+
+// CHECK-LABEL: @simplify_sgt
+//   CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+//   CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
+//       CHECK: %[[BOUND:.+]] = util.assume.int
+//       CHECK: %[[CMP1:.+]] = arith.cmpi slt, %[[BOUND]], %[[C4]] : index
+//       CHECK: %[[B1:.+]] = vector.broadcast %[[CMP1]] : i1 to vector<4xi1>
+//       CHECK: %[[CMP2:.+]] = arith.cmpi sge, %[[BOUND]], %[[C5]] : index
+//       CHECK: %[[B2:.+]] = vector.broadcast %[[CMP2]] : i1 to vector<4xi1>
+//       CHECK: return %[[B1]], %[[B2]]
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// eq/ne predicates
+//===----------------------------------------------------------------------===//
+
+// eq/ne with offset vec [1..4], sdiv=8. No multiple of 8 in [1,4], so
+// eq → false, ne → true. Swapped operands produce the same result (symmetric).
+
+func.func @fold_eq_ne(%arg0 : index)
+    -> (vector<4xi1>, vector<4xi1>, vector<4xi1>, vector<4xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %c1 = arith.constant 1 : index
+  %step = vector.step : vector<4xindex>
+  %offset = vector.broadcast %c1 : index to vector<4xindex>
+  %vec = arith.addi %step, %offset : vector<4xindex>
+  %bcast = vector.broadcast %bound : index to vector<4xindex>
+  %eq_normal = arith.cmpi eq, %vec, %bcast : vector<4xindex>
+  %eq_swapped = arith.cmpi eq, %bcast, %vec : vector<4xindex>
+  %ne_normal = arith.cmpi ne, %vec, %bcast : vector<4xindex>
+  %ne_swapped = arith.cmpi ne, %bcast, %vec : vector<4xindex>
+  return %eq_normal, %eq_swapped, %ne_normal, %ne_swapped
+      : vector<4xi1>, vector<4xi1>, vector<4xi1>, vector<4xi1>
+}
+
+// CHECK-LABEL: @fold_eq_ne
+//   CHECK-DAG: %[[FALSE:.+]] = arith.constant dense<false> : vector<4xi1>
+//   CHECK-DAG: %[[TRUE:.+]] = arith.constant dense<true> : vector<4xi1>
+//       CHECK: return %[[FALSE]], %[[FALSE]], %[[TRUE]], %[[TRUE]]
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative ranges (tests floorDiv rounding)
+//===----------------------------------------------------------------------===//
+
+// slt with negative vec range [-7..-5], sdiv=4. Tests floorDiv rounding:
+// floor(-7/4) = -2 == floor(-5/4) = -2. Threshold = -5 + 1 = -4.
+
+func.func @simplify_slt_negative_range(%arg0 : index) -> vector<3xi1> {
+  %bound = util.assume.int %arg0<udiv = 4> : index
+  %cn7 = arith.constant -7 : index
+  %step = vector.step : vector<3xindex>
+  %offset = vector.broadcast %cn7 : index to vector<3xindex>
+  %vec = arith.addi %step, %offset : vector<3xindex>
+  %bcast = vector.broadcast %bound : index to vector<3xindex>
+  %mask = arith.cmpi slt, %vec, %bcast : vector<3xindex>
+  return %mask : vector<3xi1>
+}
+
+// CHECK-LABEL: @simplify_slt_negative_range
+//   CHECK-NOT: arith.cmpi slt
+//   CHECK-DAG: %[[CN4:.+]] = arith.constant -4 : index
+//       CHECK: arith.cmpi sge, %{{.*}}, %[[CN4]] : index
+//       CHECK: vector.broadcast
+//       CHECK: return
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative tests
+//===----------------------------------------------------------------------===//
+
+// Cross-bucket: vec [4..11] spans floor(4/8)=0 and floor(11/8)=1.
+
+func.func @no_simplify_cross_bucket(%arg0 : index) -> vector<8xi1> {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %c4 = arith.constant 4 : index
+  %step = vector.step : vector<8xindex>
+  %offset = vector.broadcast %c4 : index to vector<8xindex>
+  %vec = arith.addi %step, %offset : vector<8xindex>
+  %bcast = vector.broadcast %bound : index to vector<8xindex>
+  %mask = arith.cmpi slt, %vec, %bcast : vector<8xindex>
+  return %mask : vector<8xi1>
+}
+
+// CHECK-LABEL: @no_simplify_cross_bucket
+//       CHECK: vector.broadcast %{{.*}} : index to vector<8xindex>
+//       CHECK: arith.cmpi slt, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return
+
+// -----
+
+// sle at boundary: vec [0..7] with sdiv=8. The adjusted bucket check
+// floor(-1/8)=-1 != floor(6/8)=0. Fails because scalar=0 would give
+// 0<=0=T but 1<=0=F.
+
+func.func @no_simplify_sle_at_boundary(%arg0 : index) -> vector<8xi1> {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %step = vector.step : vector<8xindex>
+  %bcast = vector.broadcast %bound : index to vector<8xindex>
+  %mask = arith.cmpi sle, %step, %bcast : vector<8xindex>
+  return %mask : vector<8xi1>
+}
+
+// CHECK-LABEL: @no_simplify_sle_at_boundary
+//       CHECK: vector.broadcast %{{.*}} : index to vector<8xindex>
+//       CHECK: arith.cmpi sle, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return
+
+// -----
+
+// sgt at boundary: same adjusted check as sle — vec [0..7] fails.
+
+func.func @no_simplify_sgt_at_boundary(%arg0 : index) -> vector<8xi1> {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %step = vector.step : vector<8xindex>
+  %bcast = vector.broadcast %bound : index to vector<8xindex>
+  %mask = arith.cmpi sgt, %step, %bcast : vector<8xindex>
+  return %mask : vector<8xi1>
+}
+
+// CHECK-LABEL: @no_simplify_sgt_at_boundary
+//       CHECK: vector.broadcast %{{.*}} : index to vector<8xindex>
+//       CHECK: arith.cmpi sgt, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return
+
+// -----
+
+// Insufficient divisibility: udiv=4 with vec width 8 spans multiple buckets.
+
+func.func @no_simplify_insufficient_divisibility(%arg0 : index) -> vector<8xi1> {
+  %bound = util.assume.int %arg0<udiv = 4> : index
+  %step = vector.step : vector<8xindex>
+  %bcast = vector.broadcast %bound : index to vector<8xindex>
+  %mask = arith.cmpi slt, %step, %bcast : vector<8xindex>
+  return %mask : vector<8xi1>
+}
+
+// CHECK-LABEL: @no_simplify_insufficient_divisibility
+//       CHECK: vector.broadcast %{{.*}} : index to vector<8xindex>
+//       CHECK: arith.cmpi slt, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return
+
+// -----
+
+// No broadcast operand — neither operand is a vector.broadcast.
+
+func.func @no_simplify_no_broadcast(
+    %v1 : vector<8xindex>, %v2 : vector<8xindex>) -> vector<8xi1> {
+  %mask = arith.cmpi slt, %v1, %v2 : vector<8xindex>
+  return %mask : vector<8xi1>
+}
+
+// CHECK-LABEL: @no_simplify_no_broadcast
+//       CHECK: arith.cmpi slt, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return
+
+// -----
+
+// Unsigned predicates: divisibility rewrite is not applied.
+
+func.func @no_simplify_unsigned(%arg0 : index) -> (vector<8xi1>, vector<8xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %step = vector.step : vector<8xindex>
+  %bcast = vector.broadcast %bound : index to vector<8xindex>
+  %ult = arith.cmpi ult, %step, %bcast : vector<8xindex>
+  %uge = arith.cmpi uge, %step, %bcast : vector<8xindex>
+  return %ult, %uge : vector<8xi1>, vector<8xi1>
+}
+
+// CHECK-LABEL: @no_simplify_unsigned
+//       CHECK: arith.cmpi ult, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: arith.cmpi uge, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return
+
+// -----
+
+// eq/ne with vec [0..7] and sdiv=8: 0 is a multiple of 8 so the range
+// contains a multiple. Cannot fold.
+
+func.func @no_fold_eq_ne_has_multiple(%arg0 : index) -> (vector<8xi1>, vector<8xi1>) {
+  %bound = util.assume.int %arg0<udiv = 8> : index
+  %step = vector.step : vector<8xindex>
+  %bcast = vector.broadcast %bound : index to vector<8xindex>
+  %eq = arith.cmpi eq, %step, %bcast : vector<8xindex>
+  %ne = arith.cmpi ne, %step, %bcast : vector<8xindex>
+  return %eq, %ne : vector<8xi1>, vector<8xi1>
+}
+
+// CHECK-LABEL: @no_fold_eq_ne_has_multiple
+//       CHECK: vector.broadcast %{{.*}} : index to vector<8xindex>
+//       CHECK: arith.cmpi eq, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: arith.cmpi ne, %{{.*}}, %{{.*}} : vector<8xindex>
+//       CHECK: return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -392,8 +392,6 @@ static void addGPUBufferizePasses(OpPassManager &funcPassManager) {
 
   addIREEPostBufferizationPasses(funcPassManager);
 
-  funcPassManager.addPass(createROCDLBufferInstructionsOptimizationPass());
-
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
@@ -564,7 +562,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/true,
-                            /*decomposeMasks=*/false);
+                            /*decomposeMasks=*/true);
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
@@ -996,7 +994,14 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createCSEPass);
 
   if (forROCDL) {
-    // This pass needs to run after the LLVMGPUVectorLoweringPass.
+    // Simplify uniform vector comparisons to scalar broadcasts using integer
+    // range and divisibility analysis. Gated on ROCDL to avoid DataFlowSolver
+    // overhead on other GPU targets (e.g. SPIR-V) where this optimization has
+    // no current benefit.
+    funcPassManager.addPass(createOptimizeComparisonOpsPass);
+    // Simplify masked buffer reads/loads. This must run after vector lowering
+    // (all vectors are 1D) and before AmdgpuMaskedloadToLoad.
+    funcPassManager.addPass(createROCDLBufferInstructionsOptimizationPass);
     funcPassManager.addPass(amdgpu::createAmdgpuMaskedloadToLoadPass);
     // This pass needs to run before the ResolveSwizzleHints pass.
     funcPassManager.addPass(amdgpu::createAmdgpuFoldMemRefOpsPass);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -6,12 +6,7 @@
 
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
-#include "iree/compiler/Codegen/Utils/Utils.h"
-#include "iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h"
-#include "llvm/Support/DebugLog.h"
-#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
-#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
-#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/IR/Matchers.h"
 
 #define DEBUG_TYPE "iree-codegen-rocdl-buffer-instructions-optimization"
 
@@ -22,207 +17,144 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-Value createI1And(Location loc, ArrayRef<Value> values, OpBuilder &builder) {
-  Value base = arith::IndexCastUIOp::create(builder, loc, builder.getI1Type(),
-                                            values[0]);
-  for (Value value : values.drop_front()) {
-    Value rhs =
-        arith::IndexCastUIOp::create(builder, loc, builder.getI1Type(), value);
-    base = arith::AndIOp::create(builder, loc, base, rhs);
+//===----------------------------------------------------------------------===//
+// Simplify masked buffer reads/loads with broadcast mask.
+//
+// When a vector.transfer_read or vector.maskedload from a fat_raw_buffer has
+// a mask that is vector.broadcast(%scalar_i1), replace with an unmasked
+// read/load + arith.select. If the mask is always true, just return the
+// unmasked read/load directly.
+//===----------------------------------------------------------------------===//
+
+/// Check if a value is a vector.broadcast of a scalar i1. If so, return
+/// the scalar source.
+static Value getBroadcastScalarI1(Value mask) {
+  auto broadcastOp = mask.getDefiningOp<vector::BroadcastOp>();
+  if (!broadcastOp) {
+    return nullptr;
   }
-  return base;
+  Value source = broadcastOp.getSource();
+  if (!source.getType().isInteger(1)) {
+    return nullptr;
+  }
+  return source;
 }
 
-// Check if the innermost mask index is divisible by the mask size using
-// divisibility analysis. Returns true if divisible or if analysis is
-// inconclusive.
-static bool isInnermostMaskIndexDivisible(Value maskIndex, int64_t maskSize,
-                                          DataFlowSolver &solver) {
-  auto *lattice =
-      solver.lookupState<IREE::Util::IntegerDivisibilityLattice>(maskIndex);
+/// Check if a scalar i1 value is a constant true.
+static bool isConstantTrue(Value scalarI1) {
+  return matchPattern(scalarI1, m_One());
+}
 
-  if (lattice && !lattice->getValue().isUninitialized()) {
-    const IREE::Util::ConstantIntDivisibility &div =
-        lattice->getValue().getValue();
-    LDBG() << "Divisibility analysis for mask index:";
-    LDBG() << "  udiv = " << div.udiv() << ", sdiv = " << div.sdiv();
-    LDBG() << "  mask size = " << maskSize;
-
-    // Check if the mask index is divisible by the mask size.
-    if (div.udiv() % maskSize == 0) {
-      LDBG() << "  -> Divisible! Can optimize.";
-      return true;
-    }
-    LDBG() << "  -> Not divisible. Skipping optimization.";
+/// Simplify a masked vector.transfer_read from a fat_raw_buffer.
+static bool simplifyMaskedTransferRead(IRRewriter &rewriter,
+                                       vector::TransferReadOp readOp) {
+  // Must have a mask.
+  Value mask = readOp.getMask();
+  if (!mask) {
     return false;
   }
-  LDBG() << "Divisibility analysis uninitialized for mask index. Skipping.";
-  return false;
-}
 
-// Determine if the mask vector is all ones or all zeros and if so, then replace
-// the masked transferReadOp with transferReadOp with no mask for when the mask
-// is all ones and the padding values when the mask is all zeros. The pattern
-// thus does the following optimization.
-//
-// Case 1: Unit dimensions with dynamic indices.
-// clang-format off
-// mask = vector.create_mask %0, ..., %n, %c8 : vector<1x ... x1x8xi1>
-// %read = vector.transfer_read %memref, %mask : memref<..., amdgpu.raw_fat_buffer>
-// becomes
-// %padding = arith.constant dense<0> : vector<1x ... x1x8xbf16>
-// %read = vector.transfer_read %memref : memref<..., amdgpu.raw_fat_buffer> // no mask!
-// %masked_read
-//   = arith.select %0 && ... && %n ? %read : %padding : index,vector<1x ... x1x8xbf16>
-//
-// Case 2: Innermost dimension with divisible dynamic index.
-// When the innermost mask dimension has a dynamic index that is divisible by the
-// mask size (determined via divisibility analysis), we can optimize similarly:
-// %divisible = util.assume.int %arg<udiv = 8> : index
-// mask = vector.create_mask %c1, %divisible : vector<1x8xi1>
-// %read = vector.transfer_read %memref, %mask : memref<1x?xbf16, amdgpu.raw_fat_buffer>
-// becomes
-// %padding = arith.constant dense<0> : vector<1x8xbf16>
-// %cmp = arith.cmpi eq, %divisible, %c8 : index
-// %read = vector.transfer_read %memref : memref<1x?xbf16, amdgpu.raw_fat_buffer> // no mask!
-// %masked_read = arith.select %cmp, %read, %padding : vector<1x8xbf16>
-// clang-format on
-// Note we currently dont support cases where multiple masks are ANDed or ORed
-// together to form the final mask to a read but such support can be added where
-// we track a set of valid masks and add that an AND or OR of valid masks is
-// valid.
-void simplifyMaskOps(RewriterBase &rewriter, vector::CreateMaskOp maskOp,
-                     DataFlowSolver &solver) {
-  Location loc = maskOp.getLoc();
-
-  // First determine if the mask meets the criteria of being either all ones or
-  // all empty.
-  SmallVector<Value> valuesToAnd;
-  SmallVector<Value> maskIndices = maskOp.getOperands();
-  ArrayRef<int64_t> maskShape = maskOp.getResult().getType().getShape();
-  bool isValid = true;
-  Value innermostNonConstantMaskIndex = nullptr;
-  for (auto [idx, maskIndex] : llvm::enumerate(maskIndices)) {
-
-    std::optional<int64_t> constantValue = getConstantIndex(maskIndex);
-    if (constantValue) {
-      if (maskShape[idx] != constantValue) {
-        isValid = false;
-        break;
-      }
-    } else {
-      // For non-constant mask indices, we either need:
-      // 1. The mask shape dimension to be 1 (will be added to valuesToAnd).
-      // 2. Or it's the innermost dimension (will be handled specially if stride
-      // is divisible).
-      bool isInnermostDim = (idx == maskIndices.size() - 1);
-      if (maskShape[idx] == 1) {
-        valuesToAnd.push_back(maskIndex);
-      } else if (isInnermostDim) {
-        // Save this for later stride divisibility check.
-        innermostNonConstantMaskIndex = maskIndex;
-      } else {
-        isValid = false;
-        break;
-      }
-    }
-  }
-  // Bail out if the mask doesnt meet the criteria or
-  // is statically all 1's in which case we dont need
-  // to do anything.
-  if (!isValid || (valuesToAnd.empty() && !innermostNonConstantMaskIndex)) {
-    return;
+  // Mask must be vector.broadcast of scalar i1.
+  Value scalarMask = getBroadcastScalarI1(mask);
+  if (!scalarMask) {
+    return false;
   }
 
-  for (Operation *user : maskOp.getResult().getUsers()) {
-    auto readOp = dyn_cast<vector::TransferReadOp>(user);
-    // Only TransferReadOps are supported.
-    if (!readOp) {
-      continue;
-    }
+  // Source must be fat_raw_buffer.
+  auto sourceType = dyn_cast<MemRefType>(readOp.getBase().getType());
+  if (!sourceType || !hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+    return false;
+  }
 
-    auto sourceType = dyn_cast<MemRefType>(readOp.getBase().getType());
-    // Only supported for fat raw buffers.
-    if (!sourceType || !hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
-      continue;
-    }
+  // Must be fully in_bounds.
+  SmallVector<bool> inBounds = readOp.getInBoundsValues();
+  if (llvm::any_of(inBounds, [](bool b) { return !b; })) {
+    return false;
+  }
 
-    SmallVector<bool> inBounds = readOp.getInBoundsValues();
-    // Only supported for reads that are fully in_bounds.
-    if (inBounds.size() != sourceType.getRank() ||
-        llvm::any_of(inBounds, [](bool inBound) { return !inBound; })) {
-      continue;
-    }
+  Location loc = readOp.getLoc();
+  rewriter.setInsertionPoint(readOp);
 
-    rewriter.setInsertionPoint(readOp);
+  // Create unmasked read, preserving the original permutation map.
+  auto newReadOp = vector::TransferReadOp::create(
+      rewriter, loc, readOp.getVectorType(), readOp.getBase(),
+      readOp.getIndices(), readOp.getPadding(), readOp.getPermutationMap(),
+      ArrayRef<bool>(inBounds));
 
-    Value selectValue = nullptr;
-
-    // Check if we need to handle the innermost dimension specially.
-    if (innermostNonConstantMaskIndex) {
-      int64_t innerDimIdx = sourceType.getRank() - 1;
-      int64_t maskInnerDimSize = maskShape[innerDimIdx];
-
-      // Use divisibility analysis to check if optimization is valid.
-      if (!isInnermostMaskIndexDivisible(innermostNonConstantMaskIndex,
-                                         maskInnerDimSize, solver)) {
-        continue;
-      }
-
-      // Create a compare: innerDimMaskIndex == maskInnerDimSize.
-      Value maskSizeConstant =
-          arith::ConstantIndexOp::create(rewriter, loc, maskInnerDimSize);
-      Value cmpResult = arith::CmpIOp::create(
-          rewriter, loc, arith::CmpIPredicate::eq,
-          innermostNonConstantMaskIndex, maskSizeConstant);
-
-      // Start with this comparison.
-      if (valuesToAnd.empty()) {
-        selectValue = cmpResult;
-      } else {
-        // Combine with other mask conditions.
-        Value andValue = createI1And(loc, valuesToAnd, rewriter);
-        selectValue = arith::AndIOp::create(rewriter, loc, andValue, cmpResult);
-      }
-    } else {
-      // No special innermost handling needed.
-      selectValue = createI1And(loc, valuesToAnd, rewriter);
-    }
-    auto constantValue = vector::BroadcastOp::create(
+  if (isConstantTrue(scalarMask)) {
+    // Always-true: just use the unmasked read directly.
+    rewriter.replaceOp(readOp, newReadOp);
+  } else {
+    // Conditional: select between the read and the padding.
+    auto paddingBroadcast = vector::BroadcastOp::create(
         rewriter, loc, readOp.getVectorType(), readOp.getPadding());
-
-    auto newReadOp = vector::TransferReadOp::create(
-        rewriter, loc, readOp.getVectorType(), readOp.getBase(),
-        readOp.getIndices(), readOp.getPadding(), ArrayRef<bool>{inBounds});
-    auto selectOp = arith::SelectOp::create(rewriter, loc, selectValue,
-                                            newReadOp, constantValue);
-    rewriter.replaceAllUsesWith(readOp, selectOp);
+    auto selectOp = arith::SelectOp::create(rewriter, loc, scalarMask,
+                                            newReadOp, paddingBroadcast);
+    rewriter.replaceOp(readOp, selectOp);
   }
+  return true;
 }
+
+/// Simplify a masked vector.maskedload from a fat_raw_buffer.
+static bool simplifyMaskedLoad(IRRewriter &rewriter,
+                               vector::MaskedLoadOp maskedLoadOp) {
+  // Mask must be vector.broadcast of scalar i1.
+  Value scalarMask = getBroadcastScalarI1(maskedLoadOp.getMask());
+  if (!scalarMask) {
+    return false;
+  }
+
+  // Source must be fat_raw_buffer.
+  auto sourceType = dyn_cast<MemRefType>(maskedLoadOp.getBase().getType());
+  if (!sourceType || !hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+    return false;
+  }
+
+  Location loc = maskedLoadOp.getLoc();
+  rewriter.setInsertionPoint(maskedLoadOp);
+
+  // Create unmasked vector.load.
+  auto loadOp =
+      vector::LoadOp::create(rewriter, loc, maskedLoadOp.getResult().getType(),
+                             maskedLoadOp.getBase(), maskedLoadOp.getIndices());
+
+  if (isConstantTrue(scalarMask)) {
+    // Always-true: just use the unmasked load directly.
+    rewriter.replaceOp(maskedLoadOp, loadOp);
+  } else {
+    // Conditional: select between the load and the passthru.
+    auto selectOp = arith::SelectOp::create(rewriter, loc, scalarMask, loadOp,
+                                            maskedLoadOp.getPassThru());
+    rewriter.replaceOp(maskedLoadOp, selectOp);
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass definition
+//===----------------------------------------------------------------------===//
 
 struct ROCDLBufferInstructionsOptimizationPass final
     : impl::ROCDLBufferInstructionsOptimizationPassBase<
           ROCDLBufferInstructionsOptimizationPass> {
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     FunctionOpInterface funcOp = getOperation();
 
-    // Setup divisibility analysis.
-    DataFlowSolver solver;
-    solver.load<dataflow::SparseConstantPropagation>();
-    solver.load<dataflow::DeadCodeAnalysis>();
-    solver.load<IREE::Util::IntegerDivisibilityAnalysis>();
-    if (failed(solver.initializeAndRun(funcOp))) {
-      return signalPassFailure();
-    }
+    IRRewriter rewriter(&getContext());
 
-    SmallVector<vector::CreateMaskOp> maskOps;
-    funcOp.walk(
-        [&](vector::CreateMaskOp maskOp) { maskOps.push_back(maskOp); });
-
-    IRRewriter rewriter(context);
-    for (vector::CreateMaskOp maskOp : maskOps) {
-      simplifyMaskOps(rewriter, maskOp, solver);
+    // Simplify masked buffer reads/loads with broadcast mask.
+    SmallVector<Operation *> maskedOps;
+    funcOp.walk([&](Operation *op) {
+      if (isa<vector::TransferReadOp, vector::MaskedLoadOp>(op)) {
+        maskedOps.push_back(op);
+      }
+    });
+    for (Operation *op : maskedOps) {
+      if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
+        simplifyMaskedTransferRead(rewriter, readOp);
+      } else if (auto maskedLoadOp = dyn_cast<vector::MaskedLoadOp>(op)) {
+        simplifyMaskedLoad(rewriter, maskedLoadOp);
+      }
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -21,13 +21,15 @@ def ROCDLAnnotateKernelForTranslationPass : Pass<
 
 def ROCDLBufferInstructionsOptimizationPass :
     InterfacePass<"iree-rocdl-buffer-instructions-optimization", "mlir::FunctionOpInterface"> {
-  let summary = "Optimizations possible with buffer fat pointers";
+  let summary = "Simplify masked buffer reads/loads for ROCDL fat raw buffers";
   let description = [{
-    Buffer fat pointers support out of bound access so we can make use of this
-    feature for optimizations.
+    Removes masks from buffer reads/loads (vector.transfer_read,
+    vector.maskedload) when the mask is a broadcast of a scalar i1,
+    replacing with an unmasked operation and arith.select.
 
     This pass is a no-op on non-ROCDL targets.
   }];
+  let dependentDialects = ["arith::ArithDialect", "vector::VectorDialect"];
 }
 
 def ROCDLConfigureBufferInstructionsPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/buffer_instructions_optimization.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/buffer_instructions_optimization.mlir
@@ -2,281 +2,265 @@
 // RUN: --pass-pipeline="builtin.module(func.func(iree-rocdl-buffer-instructions-optimization, canonicalize, cse))" %s \
 // RUN:  | FileCheck %s
 
-func.func @simplify_mask(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+// vector.broadcast of a dynamic scalar i1 mask on transfer_read.
+
+func.func @simplify_broadcast_mask_transfer_read(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %cond : i1) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
-  return %read : vector<1x1x1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  %read = vector.transfer_read %mem[%c0], %cst, %mask
+      {in_bounds = [true]}
+      : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_mask
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
-//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x1x1x8xbf16>
-//       CHECK: %[[LHS:.+]] = arith.index_castui %[[ARG1]] : index to i1
-//       CHECK: %[[RHS:.+]] = arith.index_castui %[[ARG2]] : index to i1
-//       CHECK: %[[AND:.+]] = arith.andi %[[LHS]], %[[RHS]] : i1
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//       CHECK: %[[SEL:.+]] = arith.select %[[AND]], %[[READ]], %[[CST]] : vector<1x1x1x8xbf16>
-//       CHECK: return %[[SEL]] : vector<1x1x1x8xbf16>
+// CHECK-LABEL: @simplify_broadcast_mask_transfer_read
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[COND:.+]]: i1)
+//   CHECK-DAG: %[[PAD:.+]] = arith.constant dense<0.000000e+00> : vector<8xbf16>
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[MEM]]
+//  CHECK-SAME:   {in_bounds = [true]} : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+//       CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[READ]], %[[PAD]] : vector<8xbf16>
+//       CHECK: return %[[SEL]] : vector<8xbf16>
 
 // -----
 
-func.func @simplify_mask2(%1 : memref<?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index) -> vector<1x8xbf16> {
+// vector.broadcast of a dynamic scalar i1 mask on maskedload.
+
+func.func @simplify_broadcast_mask_maskedload(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %cond : i1) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %index1, %c8 : vector<1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
-  return %read : vector<1x8xbf16>
+  %passthru = arith.constant dense<0.0> : vector<8xbf16>
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  %load = vector.maskedload %mem[%c0], %mask, %passthru
+      : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+        vector<8xi1>, vector<8xbf16> into vector<8xbf16>
+  return %load : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_mask2
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index)
-//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x8xbf16>
-//       CHECK: %[[COND:.+]] = arith.index_castui %[[ARG1]] : index to i1
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//       CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[READ]], %[[CST]] : vector<1x8xbf16>
-//       CHECK: return %[[SEL]] : vector<1x8xbf16>
+// CHECK-LABEL: @simplify_broadcast_mask_maskedload
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[COND:.+]]: i1)
+//   CHECK-DAG: %[[PT:.+]] = arith.constant dense<0.000000e+00> : vector<8xbf16>
+//       CHECK: %[[LOAD:.+]] = vector.load %[[MEM]]
+//       CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[LOAD]], %[[PT]] : vector<8xbf16>
+//       CHECK: return %[[SEL]] : vector<8xbf16>
 
 // -----
 
-func.func @simplify_mask3(%1 : memref<?x?x1x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index, %index3 : index) -> vector<1x1x1x1x8xbf16> {
+// Constant true mask on transfer_read -> direct unmasked read.
+
+func.func @simplify_constant_true_transfer_read(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>)
+    -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %index1, %index2, %c1, %index3, %c8 : vector<1x1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true, true]} : memref<?x?x1x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x1x8xbf16>
-  return %read : vector<1x1x1x1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %true = arith.constant true
+  %mask = vector.broadcast %true : i1 to vector<8xi1>
+  %read = vector.transfer_read %mem[%c0], %cst, %mask
+      {in_bounds = [true]}
+      : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_mask3
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<?x?x1x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
-//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x1x1x1x8xbf16>
-//   CHECK-DAG: %[[LHS:.+]] = arith.index_castui %[[ARG1]] : index to i1
-//   CHECK-DAG: %[[MID:.+]] = arith.index_castui %[[ARG2]] : index to i1
-//       CHECK: %[[AND1:.+]] = arith.andi %[[LHS]], %[[MID]] : i1
-//   CHECK-DAG: %[[RHS:.+]] = arith.index_castui %[[ARG3]] : index to i1
-//       CHECK: %[[AND2:.+]] = arith.andi %[[AND1]], %[[RHS]] : i1
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//       CHECK: %[[SEL:.+]] = arith.select %[[AND2]], %[[READ]], %[[CST]] : vector<1x1x1x1x8xbf16>
-//       CHECK: return %[[SEL]] : vector<1x1x1x1x8xbf16>
+// CHECK-LABEL: @simplify_constant_true_transfer_read
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>)
+//   CHECK-NOT: arith.select
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[MEM]]
+//  CHECK-SAME:   {in_bounds = [true]} : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+//       CHECK: return %[[READ]] : vector<8xbf16>
 
 // -----
 
-func.func @simplify_mask4(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %2 : vector<1x1x1x8xbf16>,
-  %3 : vector<1x1x1x8xbf16>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+// Constant true mask on maskedload -> direct vector.load.
+
+func.func @simplify_constant_true_maskedload(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>)
+    -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
-  vector.transfer_write %2, %1[%c0, %c0, %c0, %c0], %mask {in_bounds = [true, true, true, true]} : vector<1x1x1x8xbf16>, memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
-  vector.transfer_write %3, %1[%c0, %c0, %c0, %c0], %mask {in_bounds = [true, true, true, true]} : vector<1x1x1x8xbf16>, memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>
-  return %read : vector<1x1x1x8xbf16>
+  %passthru = arith.constant dense<0.0> : vector<8xbf16>
+  %true = arith.constant true
+  %mask = vector.broadcast %true : i1 to vector<8xi1>
+  %load = vector.maskedload %mem[%c0], %mask, %passthru
+      : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+        vector<8xi1>, vector<8xbf16> into vector<8xbf16>
+  return %load : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_mask4
-//  CHECK-SAME:  (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: vector<1x1x1x8xbf16>, %[[ARG2:.+]]: vector<1x1x1x8xbf16>, %[[ARG3:.+]]: index, %[[ARG4:.+]]: index)
-//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x1x1x8xbf16>
-//   CHECK-DAG: %[[CSTBF16:.+]] = arith.constant 1.000000e+00 : bf16
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask %{{.+}}, %[[ARG3]], %[[ARG4]], %{{.+}} : vector<1x1x1x8xi1>
-//       CHECK: vector.transfer_write %[[ARG1]], %[[ARG0]]{{.+}}, %[[MASK]]
-//       CHECK: %[[IDX1:.+]] = arith.index_castui %[[ARG3]] : index to i1
-//       CHECK: %[[IDX2:.+]] = arith.index_castui %[[ARG4]] : index to i1
-//       CHECK: %[[AND:.+]] = arith.andi %[[IDX1]], %[[IDX2]] : i1
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]{{.+}}, %[[CSTBF16]]
-//       CHECK: %[[SEL:.+]] = arith.select %[[AND]], %[[READ]], %[[CST]]
-//       CHECK: vector.transfer_write %[[ARG2]], %[[ARG0]]{{.+}}, %[[MASK]]
-//       CHECK: return %[[SEL]]
+// CHECK-LABEL: @simplify_constant_true_maskedload
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>)
+//   CHECK-NOT: arith.select
+//   CHECK-NOT: vector.maskedload
+//       CHECK: %[[LOAD:.+]] = vector.load %[[MEM]]
+//       CHECK: return %[[LOAD]] : vector<8xbf16>
 
 // -----
 
-func.func @simplify_mask5(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %2 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
-    %index1 : index, %index2 : index) -> (vector<1x1x1x8xbf16>, vector<1x1x1x8xbf16>)  {
+// Non-fat-buffer memref should not be simplified.
+
+func.func @no_simplify_non_fat_buffer(
+    %mem : memref<8xbf16>,
+    %cond : i1) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
-  %read2 = vector.transfer_read %2[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
-  return %read, %read2 : vector<1x1x1x8xbf16>,  vector<1x1x1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  %read = vector.transfer_read %mem[%c0], %cst, %mask
+      {in_bounds = [true]}
+      : memref<8xbf16>, vector<8xbf16>
+  return %read : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_mask5
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
-//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x1x1x8xbf16>
-//   CHECK-DAG: %[[CSTBF16:.+]] = arith.constant 1.000000e+00 : bf16
-//       CHECK: %[[IDX1:.+]] = arith.index_castui %[[ARG2]] : index to i1
-//       CHECK: %[[IDX2:.+]] = arith.index_castui %[[ARG3]] : index to i1
-//       CHECK: %[[AND:.+]] = arith.andi %[[IDX1]], %[[IDX2]] : i1
-//       CHECK: %[[READ0:.+]] = vector.transfer_read %[[ARG0]]{{.+}}, %[[CSTBF16]]
-//       CHECK: %[[SEL0:.+]] = arith.select %[[AND]], %[[READ0]], %[[CST]]
-//       CHECK: %[[READ1:.+]] = vector.transfer_read %[[ARG1]]{{.+}}, %[[CSTBF16]]
-//       CHECK: %[[SEL1:.+]] = arith.select %[[AND]], %[[READ1]], %[[CST]]
-//       CHECK: return %[[SEL0]], %[[SEL1]]
+// CHECK-LABEL: @no_simplify_non_fat_buffer
+//       CHECK: vector.broadcast
+//       CHECK: vector.transfer_read {{.*}} %{{.*}} :
+//       CHECK: return
 
 // -----
 
-func.func @no_simplify_mask_no_fat_raw_buffer(%1 : memref<1x?x?x8xbf16>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+// transfer_read not in_bounds should not be simplified.
+
+func.func @no_simplify_not_in_bounds(
+    %mem : memref<6xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %cond : i1) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16>, vector<1x1x1x8xbf16>
-  return %read : vector<1x1x1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  %read = vector.transfer_read %mem[%c0], %cst, %mask
+      {in_bounds = [false]}
+      : memref<6xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
 }
 
-// CHECK-LABEL: @no_simplify_mask_no_fat_raw_buffer
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16>, %{{.+}}: index, %{{.+}}: index)
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//  CHECK-SAME: %[[MASK]]
-//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+// CHECK-LABEL: @no_simplify_not_in_bounds
+//       CHECK: vector.broadcast
+//       CHECK: vector.transfer_read {{.*}} %{{.*}} :
+//       CHECK: return
 
 // -----
 
-func.func @no_simplify_mask_tensor(%1 : tensor<1x?x?x8xbf16>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+// Mask not from vector.broadcast should not be simplified.
+
+func.func @no_simplify_non_broadcast_mask(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %mask : vector<8xi1>) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : tensor<1x?x?x8xbf16>, vector<1x1x1x8xbf16>
-  return %read : vector<1x1x1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %read = vector.transfer_read %mem[%c0], %cst, %mask
+      {in_bounds = [true]}
+      : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
 }
 
-// CHECK-LABEL: @no_simplify_mask_tensor
-//  CHECK-SAME:   (%[[ARG0:.+]]: tensor<1x?x?x8xbf16>, %{{.+}}: index, %{{.+}}: index)
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//  CHECK-SAME: %[[MASK]]
-//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+// CHECK-LABEL: @no_simplify_non_broadcast_mask
+//       CHECK: vector.transfer_read {{.*}} %{{.*}} :
+//       CHECK: return
 
 // -----
 
-func.func @no_simplify_mask_outofbounds(%1 : memref<1x?x?x6xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+// Masked transfer_write should not be simplified (only reads are handled).
+
+func.func @no_simplify_masked_transfer_write(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %vec : vector<8xbf16>,
+    %cond : i1) {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, false]} : memref<1x?x?x6xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
-  return %read : vector<1x1x1x8xbf16>
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  vector.transfer_write %vec, %mem[%c0], %mask
+      {in_bounds = [true]}
+      : vector<8xbf16>, memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>
+  return
 }
 
-// CHECK-LABEL: @no_simplify_mask_outofbounds
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x6xbf16, #amdgpu.address_space<fat_raw_buffer>>, %{{.+}}: index, %{{.+}}: index)
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//  CHECK-SAME: %[[MASK]]
-//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+// CHECK-LABEL: @no_simplify_masked_transfer_write
+//       CHECK: vector.broadcast
+//       CHECK: vector.transfer_write
+//       CHECK: return
 
 // -----
 
-func.func @no_simplify_partial_mask(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+// Multi-dimensional transfer_read with broadcast mask should be simplified.
+
+func.func @simplify_broadcast_mask_2d_read(
+    %mem : memref<4x8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %cond : i1) -> vector<4x8xbf16> {
   %c0 = arith.constant 0 : index
-  %c6 = arith.constant 6 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c6 : vector<1x1x1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
-  return %read : vector<1x1x1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %mask = vector.broadcast %cond : i1 to vector<4x8xi1>
+  %read = vector.transfer_read %mem[%c0, %c0], %cst, %mask
+      {in_bounds = [true, true]}
+      : memref<4x8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+        vector<4x8xbf16>
+  return %read : vector<4x8xbf16>
 }
 
-// CHECK-LABEL: @no_simplify_partial_mask
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %{{.+}}: index, %{{.+}}: index)
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//  CHECK-SAME: %[[MASK]]
-//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+// CHECK-LABEL: @simplify_broadcast_mask_2d_read
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<4x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[COND:.+]]: i1)
+//   CHECK-DAG: %[[PAD:.+]] = arith.constant dense<0.000000e+00> : vector<4x8xbf16>
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[MEM]]
+//  CHECK-SAME:   {in_bounds = [true, true]}
+//       CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[READ]], %[[PAD]] : vector<4x8xbf16>
+//       CHECK: return %[[SEL]] : vector<4x8xbf16>
 
 // -----
 
-func.func @no_simplify_mask_nonunit(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x2x8xbf16> {
+// Maskedload with non-broadcast mask should not be simplified.
+
+func.func @no_simplify_maskedload_non_broadcast_mask(
+    %mem : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %mask : vector<8xi1>) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x2x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x2x8xbf16>
-  return %read : vector<1x1x2x8xbf16>
+  %passthru = arith.constant dense<0.0> : vector<8xbf16>
+  %load = vector.maskedload %mem[%c0], %mask, %passthru
+      : memref<8xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+        vector<8xi1>, vector<8xbf16> into vector<8xbf16>
+  return %load : vector<8xbf16>
 }
 
-// CHECK-LABEL: @no_simplify_mask_nonunit
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %{{.+}}: index, %{{.+}}: index)
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//  CHECK-SAME: %[[MASK]]
-//       CHECK: return %[[READ]] : vector<1x1x2x8xbf16>
+// CHECK-LABEL: @no_simplify_maskedload_non_broadcast_mask
+//       CHECK: vector.maskedload
+//       CHECK: return
 
 // -----
 
-// This type of simplification is taken care of by canonicalization directly, the test just shows
-// that we didnt break that behavior.
-func.func @simplify_trivial(%1 : memref<1x8xbf16, #amdgpu.address_space<fat_raw_buffer>>) -> vector<1x8xbf16> {
+// Maskedload from non-fat-buffer memref should not be simplified.
+
+func.func @no_simplify_maskedload_non_fat_buffer(
+    %mem : memref<8xbf16>,
+    %cond : i1) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %mask = vector.create_mask %c1, %c8 : vector<1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<1x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
-  return %read : vector<1x8xbf16>
+  %passthru = arith.constant dense<0.0> : vector<8xbf16>
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  %load = vector.maskedload %mem[%c0], %mask, %passthru
+      : memref<8xbf16>, vector<8xi1>, vector<8xbf16> into vector<8xbf16>
+  return %load : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_trivial
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x8xbf16, #amdgpu.address_space<fat_raw_buffer>>)
-//   CHECK-NOT: vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//       CHECK: return %[[READ]] : vector<1x8xbf16>
+// CHECK-LABEL: @no_simplify_maskedload_non_fat_buffer
+//       CHECK: vector.maskedload
+//       CHECK: return
 
 // -----
 
-func.func @simplify_divisible_innermost(%1 : memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, %arg0 : index) -> vector<1x8xbf16> {
+// Non-identity permutation map on transfer_read should be preserved.
+// Use affine_map<(d0, d1) -> (d0)> to read along the first dimension,
+// which is not the minor identity and will be printed explicitly.
+
+func.func @simplify_broadcast_mask_permutation_map(
+    %mem : memref<8x4xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %cond : i1) -> vector<8xbf16> {
   %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %c8 = arith.constant 8 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %divisible = util.assume.int %arg0<udiv = 8> : index
-  %mask = vector.create_mask %c1, %divisible : vector<1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
-  return %read : vector<1x8xbf16>
+  %cst = arith.constant 0.0 : bf16
+  %mask = vector.broadcast %cond : i1 to vector<8xi1>
+  %read = vector.transfer_read %mem[%c0, %c0], %cst, %mask
+      {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d0)>}
+      : memref<8x4xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
 }
 
-// CHECK-LABEL: @simplify_divisible_innermost
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index)
-//   CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
-//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x8xbf16>
-//   CHECK-DAG: %[[CSTBF16:.+]] = arith.constant 1.000000e+00 : bf16
-//       CHECK: %[[DIV:.+]] = util.assume.int %[[ARG1]]<udiv = 8> : index
-//       CHECK: %[[CMP:.+]] = arith.cmpi eq, %[[DIV]], %[[C8]] : index
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]{{.+}}, %[[CSTBF16]]
-//  CHECK-SAME: {in_bounds = [true, true]} : memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
-//       CHECK: %[[SEL:.+]] = arith.select %[[CMP]], %[[READ]], %[[CST]] : vector<1x8xbf16>
-//       CHECK: return %[[SEL]] : vector<1x8xbf16>
-
-// -----
-
-func.func @no_simplify_not_divisible(%1 : memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, %arg0 : index) -> vector<1x8xbf16> {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %c8 = arith.constant 8 : index
-  %cst = arith.constant 1.000000e+00 : bf16
-  %divisible = util.assume.int %arg0<udiv = 7> : index
-  %mask = vector.create_mask %c1, %divisible : vector<1x8xi1>
-  %read = vector.transfer_read %1[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
-  return %read : vector<1x8xbf16>
-}
-
-// CHECK-LABEL: @no_simplify_not_divisible
-//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index)
-//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
-//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
-//  CHECK-SAME: %[[MASK]]
-//       CHECK: return %[[READ]] : vector<1x8xbf16>
+// CHECK-LABEL: @simplify_broadcast_mask_permutation_map
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<8x4xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[COND:.+]]: i1)
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[MEM]]
+//  CHECK-SAME:   permutation_map = #map
+//       CHECK: arith.select %[[COND]], %[[READ]]
+//       CHECK: return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1343,8 +1343,7 @@ hal.executable public @main {
 // CHECK-DAG:     %[[ALLOCA_SUBVIEW:.+]] = memref.subview %[[ALLOCA]]{{.*}} : memref<4x1xi32, #gpu.address_space<private>> to memref<4xi32, strided<[1]>, #gpu.address_space<private>>
 // CHECK:         scf.forall {{.*}} in (16, 4) {
 // CHECK:           scf.for
-// CHECK:             %[[MASK:.+]] = vector.create_mask
-// CHECK:             %[[READ0:.+]] = vector.transfer_read{{.*}} %[[MASK]]
+// CHECK:             %[[READ0:.+]] = vector.transfer_read %{{.*}}, %[[C42]], %{{.*}} :
 // CHECK-DAG:         %[[READ:.+]] = vector.transfer_read{{.*}}: memref<1x4xi32, strided<[4, 1]>, #gpu.address_space<private>>, vector<4xi32>
 // CHECK-DAG:         vector.transfer_write %[[READ]]{{.*}}: vector<4xi32>, memref<16x4x16x32xi32, #amdgpu.address_space<fat_raw_buffer>>
 


### PR DESCRIPTION
The tile-and-fuse pipeline now decomposes masks (`decomposeMasks=true`), producing step+broadcast+cmpi+andi IR instead of create_mask ops. This commit adapts the ROCDL buffer optimization passes to work with the new IR shape.

**ROCDLBufferInstructionsOptimization** is simplified to pattern-match `vector.broadcast(%scalar_i1)` as the mask on `vector.transfer_read` and `vector.maskedload`, replacing with an unmasked operation + `arith.select` (or just the unmasked operation if the mask is constant true). Moved from post-bufferize to after vector lowering in the pipeline.

**OptimizeComparisonOps** is a new pass that simplifies vector `arith.cmpi` where one operand is a broadcast of a scalar with known divisibility. Uses IREE's `IntegerDivisibilityAnalysis` to determine if the comparison result is uniform across all vector lanes, and rewrites to a scalar comparison + broadcast.