### PR TITLE
[Preprocessing] Add pass to swap strided insert_slice with contraction

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
         "PadLinalgOps.cpp",
         "PadToIntrinsics.cpp",
         "Passes.cpp",
+        "SwapStridedInsertSliceWithContraction.cpp",
         "TransposeMatmul.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     "PadLinalgOps.cpp"
     "PadToIntrinsics.cpp"
     "Passes.cpp"
+    "SwapStridedInsertSliceWithContraction.cpp"
     "TransposeMatmul.cpp"
   DEPS
     ::PassesIncGen

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -78,9 +78,15 @@ def ConvertConvToChannelsLastPass :
   ];
 }
 
+<<<<<<< HEAD
 def ConvertStridedInsertSliceToGenericPass:
     Pass<"iree-preprocessing-convert-strided-insert-slice-to-generic", ""> {
   let summary = "Converts strided insert_slice into zero-constant destinations to linalg.generic with index arithmetic.";
+=======
+def SwapStridedInsertSliceWithContractionPass:
+    Pass<"iree-preprocessing-swap-strided-insert-slice-with-contraction", ""> {
+  let summary = "Swap strided insert_slice into zeros with consumer contraction for 1x1 backward convolutions.";
+>>>>>>> 848ef6edc1 ([Preprocessing] Add pass to swap strided insert_slice with contraction)
 }
 
 def FoldAttentionWithTransposePass :

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -78,15 +78,9 @@ def ConvertConvToChannelsLastPass :
   ];
 }
 
-<<<<<<< HEAD
 def ConvertStridedInsertSliceToGenericPass:
     Pass<"iree-preprocessing-convert-strided-insert-slice-to-generic", ""> {
   let summary = "Converts strided insert_slice into zero-constant destinations to linalg.generic with index arithmetic.";
-=======
-def SwapStridedInsertSliceWithContractionPass:
-    Pass<"iree-preprocessing-swap-strided-insert-slice-with-contraction", ""> {
-  let summary = "Swap strided insert_slice into zeros with consumer contraction for 1x1 backward convolutions.";
->>>>>>> 848ef6edc1 ([Preprocessing] Add pass to swap strided insert_slice with contraction)
 }
 
 def FoldAttentionWithTransposePass :
@@ -155,6 +149,11 @@ def PadLinalgOpsPass :
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
   ];
