### PR TITLE
[TensorExt] Remove avgRaggedColumnLength from CastToRaggedShapeOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -650,8 +650,7 @@ CastToRaggedShapeOp::getEstimatedLoopRange(RewriterBase &rewriter,
 
   // For the inner sparse dimension, the estimated range is obtained by
   // replacing the `dim(%sparseOp, innerSparseDim)` with
-  // - either `%max_column_lengths` if given, or
-  // - `dim(%source, outerSparseDim) / %num_ragged_rows`.
+  // `dim(%source, outerSparseDim) / %num_ragged_rows`.
 
   Value innerUb =
       getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[1].size);
@@ -659,9 +658,6 @@ CastToRaggedShapeOp::getEstimatedLoopRange(RewriterBase &rewriter,
       cloneAndReplaceDimInBackwardSlice(
           rewriter, loc, dominanceInfo, innerUb, *this, expectedSparseDims[1],
           [&](RewriterBase &rewriter, Location loc) {
-            if (Value avgRaggedColumnLength = getAvgRaggedColumnLength()) {
-              return avgRaggedColumnLength;
-            }
             OpFoldResult sourceDim =
                 memref::DimOp::create(rewriter, loc, getSource(),
                                       expectedSparseDims[0])

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -560,10 +560,6 @@ def IREETensorExt_CastToRaggedShapeOp :
 
     In other words, `column_lengths` is same as the `ROW_INDEX` in CSR
     representation (https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)).
-    An optional argument `max_ragged_column_length` allows specifying the dynamic
-    upper bound for the number of columns (for static upper bounds the shape of the
-    dimension in the result shaped type encodes this value)
-
     For example, if the `n` and `n+1` dimensions of the result represent this ragged structure
 
     ```
@@ -593,7 +589,6 @@ def IREETensorExt_CastToRaggedShapeOp :
     IndexAttr:$raggedDim,
     AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$columnLengths,
     Optional<Index>:$numRaggedRows,
-    Optional<Index>:$avgRaggedColumnLength,
     Variadic<Index>:$sourceDynamicDims
   );
   let results = (outs AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$result);
@@ -602,7 +597,6 @@ def IREETensorExt_CastToRaggedShapeOp :
     $source `ragged_dim` `(` $raggedDim `)`
     `column_lengths` `(` $columnLengths `)`
     (`num_ragged_rows` `(` $numRaggedRows^ `)`)?
-    (`avg_ragged_column_length` `(` $avgRaggedColumnLength^ `)`)?
     attr-dict `:`
     `(` type($source) (`{` $sourceDynamicDims^ `}`)? `,` type($columnLengths) `)`
     `->` type($result)

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -254,11 +254,10 @@ util.func public @dynamicResultDimWithStaticNumRaggedRows(%source : tensor<?x?x?
 
 // Error when `ragged_dim` + 1 dimension is static.
 util.func public @staticRaggedColumnLengths(%source : tensor<?x?x?xf32>,
-    %columnLengths : tensor<4xindex>, %avgColumnLength : index,
+    %columnLengths : tensor<4xindex>,
     %d0 : index, %d1 : index, %d2 : index) -> tensor<?x3x4x?xf32, #iree_tensor_ext.ragged_shape<1>> {
   // expected-error @+1 {{expected dimension 2 of result, i.e. `ragged_dim` + 1, to be dynamic}}
   %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
-      avg_ragged_column_length(%avgColumnLength)
       : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x4x?xf32, #iree_tensor_ext.ragged_shape<1>>
   util.return %0 : tensor<?x3x4x?xf32, #iree_tensor_ext.ragged_shape<1>>
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -180,21 +180,6 @@ util.func public @staticAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
 
 // -----
 
-// Check for dynamically specified `avg_ragged_column_length`.
-
-util.func public @dynamicAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
-    %columnLengths : tensor<4xindex>, %avgColumnLength : index,
-    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
-  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
-      avg_ragged_column_length(%avgColumnLength)
-      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
-  util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
-}
-// CHECK-LABEL: @dynamicAvgRaggedColumnLengths
-//       CHECK:     iree_tensor_ext.cast_to_ragged_shape
-
-// -----
-
 // Round trip test for SparseIterationDimsAttr
 func.func @sparseIterationDimsAttr() {
   scf.forall (%i, %j) = (0, 0) to (10, 20) step (1, 1) {

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods.mlir
@@ -47,9 +47,9 @@ func.func public @simpleTest(%source : memref<?x?xf32>, %column_lengths: memref<
 
 // -----
 
-// Check interface methods for `cast_to_ragged_shape` with `avg_ragged_column_length` specified.
-func.func public @testAvgRaggedColumnLengths(%source : memref<?x?xf32>, %column_lengths: memref<?xi32>,
-    %num_rows: index, %avg_ragged_column_length: index, %lb0 : index, %lb1 : index,
+// Check interface methods for `cast_to_ragged_shape` with estimated column length.
+func.func public @testEstimatedColumnLength(%source : memref<?x?xf32>, %column_lengths: memref<?xi32>,
+    %num_rows: index, %lb0 : index, %lb1 : index,
     %step0 : index, %step1 : index) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -57,7 +57,6 @@ func.func public @testAvgRaggedColumnLengths(%source : memref<?x?xf32>, %column_
   %source_d1 = memref.dim %source, %c1 : memref<?x?xf32>
   %0 = iree_tensor_ext.cast_to_ragged_shape %source
       ragged_dim(0) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
-      avg_ragged_column_length(%avg_ragged_column_length)
       : (memref<?x?xf32>{%source_d0, %source_d1}, memref<?xi32>)
       -> memref<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
   %d0 = memref.dim %0, %c0 : memref<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
@@ -67,11 +66,10 @@ func.func public @testAvgRaggedColumnLengths(%source : memref<?x?xf32>, %column_
   } {iree_tensor_ext.sparse_iteration_dims = #iree_tensor_ext.sparse_iteration_dims<[0, 1]>}
   return
 }
-// CHECK-ALL-LABEL: func public @testAvgRaggedColumnLengths(
+// CHECK-ALL-LABEL: func public @testEstimatedColumnLength(
 //  CHECK-ALL-SAME:     %[[SOURCE:.+]]: memref<?x?xf32>,
 //  CHECK-ALL-SAME:     %[[COLUMN_LENGTHS:.+]]: memref<?xi32>,
 //  CHECK-ALL-SAME:     %[[NUM_ROWS:[a-zA-Z0-9]+]]: index,
-//  CHECK-ALL-SAME:     %[[AVG_RAGGED_COLUMN_LENGTH:[a-zA-Z0-9]+]]: index,
 //  CHECK-ALL-SAME:     %[[LB0:[a-zA-Z0-9]+]]: index
 //  CHECK-ALL-SAME:     %[[LB1:[a-zA-Z0-9]+]]: index
 //  CHECK-ALL-SAME:     %[[STEP0:[a-zA-Z0-9]+]]: index,
@@ -88,8 +86,10 @@ func.func public @testAvgRaggedColumnLengths(%source : memref<?x?xf32>, %column_
 // LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB]] to %[[ROW_UB]] step %[[STEP1]] {
 // LOWER-LOOP-RANGE:       "some_op"(%[[IV0]], %[[IV1]])
 
+//      GET-ESTIMATED-LOOP-RANGE: %[[EST_COLS:.+]] = affine.apply
+// GET-ESTIMATED-LOOP-RANGE-SAME:     affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%[[SOURCE_D0:.+]], %[[NUM_ROWS]]]
 //      GET-ESTIMATED-LOOP-RANGE: scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]]) = (%[[LB0]], %[[LB1]])
-// GET-ESTIMATED-LOOP-RANGE-SAME:     to (%[[NUM_ROWS]], %[[AVG_RAGGED_COLUMN_LENGTH]]) step (%[[STEP0]], %[[STEP1]]) {
+// GET-ESTIMATED-LOOP-RANGE-SAME:     to (%[[NUM_ROWS]], %[[EST_COLS]]) step (%[[STEP0]], %[[STEP1]]) {
 //      GET-ESTIMATED-LOOP-RANGE:   "some_op"(%[[IV0]], %[[IV1]])
 
 // -----


### PR DESCRIPTION
This is PR 1/N of landing block sparse changes that are captured in this branch : https://github.com/MaheshRavishankar/iree/tree/users/MaheshRavishankar/blockSparseCommits

The avgRaggedColumnLength argument on CastToRaggedShapeOp was an
optional hint for the average number of columns per ragged row.
It is not clear how this should be used in reality and the current passing
e2e flow does not seem to need it. Also using this seem to just confuse the
agents. Remove it in favor of computing the estimate directly as
dim(source, outerSparseDim) / numRaggedRows, which avoids requiring
callers to provide a value that can be derived from existing operands.
                                                                                                                                                                                                                   
Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>           