### PR TITLE
[Codegen] Masked vectorization of inner_tiled

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
@@ -873,3 +873,45 @@ func.func @scaled_tensor_multi_mma(%arg0: tensor<3x5x1x32xf4E2M1FN>, %arg1: tens
 //       CHECK:   %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]], %[[LHS_SCALE]], %[[RHS_SCALE]]) outs(%[[ACC]])
 //  CHECK-SAME: : vector<3x5x1x32xf4E2M1FN>, vector<5x1x7x32xf8E4M3FN>, vector<3x5x1xf8E8M0FNU>, vector<5x7x1xf8E8M0FNU> into vector<3x7x4xf32>
 //       CHECK:   vector.transfer_write %[[MMA]], %arg4[%c0, %c0, %c0] {{.*}} : vector<3x7x4xf32>, tensor<3x7x4xf32>
+
+// -----
+
+// Masked vectorization of inner_tiled with dynamic outer dimensions.
+// Vector sizes come from the iree_codegen.vector_tile_sizes attribute.
+// The LHS has shape <?x?x4xf16> (outer dims dynamic), iteration space is
+// [i=2, j=5, k=3], so reads should be masked.
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @masked_tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    iree_codegen.vector_tile_sizes = array<i64: 2, 5, 3>,
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+    semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// CHECK-LABEL: func @masked_tensor_multi_mma
+
+// With vectorSizes, reads use create_mask for dynamic dims.
+// LHS: outer (i=2, k=3) + inner (4) → vector<2x3x4xf16>
+// RHS: outer (k=3, j=5) + inner (4) → vector<3x5x4xf16>
+// ACC: outer (i=2, j=5) + inner (4) → vector<2x5x4xf32>
+//   CHECK-DAG:   %[[CSTF16:.+]] = arith.constant 0.000000e+00 : f16
+//   CHECK-DAG:   %[[CSTF32:.+]] = arith.constant 0.000000e+00 : f32
+//       CHECK:   %[[LHS_MASK:.+]] = vector.create_mask {{.*}} : vector<2x3x4xi1>
+//       CHECK:   %[[LHS:.+]] = vector.transfer_read %arg0{{.*}}, %[[CSTF16]], %[[LHS_MASK]]{{.*}} : tensor<?x?x4xf16>, vector<2x3x4xf16>
+//       CHECK:   %[[RHS_MASK:.+]] = vector.create_mask {{.*}} : vector<3x5x4xi1>
+//       CHECK:   %[[RHS:.+]] = vector.transfer_read %arg1{{.*}}, %[[CSTF16]], %[[RHS_MASK]]{{.*}} : tensor<?x?x4xf16>, vector<3x5x4xf16>
+//       CHECK:   %[[ACC_MASK:.+]] = vector.create_mask {{.*}} : vector<2x5x4xi1>
+//       CHECK:   %[[ACC:.+]] = vector.transfer_read %arg2{{.*}}, %[[CSTF32]], %[[ACC_MASK]]{{.*}} : tensor<?x?x4xf32>, vector<2x5x4xf32>
+//       CHECK:   %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
+//  CHECK-SAME:     : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
+//       CHECK:   %[[WRITE_MASK:.+]] = vector.create_mask {{.*}} : vector<2x5x4xi1>
+//       CHECK:   vector.transfer_write %[[MMA]], %arg2{{.*}}, %[[WRITE_MASK]] {in_bounds = [false, false, true]}
+//  CHECK-SAME:     : vector<2x5x4xf32>, tensor<?x?x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -247,6 +247,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",
+        "@llvm-project//mlir:VectorUtils",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -181,6 +181,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRUBDialect
     MLIRVectorDialect
+    MLIRVectorUtils
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Dialect::LinalgExt::IR

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Utils/VectorUtils.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/IRMapping.h"
 
@@ -1042,6 +1043,28 @@ struct PadOpVectorizationModel
   }
 };
 
