### PR TITLE
[Common] Update ComplexChain definition in CombineSourceLayoutTransform

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
@@ -606,8 +607,9 @@ static void collectRelayoutChain(Operation *relayoutOp,
 /// collapse_shape).
 /// - The chain must contain at least one op that is not extract_slice or a
 /// reshape op.
-/// - Do not insert MapLoad if the chain's last op's user is
-/// tensor.insert_slice.
+/// - The chain must not contain any op that carries a `lowering_config`
+/// attribute, since such ops are roots for downstream transformations (e.g.
+/// tiling) and should not be folded into a MapLoad.
 static bool isComplexRelayoutChain(Operation *relayoutOp) {
   assert(isSupportedSingleInputRelayoutOpForSource(relayoutOp) &&
          "expected a supported relayout op");
@@ -626,21 +628,9 @@ static bool isComplexRelayoutChain(Operation *relayoutOp) {
   if (!hasReshape || allReshapeOrExtractSlice) {
     return false;
   }
-  // Do not insert MapLoad if the chain's last op's user is tensor.insert_slice.
-  auto isLastOp = [&](Operation *chainOp) {
-    return !llvm::any_of(
-        chainOp->getResult(0).getUsers(),
-        [&](Operation *userOp) { return chain.contains(userOp); });
-  };
-  for (Operation *chainOp : chain) {
-    if (!isLastOp(chainOp)) {
-      continue;
-    }
-    for (Operation *userOp : chainOp->getResult(0).getUsers()) {
-      if (isa<tensor::InsertSliceOp>(userOp)) {
-        return false;
-      }
-    }
+  if (llvm::any_of(chain,
+                   [](Operation *op) { return getLoweringConfig(op); })) {
+    return false;
   }
   return true;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -606,6 +606,8 @@ static void collectRelayoutChain(Operation *relayoutOp,
 /// collapse_shape).
 /// - The chain must contain at least one op that is not extract_slice or a
 /// reshape op.
+/// - Do not insert MapLoad if the chain's last op's user is
+/// tensor.insert_slice.
 static bool isComplexRelayoutChain(Operation *relayoutOp) {
   assert(isSupportedSingleInputRelayoutOpForSource(relayoutOp) &&
          "expected a supported relayout op");
@@ -621,7 +623,26 @@ static bool isComplexRelayoutChain(Operation *relayoutOp) {
   bool allReshapeOrExtractSlice = llvm::all_of(
       chain, llvm::IsaPred<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
                            tensor::ExtractSliceOp>);
-  return hasReshape && !allReshapeOrExtractSlice;
+  if (!hasReshape || allReshapeOrExtractSlice) {
+    return false;
+  }
+  // Do not insert MapLoad if the chain's last op's user is tensor.insert_slice.
+  auto isLastOp = [&](Operation *chainOp) {
+    return !llvm::any_of(
+        chainOp->getResult(0).getUsers(),
+        [&](Operation *userOp) { return chain.contains(userOp); });
+  };
+  for (Operation *chainOp : chain) {
+    if (!isLastOp(chainOp)) {
+      continue;
+    }
+    for (Operation *userOp : chainOp->getResult(0).getUsers()) {
+      if (isa<tensor::InsertSliceOp>(userOp)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 /// Collects direct relayout op users of `loadResult` that start complex

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -392,6 +392,32 @@ func.func @complex_chain_reshape_and_transpose(%buffer : memref<4x8xf32>) -> ten
 
 // -----
 
+// Chain with a complex relayout op chain feeding into a tensor.insert_slice.
+func.func @complex_chain_into_insert_slice(%buffer : memref<4x8xf32>) -> tensor<16x4x4xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<4x8xf32> -> tensor<4x8xf32>
+  %expanded = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 2, 8] : tensor<4x8xf32> into tensor<2x2x8xf32>
+  %init = tensor.empty() : tensor<8x2x2xf32>
+  %transposed = linalg.transpose ins(%expanded : tensor<2x2x8xf32>) outs(%init : tensor<8x2x2xf32>) permutation = [2, 0, 1]
+  %dest = tensor.empty() : tensor<16x4x4xf32>
+  %result = tensor.insert_slice %transposed into %dest[0, 0, 0] [8, 2, 2] [1, 1, 1] : tensor<8x2x2xf32> into tensor<16x4x4xf32>
+  return %result : tensor<16x4x4xf32>
+}
+// CHECK-LABEL: @complex_chain_into_insert_slice
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   tensor.expand_shape
+//       CHECK:   linalg.transpose
+//   CHECK-NOT:   iree_linalg_ext.map_load
+//       CHECK:   tensor.insert_slice
+// FOLD-LABEL: @complex_chain_into_insert_slice
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   iree_codegen.load_from_buffer
+//       FOLD:   iree_linalg_ext.map_load
+//       FOLD:   } : tensor<4x8xf32> into tensor<8x2x2xf32> -> tensor<8x2x2xf32>
+//       FOLD:   tensor.insert_slice
+
+// -----
+
 // Chain broadcast -> pad -> expand_shape folds into map_load, but copy doesn't
 // because it uses expand_shape's result (later map_load) as outs (operand 1).
 func.func @fold_broadcast_pad_expand_shape(%buffer : memref<2x64xf32>, %batch : index) -> tensor<1x4x16x4x2x16xf32> {

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -392,29 +392,27 @@ func.func @complex_chain_reshape_and_transpose(%buffer : memref<4x8xf32>) -> ten
 
 // -----
 
-// Chain with a complex relayout op chain feeding into a tensor.insert_slice.
-func.func @complex_chain_into_insert_slice(%buffer : memref<4x8xf32>) -> tensor<16x4x4xf32> {
+// Chain with a complex relayout op chain where an op has a lowering_config.
+// Ops with lowering_config are roots for downstream transformations and should
+// not be folded into a MapLoad.
+func.func @complex_chain_with_lowering_config(%buffer : memref<4x8xf32>) -> tensor<2x2x8xf32> {
   %source = iree_codegen.load_from_buffer %buffer : memref<4x8xf32> -> tensor<4x8xf32>
   %expanded = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 2, 8] : tensor<4x8xf32> into tensor<2x2x8xf32>
-  %init = tensor.empty() : tensor<8x2x2xf32>
-  %transposed = linalg.transpose ins(%expanded : tensor<2x2x8xf32>) outs(%init : tensor<8x2x2xf32>) permutation = [2, 0, 1]
-  %dest = tensor.empty() : tensor<16x4x4xf32>
-  %result = tensor.insert_slice %transposed into %dest[0, 0, 0] [8, 2, 2] [1, 1, 1] : tensor<8x2x2xf32> into tensor<16x4x4xf32>
-  return %result : tensor<16x4x4xf32>
+  %init = tensor.empty() : tensor<2x2x8xf32>
+  %copy = linalg.copy {lowering_config = #iree_gpu.derived_thread_config} ins(%expanded : tensor<2x2x8xf32>) outs(%init : tensor<2x2x8xf32>) -> tensor<2x2x8xf32>
+  return %copy : tensor<2x2x8xf32>
 }
-// CHECK-LABEL: @complex_chain_into_insert_slice
+// CHECK-LABEL: @complex_chain_with_lowering_config
 //  CHECK-SAME:   %[[BUFFER:.+]]:
 //       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
 //       CHECK:   tensor.expand_shape
-//       CHECK:   linalg.transpose
+//       CHECK:   linalg.copy
 //   CHECK-NOT:   iree_linalg_ext.map_load
-//       CHECK:   tensor.insert_slice
-// FOLD-LABEL: @complex_chain_into_insert_slice
+// FOLD-LABEL: @complex_chain_with_lowering_config
 //  FOLD-SAME:   %[[BUFFER:.+]]:
 //       FOLD:   iree_codegen.load_from_buffer
 //       FOLD:   iree_linalg_ext.map_load
-//       FOLD:   } : tensor<4x8xf32> into tensor<8x2x2xf32> -> tensor<8x2x2xf32>
-//       FOLD:   tensor.insert_slice
+//       FOLD:   } : tensor<4x8xf32> into tensor<2x2x8xf32> -> tensor<2x2x8xf32>
 
 // -----
 


### PR DESCRIPTION
With the regression reported in https://github.com/iree-org/iree/pull/23814 we see the following IR snippet :-

```
%78 = scf.for %arg9 = %c0 to %c512 step %c512 iter_args(%arg10 = %arg8) -> (tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ>) {
  %79 = affine.apply affine_map<(d0, d1) -> (d0 + d1)>(%arg9, %arg4)
  %80:8 = affine.delinearize_index %79 into (1, 1, 1, 8, 4, 16, 1, 1) : index, index, index, index, index, index, index, index
  %extracted_slice_7 = tensor.extract_slice %51[%63, %arg6, %80#3, %80#4, %80#5, 0, 0] [1, 1, 1, 1, 1, 2, 8] [1, 1, 1, 1, 1, 1, 1] : tensor<?x64x8x4x16x2x8xf8E4M3FNUZ> to tensor<1x1x1x1x1x2x8xf8E4M3FNUZ>
  %extracted_slice_8 = tensor.extract_slice %arg10[0, 0, 0, %80#3, %80#4, %80#5, 0, 0] [1, 1, 1, 1, 1, 1, 2, 8] [1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ> to tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>
  %expanded = tensor.expand_shape %extracted_slice_7 [[0, 1], [2], [3], [4], [5], [6], [7]] output_shape [1, 1, 1, 1, 1, 1, 2, 8] : tensor<1x1x1x1x1x2x8xf8E4M3FNUZ> into tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>
  %81 = linalg.copy {lowering_config = #iree_gpu.derived_thread_config} ins(%expanded : tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>) outs(%extracted_slice_8 : tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>) -> tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>
  %inserted_slice = tensor.insert_slice %81 into %arg10[0, 0, 0, %80#3, %80#4, %80#5, 0, 0] [1, 1, 1, 1, 1, 1, 2, 8] [1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ> into tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ>
  scf.yield %inserted_slice : tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ>
} {unroll_loop}
```

The above snippet has a "complex relayout op chain" as per the definition established in `CombineSourceLayoutTransform` pass [here](https://github.com/iree-org/iree/blob/e8853aa2794e427a3a0f41b045ccc39873ee62ab/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp#L602-L608).

And thus we end up with the following IR :-
```
%79 = scf.for %arg9 = %c0 to %c512 step %c512 iter_args(%arg10 = %arg8) -> (tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ>) {
  %80 = affine.apply affine_map<(d0, d1) -> (d0 + d1)>(%arg9, %arg4)
  %81:8 = affine.delinearize_index %80 into (1, 1, 1, 8, 4, 16, 1, 1) : index, index, index, index, index, index, index, index
  %82 = tensor.empty() : tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>
  %83 = iree_linalg_ext.map_load %52 into %82 {
  ^bb0(%arg11: index, %arg12: index, %arg13: index, %arg14: index, %arg15: index, %arg16: index, %arg17: index, %arg18: index):
    %84 = affine.linearize_index disjoint [%arg11, %arg12, %arg13, %arg14, %arg15, %arg16, %arg17, %arg18] by (1, 1, 1, 1, 1, 1, 2, 8) : index
    %85:7 = affine.delinearize_index %84 into (1, 1, 1, 1, 1, 2, 8) : index, index, index, index, index, index, index
    %86 = arith.addi %64, %85#0 overflow<nsw> : index
    %87 = arith.addi %arg6, %85#1 overflow<nsw> : index
    %88 = arith.addi %81#3, %85#2 overflow<nsw> : index
    %89 = arith.addi %81#4, %85#3 overflow<nsw> : index
    %90 = arith.addi %81#5, %85#4 overflow<nsw> : index
    iree_linalg_ext.yield %86, %87, %88, %89, %90, %85#5, %85#6, %0 : index, index, index, index, index, index, index, f8E4M3FNUZ
  } : tensor<?x64x8x4x16x2x8xf8E4M3FNUZ> into tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ> -> tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ>
  %inserted_slice = tensor.insert_slice %83 into %arg10[0, 0, 0, %81#3, %81#4, %81#5, 0, 0] [1, 1, 1, 1, 1, 1, 2, 8] [1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x1x1x2x8xf8E4M3FNUZ> into tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ>
  scf.yield %inserted_slice : tensor<1x1x1x8x4x16x2x8xf8E4M3FNUZ>
} {unroll_loop}
```

For [prefill_bs4$dispatch_17.mlir](https://gist.github.com/Abhishek-Varma/fe353e3e30054e62dd7839630e89401b) we see that the effect is that this dispatch runs 2x slower.

As the definition of what comprises a "complex relayout op chain" is a heuristics - this patch aims to add another extension to the same heuristics by preventing insertion of `map_load` in case any of the relayout ops have a `lowering_config` attached to them.

With the change, the entire llama 8b fp8 regression reported stands resolved.

Changes made in the current patch were also tested on the [previous 3 regressions](https://github.com/iree-org/iree/pull/23735) that necessitated the creation of `map_load` op/pass. So, the current patch simply makes the insertion of `map_load` more conservative while ensuring the regressions get solved.