### PR TITLE
[CI] Enable sccache for linux_x64_clang post-submit jobs 

### DIFF
--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -36,7 +36,9 @@ IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-1}"
 IREE_CONFIGURE_ONLY="${IREE_CONFIGURE_ONLY:-0}"
 
 source build_tools/cmake/setup_build.sh
-source build_tools/cmake/setup_ccache.sh
+if (( ${IREE_USE_SCCACHE:-0} != 1 )); then
+  source build_tools/cmake/setup_ccache.sh
+fi
 
 # Create install directory now--we need to get its real path later.
 mkdir -p "${INSTALL_DIR}"
@@ -95,6 +97,8 @@ if (( IREE_BUILD_TEST_DEPS == 1 )); then
   "$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 fi
 
-if (( IREE_USE_CCACHE == 1 )); then
+if (( ${IREE_USE_SCCACHE:-0} == 1 )); then
+  sccache --show-stats
+elif (( ${IREE_USE_CCACHE:-0} == 1 )); then
   ccache --show-stats
 fi


### PR DESCRIPTION
./setup_ccache clobbers over sccache which leads to zero hits when building linux_x64_clang. 
This change allows sccache to be used correctly (still only from this repo's PRs and not forks).

* First run took [18 minutes](https://github.com/iree-org/iree/actions/runs/23348078464/job/67918880748)
* Second run took [6 minutes](https://github.com/iree-org/iree/actions/runs/23348894907/job/67922550630?pr=23875)

```
+ sccache --show-stats
Compile requests                   6774
Compile requests executed          6774
Cache hits                         6756
Cache hits (C/C++)                 6756
Cache misses                          6
Cache misses (C/C++)                  6
```