+/// Compute the outer iteration space sizes for an InnerTiledOp.
+static SmallVector<int64_t>
+getStaticOuterLoopRanges(IREE::Codegen::InnerTiledOp tiledOp) {
+  SmallVector<AffineMap> indexingMaps = tiledOp.getIndexingMapsArray();
+  SmallVector<ShapedType> argTypes = tiledOp.getOperandShapedTypes();
+  int64_t numLoops = indexingMaps.front().getNumDims();
+  SmallVector<int64_t> staticSizes(numLoops, ShapedType::kDynamic);
+  for (auto [i, argType] : llvm::enumerate(argTypes)) {
+    AffineMap map = indexingMaps[i];
+    ArrayRef<int64_t> outerShape =
+        argType.getShape().take_front(map.getNumResults());
+    for (auto [mapResult, dimSize] :
+         llvm::zip_equal(map.getResults(), outerShape)) {
+      auto dimExpr = cast<AffineDimExpr>(mapResult);
+      if (!ShapedType::isDynamic(dimSize)) {
+        staticSizes[dimExpr.getPosition()] = dimSize;
+      }
+    }
+  }
+  return staticSizes;
+}
+
 /// External model for IREE::Codegen::InnerTiledOp. Reads tensor operands into
 /// vectors, creates a vector-semantic InnerTiledOp, and writes results back.
 struct InnerTiledOpVectorizationModel
@@ -1055,15 +1078,16 @@ struct InnerTiledOpVectorizationModel
     if (!tiledOp.hasTensorSemantics()) {
       return false;
     }
+    SmallVector<int64_t> loopRanges = getStaticOuterLoopRanges(tiledOp);
     // If vector sizes are provided (from tile size analysis or config),
-    // dynamic outer shapes are fine — they'll be masked during vectorization.
+    // dynamic outer shapes are fine - they'll be masked during vectorization.
+    // However, vector sizes must be >= the static outer dimension sizes.
     if (!vectorSizes.empty()) {
-      return true;
+      return succeeded(
+          vector::isValidMaskedInputVector(loopRanges, vectorSizes));
     }
-    // Without vector sizes, require static shapes.
-    SmallVector<ShapedType> argTypes = tiledOp.getOperandShapedTypes();
-    return llvm::all_of(argTypes,
-                        [](ShapedType st) { return st.hasStaticShape(); });
+    // Without vector sizes, require static outer shapes.
+    return !ShapedType::isDynamicShape(loopRanges);
   }
 
   FailureOr<SmallVector<Value>> vectorize(Operation *op, RewriterBase &rewriter,
@@ -1078,12 +1102,17 @@ struct InnerTiledOpVectorizationModel
     SmallVector<ShapedType> argTypes = tiledOp.getOperandShapedTypes();
     SmallVector<AffineMap> indexingMaps = tiledOp.getIndexingMapsArray();
 
-    // Determine whether we need masking: vectorSizes present and any operand
-    // has dynamic outer dimensions.
-    bool needsMasking =
-        !vectorSizes.empty() && llvm::any_of(argTypes, [](ShapedType st) {
-          return !st.hasStaticShape();
-        });
+    // If no vector sizes are provided, use static loop ranges and the inBounds
+    // attribute instead of masking.
+    bool needsMasking = true;
+    if (vectorSizes.empty()) {
+      SmallVector<int64_t> loopRanges = getStaticOuterLoopRanges(tiledOp);
+      if (ShapedType::isDynamicShape(loopRanges)) {
+        return rewriter.notifyMatchFailure(op, "unable to infer vector sizes");
+      }
+      vectorSizes = loopRanges;
+      needsMasking = false;
+    }
 
     // Construct the zero padding value for each operand. Ideally, we'd need the
     // InnerTile interface to return the padding value to use. If it is not
@@ -1102,8 +1131,8 @@ struct InnerTiledOpVectorizationModel
         readShapes.push_back(llvm::to_vector(argType.getShape()));
         continue;
       }
