### PR TITLE
Integrates/llvm@6dabcef

### DIFF
--- a/compiler/bindings/python/iree/compiler/__init__.py
+++ b/compiler/bindings/python/iree/compiler/__init__.py
@@ -11,17 +11,3 @@
 from .tools import *
 
 from iree.compiler import ir
-
-
-# Resolves collisions for attribute builders defined in multiple TD files.
-# TODO: Remove this once IREE integrates
-# https://github.com/llvm/llvm-project/pull/187191.
-def register_attribute_builder(kind, replace=True):
-    def decorator_builder(func):
-        ir.AttrBuilder.insert(kind, func, replace=replace)
-        return func
-
-    return decorator_builder
-
-
-ir.register_attribute_builder = register_attribute_builder

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -6,19 +6,6 @@
 
 from iree.compiler import ir
 
-
-# Substitute `replace=True` so that colliding registration don't error.
-# TODO(makslevental): remove after https://github.com/llvm/llvm-project/pull/117918 is resolved.
-def register_attribute_builder(kind, replace=True):
-    def decorator_builder(func):
-        ir.AttrBuilder.insert(kind, func, replace=replace)
-        return func
-
-    return decorator_builder
-
-
-ir.register_attribute_builder = register_attribute_builder
-
 # Test upstream dialects import
 from iree.compiler.dialects import (
     affine,


### PR DESCRIPTION
carry two local reverts https://github.com/iree-org/llvm-project/commit/1a0e6684daeb58ec4c63fbf8c021523ebde0a0e6 and https://github.com/iree-org/llvm-project/commit/72060ebc4f564d5e5aa1bd481e5c10303f19c3cb

bump to https://github.com/llvm/llvm-project/commit/6dabcef0b3ffa0beadd426e0fd56c61c45b5b396