### PR TITLE
Integrates/llvm@e849c68

### DIFF
--- a/compiler/src/iree/compiler/API/api_exports.c
+++ b/compiler/src/iree/compiler/API/api_exports.c
@@ -835,6 +835,7 @@ extern void mlirOperationImplementsInterfaceStatic();
 extern void mlirOperationIsBeforeInBlock();
 extern void mlirOperationMoveAfter();
 extern void mlirOperationMoveBefore();
+extern void mlirOperationNameHasTrait();
 extern void mlirOperationPrint();
 extern void mlirOperationPrintWithFlags();
 extern void mlirOperationPrintWithState();
@@ -1996,6 +1997,7 @@ uintptr_t __iree_compiler_hidden_force_extern() {
   x += (uintptr_t)&mlirOperationIsBeforeInBlock;
   x += (uintptr_t)&mlirOperationMoveAfter;
   x += (uintptr_t)&mlirOperationMoveBefore;
+  x += (uintptr_t)&mlirOperationNameHasTrait;
   x += (uintptr_t)&mlirOperationPrint;
   x += (uintptr_t)&mlirOperationPrintWithFlags;
   x += (uintptr_t)&mlirOperationPrintWithState;

--- a/compiler/src/iree/compiler/API/api_exports.def
+++ b/compiler/src/iree/compiler/API/api_exports.def
@@ -825,6 +825,7 @@ EXPORTS
   mlirOperationIsBeforeInBlock
   mlirOperationMoveAfter
   mlirOperationMoveBefore
+  mlirOperationNameHasTrait
   mlirOperationPrint
   mlirOperationPrintWithFlags
   mlirOperationPrintWithState

--- a/compiler/src/iree/compiler/API/api_exports.ld
+++ b/compiler/src/iree/compiler/API/api_exports.ld
@@ -826,6 +826,7 @@ VER_0 {
     mlirOperationIsBeforeInBlock;
     mlirOperationMoveAfter;
     mlirOperationMoveBefore;
+    mlirOperationNameHasTrait;
     mlirOperationPrint;
     mlirOperationPrintWithFlags;
     mlirOperationPrintWithState;

--- a/compiler/src/iree/compiler/API/api_exports.macos.lst
+++ b/compiler/src/iree/compiler/API/api_exports.macos.lst
@@ -824,6 +824,7 @@ _mlirOperationImplementsInterfaceStatic
 _mlirOperationIsBeforeInBlock
 _mlirOperationMoveAfter
 _mlirOperationMoveBefore
+_mlirOperationNameHasTrait
 _mlirOperationPrint
 _mlirOperationPrintWithFlags
 _mlirOperationPrintWithState


### PR DESCRIPTION
Carry two local reverts https://github.com/iree-org/llvm-project/commit/1a0e6684daeb58ec4c63fbf8c021523ebde0a0e6 and https://github.com/iree-org/llvm-project/commit/72060ebc4f564d5e5aa1bd481e5c10303f19c3cb

Add one new revert: https://github.com/iree-org/llvm-project/commit/2cb0972ae5945603ddbb165053c9fdc76f297677
- https://github.com/llvm/llvm-project/commit/3fcf10ca3b2cedecd3ba2cd01d860815a605b39d [clang][bytecode] Reapply "Use tailcalls via [[clang::musttail]]"

Bump to https://github.com/llvm/llvm-project/commit/e849c68657d88d03235b87da34c740cda3abebd4