-      // In case we need masking, outer dimensions com from vector sizes via the
-      // indexing map, the inner dimensions are static.
+      // Outer dimensions come from vector sizes via the indexing map, inner
+      // dimensions are static.
       SmallVector<int64_t> readShape;
       AffineMap map = indexingMaps[i];
       for (AffineExpr expr : map.getResults()) {
@@ -1152,8 +1181,7 @@ struct InnerTiledOpVectorizationModel
 
       auto write = vector::TransferWriteOp::create(
           rewriter, loc, result, tensorAcc, indices, inBounds);
-
-      if (needsMasking && !tensorType.hasStaticShape()) {
+      if (llvm::is_contained(inBounds, false)) {
         auto vecType = cast<VectorType>(result.getType());
         auto maskType = vecType.cloneWith({}, rewriter.getI1Type());
         SmallVector<OpFoldResult> mixedSizes =

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -1043,28 +1043,6 @@ struct PadOpVectorizationModel
   }
 };
 
-/// Compute the outer iteration space sizes for an InnerTiledOp.
-static SmallVector<int64_t>
-getStaticOuterLoopRanges(IREE::Codegen::InnerTiledOp tiledOp) {
-  SmallVector<AffineMap> indexingMaps = tiledOp.getIndexingMapsArray();
-  SmallVector<ShapedType> argTypes = tiledOp.getOperandShapedTypes();
-  int64_t numLoops = indexingMaps.front().getNumDims();
-  SmallVector<int64_t> staticSizes(numLoops, ShapedType::kDynamic);
-  for (auto [i, argType] : llvm::enumerate(argTypes)) {
-    AffineMap map = indexingMaps[i];
-    ArrayRef<int64_t> outerShape =
-        argType.getShape().take_front(map.getNumResults());
-    for (auto [mapResult, dimSize] :
-         llvm::zip_equal(map.getResults(), outerShape)) {
-      auto dimExpr = cast<AffineDimExpr>(mapResult);
-      if (!ShapedType::isDynamic(dimSize)) {
-        staticSizes[dimExpr.getPosition()] = dimSize;
-      }
-    }
-  }
-  return staticSizes;
-}
-
 /// External model for IREE::Codegen::InnerTiledOp. Reads tensor operands into
 /// vectors, creates a vector-semantic InnerTiledOp, and writes results back.
 struct InnerTiledOpVectorizationModel
@@ -1078,7 +1056,8 @@ struct InnerTiledOpVectorizationModel
     if (!tiledOp.hasTensorSemantics()) {
       return false;
     }
-    SmallVector<int64_t> loopRanges = getStaticOuterLoopRanges(tiledOp);
+    SmallVector<int64_t> loopRanges;
+    tiledOp.getIterationBounds(loopRanges);
     // If vector sizes are provided (from tile size analysis or config),
     // dynamic outer shapes are fine - they'll be masked during vectorization.
     // However, vector sizes must be >= the static outer dimension sizes.
@@ -1087,7 +1066,7 @@ struct InnerTiledOpVectorizationModel
           vector::isValidMaskedInputVector(loopRanges, vectorSizes));
     }
     // Without vector sizes, require static outer shapes.
