### PR TITLE
[Util] Add int narrowing pattern for arith.select

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -319,6 +319,122 @@ struct NarrowVectorBroadcast : OpRewritePattern<vector::BroadcastOp> {
   }
 };
 
+/// Narrow an arith.select through index_cast ops. Each operand may be either
+/// an index_cast from a narrower type or an arith.constant (which can be
+/// rematerialized in the narrow type). At least one operand must be an
+/// index_cast to determine the target narrow type.
+///
+/// Rewrites e.g.:
+///   %t = arith.index_cast %a : i32 to index
+///   %f = arith.constant 0 : index
+///   %s = arith.select %cond, %t, %f : index
+/// to:
+///   %f_narrow = arith.constant 0 : i32
+///   %s_narrow = arith.select %cond, %a, %f_narrow : i32
+///   %s = arith.index_cast %s_narrow : i32 to index
+struct NarrowArithSelect : OpRewritePattern<arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp op,
+                                PatternRewriter &rewriter) const override {
+    // The select must operate on index type.
+    if (!isa<IndexType>(getElementTypeOrSelf(op.getResult().getType()))) {
+      return failure();
+    }
+
+    // Find the index_cast that determines the narrow type. Try true first,
+    // then false.
+    Operation *trueDef = op.getTrueValue().getDefiningOp();
+    Operation *falseDef = op.getFalseValue().getDefiningOp();
+    if (!trueDef || !falseDef) {
+      return failure();
+    }
+    Operation *castOp =
+        dyn_cast<arith::IndexCastOp>(trueDef);
+    if (!castOp) {
+      castOp = dyn_cast<arith::IndexCastUIOp>(trueDef);
+    }
+    if (!castOp) {
+      castOp = dyn_cast<arith::IndexCastOp>(falseDef);
+    }
+    if (!castOp) {
+      castOp = dyn_cast<arith::IndexCastUIOp>(falseDef);
+    }
+    if (!castOp) {
+      return failure();
+    }
+
+    // Get the narrow type from the cast.
+    Type narrowElemTy = getElementTypeOrSelf(castOp->getOperand(0).getType());
+    if (isa<IndexType>(narrowElemTy)) {
+      return failure();
+    }
+    unsigned narrowBitWidth = narrowElemTy.getIntOrFloatBitWidth();
+
+    // Validate that each operand is either a matching index_cast or a
+    // constant that fits in the narrow type.
+    auto isValidOperand = [&](Operation *defOp) {
+      // Same kind of index_cast with the same narrow type.
+      if (defOp->getName() == castOp->getName()) {
+        return getElementTypeOrSelf(defOp->getOperand(0).getType()) ==
+               narrowElemTy;
+      }
+      // Constant with a value that fits in the narrow type.
+      auto constOp = dyn_cast<arith::ConstantOp>(defOp);
+      if (!constOp) {
+        return false;
+      }
+      auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue());
+      if (!intAttr) {
+        return false;
+      }
+      return APInt(64, intAttr.getInt(), /*isSigned=*/true)
+          .isSignedIntN(narrowBitWidth);
+    };
+    if (!isValidOperand(trueDef) || !isValidOperand(falseDef)) {
+      return failure();
+    }
+
+    // Rewrite: get or create narrow operands.
+    Location loc = op.getLoc();
+    Type resultType = op.getResult().getType();
+    Type narrowResultType;
+    if (auto vecType = dyn_cast<VectorType>(resultType)) {
+      narrowResultType = VectorType::get(vecType.getShape(), narrowElemTy);
+    } else {
+      narrowResultType = narrowElemTy;
+    }
+
+    auto getNarrowOperand = [&](Operation *defOp) -> Value {
+      if (defOp->getName() == castOp->getName()) {
+        return defOp->getOperand(0);
+      }
+      auto intAttr = cast<IntegerAttr>(cast<arith::ConstantOp>(defOp).getValue());
+      return arith::ConstantOp::create(
+          rewriter, loc, IntegerAttr::get(narrowElemTy, intAttr.getInt()));
+    };
+
+    Value narrowSelect = arith::SelectOp::create(
+        rewriter, loc, narrowResultType, op.getCondition(),
+        getNarrowOperand(trueDef), getNarrowOperand(falseDef));
+
+    // Re-apply the same cast on the select result.
+    Value result =
+        TypeSwitch<Operation *, Value>(castOp)
+            .Case([&](arith::IndexCastOp) {
+              return arith::IndexCastOp::create(rewriter, loc, resultType,
+                                                narrowSelect);
+            })
+            .Case([&](arith::IndexCastUIOp) {
+              return arith::IndexCastUIOp::create(rewriter, loc, resultType,
+                                                  narrowSelect);
+            });
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // scf.for induction variable range narrowing
 // If the induction variable of an scf.for can be represented as an I32,
@@ -536,7 +652,7 @@ class OptimizeIntArithmeticPass
       arith::populateIntRangeNarrowingPatterns(patterns, solver, {32});
       patterns.add<NarrowSCFForIvToI32, RemoveIndexCastForAssumeOfI32>(ctx,
                                                                        solver);
