### PR TITLE
[HAL] Support sub-byte element types in buffer view size calculation

### DIFF
--- a/runtime/src/iree/hal/buffer_view.c
+++ b/runtime/src/iree/hal/buffer_view.c
@@ -52,13 +52,14 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_create(
     iree_hal_buffer_retain(buffer_view->buffer);
     buffer_view->element_type = element_type;
     buffer_view->encoding_type = encoding_type;
-    buffer_view->byte_length =
-        iree_hal_element_dense_byte_count(buffer_view->element_type);
     buffer_view->shape_rank = shape_rank;
+    iree_device_size_t element_count = 1;
     for (iree_host_size_t i = 0; i < shape_rank; ++i) {
       buffer_view->shape[i] = shape[i];
-      buffer_view->byte_length *= shape[i];
+      element_count *= shape[i];
     }
+    buffer_view->byte_length = iree_hal_element_packed_byte_count(
+        buffer_view->element_type, element_count);
     *out_buffer_view = buffer_view;
   }
 

--- a/runtime/src/iree/hal/buffer_view.h
+++ b/runtime/src/iree/hal/buffer_view.h
@@ -116,6 +116,13 @@ typedef uint8_t iree_hal_numerical_type_t;
 #define iree_hal_element_dense_byte_count(element_type) \
   ((iree_hal_element_bit_count(element_type) + 8 - 1) / 8)
 
+// Returns the total byte count for |element_count| densely-packed elements of
+// |element_type|. For sub-byte types, multiple elements share a byte
+// (e.g. 8 i4 elements = 4 bytes). For byte-aligned types, this is equivalent
+// to element_count * iree_hal_element_dense_byte_count(element_type).
+#define iree_hal_element_packed_byte_count(element_type, element_count) \
+  (((element_count) * iree_hal_element_bit_count(element_type) + 7) / 8)
+
 // Returns true if the given |element_type| represents an integer of exactly
 // |bit_width|. This ignores the signedness of the integer type.
 #define iree_hal_element_type_is_integer(element_type, bit_width) \

--- a/runtime/src/iree/hal/buffer_view_util.c
+++ b/runtime/src/iree/hal/buffer_view_util.c
@@ -31,16 +31,16 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_size(
 
   switch (encoding_type) {
     case IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR: {
-      if (IREE_UNLIKELY(iree_hal_element_bit_count(element_type) == 0) ||
-          IREE_UNLIKELY(!iree_hal_element_is_byte_aligned(element_type))) {
-        return iree_make_status(
-            IREE_STATUS_INVALID_ARGUMENT,
-            "opaque and sub-byte aligned element types cannot be indexed");
+      if (IREE_UNLIKELY(iree_hal_element_bit_count(element_type) == 0)) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "opaque element types cannot be indexed");
       }
-      byte_length = iree_hal_element_dense_byte_count(element_type);
+      iree_device_size_t element_count = 1;
       for (iree_host_size_t i = 0; i < shape_rank; ++i) {
-        byte_length *= shape[i];
+        element_count *= shape[i];
       }
+      byte_length =
+          iree_hal_element_packed_byte_count(element_type, element_count);
       break;
     }
     default:

--- a/tests/e2e/subbyte_types/subbyte_types.mlir
+++ b/tests/e2e/subbyte_types/subbyte_types.mlir
@@ -1,3 +1,7 @@
+//===----------------------------------------------------------------------===//
+// i1 tests
+//===----------------------------------------------------------------------===//
+
 func.func @i1_type() {
   %c0 = arith.constant 0 : index
   %c255 = arith.constant 255 : i8
@@ -95,5 +99,31 @@ func.func @truncate_i1_2() {
   } -> tensor<4x4xi1, #iree_encoding.packed_storage>
   %tensor_res = flow.tensor.bitcast %truncm : tensor<4x4xi1, #iree_encoding.packed_storage> -> tensor<2xi8>
   check.expect_eq_const(%tensor_res, dense<[60, 195]> : tensor<2xi8>) : tensor<2xi8>
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// i4 tests
+//===----------------------------------------------------------------------===//
+
+func.func @i4_add() {
+  %lhs = util.unfoldable_constant dense<[1, 2, 3, 4]> : tensor<4xi4>
+  %rhs = util.unfoldable_constant dense<[1, 1, 1, 1]> : tensor<4xi4>
+  %empty = tensor.empty() : tensor<4xi4>
+  %res = linalg.generic
+        {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+        ins(%lhs, %rhs : tensor<4xi4>, tensor<4xi4>) outs(%empty: tensor<4xi4>) {
+  ^bb0(%inlhs: i4, %inrhs: i4, %out: i4):
+    %inres = arith.addi %inlhs, %inrhs: i4
+    linalg.yield %inres : i4
+  } -> tensor<4xi4>
+  check.expect_eq_const(%res, dense<[2, 3, 4, 5]> : tensor<4xi4>) : tensor<4xi4>
+  return
+}
+
+func.func @i4_representation_2d() {
+  %input = util.unfoldable_constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi4>
+  %bar = util.optimization_barrier %input : tensor<2x2xi4>
+  check.expect_eq_const(%bar, dense<[[1, 2], [3, 4]]> : tensor<2x2xi4>) : tensor<2x2xi4>
   return
 }


### PR DESCRIPTION
Compute packed size `ceil(elements * bits / 8)` instead of rejecting sub-byte types. Add i4 e2e tests.