### PR TITLE
[Codegen] Set upstream GPU attributes to set bounds on subgroup ID

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchSizeBounds.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchSizeBounds.cpp
@@ -232,6 +232,17 @@ struct PropagateDispatchSizeBoundsPass final
                        staticSubgroupSize);
     applyBounds(funcOp, workgroupSizes, workgroupCounts, maxSubgroupSize,
                 subgroupIdBound);
+
+    if (auto *gpuDialect = getContext().getLoadedDialect<gpu::GPUDialect>()) {
+      if (staticWorkgroupSize) {
+        SmallVector<int32_t, 3> blockSize(3, 1);
+        for (auto [idx, s] : llvm::enumerate(*staticWorkgroupSize)) {
+          blockSize[idx] = static_cast<int32_t>(s);
+        }
+        gpuDialect->getKnownBlockSizeAttrHelper().setAttr(
+            funcOp, DenseI32ArrayAttr::get(funcOp->getContext(), blockSize));
+      }
+    }
   }
 };
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchSizeBounds.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchSizeBounds.cpp
@@ -235,10 +235,9 @@ struct PropagateDispatchSizeBoundsPass final
 
     if (auto *gpuDialect = getContext().getLoadedDialect<gpu::GPUDialect>()) {
       if (staticWorkgroupSize) {
-        SmallVector<int32_t, 3> blockSize(3, 1);
-        for (auto [idx, s] : llvm::enumerate(*staticWorkgroupSize)) {
-          blockSize[idx] = static_cast<int32_t>(s);
-        }
+        std::array<int32_t, 3> blockSize = {1, 1, 1};
+        llvm::transform(ArrayRef<int64_t>{*staticWorkgroupSize}.take_front(3),
+                        blockSize.begin(), llvm::StaticCastTo<int32_t>);
         gpuDialect->getKnownBlockSizeAttrHelper().setAttr(
             funcOp, DenseI32ArrayAttr::get(funcOp->getContext(), blockSize));
       }

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
@@ -24,6 +24,7 @@ hal.executable private @static {
     } attributes {workgroup_size = [64 : index, 2 : index, 1 : index]}
     builtin.module {
 // CHECK-LABEL: func.func @static()
+// CHECK-SAME: gpu.known_block_size = array<i32: 64, 2, 1>
       func.func @static() {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
         %lane_id = gpu.lane_id
@@ -180,6 +181,7 @@ hal.executable private @gfx942_not_really_variable_subgroup {
     } attributes {workgroup_size = [128 : index, 1 : index, 1 : index]}
     builtin.module {
 // CHECK-LABEL: func.func @gfx942_not_really_variable_subgroup()
+// CHECK-SAME: gpu.known_block_size = array<i32: 128, 1, 1>
       func.func @gfx942_not_really_variable_subgroup() {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
         %lane_id = gpu.lane_id

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -355,7 +355,6 @@ struct ConvertToROCDLPass final
       RewritePatternSet patterns(&getContext());
       populateGpuRewritePatterns(patterns);
       populateGpuPromoteShuffleToAMDGPUPatterns(patterns, maybeChipset);
-      populateGpuSubgroupIdPatterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         return signalPassFailure();
       }


### PR DESCRIPTION
1. This removes the call to the subgroup ID expansion patterns in ConvertToROCDL, matching all the other targets (which don't use this pass), which will enable subgroup ID to correctly lower to rocdl.wave.id on gfx12!
2. To make that pattern work efficiently, set the gpu.known_block_size attribute on functions when propagating dispatch size bounds so that those OCKL calls become constants pre-gfx12 and so that, when thread_id gets emitted, we get the correct ranges in place.

(This will hopefully make Wave's job a bit easier)