### PR TITLE
[Codegen] Introduce CreateDispatchConfig pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -90,6 +90,7 @@ iree_compiler_cc_library(
         "ConvertUnsupportedFloatToIntBuffers.cpp",
         "ConvertWorkgroupForallToPCF.cpp",
         "ConvolutionToIGEMM.cpp",
+        "CreateDispatchConfig.cpp",
         "DecomposeAffineOps.cpp",
         "DecomposeConvolutionToLowerDimOps.cpp",
         "DecomposeLinalgGeneric.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -83,6 +83,7 @@ iree_cc_library(
     "ConvertUnsupportedFloatToIntBuffers.cpp"
     "ConvertWorkgroupForallToPCF.cpp"
     "ConvolutionToIGEMM.cpp"
+    "CreateDispatchConfig.cpp"
     "DecomposeAffineOps.cpp"
     "DecomposeConvolutionToLowerDimOps.cpp"
     "DecomposeLinalgGeneric.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
@@ -8,9 +8,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
-#include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/IR/IRMapping.h"
 
 namespace mlir::iree_compiler {
 
@@ -66,39 +64,20 @@ void CreateDispatchConfigPass::runOnOperation() {
       return signalPassFailure();
     }
 
-    // Dispatch config block args: (index, index, ...) — skip !hal.device.
-    unsigned configArity = exportBlock->getNumArguments() - 1;
-
-    // Create dispatch_config right after the function.
+    // Create dispatch_config right after the function, clone the export region
+    // and drop the first block argument (!hal.device).
     builder.setInsertionPointAfter(funcOp);
-    auto configOp =
-        IREE::Codegen::DispatchConfigOp::create(builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
-
-    // Create block with workload args (index type).
-    Block *configBlock = builder.createBlock(&configOp.getBody());
-    for (unsigned i = 0; i < configArity; ++i) {
-      configBlock->addArgument(builder.getIndexType(), loc);
-    }
-
-    // Clone ops from export count region into dispatch_config body.
-    // Map export block args (offset by 1) to config block args.
-    IRMapping mapping;
-    for (unsigned i = 0; i < configArity; ++i) {
-      mapping.map(exportBlock->getArgument(i + 1), configBlock->getArgument(i));
-    }
-
-    builder.setInsertionPointToEnd(configBlock);
-    for (Operation &op : exportBlock->without_terminator()) {
-      builder.clone(op, mapping);
-    }
-
-    // Replace hal.return with iree_codegen.yield.
-    auto returnOp = cast<IREE::HAL::ReturnOp>(exportBlock->getTerminator());
-    auto yieldValues =
-        llvm::map_to_vector(returnOp.getOperands(), [&](Value v) {
-          return mapping.lookupOrDefault(v);
-        });
-    IREE::Codegen::YieldOp::create(builder, returnOp.getLoc(), yieldValues);
+    auto configOp = IREE::Codegen::DispatchConfigOp::create(
+        builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
+    builder.cloneRegionBefore(exportOp.getWorkgroupCount(), configOp.getBody(),
+                              configOp.getBody().end());
+    Block *configBlock = &configOp.getBody().front();
+    configBlock->eraseArgument(0);
+    auto returnOp = cast<IREE::HAL::ReturnOp>(configBlock->getTerminator());
+    builder.setInsertionPoint(returnOp);
+    IREE::Codegen::YieldOp::create(builder, returnOp.getLoc(),
+                                   returnOp.getOperands());
+    returnOp.erase();
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
@@ -1,0 +1,106 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/IRMapping.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_CREATEDISPATCHCONFIGPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+class CreateDispatchConfigPass final
+    : public impl::CreateDispatchConfigPassBase<CreateDispatchConfigPass> {
+public:
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+void CreateDispatchConfigPass::runOnOperation() {
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  ModuleOp innerModule = variantOp.getInnerModule();
+  if (!innerModule) {
+    return;
+  }
+
+  // Build a map from symbol name to func op for placement.
+  SymbolTable symbolTable(innerModule);
+
+  OpBuilder builder(&getContext());
+  for (auto exportOp : variantOp.getExportOps()) {
+    // Find the corresponding function.
+    auto funcOp =
+        symbolTable.lookup<FunctionOpInterface>(exportOp.getSymNameAttr());
+    if (!funcOp) {
+      continue;
+    }
+
+    Location loc = funcOp.getLoc();
+    Block *exportBlock = exportOp.getWorkgroupCountBody();
+    if (!exportBlock || exportBlock->getNumArguments() == 0) {
+      // No count region — create a dispatch_config with a stub {1,1,1} body.
+      builder.setInsertionPointAfter(funcOp);
+      auto configOp = IREE::Codegen::DispatchConfigOp::create(builder, loc,
+                                                              FlatSymbolRefAttr::get(funcOp.getNameAttr()));
+      Block *block = builder.createBlock(&configOp.getBody());
+      builder.setInsertionPointToStart(block);
+      auto c1 = arith::ConstantIndexOp::create(builder, loc, 1);
+      IREE::Codegen::YieldOp::create(builder, loc, ValueRange{c1, c1, c1});
+      continue;
+    }
+
+    // Export count region block args: (!hal.device, index, index, ...).
+    // Validate first arg is !hal.device.
+    if (!isa<IREE::HAL::DeviceType>(exportBlock->getArgument(0).getType())) {
+      exportOp.emitError("expected first count region arg to be !hal.device");
+      return signalPassFailure();
+    }
+
+    // Dispatch config block args: (index, index, ...) — skip !hal.device.
+    unsigned configArity = exportBlock->getNumArguments() - 1;
+
+    // Create dispatch_config right after the function.
+    builder.setInsertionPointAfter(funcOp);
+    auto configOp =
+        IREE::Codegen::DispatchConfigOp::create(builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
+
+    // Create block with workload args (index type).
+    Block *configBlock = builder.createBlock(&configOp.getBody());
+    for (unsigned i = 0; i < configArity; ++i) {
+      configBlock->addArgument(builder.getIndexType(), loc);
+    }
+
+    // Clone ops from export count region into dispatch_config body.
+    // Map export block args (offset by 1) to config block args.
+    IRMapping mapping;
+    for (unsigned i = 0; i < configArity; ++i) {
+      mapping.map(exportBlock->getArgument(i + 1), configBlock->getArgument(i));
+    }
+
+    builder.setInsertionPointToEnd(configBlock);
+    for (Operation &op : exportBlock->without_terminator()) {
+      builder.clone(op, mapping);
+    }
+
+    // Replace hal.return with iree_codegen.yield.
+    auto returnOp = cast<IREE::HAL::ReturnOp>(exportBlock->getTerminator());
+    auto yieldValues =
+        llvm::map_to_vector(returnOp.getOperands(), [&](Value v) {
+          return mapping.lookupOrDefault(v);
+        });
+    IREE::Codegen::YieldOp::create(builder, returnOp.getLoc(), yieldValues);
+  }
+}
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
@@ -48,8 +48,8 @@ void CreateDispatchConfigPass::runOnOperation() {
     if (!exportBlock || exportBlock->getNumArguments() == 0) {
       // No count region — create a dispatch_config with a stub {1,1,1} body.
       builder.setInsertionPointAfter(funcOp);
-      auto configOp = IREE::Codegen::DispatchConfigOp::create(builder, loc,
-                                                              FlatSymbolRefAttr::get(funcOp.getNameAttr()));
+      auto configOp = IREE::Codegen::DispatchConfigOp::create(
+          builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
       Block *block = builder.createBlock(&configOp.getBody());
       builder.setInsertionPointToStart(block);
       auto c1 = arith::ConstantIndexOp::create(builder, loc, 1);

--- a/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
@@ -7,7 +7,6 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 
 namespace mlir::iree_compiler {
@@ -57,22 +56,14 @@ void CreateDispatchConfigPass::runOnOperation() {
       continue;
     }
 
-    // Export count region block args: (!hal.device, index, index, ...).
-    // Validate first arg is !hal.device.
-    if (!isa<IREE::HAL::DeviceType>(exportBlock->getArgument(0).getType())) {
-      exportOp.emitError("expected first count region arg to be !hal.device");
-      return signalPassFailure();
-    }
-
-    // Create dispatch_config right after the function, clone the export region
-    // and drop the first block argument (!hal.device).
+    // Create dispatch_config right after the function, clone the export count
+    // region as-is.
     builder.setInsertionPointAfter(funcOp);
     auto configOp = IREE::Codegen::DispatchConfigOp::create(
         builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
     builder.cloneRegionBefore(exportOp.getWorkgroupCount(), configOp.getBody(),
                               configOp.getBody().end());
     Block *configBlock = &configOp.getBody().front();
-    configBlock->eraseArgument(0);
     auto returnOp = cast<IREE::HAL::ReturnOp>(configBlock->getTerminator());
     builder.setInsertionPoint(returnOp);
     IREE::Codegen::YieldOp::create(builder, returnOp.getLoc(),

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -464,6 +464,26 @@ def ResolveWorkgroupCountHintsPass
   }];
 }
 
+def CreateDispatchConfigPass
+    : Pass<"iree-codegen-create-dispatch-config", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Create dispatch_config ops by cloning export count regions.";
+  let description = [{
+    For each `hal.executable.export`, creates an `iree_codegen.dispatch_config`
+    op in the inner module by cloning the export's count region body. The
+    dispatch_config body inherits the placeholder ops (`from_slice`,
+    `split_reduction_modifier`) with block args mapped from the export's
+    workload args (skipping `!hal.device` at position 0). The terminator is
+    replaced with `iree_codegen.yield`.
+
+    The dispatch_config op is placed immediately after its corresponding
+    function in the inner module so that functions and configs are interleaved.
+  }];
+  let dependentDialects = [
+    "iree_compiler::IREE::Codegen::IREECodegenDialect",
+  ];
+}
+
+
 def ReplaceSlowMinMaxOpsPass
     : InterfacePass<"iree-codegen-replace-slow-min-max-ops", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -469,11 +469,8 @@ def CreateDispatchConfigPass
   let summary = "Create dispatch_config ops by cloning export count regions.";
   let description = [{
     For each `hal.executable.export`, creates an `iree_codegen.dispatch_config`
-    op in the inner module by cloning the export's count region body. The
-    dispatch_config body inherits the placeholder ops (`from_slice`,
-    `split_reduction_modifier`) with block args mapped from the export's
-    workload args (skipping `!hal.device` at position 0). The terminator is
-    replaced with `iree_codegen.yield`.
+    op in the inner module by cloning the export's count region as-is. The
+    `hal.return` terminator is replaced with `iree_codegen.yield`.
 
     The dispatch_config op is placed immediately after its corresponding
     function in the inner module so that functions and configs are interleaved.

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -40,6 +40,7 @@ iree_lit_test_suite(
             "convert_workgroup_forall_to_pcf.mlir",
             "convolution_to_igemm.mlir",
             "convolutions.mlir",
+            "create_dispatch_config.mlir",
             "decompose_affine_ops.mlir",
             "decompose_boundary_pack_unpack_ops.mlir",
             "decompose_conv2d.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "convert_workgroup_forall_to_pcf.mlir"
     "convolution_to_igemm.mlir"
     "convolutions.mlir"
+    "create_dispatch_config.mlir"
     "decompose_affine_ops.mlir"
     "decompose_boundary_pack_unpack_ops.mlir"
     "decompose_conv2d.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
@@ -1,0 +1,118 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config)))" \
+// RUN:   %s | FileCheck %s
+
+// Export with from_slice count region only, which is a basic test.
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @from_slice {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "">) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @from_slice
+//       CHECK:   func.func @entry_point
+//       CHECK:   iree_codegen.dispatch_config @entry_point
+//   CHECK-NOT:     workgroup_size
+//       CHECK:     ^bb0(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
+//       CHECK:       %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[ARG0]], %[[ARG1]])
+//       CHECK:       iree_codegen.yield %[[X]], %[[Y]], %[[Z]]
+
+// -----
+
+// Export with from_slice + split_reduction_modifier.
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @split_reduction {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "">) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index,
+              %arg3: index, %arg4: index, %arg5: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5)
+      %rx, %ry, %rz = iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier
+          workgroups(%x, %y, %z) workload(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5)
+      hal.return %rx, %ry, %rz : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @split_reduction
+//       CHECK:   func.func @entry_point
+//       CHECK:   iree_codegen.dispatch_config @entry_point
+//   CHECK-NOT:     workgroup_size
+//       CHECK:     ^bb0(%[[W0:.+]]: index, %[[W1:.+]]: index, %[[W2:.+]]: index, %[[W3:.+]]: index, %[[W4:.+]]: index, %[[W5:.+]]: index):
+//       CHECK:       %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[W0]], %[[W1]], %[[W2]], %[[W3]], %[[W4]], %[[W5]])
+//       CHECK:       iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier workgroups(%[[X]], %[[Y]], %[[Z]]) workload(%[[W0]], %[[W1]], %[[W2]], %[[W3]], %[[W4]], %[[W5]])
+//       CHECK:       iree_codegen.yield
+
+// -----
+
+// Export with no count region — dispatch_config with stub body, no workgroup_size.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @no_count_region {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "">) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+    builtin.module {
+      func.func @entry_point() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @no_count_region
+//       CHECK:   func.func @entry_point
+//       CHECK:   iree_codegen.dispatch_config @entry_point
+//   CHECK-NOT:     workgroup_size
+//       CHECK:     %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:     iree_codegen.yield %[[C1]], %[[C1]], %[[C1]]
+
+// -----
+
+// Test that dispatch_config placed after its function.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @interleaving {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "">) {
+    hal.executable.export public @fn1 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export public @fn2 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @fn1() {
+        return
+      }
+      func.func @fn2() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @interleaving
+//       CHECK:   func.func @fn1
+//       CHECK:   iree_codegen.dispatch_config @fn1
+//       CHECK:   func.func @fn2
+//       CHECK:   iree_codegen.dispatch_config @fn2

--- a/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config)))" \
 // RUN:   %s | FileCheck %s
 
-// Export with from_slice count region only, which is a basic test.
+// Export with a count region.
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
@@ -23,13 +23,13 @@ hal.executable private @from_slice {
 //       CHECK:   func.func @entry_point
 //       CHECK:   iree_codegen.dispatch_config @entry_point
 //   CHECK-NOT:     workgroup_size
-//       CHECK:     ^bb0(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
+//       CHECK:     ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
 //       CHECK:       %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[ARG0]], %[[ARG1]])
 //       CHECK:       iree_codegen.yield %[[X]], %[[Y]], %[[Z]]
 
 // -----
 
-// Export with from_slice + split_reduction_modifier.
+// Export with multiple ops in the count region.
 #pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly">,
   #hal.pipeline.binding<storage_buffer>
@@ -55,7 +55,7 @@ hal.executable private @split_reduction {
 //       CHECK:   func.func @entry_point
 //       CHECK:   iree_codegen.dispatch_config @entry_point
 //   CHECK-NOT:     workgroup_size
-//       CHECK:     ^bb0(%[[W0:.+]]: index, %[[W1:.+]]: index, %[[W2:.+]]: index, %[[W3:.+]]: index, %[[W4:.+]]: index, %[[W5:.+]]: index):
+//       CHECK:     ^bb0(%[[DEVICE:.+]]: !hal.device, %[[W0:.+]]: index, %[[W1:.+]]: index, %[[W2:.+]]: index, %[[W3:.+]]: index, %[[W4:.+]]: index, %[[W5:.+]]: index):
 //       CHECK:       %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[W0]], %[[W1]], %[[W2]], %[[W3]], %[[W4]], %[[W5]])
 //       CHECK:       iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier workgroups(%[[X]], %[[Y]], %[[Z]]) workload(%[[W0]], %[[W1]], %[[W2]], %[[W3]], %[[W4]], %[[W5]])
 //       CHECK:       iree_codegen.yield

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -491,14 +491,6 @@ LogicalResult DispatchConfigOp::verify() {
     }
   }
 
-  Block &block = getBody().front();
-  for (BlockArgument arg : block.getArguments()) {
-    if (!arg.getType().isIndex()) {
-      return emitOpError("expected all block arguments to be index type, got ")
-             << arg.getType();
-    }
-  }
-
   return success();
 }
 


### PR DESCRIPTION
Clones export count region bodies into dispatch_config ops placed after the corresponding function in the inner module.

If the body does not exist, creates the body that returns `{1, 1, 1}`.

The revision also relax the constraint of block argument, so it can accept whatever types. See the discussion on disocrd: https://discord.com/channels/689900678990135345/690274711523164166/1486476323001208993

It is a step towards https://github.com/iree-org/iree/discussions/23642