-      patterns.add<NarrowVectorBroadcast>(ctx);
+      patterns.add<NarrowVectorBroadcast, NarrowArithSelect>(ctx);
     }
 
     // Populate canonicalization patterns.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic_narrowing.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic_narrowing.mlir
@@ -121,3 +121,96 @@ func.func @no_narrow_broadcast_non_index(%arg0: index) -> vector<4xi32> {
   %bcast = vector.broadcast %cast : i32 to vector<4xi32>
   return %bcast : vector<4xi32>
 }
+
+// -----
+
+// Narrow select(cond, index_cast(x), index_cast(y)) to operate in i32.
+// CHECK-LABEL: @narrow_select_both_casts
+// CHECK-SAME: (%[[COND:.+]]: i1, %[[A:.+]]: i32, %[[B:.+]]: i32)
+// CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[A]], %[[B]] : i32
+// CHECK: %[[CAST:.+]] = arith.index_cast %[[SEL]] : i32 to index
+// CHECK: return %[[CAST]]
+func.func @narrow_select_both_casts(%cond: i1, %a: i32, %b: i32) -> index {
+  %ca = arith.index_cast %a : i32 to index
+  %cb = arith.index_cast %b : i32 to index
+  %sel = arith.select %cond, %ca, %cb : index
+  return %sel : index
+}
+
+// -----
+
+// Narrow select(cond, index_cast(x), constant 0) to operate in i32.
+// CHECK-LABEL: @narrow_select_cast_and_constant
+// CHECK-SAME: (%[[COND:.+]]: i1, %[[A:.+]]: i32)
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+// CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[A]], %[[C0]] : i32
+// CHECK: %[[CAST:.+]] = arith.index_cast %[[SEL]] : i32 to index
+// CHECK: return %[[CAST]]
+func.func @narrow_select_cast_and_constant(%cond: i1, %a: i32) -> index {
+  %ca = arith.index_cast %a : i32 to index
+  %c0 = arith.constant 0 : index
+  %sel = arith.select %cond, %ca, %c0 : index
+  return %sel : index
+}
+
+// -----
+
+// Narrow select with constant on the true side.
+// CHECK-LABEL: @narrow_select_constant_and_cast
+// CHECK-SAME: (%[[COND:.+]]: i1, %[[B:.+]]: i32)
+// CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+// CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[C42]], %[[B]] : i32
+// CHECK: %[[CAST:.+]] = arith.index_cast %[[SEL]] : i32 to index
+// CHECK: return %[[CAST]]
+func.func @narrow_select_constant_and_cast(%cond: i1, %b: i32) -> index {
+  %c42 = arith.constant 42 : index
+  %cb = arith.index_cast %b : i32 to index
+  %sel = arith.select %cond, %c42, %cb : index
+  return %sel : index
+}
+
+// -----
+
+// Negative test: select on i32 (not index) — should NOT be rewritten.
+// CHECK-LABEL: @no_narrow_select_non_index
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+func.func @no_narrow_select_non_index(%cond: i1, %a: i32, %b: i32) -> i32 {
+  %sel = arith.select %cond, %a, %b : i32
+  return %sel : i32
+}
+
+// -----
+
+// Negative test: different cast types — should NOT be rewritten.
+// CHECK-LABEL: @no_narrow_select_mixed_casts
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : index
+func.func @no_narrow_select_mixed_casts(%cond: i1, %a: i32, %b: i16) -> index {
+  %ca = arith.index_cast %a : i32 to index
+  %cb = arith.index_cast %b : i16 to index
+  %sel = arith.select %cond, %ca, %cb : index
+  return %sel : index
+}
+
+// -----
+
+// Negative test: constant doesn't fit in the narrow type (i8).
+// 256 is not representable as a signed i8 (-128 to 127).
+// CHECK-LABEL: @no_narrow_select_constant_overflow
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : index
+func.func @no_narrow_select_constant_overflow(%cond: i1, %a: i8) -> index {
+  %ca = arith.index_cast %a : i8 to index
+  %c256 = arith.constant 256 : index
+  %sel = arith.select %cond, %ca, %c256 : index
+  return %sel : index
+}
+
+// -----
+
+// Negative test: operand is neither index_cast nor constant.
+// CHECK-LABEL: @no_narrow_select_non_cast_operand
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : index
+func.func @no_narrow_select_non_cast_operand(%cond: i1, %a: i32, %b: index) -> index {
+  %ca = arith.index_cast %a : i32 to index
+  %sel = arith.select %cond, %ca, %b : index
+  return %sel : index
+}


### PR DESCRIPTION
Narrow arith.select through index_cast ops when both true/false operands are either index_cast from a narrower type or arith.constant. For example:

```mlir
  %t = arith.index_cast %a : i32 to index
  %f = arith.constant 0 : index
  %s = arith.select %cond, %t, %f : index
  ->
  %f_narrow = arith.constant 0 : i32
  %s_narrow = arith.select %cond, %a, %f_narrow : i32
  %s = arith.index_cast %s_narrow : i32 to index
```