### PR TITLE
[nfc] Use `func.func` instead of `any` in lit tests.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(any(iree-codegen-test-vector-layout-analysis))" --split-input-file %s --verify-diagnostics
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-test-vector-layout-analysis))" --split-input-file %s --verify-diagnostics
 
 #layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],

--- a/compiler/src/iree/compiler/Codegen/Dialect/Map/ExternalInterfaces/test/pack_layout_vector_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Map/ExternalInterfaces/test/pack_layout_vector_analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -pass-pipeline="builtin.module(any(iree-codegen-test-vector-layout-analysis))" --split-input-file %s --verify-diagnostics
+// RUN: iree-opt -pass-pipeline="builtin.module(func.func(iree-codegen-test-vector-layout-analysis))" --split-input-file %s --verify-diagnostics
 
 // Basic propagation
 


### PR DESCRIPTION
It is a follow-up of
https://discord.com/channels/689900678990135345/1484610267571814471, because we want to keep consistency for tests. It forces the lit tests using `func.func`.