-    return !ShapedType::isDynamicShape(loopRanges);
+    return ShapedType::isStaticShape(loopRanges);
   }
 
   FailureOr<SmallVector<Value>> vectorize(Operation *op, RewriterBase &rewriter,
@@ -1106,10 +1085,10 @@ struct InnerTiledOpVectorizationModel
     // attribute instead of masking.
     bool needsMasking = true;
     if (vectorSizes.empty()) {
-      SmallVector<int64_t> loopRanges = getStaticOuterLoopRanges(tiledOp);
-      if (ShapedType::isDynamicShape(loopRanges)) {
-        return rewriter.notifyMatchFailure(op, "unable to infer vector sizes");
-      }
+      SmallVector<int64_t> loopRanges;
+      tiledOp.getIterationBounds(loopRanges);
+      assert(ShapedType::isStaticShape(loopRanges) &&
+             "unable to infer vector sizes");
       vectorSizes = loopRanges;
       needsMasking = false;
     }
@@ -1166,33 +1145,34 @@ struct InnerTiledOpVectorizationModel
     auto zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     SmallVector<Value> results;
     unsigned numInputs = tiledOp.getNumInputs();
-    for (auto [i, result, tensorAcc] :
+    for (auto [i, result, dest] :
          llvm::enumerate(newTiledOp.getResults(), tiledOp.getOutputs())) {
-      auto tensorType = cast<RankedTensorType>(tensorAcc.getType());
-      int64_t rank = tensorType.getRank();
+      auto destType = cast<ShapedType>(dest.getType());
+      int64_t rank = destType.getRank();
       SmallVector<Value> indices(rank, zero);
 
-      SmallVector<int64_t> &writeShape = readShapes[numInputs + i];
+      ArrayRef<int64_t> writeShape = readShapes[numInputs + i];
       SmallVector<bool> inBounds(rank);
       for (int64_t d = 0; d < rank; ++d) {
-        inBounds[d] = !tensorType.isDynamicDim(d) &&
-                      tensorType.getDimSize(d) >= writeShape[d];
+        inBounds[d] =
+            destType.isStaticDim(d) && destType.getDimSize(d) >= writeShape[d];
       }
 
-      auto write = vector::TransferWriteOp::create(
-          rewriter, loc, result, tensorAcc, indices, inBounds);
-      if (llvm::is_contained(inBounds, false)) {
-        auto vecType = cast<VectorType>(result.getType());
-        auto maskType = vecType.cloneWith({}, rewriter.getI1Type());
-        SmallVector<OpFoldResult> mixedSizes =
-            tensor::getMixedSizes(rewriter, loc, tensorAcc);
-        Value mask =
-            vector::CreateMaskOp::create(rewriter, loc, maskType, mixedSizes);
-        results.push_back(
-            mlir::vector::maskOperation(rewriter, write, mask)->getResult(0));
+      auto write = vector::TransferWriteOp::create(rewriter, loc, result, dest,
+                                                   indices, inBounds);
+      if (!needsMasking) {
+        results.push_back(write.getResults().front());
         continue;
       }
-      results.push_back(write.getResults().front());
+      auto vecType = cast<VectorType>(result.getType());
+      auto maskType =
+          vecType.cloneWith(/*shape=*/std::nullopt, rewriter.getI1Type());
+      SmallVector<OpFoldResult> mixedSizes =
+          tensor::getMixedSizes(rewriter, loc, dest);
+      Value mask =
+          vector::CreateMaskOp::create(rewriter, loc, maskType, mixedSizes);
+      results.push_back(
+          mlir::vector::maskOperation(rewriter, write, mask)->getResult(0));
     }
     return results;
   }

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -1055,6 +1055,12 @@ struct InnerTiledOpVectorizationModel
     if (!tiledOp.hasTensorSemantics()) {
       return false;
     }
+    // If vector sizes are provided (from tile size analysis or config),
+    // dynamic outer shapes are fine — they'll be masked during vectorization.
+    if (!vectorSizes.empty()) {
+      return true;
+    }
+    // Without vector sizes, require static shapes.
     SmallVector<ShapedType> argTypes = tiledOp.getOperandShapedTypes();
     return llvm::all_of(argTypes,
                         [](ShapedType st) { return st.hasStaticShape(); });
@@ -1070,6 +1076,14 @@ struct InnerTiledOpVectorizationModel
     Location loc = tiledOp.getLoc();
 
     SmallVector<ShapedType> argTypes = tiledOp.getOperandShapedTypes();
+    SmallVector<AffineMap> indexingMaps = tiledOp.getIndexingMapsArray();
+
+    // Determine whether we need masking: vectorSizes present and any operand
+    // has dynamic outer dimensions.
+    bool needsMasking =
+        !vectorSizes.empty() && llvm::any_of(argTypes, [](ShapedType st) {
+          return !st.hasStaticShape();
+        });
 
     // Construct the zero padding value for each operand. Ideally, we'd need the
     // InnerTile interface to return the padding value to use. If it is not
@@ -1081,13 +1095,35 @@ struct InnerTiledOpVectorizationModel
               rewriter, loc, rewriter.getZeroAttr(argType.getElementType()));
         });
 