+}
+
+def SwapStridedInsertSliceWithContractionPass:
+    Pass<"iree-preprocessing-swap-strided-insert-slice-with-contraction", ""> {
+  let summary = "Swap strided insert_slice into zeros with consumer contraction for 1x1 backward convolutions.";
 }
 
 def TransposeMatmulPass : Pass<"iree-preprocessing-transpose-matmul-pass"> {

--- a/compiler/src/iree/compiler/Preprocessing/Common/SwapStridedInsertSliceWithContraction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/SwapStridedInsertSliceWithContraction.cpp
@@ -126,40 +126,45 @@ public:
     unsigned rank = scatteredTy.getRank();
     Location loc = insertOp.getLoc();
 
-    // For strided dims, the indexing map must reference exactly one parallel
-    // loop dim; any other dims must be unit-range reductions. This accepts
-    // 1x1 convs (d_spatial + d_kernel with kernel=1) while rejecting 3x3.
+    // For strided dims, the indexing map expression must be equivalent to a
+    // single parallel loop dim (after zeroing out unit-range reduction dims).
+    // This accepts 1x1 convs (d_spatial + d_kernel with kernel=1, which
+    // simplifies to d_spatial) while rejecting 3x3, scaled dims (3*d0), or
+    // sums of parallel dims (d0 + d1).
+    MLIRContext *ctx = rewriter.getContext();
+    DenseMap<AffineExpr, AffineExpr> unitReductionMap;
+    for (unsigned i = 0, e = iterTypes.size(); i < e; ++i) {
+      if (iterTypes[i] == utils::IteratorType::reduction &&
+          i < loopRanges.size() && loopRanges[i] == 1) {
+        unitReductionMap[getAffineDimExpr(i, ctx)] =
+            getAffineConstantExpr(0, ctx);
+      }
+    }
+
     SmallVector<int64_t> newResultShape(resultTy.getShape());
     for (unsigned d = 0; d < rank; d++) {
       if (strides[d] == 1) {
         continue;
       }
-      int parallelDim = -1;
-      bool valid = true;
-      scatterMap.getResult(d).walk([&](AffineExpr e) {
-        if (auto dim = dyn_cast<AffineDimExpr>(e)) {
-          unsigned pos = dim.getPosition();
-          if (iterTypes[pos] == utils::IteratorType::parallel) {
-            parallelDim = pos;
-          } else if (pos >= loopRanges.size() || loopRanges[pos] != 1) {
-            valid = false;
-          }
-        }
-      });
-      if (!valid || parallelDim < 0) {
+      AffineExpr expr = scatterMap.getResult(d).replace(unitReductionMap);
+      auto dimExpr = dyn_cast<AffineDimExpr>(expr);
+      if (!dimExpr) {
+        return failure();
+      }
+      unsigned parallelDim = dimExpr.getPosition();
+      if (parallelDim >= iterTypes.size() ||
+          iterTypes[parallelDim] != utils::IteratorType::parallel) {
         return failure();
       }
       // Compute new result shape by mapping parallel dim through the result
       // map.
       for (auto [resIdx, resExpr] : llvm::enumerate(resultMap.getResults())) {
         auto resDimExpr = dyn_cast<AffineDimExpr>(resExpr);
-        if (resDimExpr &&
-            resDimExpr.getPosition() == static_cast<unsigned>(parallelDim)) {
+        if (resDimExpr && resDimExpr.getPosition() == parallelDim) {
           newResultShape[resIdx] = sourceTy.getDimSize(d);
         }
       }
     }
-
     auto newResultTy =
         RankedTensorType::get(newResultShape, resultTy.getElementType());
 
@@ -224,10 +229,14 @@ public:
           genericUser.getNumReductionLoops() != 0) {
         break;
       }
-      // Only follow elementwise ops with identity maps — a transpose
-      // would invalidate the shape replacement logic below.
+      // Only follow pure elementwise ops with identity maps. A transpose
+      // would invalidate the shape replacement, and linalg.index ops in the
+      // body would produce wrong results on the smaller shape.
       if (!llvm::all_of(genericUser.getIndexingMapsArray(),
                         [](AffineMap m) { return m.isIdentity(); })) {
+        break;
+      }
+      if (!genericUser.getBlock()->getOps<linalg::IndexOp>().empty()) {
         break;
       }
       consumerChain.push_back(genericUser);

--- a/compiler/src/iree/compiler/Preprocessing/Common/SwapStridedInsertSliceWithContraction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/SwapStridedInsertSliceWithContraction.cpp
@@ -1,0 +1,302 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Preprocessing/Common/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::Preprocessing {
+
+#define GEN_PASS_DEF_SWAPSTRIDEDINSERTSLICEWITHCONTRACTIONPASS
+#include "iree/compiler/Preprocessing/Common/Passes.h.inc"
+
+namespace {
+
+/// Swap a strided `tensor.insert_slice` (tensor.insert_slice into zeros) with
+/// its consumer contraction (matmul/conv) when the contraction reads the
+/// scattered tensor with a projected permutation on the strided dims. This is
+/// valid for 1x1 backward convolutions where the insert_slice commutes with the
+/// matmul.
+///
+/// Before:
+///   %scattered = insert_slice %src into %zeros [offs][sizes][strides]
+///   %result = contraction(%scattered, %filter)
+///   %trunced = truncf(%result)
+///
+/// After:
+///   %small_result = contraction(%src, %filter)
+///   %small_trunced = truncf(%small_result)
+///   %result = insert_slice %small_trunced into %zeros [offs][sizes][strides]
+class SwapStridedInsertSliceWithContraction
+    : public OpRewritePattern<tensor::InsertSliceOp> {
+public:
+  using Base::Base;
+  LogicalResult matchAndRewrite(tensor::InsertSliceOp insertOp,
+                                PatternRewriter &rewriter) const override {
+    // Destination must be a zero splat constant.
+    Value dest = insertOp.getDest();
+    Attribute destAttr;
+    if (!matchPattern(dest, m_Constant(&destAttr))) {
+      return failure();
+    }
+    auto splatAttr = dyn_cast<SplatElementsAttr>(destAttr);
+    if (!splatAttr) {
+      return failure();
+    }
+    Attribute splatVal = splatAttr.getSplatValue<Attribute>();
+    bool isZero =
+        TypeSwitch<Attribute, bool>(splatVal)
+            .Case<FloatAttr>([](auto a) { return a.getValue().isZero(); })
+            .Case<IntegerAttr>([](auto a) { return a.getValue().isZero(); })
+            .Default([](auto) { return false; });
+    if (!isZero) {
+      return failure();
+    }
+
+    // Must have static metadata with at least one non-unit stride.
+    SmallVector<int64_t> offsets(insertOp.getStaticOffsets());
+    SmallVector<int64_t> strides(insertOp.getStaticStrides());
+    SmallVector<int64_t> sizes(insertOp.getStaticSizes());
+    if (ShapedType::isDynamicShape(offsets) ||
+        ShapedType::isDynamicShape(strides) ||
+        ShapedType::isDynamicShape(sizes)) {
+      return failure();
+    }
+    if (llvm::all_of(strides, [](int64_t s) { return s == 1; })) {
+      return failure();
+    }
+
+    // The insert_slice result must feed a contraction with single use.
+    if (!insertOp->hasOneUse()) {
+      return failure();
+    }
+    Value insertResult = insertOp.getResult();
+    // The consumer must be a contraction: 2 inputs, 1 output, reductions,
+    // and a mul+add body. We check the body explicitly because
+    // isaContractionOpInterface also requires projected permutation maps,
+    // which 1x1 backward convs don't have before unit-dim folding.
+    auto genericOp = dyn_cast<linalg::GenericOp>(*insertOp->user_begin());
+    if (!genericOp || genericOp.getNumDpsInputs() != 2 ||
+        genericOp.getNumDpsInits() != 1 ||
+        genericOp.getNumReductionLoops() == 0) {
+      return failure();
+    }
+    if (!mlir::linalg::detail::isContractionBody(
+            *genericOp.getBlock(), [](Operation *first, Operation *second) {
+              return (isa<arith::MulFOp>(first) &&
+                      isa<arith::AddFOp>(second)) ||
+                     (isa<arith::MulIOp>(first) && isa<arith::AddIOp>(second));
+            })) {
+      return failure();
+    }
+
+    // Identify which operand is the insert_slice result.
+    OpOperand *scatterOperand = nullptr;
+    OpOperand *otherOperand = nullptr;
+    for (OpOperand *input : genericOp.getDpsInputOperands()) {
+      if (input->get() == insertResult) {
+        scatterOperand = input;
+      } else {
+        otherOperand = input;
+      }
+    }
+    if (!scatterOperand || !otherOperand) {
+      return failure();
+    }
+
+    Value source = insertOp.getSource();
+    auto sourceTy = cast<RankedTensorType>(source.getType());
+    auto scatteredTy = cast<RankedTensorType>(insertOp.getResult().getType());
+    auto resultTy = cast<RankedTensorType>(genericOp.getResultTypes()[0]);
+    AffineMap scatterMap = genericOp.getMatchingIndexingMap(scatterOperand);
+    AffineMap resultMap = genericOp.getIndexingMapsArray().back();
+    SmallVector<int64_t> loopRanges =
+        cast<linalg::LinalgOp>(genericOp.getOperation()).getStaticLoopRanges();
+    auto iterTypes = genericOp.getIteratorTypesArray();
+    unsigned rank = scatteredTy.getRank();
+    Location loc = insertOp.getLoc();
+
+    // For strided dims, the indexing map must reference exactly one parallel
+    // loop dim; any other dims must be unit-range reductions. This accepts
+    // 1x1 convs (d_spatial + d_kernel with kernel=1) while rejecting 3x3.
+    SmallVector<int64_t> newResultShape(resultTy.getShape());
+    for (unsigned d = 0; d < rank; d++) {
+      if (strides[d] == 1) {
+        continue;
+      }
+      int parallelDim = -1;
+      bool valid = true;
+      scatterMap.getResult(d).walk([&](AffineExpr e) {
+        if (auto dim = dyn_cast<AffineDimExpr>(e)) {
+          unsigned pos = dim.getPosition();
+          if (iterTypes[pos] == utils::IteratorType::parallel) {
+            parallelDim = pos;
+          } else if (pos >= loopRanges.size() || loopRanges[pos] != 1) {
+            valid = false;
+          }
+        }
+      });
+      if (!valid || parallelDim < 0) {
+        return failure();
+      }
+      // Compute new result shape by mapping parallel dim through the result
+      // map.
+      for (auto [resIdx, resExpr] : llvm::enumerate(resultMap.getResults())) {
+        auto resDimExpr = dyn_cast<AffineDimExpr>(resExpr);
+        if (resDimExpr &&
+            resDimExpr.getPosition() == static_cast<unsigned>(parallelDim)) {
+          newResultShape[resIdx] = sourceTy.getDimSize(d);
+        }
+      }
+    }
+
+    auto newResultTy =
+        RankedTensorType::get(newResultShape, resultTy.getElementType());
+
+    // The contraction init must come from a fill (needed to create the
+    // smaller fill).
+    rewriter.setInsertionPoint(genericOp);
+    auto fillOp =
+        genericOp.getDpsInitOperand(0)->get().getDefiningOp<linalg::FillOp>();
+    if (!fillOp) {
+      return failure();
+    }
+
+    // Helper: clone a linalg.generic with a new result type, replacing its
+    // inputs/outputs but preserving the body, maps, and iterator types.
+    auto cloneGenericWithShape =
+        [&](linalg::GenericOp op, ValueRange inputs, ValueRange outputs,
+            RankedTensorType newTy) -> linalg::GenericOp {
+      return linalg::GenericOp::create(
+          rewriter, loc, newTy, inputs, outputs, op.getIndexingMapsArray(),
+          op.getIteratorTypesArray(),
+          [&](OpBuilder &b, Location l, ValueRange args) {
+            IRMapping mapping;
+            for (auto [oldArg, newArg] :
+                 llvm::zip(op.getBlock()->getArguments(), args)) {
+              mapping.map(oldArg, newArg);
+            }
+            for (auto &bodyOp : op.getBlock()->without_terminator()) {
+              b.clone(bodyOp, mapping);
+            }
+            auto yield = cast<linalg::YieldOp>(op.getBlock()->getTerminator());
+            SmallVector<Value> yieldVals;
+            for (Value v : yield.getOperands()) {
+              yieldVals.push_back(mapping.lookupOrDefault(v));
+            }
+            linalg::YieldOp::create(b, l, yieldVals);
+          });
+    };
+
+    // Create the smaller contraction on the un-scattered source.
+    Value newEmpty = tensor::EmptyOp::create(rewriter, loc, newResultShape,
+                                             resultTy.getElementType());
+    Value newFill = linalg::FillOp::create(rewriter, loc, fillOp.getInputs(),
+                                           ValueRange{newEmpty})
+                        .getResult(0);
+    SmallVector<Value> newInputs;
+    for (OpOperand *input : genericOp.getDpsInputOperands()) {
+      newInputs.push_back(input == scatterOperand ? source : input->get());
+    }
+    Value currentResult =
+        cloneGenericWithShape(genericOp, newInputs, ValueRange{newFill},
+                              newResultTy)
+            .getResult(0);
+
+    // Clone the chain of single-input elementwise consumers (e.g., truncf)
+    // for the smaller result shape.
+    SmallVector<Operation *> consumerChain;
+    Operation *lastOp = genericOp;
+    while (lastOp->hasOneUse()) {
+      auto genericUser = dyn_cast<linalg::GenericOp>(*lastOp->user_begin());
+      if (!genericUser || genericUser.getNumDpsInputs() != 1 ||
+          genericUser.getNumDpsInits() != 1 ||
+          genericUser.getNumReductionLoops() != 0) {
+        break;
+      }
+      // Only follow elementwise ops with identity maps — a transpose
+      // would invalidate the shape replacement logic below.
+      if (!llvm::all_of(genericUser.getIndexingMapsArray(),
+                        [](AffineMap m) { return m.isIdentity(); })) {
+        break;
+      }
+      consumerChain.push_back(genericUser);
+      auto consumerElemTy =
+          cast<RankedTensorType>(genericUser.getResultTypes()[0])
+              .getElementType();
+      auto newTy = RankedTensorType::get(newResultShape, consumerElemTy);
+      Value empty = tensor::EmptyOp::create(rewriter, loc, newResultShape,
+                                            consumerElemTy);
+      currentResult =
+          cloneGenericWithShape(genericUser, ValueRange{currentResult},
+                                ValueRange{empty}, newTy)
+              .getResult(0);
+      lastOp = genericUser;
+    }
+
+    // Create the output scatter into zeros.
+    auto currentTy = cast<RankedTensorType>(currentResult.getType());
+    SmallVector<int64_t> outputShape(rank);
+    for (unsigned d = 0; d < rank; d++) {
+      outputShape[d] =
+          strides[d] != 1 ? scatteredTy.getDimSize(d) : currentTy.getDimSize(d);
+    }
+    auto outputTy =
+        RankedTensorType::get(outputShape, currentTy.getElementType());
+    Value outputZeros = arith::ConstantOp::create(
+        rewriter, loc,
+        SplatElementsAttr::get(
+            outputTy, rewriter.getZeroAttr(currentTy.getElementType())));
+    auto newInsertSlice = tensor::InsertSliceOp::create(
+        rewriter, loc, currentResult, outputZeros,
+        getAsOpFoldResult(rewriter.getI64ArrayAttr(offsets)),
+        getAsOpFoldResult(rewriter.getI64ArrayAttr(newResultShape)),
+        getAsOpFoldResult(rewriter.getI64ArrayAttr(strides)));
+
+    // Replace the last op in the chain (the one with external users) and
+    // erase everything else in reverse order.
+    Operation *replacedOp =
+        consumerChain.empty() ? genericOp.getOperation() : consumerChain.back();
+    rewriter.replaceOp(replacedOp, newInsertSlice.getResult());
+    for (auto it = consumerChain.rbegin(); it != consumerChain.rend(); ++it) {
+      if (*it != replacedOp) {
+        rewriter.eraseOp(*it);
+      }
+    }
+    if (replacedOp != genericOp.getOperation()) {
+      rewriter.eraseOp(genericOp);
+    }
+    rewriter.eraseOp(insertOp);
+
+    return success();
+  }
+};
+
+struct SwapStridedInsertSliceWithContractionPass
+    : impl::SwapStridedInsertSliceWithContractionPassBase<
+          SwapStridedInsertSliceWithContractionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, linalg::LinalgDialect,
+                    tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.insert<SwapStridedInsertSliceWithContraction>(context);
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler::Preprocessing

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "pad_to_intrinsics_wmma.mlir",
             "pdl_example.mlir",
             "preprocessing_match_ops.mlir",
+            "swap_strided_insert_slice_with_contraction.mlir",
             "transform_symbol_importing.mlir",
             "transpose_matmul.mlir",
         ],

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_lit_test_suite(
     "pad_to_intrinsics_wmma.mlir"
     "pdl_example.mlir"
     "preprocessing_match_ops.mlir"
+    "swap_strided_insert_slice_with_contraction.mlir"
     "transform_symbol_importing.mlir"
     "transpose_matmul.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/swap_strided_insert_slice_with_contraction.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/swap_strided_insert_slice_with_contraction.mlir
@@ -1,0 +1,197 @@
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --iree-preprocessing-swap-strided-insert-slice-with-contraction %s | FileCheck %s
+
+// Swapped: 1x1 backward conv with stride-2 scatter feeding a contraction
+// followed by truncf. The contraction moves before the scatter and operates
+// on the small (un-scattered) source.
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d5, d2 + d6, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+util.func public @swap_1x1_with_truncf(
+    %src: tensor<2x8x8x16xf16>,
+    %filter: tensor<16x1x1x4xf16>) -> tensor<2x18x18x4xf16> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<2x18x18x16xf16>
+  %inserted = tensor.insert_slice %src into %cst[0, 0, 0, 0] [2, 8, 8, 16] [1, 2, 2, 1]
+    : tensor<2x8x8x16xf16> into tensor<2x18x18x16xf16>
+  %cst_f32 = arith.constant 0.000000e+00 : f32
+  %empty_f32 = tensor.empty() : tensor<2x18x18x4xf32>
+  %fill = linalg.fill ins(%cst_f32 : f32) outs(%empty_f32 : tensor<2x18x18x4xf32>) -> tensor<2x18x18x4xf32>
+  %conv = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%inserted, %filter : tensor<2x18x18x16xf16>, tensor<16x1x1x4xf16>)
+    outs(%fill : tensor<2x18x18x4xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %0 = arith.extf %in : f16 to f32
+    %1 = arith.extf %in_0 : f16 to f32
+    %2 = arith.mulf %0, %1 : f32
+    %3 = arith.addf %out, %2 : f32
+    linalg.yield %3 : f32
+  } -> tensor<2x18x18x4xf32>
+  %empty_f16 = tensor.empty() : tensor<2x18x18x4xf16>
+  %trunc = linalg.generic {
+    indexing_maps = [#map3, #map3],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  } ins(%conv : tensor<2x18x18x4xf32>) outs(%empty_f16 : tensor<2x18x18x4xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %0 = arith.truncf %in : f32 to f16
+    linalg.yield %0 : f16
+  } -> tensor<2x18x18x4xf16>
+  util.return %trunc : tensor<2x18x18x4xf16>
+}
+
+// CHECK-LABEL: @swap_1x1_with_truncf
+// CHECK-SAME:      %[[SRC:.*]]: tensor<2x8x8x16xf16>, %[[FILTER:.*]]: tensor<16x1x1x4xf16>
+// CHECK-NOT:   tensor.insert_slice
+// CHECK:       %[[CONV:.*]] = linalg.generic
+// CHECK-SAME:      ins(%[[SRC]], %[[FILTER]] : tensor<2x8x8x16xf16>, tensor<16x1x1x4xf16>)
+// CHECK-SAME:      outs({{.*}} : tensor<2x8x8x4xf32>)
+// CHECK:       %[[TRUNC:.*]] = linalg.generic
+// CHECK-SAME:      ins(%[[CONV]] : tensor<2x8x8x4xf32>)
+// CHECK:       } -> tensor<2x8x8x4xf16>
+// CHECK:       %[[OUT:.*]] = tensor.insert_slice %[[TRUNC]] into
+// CHECK-SAME:      [0, 0, 0, 0] [2, 8, 8, 4] [1, 2, 2, 1]
+// CHECK-SAME:      tensor<2x8x8x4xf16> into tensor<2x18x18x4xf16>
+// CHECK:       util.return %[[OUT]]
+
+// -----
+
+// Swapped: matmul-like contraction without consumer chain (no truncf).
+#map0 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+util.func public @swap_matmul_no_consumer(
+    %src: tensor<4x10x10x32xf16>,
+    %filter: tensor<8x32xf16>) -> tensor<4x22x22x8xf32> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<4x22x22x32xf16>
+  %inserted = tensor.insert_slice %src into %cst[0, 0, 0, 0] [4, 10, 10, 32] [1, 2, 2, 1]
+    : tensor<4x10x10x32xf16> into tensor<4x22x22x32xf16>
+  %cst_f32 = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<4x22x22x8xf32>
+  %fill = linalg.fill ins(%cst_f32 : f32) outs(%empty : tensor<4x22x22x8xf32>) -> tensor<4x22x22x8xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+  } ins(%inserted, %filter : tensor<4x22x22x32xf16>, tensor<8x32xf16>)
+    outs(%fill : tensor<4x22x22x8xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %0 = arith.extf %in : f16 to f32
+    %1 = arith.extf %in_0 : f16 to f32
+    %2 = arith.mulf %0, %1 : f32
+    %3 = arith.addf %out, %2 : f32
+    linalg.yield %3 : f32
+  } -> tensor<4x22x22x8xf32>
+  util.return %result : tensor<4x22x22x8xf32>
+}
+
+// CHECK-LABEL: @swap_matmul_no_consumer
+// CHECK-SAME:      %[[SRC:.*]]: tensor<4x10x10x32xf16>, %[[FILTER:.*]]: tensor<8x32xf16>
+// CHECK-NOT:   tensor.insert_slice
+// CHECK:       %[[MATMUL:.*]] = linalg.generic
+// CHECK-SAME:      ins(%[[SRC]], %[[FILTER]] : tensor<4x10x10x32xf16>, tensor<8x32xf16>)
+// CHECK-SAME:      outs({{.*}} : tensor<4x10x10x8xf32>)
+// CHECK:       %[[OUT:.*]] = tensor.insert_slice %[[MATMUL]] into
+// CHECK-SAME:      [0, 0, 0, 0] [4, 10, 10, 8] [1, 2, 2, 1]
+// CHECK-SAME:      tensor<4x10x10x8xf32> into tensor<4x22x22x8xf32>
+// CHECK:       util.return %[[OUT]]
+
+// -----
+
+// No transformation: 3x3 conv has reduction dims with loop bound > 1.
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d5, d2 + d6, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @no_swap_3x3_conv(
+    %src: tensor<1x4x4x8xf16>,
+    %filter: tensor<8x3x3x4xf16>) -> tensor<1x8x8x4xf32> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x10x10x8xf16>
+  %inserted = tensor.insert_slice %src into %cst[0, 1, 1, 0] [1, 4, 4, 8] [1, 2, 2, 1]
+    : tensor<1x4x4x8xf16> into tensor<1x10x10x8xf16>
+  %cst_f32 = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<1x8x8x4xf32>
+  %fill = linalg.fill ins(%cst_f32 : f32) outs(%empty : tensor<1x8x8x4xf32>) -> tensor<1x8x8x4xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%inserted, %filter : tensor<1x10x10x8xf16>, tensor<8x3x3x4xf16>)
+    outs(%fill : tensor<1x8x8x4xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %0 = arith.extf %in : f16 to f32
+    %1 = arith.extf %in_0 : f16 to f32
+    %2 = arith.mulf %0, %1 : f32
+    %3 = arith.addf %out, %2 : f32
+    linalg.yield %3 : f32
+  } -> tensor<1x8x8x4xf32>
+  util.return %result : tensor<1x8x8x4xf32>
+}
+
+// CHECK-LABEL: @no_swap_3x3_conv
+// CHECK:       tensor.insert_slice
+// CHECK:       linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<1x10x10x8xf16>, tensor<8x3x3x4xf16>)
+
+// -----
+
+// No transformation: destination is not a zero constant.
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+util.func public @no_swap_nonzero_dest(
+    %src: tensor<4x8xf32>,
+    %dest: tensor<8x8xf32>,
+    %filter: tensor<4x8xf32>) -> tensor<8x4xf32> {
+  %inserted = tensor.insert_slice %src into %dest[0, 0] [4, 8] [2, 1]
+    : tensor<4x8xf32> into tensor<8x8xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<8x4xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8x4xf32>) -> tensor<8x4xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%inserted, %filter : tensor<8x8xf32>, tensor<4x8xf32>)
+    outs(%fill : tensor<8x4xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %0 = arith.mulf %in, %in_0 : f32
+    %1 = arith.addf %out, %0 : f32
+    linalg.yield %1 : f32
+  } -> tensor<8x4xf32>
+  util.return %result : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: @no_swap_nonzero_dest
+// CHECK:       tensor.insert_slice %{{.*}} into %{{.*}}
+// CHECK:       linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<8x8xf32>, tensor<4x8xf32>)
+
+// -----
+
+// No transformation: all strides are 1.
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+util.func public @no_swap_unit_strides(
+    %src: tensor<4x8xf32>,
+    %filter: tensor<4x8xf32>) -> tensor<8x4xf32> {
+  %cst_dest = arith.constant dense<0.000000e+00> : tensor<8x8xf32>
+  %inserted = tensor.insert_slice %src into %cst_dest[0, 0] [4, 8] [1, 1]
+    : tensor<4x8xf32> into tensor<8x8xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<8x4xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8x4xf32>) -> tensor<8x4xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%inserted, %filter : tensor<8x8xf32>, tensor<4x8xf32>)
+    outs(%fill : tensor<8x4xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %0 = arith.mulf %in, %in_0 : f32
+    %1 = arith.addf %out, %0 : f32
+    linalg.yield %1 : f32
+  } -> tensor<8x4xf32>
+  util.return %result : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: @no_swap_unit_strides
+// CHECK:       tensor.insert_slice
+// CHECK:       linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<8x8xf32>, tensor<4x8xf32>)

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/swap_strided_insert_slice_with_contraction.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/swap_strided_insert_slice_with_contraction.mlir
@@ -195,3 +195,69 @@ util.func public @no_swap_unit_strides(
 // CHECK:       tensor.insert_slice
 // CHECK:       linalg.generic
 // CHECK-SAME:      ins({{.*}} : tensor<8x8xf32>, tensor<4x8xf32>)
+
+// -----
+
+// No transformation: strided dim has a scaled indexing expression (3*d0).
+#map_scaled0 = affine_map<(d0, d1, d2) -> (3 * d0, d2)>
+#map_scaled1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map_scaled2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+util.func public @no_swap_scaled_dim(
+    %src: tensor<4x8xf32>,
+    %filter: tensor<4x8xf32>) -> tensor<2x4xf32> {
+  %cst_dest = arith.constant dense<0.000000e+00> : tensor<8x8xf32>
+  %inserted = tensor.insert_slice %src into %cst_dest[0, 0] [4, 8] [2, 1]
+    : tensor<4x8xf32> into tensor<8x8xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<2x4xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<2x4xf32>) -> tensor<2x4xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map_scaled0, #map_scaled1, #map_scaled2],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%inserted, %filter : tensor<8x8xf32>, tensor<4x8xf32>)
+    outs(%fill : tensor<2x4xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %0 = arith.mulf %in, %in_0 : f32
+    %1 = arith.addf %out, %0 : f32
+    linalg.yield %1 : f32
+  } -> tensor<2x4xf32>
+  util.return %result : tensor<2x4xf32>
+}
+
+// CHECK-LABEL: @no_swap_scaled_dim
+// CHECK:       tensor.insert_slice
+// CHECK:       linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<8x8xf32>, tensor<4x8xf32>)
+
+// -----
+
+// No transformation: strided dim maps to sum of two parallel dims (d0 + d1).
+#map_sum0 = affine_map<(d0, d1, d2, d3) -> (d0 + d1, d3)>
+#map_sum1 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map_sum2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+util.func public @no_swap_parallel_sum(
+    %src: tensor<4x8xf32>,
+    %filter: tensor<4x8xf32>) -> tensor<3x3x4xf32> {
+  %cst_dest = arith.constant dense<0.000000e+00> : tensor<8x8xf32>
+  %inserted = tensor.insert_slice %src into %cst_dest[0, 0] [4, 8] [2, 1]
+    : tensor<4x8xf32> into tensor<8x8xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<3x3x4xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<3x3x4xf32>) -> tensor<3x3x4xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map_sum0, #map_sum1, #map_sum2],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+  } ins(%inserted, %filter : tensor<8x8xf32>, tensor<4x8xf32>)
+    outs(%fill : tensor<3x3x4xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %0 = arith.mulf %in, %in_0 : f32
+    %1 = arith.addf %out, %0 : f32
+    linalg.yield %1 : f32
+  } -> tensor<3x3x4xf32>
+  util.return %result : tensor<3x3x4xf32>
+}
+
+// CHECK-LABEL: @no_swap_parallel_sum
+// CHECK:       tensor.insert_slice
+// CHECK:       linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<8x8xf32>, tensor<4x8xf32>)


### PR DESCRIPTION
Add `iree-preprocessing-swap-strided-insert-slice-with-contraction` pass that swaps a strided `tensor.insert_slice` into zeros with its consumer contraction for 1x1 backward convolutions.

For 1x1 backward data convolutions the strided insert_slice commutes with the contraction because the reduction dimensions have loop bound 1. This pass reorders the computation: the contraction operates on the small un-scattered source (e.g., 2x8x8 instead of 2x18x18 for stride 2), then the result is scattered into the output. This reduces contraction FLOPs by ~4x.

This PR is a partial implementation for https://github.com/iree-org/iree/issues/23976.