### PR TITLE
[Codegen] Introduce PropagateDispatchConfig pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -148,6 +148,7 @@ iree_compiler_cc_library(
         "Passes.cpp",
         "PatchFuncOps.cpp",
         "PropagateConstantOffsets.cpp",
+        "PropagateDispatchConfig.cpp",
         "PropagateDispatchSizeBounds.cpp",
         "PropagateReshapesByExpansion.cpp",
         "ReconcileTranslationInfo.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -141,6 +141,7 @@ iree_cc_library(
     "Passes.cpp"
     "PatchFuncOps.cpp"
     "PropagateConstantOffsets.cpp"
+    "PropagateDispatchConfig.cpp"
     "PropagateDispatchSizeBounds.cpp"
     "PropagateReshapesByExpansion.cpp"
     "ReconcileTranslationInfo.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -485,9 +485,8 @@ def PropagateDispatchConfigPass
   let summary = "Propagate dispatch_config into hal.executable.export count regions.";
   let description = [{
     For each `iree_codegen.dispatch_config` in the inner module:
-    1. Find the matching `hal.executable.export` by function_ref name.
-    2. Replace the export count region body with the dispatch_config
-       body, mapping block args (offset by 1 for `!hal.device`) and
+    1. Find the matching `hal.executable.export` by symbol name.
+    2. Move the dispatch_config region body into the export count region,
        replacing `iree_codegen.yield` with `hal.return`.
     3. Set workgroup_size / subgroup_size on the export.
     4. Erase the dispatch_config op.

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -480,7 +480,19 @@ def CreateDispatchConfigPass
   ];
 }
 
-
+def PropagateDispatchConfigPass
+    : Pass<"iree-codegen-propagate-dispatch-config", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Propagate dispatch_config into hal.executable.export count regions.";
+  let description = [{
+    For each `iree_codegen.dispatch_config` in the inner module:
+    1. Find the matching `hal.executable.export` by function_ref name.
+    2. Replace the export count region body with the dispatch_config
+       body, mapping block args (offset by 1 for `!hal.device`) and
+       replacing `iree_codegen.yield` with `hal.return`.
+    3. Set workgroup_size / subgroup_size on the export.
+    4. Erase the dispatch_config op.
+  }];
+}
 def ReplaceSlowMinMaxOpsPass
     : InterfacePass<"iree-codegen-replace-slow-min-max-ops", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/Support/DebugLog.h"
