### PR TITLE
[GPU] Implement CDNA block intrinsics (3/6)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -178,6 +178,17 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
   int64_t innerNDim = opInfo.getNDims().back();
   int64_t innerKDim = opInfo.getKDims().back();
 
+  bool isBlock = intrinsic.isBlockIntrinsic();
+  // For block intrinsics the innermost batch dim is consumed by the intrinsic.
+  int64_t innerBDim = -1;
+  if (isBlock) {
+    if (opInfo.getBatchDims().empty()) {
+      return candidate->emitError(
+          "block intrinsic requires at least one batch dimension");
+    }
+    innerBDim = opInfo.getBatchDims().back();
+  }
+
   SmallVector<int64_t> batchCounts(bounds);
 
   // Subgroup distribution layouts.
@@ -191,10 +202,18 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
   // Since these MMA intrinsics have a given tile size for each subgroup, we can
   // calculate the batch dimensions without looking at the subgroup layout.
   SmallVector<int64_t> subgroupSize(rank, 1);
-  auto [mSize, nSize, kSize] = intrinsic.getMNKShape();
-  subgroupSize[innerMDim] = mSize;
-  subgroupSize[innerNDim] = nSize;
-  subgroupSize[innerKDim] = kSize;
+  if (isBlock) {
+    auto [bSize, mSize, nSize, kSize] = intrinsic.getBMNKShape();
+    subgroupSize[innerBDim] = bSize;
+    subgroupSize[innerMDim] = mSize;
+    subgroupSize[innerNDim] = nSize;
+    subgroupSize[innerKDim] = kSize;
+  } else {
+    auto [mSize, nSize, kSize] = intrinsic.getMNKShape();
+    subgroupSize[innerMDim] = mSize;
+    subgroupSize[innerNDim] = nSize;
+    subgroupSize[innerKDim] = kSize;
+  }
 
   for (auto i : llvm::seq<int64_t>(rank)) {
     batchCounts[i] = llvm::divideCeil(batchCounts[i], subgroupSize[i]);
@@ -203,8 +222,8 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
   // MMA intrinsics can be weird and usually don't have a single subgroup
   // iteration space, so we need to find their value subgroup iteration space
   // individually.
-  auto getFragmentLayout = [&](int operandIndex, int64_t outerDim,
-                               int64_t innerDim,
+  auto getFragmentLayout = [&](int operandIndex, int64_t blockDim,
+                               int64_t outerDim, int64_t innerDim,
                                AffineMap map) -> VectorLayoutInterface {
     // Note that the struct MMASingleSubgroupLayout contains the partial layout
     // for the canonical (M, K) x (K, N) -> (M, N) matmul form. We treat the
@@ -217,14 +236,32 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
 
     MMASingleSubgroupLayout subgroupLayout =
         IREE::GPU::getSingleSubgroupLayout(intrinsic, operandIndex);
-    outerCounts[outerDim] = subgroupLayout.outer[0];
-    outerCounts[innerDim] = subgroupLayout.outer[1];
-    threadCounts[outerDim] = subgroupLayout.thread[0];
-    threadCounts[innerDim] = subgroupLayout.thread[1];
-    threadStrides[outerDim] = subgroupLayout.tstrides[0];
-    threadStrides[innerDim] = subgroupLayout.tstrides[1];
-    elementCounts[outerDim] = subgroupLayout.element[0];
-    elementCounts[innerDim] = subgroupLayout.element[1];
+
+    if (isBlock) {
+      // 3D layout: indices 0=Block, 1=outer(M/K), 2=inner(K/N).
+      outerCounts[blockDim] = subgroupLayout.outer[0];
+      outerCounts[outerDim] = subgroupLayout.outer[1];
+      outerCounts[innerDim] = subgroupLayout.outer[2];
+      threadCounts[blockDim] = subgroupLayout.thread[0];
+      threadCounts[outerDim] = subgroupLayout.thread[1];
+      threadCounts[innerDim] = subgroupLayout.thread[2];
+      threadStrides[blockDim] = subgroupLayout.tstrides[0];
+      threadStrides[outerDim] = subgroupLayout.tstrides[1];
+      threadStrides[innerDim] = subgroupLayout.tstrides[2];
+      elementCounts[blockDim] = subgroupLayout.element[0];
+      elementCounts[outerDim] = subgroupLayout.element[1];
+      elementCounts[innerDim] = subgroupLayout.element[2];
+    } else {
+      outerCounts[outerDim] = subgroupLayout.outer[0];
+      outerCounts[innerDim] = subgroupLayout.outer[1];
+      threadCounts[outerDim] = subgroupLayout.thread[0];
+      threadCounts[innerDim] = subgroupLayout.thread[1];
+      threadStrides[outerDim] = subgroupLayout.tstrides[0];
+      threadStrides[innerDim] = subgroupLayout.tstrides[1];
+      elementCounts[outerDim] = subgroupLayout.element[0];
+      elementCounts[innerDim] = subgroupLayout.element[1];
+    }
+
     // Get the fragment layout for the entire iteration space and then project
     // it. This is significantly easier than trying to create a layout for each
     // fragment itself.
@@ -234,12 +271,15 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
     return fragmentSpaceLayout.apply(map);
   };
 
-  VectorLayoutInterface lhs = getFragmentLayout(
-      IREE::GPU::kMMAOperandLhs, innerMDim, innerKDim, contractIndexingMaps[0]);
-  VectorLayoutInterface rhs = getFragmentLayout(
-      IREE::GPU::kMMAOperandRhs, innerKDim, innerNDim, contractIndexingMaps[1]);
-  VectorLayoutInterface acc = getFragmentLayout(
-      IREE::GPU::kMMAOperandAcc, innerMDim, innerNDim, contractIndexingMaps[2]);
+  VectorLayoutInterface lhs =
+      getFragmentLayout(IREE::GPU::kMMAOperandLhs, innerBDim, innerMDim,
+                        innerKDim, contractIndexingMaps[0]);
+  VectorLayoutInterface rhs =
+      getFragmentLayout(IREE::GPU::kMMAOperandRhs, innerBDim, innerKDim,
+                        innerNDim, contractIndexingMaps[1]);
+  VectorLayoutInterface acc =
+      getFragmentLayout(IREE::GPU::kMMAOperandAcc, innerBDim, innerMDim,
+                        innerNDim, contractIndexingMaps[2]);
 
   return ContractionLayout{lhs, rhs, acc};
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -420,3 +420,53 @@ func.func @contraction_ceildiv_batch(%lhs: tensor<1x1x63xf16>,
 // CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]])
 // CHECK: linalg.generic
 // CHECK-SAME: ins(%[[LHS]], %[[RHS]]
+
+// -----
+
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+                                              workgroup_size = [64, 1, 1]
+                                              subgroup_size = 64>
+
+#maps_block = [
+  affine_map<(b, m, n, k) -> (b, m, k)>,
+  affine_map<(b, m, n, k) -> (b, k, n)>,
+  affine_map<(b, m, n, k) -> (b, m, n)>
+]
+
+#traits_block = {
+  indexing_maps = #maps_block,
+  iterator_types = ["parallel", "parallel", "parallel", "reduction"],
+  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x4x2B_F16>,
+                                              subgroup_basis = [[1, 1, 1, 1], [0, 1, 2, 3]]}>
+}
+
+func.func @batch_matmul_block_intrinsic(%lhs: tensor<4x32x4xf16>,
+                                        %rhs: tensor<4x4x32xf16>,
+                                        %init: tensor<4x32x32xf32>)
+                                        -> tensor<4x32x32xf32>
+                                        attributes { translation_info = #translation } {
+  %out = linalg.generic #traits_block
+                        ins(%lhs, %rhs: tensor<4x32x4xf16>, tensor<4x4x32xf16>)
+                        outs(%init: tensor<4x32x32xf32>) {
+    ^bb0(%in: f16, %in_1: f16, %out: f32):
+      %ex   = arith.extf %in   : f16 to f32
+      %ex_1 = arith.extf %in_1 : f16 to f32
+      %mul  = arith.mulf %ex, %ex_1 : f32
+      %sum  = arith.addf %out, %mul : f32
+      linalg.yield %sum : f32
+  } -> tensor<4x32x32xf32>
+  return %out : tensor<4x32x32xf32>
+}
+
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1, 1], batch_tile = [2, 1, 1], outer_tile = [1, 1, 1], thread_tile = [2, 32, 1], element_tile = [1, 1, 4], subgroup_strides = [0, 0, 0], thread_strides = [32, 1, 0]>
+// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1, 1], batch_tile = [2, 1, 1], outer_tile = [1, 1, 1], thread_tile = [2, 1, 32], element_tile = [1, 4, 1], subgroup_strides = [0, 0, 0], thread_strides = [32, 0, 1]>
+// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1, 1], batch_tile = [2, 1, 1], outer_tile = [1, 4, 1], thread_tile = [1, 2, 32], element_tile = [2, 4, 1], subgroup_strides = [0, 0, 0], thread_strides = [0, 32, 1]>
+
+// CHECK-LABEL: func.func @batch_matmul_block_intrinsic
+
+// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]])
+// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]])
+// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED2]])
+// CHECK: linalg.generic
+// CHECK-SAME: ins(%[[LHS]], %[[RHS]]
+// CHECK-SAME: outs(%[[ACC]]


### PR DESCRIPTION
Extend LLVMGPUConfigureTensorLayouts to handle CDNA block intrinsics, enabling VectorDistribute support.

Part of iree-org/iree#23941