### PR TITLE
[Util] Implement int divisibility inference for Add/Sub/Min/Max arith ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
@@ -331,6 +331,102 @@ util.func @scf_forall_multiple_ivs(%arg0 : index, %arg1 : index, %arg2 : index,
 
 // -----
 
+// CHECK-LABEL: @arith_addi_gcd
+util.func @arith_addi_gcd(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 16>,
+                         %arg1<udiv = 24> : index, index
+  %1 = arith.addi %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 8, sdiv = 8"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_addi_same_divisibility
+util.func @arith_addi_same_divisibility(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 32>,
+                         %arg1<udiv = 32> : index, index
+  %1 = arith.addi %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 32, sdiv = 32"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_subi_gcd
+util.func @arith_subi_gcd(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 12>,
+                         %arg1<udiv = 18> : index, index
+  %1 = arith.subi %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 6, sdiv = 6"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_minui_gcd
+util.func @arith_minui_gcd(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 16>,
+                         %arg1<udiv = 24> : index, index
+  %1 = arith.minui %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 8, sdiv = 8"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_maxui_gcd
+util.func @arith_maxui_gcd(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 12>,
+                         %arg1<udiv = 18> : index, index
+  %1 = arith.maxui %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 6, sdiv = 6"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_minsi_gcd
+util.func @arith_minsi_gcd(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 12>,
+                         %arg1<udiv = 18> : index, index
+  %1 = arith.minsi %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 6, sdiv = 6"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_maxsi_gcd
+util.func @arith_maxsi_gcd(%arg0 : index, %arg1 : index) -> index {
+  %0:2 = util.assume.int %arg0<udiv = 12>,
+                         %arg1<udiv = 18> : index, index
+  %1 = arith.maxsi %0#0, %0#1 : index
+  // CHECK: divisibility = "udiv = 6, sdiv = 6"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
+// CHECK-LABEL: @arith_addi_with_constant
+util.func @arith_addi_with_constant(%arg0 : index) -> index {
+  %0 = util.assume.int %arg0<udiv = 16> : index
+  %c24 = arith.constant 24 : index
+  %1 = arith.addi %0, %c24 : index
+  // CHECK: divisibility = "udiv = 8, sdiv = 8"
+  %2 = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return %2 : index
+}
+
+// -----
+
 // CHECK-LABEL: @delinearize_static_no_outer
 util.func @delinearize_static_no_outer(%arg0 : index) {
   %input = util.assume.int %arg0<udiv = 8> : index

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -375,6 +375,23 @@ struct AffineDelinearizeIndexInferIntDivisibilityOpInterface
   }
 };
 
+/// Helper for binary arith ops whose result divisibility is the GCD (union) of
+/// their operands' divisibilities. This covers add, sub, min, and max.
+template <typename OpTy>
+struct ArithBinaryGCDInferIntDivisibilityOpInterface
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+          ArithBinaryGCDInferIntDivisibilityOpInterface<OpTy>, OpTy> {
+
+  void inferResultDivisibility(
+      Operation *op, ArrayRef<IREE::Util::IntegerDivisibility> argDivs,
+      IREE::Util::SetIntDivisibilityFn setResultDivs) const {
+    auto binOp = cast<OpTy>(op);
+    auto lhsDiv = getDivisibilityOfOperand(binOp.getLhs(), argDivs[0]);
+    auto rhsDiv = getDivisibilityOfOperand(binOp.getRhs(), argDivs[1]);
+    setResultDivs(binOp.getResult(), lhsDiv.getUnion(rhsDiv));
+  }
+};
+
 struct ArithConstantInferIntDivisibilityOpInterface
     : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           ArithConstantInferIntDivisibilityOpInterface, arith::ConstantOp> {
@@ -1311,6 +1328,22 @@ void registerUtilExternalModels(DialectRegistry &registry) {
     arith::MulIOp::attachInterface<ArithMulIInferIntDivisibilityOpInterface>(
         *context);
     arith::DivUIOp::attachInterface<ArithDivUIInferIntDivisibilityOpInterface>(
+        *context);
+    arith::AddIOp::attachInterface<
+        ArithBinaryGCDInferIntDivisibilityOpInterface<arith::AddIOp>>(*context);
+    arith::SubIOp::attachInterface<
+        ArithBinaryGCDInferIntDivisibilityOpInterface<arith::SubIOp>>(*context);
+    arith::MinUIOp::attachInterface<
+        ArithBinaryGCDInferIntDivisibilityOpInterface<arith::MinUIOp>>(
+        *context);
+    arith::MaxUIOp::attachInterface<
+        ArithBinaryGCDInferIntDivisibilityOpInterface<arith::MaxUIOp>>(
+        *context);
+    arith::MinSIOp::attachInterface<
+        ArithBinaryGCDInferIntDivisibilityOpInterface<arith::MinSIOp>>(
+        *context);
+    arith::MaxSIOp::attachInterface<
+        ArithBinaryGCDInferIntDivisibilityOpInterface<arith::MaxSIOp>>(
         *context);
   });
 


### PR DESCRIPTION
Implements the IntegerDivsibilityAnalysis for basic arith ops:
 - arith.addi/subi
 - arith.minsi/maxsi
 - arith.minui/maxui

The divisibility analysis is the same for each of these ops, just returning the GCD of each operand's divisibility.