### PR TITLE
[LLVMGPU] Only set reduction lowering_config for ops that need it

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
@@ -158,14 +158,51 @@ static LogicalResult checkSingleCombiner(linalg::LinalgOp op) {
   return success();
 }
 
-static llvm::FailureOr<IREE::GPU::LoweringConfigAttr>
-getVectorDistributeReductionConfig(
+/// Stores per-op tile sizes without building the lowering config attribute.
+/// The workgroup tile sizes are tracked separately in sharedWgpTiles and only
+/// applied to the last compute operation.
+struct TileSizesConfig {
+  SmallVector<int64_t> tileSizes; // Tile sizes for "serial" or
+                                  // "partial_reduction" level.
+  SmallVector<int64_t> threadTileSizes;
+  SmallVector<int64_t> threadCounts;
+  SmallVector<int64_t> subgroupCounts;
+  bool isReduction = false;
+
+  LoweringConfigAttr
+  buildConfig(MLIRContext *context,
+              std::optional<ArrayRef<int64_t>> workgroupTileSizes) const {
+    Builder b(context);
+    SmallVector<int64_t> mapping(tileSizes.size());
+    std::iota(mapping.begin(), mapping.end(), 0);
+
+    ArrayAttr subgroupBasisAttr = b.getArrayAttr(
+        {b.getI64ArrayAttr(subgroupCounts), b.getI64ArrayAttr(mapping)});
+    ArrayAttr laneBasisAttr = b.getArrayAttr(
+        {b.getI64ArrayAttr(threadCounts), b.getI64ArrayAttr(mapping)});
+
+    SmallVector<NamedAttribute> configAttrs;
+    if (workgroupTileSizes) {
+      configAttrs.push_back(
+          b.getNamedAttr("workgroup", b.getI64ArrayAttr(*workgroupTileSizes)));
+    }
+    configAttrs.push_back(
+        b.getNamedAttr(isReduction ? "partial_reduction" : "serial",
+                       b.getI64ArrayAttr(tileSizes)));
+    configAttrs.push_back(
+        b.getNamedAttr("thread", b.getI64ArrayAttr(threadTileSizes)));
+    configAttrs.push_back(b.getNamedAttr("lane_basis", laneBasisAttr));
+    configAttrs.push_back(b.getNamedAttr("subgroup_basis", subgroupBasisAttr));
+
+    auto configDict = b.getDictionaryAttr(configAttrs);
+    return IREE::GPU::LoweringConfigAttr::get(context, configDict);
+  }
+};
+
+static FailureOr<TileSizesConfig> getVectorDistributeReductionConfig(
     linalg::LinalgOp op, IREE::GPU::TargetAttr target,
     llvm::SmallDenseMap<unsigned, unsigned> &sharedWgpTiles,
     int64_t workgroupSize, int64_t subgroupSize, int64_t threadLoads) {
-  MLIRContext *context = op.getContext();
-  Builder b(context);
-
   SmallVector<unsigned> parallelDims;
   SmallVector<unsigned> reductionDims;
   op.getParallelDims(parallelDims);
@@ -173,12 +210,9 @@ getVectorDistributeReductionConfig(
 
   SmallVector<int64_t> bounds = op.getStaticLoopRanges();
 
-  SmallVector<int64_t> workgroupTileSizes(op.getNumLoops(), 0);
   SmallVector<int64_t> threadTileSizes(op.getNumLoops(), 0);
   SmallVector<int64_t> threadCounts(op.getNumLoops(), 1);
-  SmallVector<int64_t> subGroupCounts(op.getNumLoops(), 1);
-  SmallVector<int64_t> mapping(op.getNumLoops());
-  std::iota(mapping.begin(), mapping.end(), 0);
+  SmallVector<int64_t> subgroupCounts(op.getNumLoops(), 1);
 
   // Set the configuration for the operation with no reduction dims.
   // The workgroup tile sizes are set by the reduction operation.
@@ -186,10 +220,8 @@ getVectorDistributeReductionConfig(
     SmallVector<int64_t> serialTileSizes(op.getNumLoops(), 1);
 
     // For the shared wgp dimension, set the serial tile sizes to be zero.
-    // Copy the workgroup tiles sizes from the sharedWgpDims.
     for (const auto &[dim, tile_size] : sharedWgpTiles) {
       serialTileSizes[dim] = 0;
-      workgroupTileSizes[dim] = tile_size;
     }
 
     int64_t parallelSize = bounds[parallelDims.back()];
@@ -238,25 +270,10 @@ getVectorDistributeReductionConfig(
     serialTileSizes[parallelDims.back()] = lastDimReductionTileSize;
     threadTileSizes[parallelDims.back()] = threadLoads;
     threadCounts[parallelDims.back()] = threadBasis;
-    subGroupCounts[parallelDims.back()] = subgroupBasis;
+    subgroupCounts[parallelDims.back()] = subgroupBasis;
 
-    ArrayAttr subgroupBasisAttr = b.getArrayAttr(
-        {b.getI64ArrayAttr(subGroupCounts), b.getI64ArrayAttr(mapping)});
-
-    ArrayAttr laneBasisAttr = b.getArrayAttr(
-        {b.getI64ArrayAttr(threadCounts), b.getI64ArrayAttr(mapping)});
-
-    NamedAttribute configAttrs[] = {
-        NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
-        NamedAttribute("serial", b.getI64ArrayAttr(serialTileSizes)),
-        NamedAttribute("thread", b.getI64ArrayAttr(threadTileSizes)),
-        NamedAttribute("lane_basis", laneBasisAttr),
-        NamedAttribute("subgroup_basis", subgroupBasisAttr)};
-
-    auto configDict = b.getDictionaryAttr(configAttrs);
-    auto loweringConfig =
-        IREE::GPU::LoweringConfigAttr::get(context, configDict);
-    return loweringConfig;
+    return TileSizesConfig{serialTileSizes, threadTileSizes, threadCounts,
+                           subgroupCounts, /*isReduction=*/false};
   }
 
   // Setting the config for operation with atleast one reduction dimension.
@@ -279,11 +296,6 @@ getVectorDistributeReductionConfig(
       numParallelReductions = parallelFactor;
     }
     sharedWgpTiles[parallelIdx] = numParallelReductions;
-  }
-
-  // Set the workgroup tile sizes according to the sharedWgpDims.
-  for (const auto &[dim, tile_size] : sharedWgpTiles) {
-    workgroupTileSizes[dim] = tile_size;
   }
 
   for (int64_t dim : reductionDims) {
@@ -322,26 +334,11 @@ getVectorDistributeReductionConfig(
   partialReductionTileSizes[lastReductionDim] = partialReductionSize;
   threadTileSizes[lastReductionDim] = threadLoads;
   threadCounts[lastReductionDim] = threadBasis;
-  subGroupCounts[lastReductionDim] = subgroupBasis;
+  subgroupCounts[lastReductionDim] = subgroupBasis;
 
-  ArrayAttr subgroupBasisAttr = b.getArrayAttr(
-      {b.getI64ArrayAttr(subGroupCounts), b.getI64ArrayAttr(mapping)});
-
-  ArrayAttr threadBasisAttr = b.getArrayAttr(
-      {b.getI64ArrayAttr(threadCounts), b.getI64ArrayAttr(mapping)});
-
-  SmallVector<NamedAttribute> configAttrs = {
-      b.getNamedAttr("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
-      b.getNamedAttr("partial_reduction",
-                     b.getI64ArrayAttr(partialReductionTileSizes)),
-      b.getNamedAttr("thread", b.getI64ArrayAttr(threadTileSizes)),
-      b.getNamedAttr("lane_basis", threadBasisAttr),
-      b.getNamedAttr("subgroup_basis", subgroupBasisAttr),
-  };
-
-  auto configDict = b.getDictionaryAttr(configAttrs);
-  auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
-  return loweringConfig;
+  return TileSizesConfig{partialReductionTileSizes, threadTileSizes,
+                         threadCounts, subgroupCounts,
+                         /*isReduction=*/true};
 }
 
 static LogicalResult
@@ -371,69 +368,74 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
     sharedWgpTiles[i] = 1;
   }
 
-  // Determines if a lowering configuration should be attached to the given
-  // LinalgOp with only parallel dims. This is needed if the op cannot be fused
-  // with a reduction or introduces new loop dimensions.
-  auto shouldAttachLoweringConfig = [&](linalg::LinalgOp linalgOp) -> bool {
-    // If any output has a non-identity indexing map, the op needs its own
-    // layout anchors for vector distribution to handle the permuted write.
-    // Check this first since it takes precedence over fusion preferences.
+  // An operation needs a lowering config if it cannot infer its configuration
+  // from its outputs. For each output that feeds into a computeOp, the
+  // consumer's config determines the tiling for the dimensions referenced by
+  // the output indexing map. If all iteration dimensions are covered this way,
+  // no config is needed.
+  auto needsLoweringConfig = [&](linalg::LinalgOp linalgOp) -> bool {
+    llvm::SmallDenseSet<unsigned> coveredDims;
     for (OpOperand &output : linalgOp.getDpsInitsMutable()) {
-      if (!linalgOp.getMatchingIndexingMap(&output).isIdentity()) {
-        return true;
+      OpResult result = linalgOp.getTiedOpResult(&output);
+      bool hasComputeOpUser =
+          llvm::any_of(result.getUsers(), [&](Operation *user) {
+            auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
+            return linalgUser && computeOps.contains(linalgUser);
+          });
+      if (!hasComputeOpUser) {
+        continue;
+      }
+
+      AffineMap outputMap = linalgOp.getMatchingIndexingMap(&output);
+      for (unsigned i = 0; i < outputMap.getNumResults(); ++i) {
+        if (auto dimExpr = dyn_cast<AffineDimExpr>(outputMap.getResult(i))) {
+          coveredDims.insert(dimExpr.getPosition());
+        }
       }
     }
 
-    // If the operation has a gather, we want to fuse it with the
-    // reduction.
-    if (hasExternalCapture(cast<linalg::GenericOp>(linalgOp))) {
-      return false;
-    }
-    // If some of the users are in computeOps and some are outside of
-    // computeOps; attach lowering config, since the op can't be fused.
-    if (llvm::any_of(linalgOp->getUsers(),
-                     [&](Operation *user) {
-                       auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
-                       return linalgUser && computeOps.contains(linalgUser);
-                     }) &&
-        llvm::any_of(linalgOp->getUsers(), [&](Operation *user) {
-          auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
-          return !linalgUser;
-        })) {
-      return true;
-    }
-
-    // If the indexing map introduces new dimensions (more inputs than results),
-    // attach a lowering config.
-    for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
-      int64_t operandIdx = linalgOp.getIndexingMapIndex(operand);
-      AffineMap indexingMap = linalgOp.getIndexingMapsArray()[operandIdx];
-      if (indexingMap.getNumResults() > 0 &&
-          indexingMap.getNumInputs() > indexingMap.getNumResults()) {
+    for (unsigned i = 0; i < linalgOp.getNumLoops(); ++i) {
+      if (!coveredDims.contains(i)) {
         return true;
       }
     }
-
     return false;
   };
 
-  SmallVector<std::tuple<Operation *, LoweringConfigAttr>> loweringConfigs;
+  // Compute tile sizes for ops that need a lowering config.
+  SmallVector<std::pair<linalg::LinalgOp, TileSizesConfig>, 4> tileSizeConfigs;
   for (linalg::LinalgOp linalgOp : computeOps) {
-    if (hasReductionIterator(linalgOp) ||
-        shouldAttachLoweringConfig(linalgOp)) {
-      auto loweringConfig = getVectorDistributeReductionConfig(
-          linalgOp, target, sharedWgpTiles, workgroupSize, subgroupSize,
-          threadLoads);
-      if (failed(loweringConfig)) {
-        return failure();
-      }
-      loweringConfigs.push_back({linalgOp, *loweringConfig});
+    if (!needsLoweringConfig(linalgOp)) {
+      continue;
     }
+
+    auto config = getVectorDistributeReductionConfig(
+        linalgOp, target, sharedWgpTiles, workgroupSize, subgroupSize,
+        threadLoads);
+    if (failed(config)) {
+      return failure();
+    }
+    tileSizeConfigs.push_back({linalgOp, *config});
   }
-  // Only set lowering configs once we've successfully determined them for all
-  // operations, to avoid leaving the IR in an inconsistent state on failure.
-  for (auto &[linalgOp, loweringConfig] : loweringConfigs) {
-    setLoweringConfig(linalgOp, loweringConfig);
+
+  // Build and set lowering configurations. Only the first op in
+  // tileSizeConfigs (the last compute op in topological order) gets the
+  // workgroup tile sizes.
+  if (tileSizeConfigs.empty()) {
+    return success();
+  }
+
+  MLIRContext *context = tileSizeConfigs.front().first->getContext();
+  auto &[firstOp, firstConfig] = tileSizeConfigs.front();
+  SmallVector<int64_t> workgroupTileSizes(firstOp.getNumLoops(), 0);
+  for (const auto &[dim, tileSize] : sharedWgpTiles) {
+    workgroupTileSizes[dim] = tileSize;
+  }
+  setLoweringConfig(firstOp,
+                    firstConfig.buildConfig(context, workgroupTileSizes));
+
+  for (auto &[linalgOp, config] : llvm::drop_begin(tileSizeConfigs)) {
+    setLoweringConfig(linalgOp, config.buildConfig(context, std::nullopt));
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
@@ -172,8 +172,7 @@ struct TileSizesConfig {
   buildConfig(MLIRContext *context,
               std::optional<ArrayRef<int64_t>> workgroupTileSizes) const {
     Builder b(context);
-    SmallVector<int64_t> mapping(tileSizes.size());
-    std::iota(mapping.begin(), mapping.end(), 0);
+    auto mapping = llvm::to_vector(llvm::seq<int64_t>(0, tileSizes.size()));
 
     ArrayAttr subgroupBasisAttr = b.getArrayAttr(
         {b.getI64ArrayAttr(subgroupCounts), b.getI64ArrayAttr(mapping)});
@@ -367,13 +366,24 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
     sharedWgpTiles[i] = 1;
   }
 
-  // An operation needs a lowering config if it cannot infer its configuration
-  // from its outputs. For each output that feeds into a computeOp, the
-  // consumer's config determines the tiling for the dimensions referenced by
-  // the output indexing map. If all iteration dimensions are covered this way,
-  // no config is needed.
+  // An operation needs a lowering config in 2 cases:
+  //   - It has some dims which are not part of shared workgroup dims (we only
+  //     distribute threads on non shared dims).
+  //   - It cannot infer it's config from it's consumer compute ops.
   auto needsLoweringConfig = [&](linalg::LinalgOp linalgOp) -> bool {
-    llvm::SmallDenseSet<unsigned> coveredDims;
+    // Track which dims we have enough information about.
+    llvm::SmallBitVector coveredDims(linalgOp.getNumLoops());
+
+    // We have config information about shared parallel dims.
+    for (const auto &[dim, _] : sharedWgpTiles) {
+      coveredDims.set(dim);
+    }
+
+    // Since compute ops are iterated in reverse topological order, the consumer
+    // compute ops already have config information. We can assume that they can
+    // be used to infer the config of the current op.
+    //
+    // Cover dimensions that can be inferred by consumer compute ops.
     for (OpOperand &output : linalgOp.getDpsInitsMutable()) {
       OpResult result = linalgOp.getTiedOpResult(&output);
       bool hasComputeOpUser =
@@ -388,17 +398,14 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
       AffineMap outputMap = linalgOp.getMatchingIndexingMap(&output);
       for (unsigned i = 0; i < outputMap.getNumResults(); ++i) {
         if (auto dimExpr = dyn_cast<AffineDimExpr>(outputMap.getResult(i))) {
-          coveredDims.insert(dimExpr.getPosition());
+          coveredDims.set(dimExpr.getPosition());
         }
       }
     }
 
-    for (unsigned i = 0; i < linalgOp.getNumLoops(); ++i) {
-      if (!coveredDims.contains(i)) {
-        return true;
-      }
-    }
-    return false;
+    // If any dimension is not covered, then we need a lowering config for this
+    // op.
+    return !coveredDims.all();
   };
 
   // Compute tile sizes for ops that need a lowering config.
@@ -417,9 +424,10 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
     tileSizeConfigs.push_back({linalgOp, *config});
   }
 
-  // Build and set lowering configurations. Only the first op in
-  // tileSizeConfigs (the last compute op in topological order) gets the
-  // workgroup tile sizes.
+  // Build and set lowering configurations. Only the last operation in the
+  // dispatch gets the workgroup tile sizes. This is because workgroup tile
+  // sizes can only be set on dimensions that are shared on all operations, so
+  // we just need to set it on one operation. We just choose the last operation.
   if (tileSizeConfigs.empty()) {
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
@@ -158,12 +158,11 @@ static LogicalResult checkSingleCombiner(linalg::LinalgOp op) {
   return success();
 }
 
-/// Stores per-op tile sizes without building the lowering config attribute.
-/// The workgroup tile sizes are tracked separately in sharedWgpTiles and only
-/// applied to the last compute operation.
+/// Storage for tracking tile size configuration. Workgroup tile sizes are
+/// tracked separate. "tileSizes" materializes as serial level for parallel
+/// iterators and reduction level for reduction iterators.
 struct TileSizesConfig {
-  SmallVector<int64_t> tileSizes; // Tile sizes for "serial" or
-                                  // "partial_reduction" level.
+  SmallVector<int64_t> tileSizes;
   SmallVector<int64_t> threadTileSizes;
   SmallVector<int64_t> threadCounts;
   SmallVector<int64_t> subgroupCounts;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -739,9 +739,6 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   tileAndDistributeToWorkgroup(funcPassManager,
                                /*strategy=*/reorderStrategy);
 
-  // Some of the elementwise fusion can benefit from this pass.
-  funcPassManager.addPass(createRematerializeParallelOpsPass());
-
   funcPassManager.addPass(
       IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -153,8 +153,7 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]{{\]}},
 // CHECK-SAME:               partial_reduction = [0, 0, 1, 8192],
 // CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]{{\]}},
-// CHECK-SAME:               thread = [0, 0, 1, 8],
-// CHECK-SAME:               workgroup = [1, 1, 0, 0]
+// CHECK-SAME:               thread = [0, 0, 1, 8]
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1],
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
 // CHECK-SAME:    ins{{.*}}, {{.*}} : tensor<2x32x10x16384xf32>, tensor<2x32xf32>)
@@ -163,7 +162,7 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]{{\]}},
 // CHECK-SAME:              partial_reduction = [0, 0, 1, 8192],
 // CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]{{\]}},
-// CHECK-SAME:              thread = [0, 0, 1, 8],
+// CHECK-SAME:              thread = [0, 0, 1, 8]
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1, #map],
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
 // CHECK-SAME:    ins({{.*}}, %{{.*}}, {{.*}} : tensor<2x32x10x16384xf16>, tensor<2x32xf32>, tensor<2x32xf32>)
@@ -317,12 +316,7 @@ func.func @test_multiple_stores(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
 //       CHECK: func.func @test_multiple_stores
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
-//  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
-//  CHECK-SAME:               serial = [0, 4096],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 16], [0, 1]],
-//  CHECK-SAME:               thread = [0, 4],
-//  CHECK-SAME:               workgroup = [1, 0]
+//  CHECK-NOT:      lowering_config
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]{{\]}},

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -519,9 +519,9 @@ hal.executable private @i4_dequant_matvec {
 //         CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<1x1x1x1x1x1x1x1x1xf16>)
 //         CHECK:     vector.transfer_read {{.*}} : memref<32x128xf16, {{.*}}>, vector<1x4xf16>
 //         CHECK:     vector.transfer_read {{.*}} : memref<4096x32x128xi4, {{.*}}>, vector<1x1x4xi4>
-//         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
-//         CHECK:     arith.subf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
-//         CHECK:     arith.mulf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x1x1x1x4xi4> to vector<1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     arith.subf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>
+//         CHECK:     arith.mulf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>
 //         CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<1x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<1x1x1x1x1x1x1x1x1xf16>
 
 //         CHECK:   vector.shape_cast %{{.*}} : vector<1x1x1x1x1x1x1x1x1xf16> to vector<1x1x1xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -140,9 +140,9 @@ hal.executable private @i4_dequant_matvec {
 //     RDNA3-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //     RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x1x1x1x1xf16>
 //         RDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x1x1x1x1xf16>)
-//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x4xf16>
 //         RDNA3:   vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<4x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<4x1x1x1x1x1x1x1x1xf16>
 
 //         RDNA3:   vector.shape_cast %{{.*}} : vector<4x1x1x1x1x1x1x1x1xf16> to vector<4x1x1xf16>


### PR DESCRIPTION
An operation only needs a reduction lowering_config if it cannot infer it from a consumer compute op. Before this patch, we were adding lowering_configs for some elementwise operations that didn't need them and caused extra loops if we did not add the rematerialize elementwise operations pass.

Before this patch we would end up with something like:

```
elementwise {lowering_config}
reduce {lowering_config}
```

The rematerialize pass would fuse the elementwise with the reduction keeping:

```
reduce {lowering_config}
```

if we didn't do this, the elementwise and reduce would end up in their own scf.for loop. This was a workkaround of us setting lowering_config on the elementwise sometimes accidently. This patch makes it so that we only set:

```
elementwise
reduce {lowering_config}
```

This patch fixes the lowering_config setting and removes the rematerialize elementwise operations pass from VectorDistribute pipeline.