### PR TITLE
[LLVMGPU] Defer HoistExecutableObjectPass to the end of pipeline.

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
@@ -334,6 +334,7 @@ LogicalResult handleArgmaxUkernel(RewriterBase &rewriter, StringRef name,
   auto ukernelOp = IREE::Codegen::UKernelGenericOp::create(
       rewriter, loc, contextualOp->getResultTypes(), name, inputs, outputs,
       otherOperands, fnDefAttrs, /*num_strided_outer_dims=*/0);
+  ukernelOp->setDiscardableAttrs(contextualOp->getDiscardableAttrDictionary());
   if (returnsMaxValue) {
     rewriter.replaceAllUsesWith(genericOp.getResults()[1],
                                 ukernelOp.getResults()[1]);
@@ -415,11 +416,13 @@ LogicalResult handleInnerTiledMmaUkernel(
   }
   auto fnDefAttrs = DictionaryAttr::get(
       context, {{"vm.import.module", StringAttr::get(context, "rocm")}});
-  rewriter.replaceOpWithNewOp<IREE::Codegen::UKernelGenericOp>(
+  auto discardableAttrs = op->getDiscardableAttrDictionary();
+  auto newOp = rewriter.replaceOpWithNewOp<IREE::Codegen::UKernelGenericOp>(
       op, op.getOutputs().getTypes(), name, inputs, outputs,
       ValueRange{sharedMemory, constI32(sharedMemoryBytes), k, intrinsicsM,
                  subgroupsM, intrinsicsN, subgroupsN, intrinsicsK},
       fnDefAttrs, stridedDims);
+  newOp->setDiscardableAttrs(discardableAttrs);
   return success();
 }
 

--- a/compiler/plugins/target/ROCM/test/lower_rocm_ukernel_descriptor.mlir
+++ b/compiler/plugins/target/ROCM/test/lower_rocm_ukernel_descriptor.mlir
@@ -7,7 +7,7 @@
 // CHECK:               %[[C0:.*]] = arith.constant 0 : index
 // CHECK:               %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?xf32>
 // CHECK:               %[[FALSE:.*]] = arith.constant false
-// CHECK:               %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f32i64"
+// CHECK:               %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_argmax_f32i64", bitcode>} "iree_uk_amdgpu_argmax_f32i64"
 // CHECK-SAME:            ins(%[[ARG0]] : tensor<?xf32>)
 // CHECK-SAME:            outs(%[[ARG1]], %[[ARG2]] : tensor<f32>, tensor<i64>)
 // CHECK-SAME:            (%[[DIM]], %[[FALSE]] : index, i1)
@@ -42,7 +42,7 @@ module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
 // CHECK:               %[[C0:.*]] = arith.constant 0 : index
 // CHECK:               %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?xf32>
 // CHECK:               %[[TRUE:.*]] = arith.constant true
-// CHECK:               %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f32i64"
+// CHECK:               %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_argmax_f32i64", bitcode>} "iree_uk_amdgpu_argmax_f32i64"
 // CHECK-SAME:            ins(%[[ARG0]] : tensor<?xf32>)
 // CHECK-SAME:            outs(%[[ARG1]], %[[ARG2]] : tensor<f32>, tensor<i64>)
 // CHECK-SAME:            (%[[DIM]], %[[TRUE]] : index, i1)
@@ -84,7 +84,7 @@ module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
 // CHECK:               %[[C4:.*]] = arith.constant 4 : i32
 // CHECK:               %[[C2_1:.*]] = arith.constant 2 : i32
 // CHECK:               %[[C8192:.*]] = arith.constant 8192 : i32
-// CHECK:               %[[UK_GENERIC:.*]] = iree_codegen.ukernel.generic "iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8"
+// CHECK:               %[[UK_GENERIC:.*]] = iree_codegen.ukernel.generic {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8", bitcode>} "iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8"
 // CHECK-SAME:            ins(%[[ARG0]], %[[ARG1]] : tensor<1x2x8x4x16x2x8xi8>, tensor<1x2x4x2x4x16x2x8xi8>)
 // CHECK-SAME:            outs(%[[ARG2]] : tensor<1x1x4x8x2x4x16x4xi32>)
 // CHECK-SAME:            (%[[ALLOC]], %[[C8192]], %[[DIM_CAST]], %[[C8]], %[[C1]], %[[C2]], %[[C4]], %[[C2_1]] : tensor<8192xi8>, i32, i32, i32, i32, i32, i32, i32)
@@ -124,7 +124,7 @@ module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
 // CHECK:               %[[C4:.*]] = arith.constant 4 : i32
 // CHECK:               %[[C2_1:.*]] = arith.constant 2 : i32
 // CHECK:               %[[C0:.*]] = arith.constant 0 : i32
-// CHECK:               %[[UK_GENERIC:.*]] = iree_codegen.ukernel.generic "iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8"
+// CHECK:               %[[UK_GENERIC:.*]] = iree_codegen.ukernel.generic {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8", bitcode>} "iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8"
 // CHECK-SAME:            ins(%[[ARG0]], %[[ARG1]] : tensor<1x2x8x4x16x2x8xi8>, tensor<1x2x4x2x4x16x2x8xi8>)
 // CHECK-SAME:            outs(%[[ARG2]] : tensor<1x1x4x8x2x4x16x4xi32>)
 // CHECK-SAME:            (%[[NULL]], %[[C0]], %[[DIM_CAST]], %[[C8]], %[[C1]], %[[C2]], %[[C4]], %[[C2_1]] : !iree_codegen.null_pointer, i32, i32, i32, i32, i32, i32, i32)
@@ -150,7 +150,7 @@ module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
 
 // -----
 
-// CHECK:               %[[UK_GENERIC:.*]] = iree_codegen.ukernel.generic "iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8"
+// CHECK:               %[[UK_GENERIC:.*]] = iree_codegen.ukernel.generic {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8", bitcode>} "iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8"
 // CHECK-SAME{LITERAL}:   strided_dims([[], [], [2]])
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.ukernel_provider = #rocm.ukernel_provider, ukernels = "all"}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>

--- a/compiler/plugins/target/ROCM/test/ukernel_pipeline_transform.mlir
+++ b/compiler/plugins/target/ROCM/test/ukernel_pipeline_transform.mlir
@@ -44,7 +44,7 @@ func.func @argmax_1d_f16i64() attributes {
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Default> workgroup_size = [32, 1, 1]>
 //       CHECK: func.func @argmax_1d_f16i64()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f16i64"
+//       CHECK:   iree_codegen.ukernel.generic {hal.executable.objects = {{.*}}} "iree_uk_amdgpu_argmax_f16i64"
 
 // -----
 
@@ -94,7 +94,7 @@ func.func @argmax_2d_f32i64() attributes {
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   %[[SUBVIEW:.*]] = memref.subview{{.*}} memref<16x?xf32
 // CHECK-SAME:        to memref<1x?xf32
-//      CHECK:   iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f32i64" ins(%[[SUBVIEW]]
+//      CHECK:   iree_codegen.ukernel.generic {hal.executable.objects = {{.*}}} "iree_uk_amdgpu_argmax_f32i64" ins(%[[SUBVIEW]]
 
 // -----
 
@@ -199,7 +199,7 @@ func.func @argmax_1d_bf16i64() attributes {
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Default> workgroup_size = [32, 1, 1]>
 //       CHECK: func.func @argmax_1d_bf16i64()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_bf16i64"
+//       CHECK:   iree_codegen.ukernel.generic {hal.executable.objects = {{.*}}} "iree_uk_amdgpu_argmax_bf16i64"
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
@@ -125,11 +125,15 @@ convertToUKernelGeneric(RewriterBase &rewriter, Operation *op, StringRef name,
     }
   }
   // Default ukernel generic op is created when a provider doesn't exist or when
-  // the provider doesn't implement the replacement method.
-  rewriter.replaceOpWithNewOp<IREE::Codegen::UKernelGenericOp>(
+  // the provider doesn't implement the replacement method. Preserve discardable
+  // attributes (e.g., hal.executable.objects) so they can be used by later
+  // transformations.
+  auto discardableAttrs = op->getDiscardableAttrDictionary();
+  auto newOp = rewriter.replaceOpWithNewOp<IREE::Codegen::UKernelGenericOp>(
       op, op->getResults().getTypes(), name, tensorInputs, tensorOutputs,
       otherOperands, DictionaryAttr(),
       /*strided_outer_dims=*/0);
+  newOp->setDiscardableAttrs(discardableAttrs);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_bitcode_descriptor.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_bitcode_descriptor.mlir
@@ -5,7 +5,7 @@
 // CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]: tensor<16x32xf32>
 // CHECK-NOT:     linalg.generic
 // CHECK:         %[[OUT:.+]] = linalg.fill
-// CHECK:         %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "test"
+// CHECK:         %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"test", bitcode>} "test"
 // CHECK-SAME:       ins(%[[LHS]], %[[RHS]] : tensor<16x32xf32>, tensor<16x32xf32>)
 // CHECK-SAME:       outs(%[[OUT]] : tensor<16x16xf32>)
 // CHECK:         return %[[MICRO_KERNEL]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1129,10 +1129,6 @@ void buildLLVMGPUCodegenConfigurationPassPipeline(
 
 void buildLLVMGPUCodegenPassPipeline(OpPassManager &variantPassManager,
                                      bool useROCM, bool preserveDebugInfo) {
-  // LLVMGPUSelectLoweringStrategyPass may have created ExecutableObjectAttr.
-  // Hoisting them now deduplicates them and ensures that rewrite patterns don't
-  // need to think about explicitly copying them over to new ops.
-  variantPassManager.addPass(IREE::HAL::createHoistExecutableObjectsPass());
   {
     OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
     modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());
@@ -1162,6 +1158,10 @@ void buildLLVMGPUCodegenPassPipeline(OpPassManager &variantPassManager,
   //===--------------------------------------------------------------------===//
   addLowerToLLVMGPUPasses(variantPassManager.nest<ModuleOp>(), useROCM,
                           preserveDebugInfo);
+
+  // Ukernel selection attaches hal.executable.objects to individual ops. Hoist
+  // them to the variant level where the serializer expects them for linking.
+  variantPassManager.addPass(IREE::HAL::createHoistExecutableObjectsPass());
 
   LLVM_DEBUG({
     llvm::dbgs() << "Using LLVMGPU pass pipeline:\n";


### PR DESCRIPTION
Codegen should only touch the variant op in the boundaries, so the revision defers the pass to the end of the pipeline. To achieve it, the revision preserve discardable attribute (e.g., `hal.executable.objects`) when lowering ukernels, so the attribute is still visible for the HoistExecutableObjectsPass. Thus, it can be available for bitcode linking during serialization.

If the attribute is dropped, it causes the HAL pipeline's HoistExecutableObjectsPass to find nothing to hoist, and serialization would fail with unresolved external function errors for data-tiled MMA ukernels.

It is a preparation for making codegen pipeline work on module-scope, which will benefit device-codegen-only project as well.