### PR TITLE
[GPUHeuristics] Remove MNT boost for VeryLargeGemm on CDNA4

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -1296,9 +1296,7 @@ static constexpr ArchSeedSet kCDNA4Seeds = {
         /*LargeGemm=*/     {4, 16, 2, kCacheLineSizeBits / 2,
                             /*minUtilizationThreshold=*/0.50,
                             /*boostMNTileCountPerSubgroup=*/32},
-        /*VeryLargeGemm=*/ {4, 16, 2, kCacheLineSizeBits / 2,
-                            /*minUtilizationThreshold=*/0.50,
-                            /*boostMNTileCountPerSubgroup=*/32},
+        /*VeryLargeGemm=*/ {4, 16, 2, kCacheLineSizeBits / 2},
     },
     /*scaledGemm=*/{
         /*SmallGemm=*/     {2, 2,  4, 2 * kCacheLineSizeBits},


### PR DESCRIPTION
Fixes #23831.

#23652 added `boostMNTileCountPerSubgroup=32` for CDNA4 LargeGemm but
applied the same boost to VeryLargeGemm. That PR only benchmarked
LargeGemm shapes and didn't cover VeryLargeGemm.

For LargeGemm the heuristic selects the `MFMA_F32_16x16x32` intrinsic
where MNT=32 fits within register limits. However, for VeryLargeGemm
shapes (e.g. 16384x16384x16384), the heuristic prefers the larger
`MFMA_F32_32x32x16` intrinsic, and the boosted MNT=32 results in VGPR
spilling, causing a ~10x regression on mi355x:

| Metric | Before | After |
|---|---|---|
| Time | 10 ms | 104 ms |
| Scratch Allocation | 0 B/work-item | 1208 B/work-item |
| VGPRs | 216 | 256 (max) |
| VMEM instructions | 71M | 618M (8.7x) |

This patch removes `boostMNTileCountPerSubgroup` and
`minUtilizationThreshold` from VeryLargeGemm CDNA4 seeds, reverting
to default. LargeGemm seeds are unchanged.