### PR TITLE
[LinalgExt] Add padding attributes to im2col op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -730,6 +730,11 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
 ///   `%k` = `(%k_off + %K) mod 640`
 ///
 FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
+  // Decomposition of padded im2col ops is not yet implemented.
+  if (hasPadding()) {
+    return failure();
+  }
+
   Location loc = getLoc();
   Value inputSlice = getInput();
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2246,6 +2246,30 @@ SmallVector<SmallVector<OpFoldResult>> Im2colOp::getMixedOutputSizes() {
   return result;
 }
 
+/// Return all static and dynamic input_pad_low as OpFoldResults.
+SmallVector<OpFoldResult> Im2colOp::getMixedInputPadLow() {
+  return LinalgExt::getMixedValues(getContext(), getStaticInputPadLow(),
+                                   getInputPadLow());
+}
+
+/// Return all static and dynamic input_pad_high as OpFoldResults.
+SmallVector<OpFoldResult> Im2colOp::getMixedInputPadHigh() {
+  return LinalgExt::getMixedValues(getContext(), getStaticInputPadHigh(),
+                                   getInputPadHigh());
+}
+
+/// Return all static and dynamic output_pad_low as OpFoldResults.
+SmallVector<OpFoldResult> Im2colOp::getMixedOutputPadLow() {
+  return LinalgExt::getMixedValues(getContext(), getStaticOutputPadLow(),
+                                   getOutputPadLow());
+}
+
+/// Return all static and dynamic output_pad_high as OpFoldResults.
+SmallVector<OpFoldResult> Im2colOp::getMixedOutputPadHigh() {
+  return LinalgExt::getMixedValues(getContext(), getStaticOutputPadHigh(),
+                                   getOutputPadHigh());
+}
+
 void Im2colOp::setMixedOffsets(SmallVector<OpFoldResult> newOffsets) {
   SmallVector<int64_t> staticOffsets;
   SmallVector<Value> dynamicOffsets;
@@ -2280,6 +2304,57 @@ void Im2colOp::setMixedOutputSizes(
       dispatchNestedOutputSizes(getContext(), outputSizes);
   setStaticOutputSizesAttr(ArrayAttr::get(getContext(), innerArrayAttrs));
   getOutputSizesMutable().assign(dynamicValues);
+}
+
+void Im2colOp::setMixedInputPadLow(SmallVector<OpFoldResult> padLow) {
+  SmallVector<int64_t> staticPadLow;
+  SmallVector<Value> dynamicPadLow;
+  dispatchIndexOpFoldResults(padLow, dynamicPadLow, staticPadLow);
+  setStaticInputPadLow(staticPadLow);
+  getInputPadLowMutable().assign(dynamicPadLow);
+}
+
+void Im2colOp::setMixedInputPadHigh(SmallVector<OpFoldResult> padHigh) {
+  SmallVector<int64_t> staticPadHigh;
+  SmallVector<Value> dynamicPadHigh;
+  dispatchIndexOpFoldResults(padHigh, dynamicPadHigh, staticPadHigh);
+  setStaticInputPadHigh(staticPadHigh);
+  getInputPadHighMutable().assign(dynamicPadHigh);
+}
+
+void Im2colOp::setMixedOutputPadLow(SmallVector<OpFoldResult> padLow) {
+  SmallVector<int64_t> staticPadLow;
+  SmallVector<Value> dynamicPadLow;
+  dispatchIndexOpFoldResults(padLow, dynamicPadLow, staticPadLow);
+  setStaticOutputPadLow(staticPadLow);
+  getOutputPadLowMutable().assign(dynamicPadLow);
+}
+
+void Im2colOp::setMixedOutputPadHigh(SmallVector<OpFoldResult> padHigh) {
+  SmallVector<int64_t> staticPadHigh;
+  SmallVector<Value> dynamicPadHigh;
+  dispatchIndexOpFoldResults(padHigh, dynamicPadHigh, staticPadHigh);
+  setStaticOutputPadHigh(staticPadHigh);
+  getOutputPadHighMutable().assign(dynamicPadHigh);
+}
+
+bool Im2colOp::hasOutputPadding() {
+  SmallVector<OpFoldResult> outPadLow = getMixedOutputPadLow();
+  SmallVector<OpFoldResult> outPadHigh = getMixedOutputPadHigh();
+  if (outPadLow.empty()) {
+    return false;
+  }
+  for (auto pad : outPadLow) {
+    if (!isConstantIntValue(pad, 0)) {
+      return true;
+    }
+  }
+  for (auto pad : outPadHigh) {
+    if (!isConstantIntValue(pad, 0)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 SmallVector<int64_t> Im2colOp::getBatchOutputDims() {
@@ -2381,15 +2456,16 @@ Im2colOp::getInputToOutputDimVectorizationMap() {
 }
 
 /// Custom builder methods for im2col op.
-void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
-                     Value output, ArrayRef<int64_t> strides,
-                     ArrayRef<int64_t> dilations,
-                     ArrayRef<OpFoldResult> kernelSize,
-                     ArrayRef<OpFoldResult> offsets,
-                     ArrayRef<SmallVector<OpFoldResult>> outputSizes,
-                     ArrayRef<int64_t> batchPos, ArrayRef<int64_t> mPos,
-                     ArrayRef<int64_t> kPos, ArrayRef<int64_t> inputKPerm,
-                     ArrayRef<int64_t> outputPerm) {
+void Im2colOp::build(
+    OpBuilder &builder, OperationState &state, Value input, Value output,
+    ArrayRef<int64_t> strides, ArrayRef<int64_t> dilations,
+    ArrayRef<OpFoldResult> kernelSize, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<SmallVector<OpFoldResult>> outputSizes, ArrayRef<int64_t> batchPos,
+    ArrayRef<int64_t> mPos, ArrayRef<int64_t> kPos,
+    ArrayRef<int64_t> inputKPerm, ArrayRef<int64_t> outputPerm,
+    ArrayRef<OpFoldResult> inputPadLow, ArrayRef<OpFoldResult> inputPadHigh,
+    ArrayRef<OpFoldResult> outputPadLow, ArrayRef<OpFoldResult> outputPadHigh,
+    Value padValue) {
   assert(strides.size() == kernelSize.size() &&
          dilations.size() == kernelSize.size() &&
          mPos.size() == kernelSize.size() &&
@@ -2405,6 +2481,20 @@ void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
   ArrayAttr staticOutputSizesAttr =
       ArrayAttr::get(builder.getContext(), innerArrayAttrs);
 
+  SmallVector<int64_t> staticInputPadLow, staticInputPadHigh;
+  SmallVector<Value> dynamicInputPadLow, dynamicInputPadHigh;
+  dispatchIndexOpFoldResults(inputPadLow, dynamicInputPadLow,
+                             staticInputPadLow);
+  dispatchIndexOpFoldResults(inputPadHigh, dynamicInputPadHigh,
+                             staticInputPadHigh);
+
+  SmallVector<int64_t> staticOutputPadLow, staticOutputPadHigh;
+  SmallVector<Value> dynamicOutputPadLow, dynamicOutputPadHigh;
+  dispatchIndexOpFoldResults(outputPadLow, dynamicOutputPadLow,
+                             staticOutputPadLow);
+  dispatchIndexOpFoldResults(outputPadHigh, dynamicOutputPadHigh,
+                             staticOutputPadHigh);
+
   SmallVector<Type> resultType;
   auto outputType = output.getType();
   if (isa<RankedTensorType>(outputType)) {
@@ -2418,7 +2508,11 @@ void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
         staticOutputSizesAttr, builder.getDenseI64ArrayAttr(batchPos),
         builder.getDenseI64ArrayAttr(mPos), builder.getDenseI64ArrayAttr(kPos),
         builder.getDenseI64ArrayAttr(inputKPerm),
-        builder.getDenseI64ArrayAttr(outputPerm));
+        builder.getDenseI64ArrayAttr(outputPerm), dynamicInputPadLow,
+        builder.getDenseI64ArrayAttr(staticInputPadLow), dynamicInputPadHigh,
+        builder.getDenseI64ArrayAttr(staticInputPadHigh), dynamicOutputPadLow,
+        builder.getDenseI64ArrayAttr(staticOutputPadLow), dynamicOutputPadHigh,
+        builder.getDenseI64ArrayAttr(staticOutputPadHigh), padValue);
 }
 
 LogicalResult Im2colOp::verify() {
@@ -2563,6 +2657,66 @@ LogicalResult Im2colOp::verify() {
     return op->emitOpError(
         "expected output_perm to have the same rank as the result");
   }
+
+  // Verify padding attributes. This must happen before the batch-dim shape
+  // check below, which indexes into padLow/padHigh.
+  SmallVector<OpFoldResult> padLow = getMixedInputPadLow();
+  SmallVector<OpFoldResult> padHigh = getMixedInputPadHigh();
+  Value padVal = getPadValue();
+
+  // pad_low and pad_high must have the same size.
+  if (padLow.size() != padHigh.size()) {
+    return op->emitOpError(
+        "expected input_pad_low and input_pad_high to have the same size");
+  }
+
+  // If either pad_low or pad_high is non-empty, they must match input rank.
+  if (!padLow.empty() && padLow.size() != inputRank) {
+    return op->emitOpError("expected input_pad_low size (")
+           << padLow.size() << ") to match input rank (" << inputRank << ")";
+  }
+
+  // If padding sizes are non-empty, pad_value must be present.
+  if (!padLow.empty() && !padVal) {
+    return op->emitOpError(
+        "expected pad_value when input_pad_low/input_pad_high are specified");
+  }
+
+  // pad_value can exist without input padding. It indicates that some type
+  // of padding is present (input or output), and specifies the value to use
+  // for out-of-bounds positions.
+
+  // Verify output padding attributes.
+  SmallVector<OpFoldResult> outPadLow = getMixedOutputPadLow();
+  SmallVector<OpFoldResult> outPadHigh = getMixedOutputPadHigh();
+
+  // output_pad_low and output_pad_high must have the same size.
+  if (outPadLow.size() != outPadHigh.size()) {
+    return op->emitOpError(
+        "expected output_pad_low and output_pad_high to have the same size");
+  }
+
+  // If either is non-empty, they must match the output rank.
+  if (!outPadLow.empty() &&
+      outPadLow.size() != static_cast<size_t>(outputRank)) {
+    return op->emitOpError("expected output_pad_low size (")
+           << outPadLow.size() << ") to match output rank (" << outputRank
+           << ")";
+  }
+
+  // If output padding is non-empty, pad_value must be present.
+  if (!outPadLow.empty() && !padVal) {
+    return op->emitOpError(
+        "expected pad_value when output_pad_low/output_pad_high are specified");
+  }
+
+  // Note: batch dim shapes between input and output are intentionally NOT
+  // verified. With offset-based batch indexing, the output batch dim can be:
+  //   - smaller (tiled: output is a tile, input is the full tensor)
+  //   - equal (untiled case)
+  //   - larger (output padding for alignment, e.g. tile=64, actual=56)
+  // The output_sizes attribute encodes the valid batch region; padding and
+  // bounds checking are handled by computeIm2colValidSize.
 
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1326,6 +1326,21 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
       actual output tensor layout. For example, `output_perm = [2, 0, 1]` means
       the result is in `KxBxM` layout.
 
+    **Padding** (optional):
+    - `input_pad_low` / `input_pad_high`: per-input-dimension padding amounts,
+      representing absorbed input padding (e.g., from a folded tensor.pad).
+      Source coordinates are computed in the padded coordinate space; reads
+      outside the unpadded input bounds produce `pad_value`.
+    - `output_pad_low` / `output_pad_high`: per-output-dimension padding
+      amounts in actual output tensor dim order, representing how many
+      positions at the start/end of each output dimension are outside the
+      valid region. Valid region for output dim d is
+      `[output_pad_low[d], tensor_dim[d] - output_pad_high[d])`.
+      Updated during tiling to reflect tile-local padding amounts.
+    - `pad_value`: the value for out-of-bounds positions. Can be present
+      without `input_pad_low`/`input_pad_high` when only output padding exists
+      (e.g., from GEMM alignment). When absent, there is no padding.
+
     #### Semantics
 
     For each output position `(b, m, k)`, the op computes input coordinates,
@@ -1352,6 +1367,35 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
           outs(%out : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
     ```
 
+    With input padding (same padding absorbed from tensor.pad):
+    ```mlir
+      %im2col = iree_linalg_ext.im2col
+          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+          offsets = [0, 0, 0]
+          output_sizes = [[2], [34, 34], [3, 3, 640]]
+          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0]
+          pad_value(%cst : f32)
+          ins(%in : tensor<2x34x34x640xf32>)
+          outs(%out : tensor<2x1156x5760xf32>) -> tensor<2x1156x5760xf32>
+    ```
+
+    With output-only padding (GEMM alignment, no input padding):
+    ```mlir
+      // M valid = 32*32 = 1024; output has 1040 (16 extra M positions filled
+      // with pad_value for GEMM alignment). K valid = 3*3*640 = 5760.
+      %im2col = iree_linalg_ext.im2col
+          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+          offsets = [0, 0, 0]
+          output_sizes = [[2], [32, 32], [3, 3, 640]]
+          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+          pad_value(%cst : f32)
+          ins(%in : tensor<2x34x34x640xf32>)
+          outs(%out : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+    ```
   }];
 
   let arguments = (ins AnyShaped:$input, AnyShaped:$output,
@@ -1361,7 +1405,15 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
       Variadic<Index>:$output_sizes, ArrayAttr:$static_output_sizes,
       DenseI64ArrayAttr:$batch_pos, DenseI64ArrayAttr:$m_pos,
       DenseI64ArrayAttr:$k_pos, DenseI64ArrayAttr:$input_k_perm,
-      DenseI64ArrayAttr:$output_perm);
+      DenseI64ArrayAttr:$output_perm, Variadic<Index>:$input_pad_low,
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$static_input_pad_low,
+      Variadic<Index>:$input_pad_high,
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$static_input_pad_high,
+      Variadic<Index>:$output_pad_low,
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$static_output_pad_low,
+      Variadic<Index>:$output_pad_high,
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$static_output_pad_high,
+      Optional<AnyType>:$pad_value);
 
   let results = (outs Variadic<AnyShaped>:$results);
   let hasFolder = 1;
@@ -1380,6 +1432,15 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     `k_pos` `=` $k_pos
     `input_k_perm` `=` $input_k_perm
     `output_perm` `=` $output_perm
+    (`input_pad_low` `=`
+     custom<DynamicIndexList>($input_pad_low, $static_input_pad_low)
+     `input_pad_high` `=`
+     custom<DynamicIndexList>($input_pad_high, $static_input_pad_high)^)?
+    (`output_pad_low` `=`
+     custom<DynamicIndexList>($output_pad_low, $static_output_pad_low)
+     `output_pad_high` `=`
+     custom<DynamicIndexList>($output_pad_high, $static_output_pad_high)^)?
+    (`pad_value` `(` $pad_value^ `:` type($pad_value) `)`)?
     `ins` `(` $input `:` type($input) `)`
     `outs` `(` $output `:` type($output) `)`
     (`->` type($results)^)?
@@ -1391,7 +1452,12 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
       "ArrayRef<SmallVector<OpFoldResult>>":$output_sizes,
       "ArrayRef<int64_t>":$batch_dimensions, "ArrayRef<int64_t>":$m_dimensions,
       "ArrayRef<int64_t>":$k_dimensions, "ArrayRef<int64_t>":$input_k_perm,
-      "ArrayRef<int64_t>":$output_perm)>];
+      "ArrayRef<int64_t>":$output_perm,
+      CArg<"ArrayRef<OpFoldResult>", "{}">:$input_pad_low,
+      CArg<"ArrayRef<OpFoldResult>", "{}">:$input_pad_high,
+      CArg<"ArrayRef<OpFoldResult>", "{}">:$output_pad_low,
+      CArg<"ArrayRef<OpFoldResult>", "{}">:$output_pad_high,
+      CArg<"Value", "Value()">:$pad_value)>];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration#[{
     ShapedType getInputType() {
@@ -1434,10 +1500,24 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     SmallVector<OpFoldResult> getMixedKernelSize();
     SmallVector<OpFoldResult> getMixedOffsets();
     SmallVector<SmallVector<OpFoldResult>> getMixedOutputSizes();
+    SmallVector<OpFoldResult> getMixedInputPadLow();
+    SmallVector<OpFoldResult> getMixedInputPadHigh();
+    SmallVector<OpFoldResult> getMixedOutputPadLow();
+    SmallVector<OpFoldResult> getMixedOutputPadHigh();
 
     // Set op metadata.
     void setMixedOffsets(SmallVector<OpFoldResult> offsets);
     void setMixedOutputSizes(ArrayRef<SmallVector<OpFoldResult>> outputSizes);
+    void setMixedInputPadLow(SmallVector<OpFoldResult> padLow);
+    void setMixedInputPadHigh(SmallVector<OpFoldResult> padHigh);
+    void setMixedOutputPadLow(SmallVector<OpFoldResult> padLow);
+    void setMixedOutputPadHigh(SmallVector<OpFoldResult> padHigh);
+
+    // Returns true if the op has any padding (input or output).
+    bool hasPadding() { return static_cast<bool>(getPadValue()); }
+
+    // Returns true if the op has non-zero output padding.
+    bool hasOutputPadding();
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -2200,6 +2200,60 @@ Im2colOp::getTiledImplementation(OpBuilder &builder,
         addOfrs(builder, loc, offsets[actual], newOffsets[canonical]);
   }
 
+  // Compute tile-local output padding amounts.
+  // new_pad_low[d] = max(output_pad_low[d] - tileOff[d], 0)
+  // new_pad_high[d] = max(tileOff[d] + tileSize[d] - (origDim[d] -
+  //                       output_pad_high[d]), 0)
+  SmallVector<OpFoldResult> existingOutPadLow = getMixedOutputPadLow();
+  SmallVector<OpFoldResult> existingOutPadHigh = getMixedOutputPadHigh();
+  SmallVector<OpFoldResult> newOutPadLow, newOutPadHigh;
+  if (!existingOutPadLow.empty()) {
+    MLIRContext *ctx = builder.getContext();
+    AffineExpr d0 = getAffineDimExpr(0, ctx);
+    AffineExpr d1 = getAffineDimExpr(1, ctx);
+    AffineMap posMaxMap =
+        AffineMap::get(1, 0, {d0, getAffineConstantExpr(0, ctx)}, ctx);
+    AffineMap subMap = AffineMap::get(2, 0, d0 - d1, ctx);
+
+    SmallVector<OpFoldResult> origDims =
+        tensor::getMixedSizes(builder, loc, getOutput());
+    OpFoldResult zero = builder.getIndexAttr(0);
+
+    for (int64_t d = 0; d < getOutputRank(); ++d) {
+      // new_pad_low = max(pad_low - tileOff, 0)
+      // When pad_low is statically zero, skip the computation and keep zero.
+      OpFoldResult tilePadLow;
+      if (isZeroInteger(existingOutPadLow[d])) {
+        tilePadLow = zero;
+      } else {
+        OpFoldResult lowDiff = affine::makeComposedFoldedAffineApply(
+            builder, loc, subMap, {existingOutPadLow[d], offsets[d]});
+        tilePadLow = affine::makeComposedFoldedAffineMax(builder, loc,
+                                                         posMaxMap, {lowDiff});
+      }
+
+      // validEnd = origDim - pad_high; overrun = tileOff + tileSize - validEnd
+      // When pad_high is statically zero, skip the computation and keep zero.
+      OpFoldResult tilePadHigh;
+      if (isZeroInteger(existingOutPadHigh[d])) {
+        tilePadHigh = zero;
+      } else {
+        OpFoldResult validEnd = affine::makeComposedFoldedAffineApply(
+            builder, loc, subMap, {origDims[d], existingOutPadHigh[d]});
+        OpFoldResult tileEnd = affine::makeComposedFoldedAffineApply(
+            builder, loc, AffineMap::get(2, 0, d0 + d1, ctx),
+            {offsets[d], sizes[d]});
+        OpFoldResult highDiff = affine::makeComposedFoldedAffineApply(
+            builder, loc, subMap, {tileEnd, validEnd});
+        tilePadHigh = affine::makeComposedFoldedAffineMax(
+            builder, loc, posMaxMap, {highDiff});
+      }
+
+      newOutPadLow.push_back(tilePadLow);
+      newOutPadHigh.push_back(tilePadHigh);
+    }
+  }
+
   // Create the tiled op. The input is not sliced (batch offset is in the op).
   SmallVector<Value> operands = {inputValue, outputSlice->getResult(0)};
   // Copy all metadata operands from the untiled operation.
@@ -2210,6 +2264,11 @@ Im2colOp::getTiledImplementation(OpBuilder &builder,
   // Set the new offsets, since they have changed with tiling.
   // output_sizes remain unchanged by tiling (key design property).
   tiledOp.setMixedOffsets(newOffsets);
+  // Set tile-local output padding amounts.
+  if (!newOutPadLow.empty()) {
+    tiledOp.setMixedOutputPadLow(newOutPadLow);
+    tiledOp.setMixedOutputPadHigh(newOutPadHigh);
+  }
 
   return TilingResult{
       {tiledOp}, SmallVector<Value>(tiledOp->getResults()), {outputSlice}};

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1343,6 +1343,46 @@ func.func @illegal_im2col_output_perm_rank(%arg0: tensor<2x34x34x640xf32>) -> te
 
 // -----
 
+func.func @illegal_im2col_pad_size_mismatch(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<2x1024x5760xf32>
+  // expected-error @+1 {{expected input_pad_low and input_pad_high to have the same size}}
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
+           input_pad_low = [0, 1, 1] input_pad_high = [0, 1, 1, 0] pad_value(%cst : f32)
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
+  return %1 : tensor<2x1024x5760xf32>
+}
+
+// -----
+
+func.func @illegal_im2col_pad_rank_mismatch(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<2x1024x5760xf32>
+  // expected-error @+1 {{expected input_pad_low size (2) to match input rank (4)}}
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
+           input_pad_low = [0, 1] input_pad_high = [0, 1] pad_value(%cst : f32)
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
+  return %1 : tensor<2x1024x5760xf32>
+}
+
+// Note: The verifier also checks that pad_value is present when
+// input_pad_low/input_pad_high are specified, and vice versa. However, the
+// custom parser always parses all three together (or none), so these error
+// paths are unreachable from textual IR and cannot be tested here. They serve
+// as defensive checks for programmatically constructed ops.
+
+// -----
+
 func.func @illegal_winograd_input_shape(%arg0: tensor<1x10x10x32xf32>) -> tensor<8x8x1x6x6x32xf32> {
   %0 = tensor.empty() : tensor<8x8x1x6x6x32xf32>
   // expected-error @+1 {{incompatible output shape}}

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1517,7 +1517,7 @@ func.func @im2col_expanded(%arg0: tensor<2x3x34x34x640xf32>) -> tensor<2x3x32x32
 
 // -----
 
-func.func @im2col_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1296x5760xf32> {
+func.func @im2col_input_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1296x5760xf32> {
   %cst = arith.constant 0.0 : f32
   %0 = tensor.empty() : tensor<2x1296x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
@@ -1530,7 +1530,7 @@ func.func @im2col_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1296x5760x
            outs(%0 : tensor<2x1296x5760xf32>) -> tensor<2x1296x5760xf32>
   return %1 : tensor<2x1296x5760xf32>
 }
-// CHECK-LABEL: func.func @im2col_padding(
+// CHECK-LABEL: func.func @im2col_input_padding(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
 // CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1296x5760xf32>
@@ -1547,7 +1547,7 @@ func.func @im2col_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1296x5760x
 // -----
 
 // Verify output_pad_low/output_pad_high roundtrip with input padding.
-func.func @im2col_output_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
+func.func @im2col_input_and_output_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
   %cst = arith.constant 0.0 : f32
   %0 = tensor.empty() : tensor<2x1040x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
@@ -1562,7 +1562,7 @@ func.func @im2col_output_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x104
            outs(%0 : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
   return %1 : tensor<2x1040x5760xf32>
 }
-// CHECK-LABEL: func.func @im2col_output_padding(
+// CHECK-LABEL: func.func @im2col_input_and_output_padding(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
 // CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1040x5760xf32>
@@ -1581,7 +1581,7 @@ func.func @im2col_output_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x104
 // -----
 
 // Verify output_pad_low/output_pad_high without input padding.
-func.func @im2col_output_padding_only(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
+func.func @im2col_output_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
   %cst = arith.constant 0.0 : f32
   %0 = tensor.empty() : tensor<2x1040x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
@@ -1595,7 +1595,7 @@ func.func @im2col_output_padding_only(%arg0: tensor<2x34x34x640xf32>) -> tensor<
            outs(%0 : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
   return %1 : tensor<2x1040x5760xf32>
 }
-// CHECK-LABEL: func.func @im2col_output_padding_only(
+// CHECK-LABEL: func.func @im2col_output_padding(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
 // CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1040x5760xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1517,6 +1517,101 @@ func.func @im2col_expanded(%arg0: tensor<2x3x34x34x640xf32>) -> tensor<2x3x32x32
 
 // -----
 
+func.func @im2col_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1296x5760xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<2x1296x5760xf32>
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           offsets = [0, 0, 0] output_sizes = [[2], [36, 36], [3, 3, 640]]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
+           input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0] pad_value(%cst : f32)
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1296x5760xf32>) -> tensor<2x1296x5760xf32>
+  return %1 : tensor<2x1296x5760xf32>
+}
+// CHECK-LABEL: func.func @im2col_padding(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
+// CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1296x5760xf32>
+// CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [36, 36], [3, 3, 640]]
+// CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
+// CHECK-SAME:      input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0] pad_value(%[[CST]] : f32)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
+// CHECK-SAME:      outs(%[[D0]] : tensor<2x1296x5760xf32>) -> tensor<2x1296x5760xf32>
+// CHECK:         return %[[D1]] : tensor<2x1296x5760xf32>
+
+// -----
+
+// Verify output_pad_low/output_pad_high roundtrip with input padding.
+func.func @im2col_output_padding(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<2x1040x5760xf32>
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
+           input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0]
+           output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+           pad_value(%cst : f32)
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+  return %1 : tensor<2x1040x5760xf32>
+}
+// CHECK-LABEL: func.func @im2col_output_padding(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
+// CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1040x5760xf32>
+// CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
+// CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
+// CHECK-SAME:      input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0]
+// CHECK-SAME:      output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+// CHECK-SAME:      pad_value(%[[CST]] : f32)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
+// CHECK-SAME:      outs(%[[D0]] : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+// CHECK:         return %[[D1]] : tensor<2x1040x5760xf32>
+
+// -----
+
+// Verify output_pad_low/output_pad_high without input padding.
+func.func @im2col_output_padding_only(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<2x1040x5760xf32>
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           offsets = [0, 0, 0] output_sizes = [[2], [32, 32], [3, 3, 640]]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
+           output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+           pad_value(%cst : f32)
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+  return %1 : tensor<2x1040x5760xf32>
+}
+// CHECK-LABEL: func.func @im2col_output_padding_only(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
+// CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<2x1040x5760xf32>
+// CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:      offsets = [0, 0, 0] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
+// CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
+// CHECK-SAME:      output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+// CHECK-SAME:      pad_value(%[[CST]] : f32)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
+// CHECK-SAME:      outs(%[[D0]] : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+// CHECK:         return %[[D1]] : tensor<2x1040x5760xf32>
+
+// -----
+
 func.func @winograd_filter_transform(%arg0: tensor<3x3x64x128xf32>) -> tensor<8x8x64x128xf32> {
   %0 = tensor.empty() : tensor<8x8x64x128xf32>
   %1 = iree_linalg_ext.winograd.filter_transform

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1372,6 +1372,74 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
+func.func @im2col_padded(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<2x1040x5760xf32>
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           offsets = [0, 34, 1000] output_sizes = [[2], [32, 32], [3, 3, 640]]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+           input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0]
+           output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+           pad_value(%cst : f32)
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+  return %1 : tensor<2x1040x5760xf32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["iree_linalg_ext.im2col"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %1, %loops:3 = transform.structured.tile_using_for %0 tile_sizes [1, 5, 4] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0) -> (d0 + 34)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0) -> (d0 + 1000)>
+// Preserve-zero-padding optimization: batch (dim 0) and K (dim 2) have zero
+// output padding on both sides, so pad computation is skipped for those dims.
+// Only M (dim 1) has non-trivial output_pad_high.
+// CHECK-DAG:  #[[PADHI_M:.+]] = affine_map<(d0) -> (0, d0 - 1019)>
+// CHECK:      func.func @im2col_padded(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>) -> tensor<2x1040x5760xf32>
+// CHECK-DAG:    %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG:    %[[C5:.+]] = arith.constant 5 : index
+// CHECK-DAG:    %[[C5760:.+]] = arith.constant 5760 : index
+// CHECK-DAG:    %[[C1040:.+]] = arith.constant 1040 : index
+// CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<2x1040x5760xf32>
+// CHECK:        %[[RES0:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK-SAME:       iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<2x1040x5760xf32>)
+// CHECK:          %[[RES1:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1040]] step %[[C5]]
+// CHECK-SAME:       iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[ARG2]]) -> (tensor<2x1040x5760xf32>)
+// CHECK:            %[[RES2:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C5760]] step %[[C4]]
+// CHECK-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]]) -> (tensor<2x1040x5760xf32>)
+// CHECK-DAG:          %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG1]], %[[ARG3]], %[[ARG5]]]
+// CHECK-SAME:           [1, 5, 4] [1, 1, 1] : tensor<2x1040x5760xf32> to tensor<1x5x4xf32>
+// CHECK-DAG:          %[[MOFFSET:.+]] = affine.apply #[[MAP]](%[[ARG3]])
+// CHECK-DAG:          %[[KOFFSET:.+]] = affine.apply #[[MAP1]](%[[ARG5]])
+// Only M dim output_pad_high is recomputed per tile (batch and K are zero).
+// CHECK-DAG:          %[[PH1:.+]] = affine.max #[[PADHI_M]](%[[ARG3]])
+// CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:           offsets = [%[[ARG1]], %[[MOFFSET]], %[[KOFFSET]]] output_sizes = {{\[}}[2], [32, 32], [3, 3, 640]]
+// CHECK-SAME:           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+// CHECK-SAME:           input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0]
+// CHECK-SAME:           output_pad_low = [0, 0, 0] output_pad_high = [0, %[[PH1]], 0]
+// CHECK-SAME:           pad_value(%[[CST]] : f32)
+// CHECK-SAME:           ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
+// CHECK-SAME:           outs(%[[EXTRACTED_SLICE]] : tensor<1x5x4xf32>) -> tensor<1x5x4xf32>
+// CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
+// CHECK-SAME:           [%[[ARG1]], %[[ARG3]], %[[ARG5]]] [1, 5, 4] [1, 1, 1]
+// CHECK-SAME:           tensor<1x5x4xf32> into tensor<2x1040x5760xf32>
+// CHECK:              scf.yield %[[INSERTED_SLICE]] : tensor<2x1040x5760xf32>
+// CHECK:            scf.yield %[[RES2]] : tensor<2x1040x5760xf32>
+// CHECK:          scf.yield %[[RES1]] : tensor<2x1040x5760xf32>
+// CHECK:        return %[[RES0]] : tensor<2x1040x5760xf32>
+
+// -----
+
 func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   %1 = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]


### PR DESCRIPTION
Add optional padding fields to the im2col op:
- input_pad_low/high: per-input-dimension padding amounts
- output_pad_low/high: per-output-dimension padding amounts
- pad_value: the value for out-of-bounds positions

This includes:
- Op definition updates
- Padding accessors, setters, and verifier checks
- Tiling interface implementation
- Decomposition bail-out for padded im2col ops (full padding support in https://github.com/iree-org/iree/pull/23855)
- Roundtrip, verifier, and tiling tests

This change is effectively non-functional, since we do not yet make use of the padding attributes. The follow-up PR will introduce canonicalizers that fold padding into im2col, which will enable the padding path.