### PR TITLE
[Codegen][CAPI] Fix C API assertion for GPU pipeline attributes in TranslationInfoAttr

### DIFF
--- a/compiler/bindings/c/iree/compiler/dialects/iree_codegen.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_codegen.h
@@ -37,7 +37,9 @@ ireeAttributeIsACodegenTranslationInfoAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirTypeID ireeCodegenTranslationInfoAttrGetTypeID(void);
 
 struct ireeCodegenTranslationInfoParameters {
-  MlirAttribute passPipeline;      // DispatchLoweringPassPipelineAttr.
+  // DispatchLoweringPassPipelineAttr or any attribute implementing
+  // PipelineAttrInterface (e.g., #iree_gpu.pipeline<...>).
+  MlirAttribute passPipeline;
   MlirAttribute codegenSpec;       // Optional SymbolRefAttr.
   const int64_t *workgroupSize;    // Optional ArrayRef<int64_t>.
   size_t numWorkgroupSizeElements; // Size of the ArrayRef above.

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -157,6 +157,25 @@ def codegen_translation_info_full():
     assert translation_info.configuration == configuration
 
 
+@run
+def codegen_translation_info_with_gpu_pipeline():
+    """Test TranslationInfoAttr with GPU PipelineAttr."""
+    gpu_pipeline_attr = iree_gpu.PipelineAttr.get(
+        iree_gpu.LoweringPipeline.VectorDistribute
+    )
+
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        gpu_pipeline_attr, None, [64, 4, 1], 32
+    )
+    assert translation_info is not None
+    assert translation_info.pass_pipeline == gpu_pipeline_attr
+    assert translation_info.codegen_spec is None
+    assert translation_info.workgroup_size == [64, 4, 1]
+    assert translation_info.subgroup_size == 32
+    assert translation_info.configuration is None
+    assert "#iree_gpu.pipeline<VectorDistribute>" in str(translation_info)
+
+
 # ======================================================================
 # IREE GPU Dialect
 # ======================================================================

--- a/compiler/src/iree/compiler/API/Internal/IREECodegenDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREECodegenDialectCAPI.cpp
@@ -16,6 +16,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/dialects/iree_codegen.h"
+#include "iree/compiler/dialects/iree_gpu.h"
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/AffineMap.h"
@@ -76,9 +77,13 @@ MlirTypeID ireeCodegenTranslationInfoAttrGetTypeID() {
 MlirAttribute ireeCodegenTranslationInfoAttrGet(
     MlirContext mlirCtx, ireeCodegenTranslationInfoParameters parameters) {
   assert(!mlirAttributeIsNull(parameters.passPipeline) &&
-         ireeAttributeIsACodegenDispatchLoweringPassPipelineAttr(
-             parameters.passPipeline) &&
-         "Invalid pass pipeline attr");
+         "Invalid pass pipeline attr: cannot be null");
+
+  assert(
+      (ireeAttributeIsACodegenDispatchLoweringPassPipelineAttr(
+           parameters.passPipeline) ||
+       ireeAttributeIsAGPUPipelineAttr(parameters.passPipeline)) &&
+      "passPipeline must be DispatchLoweringPassPipelineAttr or PipelineAttr");
 
   assert((mlirAttributeIsNull(parameters.codegenSpec) ||
           mlirAttributeIsASymbolRef(parameters.codegenSpec)) &&
@@ -88,10 +93,7 @@ MlirAttribute ireeCodegenTranslationInfoAttrGet(
           mlirAttributeIsADictionary(parameters.configuration)) &&
          "Invalid configuration attr");
 
-  DispatchLoweringPassPipeline passPipeline =
-      llvm::cast<DispatchLoweringPassPipelineAttr>(
-          unwrap(parameters.passPipeline))
-          .getValue();
+  mlir::Attribute pipelineAttr = unwrap(parameters.passPipeline);
   auto codegenSpec = llvm::cast_if_present<mlir::SymbolRefAttr>(
       unwrap(parameters.codegenSpec));
 
@@ -106,8 +108,8 @@ MlirAttribute ireeCodegenTranslationInfoAttrGet(
       unwrap(parameters.configuration));
 
   mlir::MLIRContext *ctx = unwrap(mlirCtx);
-  return wrap(TranslationInfoAttr::get(ctx, passPipeline, codegenSpec,
-                                       workgroupSize, subgroupSize,
+  return wrap(TranslationInfoAttr::get(ctx, pipelineAttr, codegenSpec,
+                                       workgroupSize, subgroupSize.value_or(0),
                                        configuration));
 }
 


### PR DESCRIPTION
Context: some changes happen from the IREE side: 
- https://github.com/iree-org/iree/pull/23590
- https://github.com/iree-org/iree/pull/23687
- https://github.com/iree-org/iree/pull/23816
and tuner CI error: https://github.com/nod-ai/amd-shark-ai/actions/runs/23314739415/job/67811065632?pr=2865#step:8:135

This PR fixes the C API assertion in `TranslationInfoAttr.get()` to accept `PipelineAttr` in addition to `DispatchLoweringPassPipelineAttr`

 Assisted-by:  [Claude Code](https://claude.ai/code)