### PR TITLE
[Codegen] Skip bf16 expansion for targets with native conversion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -332,7 +332,6 @@ struct ConvertToROCDLPass final
       vector::populateVectorTransposeLoweringPatterns(
           patterns, options.vectorTransposeLowering);
       vector::populateVectorTransferLoweringPatterns(patterns);
-      arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",
             "convert_to_rocdl_gfx1201.mlir",
+            "convert_to_rocdl_gfx942.mlir",
             "convert_to_rocdl_gfx950.mlir",
             "create_async_groups.mlir",
             "create_tile_sizes.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"
     "convert_to_rocdl_gfx1201.mlir"
+    "convert_to_rocdl_gfx942.mlir"
     "convert_to_rocdl_gfx950.mlir"
     "create_async_groups.mlir"
     "create_tile_sizes.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx942.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-convert-to-rocdl %s | FileCheck %s
+
+// Verify that arith.truncf f32 to bf16 is not expanded on gfx942. The LLVM
+// backend handles bf16 emulation during instruction selection for targets
+// lacking native bf16 conversion instructions (v_cvt_pk_bf16_f32).
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+module {
+  func.func @bf16_truncf_native() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<64xf32>
+    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<64xbf16>
+    %val = memref.load %0[%c0] : memref<64xf32>
+    %trunc = arith.truncf %val : f32 to bf16
+    memref.store %trunc, %1[%c0] : memref<64xbf16>
+    return
+  }
+}
+// CHECK-LABEL: llvm.func @bf16_truncf_native
+//       CHECK:   llvm.fptrunc
+//   CHECK-NOT:   llvm.lshr
+//       CHECK:   llvm.return
+
+// -----
+
+// Verify that arith.extf bf16 to f32 is not expanded on gfx942.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+module {
+  func.func @bf16_extf_native() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<64xbf16>
+    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<64xf32>
+    %val = memref.load %0[%c0] : memref<64xbf16>
+    %ext = arith.extf %val : bf16 to f32
+    memref.store %ext, %1[%c0] : memref<64xf32>
+    return
+  }
+}
+// CHECK-LABEL: llvm.func @bf16_extf_native
+//       CHECK:   llvm.fpext
+//   CHECK-NOT:   llvm.shl
+//       CHECK:   llvm.return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck %s
 
 // Test permlane lowering on gfx950.
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -26,9 +26,9 @@ module {
   }
 }
 
-// CHECK-PERMLANE-LABEL: llvm.func @test_permlane_16_32_lowering
-// CHECK-PERMLANE: rocdl.permlane32.swap
-// CHECK-PERMLANE: rocdl.permlane16.swap
+// CHECK-LABEL: llvm.func @test_permlane_16_32_lowering
+// CHECK: rocdl.permlane32.swap
+// CHECK: rocdl.permlane16.swap
 
 // -----
 
@@ -39,5 +39,29 @@ module {
   }
 }
 
-// CHECK-PERMLANE-LABEL: llvm.func @global_subgroup_barrier
-//       CHECK-PERMLANE:   rocdl.s.barrier
+// CHECK-LABEL: llvm.func @global_subgroup_barrier
+//       CHECK:   rocdl.s.barrier
+
+// -----
+
+// Verify that arith.truncf f32 to bf16 is NOT expanded on gfx950, which has
+// native bf16 conversion instructions (v_cvt_pk_bf16_f32).
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+module {
+  func.func @bf16_truncf_native() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<64xf32>
+    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<64xbf16>
+    %val = memref.load %0[%c0] : memref<64xf32>
+    %trunc = arith.truncf %val : f32 to bf16
+    memref.store %trunc, %1[%c0] : memref<64xbf16>
+    return
+  }
+}
+// CHECK-LABEL: llvm.func @bf16_truncf_native
+//       CHECK:   llvm.fptrunc
+//   CHECK-NOT:   llvm.lshr
+//       CHECK:   llvm.return


### PR DESCRIPTION
Don't expand arith.truncf to integer bit manipulation for bf16 dtype. On targets like gfx950 and gfx12+, which have v_cvt_pk_bf16_f32 for hardware f32→bf16 conversion, this expansion costs VGPRs. On targets that don't have an explicit intrinsic to perform this conversion, llvm backend will handle the conversion for us. In either case this expansion is unnecessary.

On gfx950, This frees 12 VGPRs in scaled gemm workloads across 50 shapes (profiled with rocprofv3).

Made-with: Cursor