### PR TITLE
[LinalgExt] Replace local linearize-delinearize simplification with upstream patterns

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapStore.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapStore.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
-#include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-decompose-map-store"
@@ -101,134 +100,6 @@ struct FoldSubViewIntoMapStore final : OpRewritePattern<MapStoreOp> {
     rewriter.modifyOpInPlace(subViewOp, [&]() {
       mapStoreOp.getOutputMutable().assign(subViewSource);
     });
-    return success();
-  }
-};
-
-/// Simplify linearize→delinearize pairs where dimension products match.
-///
-/// When a delinearize directly consumes a linearize, we can group linearize
-/// dimensions and match them to delinearize dimensions when their products
-/// are equal. This breaks down the original operations into smaller chunks that
-/// will avoid long multiply-add and divide-remainder chains when these
-/// linearize→delinearize are further lowered.
-///
-/// This optimization currently handles one-to-one matches (a single linearize
-/// dimension matches a single delinearize dimension) and many-to-one matches
-/// (multiple linearize dimensions grouped together match a single delinearize
-/// dimension).
-///
-/// Example:
-///   %lin = affine.linearize_index [%a, %b, %c, %d, %e] by (%dyn0, 64, 4, 8, 8)
-///   %delin:3 = affine.delinearize_index %lin into (%dyn1, 256, 64)
-///
-/// If %dyn0 == %dyn1, 64*4 == 256, and 8*8 == 64, then we can simplify to:
-///   %delin#0 = %a  (direct passthrough)
-///   %delin#1 = affine.linearize_index [%b, %c] by (64, 4)
-///   %delin#2 = affine.linearize_index [%d, %e] by (8, 8)
-struct SimplifyLinearizeDelinearizePairs final
-    : OpRewritePattern<affine::AffineDelinearizeIndexOp> {
-  using Base::Base;
-  LogicalResult matchAndRewrite(affine::AffineDelinearizeIndexOp delinearizeOp,
-                                PatternRewriter &rewriter) const override {
-    // Find the linearize op that produces the input to this delinearize.
-    auto linearizeOp = delinearizeOp.getLinearIndex()
-                           .getDefiningOp<affine::AffineLinearizeIndexOp>();
-    if (!linearizeOp) {
-      return rewriter.notifyMatchFailure(
-          delinearizeOp, "delinearize op does not consume a linearize op");
-    }
-    // We only handle disjoint linearizations.
-    if (!linearizeOp.getDisjoint()) {
-      return rewriter.notifyMatchFailure(delinearizeOp,
-                                         "linearize op is not disjoint");
-    }
-    SmallVector<OpFoldResult> linearizeBases = linearizeOp.getMixedBasis();
-    SmallVector<OpFoldResult> delinearizeBases = delinearizeOp.getMixedBasis();
-    ValueRange linearizeInputs = linearizeOp.getMultiIndex();
-
-    Location loc = delinearizeOp.getLoc();
-    MLIRContext *ctx = rewriter.getContext();
-
-    // Structure to store the inputs and bases for new linearize ops.
-    struct LinearizeInfo {
-      SmallVector<Value> inputs;
-      SmallVector<OpFoldResult> bases;
-    };
-    SmallVector<LinearizeInfo> newLinearizeInfos;
-
-    // For each delinearize output dimension, try to match it with a product of
-    // one or more linearize dimensions. We build up the product incrementally
-    // and check for equality using value bounds analysis, which works for both
-    // static and dynamic dimensions.
-    // TODO(#23032): Consider separating bounds checking from transformation
-    // patterns into a shared utility for better organization of index analysis.
-    size_t linIdx = 0;
-    for (size_t delinIdx = 0;
-         delinIdx < delinearizeBases.size() && linIdx < linearizeBases.size();
-         ++delinIdx) {
-      LinearizeInfo newLinearizeInfo;
-      // Track operands for the AffineMap-based product expression.
-      SmallVector<Value> productOperands;
-      // Accumulate dimensions from the linearize op until we find a match.
-      while (linIdx < linearizeBases.size()) {
-        newLinearizeInfo.inputs.push_back(linearizeInputs[linIdx]);
-        newLinearizeInfo.bases.push_back(linearizeBases[linIdx]);
-
-        // Build up the product of basis dimension using affine expressions.
-        AffineExpr productExpr = getAffineConstantExpr(1, ctx);
-        productOperands.clear();
-        for (OpFoldResult basis : newLinearizeInfo.bases) {
-          if (auto attr = dyn_cast<Attribute>(basis)) {
-            // Handle the static basis as a constant expression.
-            int64_t val = cast<IntegerAttr>(attr).getInt();
-            productExpr = productExpr * getAffineConstantExpr(val, ctx);
-          } else {
-            // Handle the dynamic basis as a symbol expression.
-            Value val = cast<Value>(basis);
-            productOperands.push_back(val);
-            productExpr = productExpr *
-                          getAffineSymbolExpr(productOperands.size() - 1, ctx);
-          }
-        }
-        ++linIdx;
-        // Create Variable from the product expression.
-        AffineMap productMap =
-            AffineMap::get(0, productOperands.size(), productExpr, ctx);
-        ValueBoundsConstraintSet::Variable productVar(productMap,
-                                                      productOperands);
-        ValueBoundsConstraintSet::Variable delinearizeVar(
-            delinearizeBases[delinIdx]);
-
-        FailureOr<bool> areEqual =
-            ValueBoundsConstraintSet::areEqual(productVar, delinearizeVar);
-        if (succeeded(areEqual) && *areEqual) {
-          newLinearizeInfos.push_back(newLinearizeInfo);
-          break;
-        }
-      }
-    }
-
-    if (newLinearizeInfos.size() != delinearizeOp.getNumResults()) {
-      return rewriter.notifyMatchFailure(
-          delinearizeOp, "could not match all delinearize outputs");
-    }
-
-    SmallVector<Value> newResults;
-    for (const auto &info : newLinearizeInfos) {
-      if (info.inputs.size() == 1) {
-        // If there is a one-to-one match between linearize and delinearize
-        // dimensions, just pass through the linearize input.
-        newResults.push_back(info.inputs[0]);
-      } else {
-        // Otherwise, for a many-to-one match, create a new linearize op.
-        Value newLinearized = affine::AffineLinearizeIndexOp::create(
-            rewriter, loc, info.inputs, info.bases,
-            /*disjoint=*/true);
-        newResults.push_back(newLinearized);
-      }
-    }
-    rewriter.replaceOp(delinearizeOp, newResults);
     return success();
   }
 };
