### PR TITLE
Remove unused cmake target: iree-run-module-test-deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -816,13 +816,6 @@ add_custom_target(iree-test-deps
     iree-sample-deps
 )
 
-# Testing rules that generate test scripts for iree-run-module-test will add
-# dependencies to this target. It is a subset of `iree-test-deps`.
-add_custom_target(iree-run-module-test-deps
-  COMMENT
-    "Building IREE run module test targets"
-)
-
 # Convenience target for running IREE tests.
 add_custom_target(iree-run-tests
   COMMENT


### PR DESCRIPTION
iree-test-deps does not depend on iree-run-module-test-deps. Remove the unused target to reduce confusion.