### PR TITLE
[LLVMGPU] Support minor identity permutation maps in ROCDLBufferInstructionsOptimization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -147,9 +147,18 @@ void simplifyMaskOps(RewriterBase &rewriter, vector::CreateMaskOp maskOp,
       continue;
     }
 
+    // Only supported for identity or minor identity permutation maps.
+    // Non-trivial maps result in non-contiguous accesses which defeat the
+    // purpose of this optimization.
+    if (!readOp.getPermutationMap().isMinorIdentity()) {
+      continue;
+    }
+
     SmallVector<bool> inBounds = readOp.getInBoundsValues();
-    // Only supported for reads that are fully in_bounds.
-    if (inBounds.size() != sourceType.getRank() ||
+    // Only supported for reads that are fully in_bounds. The inBounds size
+    // matches the vector rank (not the memref rank) when a minor identity
+    // permutation map projects fewer dimensions.
+    if (inBounds.size() != readOp.getVectorType().getRank() ||
         llvm::any_of(inBounds, [](bool inBound) { return !inBound; })) {
       continue;
     }
@@ -160,7 +169,7 @@ void simplifyMaskOps(RewriterBase &rewriter, vector::CreateMaskOp maskOp,
 
     // Check if we need to handle the innermost dimension specially.
     if (innermostNonConstantMaskIndex) {
-      int64_t innerDimIdx = sourceType.getRank() - 1;
+      int64_t innerDimIdx = maskShape.size() - 1;
       int64_t maskInnerDimSize = maskShape[innerDimIdx];
 
       // Use divisibility analysis to check if optimization is valid.
@@ -193,7 +202,8 @@ void simplifyMaskOps(RewriterBase &rewriter, vector::CreateMaskOp maskOp,
 
     auto newReadOp = vector::TransferReadOp::create(
         rewriter, loc, readOp.getVectorType(), readOp.getBase(),
-        readOp.getIndices(), readOp.getPadding(), ArrayRef<bool>{inBounds});
+        readOp.getIndices(), readOp.getPadding(), readOp.getPermutationMap(),
+        ArrayRef<bool>{inBounds});
     auto selectOp = arith::SelectOp::create(rewriter, loc, selectValue,
                                             newReadOp, constantValue);
     rewriter.replaceAllUsesWith(readOp, selectOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/buffer_instructions_optimization.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/buffer_instructions_optimization.mlir
@@ -280,3 +280,57 @@ func.func @no_simplify_not_divisible(%1 : memref<1x?xbf16, #amdgpu.address_space
 //       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
 //  CHECK-SAME: %[[MASK]]
 //       CHECK: return %[[READ]] : vector<1x8xbf16>
+
+// -----
+
+// 1D vector read from a 4D memref with a minor identity permutation map
+// (d0, d1, d2, d3) -> (d3). The mask is 1D (vector<8xi1>) and inBounds has
+// size 1 (matching the vector rank, not the memref rank). Verifies the pass
+// handles projected permutation maps correctly.
+func.func @simplify_mask_permutation_map(
+    %mem : memref<32x7x7x297xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %idx0 : index, %idx1 : index, %idx2 : index,
+    %mask_size : index) -> vector<8xbf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : bf16
+  %divisible = util.assume.int %mask_size<udiv = 8> : index
+  %mask = vector.create_mask %divisible : vector<8xi1>
+  %read = vector.transfer_read %mem[%idx0, %idx1, %idx2, %c0], %cst, %mask
+      {in_bounds = [true], permutation_map = affine_map<(d0, d1, d2, d3) -> (d3)>}
+      : memref<32x7x7x297xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
+}
+
+// CHECK-LABEL: @simplify_mask_permutation_map
+//  CHECK-SAME:   (%[[MEM:.+]]: memref<32x7x7x297xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[I0:.+]]: index, %[[I1:.+]]: index, %[[I2:.+]]: index, %[[MS:.+]]: index)
+//   CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8xbf16>
+//   CHECK-DAG: %[[PAD:.+]] = arith.constant 0.000000e+00 : bf16
+//       CHECK: %[[DIV:.+]] = util.assume.int %[[MS]]<udiv = 8> : index
+//       CHECK: %[[CMP:.+]] = arith.cmpi eq, %[[DIV]], %[[C8]] : index
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[MEM]][%[[I0]], %[[I1]], %[[I2]], %{{.*}}], %[[PAD]]
+//  CHECK-SAME: {in_bounds = [true]}
+//  CHECK-SAME: : memref<32x7x7x297xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+//       CHECK: %[[SEL:.+]] = arith.select %[[CMP]], %[[READ]], %[[CST]] : vector<8xbf16>
+//       CHECK: return %[[SEL]] : vector<8xbf16>
+
+// -----
+
+// Non-minor-identity permutation map: projects the leading dim instead of
+// the trailing dim, resulting in non-contiguous accesses.
+func.func @no_simplify_mask_non_minor_identity_perm_map(
+    %mem : memref<8x1x32xbf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %index : index) -> vector<8xbf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %index : vector<8xi1>
+  %read = vector.transfer_read %mem[%c0, %c0, %c0], %cst, %mask
+      {in_bounds = [true], permutation_map = affine_map<(d0, d1, d2) -> (d0)>}
+      : memref<8x1x32xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<8xbf16>
+  return %read : vector<8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_mask_non_minor_identity_perm_map
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read {{.*}} %[[MASK]]
+//       CHECK: return %[[READ]] : vector<8xbf16>


### PR DESCRIPTION
The pass was bailing out on vector.transfer_read ops with non-identity permutation maps (e.g., 1D reads from a 4D memref). After https://github.com/iree-org/iree/pull/23855, we will frequently see 1D reads, which need to be supported here. Ideally, we will do something like what is done in https://github.com/iree-org/iree/pull/23859, but that approach is causing performance regressions that are difficult to deal with. For now, this provides a solution for the new mask types we will be seeing.