### PR TITLE
[Base] fix printf issue in gcc

### DIFF
--- a/runtime/src/iree/base/printf.c
+++ b/runtime/src/iree/base/printf.c
@@ -775,13 +775,12 @@ static const double kPowersOf10[] = {
 };
 
 static double iree_printf_pow10(int n) {
-  // Compute |n| in unsigned arithmetic so INT_MIN stays well-defined.
-  // Keeping the magnitude in an unsigned value that is range-checked before
-  // the table lookup also avoids a GCC 11 -O3 false-positive -Warray-bounds
-  // in constprop on this fast path.
-  unsigned int abs_n = n < 0 ? 0u - (unsigned int)n : (unsigned int)n;
+  // Keep the table lookup behind a simple checked unsigned magnitude. GCC 11 at
+  // -O3 can otherwise warn with a false-positive -Warray-bounds after inlining
+  // and constprop when it reasons about wrapped unsigned values.
+  unsigned int abs_n = n < 0 ? -(unsigned int)n : (unsigned int)n;
   if (abs_n <= 22) {
-    return n < 0 ? 1.0 / kPowersOf10[abs_n] : kPowersOf10[n];
+    return n < 0 ? 1.0 / kPowersOf10[abs_n] : kPowersOf10[abs_n];
   }
 
   // For large exponents, use iterative multiplication/division.

--- a/runtime/src/iree/base/printf.c
+++ b/runtime/src/iree/base/printf.c
@@ -775,13 +775,15 @@ static const double kPowersOf10[] = {
 };
 
 static double iree_printf_pow10(int n) {
-  if (n >= 0 && n <= 22) return kPowersOf10[n];
-  // GCC 11 at -O3 inlines this function and then its interprocedural
-  // constprop reports a false-positive -Warray-bounds on the table lookup
-  // below, claiming the index could be -1. The unsigned cast + bounds check
-  // gives GCC an ironclad range proof it cannot optimize through.
-  unsigned int abs_n = (unsigned int)(-n);
-  if (abs_n >= 1 && abs_n <= 22) return 1.0 / kPowersOf10[abs_n];
+  // Compute |n| in unsigned arithmetic so INT_MIN stays well-defined.
+  // Keeping the magnitude in an unsigned value that is range-checked before
+  // the table lookup also avoids a GCC 11 -O3 false-positive -Warray-bounds
+  // in constprop on this fast path.
+  unsigned int abs_n = n < 0 ? 0u - (unsigned int)n : (unsigned int)n;
+  if (abs_n <= 22) {
+    return n < 0 ? 1.0 / kPowersOf10[abs_n] : kPowersOf10[n];
+  }
+
   // For large exponents, use iterative multiplication/division.
   // This loses precision in the last few digits but is fine for our use case
   // (debug formatting at precision <= 17).


### PR DESCRIPTION
`unsigned int abs_n = (unsigned int)(-n);` did not provide the “ironclad range proof” we were looking for gcc 11 because the cast happens after `-n` is evaluated, so we can still get errors (https://github.com/iree-org/iree/actions/runs/23336776640/job/67880398515) complaining about it. fix by just casting first to get the intended behavior. While we’re here, made things a bit more explicit and simplify the lookup a bit. 

working gcc run: https://github.com/iree-org/iree/actions/runs/23359589322