### PR TITLE
[Codegen][GPU] Use gpu::AddressSpace::Global for constants

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
@@ -278,6 +278,18 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   // data races on GPU.
   options.checkParallelRegions = false;
 
+  // ROCM needs global address space for constants to avoid invalid opcodes
+  // when accessed with dynamic indexing (e.g., split reduction).
+  if (auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp)) {
+    if (target.getBackend() == "rocm") {
+      options.defaultMemorySpaceFn =
+          [](TensorType t) -> std::optional<Attribute> {
+        return gpu::AddressSpaceAttr::get(t.getContext(),
+                                          gpu::AddressSpace::Global);
+      };
+    }
+  }
+
   bufferization::BufferizationState bufferizationState;
   if (failed(runIREEOneShotBufferize(funcOp, options, bufferizationState))) {
     return signalPassFailure();
@@ -294,28 +306,24 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
 }
 
 void IREEBufferizeConstantsPass::runOnOperation() {
-  Operation *op = getOperation();
-
-  // For ROCM, constants use gpu::AddressSpace::Global to avoid crashes when
-  // accessed with dynamic indexing (e.g., split reduction). AMDGPU's flat
-  // vector load codegen cannot handle dynamic indices on constants in the
-  // default flat address space (0).
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(op);
-  bool isROCM = isROCMBackend(targetAttr);
-
   mlir::bufferization::OneShotBufferizationOptions opt;
   opt.copyBeforeWrite = true;
   opt.opFilter.allowOperation(arith::ConstantOp::getOperationName());
 
-  // For ROCM, use gpu::AddressSpace::Global for constants.
-  opt.defaultMemorySpaceFn =
-      [isROCM](TensorType t) -> std::optional<Attribute> {
-    if (isROCM) {
+  // ROCM needs global address space for constants to avoid invalid opcodes
+  // when accessed with dynamic indexing (e.g., split reduction).
+  Operation *op = getOperation();
+  bool isROCM = false;
+  if (auto target = IREE::HAL::ExecutableTargetAttr::lookup(op)) {
+    isROCM = target.getBackend() == "rocm";
+  }
+
+  if (isROCM) {
+    opt.defaultMemorySpaceFn = [](TensorType t) -> std::optional<Attribute> {
       return gpu::AddressSpaceAttr::get(t.getContext(),
                                         gpu::AddressSpace::Global);
-    }
-    return Attribute();
-  };
+    };
+  }
 
   bufferization::BufferizationState bufferizationState;
   if (failed(mlir::bufferization::runOneShotBufferize(

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
@@ -278,16 +278,14 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   // data races on GPU.
   options.checkParallelRegions = false;
 
-  // ROCM needs global address space for constants to avoid invalid opcodes
+  // GPU targets need global address space for constants to avoid issues
   // when accessed with dynamic indexing (e.g., split reduction).
-  if (auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp)) {
-    if (target.getBackend() == "rocm") {
-      options.defaultMemorySpaceFn =
-          [](TensorType t) -> std::optional<Attribute> {
-        return gpu::AddressSpaceAttr::get(t.getContext(),
-                                          gpu::AddressSpace::Global);
-      };
-    }
+  if (isGPUBackend(IREE::HAL::ExecutableTargetAttr::lookup(funcOp))) {
+    options.defaultMemorySpaceFn =
+        [](TensorType t) -> std::optional<Attribute> {
+      return gpu::AddressSpaceAttr::get(t.getContext(),
+                                        gpu::AddressSpace::Global);
+    };
   }
 
   bufferization::BufferizationState bufferizationState;
@@ -310,15 +308,9 @@ void IREEBufferizeConstantsPass::runOnOperation() {
   opt.copyBeforeWrite = true;
   opt.opFilter.allowOperation(arith::ConstantOp::getOperationName());
 
-  // ROCM needs global address space for constants to avoid invalid opcodes
+  // GPU targets need global address space for constants to avoid issues
   // when accessed with dynamic indexing (e.g., split reduction).
-  Operation *op = getOperation();
-  bool isROCM = false;
-  if (auto target = IREE::HAL::ExecutableTargetAttr::lookup(op)) {
-    isROCM = target.getBackend() == "rocm";
-  }
-
-  if (isROCM) {
+  if (isGPUBackend(IREE::HAL::ExecutableTargetAttr::lookup(getOperation()))) {
     opt.defaultMemorySpaceFn = [](TensorType t) -> std::optional<Attribute> {
       return gpu::AddressSpaceAttr::get(t.getContext(),
                                         gpu::AddressSpace::Global);

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
@@ -136,7 +136,7 @@ public:
   using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<arith::ArithDialect, bufferization::BufferizationDialect,
-                    memref::MemRefDialect>();
+                    gpu::GPUDialect, memref::MemRefDialect>();
   }
 
   void runOnOperation() override;
@@ -294,9 +294,29 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
 }
 
 void IREEBufferizeConstantsPass::runOnOperation() {
+  Operation *op = getOperation();
+
+  // For ROCM, constants use gpu::AddressSpace::Global to avoid crashes when
+  // accessed with dynamic indexing (e.g., split reduction). AMDGPU's flat
+  // vector load codegen cannot handle dynamic indices on constants in the
+  // default flat address space (0).
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(op);
+  bool isROCM = isROCMBackend(targetAttr);
+
   mlir::bufferization::OneShotBufferizationOptions opt;
   opt.copyBeforeWrite = true;
   opt.opFilter.allowOperation(arith::ConstantOp::getOperationName());
+
+  // For ROCM, use gpu::AddressSpace::Global for constants.
+  opt.defaultMemorySpaceFn =
+      [isROCM](TensorType t) -> std::optional<Attribute> {
+    if (isROCM) {
+      return gpu::AddressSpaceAttr::get(t.getContext(),
+                                        gpu::AddressSpace::Global);
+    }
+    return Attribute();
+  };
+
   bufferization::BufferizationState bufferizationState;
   if (failed(mlir::bufferization::runOneShotBufferize(
           getOperation(), opt, bufferizationState,

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -72,6 +72,7 @@ iree_lit_test_suite(
             "hoist_unrolled_vector_extract_insert_slice.mlir",
             "insert_batch_dim_for_batchless_conv.mlir",
             "insert_smt_constraints.mlir",
+            "iree_bufferize_constants.mlir",
             "iree_codegen_canonicalize.mlir",
             "iree_comprehensive_bufferize.mlir",
             "iree_expand_strided_metadata.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_lit_test_suite(
     "hoist_unrolled_vector_extract_insert_slice.mlir"
     "insert_batch_dim_for_batchless_conv.mlir"
     "insert_smt_constraints.mlir"
+    "iree_bufferize_constants.mlir"
     "iree_codegen_canonicalize.mlir"
     "iree_comprehensive_bufferize.mlir"
     "iree_expand_strided_metadata.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_bufferize_constants.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_bufferize_constants.mlir
@@ -114,19 +114,96 @@ module attributes {hal.executable.target = #executable_target_rocm} {
 
 // -----
 
-// Test with CUDA target (should also use default, no gpu.address_space).
+// Test with CUDA target (should also use gpu.address_space<global>).
 
 #executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32> = dense<[1, 2, 3, 4]>
-// CHECK-NOT: #gpu.address_space
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
 // CHECK: func.func @constant_cuda
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
 module attributes {hal.executable.target = #executable_target_cuda} {
   func.func @constant_cuda() {
+    %c0 = arith.constant 0 : index
+
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0] : tensor<4xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}
+
+// -----
+
+// Test with Vulkan target (should use gpu.address_space<global>).
+
+#executable_target_vulkan = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: func.func @constant_vulkan
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+module attributes {hal.executable.target = #executable_target_vulkan} {
+  func.func @constant_vulkan() {
+    %c0 = arith.constant 0 : index
+
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0] : tensor<4xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}
+
+// -----
+
+// Test with Metal target (should use gpu.address_space<global>).
+
+#executable_target_metal = #hal.executable.target<"metal-spirv", "metal-spirv-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: func.func @constant_metal
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+module attributes {hal.executable.target = #executable_target_metal} {
+  func.func @constant_metal() {
+    %c0 = arith.constant 0 : index
+
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0] : tensor<4xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}
+
+// -----
+
+// Test with WebGPU target (should use gpu.address_space<global>).
+
+#executable_target_webgpu = #hal.executable.target<"webgpu-spirv", "webgpu-spirv-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: func.func @constant_webgpu
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+module attributes {hal.executable.target = #executable_target_webgpu} {
+  func.func @constant_webgpu() {
     %c0 = arith.constant 0 : index
 
     %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_bufferize_constants.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_bufferize_constants.mlir
@@ -1,0 +1,140 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-codegen-iree-bufferize-constants)" %s | FileCheck %s
+
+// Test that constants are bufferized with gpu.address_space<global> for ROCM targets
+// when accessed with dynamic indexing (e.g., split reduction scenario).
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>> = dense<[1, 2, 3, 4]>
+// CHECK: func.func @constant_with_dynamic_indexing_rocm
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+module attributes {hal.executable.target = #executable_target_rocm} {
+  func.func @constant_with_dynamic_indexing_rocm() {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+
+    // A constant that will be accessed with dynamic indexing.
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    // Dynamic indexing pattern (similar to split reduction).
+    scf.for %i = %c0 to %c4 step %c1 {
+      %extracted = tensor.extract %cst[%i] : tensor<4xi32>
+      memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    }
+    return
+  }
+}
+
+// -----
+
+// Test with a larger constant (the actual crash scenario).
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<100x100xi32, #gpu.address_space<global>>
+// CHECK: func.func @large_constant_rocm
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<100x100xi32, #gpu.address_space<global>>
+module attributes {hal.executable.target = #executable_target_rocm} {
+  func.func @large_constant_rocm() {
+    %c0 = arith.constant 0 : index
+
+    // Large constant that triggered the original crash.
+    %cst = arith.constant dense<1> : tensor<100x100xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0, %c0] : tensor<100x100xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}
+
+// -----
+
+// Test that non-ROCM targets use default memory space (no gpu.address_space).
+
+#executable_target_llvm = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32> = dense<[1, 2, 3, 4]>
+// CHECK-NOT: #gpu.address_space
+// CHECK: func.func @constant_default_cpu
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32>
+module attributes {hal.executable.target = #executable_target_llvm} {
+  func.func @constant_default_cpu() {
+    %c0 = arith.constant 0 : index
+
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0] : tensor<4xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}
+
+// -----
+
+// Test splat constant (optimizes differently but should still work).
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<10xi32, #gpu.address_space<global>>
+// CHECK: func.func @splat_constant_rocm
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<10xi32, #gpu.address_space<global>>
+module attributes {hal.executable.target = #executable_target_rocm} {
+  func.func @splat_constant_rocm() {
+    %c0 = arith.constant 0 : index
+
+    // Splat constant.
+    %cst = arith.constant dense<42> : tensor<10xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0] : tensor<10xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}
+
+// -----
+
+// Test with CUDA target (should also use default, no gpu.address_space).
+
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32> = dense<[1, 2, 3, 4]>
+// CHECK-NOT: #gpu.address_space
+// CHECK: func.func @constant_cuda
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32>
+module attributes {hal.executable.target = #executable_target_cuda} {
+  func.func @constant_cuda() {
+    %c0 = arith.constant 0 : index
+
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+
+    %result = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i32, #hal.descriptor_type<storage_buffer>>
+
+    %extracted = tensor.extract %cst[%c0] : tensor<4xi32>
+    memref.store %extracted, %result[] : memref<i32, #hal.descriptor_type<storage_buffer>>
+    return
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3122,9 +3122,9 @@ func.func @map_store_mixed_semantics(%input: tensor<16xf32>, %output: memref<16x
 
 // -----
 
-// Test that constants use gpu.address_space<global> for ROCM targets.
-// This is needed to avoid invalid opcodes when constants are accessed
-// with dynamic indexing (e.g., split reduction).
+// Test that constants use gpu.address_space<global> for GPU targets.
+// This is needed to avoid issues when constants are accessed with
+// dynamic indexing (e.g., split reduction).
 
 #executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3119,3 +3119,39 @@ func.func @map_store_mixed_semantics(%input: tensor<16xf32>, %output: memref<16x
 //       CHECK:   iree_linalg_ext.map_store %[[INPUT_BUF]] into %[[OUTPUT]]
 //       CHECK:   } : memref<16xf32> into memref<16xf32>
 //       CHECK:   return
+
+// -----
+
+// Test that constants use gpu.address_space<global> for ROCM targets.
+// This is needed to avoid invalid opcodes when constants are accessed
+// with dynamic indexing (e.g., split reduction).
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#map = affine_map<(d0) -> (d0)>
+
+module attributes {hal.executable.target = #executable_target_rocm} {
+  func.func @constant_to_buffer_rocm() {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+    %input = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xi32>>
+    %output = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xi32>>
+    %input_tensor = iree_tensor_ext.dispatch.tensor.load %input, offsets = [0], sizes = [4], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xi32>> -> tensor<4xi32>
+    %init = tensor.empty() : tensor<4xi32>
+    %result = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]}
+      ins(%input_tensor, %cst : tensor<4xi32>, tensor<4xi32>) outs(%init : tensor<4xi32>) {
+    ^bb0(%in0: i32, %in1: i32, %out: i32):
+      %sum = arith.addi %in0, %in1 : i32
+      linalg.yield %sum : i32
+    } -> tensor<4xi32>
+    iree_tensor_ext.dispatch.tensor.store %result, %output, offsets = [0], sizes = [4], strides = [1] : tensor<4xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xi32>>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @constant_to_buffer_rocm
+// CHECK:         %[[CST:.+]] = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+// CHECK:         bufferization.to_buffer %[[CST]] {{.*}} : tensor<4xi32> to memref<4xi32, #gpu.address_space<global>>

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -176,6 +176,16 @@ bool isWebGPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return targetAttr && targetAttr.getBackend().getValue().starts_with("webgpu");
 }
 
+bool isGPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  if (!targetAttr) {
+    return false;
+  }
+  StringRef backend = targetAttr.getBackend().getValue();
+  return backend.starts_with("rocm") || backend.starts_with("cuda") ||
+         backend.starts_with("vulkan") || backend.starts_with("metal") ||
+         backend.starts_with("webgpu");
+}
+
 static const char *getDefaultEnabledUkernels(DictionaryAttr targetConfig) {
   const char *kNone = "none";
   if (isX86_64(targetConfig)) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -76,6 +76,8 @@ bool isLLVMCPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isROCMBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isWebGPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
+/// Returns true for any GPU backend (rocm, cuda, vulkan, metal, webgpu).
+bool isGPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 // Returns true if the ukernel with given `ukernelName` is enabled.
 // If `ukernelName` is empty (the default), returns true if any ukernel


### PR DESCRIPTION
This PR fixes crashes on ROCM when constants are accessed with dynamic indexing, which is triggered by split reduction.  

Below the MLIR is what we found with crashes: bufferized constants placed in the default flat address space (0) cause crashes during code generation when accessed with dynamic indexing. This occurs because AMDGPU's flat vector load codegen cannot handle dynamic indices on constants in flat memory.

```mlir
// Constant bufferized to default address space (0).
memref.global "private" constant @__constant_4x15xi32 : memref<4x15xi32> = dense<...>

func.func @split_reduction(%arg0: ...) {
  %cst = memref.get_global @__constant_4x15xi32 : memref<4x15xi32>

  // Split reduction: parallel workgroups process different slices.
  scf.forall (%wg_id) in (%num_wgs) {
    // Dynamic index computed from workgroup ID (trigger crash).
    %val = memref.load %cst[%wg_id, %i] : memref<4x15xi32>
    ...
  }
}
```

After this PR

```mlir
// Constant bufferized to global address space for ROCM.
memref.global "private" constant @__constant_4x15xi32 : memref<4x15xi32, #gpu.address_space<global>> = dense<...>

func.func @split_reduction(%arg0: ...) {
  %cst = memref.get_global @__constant_4x15xi32 : memref<4x15xi32, #gpu.address_space<global>>

  // Split reduction with global address space.
  scf.forall (%wg_id) in (%num_wgs) {
    %val = memref.load %cst[%wg_id, %i] : memref<4x15xi32, #gpu.address_space<global>>
    ...
  }
}
```

Refer to gist for detailed repro mlir: https://gist.github.com/bangtianliu/ef9eb622998237e63fe25f5770cda5da, and also you need to comment out below code: https://github.com/iree-org/iree/blob/c0ec02880cae915d63547c1eb491d024a555fad1/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp#L104-L108 to enable split reduction for the <4x15xi32> case. 

Note: The PR extends the fix to all GPU backends.

