### PR TITLE
feat(ScheduleAllocation): limit max allocation size in constants and result reservations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -1280,6 +1280,38 @@ struct ConstantAllocation {
   SmallVector<ConstantReservation> reservations;
 };
 
+// A bucket for collecting objects (e.g. AsyncConstantOps, ResourceReservation)
+// while tracking the total (static) size of the objects in the bucket.
+template <typename ObjT>
+struct SizeTrackingBucket {
+  SmallVector<ObjT> objs;
+  int64_t totalSize = 0;
+};
+
+Value getSizeInBucket(IREE::Stream::AsyncConstantOp &obj);
+
+Value getSizeInBucket(class ResourceReservation &obj);
+
+// List of size limited buckets (see SizeLimitedBucket above). Automatically
+// create a new bucket when the size of the previous one hits the limit.
+template <typename ObjT>
+struct SizeLimitedBucketList {
+  SmallVector<SizeTrackingBucket<ObjT>> buckets;
+
+  void add(ObjT &obj, int64_t maxSize) {
+    APInt opSizeInt;
+    int64_t opSize = 0;
+    if (matchPattern(getSizeInBucket(obj), m_ConstantInt(&opSizeInt))) {
+      opSize = opSizeInt.getZExtValue();
+    }
+    if (buckets.empty() || buckets.back().totalSize + opSize > maxSize) {
+      buckets.push_back(SizeTrackingBucket<ObjT>());
+    }
+    buckets.back().objs.push_back(obj);
+    buckets.back().totalSize += opSize;
+  }
+};
+
 // Returns true if |value| has one use and it is a stream.yield op.
 static bool isOnlyUseYield(Value value) {
   for (auto *user : value.getUsers()) {
@@ -1340,6 +1372,10 @@ allocateConstantBatch(IREE::Stream::AsyncExecuteOp executeOp,
   return allocation;
 }
 
+Value getSizeInBucket(IREE::Stream::AsyncConstantOp &obj) {
+  return obj.getResultSize();
+}
+
 // Extracts stream.async.constant ops with the given lifetime from |executeOp|
 // into their own dedicated stream.resource.constants upload op. The uploaded
 // constants will be captured by the region for use within as if they had still
@@ -1348,6 +1384,9 @@ static SmallVector<ConstantAllocation> extractConstantsWithLifetime(
     IREE::Stream::AsyncExecuteOp executeOp, IREE::Stream::Lifetime lifetime,
     AffinityAnalysis &affinityAnalysis, OpBuilder &externalBuilder) {
   SmallVector<ConstantAllocation> constantAllocations;
+  int64_t maxAllocationSize =
+      IREE::Stream::ResourceConfigAttr::lookup(executeOp)
+          .getMaxAllocationSize();
 
   [[maybe_unused]] std::unique_ptr<AsmState> asmState;
   LLVM_DEBUG(asmState = std::make_unique<AsmState>(executeOp->getParentOp()));
@@ -1355,9 +1394,12 @@ static SmallVector<ConstantAllocation> extractConstantsWithLifetime(
   // Bucket constant ops by affinity and whether they are global (from our
   // perspective, in that they escape into the global program) or local (only
   // used within this region and guaranteed dead by the end).
+  // Due to size limitations, a single affinity might have to use multiple
+  // buckets.
+  using ConstantsBucketList =
+      SizeLimitedBucketList<IREE::Stream::AsyncConstantOp>;
   using ConstantsForAffinityMap =
-      llvm::MapVector<IREE::Stream::AffinityAttr,
-                      SmallVector<IREE::Stream::AsyncConstantOp>>;
+      llvm::MapVector<IREE::Stream::AffinityAttr, ConstantsBucketList>;
   ConstantsForAffinityMap globalConstantOps;
   ConstantsForAffinityMap localConstantOps;
   for (auto constantOp : executeOp.getOps<IREE::Stream::AsyncConstantOp>()) {
@@ -1414,9 +1456,9 @@ static SmallVector<ConstantAllocation> extractConstantsWithLifetime(
 
     // Append to affinity bucket.
     if (resultValue) {
-      globalConstantOps[allocationAffinity].push_back(constantOp);
+      globalConstantOps[allocationAffinity].add(constantOp, maxAllocationSize);
     } else {
-      localConstantOps[allocationAffinity].push_back(constantOp);
+      localConstantOps[allocationAffinity].add(constantOp, maxAllocationSize);
     }
   }
 
@@ -1426,13 +1468,17 @@ static SmallVector<ConstantAllocation> extractConstantsWithLifetime(
   // we run all initializers to completion and are (as much as we can be) pretty
   // sure the non-transient allocation gets released by the time we get back to
   // user code.
-  for (auto [affinityAttr, constantOps] : globalConstantOps) {
-    constantAllocations.push_back(allocateConstantBatch(
-        executeOp, affinityAttr, constantOps, externalBuilder));
+  for (auto [affinityAttr, constantsBucketList] : globalConstantOps) {
+    for (auto &constantsBucket : constantsBucketList.buckets) {
+      constantAllocations.push_back(allocateConstantBatch(
+          executeOp, affinityAttr, constantsBucket.objs, externalBuilder));
+    }
   }
-  for (auto [affinityAttr, constantOps] : localConstantOps) {
-    constantAllocations.push_back(allocateConstantBatch(
-        executeOp, affinityAttr, constantOps, externalBuilder));
+  for (auto [affinityAttr, constantsBucketList] : localConstantOps) {
+    for (auto &constantsBucket : constantsBucketList.buckets) {
+      constantAllocations.push_back(allocateConstantBatch(
+          executeOp, affinityAttr, constantsBucket.objs, externalBuilder));
+    }
   }
 
   return constantAllocations;
@@ -1492,9 +1538,12 @@ struct ResultAllocation {
   SmallVector<ResultReservationSet> reservationSets;
 };
 
+Value getSizeInBucket(ResultReservation &obj) { return obj.resultSize; }
+
 // A map of allocation placement affinities to the alloc reservations requested.
+using ResultReservationsBucketList = SizeLimitedBucketList<ResultReservation>;
 using ResultAllocationMap =
-    llvm::MapVector<IREE::Stream::AffinityAttr, SmallVector<ResultReservation>>;
+    llvm::MapVector<IREE::Stream::AffinityAttr, ResultReservationsBucketList>;
 
 // Produces parameters for one or more result allocations composed of an ordered
 // set of |reservations| with matching lifetimes. Allocations will be bucketed
@@ -1504,18 +1553,29 @@ static std::vector<ResultAllocation>
 reserveResultAllocations(ResultAllocationMap &reservationMap) {
   std::vector<ResultAllocation> result;
   for (auto &[affinityAttr, reservations] : reservationMap) {
+    // Each bucket already respects the max size budget, so produce one
+    // ResultReservationSet per bucket per lifetime to preserve the splitting.
     // We want deterministic ordering of the allocations for each lifetime type
     // so we build them all here and then just nuke the ones we don't end up
     // using.
-    SmallVector<ResultReservationSet> sets(
-        IREE::Stream::getMaxEnumValForLifetime() + 1);
-    for (auto &reservation : reservations) {
-      auto &set =
-          sets[static_cast<unsigned>(reservation.resultType.getLifetime())];
-      set.reservationLocs.push_back(reservation.loc);
-      set.reservationTypes.push_back(reservation.resultType);
-      set.reservationSizes.push_back(reservation.resultSize);
-      set.reservations.push_back(std::move(reservation));
+    SmallVector<ResultReservationSet> sets;
+    for (auto &bucket : reservations.buckets) {
+      // Sub-bucket by lifetime within each size-limited bucket.
+      llvm::DenseMap<unsigned, size_t> lifetimeToSetIndex;
+      for (auto &reservation : bucket.objs) {
+        unsigned lifetime =
+            static_cast<unsigned>(reservation.resultType.getLifetime());
+        auto it = lifetimeToSetIndex.find(lifetime);
+        if (it == lifetimeToSetIndex.end()) {
+          lifetimeToSetIndex[lifetime] = sets.size();
+          sets.push_back(ResultReservationSet());
+        }
+        auto &set = sets[lifetimeToSetIndex[lifetime]];
+        set.reservationLocs.push_back(reservation.loc);
+        set.reservationTypes.push_back(reservation.resultType);
+        set.reservationSizes.push_back(reservation.resultSize);
+        set.reservations.push_back(std::move(reservation));
+      }
     }
 
     // Remove unused sets. This does a bunch of moves and is really bad but eh.
@@ -1640,6 +1700,9 @@ static bool isExecutedOnce(Operation *op) {
 static LogicalResult
 allocateExecutionRegion(IREE::Stream::AsyncExecuteOp executeOp,
                         AffinityAnalysis &affinityAnalysis) {
+  int64_t maxAllocationSize =
+      IREE::Stream::ResourceConfigAttr::lookup(executeOp)
+          .getMaxAllocationSize();
   LLVM_DEBUG(llvm::dbgs() << "[[ Allocating execution region ]]\n");
 
   AllocationScope scope(executeOp);
@@ -1868,7 +1931,8 @@ allocateExecutionRegion(IREE::Stream::AsyncExecuteOp executeOp,
       resultReservation.result.printAsOperand(llvm::dbgs(), asmState);
       llvm::dbgs() << "\n";
     });
-    resultReservations[allocationAffinity].push_back(resultReservation);
+    resultReservations[allocationAffinity].add(resultReservation,
+                                               maxAllocationSize);
   }
   for (auto &resultAllocation : reserveResultAllocations(resultReservations)) {
     for (auto &reservationSet : resultAllocation.reservationSets) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_allocation.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_allocation.mlir
@@ -984,3 +984,114 @@ util.func public @multiAffinityLotsOfDevices(%wait_timepoint: !stream.timepoint)
 
   util.return
 }
+
+// -----
+
+// Tests that constants are split into multiple batches when their total size
+// exceeds the max allocation size from the resource config. With a 16-byte
+// limit and an 8-byte + 16-byte constant, the second spills to a new batch.
+
+#splitConstantsBySize = #stream.resource_config<{
+  max_allocation_size = 16,
+  min_buffer_offset_alignment = 16,
+  max_buffer_range = 1073741824,
+  min_buffer_range_alignment = 16,
+  index_bits = 32
+}>
+
+// CHECK-LABEL: @splitConstantsByMaxAllocationSize
+util.func public @splitConstantsByMaxAllocationSize(%timepoint: !stream.timepoint)
+    attributes {stream.resources = #splitConstantsBySize} {
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+
+  // An 8-byte and a 16-byte constant. The bucket logic adds raw sizes:
+  // bucket has 8, adding 16 = 24 > 16, so the second spills to a new batch.
+
+  // CHECK: %[[CST0:.+]], %[[CST0_TIMEPOINT:.+]] = stream.resource.constants :
+  // CHECK-NEXT: !stream.resource<constant>{%c8} = dense<3> : tensor<8xi8>
+
+  // CHECK: %[[CST1:.+]], %[[CST1_TIMEPOINT:.+]] = stream.resource.constants :
+  // CHECK-NEXT: !stream.resource<constant>{%c16} = dense<4> : tensor<16xi8>
+
+  %results:2, %result_timepoint = stream.async.execute await(%timepoint) => with() -> (!stream.resource<constant>{%c8}, !stream.resource<constant>{%c16}) {
+    %cst0 = stream.async.constant : !stream.resource<constant>{%c8} = dense<3> : tensor<8xi8>
+    %cst1 = stream.async.constant : !stream.resource<constant>{%c16} = dense<4> : tensor<16xi8>
+    stream.yield %cst0, %cst1 : !stream.resource<constant>{%c8}, !stream.resource<constant>{%c16}
+  } => !stream.timepoint
+
+  util.optimization_barrier %results#0 : !stream.resource<constant>
+  util.optimization_barrier %results#1 : !stream.resource<constant>
+  util.return
+}
+
+// -----
+
+// Tests that a single constant exceeding the max allocation size still gets
+// allocated (does not cause an infinite loop).
+
+#singleConstantExceedsSize = #stream.resource_config<{
+  max_allocation_size = 4,
+  min_buffer_offset_alignment = 16,
+  max_buffer_range = 1073741824,
+  min_buffer_range_alignment = 16,
+  index_bits = 32
+}>
+
+// CHECK-LABEL: @singleConstantExceedsMaxAllocationSize
+util.func public @singleConstantExceedsMaxAllocationSize(%timepoint: !stream.timepoint)
+    attributes {stream.resources = #singleConstantExceedsSize} {
+  %c16 = arith.constant 16 : index
+
+  // The constant is 16 bytes but the limit is 4 bytes.
+  // It still gets its own batch (the bucket starts empty so it's added).
+  // CHECK: %[[CST:.+]], %[[CST_TIMEPOINT:.+]] = stream.resource.constants :
+  // CHECK-NEXT: !stream.resource<constant>{%c16} = dense<5> : tensor<16xi8>
+
+  %result, %result_timepoint = stream.async.execute await(%timepoint) => with() -> (!stream.resource<constant>{%c16}) {
+    %cst = stream.async.constant : !stream.resource<constant>{%c16} = dense<5> : tensor<16xi8>
+    stream.yield %cst : !stream.resource<constant>{%c16}
+  } => !stream.timepoint
+
+  util.optimization_barrier %result : !stream.resource<constant>
+  util.return
+}
+
+// -----
+
+// Tests that results are split into multiple allocations when their total size
+// exceeds the max allocation size from the resource config.
+
+#splitResultsBySize = #stream.resource_config<{
+  max_allocation_size = 100,
+  min_buffer_offset_alignment = 16,
+  max_buffer_range = 1073741824,
+  min_buffer_range_alignment = 16,
+  index_bits = 32
+}>
+
+// CHECK-LABEL: @splitResultsByMaxAllocationSize
+util.func public @splitResultsByMaxAllocationSize()
+    attributes {stream.resources = #splitResultsBySize} {
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c254_i32 = arith.constant 254 : i32
+  %c255_i32 = arith.constant 255 : i32
+
+  // Two results: 64 bytes and 128 bytes. The first fits (64 <= 100), but
+  // adding the second would exceed (64 + 128 = 192 > 100). So they should be
+  // allocated separately, each getting its own alloca.
+  // CHECK: stream.resource.alloca uninitialized
+  // CHECK: stream.resource.alloca uninitialized
+
+  %results:2, %result_timepoint = stream.async.execute with() -> (!stream.resource<transient>{%c64}, !stream.resource<transient>{%c128}) {
+    %0 = stream.async.splat %c254_i32 : i32 -> !stream.resource<transient>{%c64}
+    %1 = stream.async.splat %c255_i32 : i32 -> !stream.resource<transient>{%c128}
+    stream.yield %0, %1 : !stream.resource<transient>{%c64}, !stream.resource<transient>{%c128}
+  } => !stream.timepoint
+
+  util.optimization_barrier %result_timepoint : !stream.timepoint
+  util.optimization_barrier %results#0 : !stream.resource<transient>
+  util.optimization_barrier %results#1 : !stream.resource<transient>
+  util.return
+}


### PR DESCRIPTION
Extend the ScheduleAllocationPass to limit the size of the allocations for constants and result reservations to the maximum set by the --iree-stream-resource-max-allocation-size parameter when joining multiple ones into a single buffer.
If a single constant or result is already bigger than the maximum allocation size, it will still be allocated, but in a separate buffer.

This is required for custom devices that have a strict upper limit on the size of each device memory allocation. When compiling bigger models, the joining of constants and results produced buffers larger than this limit. This change makes those join operations respect this limit.