### PR TITLE
[Codegen] Absorb SwizzleHintOp into alloc attribute for pipelining

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/AbsorbSwizzleHintToAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/AbsorbSwizzleHintToAlloc.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_ABSORBSWIZZLEHINTTOALLOCPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+struct AbsorbSwizzleHintToAllocPass final
+    : impl::AbsorbSwizzleHintToAllocPassBase<AbsorbSwizzleHintToAllocPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Absorbs `iree_codegen.swizzle_hint` ops into an attribute on the defining
+/// `memref.alloc`, then erases the hint. This allows downstream passes
+/// (multi-buffering, pipelining) to operate properly.
+static LogicalResult
+absorbSwizzleHintToAlloc(RewriterBase &rewriter,
+                         IREE::Codegen::SwizzleHintOp hintOp) {
+  auto allocOp = hintOp.getOperand().getDefiningOp<memref::AllocOp>();
+  if (!allocOp) {
+    return hintOp.emitError()
+           << "expected swizzle_hint operand to be defined by a memref.alloc";
+  }
+
+  allocOp->setAttr("iree_codegen.swizzle", hintOp.getSwizzleAttr());
+  rewriter.replaceOp(hintOp, hintOp.getOperand());
+  return success();
+}
+
+void AbsorbSwizzleHintToAllocPass::runOnOperation() {
+  FunctionOpInterface funcOp = getOperation();
+  SmallVector<IREE::Codegen::SwizzleHintOp> hintOps;
+  funcOp.walk(
+      [&](IREE::Codegen::SwizzleHintOp hint) { hintOps.push_back(hint); });
+
+  IRRewriter rewriter(funcOp->getContext());
+  for (IREE::Codegen::SwizzleHintOp hintOp : hintOps) {
+    if (failed(absorbSwizzleHintToAlloc(rewriter, hintOp))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -73,6 +73,7 @@ iree_gentbl_cc_library(
 iree_compiler_cc_library(
     name = "Common",
     srcs = [
+        "AbsorbSwizzleHintToAlloc.cpp",
         "AddFastMathFlags.cpp",
         "BlockDynamicDimensions.cpp",
         "BubbleUpOrdinalOps.cpp",
@@ -150,6 +151,7 @@ iree_compiler_cc_library(
         "PropagateDispatchSizeBounds.cpp",
         "PropagateReshapesByExpansion.cpp",
         "ReconcileTranslationInfo.cpp",
+        "ReinsertSwizzleHints.cpp",
         "RematerializeParallelOps.cpp",
         "RemoveIndexHints.cpp",
         "RemoveSingleIterationLoop.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_cc_library(
     "Transforms.h"
     "UserConfig.h"
   SRCS
+    "AbsorbSwizzleHintToAlloc.cpp"
     "AddFastMathFlags.cpp"
     "BlockDynamicDimensions.cpp"
     "BubbleUpOrdinalOps.cpp"
@@ -143,6 +144,7 @@ iree_cc_library(
     "PropagateDispatchSizeBounds.cpp"
     "PropagateReshapesByExpansion.cpp"
     "ReconcileTranslationInfo.cpp"
+    "ReinsertSwizzleHints.cpp"
     "RematerializeParallelOps.cpp"
     "RemoveIndexHints.cpp"
     "RemoveSingleIterationLoop.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -19,6 +19,11 @@ def AddFastMathFlagsPass
                 "given a floating-point mode.";
 }
 
+def AbsorbSwizzleHintToAllocPass :
+    InterfacePass<"iree-codegen-absorb-swizzle-hint-to-alloc", "mlir::FunctionOpInterface"> {
+  let summary = "Absorbs swizzle_hint ops into attributes on the defining alloc";
+}
+
 def BlockDynamicDimensionsPass
     : Pass<"iree-codegen-block-dynamic-dimensions"> {
   let summary = "Expand dynamic dimensions that are known to be multiples of "
@@ -1000,6 +1005,11 @@ def RemoveIndexHintsPass :
 def RemoveSingleIterationLoopPass :
     InterfacePass<"iree-codegen-remove-single-iteration-loop", "mlir::FunctionOpInterface"> {
   let summary = "Remove distributed loop with single iteration.";
+}
+
+def ReinsertSwizzleHintsPass :
+    InterfacePass<"iree-codegen-reinsert-swizzle-hints", "mlir::FunctionOpInterface"> {
+  let summary = "Re-inserts swizzle_hint ops from alloc attributes at vector.load/store sites";
 }
 
 def ResolveSwizzleHintsPass :

--- a/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
@@ -1,0 +1,142 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_REINSERTSWIZZLEHINTSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+struct ReinsertSwizzleHintsPass final
+    : impl::ReinsertSwizzleHintsPassBase<ReinsertSwizzleHintsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Traces a memref value backward through view-like ops, memref.cast, and
+/// scf.for iter_args/results to find the root memref.alloc.
+static memref::AllocOp traceToAllocation(Value val) {
+  DenseSet<Value> visited;
+  SmallVector<Value> worklist = {val};
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (!visited.insert(current).second) {
+      continue;
+    }
+    Operation *defOp = current.getDefiningOp();
+    if (!defOp) {
+      auto blockArg = cast<BlockArgument>(current);
+      auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+      unsigned argIdx = blockArg.getArgNumber();
+      if (!forOp || argIdx == 0) {
+        continue;
+      }
+      worklist.push_back(forOp.getInitArgs()[argIdx - 1]);
+    } else if (auto allocOp = dyn_cast<memref::AllocOp>(defOp)) {
+      return allocOp;
+    } else if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
+      unsigned resultIdx = cast<OpResult>(current).getResultNumber();
+      worklist.push_back(forOp.getInitArgs()[resultIdx]);
+    } else if (isa<ViewLikeOpInterface>(defOp)) {
+      worklist.push_back(defOp->getOperand(0));
+    } else if (auto castOp = dyn_cast<memref::CastOp>(defOp)) {
+      worklist.push_back(castOp.getSource());
+    }
+  }
+  return nullptr;
+}
+
+/// Returns the swizzle attribute on the alloc that val traces to, using
+/// cache to avoid repeated tracing.
+static IREE::Codegen::SwizzleAttrInterface lookupSwizzleAttr(
+    Value val,
+    DenseMap<Operation *, IREE::Codegen::SwizzleAttrInterface> &cache) {
+  memref::AllocOp allocOp = traceToAllocation(val);
+  if (!allocOp) {
+    return nullptr;
+  }
+  auto it = cache.find(allocOp.getOperation());
+  if (it != cache.end()) {
+    return it->second;
+  }
+  auto swizzle = allocOp->getAttrOfType<IREE::Codegen::SwizzleAttrInterface>(
+      "iree_codegen.swizzle");
+  cache[allocOp.getOperation()] = swizzle;
+  return swizzle;
+}
+
+/// Wraps |source| with collapse_shape -> swizzle_hint -> expand_shape so that
+/// downstream ResolveSwizzleHints can apply the XOR transform. For 1D memrefs,
+/// only the swizzle_hint is inserted.
+static Value insertSwizzleHint(IRRewriter &rewriter, Location loc, Value source,
+                               IREE::Codegen::SwizzleAttrInterface swizzle) {
+  auto sourceType = cast<MemRefType>(source.getType());
+
+  Value hintInput = source;
+  SmallVector<ReassociationIndices> reassoc;
+
+  if (sourceType.getRank() > 1) {
+    reassoc.push_back(
+        llvm::to_vector(llvm::seq<int64_t>(0, sourceType.getRank())));
+    hintInput = memref::CollapseShapeOp::create(rewriter, loc, source, reassoc);
+  }
+
+  auto hintOp =
+      IREE::Codegen::SwizzleHintOp::create(rewriter, loc, hintInput, swizzle);
+
+  if (sourceType.getRank() > 1) {
+    return memref::ExpandShapeOp::create(rewriter, loc, sourceType.getShape(),
+                                         hintOp.getResult(), reassoc);
+  }
+  return hintOp.getResult();
+}
+
+void ReinsertSwizzleHintsPass::runOnOperation() {
+  FunctionOpInterface funcOp = getOperation();
+  IRRewriter rewriter(funcOp->getContext());
+  DenseMap<Operation *, IREE::Codegen::SwizzleAttrInterface> swizzleCache;
+
+  // For each vector.load/store whose base traces to a swizzled alloc, wrap the
+  // base with collapse_shape -> swizzle_hint -> expand_shape.
+  funcOp.walk([&](Operation *op) {
+    Value base;
+    if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
+      base = loadOp.getBase();
+    } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
+      base = storeOp.getBase();
+    } else {
+      return;
+    }
+    IREE::Codegen::SwizzleAttrInterface swizzle =
+        lookupSwizzleAttr(base, swizzleCache);
+    if (!swizzle) {
+      return;
+    }
+    rewriter.setInsertionPoint(op);
+    Value wrapped = insertSwizzleHint(rewriter, op->getLoc(), base, swizzle);
+    if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
+      loadOp.getBaseMutable().assign(wrapped);
+    } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
+      storeOp.getBaseMutable().assign(wrapped);
+    }
+  });
+
+  // Clean up the swizzle attributes from allocs now that hints are inserted.
+  funcOp.walk([](memref::AllocOp allocOp) {
+    allocOp->removeAttr("iree_codegen.swizzle");
+  });
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "absorb_swizzle_hint_to_alloc.mlir",
             "add_fmfs.mlir",
             "affinemin_canonicalization.mlir",
             "batch_matmuls.mlir",
@@ -114,6 +115,7 @@ iree_lit_test_suite(
             "reconcile_translation_info.mlir",
             "reconcile_translation_info_linearize.mlir",
             "reductions.mlir",
+            "reinsert_swizzle_hints.mlir",
             "rematerialize_parallel_ops.mlir",
             "remove_dead_allocs.mlir",
             "remove_index_hints.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "absorb_swizzle_hint_to_alloc.mlir"
     "add_fmfs.mlir"
     "affinemin_canonicalization.mlir"
     "batch_matmuls.mlir"
@@ -109,6 +110,7 @@ iree_lit_test_suite(
     "reconcile_translation_info.mlir"
     "reconcile_translation_info_linearize.mlir"
     "reductions.mlir"
+    "reinsert_swizzle_hints.mlir"
     "rematerialize_parallel_ops.mlir"
     "remove_dead_allocs.mlir"
     "remove_index_hints.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/absorb_swizzle_hint_to_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/absorb_swizzle_hint_to_alloc.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-absorb-swizzle-hint-to-alloc))" \
+// RUN:   --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+func.func @absorb_swizzle_hint_to_alloc() {
+  %alloc0 = memref.alloc() : memref<8192xbf16, #gpu.address_space<workgroup>>
+  %hint0 = iree_codegen.swizzle_hint %alloc0[#iree_codegen.xor_shuffle<128, 8>]
+    : memref<8192xbf16, #gpu.address_space<workgroup>>
+  %alloc1 = memref.alloc() : memref<16384xbf16, #gpu.address_space<workgroup>>
+  %hint1 = iree_codegen.swizzle_hint %alloc1[#iree_codegen.xor_shuffle<256, 16>]
+    : memref<16384xbf16, #gpu.address_space<workgroup>>
+  memref.dealloc %alloc0 : memref<8192xbf16, #gpu.address_space<workgroup>>
+  memref.dealloc %alloc1 : memref<16384xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: func @absorb_swizzle_hint_to_alloc
+//   CHECK-DAG:   memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+//  CHECK-SAME:     : memref<8192xbf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 16>}
+//  CHECK-SAME:     : memref<16384xbf16, #gpu.address_space<workgroup>>
+//   CHECK-NOT:   iree_codegen.swizzle_hint
+//       CHECK:   return

--- a/compiler/src/iree/compiler/Codegen/Common/test/reinsert_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reinsert_swizzle_hints.mlir
@@ -1,0 +1,89 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reinsert-swizzle-hints))" \
+// RUN:   --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+func.func @load_1d() -> vector<8xbf16> {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<1024xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %v = vector.load %alloc[%c0]
+    : memref<1024xbf16, #gpu.address_space<workgroup>>, vector<8xbf16>
+  return %v : vector<8xbf16>
+}
+
+// CHECK-LABEL: func @load_1d
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<1024xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[ALLOC]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   vector.load %[[HINT]][%{{.+}}]
+
+// -----
+
+func.func @load_2d() -> vector<8xbf16> {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %v = vector.load %alloc[%c0, %c0]
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>, vector<8xbf16>
+  return %v : vector<8xbf16>
+}
+
+// CHECK-LABEL: func @load_2d
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<8x128xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[ALLOC]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[COLLAPSED]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   vector.load %[[EXPANDED]][%{{.+}}, %{{.+}}]
+
+// -----
+
+func.func @store_2d(%v: vector<8xbf16>) {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  vector.store %v, %alloc[%c0, %c0]
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>, vector<8xbf16>
+  return
+}
+
+// CHECK-LABEL: func @store_2d
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<8x128xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[ALLOC]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[COLLAPSED]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   vector.store %{{.+}}, %[[EXPANDED]][%{{.+}}, %{{.+}}]
+
+// -----
+
+func.func @no_hint_without_swizzle() -> vector<8xbf16> {
+  %alloc = memref.alloc() : memref<1024xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %v = vector.load %alloc[%c0]
+    : memref<1024xbf16, #gpu.address_space<workgroup>>, vector<8xbf16>
+  return %v : vector<8xbf16>
+}
+
+// CHECK-LABEL: func @no_hint_without_swizzle
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc()
+//       CHECK:   vector.load %[[ALLOC]][%{{.+}}]
+//   CHECK-NOT:   swizzle_hint
+
+// -----
+
+func.func @trace_through_subview() -> vector<8xbf16> {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %subview = memref.subview %alloc[0, 0][4, 128][1, 1]
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+    to memref<4x128xbf16, strided<[128, 1]>, #gpu.address_space<workgroup>>
+  %v = vector.load %subview[%c0, %c0]
+    : memref<4x128xbf16, strided<[128, 1]>, #gpu.address_space<workgroup>>, vector<8xbf16>
+  return %v : vector<8xbf16>
+}
+
+// CHECK-LABEL: func @trace_through_subview
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<8x128xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[ALLOC]]
+//       CHECK:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[SUBVIEW]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[COLLAPSED]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   vector.load %[[EXPANDED]][%{{.+}}, %{{.+}}]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -608,6 +608,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   }
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   if (forROCDL && pipelineOptions.prefetchNumStages >= 2) {
+    funcPassManager.addPass(createAbsorbSwizzleHintToAllocPass());
     funcPassManager.addPass(createFissionTransferOpsInControlFlowPass());
     funcPassManager.addPass(createRemoveSingleIterationLoopPass());
     ROCDLPrefetchSharedMemoryPassOptions prefetchOpts;
@@ -849,6 +850,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
   }
   if (forROCDL && options.prefetchNumStages >= 2) {
+    funcPassManager.addPass(createAbsorbSwizzleHintToAllocPass());
     ROCDLPrefetchSharedMemoryPassOptions prefetchOpts;
     prefetchOpts.numStages = options.prefetchNumStages;
     funcPassManager.addPass(createROCDLPrefetchSharedMemoryPass(prefetchOpts));
@@ -992,6 +994,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   funcPassManager.addPass(createLLVMGPUVectorLoweringPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass);
+  funcPassManager.addPass(createReinsertSwizzleHintsPass);
   addLowerAndOptimizeAddressComputationPasses(funcPassManager);
 
   if (forROCDL) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -271,7 +271,7 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
                                                unsigned numBuffers) {
   SetVector<memref::AllocOp> sharedAllocs;
 
-  // Find all LDS allocations used by gather_to_lds
+  // Find all LDS allocations used by gather_to_lds.
   forOp->walk([&](amdgpu::GatherToLDSOp gatherOp) {
     if (auto alloc = traceToAllocation(gatherOp.getDst())) {
       if (hasSharedMemoryAddressSpace(alloc.getType())) {
@@ -287,7 +287,7 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
 
   LDBG() << "Multi-buffering " << sharedAllocs.size() << " LDS allocations";
 
-  // First, clone view ops inside the loop for each allocation
+  // First, clone view ops inside the loop for each allocation.
   for (memref::AllocOp alloc : sharedAllocs) {
     if (failed(cloneViewOpsInsideLoop(alloc, forOp))) {
       LDBG() << "Failed to clone view ops for: " << *alloc;
@@ -295,13 +295,19 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
     }
   }
 
-  // Now apply multi-buffering
+  // Now apply multi-buffering, and copy the swizzle attribute if present.
   for (memref::AllocOp alloc : sharedAllocs) {
     Location loc = alloc.getLoc();
-    if (failed(memref::multiBuffer(alloc, numBuffers,
-                                   /*skipOverrideAnalysis=*/true))) {
+    auto swizzleAttr = alloc->getAttr("iree_codegen.swizzle");
+    FailureOr<memref::AllocOp> newAlloc =
+        memref::multiBuffer(alloc, numBuffers,
+                            /*skipOverrideAnalysis=*/true);
+    if (failed(newAlloc)) {
       LDBG() << "Failed to multi-buffer LDS allocation at " << loc;
       return failure();
+    }
+    if (swizzleAttr) {
+      (*newAlloc)->setAttr("iree_codegen.swizzle", swizzleAttr);
     }
     LDBG() << "Multi-buffered LDS allocation with " << numBuffers
            << " buffers at " << loc;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -699,3 +699,29 @@ func.func @gather_to_lds_nested_loop_async(
   }
   return
 }
+
+// -----
+
+// Verify that the iree_codegen.swizzle attribute on memref.alloc is preserved
+// through multi-buffering.
+
+// CHECK-LABEL: @gather_to_lds_with_swizzle_attr
+// CHECK: memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>} : memref<2x1xf32, #gpu.address_space<workgroup>>
+func.func @gather_to_lds_with_swizzle_attr(
+    %global: memref<128x128xf32>,
+    %output: memref<128xf32>) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %lds = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>} : memref<1xf32, #gpu.address_space<workgroup>>
+  %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
+    amdgpu.gather_to_lds %global[%c0, %k], %lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    %val = vector.transfer_read %lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %sum = arith.addf %val, %acc : vector<1xf32>
+    scf.yield %sum : vector<1xf32>
+  }
+  vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  return
+}


### PR DESCRIPTION
Absorb `SwizzleHintOp` into an attribute on `memref.alloc` before pipelining, then re-insert hints at leaf users afterward. This decouples swizzle from both `memref::multiBuffer` and `scf::pipelineForLoop`, as neither upstream utility handles `SwizzleHintOp`.

- **AbsorbSwizzleHintToAllocPass** (before pipeliner): moves swizzle info from the SSA chain to an `iree_codegen.swizzle` attribute on the alloc, erases SwizzleHintOp. Multi-buffering and pipelining proceed on clean IR.
- **ROCDLPrefetchSharedMemoryCopy**: copies the swizzle attribute to the new alloc after `memref::multiBuffer`.
- **ReinsertSwizzleHintsPass** (after vector lowering): traces back to attributed allocs and inserts `collapse_shape -> swizzle_hint -> expand_shape` at each use site.

Fixes: #23919

Assisted-by: Cursor (Claude)