### PR TITLE
[Util] Add NarrowVectorBroadcast pattern to OptimizeIntArithmeticPass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -88,6 +88,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:UBDialect",
+        "@llvm-project//mlir:VectorDialect",
     ],
 )
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
     MLIRTransformUtils
     MLIRTransforms
     MLIRUBDialect
+    MLIRVectorDialect
     iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::Analysis::Attributes
     iree::compiler::Dialect::Util::Analysis::Constant

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
@@ -19,6 +20,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -264,6 +266,60 @@ struct RemoveIndexCastForAssumeOfI32 : OpRewritePattern<Util::AssumeIntOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// vector.broadcast cast commutation
+// Rewrites broadcast(cast(x)) → cast(broadcast(x)) so that the broadcast
+// operates on the narrower type.  This is a purely structural rewrite —
+// no range analysis needed.  It enables downstream patterns (e.g. NarrowCmpI)
+// to fold away intermediate casts.
+//===----------------------------------------------------------------------===//
+
+struct NarrowVectorBroadcast : OpRewritePattern<vector::BroadcastOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::BroadcastOp op,
+                                PatternRewriter &rewriter) const override {
+    // The broadcast source must be defined by a widening cast op.
+    Value source = op.getSource();
+    Operation *castOp = source.getDefiningOp();
+    if (!castOp || !isa<arith::IndexCastOp, arith::IndexCastUIOp>(castOp)) {
+      return failure();
+    }
+
+    // The broadcast must operate on index type and the cast source must be
+    // a non-index type (i.e. we are narrowing from index to integer).
+    Value castInput = castOp->getOperand(0);
+    Type srcElemTy = getElementTypeOrSelf(castInput.getType());
+    if (!isa<IndexType>(getElementTypeOrSelf(source.getType())) ||
+        isa<IndexType>(srcElemTy)) {
+      return failure();
+    }
+
+    VectorType resultType = cast<VectorType>(op.getResult().getType());
+    Location loc = op.getLoc();
+
+    // Broadcast in the narrower (input) type.
+    VectorType narrowBcastType =
+        VectorType::get(resultType.getShape(), srcElemTy);
+    Value narrowBcast =
+        vector::BroadcastOp::create(rewriter, loc, narrowBcastType, castInput);
+
+    // Re-apply the same cast on the broadcast result.
+    Value result = TypeSwitch<Operation *, Value>(castOp)
+                       .Case([&](arith::IndexCastOp) {
+                         return arith::IndexCastOp::create(
+                             rewriter, loc, resultType, narrowBcast);
+                       })
+                       .Case([&](arith::IndexCastUIOp) {
+                         return arith::IndexCastUIOp::create(
+                             rewriter, loc, resultType, narrowBcast);
+                       });
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // scf.for induction variable range narrowing
 // If the induction variable of an scf.for can be represented as an I32,
 // make that change to save on registers etc.
@@ -480,6 +536,7 @@ class OptimizeIntArithmeticPass
       arith::populateIntRangeNarrowingPatterns(patterns, solver, {32});
       patterns.add<NarrowSCFForIvToI32, RemoveIndexCastForAssumeOfI32>(ctx,
                                                                        solver);
+      patterns.add<NarrowVectorBroadcast>(ctx);
     }
 
     // Populate canonicalization patterns.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic_narrowing.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic_narrowing.mlir
@@ -66,3 +66,58 @@ util.func @narrow_scf_for(%arg0: memref<?xf32>) {
   }
   util.return
 }
+
+// -----
+
+// Verify that broadcast(index_castui(x)) is rewritten to index_castui(broadcast(x)).
+// CHECK-LABEL: @narrow_broadcast_index_castui
+// CHECK-SAME: (%[[ARG0:.+]]: i32)
+// CHECK: %[[BCAST:.+]] = vector.broadcast %[[ARG0]] : i32 to vector<4xi32>
+// CHECK: %[[CAST:.+]] = arith.index_castui %[[BCAST]] : vector<4xi32> to vector<4xindex>
+// CHECK: return %[[CAST]]
+func.func @narrow_broadcast_index_castui(%arg0: i32) -> vector<4xindex> {
+  %cast = arith.index_castui %arg0 : i32 to index
+  %bcast = vector.broadcast %cast : index to vector<4xindex>
+  return %bcast : vector<4xindex>
+}
+
+// -----
+
+// Verify that broadcast(index_cast(x)) is rewritten to index_cast(broadcast(x)).
+// CHECK-LABEL: @narrow_broadcast_index_cast
+// CHECK-SAME: (%[[ARG0:.+]]: i32)
+// CHECK: %[[BCAST:.+]] = vector.broadcast %[[ARG0]] : i32 to vector<2xi32>
+// CHECK: %[[CAST:.+]] = arith.index_cast %[[BCAST]] : vector<2xi32> to vector<2xindex>
+// CHECK: return %[[CAST]]
+func.func @narrow_broadcast_index_cast(%arg0: i32) -> vector<2xindex> {
+  %cast = arith.index_cast %arg0 : i32 to index
+  %bcast = vector.broadcast %cast : index to vector<2xindex>
+  return %bcast : vector<2xindex>
+}
+
+// -----
+
+// Verify that broadcast(index_castui(vector)) is also rewritten.
+// CHECK-LABEL: @narrow_broadcast_vector_index_castui
+// CHECK-SAME: (%[[ARG0:.+]]: vector<4xi32>)
+// CHECK: %[[BCAST:.+]] = vector.broadcast %[[ARG0]] : vector<4xi32> to vector<2x4xi32>
+// CHECK: %[[CAST:.+]] = arith.index_castui %[[BCAST]] : vector<2x4xi32> to vector<2x4xindex>
+// CHECK: return %[[CAST]]
+func.func @narrow_broadcast_vector_index_castui(%arg0: vector<4xi32>) -> vector<2x4xindex> {
+  %cast = arith.index_castui %arg0 : vector<4xi32> to vector<4xindex>
+  %bcast = vector.broadcast %cast : vector<4xindex> to vector<2x4xindex>
+  return %bcast : vector<2x4xindex>
+}
+
+// -----
+
+// Negative test: broadcast is on i32 (not index) — should NOT be rewritten.
+// CHECK-LABEL: @no_narrow_broadcast_non_index
+// CHECK: %[[CAST:.+]] = arith.index_cast %{{.*}} : index to i32
+// CHECK: %[[BCAST:.+]] = vector.broadcast %[[CAST]] : i32 to vector<4xi32>
+// CHECK: return %[[BCAST]]
+func.func @no_narrow_broadcast_non_index(%arg0: index) -> vector<4xi32> {
+  %cast = arith.index_cast %arg0 : index to i32
+  %bcast = vector.broadcast %cast : i32 to vector<4xi32>
+  return %bcast : vector<4xi32>
+}


### PR DESCRIPTION
When doing integer type narrowing, index casts can be leftover because broadcast ops don't get narrowed, so we get left with sequences like:
```mlir
%add = arith.addi %lhs, %rhs : i32
%cast0 = arith.index_cast %add : i32 to index
%broadcast = vector.broadcast %cast0 : index to vector<4xindex>
%cast1 = arith.index_cast %broadcast : vector<4xindex> to vector<4xi32>
```

This PR adds a cleanup pattern that narrows the broadcast op so that the index casts can all fold.