### PR TITLE
Unify RISC-V CMake variables for RV32 and RV64

### DIFF
--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -681,20 +681,14 @@ function(iree_compile_flags_for_platform OUT_FLAGS IN_FLAGS)
     list(APPEND _FLAGS "--iree-llvmcpu-target-triple=${_TARGET_TRIPLE}")
   endif()
 
-  if(IREE_ARCH STREQUAL "riscv_64" AND
+  if((IREE_ARCH STREQUAL "riscv_64" OR
+      IREE_ARCH STREQUAL "riscv_32") AND
      CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
      NOT IN_FLAGS MATCHES "iree-llvmcpu-target-triple")
-    # RV64 Linux crosscompile toolchain can support iree-compile with
-    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
+    # RISC-V Linux crosscompile toolchain can support iree-compile with
+    # specific CPU flags. Add the llvm flags to support RISC-V RVV codegen if
     # llvm-target-triple is not specified.
-    list(APPEND _FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
-  elseif(IREE_ARCH STREQUAL "riscv_32" AND
-         CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-         NOT IN_FLAGS MATCHES "iree-llvmcpu-target-triple")
-    # RV32 Linux crosscompile toolchain can support iree-compile with
-    # specific CPU flags. Add the llvm flags to support RV32 RVV codegen if
-    # llvm-target-triple is not specified.
-    list(APPEND _FLAGS ${RISCV32_TEST_DEFAULT_LLVM_FLAGS})
+    list(APPEND _FLAGS ${RISCV_TEST_DEFAULT_LLVM_FLAGS})
   endif()
 
   if(EMSCRIPTEN AND NOT IN_FLAGS MATCHES "iree-llvmcpu-target-triple")

--- a/build_tools/cmake/linux_riscv32.cmake
+++ b/build_tools/cmake/linux_riscv32.cmake
@@ -41,7 +41,7 @@ set(RISCV_COMPILER_FLAGS "\
     -Wno-atomic-alignment")
 set(RISCV_LINKER_FLAGS "-lstdc++ -lpthread -lm -ldl -latomic")
 set(RISCV_QEMU_CPU_FLAGS "rv32,Zve32f=true,vlen=512,elen=32,vext_spec=v1.0")
-set(RISCV32_TEST_DEFAULT_LLVM_FLAGS
+set(RISCV_TEST_DEFAULT_LLVM_FLAGS
   "--iree-llvmcpu-target-triple=riscv32"
   "--iree-llvmcpu-target-abi=ilp32d"
   "--iree-llvmcpu-target-cpu-features=+m,+a,+f,+d,+zvl512b,+zve32f"

--- a/build_tools/cmake/linux_riscv64.cmake
+++ b/build_tools/cmake/linux_riscv64.cmake
@@ -49,7 +49,7 @@ endif()
 set(RISCV_COMPILER_FLAGS "\
     -march=rv64i2p1ma2p1f2p2d2p2c2p0 -mabi=lp64d")
 set(RISCV_QEMU_CPU_FLAGS "rv64,Zve64d=true,vlen=512,elen=64,vext_spec=v1.0")
-set(RISCV64_TEST_DEFAULT_LLVM_FLAGS
+set(RISCV_TEST_DEFAULT_LLVM_FLAGS
   "--iree-llvmcpu-target-triple=riscv64"
   "--iree-llvmcpu-target-abi=lp64d"
   "--iree-llvmcpu-target-cpu-features=+m,+a,+f,+d,+c,+zvl512b,+v"


### PR DESCRIPTION
Merge RISCV32_TEST_DEFAULT_LLVM_FLAGS and
RISCV64_TEST_DEFAULT_LLVM_FLAGS into a single
RISCV_TEST_DEFAULT_LLVM_FLAGS variable to simplify condition checks in iree_macros.cmake.