### PR TITLE
[Util] Add integer divisibility inference for arith.select

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_integer_divisibility_analysis.mlir
@@ -498,3 +498,45 @@ util.func @delinearize_dynamic_basis(%arg0 : index, %arg1 : index) {
   %probe1 = "iree_unregistered.test_int_divisibility"(%0#1) : (index) -> index
   util.return
 }
+
+// -----
+
+// arith.select: divisibility is the GCD of true and false operands.
+// Both operands are divisible by 16, so the result is divisible by 16.
+// CHECK-LABEL: @select_divisibility_both_divisible
+util.func @select_divisibility_both_divisible(%arg0 : index, %arg1 : index, %cond : i1) {
+  %0 = util.assume.int %arg0<udiv = 16> : index
+  %1 = util.assume.int %arg1<udiv = 16> : index
+  %2 = arith.select %cond, %0, %1 : index
+  // CHECK: divisibility = "udiv = 16, sdiv = 16"
+  %probe = "iree_unregistered.test_int_divisibility"(%2) : (index) -> index
+  util.return
+}
+
+// -----
+
+// arith.select: GCD of different divisibilities. True is div by 16,
+// false is div by 12, so result is div by GCD(16, 12) = 4.
+// CHECK-LABEL: @select_divisibility_gcd
+util.func @select_divisibility_gcd(%arg0 : index, %arg1 : index, %cond : i1) {
+  %0 = util.assume.int %arg0<udiv = 16> : index
+  %1 = util.assume.int %arg1<udiv = 12> : index
+  %2 = arith.select %cond, %0, %1 : index
+  // CHECK: divisibility = "udiv = 4, sdiv = 4"
+  %probe = "iree_unregistered.test_int_divisibility"(%2) : (index) -> index
+  util.return
+}
+
+// -----
+
+// arith.select with constant false value 0: divisibility of 0 is 0
+// (divides everything), so result takes the true operand's divisibility.
+// CHECK-LABEL: @select_divisibility_with_constant_zero
+util.func @select_divisibility_with_constant_zero(%arg0 : index, %cond : i1) {
+  %c0 = arith.constant 0 : index
+  %0 = util.assume.int %arg0<udiv = 8> : index
+  %1 = arith.select %cond, %0, %c0 : index
+  // CHECK: divisibility = "udiv = 8, sdiv = 8"
+  %probe = "iree_unregistered.test_int_divisibility"(%1) : (index) -> index
+  util.return
+}

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -392,6 +392,26 @@ struct ArithBinaryGCDInferIntDivisibilityOpInterface
   }
 };
 
+/// For arith.select, the result divisibility is the GCD of the true and false
+/// operands' divisibilities. The condition (operand 0) is i1 and irrelevant.
+struct ArithSelectInferIntDivisibilityOpInterface
+    : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
+          ArithSelectInferIntDivisibilityOpInterface, arith::SelectOp> {
+
+  void inferResultDivisibility(
+      Operation *op, ArrayRef<IREE::Util::IntegerDivisibility> argDivs,
+      IREE::Util::SetIntDivisibilityFn setResultDivs) const {
+    auto selectOp = cast<arith::SelectOp>(op);
+    // argDivs[0] is the condition (i1), argDivs[1] is true, argDivs[2] is
+    // false.
+    auto trueDiv =
+        getDivisibilityOfOperand(selectOp.getTrueValue(), argDivs[1]);
+    auto falseDiv =
+        getDivisibilityOfOperand(selectOp.getFalseValue(), argDivs[2]);
+    setResultDivs(selectOp.getResult(), trueDiv.getUnion(falseDiv));
+  }
+};
+
 struct ArithConstantInferIntDivisibilityOpInterface
     : IREE::Util::InferIntDivisibilityOpInterface::ExternalModel<
           ArithConstantInferIntDivisibilityOpInterface, arith::ConstantOp> {
@@ -1345,6 +1365,8 @@ void registerUtilExternalModels(DialectRegistry &registry) {
     arith::MaxSIOp::attachInterface<
         ArithBinaryGCDInferIntDivisibilityOpInterface<arith::MaxSIOp>>(
         *context);
+    arith::SelectOp::attachInterface<
+        ArithSelectInferIntDivisibilityOpInterface>(*context);
   });
 
   registry.addExtension(


### PR DESCRIPTION
The result divisibility of arith.select is the GCD of the true and false operands' divisibilities (the i1 condition is irrelevant).