### PR TITLE
[Codegen] Define DispatchConfigOp and YieldOp to IREE::Codegen.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
@@ -39,6 +39,7 @@ iree_td_library(
     deps = [
         "//compiler/src/iree/compiler/Codegen/Interfaces:td_files",
         "//compiler/src/iree/compiler/Utils:td_files",
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:LinalgOpsTdFiles",
@@ -108,6 +109,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
@@ -58,6 +58,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRArithUtils
     MLIRBufferizationDialect
+    MLIRControlFlowInterfaces
     MLIRDestinationStyleOpInterface
     MLIRFuncDialect
     MLIRFunctionInterfaces

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -26,31 +26,46 @@
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Support/LLVM.h"
 
+using namespace mlir;
+using namespace mlir::iree_compiler::IREE::Codegen;
+namespace IREE = mlir::iree_compiler::IREE;
+
+//===----------------------------------------------------------------------===//
+// Custom parsers/printers (must precede generated .cpp.inc)
+//===----------------------------------------------------------------------===//
+
 // Custom parse/print helper for the knobs dictionary in constraints op.
 // Prints `knobs = { ... }` on its own line with newlines before and after.
-static mlir::ParseResult parseKnobsDictionary(mlir::OpAsmParser &parser,
-                                              mlir::DictionaryAttr &attr) {
+static ParseResult parseKnobsDictionary(OpAsmParser &parser,
+                                        DictionaryAttr &attr) {
   if (parser.parseKeyword("knobs") || parser.parseEqual()) {
-    return mlir::failure();
+    return failure();
   }
   return parser.parseAttribute(attr);
 }
-static void printKnobsDictionary(mlir::OpAsmPrinter &p, mlir::Operation *,
-                                 mlir::DictionaryAttr attr) {
+static void printKnobsDictionary(OpAsmPrinter &p, Operation *,
+                                 DictionaryAttr attr) {
   p.printNewline();
   p << " knobs = ";
   p.printAttributeWithoutType(attr);
   p.printNewline();
 }
 
+/// Parses a string attribute printed in `@name` syntax.
+static ParseResult parseFunctionRef(OpAsmParser &parser, StringAttr &attr) {
+  return parser.parseSymbolName(attr);
+}
+
+/// Prints a string attribute in `@name` syntax.
+static void printFunctionRef(OpAsmPrinter &printer, Operation *,
+                             StringAttr attr) {
+  printer.printSymbolName(attr.getValue());
+}
+
 // clang-format off
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp.inc" // IWYU pragma: keep
 // clang-format on
-
-using namespace mlir;
-using namespace mlir::iree_compiler::IREE::Codegen;
-namespace IREE = mlir::iree_compiler::IREE;
 
 //===----------------------------------------------------------------------===//
 // ExtractStridedMetadataOp
@@ -471,6 +486,59 @@ void WorkgroupCountHintOp::print(OpAsmPrinter &printer) {
   printer.printOptionalAttrDict((*this)->getAttrs(),
                                 /*elidedAttrs=*/{"static_sizes"});
 }
+
+//===----------------------------------------------------------------------===//
+// DispatchConfigOp
+//===----------------------------------------------------------------------===//
+
+void DispatchConfigOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                             StringRef functionRef) {
+  odsState.addAttribute("function_ref", odsBuilder.getStringAttr(functionRef));
+  // Create the required single-block region (SizedRegion<1>).
+  odsState.addRegion();
+}
+
+LogicalResult DispatchConfigOp::verify() {
+  if (auto wgSize = getWorkgroupSize()) {
+    if (wgSize->empty() || wgSize->size() > 3) {
+      return emitOpError("workgroup_size must have 1 to 3 entries, got ")
+             << wgSize->size();
+    }
+  }
+
+  Block &block = getBody().front();
+  for (BlockArgument arg : block.getArguments()) {
+    if (!arg.getType().isIndex()) {
+      return emitOpError("expected all block arguments to be index type, got ")
+             << arg.getType();
+    }
+  }
+
+  return success();
+}
+
+LogicalResult DispatchConfigOp::verifyRegions() {
+  Block &block = getBody().front();
+  // The terminator must yield exactly 3 index values (workgroup count x, y, z).
+  auto yieldOp = cast<YieldOp>(block.getTerminator());
+  if (yieldOp.getNumOperands() != 3) {
+    return emitOpError("expected terminator to yield exactly 3 operands "
+                       "(workgroup count x, y, z), got ")
+           << yieldOp.getNumOperands();
+  }
+  for (auto [i, type] : llvm::enumerate(yieldOp.getOperandTypes())) {
+    if (!type.isIndex()) {
+      return emitOpError("expected terminator operand #")
+             << i << " to be index type, got " << type;
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// WorkgroupCountHintOp
+//===----------------------------------------------------------------------===//
 
 void WorkgroupCountHintOp::build(OpBuilder &builder, OperationState &state,
                                  ArrayRef<OpFoldResult> sizes) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -478,9 +478,9 @@ void WorkgroupCountHintOp::print(OpAsmPrinter &printer) {
 
 void DispatchConfigOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                              FlatSymbolRefAttr functionRef) {
-  odsState.addAttribute("function_ref", functionRef);
-  // Create the required single-block region (SizedRegion<1>).
-  odsState.addRegion();
+  DispatchConfigOp::build(odsBuilder, odsState, functionRef,
+                          /*workgroup_size=*/nullptr,
+                          /*subgroup_size=*/nullptr);
 }
 
 LogicalResult DispatchConfigOp::verify() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -51,17 +51,6 @@ static void printKnobsDictionary(OpAsmPrinter &p, Operation *,
   p.printNewline();
 }
 
-/// Parses a string attribute printed in `@name` syntax.
-static ParseResult parseFunctionRef(OpAsmParser &parser, StringAttr &attr) {
-  return parser.parseSymbolName(attr);
-}
-
-/// Prints a string attribute in `@name` syntax.
-static void printFunctionRef(OpAsmPrinter &printer, Operation *,
-                             StringAttr attr) {
-  printer.printSymbolName(attr.getValue());
-}
-
 // clang-format off
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp.inc" // IWYU pragma: keep
@@ -492,8 +481,8 @@ void WorkgroupCountHintOp::print(OpAsmPrinter &printer) {
 //===----------------------------------------------------------------------===//
 
 void DispatchConfigOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                             StringRef functionRef) {
-  odsState.addAttribute("function_ref", odsBuilder.getStringAttr(functionRef));
+                             FlatSymbolRefAttr functionRef) {
+  odsState.addAttribute("function_ref", functionRef);
   // Create the required single-block region (SizedRegion<1>).
   odsState.addRegion();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -26,25 +26,17 @@
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Support/LLVM.h"
 
-using namespace mlir;
-using namespace mlir::iree_compiler::IREE::Codegen;
-namespace IREE = mlir::iree_compiler::IREE;
-
-//===----------------------------------------------------------------------===//
-// Custom parsers/printers (must precede generated .cpp.inc)
-//===----------------------------------------------------------------------===//
-
 // Custom parse/print helper for the knobs dictionary in constraints op.
 // Prints `knobs = { ... }` on its own line with newlines before and after.
-static ParseResult parseKnobsDictionary(OpAsmParser &parser,
-                                        DictionaryAttr &attr) {
+static mlir::ParseResult parseKnobsDictionary(mlir::OpAsmParser &parser,
+                                              mlir::DictionaryAttr &attr) {
   if (parser.parseKeyword("knobs") || parser.parseEqual()) {
-    return failure();
+    return mlir::failure();
   }
   return parser.parseAttribute(attr);
 }
-static void printKnobsDictionary(OpAsmPrinter &p, Operation *,
-                                 DictionaryAttr attr) {
+static void printKnobsDictionary(mlir::OpAsmPrinter &p, mlir::Operation *,
+                                 mlir::DictionaryAttr attr) {
   p.printNewline();
   p << " knobs = ";
   p.printAttributeWithoutType(attr);
@@ -55,6 +47,10 @@ static void printKnobsDictionary(OpAsmPrinter &p, Operation *,
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp.inc" // IWYU pragma: keep
 // clang-format on
+
+using namespace mlir;
+using namespace mlir::iree_compiler::IREE::Codegen;
+namespace IREE = mlir::iree_compiler::IREE;
 
 //===----------------------------------------------------------------------===//
 // ExtractStridedMetadataOp

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -745,10 +745,10 @@ def IREECodegen_DispatchConfigOp :
     The terminator must yield exactly 3 index values, matching the
     contract of `hal.executable.export`'s workgroup count region.
 
-    The `function_ref` names the corresponding `func.func`. The op is
-    not a Symbol because it lives alongside the `func.func` of the same
-    name in a `builtin.module` symbol table, and two ops cannot define
-    the same symbol.
+    The `function_ref` is a symbol reference to the corresponding
+    `func.func`. The op itself is not a Symbol because it lives
+    alongside the `func.func` of the same name in a `builtin.module`
+    symbol table, and two ops cannot define the same symbol.
 
     Example:
     ```mlir
@@ -763,18 +763,18 @@ def IREECodegen_DispatchConfigOp :
   }];
 
   let arguments = (ins
-    StrAttr:$function_ref,
+    FlatSymbolRefAttr:$function_ref,
     OptionalAttr<DenseI64ArrayAttr>:$workgroup_size,
     OptionalAttr<I64Attr>:$subgroup_size
   );
   let regions = (region SizedRegion<1>:$body);
 
   let builders = [
-    OpBuilder<(ins "::llvm::StringRef":$functionRef)>,
+    OpBuilder<(ins "::mlir::FlatSymbolRefAttr":$functionRef)>,
   ];
 
   let assemblyFormat = [{
-    custom<FunctionRef>($function_ref)
+    $function_ref
     (`workgroup_size` `=` $workgroup_size^)?
     (`subgroup_size` `=` $subgroup_size^)?
     $body attr-dict

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -17,6 +17,7 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/Properties.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/TilingInterface.td"
 include "mlir/Interfaces/VectorInterfaces.td"
@@ -728,6 +729,61 @@ def IREECodegen_AssertOp :
 }
 
 //===----------------------------------------------------------------------===//
+// DispatchConfigOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_DispatchConfigOp :
+    Op<IREECodegen_Dialect, "dispatch_config", [
+      IsolatedFromAbove,
+      SingleBlockImplicitTerminator<"YieldOp">,
+    ]> {
+  let summary = [{Holds the workgroup count computation for a dispatch.}];
+  let description = [{
+    A module-level op that captures the workgroup count computation and
+    dispatch metadata for a function. The region computes the workgroup
+    count (x, y, z) from workload values passed as block arguments.
+    The terminator must yield exactly 3 index values, matching the
+    contract of `hal.executable.export`'s workgroup count region.
+
+    The `function_ref` names the corresponding `func.func`. The op is
+    not a Symbol because it lives alongside the `func.func` of the same
+    name in a `builtin.module` symbol table, and two ops cannot define
+    the same symbol.
+
+    Example:
+    ```mlir
+    iree_codegen.dispatch_config @matmul
+        workgroup_size = [64, 16, 1] subgroup_size = 64 {
+      ^bb0(%w0: index, %w1: index, %w2: index, %w3: index):
+        %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 256)>()[%w2]
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %0, %c1, %c1 : index, index, index
+    }
+    ```
+  }];
+
+  let arguments = (ins
+    StrAttr:$function_ref,
+    OptionalAttr<DenseI64ArrayAttr>:$workgroup_size,
+    OptionalAttr<I64Attr>:$subgroup_size
+  );
+  let regions = (region SizedRegion<1>:$body);
+
+  let builders = [
+    OpBuilder<(ins "::llvm::StringRef":$functionRef)>,
+  ];
+
+  let assemblyFormat = [{
+    custom<FunctionRef>($function_ref)
+    (`workgroup_size` `=` $workgroup_size^)?
+    (`subgroup_size` `=` $subgroup_size^)?
+    $body attr-dict
+  }];
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // KnobOp
 //===----------------------------------------------------------------------===//
 
@@ -782,6 +838,31 @@ def IREECodegen_LookupOp :
   let results = (outs IntType:$result);
   let assemblyFormat = "$index $keys `->` $values attr-dict `:` type($result)";
   let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// YieldOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_YieldOp :
+    Op<IREECodegen_Dialect, "yield", [
+      Pure,
+      ReturnLike,
+      Terminator,
+    ]> {
+  let summary = [{IREECodegen yield op.}];
+  let description = [{
+    `iree_codegen.yield` is a special terminator operation for blocks inside
+    regions in `iree_codegen` ops.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let builders = [
+    OpBuilder<(ins), [{ /* nothing to do */ }]>,
+  ];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREECODEGENOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -2,13 +2,11 @@
 
 // -----
 
-module {
-  func.func @export_config_invalid_type() attributes {
-    // expected-error @+1 {{expected workgroup size to have atmost 3 entries}}
-    export_config = #iree_codegen.export_config<workgroup_size = [4, 1, 1, 1]>
-  } {
-    return
-  }
+func.func @export_config_invalid_type() attributes {
+  // expected-error @+1 {{expected workgroup size to have atmost 3 entries}}
+  export_config = #iree_codegen.export_config<workgroup_size = [4, 1, 1, 1]>
+} {
+  return
 }
 
 // -----
@@ -80,6 +78,25 @@ func.func @constraints_block_arg_mismatch(%arg0: index) {
 
 // -----
 
+// dispatch_config with no terminator. Uses generic format to bypass
+// SingleBlockImplicitTerminator inserting a yield automatically.
+"iree_codegen.dispatch_config"() <{function_ref = "no_terminator", workgroup_size = array<i64: 64, 1, 1>}> ({
+^bb0(%w0: index):
+  // expected-error@+1 {{block with no terminator}}
+  %c1 = "arith.constant"() <{value = 1 : index}> : () -> index
+}) : () -> ()
+
+// -----
+
+// expected-error @+1 {{expected terminator to yield exactly 3 operands (workgroup count x, y, z), got 2}}
+iree_codegen.dispatch_config @bad_yield
+    workgroup_size = [64, 1, 1] {
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c1, %c1 : index, index
+}
+
+// -----
+
 // Knob op: duplicate knob name.
 func.func @duplicate_knob_name(%arg0: index) {
   iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
@@ -109,6 +126,14 @@ func.func @constraints_block_arg_too_few(%arg0: index, %arg1: index) {
 
 // -----
 
+// expected-error @+1 {{expected terminator to yield exactly 3 operands (workgroup count x, y, z), got 0}}
+iree_codegen.dispatch_config @empty_yield
+    workgroup_size = [64, 1, 1] {
+  iree_codegen.yield
+}
+
+// -----
+
 // Knob op: knob name not found in knobs dict.
 func.func @knob_name_not_found(%arg0: index) {
   iree_codegen.smt.constraints target = <set = 0>, pipeline = None,
@@ -133,6 +158,15 @@ func.func @string_attr_not_a_knob(%arg0: index) {
     %bad = iree_codegen.smt.knob "wg_m" : !smt.int
   }
   return
+}
+
+// -----
+
+// expected-error @+1 {{workgroup_size must have 1 to 3 entries, got 0}}
+iree_codegen.dispatch_config @empty_wg_size
+    workgroup_size = [] {
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c1, %c1, %c1 : index, index, index
 }
 
 // -----
@@ -249,4 +283,13 @@ func.func @one_of_knob_name_not_found(%arg0: index) {
     %bad = iree_codegen.smt.knob "nonexistent" : !smt.int
   }
   return
+}
+
+// -----
+
+// expected-error @+1 {{workgroup_size must have 1 to 3 entries, got 4}}
+iree_codegen.dispatch_config @big_wg_size
+    workgroup_size = [64, 1, 1, 1] {
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c1, %c1, %c1 : index, index, index
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -80,7 +80,7 @@ func.func @constraints_block_arg_mismatch(%arg0: index) {
 
 // dispatch_config with no terminator. Uses generic format to bypass
 // SingleBlockImplicitTerminator inserting a yield automatically.
-"iree_codegen.dispatch_config"() <{function_ref = "no_terminator", workgroup_size = array<i64: 64, 1, 1>}> ({
+"iree_codegen.dispatch_config"() <{function_ref = @no_terminator, workgroup_size = array<i64: 64, 1, 1>}> ({
 ^bb0(%w0: index):
   // expected-error@+1 {{block with no terminator}}
   %c1 = "arith.constant"() <{value = 1 : index}> : () -> index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -362,3 +362,19 @@ iree_codegen.dispatch_config @static_count
 // CHECK:         %[[C2:.+]] = arith.constant 2 : index
 // CHECK:         %[[C1:.+]] = arith.constant 1 : index
 // CHECK:         iree_codegen.yield %[[C4]], %[[C2]], %[[C1]] : index, index, index
+
+// -----
+
+iree_codegen.dispatch_config @no_config {
+  %c4 = arith.constant 4 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c4, %c2, %c1 : index, index, index
+}
+// CHECK-LABEL: iree_codegen.dispatch_config @no_config
+// CHECK-NOT:     workgroup_size
+// CHECK-NOT:     subgroup_size
+// CHECK:         %[[C4:.+]] = arith.constant 4 : index
+// CHECK:         %[[C2:.+]] = arith.constant 2 : index
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         iree_codegen.yield %[[C4]], %[[C2]], %[[C1]] : index, index, index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -316,3 +316,49 @@ func.func @smt_lookup_sparse(%arg0: index) {
 // CHECK-LABEL: func.func @smt_lookup_sparse(
 // CHECK:    %[[IDX:.*]] = iree_codegen.smt.knob "mma_idx" : !smt.int
 // CHECK:    iree_codegen.smt.lookup %[[IDX]] [3, 7, 12] -> [16, 32, 64] : !smt.int
+
+// -----
+
+iree_codegen.dispatch_config @matmul
+    workgroup_size = [64, 16, 1] subgroup_size = 64 {
+  ^bb0(%w0: index, %w1: index):
+    %c1 = arith.constant 1 : index
+    iree_codegen.yield %w0, %w1, %c1 : index, index, index
+}
+// CHECK-LABEL: iree_codegen.dispatch_config @matmul
+// CHECK-SAME:    workgroup_size = [64, 16, 1]
+// CHECK-SAME:    subgroup_size = 64
+// CHECK:       ^bb0(%[[W0:.+]]: index, %[[W1:.+]]: index):
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         iree_codegen.yield %[[W0]], %[[W1]], %[[C1]] : index, index, index
+
+// -----
+
+iree_codegen.dispatch_config @no_subgroup
+    workgroup_size = [256, 1, 1] {
+  ^bb0(%w0: index):
+    %c1 = arith.constant 1 : index
+    iree_codegen.yield %w0, %c1, %c1 : index, index, index
+}
+// CHECK-LABEL: iree_codegen.dispatch_config @no_subgroup
+// CHECK-SAME:    workgroup_size = [256, 1, 1]
+// CHECK-NOT:     subgroup_size
+// CHECK:       ^bb0(%[[W0:.+]]: index):
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         iree_codegen.yield %[[W0]], %[[C1]], %[[C1]] : index, index, index
+
+// -----
+
+iree_codegen.dispatch_config @static_count
+    workgroup_size = [64] {
+  %c4 = arith.constant 4 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c4, %c2, %c1 : index, index, index
+}
+// CHECK-LABEL: iree_codegen.dispatch_config @static_count
+// CHECK-SAME:    workgroup_size = [64]
+// CHECK:         %[[C4:.+]] = arith.constant 4 : index
+// CHECK:         %[[C2:.+]] = arith.constant 2 : index
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         iree_codegen.yield %[[C4]], %[[C2]], %[[C1]] : index, index, index


### PR DESCRIPTION
- `dispatch_config`: module-level op holding workgroup count computation and dispatch metadata (workgroup_size, subgroup_size) for a function. Uses IsolatedFromAbove with a single-block region whose block args are workload values (index type). The regions returns exactly 3 index values (workgroup count x, y, z), which is as the same as HAK::ExportOp that requires exactly three yielded values in `verifyWorkgroupCountRegion`.
- `yield`: terminator for IREE::Codegen op's regions.

The dispatch_config op uses a plain StrAttr (printed as @name) rather than the Symbol trait, because it must coexist with a func.func of the same name in the same builtin.module symbol table. It can't be symbol, because two ops can't define the same symbol. The dispatch_config op is expected to live along the corresponding func op.

It is a step towards https://github.com/iree-org/iree/discussions/23642