### PR TITLE
[Codegen][CPU] Switch LLVMCPU to module-scope pipeline.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -14,6 +14,7 @@
 #include "compiler/plugins/target/LLVMCPU/LibraryBuilder.h"
 #include "compiler/plugins/target/LLVMCPU/LinkerTool.h"
 #include "compiler/plugins/target/LLVMCPU/StaticLibraryGenerator.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
@@ -241,15 +242,18 @@ public:
   void
   buildConfigurationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                  OpPassManager &passManager) final {
-    buildLLVMCPUCodegenConfigurationPassPipeline(passManager, codegenOptions_);
+    buildCodegenConfigurationPreProcessingPassPipeline(passManager);
+    buildLLVMCPUCodegenConfigurationPassPipeline(passManager.nest<ModuleOp>(),
+                                                 codegenOptions_);
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                     OpPassManager &passManager) final {
     bool enableAArch64SME = isAArch64(targetAttr.getConfiguration()) &&
                             hasSMEFeature(targetAttr.getConfiguration());
-    buildLLVMCPUCodegenPassPipeline(passManager, codegenOptions_,
-                                    enableAArch64SME);
+    buildLLVMCPUCodegenPassPipeline(passManager.nest<ModuleOp>(),
+                                    codegenOptions_, enableAArch64SME);
+    buildCodegenTranslationPostProcessingPassPipeline(passManager);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) final {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
@@ -11,6 +11,17 @@
 
 namespace mlir::iree_compiler {
 
+void buildCodegenConfigurationPreProcessingPassPipeline(
+    OpPassManager &variantPassManager) {
+  variantPassManager.addPass(createSpecializeExportsPass());
+  variantPassManager.addPass(createCreateDispatchConfigPass());
+}
+
+void buildCodegenTranslationPostProcessingPassPipeline(
+    OpPassManager &variantPassManager) {
+  variantPassManager.addPass(createPropagateDispatchConfigPass());
+}
+
 void addCommonTargetExecutablePreprocessingPasses(
     FunctionLikeNest &funcPassManager, bool useDecomposeSoftmaxFusion) {
   funcPassManager.addPass(createTypePropagationPass)

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -36,6 +36,16 @@ void registerTransformDialectTranslationDependentDialects(
 void addCommonTargetExecutablePreprocessingPasses(
     FunctionLikeNest &funcPassManager, bool useDecomposeSoftmaxFusion = true);
 
+/// Variant-scoped pre-processing passes run before the configuration pipeline.
+/// Includes specialize-exports and create-dispatch-config.
+void buildCodegenConfigurationPreProcessingPassPipeline(
+    OpPassManager &variantPassManager);
+
+/// Variant-scoped post-processing passes run after the translation pipeline.
+/// Includes hoist-executable-objects and propagate-dispatch-config.
+void buildCodegenTranslationPostProcessingPassPipeline(
+    OpPassManager &variantPassManager);
+
 /// Post-bufferization passes run to cleanup the IR
 /// (ResolveShapedTypeResultDims, Canonicalization/CSE and
 /// CleanupBufferAllocView).

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -1117,7 +1118,9 @@ void ConvertToLLVMPass::runOnOperation() {
   >(abi, typeConverter);
   // clang-format on
 
-  target.addLegalOp<ModuleOp>();
+  target.addLegalOp<ModuleOp, IREE::Codegen::DispatchConfigOp,
+                    IREE::Codegen::YieldOp>();
+  target.markOpRecursivelyLegal<IREE::Codegen::DispatchConfigOp>();
   target.addIllegalDialect<func::FuncDialect, mlir::arith::ArithDialect,
                            IREE::Util::UtilDialect, IREE::HAL::HALDialect,
                            math::MathDialect, tosa::TosaDialect>();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -646,43 +646,33 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
 }
 
 void buildLLVMCPUCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts) {
-  variantPassManager.addPass(createSpecializeExportsPass());
-  variantPassManager.addPass(createCreateDispatchConfigPass());
-  OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
+    OpPassManager &modulePassManager, const CPUCodegenOptions &cpuOpts) {
   buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager, cpuOpts);
 }
 
-void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
+void buildLLVMCPUCodegenPassPipeline(OpPassManager &modulePassManager,
                                      const CPUCodegenOptions &cpuOpts,
                                      bool enableAArch64SME) {
-  {
-    OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
-    modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());
-    FunctionLikeNest(modulePassManager)
-        .addPass([&]() {
-          return createLLVMCPULowerExecutableTargetPass(
-              LLVMCPULowerExecutableTargetPassOptions{cpuOpts});
-        })
-        .addPass(createVerifyWorkgroupDistributionPass);
-    if (clPatchFuncOps) {
-      modulePassManager.addPass(createPatchFuncOpsPass());
-    }
-    modulePassManager.addPass(createReconcileTranslationInfoPass());
-    modulePassManager.addPass(createResolveWorkgroupCountHintsPass());
+  modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());
+  FunctionLikeNest(modulePassManager)
+      .addPass([&]() {
+        return createLLVMCPULowerExecutableTargetPass(
+            LLVMCPULowerExecutableTargetPassOptions{cpuOpts});
+      })
+      .addPass(createVerifyWorkgroupDistributionPass);
+  if (clPatchFuncOps) {
+    modulePassManager.addPass(createPatchFuncOpsPass());
   }
-  variantPassManager.addPass(createPropagateDispatchConfigPass());
-  variantPassManager.addPass(createIREECodegenLowerAffinePass());
-  variantPassManager.addPass(IREE::Util::createDropCompilerHintsPass());
+  modulePassManager.addPass(createReconcileTranslationInfoPass());
+  modulePassManager.addPass(createResolveWorkgroupCountHintsPass());
 
-  // Run conversion to LLVM at `ModuleOp` granularity.
-  {
-    OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
-    addLowerToLLVMPasses(modulePassManager, enableAArch64SME, cpuOpts);
-  }
+  modulePassManager.addPass(createIREECodegenLowerAffinePass());
+  modulePassManager.addPass(IREE::Util::createDropCompilerHintsPass());
+
+  addLowerToLLVMPasses(modulePassManager, enableAArch64SME, cpuOpts);
   LLVM_DEBUG({
     llvm::dbgs() << "LLVMCPU codegen pass pipeline:\n";
-    variantPassManager.printAsTextualPipeline(llvm::dbgs());
+    modulePassManager.printAsTextualPipeline(llvm::dbgs());
     llvm::dbgs() << "\n";
   });
 }
@@ -801,12 +791,12 @@ void registerCodegenLLVMCPUPasses() {
       LinalgLLVMPipeline(
           "iree-codegen-linalg-to-llvm-pipeline",
           "Runs the progressive lowering pipeline from Linalg to LLVM",
-          [](OpPassManager &variantPassManager,
+          [](OpPassManager &modulePassManager,
              LinalgToLLVMPipelineOptions const &options) {
             // Use global codegen options for pipeline registration.
             const CPUCodegenOptions &cpuOpts =
                 CPUCodegenOptions::FromFlags::get();
-            buildLLVMCPUCodegenPassPipeline(variantPassManager, cpuOpts,
+            buildLLVMCPUCodegenPassPipeline(modulePassManager, cpuOpts,
                                             options.enableArmSME);
           });
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -140,12 +140,12 @@ void addMultiTilingExpertPassPipeline(
 /// Populates passes needed for preprocessing before codegen lowerings, as well
 /// as high level lowering strategy selection.
 void buildLLVMCPUCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager, const CPUCodegenOptions &cpuOpts);
+    OpPassManager &modulePassManager, const CPUCodegenOptions &cpuOpts);
 
 /// Populates passes needed to lower high level ops, e.g., linalg, vector, etc,
-/// to LLVM dialect via the structured ops path. The  `variantPassManager`
+/// to LLVM dialect via the structured ops path. The `modulePassManager`
 /// should operate on the module within the IREE::HAL::ExecutableOp.
-void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
+void buildLLVMCPUCodegenPassPipeline(OpPassManager &modulePassManager,
                                      const CPUCodegenOptions &codegenOptions,
                                      bool enableAArch64SME = false);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_arm_sme_streaming_mode_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_arm_sme_streaming_mode_tests.mlir
@@ -7,22 +7,18 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_cpu.lowering_config<distribution = [0], vector_common_parallel = [1]>
-module {
-module {
-  func.func @fixed_size_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
-      translation_info = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>} {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    %2 = tensor.empty() : tensor<1xf32>
-    %3 = linalg.fill {lowering_config = #config}
-        ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
-    iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    return
-  }
-}
+func.func @fixed_size_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
+    translation_info = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  %2 = tensor.empty() : tensor<1xf32>
+  %3 = linalg.fill {lowering_config = #config}
+      ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  return
 }
 
 /// A dispatch region that only uses fixed-size vectors should never use
@@ -44,22 +40,18 @@ module {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_cpu.lowering_config<distribution = [0], vector_common_parallel = [[1]]>
-module {
-module {
-  func.func @scalable_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
-      translation_info = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>} {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    %2 = tensor.empty() : tensor<1xf32>
-    %3 = linalg.fill {lowering_config = #config}
-        ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
-    iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
-    return
-  }
-}
+func.func @scalable_dispatch() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
+    translation_info = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  %2 = tensor.empty() : tensor<1xf32>
+  %3 = linalg.fill {lowering_config = #config}
+      ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xf32>>
+  return
 }
 
 /// A dispatch region that uses scalable vectors (but not ArmSME dialect
@@ -82,22 +74,18 @@ module {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #config = #iree_cpu.lowering_config<distribution = [0, 0], vector_common_parallel = [[4], [4]]>
-module {
-module {
-  func.func @scalable_dispatch_using_za() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
-      translation_info = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>} {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
-    %2 = tensor.empty() : tensor<100x100xf32>
-    %3 = linalg.fill {lowering_config = #config}
-        ins(%cst : f32) outs(%2 : tensor<100x100xf32>) -> tensor<100x100xf32>
-    iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [100, 100], strides = [100, 1] : tensor<100x100xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
-    return
-  }
-}
+func.func @scalable_dispatch_using_za() attributes {hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>,
+    translation_info = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
+  %2 = tensor.empty() : tensor<100x100xf32>
+  %3 = linalg.fill {lowering_config = #config}
+      ins(%cst : f32) outs(%2 : tensor<100x100xf32>) -> tensor<100x100xf32>
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [100, 100], strides = [100, 1] : tensor<100x100xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<100x100xf32>>
+  return
 }
 
 /// A dispatch region that uses ArmSME operations (that require the ZA state)


### PR DESCRIPTION
Move variant-scope passes (specialize-exports, create-dispatch-config, propagate-dispatch-config) to shared pre/post-processing helpers so the LLVMCPU codegen pipeline becomes a pure module-scope pipeline.

- `buildCodegenConfigurationPreProcessingPassPipeline()`, which includes `SpecializeExportsPass` and `CreateDispatchConfigPass`.
- `buildCodegenTranslationPostProcessingPassPipeline()`, which includes `PropagateDispatchConfigPass`.

The nested modules are removed from `pipeline_arm_sme_streaming_mode_tests.mlir`, because now the pipeline work on modules.