### PR TITLE
[CI] shut down bazel

### DIFF
--- a/.github/workflows/ci_linux_x64_bazel.yml
+++ b/.github/workflows/ci_linux_x64_bazel.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Save Bazel disk cache
         if: always() && github.ref == 'refs/heads/main'
         run: |
+          bazel shutdown
           tar -czf /tmp/cache.tar.gz -C "${BAZEL_DISK_CACHE_DIR}" .
           python3 ./build_tools/bazel/azure_cache.py upload /tmp/cache.tar.gz
 


### PR DESCRIPTION
Needed to avoid errors like:

```
tar: ./cas/1b/1bcc4e17352c020d3babea3f0575022ca65fd3cf40fd51f41a33a4a97d805d29: File removed before we read it
tar: ./cas/1b/1bf6e111e2a64ed17f46037b99287b52c13f04e4cd0037b0107d2cc21121920e: File removed before we read it
tar: ./cas/1b/1b9feda70f873671f182d16bf9ca4471a8c12d7055bf08cd5a86635cb49f51b6: File removed before we read it
tar: ./cas/1b/1be102ec1f295e0743e95f9edff0b8ac2d822fe0b6a83d94b9dc1f32e49cc9d8: File removed before we read it
tar: ./cas/1b: file changed as we read it
tar: .: file changed as we read it
```