### PR TITLE
[Codegen] Remove ROCDL index==i32; add indexIsI64 to OptimizeIntArithmetic

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -47,19 +47,6 @@ namespace mlir::iree_compiler {
 #define GEN_PASS_DEF_CONVERTTOROCDLPASS
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
 
-static llvm::cl::opt<int>
-    clROCMIndexingBits("iree-rocm-index-bits",
-                       llvm::cl::desc("Set the bit width of indices in ROCm."),
-                       llvm::cl::init(64));
-static llvm::cl::opt<int> clROCMIndexingBitsDeprecated(
-    "iree-hip-index-bits",
-    llvm::cl::desc("Deprecated; use --iree-rocm-index-bits instead."),
-    llvm::cl::init(64), llvm::cl::cb<void, int>([](int value) {
-      llvm::errs() << "warning: --iree-hip-index-bits is deprecated; "
-                   << "use --iree-rocm-index-bits instead\n";
-      clROCMIndexingBits = value;
-    }));
-
 namespace {
 
 // Lower iree_gpu.global_subgroup_barrier to just the hardware barrier
@@ -243,14 +230,6 @@ struct ConvertToROCDLPass final
   void runOnOperation() override {
     ModuleOp m = getOperation();
 
-    if (clROCMIndexingBits != 32 && clROCMIndexingBits != 64) {
-      m.emitOpError() << "unsupported: ROCm index bit widths must either be "
-                         "64 or 32, got "
-                      << clROCMIndexingBits;
-      return signalPassFailure();
-    }
-    bool use32BitIndices = clROCMIndexingBits == 32;
-
     StringRef targetArch = getGPUTargetAttr(m).getArch();
     FailureOr<amdgpu::Chipset> maybeChipset =
         amdgpu::Chipset::parse(targetArch);
@@ -259,9 +238,8 @@ struct ConvertToROCDLPass final
       return signalPassFailure();
     }
 
-    /// Customize the bitwidth used for the device side index computations.
     LowerToLLVMOptions options(m.getContext(), DataLayout(m));
-    options.overrideIndexBitwidth(use32BitIndices ? 32 : 64);
+    options.overrideIndexBitwidth(64);
     LLVMTypeConverter converter(m.getContext(), options);
     populateGpuMemorySpaceAttributeConversions(
         converter, [](gpu::AddressSpace space) {
@@ -322,10 +300,10 @@ struct ConvertToROCDLPass final
       vector::populateVectorToElementsUnrollPatterns(patterns);
       vector::populateVectorGatherLoweringPatterns(patterns);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
-      // We currently always use 64 bit indices, thus ensure the bit width of
-      // the mask compare is consistent.
+      // Use 64-bit indices for mask materialization to match the index
+      // bitwidth.
       vector::populateVectorMaskMaterializationPatterns(
-          patterns, /*force32BitVectorIndices=*/use32BitIndices);
+          patterns, /*force32BitVectorIndices=*/false);
       vector::populateVectorShapeCastLoweringPatterns(patterns);
       // TODO: doubtful that the "default" does what one want here, it is likely
       // better to use something else.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -942,7 +942,8 @@ addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
       .addPass(createIREELowerAffinePass)
       .addPass([]() {
         return IREE::Util::createOptimizeIntArithmeticPass(
-            IREE::Util::OptimizeIntArithmeticPassOptions{/*narrowToI32=*/true});
+            IREE::Util::OptimizeIntArithmeticPassOptions{/*narrowToI32=*/true,
+                                                         /*indexIsI64=*/true});
       })
       // Do another round of LICM now that we've lowered and optimized
       // arithmetic

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-convert-to-rocdl %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-convert-to-rocdl --iree-rocm-index-bits=32 %s | FileCheck %s --check-prefix=INDEX32
 
 // Test that that standard and GPU ops are converted to LLVM and NVVM.
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -26,14 +25,12 @@ builtin.module {
   }
 }
 //   CHECK-LABEL: llvm.func @abs_ex_dispatch_0
-// INDEX32-LABEL: llvm.func @abs_ex_dispatch_0
 //    CHECK-SAME: (%{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readnone})
 //         CHECK:    llvm.call @__ockl_get_local_size({{.*}}) : (i32) -> (i64
 //         CHECK:    llvm.getelementptr inbounds|nuw %{{.*}} : (!llvm.ptr, i64) -> !llvm.ptr, f32
-//       INDEX32:    llvm.getelementptr inbounds|nuw %{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, f32
 //         CHECK:    llvm.fadd
 
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -343,6 +343,8 @@ struct NarrowSCFForIvToI32 : OpRewritePattern<scf::ForOp> {
     if (!srcType.isIndex() && !srcType.isInteger(64)) {
       return rewriter.notifyMatchFailure(forOp, "IV isn't an index or i64");
     }
+    // Note: we pass index-is-i64=false here to use this truncation correctness
+    // helper as a way to check if the index typ falls inside 32 bits.
     if (!staticallyLegalToConvertToUnsigned(solver, iv,
                                             /*indexIsI64=*/false)) {
       return rewriter.notifyMatchFailure(forOp, "IV isn't non-negative");

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -62,8 +62,8 @@ static constexpr uint64_t SAFE_INDEX_UNSIGNED_MAX_VALUE =
 /// Succeeds when a value is statically non-negative in that it has a lower
 /// bound on its value (if it is treated as signed) and that bound is
 /// non-negative.
-static bool staticallyLegalToConvertToUnsigned(DataFlowSolver &solver,
-                                               Value v) {
+static bool staticallyLegalToConvertToUnsigned(DataFlowSolver &solver, Value v,
+                                               bool indexIsI64) {
   auto *result = solver.lookupState<IntegerValueRangeLattice>(v);
   if (!result || result->getValue().isUninitialized()) {
     return false;
@@ -71,24 +71,23 @@ static bool staticallyLegalToConvertToUnsigned(DataFlowSolver &solver,
   const ConstantIntRanges &range = result->getValue().getValue();
   bool isNonNegative = range.smin().isNonNegative();
   Type type = v.getType();
-  if (isa<IndexType>(type)) {
+  if (isa<IndexType>(type) && !indexIsI64) {
     bool canSafelyTruncate =
         range.umin().getZExtValue() <= SAFE_INDEX_UNSIGNED_MAX_VALUE &&
         range.umax().getZExtValue() <= SAFE_INDEX_UNSIGNED_MAX_VALUE;
     return isNonNegative && canSafelyTruncate;
-  } else {
-    return isNonNegative;
   }
+  return isNonNegative;
 }
 
 /// Succeeds if an op can be converted to its unsigned equivalent without
-/// changing its semantics. This is the case when none of its openands or
+/// changing its semantics. This is the case when none of its operands or
 /// results can be below 0 when analyzed from a signed perspective.
 static LogicalResult
-staticallyLegalToConvertToUnsignedOp(DataFlowSolver &solver, Operation *op) {
-  auto nonNegativePred = [&solver](Value v) -> bool {
-    bool isNonNegative = staticallyLegalToConvertToUnsigned(solver, v);
-    return isNonNegative;
+staticallyLegalToConvertToUnsignedOp(DataFlowSolver &solver, Operation *op,
+                                     bool indexIsI64) {
+  auto nonNegativePred = [&](Value v) -> bool {
+    return staticallyLegalToConvertToUnsigned(solver, v, indexIsI64);
   };
   return success(llvm::all_of(op->getOperands(), nonNegativePred) &&
                  llvm::all_of(op->getResults(), nonNegativePred));
@@ -96,12 +95,14 @@ staticallyLegalToConvertToUnsignedOp(DataFlowSolver &solver, Operation *op) {
 
 template <typename Signed, typename Unsigned>
 struct ConvertOpToUnsigned : OpRewritePattern<Signed> {
-  ConvertOpToUnsigned(MLIRContext *context, DataFlowSolver &solver)
-      : OpRewritePattern<Signed>(context), solver(solver) {}
+  ConvertOpToUnsigned(MLIRContext *context, DataFlowSolver &solver,
+                      bool indexIsI64)
+      : OpRewritePattern<Signed>(context), solver(solver),
+        indexIsI64(indexIsI64) {}
 
   LogicalResult matchAndRewrite(Signed op,
                                 PatternRewriter &rewriter) const override {
-    if (failed(staticallyLegalToConvertToUnsignedOp(solver, op))) {
+    if (failed(staticallyLegalToConvertToUnsignedOp(solver, op, indexIsI64))) {
       return failure();
     }
     rewriter.replaceOpWithNewOp<Unsigned>(op, op->getResultTypes(),
@@ -110,6 +111,7 @@ struct ConvertOpToUnsigned : OpRewritePattern<Signed> {
   }
 
   DataFlowSolver &solver;
+  bool indexIsI64;
 };
 
 //===----------------------------------------------------------------------===//
@@ -131,8 +133,9 @@ struct ConvertOpToUnsigned : OpRewritePattern<Signed> {
 struct ConvertUnsignedI64IndexCastProducerToIndex
     : OpRewritePattern<arith::IndexCastUIOp> {
   ConvertUnsignedI64IndexCastProducerToIndex(MLIRContext *context,
-                                             DataFlowSolver &solver)
-      : OpRewritePattern(context), solver(solver) {}
+                                             DataFlowSolver &solver,
+                                             bool indexIsI64)
+      : OpRewritePattern(context), solver(solver), indexIsI64(indexIsI64) {}
 
   LogicalResult matchAndRewrite(arith::IndexCastUIOp origIndexOp,
                                 PatternRewriter &rewriter) const override {
@@ -152,6 +155,9 @@ struct ConvertUnsignedI64IndexCastProducerToIndex
     }
 
     auto pred = [&](Value v) -> bool {
+      if (indexIsI64) {
+        return true;
+      }
       auto *result = solver.lookupState<IntegerValueRangeLattice>(v);
       if (!result || result->getValue().isUninitialized()) {
         return false;
@@ -196,6 +202,7 @@ struct ConvertUnsignedI64IndexCastProducerToIndex
   }
 
   DataFlowSolver &solver;
+  bool indexIsI64;
 };
 
 //===----------------------------------------------------------------------===//
@@ -336,10 +343,12 @@ struct NarrowSCFForIvToI32 : OpRewritePattern<scf::ForOp> {
     if (!srcType.isIndex() && !srcType.isInteger(64)) {
       return rewriter.notifyMatchFailure(forOp, "IV isn't an index or i64");
     }
-    if (!staticallyLegalToConvertToUnsigned(solver, iv)) {
+    if (!staticallyLegalToConvertToUnsigned(solver, iv,
+                                            /*indexIsI64=*/false)) {
       return rewriter.notifyMatchFailure(forOp, "IV isn't non-negative");
     }
-    if (!staticallyLegalToConvertToUnsigned(solver, forOp.getStep())) {
+    if (!staticallyLegalToConvertToUnsigned(solver, forOp.getStep(),
+                                            /*indexIsI64=*/false)) {
       return rewriter.notifyMatchFailure(forOp, "Step isn't non-negative");
     }
     auto *ivState = solver.lookupState<IntegerValueRangeLattice>(iv);
@@ -559,8 +568,8 @@ class OptimizeIntArithmeticPass
                  ConvertOpToUnsigned<arith::RemSIOp, arith::RemUIOp>,
                  ConvertOpToUnsigned<arith::MinSIOp, arith::MinUIOp>,
                  ConvertOpToUnsigned<arith::MaxSIOp, arith::MaxUIOp>,
-                 ConvertOpToUnsigned<arith::ExtSIOp, arith::ExtUIOp>>(ctx,
-                                                                      solver);
+                 ConvertOpToUnsigned<arith::ExtSIOp, arith::ExtUIOp>>(
+        ctx, solver, indexIsI64);
 
     // Populate divisibility patterns.
     patterns.add<RemUIDivisibilityByConstant>(ctx, solver);

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -190,7 +190,11 @@ def OptimizeIntArithmeticPass : Pass<"iree-util-optimize-int-arithmetic", ""> {
     Option<"narrowToI32", "narrow-to-i32", "bool",
       /*default=*/"false",
       "Flag indicating if computations that can be performed with 32 bits should be."
-      " Mainly used for GPU code generation to not waste registers.">
+      " Mainly used for GPU code generation to not waste registers.">,
+    Option<"indexIsI64", "index-is-i64", "bool",
+      /*default=*/"false",
+      "Flag indicating that the ultimate width of index is known to be 64-bits,"
+      " relaxing conservative guards that ensure correctness for 32-bit index targets.">
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic_narrowing.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic_narrowing.mlir
@@ -1,6 +1,9 @@
 // RUN: iree-opt --split-input-file \
 // RUN:  --iree-util-optimize-int-arithmetic=narrow-to-i32=true --cse %s \
-// RUN:  | FileCheck %s
+// RUN:  | FileCheck %s --check-prefixes=CHECK,DEFAULT
+// RUN: iree-opt --split-input-file \
+// RUN:  --iree-util-optimize-int-arithmetic="narrow-to-i32=true index-is-i64=true" --cse %s \
+// RUN:  | FileCheck %s --check-prefixes=CHECK,I64
 // We inherit a number of patterns from upstream for narrowing specific arith
 // operations. Those are not the focus of testing, but we may test some of them
 // here incidentally as part of verifying that the overall pass and local
@@ -83,6 +86,20 @@ func.func @narrow_broadcast_index_castui(%arg0: i32) -> vector<4xindex> {
 
 // -----
 
+// Verify that we take divsi to divui on index if the input is non-negative as
+// an i64 but out of range as an i32 only if we know that index is i64.
+// CHECK-LABEL: @index_divsi_beyond_i32_range
+// DEFAULT: arith.divsi
+// I64: arith.divui
+util.func @index_divsi_beyond_i32_range(%arg0 : index) -> index {
+  %cst = arith.constant 5 : index
+  %0 = util.assume.int %arg0<umin=10, umax=5000000000> : index
+  %1 = arith.divsi %0, %cst : index
+  util.return %1 : index
+}
+
+// -----
+
 // Verify that broadcast(index_cast(x)) is rewritten to index_cast(broadcast(x)).
 // CHECK-LABEL: @narrow_broadcast_index_cast
 // CHECK-SAME: (%[[ARG0:.+]]: i32)
@@ -93,6 +110,21 @@ func.func @narrow_broadcast_index_cast(%arg0: i32) -> vector<2xindex> {
   %cast = arith.index_cast %arg0 : i32 to index
   %bcast = vector.broadcast %cast : index to vector<2xindex>
   return %bcast : vector<2xindex>
+}
+
+// -----
+
+// Verify that we move index casts across arithmetic if the inputs are outside
+// of i32 range only if we know that index is i64.
+// CHECK-LABEL: @i64_index_cast_beyond_i32_range
+// DEFAULT: arith.addi %{{.*}}, %{{.*}} : i64
+// I64: arith.addi %{{.*}}, %{{.*}} : index
+util.func @i64_index_cast_beyond_i32_range(%arg0 : i64) -> index {
+  %c1 = arith.constant 1 : i64
+  %0 = util.assume.int %arg0<umin=10, umax=4294967295> : i64
+  %1 = arith.addi %0, %c1 : i64
+  %2 = arith.index_castui %1 : i64 to index
+  util.return %2 : index
 }
 
 // -----
@@ -120,4 +152,35 @@ func.func @no_narrow_broadcast_non_index(%arg0: index) -> vector<4xi32> {
   %cast = arith.index_cast %arg0 : index to i32
   %bcast = vector.broadcast %cast : i32 to vector<4xi32>
   return %bcast : vector<4xi32>
+}
+
+// -----
+
+// Verify that we only move index_casts across i64 orithmetic if we know the
+// inputs are i64.
+// CHECK-LABEL: @i64_index_cast_no_range_info
+// DEFAULT: arith.addi %{{.*}}, %{{.*}} : i64
+// I64: arith.addi %{{.*}}, %{{.*}} : index
+util.func @i64_index_cast_no_range_info(%arg0 : i64, %arg1 : i64) -> index {
+  %0 = arith.addi %arg0, %arg1 : i64
+  %1 = arith.index_castui %0 : i64 to index
+  util.return %1 : index
+}
+
+// -----
+
+// Negative test: ensure we don't narrow scf.for IVs to i32 when they might
+// be out of i32 range.
+// CHECK-LABEL: @no_narrow_scf_for_large_iv
+// CHECK-NOT: : i32
+// CHECK: util.return
+util.func @no_narrow_scf_for_large_iv(%arg0: memref<?xf32>) {
+  %c0_f32 = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c3000000000 = arith.constant 3000000000 : index
+  scf.for %iv = %c0 to %c3000000000 step %c1 {
+    memref.store %c0_f32, %arg0[%iv] : memref<?xf32>
+  }
+  util.return
 }


### PR DESCRIPTION
Integer range analysis now handles narrowing to i32 where safe, making the --iree-rocm-index-bits option (which lowered all ROCDL indices to 32-bit) obsolete. Remove it so the ROCDL path matches NVVM (which always has 64-bit indices at the LLVM conversion level).

Add an indexIsI64 option to OptimizeIntArithmeticPass that relaxes the SAFE_INDEX_UNSIGNED_MAX_VALUE guard on signed-to-unsigned conversions for index values. On LLVMGPU targets where index is always 64-bit, this guard is unnecessarily conservative and blocks valid optimizations. For-loop IV narrowing (NarrowSCFForIvToI32 retains its own range checks unconditionally.)

Performance impact: on whole models, within the noise floor (as expected, this killed off a few instructions) but there is a consistent minor trend on the torch_models CI that gives a 1.01x geometric mean speedup, so there's not much reason not to do this. Table below.