@@ -546,8 +417,8 @@ struct DecomposeMapStorePass final
     mlir::FunctionOpInterface funcOp = getOperation();
 
     RewritePatternSet patterns(context);
-    patterns.add<FoldSubViewIntoMapStore, SimplifyLinearizeDelinearizePairs>(
-        context);
+    patterns.add<FoldSubViewIntoMapStore>(context);
+    affine::populateSimplifyAffineWithBoundsPatterns(patterns);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_store.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_store.mlir
@@ -366,40 +366,8 @@ func.func @map_store_with_mask_on_inner_dim(
 
 // -----
 
-// A simple linearize→delinearize pair with static dimensions.
-// The pattern matches dimension products: 2*4 = 8 and 8*8 = 64.
-// This results in the delinearize outputs being replaced with new linearize
-// ops that group the matched dimensions.
-func.func @simplify_linearize_delinearize_pair_static(
-    %input: vector<2x4x8x8xf32>,
-    %output: memref<8x64xf32>
-) {
-  iree_linalg_ext.map_store %input into %output {
-    ^bb0(%idx0: index, %idx1: index, %idx2: index, %idx3: index):
-      %mask = arith.constant true
-      %linearized = affine.linearize_index disjoint [%idx0, %idx1, %idx2, %idx3] by (2, 4, 8, 8) : index
-      %delinearized:2 = affine.delinearize_index %linearized into (8, 64) : index, index
-      iree_linalg_ext.yield %delinearized#0, %delinearized#1, %mask : index, index, i1
-  } : vector<2x4x8x8xf32> into memref<8x64xf32>
-  return
-}
-// PREPROCESSING-LABEL: func.func @simplify_linearize_delinearize_pair_static(
-//  PREPROCESSING-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]: vector<2x4x8x8xf32>
-//  PREPROCESSING-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]: memref<8x64xf32>
-//       PREPROCESSING:   %[[TRUE:.+]] = arith.constant true
-//       PREPROCESSING:   iree_linalg_ext.map_store %[[INPUT]] into %[[OUTPUT]] {
-//       PREPROCESSING:     ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
-//       PREPROCESSING:       %[[LIN_0:.+]] = affine.linearize_index disjoint [%[[IDX0]], %[[IDX1]]] by (2, 4)
-//       PREPROCESSING:       %[[LIN_1:.+]] = affine.linearize_index disjoint [%[[IDX2]], %[[IDX3]]] by (8, 8)
-//       PREPROCESSING:       iree_linalg_ext.yield %[[LIN_0]], %[[LIN_1]], %[[TRUE]]
-
-// -----
-
-// A simple linearize→delinearize pair with dynamic dimensions.
-// The pattern matches:
-//   - %dim_ceildiv_128 * 128 = %dim_aligned_128
-//   - 208 = 208 (pass through)
-//   - 2 * 8 * 16 = 256
+// Verify that affine::populateSimplifyAffineWithBoundsPatterns is applied during
+// preprocessing.
 func.func @simplify_linearize_delinearize_pair_dynamic(
     %input: vector<1x128x208x2x8x16xf32>,
     %output: memref<?x208x256xf32>,
@@ -427,53 +395,3 @@ func.func @simplify_linearize_delinearize_pair_dynamic(
 //       PREPROCESSING:       %[[LIN_0:.+]] = affine.linearize_index disjoint [%[[IDX0]], %[[IDX1]]] by (%[[DIM_CEILDIV_128]], 128)
 //       PREPROCESSING:       %[[LIN_1:.+]] = affine.linearize_index disjoint [%[[IDX3]], %[[IDX4]], %[[IDX5]]] by (2, 8, 16)
 //       PREPROCESSING:       iree_linalg_ext.yield %[[LIN_0]], %[[IDX2]], %[[LIN_1]], %[[TRUE]]
-
-// -----
-
-// Negative test: NOT simplify because dimension products don't align.
-// The pattern cannot match:
-//   - 2 * 4 = 8 != 16
-// This results in the original linearize and delinearize ops remaining
-// unchanged.
-func.func @no_simplify_linearize_delinearize_pair_static(
-    %input: vector<2x4x8x8xf32>,
-    %output: memref<16x64xf32>
-) {
-  iree_linalg_ext.map_store %input into %output {
-    ^bb0(%idx0: index, %idx1: index, %idx2: index, %idx3: index):
-      %mask = arith.constant true
-      %linearized = affine.linearize_index disjoint [%idx0, %idx1, %idx2, %idx3] by (2, 4, 8, 8) : index
-      %delinearized:2 = affine.delinearize_index %linearized into (16, 64) : index, index
-      iree_linalg_ext.yield %delinearized#0, %delinearized#1, %mask : index, index, i1
-  } : vector<2x4x8x8xf32> into memref<16x64xf32>
-  return
-}
-// PREPROCESSING-LABEL: func.func @no_simplify_linearize_delinearize_pair_static(
-// PREPROCESSING:       affine.linearize_index disjoint [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] by (2, 4, 8, 8)
-// PREPROCESSING:       affine.delinearize_index %{{.*}} into (16, 64)
-
-// -----
-
-// Negative test: NOT simplify because dimension products don't align.
-// The pattern cannot match:
-//   - %dim0 * 128 != %dim1 (unrelated dynamic dimensions)
-// This results in the original linearize and delinearize ops remaining
-// unchanged.
-func.func @no_simplify_linearize_delinearize_pair_dynamic(
-    %input: vector<1x128x4x16xf32>,
-    %output: memref<?x64xf32>,
-    %dim0: index,
-    %dim1: index
-) {
-  iree_linalg_ext.map_store %input into %output {
-    ^bb0(%idx0: index, %idx1: index, %idx2: index, %idx3: index):
-      %mask = arith.constant true
-      %linearized = affine.linearize_index disjoint [%idx0, %idx1, %idx2, %idx3] by (%dim0, 128, 4, 16) : index
-      %delinearized:2 = affine.delinearize_index %linearized into (%dim1, 64) : index, index
-      iree_linalg_ext.yield %delinearized#0, %delinearized#1, %mask : index, index, i1
-  } : vector<1x128x4x16xf32> into memref<?x64xf32>
-  return
-}
-// PREPROCESSING-LABEL: func.func @no_simplify_linearize_delinearize_pair_dynamic(
-// PREPROCESSING:       affine.linearize_index disjoint [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] by (%{{.*}}, 128, 4, 16)
-// PREPROCESSING:       affine.delinearize_index %{{.*}} into (%{{.*}}, 64)


### PR DESCRIPTION
Replace the local `SimplifyLinearizeDelinearizePairs` pattern in `DecomposeMapStore` with the upstream `affine::populateSimplifyAffineWithBoundsPatterns` (llvm/llvm-project#187245).