### PR TITLE
[GPU] Fix WMMA col_major LHS/RHS swap in createMmaOp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -796,6 +796,12 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
         .getResult();
   }
   if (is_AMD_WMMA(intrinsic)) {
+    // As with MFMA, the thread layouts of the lhs and rhs are transpositions
+    // of one another for all WMMA variants, so swapping produces a column
+    // major result.
+    if (colMajor) {
+      std::swap(lhs, rhs);
+    }
     return amdgpu::WMMAOp::create(builder, loc, resultType, layout.mSize,
                                   layout.nSize, layout.kSize, lhs, rhs, acc)
         .getResult();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -46,6 +46,15 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>
 
 module {
+  func.func @test_col_major_WMMAR3_f16_16x16x16_f32() attributes {
+      mma_types = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16, col_major = true>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_col_major_WMMAR3_f16_16x16x16_f32
+//  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16, col_major = true>
+
+module {
   func.func @test_data_tiled_mfma_f32_16x16x4_f32() attributes {
       mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 4, subgroups_m = 2, intrinsics_k = 1, operands_interleaving_intrinsics_k = [0, 1]>} {
     return
@@ -62,6 +71,15 @@ module {
 }
 // CHECK-LABEL: func @test_WMMAR4_f16_16x16x16_f32
 //  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>
+
+module {
+  func.func @test_col_major_WMMAR4_f16_16x16x16_f32() attributes {
+      mma_types = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16, col_major = true>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_col_major_WMMAR4_f16_16x16x16_f32
+//  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16, col_major = true>
 
 module {
   func.func @test_WMMA_f32_16x16x4_f32() attributes {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_inner_tiled.mlir
@@ -181,6 +181,40 @@ module attributes { transform.with_named_sequence } {
  affine_map<() -> ()>,
  affine_map<() -> ()>
 ]
+func.func @lower_col_major_multi_mma_wmmar3_16x16x16(%lhs: vector<16xf16>, %rhs: vector<16xf16>, %acc: vector<8xf32>) -> vector<8xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [],
+    kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16, col_major = true>,
+    semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+  } : vector<16xf16>, vector<16xf16> into vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_col_major_multi_mma_wmmar3_16x16x16
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<16xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<16xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<8xf32>
+//       CHECK:   amdgpu.wmma 16x16x16 %[[RHS]] * %[[LHS]] + %[[ACC]]
+//  CHECK-SAME:     : vector<16xf16>, vector<16xf16>, vector<8xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
 func.func @lower_multi_mma_wmmar4_16x16x16(%lhs: vector<8xf16>, %rhs: vector<8xf16>, %acc: vector<8xf32>) -> vector<8xf32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
@@ -206,6 +240,40 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<8xf16>
 //  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<8xf32>
 //       CHECK:   amdgpu.wmma 16x16x16 %[[LHS]] * %[[RHS]] + %[[ACC]]
+//  CHECK-SAME:     : vector<8xf16>, vector<8xf16>, vector<8xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_col_major_multi_mma_wmmar4_16x16x16(%lhs: vector<8xf16>, %rhs: vector<8xf16>, %acc: vector<8xf32>) -> vector<8xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [],
+    kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16, col_major = true>,
+    semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+  } : vector<8xf16>, vector<8xf16> into vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_col_major_multi_mma_wmmar4_16x16x16
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<8xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<8xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<8xf32>
+//       CHECK:   amdgpu.wmma 16x16x16 %[[RHS]] * %[[LHS]] + %[[ACC]]
 //  CHECK-SAME:     : vector<8xf16>, vector<8xf16>, vector<8xf32>
 
 // -----


### PR DESCRIPTION
The `col_major` flag on MMAAttr triggers an LHS/RHS operand swap in createMmaOp() to produce a column-major result. This swap was implemented for MFMA but missing for WMMA, so col_major = true had no effect on any WMMA intrinsic.

Add the swap for the `is_AMD_WMMA` branch with tests for `WMMAR3` and `WMMAR4`. Benchmarking standalone matmuls on RX 9070 XT (gfx1201) showed no measurable performance difference between row-major and col-major. Further testing on attention and other workloads is still needed to evaluate the full performance impact.

This PR is to solve https://github.com/nod-ai/amd-shark-ai/issues/2872.