### PR TITLE
Add 256-alignment padding tier for IGEMM tile size heuristics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -747,6 +747,9 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           paddingCanBeExpensive) {
         return bounds[dim];
       }
+      if (bounds[dim] > 256) {
+        return maybePaddedBounds(bounds[dim], 256);
+      }
       if (bounds[dim] > 128) {
         return maybePaddedBounds(bounds[dim], 128);
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -453,6 +453,28 @@ func.func @unaligned_matmul_nn_layout(%lhs : tensor<513x513xf16>, %rhs : tensor<
 
 // -----
 
+func.func @matmul_overpad_to_256(%lhs: tensor<4160x4160xf16>, %rhs: tensor<4160x4160xf16>) -> tensor<4160x4160xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<4160x4160xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4160x4160xf32>) -> tensor<4160x4160xf32>
+  %mm = linalg.matmul ins(%lhs, %rhs : tensor<4160x4160xf16>, tensor<4160x4160xf16>) outs(%fill : tensor<4160x4160xf32>) -> tensor<4160x4160xf32>
+  return %mm : tensor<4160x4160xf32>
+}
+
+// Verify that dimensions slightly above 256 use the 256-alignment padding tier.
+// CHECK-LABEL: func.func @matmul_overpad_to_256(
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
+// CHECK:         linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:      padding = [128, 128, 32]
+// CHECK-SAME:      promote_operands = [0, 1]
+// CHECK-SAME:      reduction = [0, 0, 2]
+// CHECK-SAME:      subgroup = [4, 4, 0]
+// CHECK-SAME:      workgroup = [128, 128, 0]
+
+// -----
+
 func.func @large_scatter(%arg0: tensor<3x2048x2048xf32>,
                    %arg1: tensor<3x1xi32>) -> tensor<3x2048x2048xf32> {
   %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -541,3 +541,25 @@ func.func @group_conv_small_channels(%arg0: tensor<32x102x102x32x8xf16>, %arg1: 
 // IGEMM-SAME:      reduction = [0, 0, 0, 0, 0, 8]
 // IGEMM-SAME:      subgroup = [0, 1, 1, 1, 1, 0]
 // IGEMM-SAME:      workgroup = [4, 16, 1, 3, 16, 0]
+
+// -----
+
+// Verify that dimensions slightly above 256 use the 256-alignment padding tier.
+func.func @matmul_overpad_to_256(%lhs: tensor<4160x4160xf16>, %rhs: tensor<4160x4160xf16>) -> tensor<4160x4160xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<4160x4160xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4160x4160xf32>) -> tensor<4160x4160xf32>
+  %mm = linalg.matmul ins(%lhs, %rhs : tensor<4160x4160xf16>, tensor<4160x4160xf16>) outs(%fill : tensor<4160x4160xf32>) -> tensor<4160x4160xf32>
+  return %mm : tensor<4160x4160xf32>
+}
+
+// MI355X-LABEL: func.func @matmul_overpad_to_256(
+//  MI355X-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
+//  MI355X-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64
+//       MI355X:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  MI355X-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
+//  MI355X-SAME:     padding = [128, 256, 32]
+//  MI355X-SAME:     promote_operands = [0, 1]
+//  MI355X-SAME:     reduction = [0, 0, 1]
+//  MI355X-SAME:     subgroup = [4, 8, 0]
+//  MI355X-SAME:     workgroup = [128, 256, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
@@ -32,7 +32,7 @@ func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
   } -> tensor<384x128xf32>
   return %1 : tensor<384x128xf32>
 }
-//      CHECK: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128, 0]]>
+//      CHECK: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128, 0]]>
 //      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64,
 // CHECK-LABEL: func @custom_op
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
@@ -40,7 +40,7 @@ func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
 // CHECK-SAME:       lowering_config = #[[$CONFIG]]
 //      CHECK:   ^bb
 //      CHECK:     linalg.matmul
-// CHECK-SAME:         lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, promote_operands = [0, 1], reduction = [0, 0, 16], subgroup = [2, 4, 0], workgroup = [64, 128, 0]
+// CHECK-SAME:         lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, padding = [32, 128, 64], promote_operands = [0, 1, 2], reduction = [0, 0, 16], subgroup = [1, 4, 0], workgroup = [32, 128, 0]
 //      CHECK:   iree_linalg_ext.yield
 
 // -----


### PR DESCRIPTION
Adds a padding tier for dims > 256 to align to 256, complementing the existing 128 and 32 tiers.