### PR TITLE
Add byte_offset to hal.tensor.import for subspan alignment

### DIFF
--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -221,6 +221,7 @@ private:
           recalculateBuilder, loc, inputValue.getType(), inputPlaceholder,
           inputValue.getType(), dynamicDims, /*consume=*/false,
           /*wait_fence=*/Value{},
+          /*byte_offset=*/Value{},
           /*name=*/nullptr,
           /*affinity=*/nullptr);
       inputValue.replaceAllUsesWith(castOp.getTarget());
@@ -522,6 +523,7 @@ private:
           TypeAttr::get(inputDynamicDims.tensorType), dynamicDims,
           /*consume=*/UnitAttr{},
           /*wait_fence=*/Value{},
+          /*byte_offset=*/Value{},
           /*name=*/nullptr,
           /*affinity=*/nullptr));
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -49,6 +49,10 @@ struct ElideUnusedOp : OpRewritePattern<Op> {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult TensorImportOp::fold(FoldAdaptor operands) {
+  // Cannot fold if there is a byte offset — the import is a subview.
+  if (getByteOffset()) {
+    return {};
+  }
   if (auto exportOp = getSource().getDefiningOp<TensorExportOp>()) {
     if (exportOp.getSource().getType() == getTarget().getType() &&
         exportOp.getSourceEncoding() == getTargetEncoding()) {
@@ -60,6 +64,10 @@ OpFoldResult TensorImportOp::fold(FoldAdaptor operands) {
 
 OpFoldResult TensorExportOp::fold(FoldAdaptor operands) {
   if (auto importOp = getSource().getDefiningOp<TensorImportOp>()) {
+    // Cannot fold through an import with byte_offset — it's a subview.
+    if (importOp.getByteOffset()) {
+      return {};
+    }
     if (importOp.getSource().getType() == getTarget().getType() &&
         importOp.getTargetEncoding() == getSourceEncoding()) {
       return importOp.getSource();

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -629,6 +629,15 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
                            TypeAttr targetEncoding, bool consume,
                            Value waitFence, StringAttr name,
                            Attribute affinity) {
+  build(builder, result, resultType, source, targetEncoding, consume, waitFence,
+        /*byteOffset=*/Value{}, name, affinity);
+}
+
+void TensorImportOp::build(OpBuilder &builder, OperationState &result,
+                           Type resultType, Value source,
+                           TypeAttr targetEncoding, bool consume,
+                           Value waitFence, Value byteOffset, StringAttr name,
+                           Attribute affinity) {
   auto shapedType = cast<ShapedType>(resultType);
   assert((isa<IREE::HAL::BufferViewType>(source.getType()) ||
           shapedType.hasStaticShape()) &&
@@ -644,8 +653,8 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
         builder.getIndexAttr(i)));
   }
   build(builder, result, resultType, source, targetEncoding, dynamicDims,
-        consume ? builder.getUnitAttr() : UnitAttr{}, waitFence, name,
-        affinity);
+        consume ? builder.getUnitAttr() : UnitAttr{}, waitFence, byteOffset,
+        name, affinity);
 }
 
 static LogicalResult verifyTypeStorageCompatibility(Operation *op,

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -125,6 +125,7 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
     HAL_ShapeDynamicDims:$target_dims,
     UnitAttr:$consume,
     Optional<HAL_Fence>:$wait_fence,
+    Optional<Index>:$byte_offset,
     OptionalAttr<StrAttr>:$name,
     OptionalAttr<AnyAttr>:$affinity
   );
@@ -137,6 +138,7 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
     (`wait` `(` $wait_fence^ `)` `=` `` `>`)?
     (`consume` $consume^)?
     $source
+    (`offset` `(` $byte_offset^ `)`)?
     ($name^)?
     `:` type($source) `->`
     custom<TypeAlias>($target_encoding, type($target)) (`{` $target_dims^ `}`)?
@@ -158,6 +160,16 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
       "TypeAttr":$targetEncoding,
       "bool":$consume,
       "Value":$waitFence,
+      "StringAttr":$name,
+      "Attribute":$affinity
+    )>,
+    OpBuilder<(ins
+      "Type":$resultType,
+      "Value":$source,
+      "TypeAttr":$targetEncoding,
+      "bool":$consume,
+      "Value":$waitFence,
+      "Value":$byteOffset,
       "StringAttr":$name,
       "Attribute":$affinity
     )>,

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_folding.mlir
@@ -12,6 +12,19 @@ util.func public @foldTensorImportExport(%arg0: !hal.buffer_view) -> !hal.buffer
 
 // -----
 
+// Import with byte_offset must not fold — the import is a subview.
+
+// CHECK-LABEL: @noFoldTensorImportExportWithOffset
+util.func public @noFoldTensorImportExportWithOffset(%arg0: !hal.buffer_view, %arg1: index) -> !hal.buffer_view {
+  // CHECK: hal.tensor.import
+  %0 = hal.tensor.import %arg0 offset(%arg1) : !hal.buffer_view -> tensor<5xi32>
+  // CHECK: hal.tensor.export
+  %1 = hal.tensor.export %0 : tensor<5xi32> -> !hal.buffer_view
+  util.return %1 : !hal.buffer_view
+}
+
+// -----
+
 // TODO(benvanik): add a canonicalizer to take buffer_view -> buffer and turn
 // it into a hal.buffer_view.buffer op and buffer -> buffer_view into a
 // hal.buffer_view.create.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
@@ -27,6 +27,24 @@ util.func public @tensorImportAsync(%arg0: !hal.buffer_view, %arg1: !hal.fence) 
 
 // -----
 
+// CHECK-LABEL: @tensorImportOffset
+util.func public @tensorImportOffset(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: index) -> tensor<4xf32> {
+  // CHECK: hal.tensor.import wait(%arg1) => %arg0 offset(%arg2) : !hal.buffer_view -> tensor<4xf32>
+  %0 = hal.tensor.import wait(%arg1) => %arg0 offset(%arg2) : !hal.buffer_view -> tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @tensorImportOffsetDynamic
+util.func public @tensorImportOffsetDynamic(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: index, %arg3: index) -> tensor<?xf32> {
+  // CHECK: hal.tensor.import wait(%arg1) => %arg0 offset(%arg2) : !hal.buffer_view -> tensor<?xf32>{%arg3}
+  %0 = hal.tensor.import wait(%arg1) => %arg0 offset(%arg2) : !hal.buffer_view -> tensor<?xf32>{%arg3}
+  util.return %0 : tensor<?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorExportDynamic
 util.func public @tensorExportDynamic(%arg0: tensor<?x3xi32>, %arg1: index) -> !hal.buffer_view {
   // CHECK: hal.tensor.export %arg0 "goodbye" : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -63,13 +63,24 @@ struct ConvertTensorImportOp
     // Import (buffer view to stream resource).
     auto resultType = rewriter.getType<IREE::Stream::ResourceType>(
         IREE::Stream::Lifetime::External);
-    Value resultSize = IREE::Stream::TensorSizeOfOp::create(
+    Value tensorSize = IREE::Stream::TensorSizeOfOp::create(
         rewriter, op.getLoc(), rewriter.getIndexType(),
         TypeAttr::get(op.getTarget().getType()),
         flattenValues(adaptor.getTargetDims()), executionAffinityAttr);
+
+    // When a byte_offset is specified, the tensor data starts at that offset
+    // within the source buffer. Import the full extent (offset + tensor size)
+    // and then subview to expose the offset to alignment analysis.
+    Value byteOffset = op.getByteOffset();
+    Value importSize = tensorSize;
+    if (byteOffset) {
+      importSize =
+          arith::AddIOp::create(rewriter, op.getLoc(), byteOffset, tensorSize);
+    }
+
     Value resource = IREE::Stream::TensorImportOp::create(
         rewriter, op.getLoc(), resultType, adaptor.getSource().front(),
-        targetType, flattenValues(adaptor.getTargetDims()), resultSize,
+        targetType, flattenValues(adaptor.getTargetDims()), importSize,
         op.getConsume(), executionAffinityAttr);
 
     // Await the fence, if needed. When not specified the resource is assumed to
@@ -81,16 +92,30 @@ struct ConvertTensorImportOp
           ValueRange{waitFence}, executionAffinityAttr);
       resource = IREE::Stream::TimepointAwaitOp::create(
                      rewriter, op.getLoc(), ValueRange{resource},
-                     ValueRange{resultSize}, waitTimepoint)
+                     ValueRange{importSize}, waitTimepoint)
                      .getResult(0);
+    }
+
+    // If byte_offset was specified, create a subview at that offset before
+    // the transfer. This makes the non-zero offset visible to
+    // AnnotateDispatchArguments, which computes alignment as
+    // gcd(base_alignment, offset).
+    Value transferSource = resource;
+    Value transferSize = importSize;
+    if (byteOffset) {
+      transferSource = IREE::Stream::ResourceSubviewOp::create(
+          rewriter, op.getLoc(), resource, importSize, byteOffset, tensorSize);
+      transferSize = tensorSize;
     }
 
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
     Value newImport = IREE::Stream::AsyncTransferOp::create(
-        rewriter, op.getLoc(), unknownType, resource, resultSize, resultSize,
+        rewriter, op.getLoc(), unknownType, transferSource, transferSize,
+        transferSize,
         /*source_affinity=*/executionAffinityAttr,
         /*target_affinity=*/executionAffinityAttr);
-    rewriter.replaceOpWithMultiple(op, {{newImport, resultSize}});
+
+    rewriter.replaceOpWithMultiple(op, {{newImport, transferSize}});
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
@@ -20,6 +20,47 @@ util.func public @importBufferView(%view: !hal.buffer_view) -> tensor<?x?x4xf32>
 
 // -----
 
+// CHECK-LABEL: @importBufferViewWithOffset
+// CHECK-SAME: (%[[VIEW:.+]]: !hal.buffer_view, %[[FENCE:.+]]: !hal.fence, %[[OFFSET:.+]]: index)
+// CHECK-SAME: -> (!stream.resource<*>, index)
+util.func public @importBufferViewWithOffset(%view: !hal.buffer_view, %fence: !hal.fence, %offset: index) -> tensor<4xf32> {
+  //  CHECK-DAG: %[[TENSOR_SIZE:.+]] = stream.tensor.sizeof tensor<4xf32>
+  //  CHECK-DAG: %[[TOTAL_SIZE:.+]] = arith.addi %[[OFFSET]], %[[TENSOR_SIZE]]
+  //      CHECK: %[[RESOURCE:.+]] = stream.tensor.import %[[VIEW]]
+  // CHECK-SAME:     : !hal.buffer_view -> tensor<4xf32> in !stream.resource<external>{%[[TOTAL_SIZE]]}
+  //      CHECK: %[[TIMEPOINT:.+]] = stream.timepoint.import %[[FENCE]]
+  //      CHECK: %[[SYNCED:.+]] = stream.timepoint.await %[[TIMEPOINT]] => %[[RESOURCE]]
+  // CHECK-SAME:     : !stream.resource<external>{%[[TOTAL_SIZE]]}
+  //      CHECK: %[[SUBVIEW:.+]] = stream.resource.subview %[[SYNCED]][%[[OFFSET]]] :
+  // CHECK-SAME:     !stream.resource<external>{%[[TOTAL_SIZE]]} -> !stream.resource<external>{%[[TENSOR_SIZE]]}
+  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.clone %[[SUBVIEW]]
+  // CHECK-SAME:     : !stream.resource<external>{%[[TENSOR_SIZE]]} -> !stream.resource<*>{%[[TENSOR_SIZE]]}
+  %0 = hal.tensor.import wait(%fence) => %view offset(%offset) : !hal.buffer_view -> tensor<4xf32>
+  // CHECK: util.return %[[RESULT]], %[[TENSOR_SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @importBufferViewWithOffsetNoFence
+// CHECK-SAME: (%[[VIEW:.+]]: !hal.buffer_view, %[[OFFSET:.+]]: index)
+// CHECK-SAME: -> (!stream.resource<*>, index)
+util.func public @importBufferViewWithOffsetNoFence(%view: !hal.buffer_view, %offset: index) -> tensor<4xf32> {
+  //  CHECK-DAG: %[[TENSOR_SIZE:.+]] = stream.tensor.sizeof tensor<4xf32>
+  //  CHECK-DAG: %[[TOTAL_SIZE:.+]] = arith.addi %[[OFFSET]], %[[TENSOR_SIZE]]
+  //      CHECK: %[[RESOURCE:.+]] = stream.tensor.import %[[VIEW]]
+  // CHECK-SAME:     : !hal.buffer_view -> tensor<4xf32> in !stream.resource<external>{%[[TOTAL_SIZE]]}
+  //      CHECK: %[[SUBVIEW:.+]] = stream.resource.subview %[[RESOURCE]][%[[OFFSET]]] :
+  // CHECK-SAME:     !stream.resource<external>{%[[TOTAL_SIZE]]} -> !stream.resource<external>{%[[TENSOR_SIZE]]}
+  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.clone %[[SUBVIEW]]
+  // CHECK-SAME:     : !stream.resource<external>{%[[TENSOR_SIZE]]} -> !stream.resource<*>{%[[TENSOR_SIZE]]}
+  %0 = hal.tensor.import %view offset(%offset) : !hal.buffer_view -> tensor<4xf32>
+  // CHECK: util.return %[[RESULT]], %[[TENSOR_SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @importBufferViewBitcasting
 // CHECK-SAME: (%[[VIEW:.+]]: !hal.buffer_view) -> (!stream.resource<*>, index)
 util.func public @importBufferViewBitcasting(%view: !hal.buffer_view) -> tensor<4xbf16> {


### PR DESCRIPTION
Adds an optional byte_offset operand to HAL_TensorImportOp so that non-zero offsets into parent buffers survive into the stream dialect. The HAL-to-Stream conversion creates a stream.resource.subview at the offset, making it visible to AnnotateDispatchArguments which computes correct alignment via GCD (e.g. gcd(64, 16) = 16).

Syntax: hal.tensor.import %bv offset(%off) : !hal.buffer_view -> tensor<...>