### PR TITLE
[LLVMGPU] Use native bf16 truncf on AMDGPU targets that support it

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -332,7 +332,18 @@ struct ConvertToROCDLPass final
       vector::populateVectorTransposeLoweringPatterns(
           patterns, options.vectorTransposeLowering);
       vector::populateVectorTransferLoweringPatterns(patterns);
-      arith::populateExpandBFloat16Patterns(patterns);
+      // Skip bf16 expansion if the target has native bf16 conversion
+      // instructions (v_cvt_pk_bf16_f32 and related, i.e., LLVM
+      // FeatureBF16ConversionInsts) present on gfx950+, gfx1250+, gfx13+.
+      // The LLVM AMDGPU backend will lower arith.truncf (f32 -> bf16) to the
+      // native hardware instruction rather than a bitshift sequence.
+      auto hasBF16ConversionInsts = [](const amdgpu::Chipset &c) {
+        return (c.majorVersion == 9 && c.minorVersion >= 5) ||
+               (c.majorVersion == 12 && c.minorVersion >= 5) ||
+               c.majorVersion >= 13;
+      };
+      if (!hasBF16ConversionInsts(*maybeChipset))
+        arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -1,4 +1,10 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
+// Targets with native bf16 conversion instructions (hasBF16ConversionInsts):
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950  --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-NATIVE-BF16 %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1250 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-NATIVE-BF16 %s
+// Targets without native bf16 conversion (software expansion via bitshifts):
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-NO-NATIVE-BF16 %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx90a --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-NO-NATIVE-BF16 %s
 
 // Test permlane lowering on gfx950.
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -41,3 +47,36 @@ module {
 
 // CHECK-PERMLANE-LABEL: llvm.func @global_subgroup_barrier
 //       CHECK-PERMLANE:   rocdl.s.barrier
+
+// -----
+
+// Test that targets with native bf16 conversion instructions (gfx950, gfx1250)
+// skip software bf16 expansion, while targets without it (gfx942, gfx90a)
+// expand via a bitshift sequence.
+#pipeline_layout_bf16 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+module {
+  func.func @test_bf16_truncf() {
+    %c0 = arith.constant 0 : index
+    %in  = hal.interface.binding.subspan layout(#pipeline_layout_bf16) binding(0) alignment(64) offset(%c0) : memref<4xf32>
+    %out = hal.interface.binding.subspan layout(#pipeline_layout_bf16) binding(1) alignment(64) offset(%c0) : memref<4xbf16>
+    %tid = gpu.thread_id x
+    %val = memref.load %in[%tid] : memref<4xf32>
+    %tr  = arith.truncf %val : f32 to bf16
+    memref.store %tr, %out[%tid] : memref<4xbf16>
+    return
+  }
+}
+
+// On targets with native bf16 conversion the truncf is lowered directly
+// without a software bitshift sequence.
+// CHECK-NATIVE-BF16-LABEL: llvm.func @test_bf16_truncf
+// CHECK-NATIVE-BF16-NOT: llvm.lshr
+// CHECK-NATIVE-BF16-NOT: llvm.and
+
+// On targets without native bf16 conversion the truncf is expanded via
+// a software bitshift sequence.
+// CHECK-NO-NATIVE-BF16-LABEL: llvm.func @test_bf16_truncf
+// CHECK-NO-NATIVE-BF16: llvm.lshr


### PR DESCRIPTION
Skip arith bf16 expansion on chipsets with native bf16 conversion instructions (FeatureBF16ConversionInsts: gfx950+, gfx1250+, gfx13+). The LLVM AMDGPU backend lowers arith.truncf (f32->bf16) to the native v_cvt_pk_bf16_f32 instruction rather than a bitshift sequence.