### PR TITLE
Revert "[LLVMGPU] Move address computation optimization after vector …

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -911,6 +911,10 @@ void addGPUBaseLoweringPassPipeline(OpPassManager &funcPassManager) {
 static void
 addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
   funcPassManager
+      // Lower any remaining vector.transfer_read and vector.transfer_write ops,
+      // since some of the following patterns have trouble dealing with their
+      // full complexity.
+      .addPass(createVectorTransferLoweringPass)
       .addPass(createIREECodegenFoldMemRefAliasOpsPass)
       // Propagate constants close to loads/stores to improve the ability for
       // swizzling to CSE.
@@ -986,10 +990,10 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createCSEPass);
 
   // This pass needs to run before SCF -> CF.
+  addLowerAndOptimizeAddressComputationPasses(funcPassManager);
   funcPassManager.addPass(createLLVMGPUVectorLoweringPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass);
-  addLowerAndOptimizeAddressComputationPasses(funcPassManager);
 
   if (forROCDL) {
     // This pass needs to run after the LLVMGPUVectorLoweringPass.


### PR DESCRIPTION
…lowering (#23865)"

This reverts commit 35da16648cb99dd7d42356d432b920395b95d274.