### PR TITLE
[SPIRV] Fix crash in getMemoryVectorSize on non-int/float types

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -113,6 +113,11 @@ int getComputeVectorSize(int64_t size) {
 }
 
 int getMemoryVectorSize(Value source, Type scalarType, int64_t size) {
+  // Only optimize memory access for int/float types with known bitwidths.
+  // Types like index or i1 cannot be bitcast to 32-bit element vectors.
+  if (!scalarType.isIntOrFloat() || scalarType.isInteger(1)) {
+    return 1;
+  }
   int bitwidth = scalarType.getIntOrFloatBitWidth();
   while (auto sliceOp = source.getDefiningOp<tensor::ExtractSliceOp>()) {
     source = sliceOp.getSource();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -48,6 +48,7 @@ iree_lit_test_suite(
             "illegal_configuration.mlir",
             "initial_vector_lowering_0d.mlir",
             "initial_vector_lowering_extract_insert_unit_dim.mlir",
+            "initial_vector_lowering_index_type.mlir",
             "link_executables.mlir",
             "lower_masks.mlir",
             "lowering_matmul_fusion.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_lit_test_suite(
     "illegal_configuration.mlir"
     "initial_vector_lowering_0d.mlir"
     "initial_vector_lowering_extract_insert_unit_dim.mlir"
+    "initial_vector_lowering_index_type.mlir"
     "link_executables.mlir"
     "lower_masks.mlir"
     "lowering_matmul_fusion.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/initial_vector_lowering_index_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/initial_vector_lowering_index_type.mlir
@@ -1,0 +1,13 @@
+// RUN: iree-opt %s --pass-pipeline='builtin.module(func.func(iree-spirv-initial-vector-lowering))' \
+// RUN:  | FileCheck %s
+
+// Verify that vector unrolling does not crash on index element types.
+// getMemoryVectorSize() must handle types that are not int or float.
+
+// CHECK-LABEL: func.func @transfer_read_index_type
+func.func @transfer_read_index_type(%mem: memref<64xindex>) -> vector<4xindex> {
+  %c0 = arith.constant 0 : index
+  %idx = arith.constant 0 : index
+  %0 = vector.transfer_read %mem[%c0], %idx {in_bounds = [true]} : memref<64xindex>, vector<4xindex>
+  return %0 : vector<4xindex>
+}


### PR DESCRIPTION
`getMemoryVectorSize()` crashes on SPIRV on `index` element types because `getIntOrFloatBitWidth()` only handles int/float.

This two-lines fix adds a type guard to prevent this, as the llvm-cpu backend does.
Test included.

Assisted-by: claude
ci-extra: macos_arm64_clang