-    SmallVector<Value> newOperands = tiledOp.getOperands();
-    for (auto [operand, type, padValue] :
-         llvm::zip_equal(newOperands, argTypes, padValues)) {
-      operand = vector::createReadOrMaskedRead(
-          rewriter, loc, operand, type.getShape(), padValue,
-          /*useInBoundsInsteadOfMasking=*/true);
+    // Compute the read shape for each operand.
+    SmallVector<SmallVector<int64_t>> readShapes;
+    for (auto [i, argType] : llvm::enumerate(argTypes)) {
+      if (!needsMasking) {
+        readShapes.push_back(llvm::to_vector(argType.getShape()));
+        continue;
+      }
+      // In case we need masking, outer dimensions com from vector sizes via the
+      // indexing map, the inner dimensions are static.
+      SmallVector<int64_t> readShape;
+      AffineMap map = indexingMaps[i];
+      for (AffineExpr expr : map.getResults()) {
+        auto dimExpr = cast<AffineDimExpr>(expr);
+        readShape.push_back(vectorSizes[dimExpr.getPosition()]);
+      }
+      ArrayRef<int64_t> innerShape = tiledOp.getOperandInnerShape(i);
+      readShape.append(innerShape.begin(), innerShape.end());
+      readShapes.push_back(std::move(readShape));
     }
+
+    // Read each operand into a vector, with masking if needed.
+    SmallVector<Value> newOperands(tiledOp->getOperands());
+    for (auto [operand, readShape, padValue] :
+         llvm::zip_equal(newOperands, readShapes, padValues)) {
+      operand = vector::createReadOrMaskedRead(
+          rewriter, loc, operand, readShape, padValue,
+          /*useInBoundsInsteadOfMasking=*/!needsMasking);
+    }
+
     auto newTiledOp = IREE::Codegen::InnerTiledOp::create(
         rewriter, loc,
         ValueRange{newOperands}.take_front(tiledOp.getNumInputs()),
@@ -1095,15 +1131,39 @@ struct InnerTiledOpVectorizationModel
         tiledOp.getIndexingMaps(), tiledOp.getIteratorTypes(),
         tiledOp.getKind(), tiledOp.getSemantics());
 
+    // Write results back to tensor, with masking if needed.
+    // TODO: Use createWriteOrMaskedWrite once it is promoted to a public
+    // utility in mlir/Dialect/Vector/Utils/VectorUtils.h.
     auto zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     SmallVector<Value> results;
-    for (auto [result, tensorAcc] :
-         llvm::zip_equal(newTiledOp.getResults(), tiledOp.getOutputs())) {
-      int64_t rank = cast<RankedTensorType>(tensorAcc.getType()).getRank();
+    unsigned numInputs = tiledOp.getNumInputs();
+    for (auto [i, result, tensorAcc] :
+         llvm::enumerate(newTiledOp.getResults(), tiledOp.getOutputs())) {
+      auto tensorType = cast<RankedTensorType>(tensorAcc.getType());
+      int64_t rank = tensorType.getRank();
+      SmallVector<Value> indices(rank, zero);
+
+      SmallVector<int64_t> &writeShape = readShapes[numInputs + i];
+      SmallVector<bool> inBounds(rank);
+      for (int64_t d = 0; d < rank; ++d) {
+        inBounds[d] = !tensorType.isDynamicDim(d) &&
+                      tensorType.getDimSize(d) >= writeShape[d];
+      }
+
       auto write = vector::TransferWriteOp::create(
-          rewriter, loc, result, tensorAcc,
-          /*indices=*/SmallVector<Value>(rank, zero),
-          /*inBounds=*/SmallVector<bool>(rank, true));
+          rewriter, loc, result, tensorAcc, indices, inBounds);
+
+      if (needsMasking && !tensorType.hasStaticShape()) {
+        auto vecType = cast<VectorType>(result.getType());
+        auto maskType = vecType.cloneWith({}, rewriter.getI1Type());
+        SmallVector<OpFoldResult> mixedSizes =
+            tensor::getMixedSizes(rewriter, loc, tensorAcc);
+        Value mask =
+            vector::CreateMaskOp::create(rewriter, loc, maskType, mixedSizes);
+        results.push_back(
+            mlir::vector::maskOperation(rewriter, write, mask)->getResult(0));
+        continue;
+      }
       results.push_back(write.getResults().front());
     }
     return results;


### PR DESCRIPTION
So far, vectorization of `inner_tiled` did not support dynamic tensor shapes. This PR enables vectorization of `inner_tiled` with dynamic tensor shapes in the outer dimensions through masking for the case that vector sizes are provided.

The two main changes in this PR are:
- Add support for `inner_tiled`, `linalg.pack` and `linalg.unpack` operations to the vector tile size analysis. The vector tile sizes computed by this analysis can serve as vector sizes for the vectorization.
- Vectorization of `inner_tiled` with dynamic tensor sizes, assuming the provided vector sizes and using masked reads/writes to mask out OOB values.

This is part of https://github.com/iree-org/iree/issues/23415.

Assisted-by: Claude Code