### PR TITLE
[DispatchCreation] Dynamic selection of split reduction target tile size for outer reductions 

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -91,6 +91,18 @@ getOuterReductionSizes(PartialReductionOpInterface op,
   }
   SmallVector<int64_t> opReductionSizes = std::move(*maybeSizes);
 
+  // Compute total reduction work to determine the optimal target size.
+  int64_t totalReductionWork = 1;
+  for (int64_t dimSize : opReductionSizes) {
+    totalReductionWork *= dimSize;
+  }
+  // Scale the target tile size proportionally to the total reduction work.
+  // The formula below is determined based on empirical data.
+  int64_t scaledTarget = std::min<int64_t>(
+      splitReductionTargetSize,
+      std::max<int64_t>(4, static_cast<int64_t>(std::ceil(std::sqrt(
+                               static_cast<double>(totalReductionWork))))));
+
   int64_t currentSplitReductionSize = 1;
   SmallVector<int64_t> tileSizes(opReductionSizes.size());
   // Tile dimensions until we reach or exceed the target. Tile sizes must
@@ -98,7 +110,7 @@ getOuterReductionSizes(PartialReductionOpInterface op,
   // we prefer tiling those.
   for (int64_t i = tileSizes.size() - 1; i >= 0; i--) {
     int64_t remainingSize =
-        llvm::divideCeil(splitReductionTargetSize, currentSplitReductionSize);
+        llvm::divideCeil(scaledTarget, currentSplitReductionSize);
     int64_t dimSize = opReductionSizes[i];
     if (dimSize == ShapedType::kDynamic) {
       LDBG() << "skipping op; has dynamic reduction dims";

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
@@ -14,10 +14,10 @@ util.func public @basic_reduction(%arg0: tensor<4096xf32>) -> tensor<f32> {
     linalg.yield %3 : f32
   } -> tensor<f32>
   // CHECK: %[[SPLIT:.+]] = flow.dispatch.workgroups(%[[ARG0]])
-  // CHECK:   scf.forall (%{{.+}}) = (0) to (4096) step (1024)
-  // CHECK:     linalg.generic {{.+}} ins({{.+}} : tensor<1024xf32>) outs({{.+}} : tensor<f32>)
+  // CHECK:   scf.forall (%{{.+}}) = (0) to (4096) step (64)
+  // CHECK:     linalg.generic {{.+}} ins({{.+}} : tensor<64xf32>) outs({{.+}} : tensor<f32>)
   // CHECK: %[[RESULT:.+]] = flow.dispatch.workgroups(%[[SPLIT]])
-  // CHECK:   linalg.reduce ins({{.+}} : tensor<4xf32>) outs({{.+}} : tensor<f32>)
+  // CHECK:   linalg.reduce ins({{.+}} : tensor<64xf32>) outs({{.+}} : tensor<f32>)
   // CHECK: return %[[RESULT]]
   util.return %2 : tensor<f32>
 }
@@ -48,15 +48,15 @@ util.func public @basic_arg_compare(%arg0: tensor<4096xf32>)
   } -> tensor<f32>, tensor<i32>
 
   // First level: tile reduction in 1024-size chunks.
-  // CHECK: %[[SPLIT:.+]]:2 = flow.dispatch.workgroups(%[[ARG0]]) : (tensor<4096xf32>) -> (tensor<4xf32>, tensor<4xi32>)
-  // CHECK:   scf.forall ({{.*}}) = (0) to (4096) step (1024)
+  // CHECK: %[[SPLIT:.+]]:2 = flow.dispatch.workgroups(%[[ARG0]]) : (tensor<4096xf32>) -> (tensor<64xf32>, tensor<64xi32>)
+  // CHECK:   scf.forall ({{.*}}) = (0) to (4096) step (64)
   // CHECK:     iree_linalg_ext.arg_compare
-  // CHECK-SAME: ins({{.*}} : tensor<1024xf32>)
+  // CHECK-SAME: ins({{.*}} : tensor<64xf32>)
 
   // Second level: merge 4 partials via arg_compare with explicit-index mode.
   // CHECK: %[[RESULT:.+]]:2 = flow.dispatch.workgroups(%[[SPLIT]]#0, %[[SPLIT]]#1)
   // CHECK:   iree_linalg_ext.arg_compare
-  // CHECK-SAME: ins({{.*}} : tensor<4xf32>, tensor<4xi32>)
+  // CHECK-SAME: ins({{.*}} : tensor<64xf32>, tensor<64xi32>)
   // CHECK-SAME: outs({{.*}} : tensor<f32>, tensor<i32>)
 
   // CHECK: util.return %[[RESULT]]#0, %[[RESULT]]#1

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @basic
 util.func public @basic(%arg0: tensor<4096xf32>) -> tensor<1xf32> {
-  // CHECK: iree_linalg_ext.split_reduction = [1024 : index]
+  // CHECK: iree_linalg_ext.split_reduction = [64 : index]
   %1 = arith.constant dense<0.0> : tensor<1xf32>
   %2 = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (0)>],
@@ -20,7 +20,7 @@ util.func public @basic(%arg0: tensor<4096xf32>) -> tensor<1xf32> {
 // CHECK-LABEL: @basic_multi_dim
 util.func public @basic_multi_dim(%arg0: tensor<4x512xf32>) -> tensor<f32> {
   // With multiple reduction dims, inner dims are tiled first.
-  // CHECK: iree_linalg_ext.split_reduction = [2 : index, 512 : index]
+  // CHECK: iree_linalg_ext.split_reduction = [1 : index, 64 : index]
   %1 = arith.constant dense<0.0> : tensor<f32>
   %2 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> ()>],
@@ -36,15 +36,15 @@ util.func public @basic_multi_dim(%arg0: tensor<4x512xf32>) -> tensor<f32> {
 // -----
 
 // CHECK-LABEL: @basic_round_split_tile_size_up
-util.func public @basic_round_split_tile_size_up(%arg0: tensor<255x255xf32>) -> tensor<f32> {
+util.func public @basic_round_split_tile_size_up(%arg0: tensor<1255x1255xf32>) -> tensor<f32> {
   // To get the tile size to divide the iteration domain evenly, we chose a tile
-  // size (5x255=1275) that exceeds the specified target tile size (1024).
-  // CHECK: iree_linalg_ext.split_reduction = [5 : index, 255 : index]
+  // size (1x1255) that exceeds the specified target tile size (1024).
+  // CHECK: iree_linalg_ext.split_reduction = [1 : index, 1255 : index]
   %1 = arith.constant dense<0.0> : tensor<f32>
   %2 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> ()>],
       iterator_types = ["reduction", "reduction"]
-  } ins(%arg0 : tensor<255x255xf32>) outs(%1 : tensor<f32>) {
+  } ins(%arg0 : tensor<1255x1255xf32>) outs(%1 : tensor<f32>) {
   ^bb0(%in: f32, %out: f32):
     %3 = arith.addf %in, %out : f32
     linalg.yield %3 : f32
@@ -57,7 +57,7 @@ util.func public @basic_round_split_tile_size_up(%arg0: tensor<255x255xf32>) -> 
 // CHECK-LABEL: @inner_dynamic_parallel
 util.func public @inner_dynamic_parallel(%arg0: tensor<4096x?xf32>, %d0: index) -> tensor<?xf32> {
   // Dynamic parallel dimensions shouldn't prevent tiling.
-  // CHECK: iree_linalg_ext.split_reduction = [1024 : index]
+  // CHECK: iree_linalg_ext.split_reduction = [64 : index]
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f32
   %0 = tensor.empty(%d0) : tensor<?xf32>
@@ -98,7 +98,7 @@ util.func public @negative_outer_dynamic_reduction(%arg0: tensor<?x64xf32>, %d0:
 // CHECK-LABEL: @arg_compare_basic
 util.func public @arg_compare_basic(%arg0: tensor<4096xf32>)
     -> (tensor<f32>, tensor<index>) {
-  // CHECK: iree_linalg_ext.split_reduction = [1024 : index]
+  // CHECK: iree_linalg_ext.split_reduction = [64 : index]
   %c0f = arith.constant 0.0 : f32
   %c0i = arith.constant 0 : index
 
@@ -127,7 +127,7 @@ util.func public @arg_compare_basic(%arg0: tensor<4096xf32>)
 util.func public @arg_compare_inner_dynamic_parallel(%arg0: tensor<4096x?xf32>, %d0: index)
     -> (tensor<?xf32>, tensor<?xindex>) {
   // Dynamic parallel dimension shouldn't prevent tiling.
-  // CHECK: iree_linalg_ext.split_reduction = [1024 : index]
+  // CHECK: iree_linalg_ext.split_reduction = [64 : index]
   %c0f = arith.constant 0.0 : f32
   %c0i = arith.constant 0 : index
 


### PR DESCRIPTION
This PR updates the logic to select the target tile size of split reduction for outer reductions proportional to the total reduction work to be carried out.  This should help select tiles dynamically based on the problem size to improve parallelism. The proposed decision formula is derived from experiments on Mi355.