+#include "mlir/IR/IRMapping.h"
+
+#define DEBUG_TYPE "iree-codegen-propagate-dispatch-config"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_PROPAGATEDISPATCHCONFIGPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+class PropagateDispatchConfigPass final
+    : public impl::PropagateDispatchConfigPassBase<
+          PropagateDispatchConfigPass> {
+public:
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+void PropagateDispatchConfigPass::runOnOperation() {
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  ModuleOp innerModule = variantOp.getInnerModule();
+  if (!innerModule) {
+    return;
+  }
+
+  // Collect all dispatch_config ops.
+  SmallVector<IREE::Codegen::DispatchConfigOp> configOps;
+  innerModule->walk(
+      [&](IREE::Codegen::DispatchConfigOp op) { configOps.push_back(op); });
+  if (configOps.empty()) {
+    return;
+  }
+
+  // Build a map from export name to export op.
+  DenseMap<StringRef, IREE::HAL::ExecutableExportOp> exportMap;
+  for (auto exportOp : variantOp.getExportOps()) {
+    exportMap[exportOp.getSymName()] = exportOp;
+  }
+
+  for (IREE::Codegen::DispatchConfigOp configOp : configOps) {
+    StringRef funcRef = configOp.getFunctionRef();
+
+    if (!exportMap.contains(funcRef)) {
+      // No export for this function (e.g. a helper that is not an entry
+      // point).  Erase the dispatch_config and move on.
+      configOp.erase();
+      continue;
+    }
+    IREE::HAL::ExecutableExportOp exportOp = exportMap[funcRef];
+
+    // Replace the export count region body with the dispatch_config body.
+    // Map dispatch_config block args to export block args (offset by 1
+    // for !hal.device at position 0).
+    Region &countRegion = exportOp.getWorkgroupCount();
+    OpBuilder builder(&getContext());
+
+    if (!countRegion.empty()) {
+      Block &configBlock = configOp.getBody().front();
+      Block *exportBlock = exportOp.getWorkgroupCountBody();
+      unsigned configArity = configBlock.getNumArguments();
+      unsigned exportArity = exportBlock->getNumArguments();
+      // Export count region has !hal.device as block arg 0, then workloads.
+      if (configArity + 1 > exportArity) {
+        configOp.emitError("workload arity mismatch: dispatch_config has ")
+            << configArity << " args but export count region has "
+            << exportArity << " (expected >= " << configArity + 1
+            << " = config args + !hal.device)";
+        return signalPassFailure();
+      }
+      exportBlock->clear();
+      IRMapping mapping;
+      for (unsigned i = 0; i < configArity; ++i) {
+        mapping.map(configBlock.getArgument(i),
+                    exportBlock->getArgument(i + 1));
+      }
+      builder.setInsertionPointToEnd(exportBlock);
+      for (Operation &op : configBlock.without_terminator()) {
+        builder.clone(op, mapping);
+      }
+      // Replace iree_codegen.yield with hal.return.
+      auto yieldOp = cast<IREE::Codegen::YieldOp>(configBlock.getTerminator());
+      auto returnValues =
+          llvm::map_to_vector(yieldOp.getOperands(), [&](Value v) {
+            return mapping.lookupOrDefault(v);
+          });
+      IREE::HAL::ReturnOp::create(builder, yieldOp.getLoc(), returnValues);
+    }
+
+    // Set workgroup_size and subgroup_size on the export.
+    auto wgSize = configOp.getWorkgroupSize();
+    if (!wgSize) {
+      configOp.emitError("missing workgroup_size attribute");
+      return signalPassFailure();
+    }
+    SmallVector<int64_t, 3> wgSizePadded(wgSize->begin(), wgSize->end());
+    while (wgSizePadded.size() < 3) {
+      wgSizePadded.push_back(1);
+    }
+    exportOp.setWorkgroupSizeAttr(builder.getIndexArrayAttr(wgSizePadded));
+    if (auto subgroupSize = configOp.getSubgroupSize()) {
+      exportOp.setSubgroupSizeAttr(builder.getIndexAttr(subgroupSize.value()));
+    }
+
+    configOp.erase();
+  }
+}
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
@@ -7,9 +7,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/DebugLog.h"
-#include "mlir/IR/IRMapping.h"
 
 #define DEBUG_TYPE "iree-codegen-propagate-dispatch-config"
 
@@ -43,59 +41,41 @@ void PropagateDispatchConfigPass::runOnOperation() {
     return;
   }
 
-  // Build a map from export name to export op.
-  DenseMap<StringRef, IREE::HAL::ExecutableExportOp> exportMap;
-  for (auto exportOp : variantOp.getExportOps()) {
-    exportMap[exportOp.getSymName()] = exportOp;
-  }
-
+  SymbolTable symbolTable(variantOp);
   for (IREE::Codegen::DispatchConfigOp configOp : configOps) {
     StringRef funcRef = configOp.getFunctionRef();
-
-    if (!exportMap.contains(funcRef)) {
-      // No export for this function (e.g. a helper that is not an entry
-      // point).  Erase the dispatch_config and move on.
+    auto exportOp =
+        symbolTable.lookup<IREE::HAL::ExecutableExportOp>(funcRef);
+    if (!exportOp) {
+      // No export for this function, so erase the dispatch_config and move on.
       configOp.erase();
       continue;
     }
-    IREE::HAL::ExecutableExportOp exportOp = exportMap[funcRef];
 
-    // Replace the export count region body with the dispatch_config body.
-    // Map dispatch_config block args to export block args (offset by 1
-    // for !hal.device at position 0).
+    // Move the dispatch_config region body into the export count region,
+    // replacing iree_codegen.yield with hal.return.
     Region &countRegion = exportOp.getWorkgroupCount();
     OpBuilder builder(&getContext());
 
     if (!countRegion.empty()) {
       Block &configBlock = configOp.getBody().front();
       Block *exportBlock = exportOp.getWorkgroupCountBody();
-      unsigned configArity = configBlock.getNumArguments();
-      unsigned exportArity = exportBlock->getNumArguments();
-      // Export count region has !hal.device as block arg 0, then workloads.
-      if (configArity + 1 > exportArity) {
-        configOp.emitError("workload arity mismatch: dispatch_config has ")
-            << configArity << " args but export count region has "
-            << exportArity << " (expected >= " << configArity + 1
-            << " = config args + !hal.device)";
+      TypeRange configArgTypes = configBlock.getArgumentTypes();
+      TypeRange exportArgTypes = exportBlock->getArgumentTypes();
+      if (configArgTypes != exportArgTypes) {
+        configOp.emitError("block argument mismatch: dispatch_config has (")
+            << configArgTypes << ") but export count region has ("
+            << exportArgTypes << ")";
         return signalPassFailure();
       }
-      exportBlock->clear();
-      IRMapping mapping;
-      for (unsigned i = 0; i < configArity; ++i) {
-        mapping.map(configBlock.getArgument(i),
-                    exportBlock->getArgument(i + 1));
-      }
-      builder.setInsertionPointToEnd(exportBlock);
-      for (Operation &op : configBlock.without_terminator()) {
-        builder.clone(op, mapping);
-      }
+      countRegion.takeBody(configOp.getBody());
       // Replace iree_codegen.yield with hal.return.
-      auto yieldOp = cast<IREE::Codegen::YieldOp>(configBlock.getTerminator());
-      auto returnValues =
-          llvm::map_to_vector(yieldOp.getOperands(), [&](Value v) {
-            return mapping.lookupOrDefault(v);
-          });
-      IREE::HAL::ReturnOp::create(builder, yieldOp.getLoc(), returnValues);
+      Block &block = countRegion.front();
+      auto yieldOp = cast<IREE::Codegen::YieldOp>(block.getTerminator());
+      builder.setInsertionPoint(yieldOp);
+      IREE::HAL::ReturnOp::create(builder, yieldOp.getLoc(),
+                                   yieldOp.getOperands());
+      yieldOp.erase();
     }
 
     // Set workgroup_size and subgroup_size on the export.

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
@@ -67,7 +67,10 @@ void PropagateDispatchConfigPass::runOnOperation() {
             << exportArgTypes << ")";
         return signalPassFailure();
       }
-      countRegion.takeBody(configOp.getBody());
+      countRegion.dropAllReferences();
+      countRegion.getBlocks().clear();
+      builder.cloneRegionBefore(configOp.getBody(), countRegion,
+                                countRegion.end());
       // Replace iree_codegen.yield with hal.return.
       Block &block = countRegion.front();
       auto yieldOp = cast<IREE::Codegen::YieldOp>(block.getTerminator());

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
@@ -44,8 +44,7 @@ void PropagateDispatchConfigPass::runOnOperation() {
   SymbolTable symbolTable(variantOp);
   for (IREE::Codegen::DispatchConfigOp configOp : configOps) {
     StringRef funcRef = configOp.getFunctionRef();
-    auto exportOp =
-        symbolTable.lookup<IREE::HAL::ExecutableExportOp>(funcRef);
+    auto exportOp = symbolTable.lookup<IREE::HAL::ExecutableExportOp>(funcRef);
     if (!exportOp) {
       // No export for this function, so erase the dispatch_config and move on.
       configOp.erase();
@@ -74,7 +73,7 @@ void PropagateDispatchConfigPass::runOnOperation() {
       auto yieldOp = cast<IREE::Codegen::YieldOp>(block.getTerminator());
       builder.setInsertionPoint(yieldOp);
       IREE::HAL::ReturnOp::create(builder, yieldOp.getLoc(),
-                                   yieldOp.getOperands());
+                                  yieldOp.getOperands());
       yieldOp.erase();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
@@ -35,10 +35,10 @@ void PropagateDispatchConfigPass::runOnOperation() {
     return;
   }
 
-  // Collect all dispatch_config ops.
-  SmallVector<IREE::Codegen::DispatchConfigOp> configOps;
-  innerModule->walk(
-      [&](IREE::Codegen::DispatchConfigOp op) { configOps.push_back(op); });
+  // Collect all dispatch_config ops. These are direct children of the module
+  // (like func.func), so no walk needed.
+  SmallVector<IREE::Codegen::DispatchConfigOp> configOps =
+      llvm::to_vector(innerModule.getOps<IREE::Codegen::DispatchConfigOp>());
   if (configOps.empty()) {
     return;
   }
@@ -99,7 +99,7 @@ void PropagateDispatchConfigPass::runOnOperation() {
     }
 
     // Set workgroup_size and subgroup_size on the export.
-    auto wgSize = configOp.getWorkgroupSize();
+    std::optional<ArrayRef<int64_t>> wgSize = configOp.getWorkgroupSize();
     if (!wgSize) {
       configOp.emitError("missing workgroup_size attribute");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -110,6 +110,7 @@ iree_lit_test_suite(
             "pad_dynamic_alloc.mlir",
             "patch_func_ops.mlir",
             "propagate_constant_offsets.mlir",
+            "propagate_dispatch_config.mlir",
             "propagate_dispatch_size_bounds.mlir",
             "propagate_reshapes_by_expansion.mlir",
             "reconcile_translation_info.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -105,6 +105,7 @@ iree_lit_test_suite(
     "pad_dynamic_alloc.mlir"
     "patch_func_ops.mlir"
     "propagate_constant_offsets.mlir"
+    "propagate_dispatch_config.mlir"
     "propagate_dispatch_size_bounds.mlir"
     "propagate_reshapes_by_expansion.mlir"
     "reconcile_translation_info.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_config.mlir
@@ -1,0 +1,186 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-propagate-dispatch-config)))" --verify-diagnostics %s | FileCheck %s
+
+// Basic: single dispatch_config + export.
+hal.executable private @basic_exe {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export @matmul ordinal(0)
+        layout(#hal.pipeline.layout<bindings = [
+          #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+          #hal.pipeline.binding<storage_buffer, Indirect>
+        ]>)
+        count(%device: !hal.device, %w0: index, %w1: index)
+            -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0, %w1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul() {
+        return
+      }
+      iree_codegen.dispatch_config @matmul
+          workgroup_size = [64, 16, 1] subgroup_size = 64 {
+        ^bb0(%w0: index, %w1: index):
+          %c1 = arith.constant 1 : index
+          %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%w0]
+          iree_codegen.yield %0, %w1, %c1 : index, index, index
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @basic_exe
+//       CHECK:   hal.executable.export public @matmul
+//       CHECK:     count(%[[DEV:.+]]: !hal.device, %[[W0:.+]]: index, %[[W1:.+]]: index)
+//       CHECK:       %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:       %[[X:.+]] = affine.apply
+//       CHECK:       hal.return %[[X]], %[[W1]], %[[C1]]
+//       CHECK:     } attributes {subgroup_size = 64 : index, workgroup_size = [64 : index, 16 : index, 1 : index]}
+//       CHECK:   builtin.module
+//       CHECK:     func.func @matmul()
+//   CHECK-NOT:     iree_codegen.dispatch_config
+
+// -----
+
+// Multiple dispatch_configs (specialization).
+hal.executable private @specialized_exe {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export @matmul ordinal(0)
+        layout(#hal.pipeline.layout<bindings = [
+          #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+          #hal.pipeline.binding<storage_buffer, Indirect>
+        ]>)
+        count(%device: !hal.device, %w0: index)
+            -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export @matmul_0 ordinal(1)
+        layout(#hal.pipeline.layout<bindings = [
+          #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+          #hal.pipeline.binding<storage_buffer, Indirect>
+        ]>)
+        count(%device: !hal.device, %w0: index)
+            -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul() {
+        return
+      }
+      func.func @matmul_0() {
+        return
+      }
+      iree_codegen.dispatch_config @matmul
+          workgroup_size = [64, 16, 1] subgroup_size = 64 {
+        ^bb0(%w0: index):
+          %c1 = arith.constant 1 : index
+          iree_codegen.yield %w0, %c1, %c1 : index, index, index
+      }
+      iree_codegen.dispatch_config @matmul_0
+          workgroup_size = [256, 1, 1] subgroup_size = 64 {
+        ^bb0(%w0: index):
+          %c1 = arith.constant 1 : index
+          %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%w0]
+          iree_codegen.yield %0, %c1, %c1 : index, index, index
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @specialized_exe
+//       CHECK:   hal.executable.export public @matmul
+//       CHECK:     count(%{{.+}}: !hal.device, %[[W0A:.+]]: index)
+//       CHECK:       %[[C1A:.+]] = arith.constant 1 : index
+//       CHECK:       hal.return %[[W0A]], %[[C1A]], %[[C1A]]
+//       CHECK:     } attributes {subgroup_size = 64 : index, workgroup_size = [64 : index, 16 : index, 1 : index]}
+//       CHECK:   hal.executable.export public @matmul_0
+//       CHECK:     count(%{{.+}}: !hal.device, %[[W0B:.+]]: index)
+//       CHECK:       %[[C1B:.+]] = arith.constant 1 : index
+//       CHECK:       %[[X:.+]] = affine.apply
+//       CHECK:       hal.return %[[X]], %[[C1B]], %[[C1B]]
+//       CHECK:     } attributes {subgroup_size = 64 : index, workgroup_size = [256 : index, 1 : index, 1 : index]}
+
+// -----
+
+// No subgroup_size attribute.
+hal.executable private @no_subgroup_exe {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export @entry ordinal(0)
+        layout(#hal.pipeline.layout<bindings = [
+          #hal.pipeline.binding<storage_buffer, Indirect>
+        ]>)
+        count(%device: !hal.device, %w0: index)
+            -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry() {
+        return
+      }
+      iree_codegen.dispatch_config @entry
+          workgroup_size = [1024, 1, 1] {
+        ^bb0(%w0: index):
+          %c1 = arith.constant 1 : index
+          iree_codegen.yield %w0, %c1, %c1 : index, index, index
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @no_subgroup_exe
+//       CHECK:   hal.executable.export public @entry
+//       CHECK:       hal.return
+//       CHECK:     } attributes {workgroup_size = [1024 : index, 1 : index, 1 : index]}
+//   CHECK-NOT:     subgroup_size
+
+// -----
+
+// No dispatch_config ops — pass is a no-op.
+hal.executable private @noop_exe {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export @entry ordinal(0)
+        layout(#hal.pipeline.layout<bindings = [
+          #hal.pipeline.binding<storage_buffer, Indirect>
+        ]>)
+        count(%device: !hal.device, %w0: index)
+            -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @noop_exe
+//       CHECK:   iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+// -----
+
+// Error: arity mismatch.
+hal.executable private @arity_mismatch_exe {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export @entry ordinal(0)
+        layout(#hal.pipeline.layout<bindings = [
+          #hal.pipeline.binding<storage_buffer, Indirect>
+        ]>)
+        count(%device: !hal.device, %w0: index)
+            -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry() {
+        return
+      }
+      // expected-error @+1 {{workload arity mismatch}}
+      iree_codegen.dispatch_config @entry
+          workgroup_size = [64, 1, 1] {
+        ^bb0(%w0: index, %w1: index, %w2: index):
+          %c1 = arith.constant 1 : index
+          iree_codegen.yield %w0, %c1, %c1 : index, index, index
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_config.mlir
@@ -19,7 +19,7 @@ hal.executable private @basic_exe {
       }
       iree_codegen.dispatch_config @matmul
           workgroup_size = [64, 16, 1] subgroup_size = 64 {
-        ^bb0(%w0: index, %w1: index):
+        ^bb0(%device: !hal.device, %w0: index, %w1: index):
           %c1 = arith.constant 1 : index
           %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%w0]
           iree_codegen.yield %0, %w1, %c1 : index, index, index
@@ -72,13 +72,13 @@ hal.executable private @specialized_exe {
       }
       iree_codegen.dispatch_config @matmul
           workgroup_size = [64, 16, 1] subgroup_size = 64 {
-        ^bb0(%w0: index):
+        ^bb0(%device: !hal.device, %w0: index):
           %c1 = arith.constant 1 : index
           iree_codegen.yield %w0, %c1, %c1 : index, index, index
       }
       iree_codegen.dispatch_config @matmul_0
           workgroup_size = [256, 1, 1] subgroup_size = 64 {
-        ^bb0(%w0: index):
+        ^bb0(%device: !hal.device, %w0: index):
           %c1 = arith.constant 1 : index
           %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%w0]
           iree_codegen.yield %0, %c1, %c1 : index, index, index
@@ -119,7 +119,7 @@ hal.executable private @no_subgroup_exe {
       }
       iree_codegen.dispatch_config @entry
           workgroup_size = [1024, 1, 1] {
-        ^bb0(%w0: index):
+        ^bb0(%device: !hal.device, %w0: index):
           %c1 = arith.constant 1 : index
           iree_codegen.yield %w0, %c1, %c1 : index, index, index
       }
@@ -174,10 +174,10 @@ hal.executable private @arity_mismatch_exe {
       func.func @entry() {
         return
       }
-      // expected-error @+1 {{workload arity mismatch}}
+      // expected-error @+1 {{block argument mismatch}}
       iree_codegen.dispatch_config @entry
           workgroup_size = [64, 1, 1] {
-        ^bb0(%w0: index, %w1: index, %w2: index):
+        ^bb0(%device: !hal.device, %w0: index, %w1: index, %w2: index):
           %c1 = arith.constant 1 : index
           iree_codegen.yield %w0, %c1, %c1 : index, index, index
       }


### PR DESCRIPTION
The pass clones the dispatch metadata and slice computation from IREE::Codegen::DispatchConfig op to HAL::ExportOp. It works at `IREE::HAL::ExecutableVariantOp` scope because it needs to access the export op and configs within the inner module.

It is a step towards https://github.com/iree-org/iree/discussions/23642