### PR TITLE
[async] Fix flaky CreateRefusedAddress on Windows IOCP.

### DIFF
--- a/runtime/src/iree/async/cts/core/error_propagation_test.cc
+++ b/runtime/src/iree/async/cts/core/error_propagation_test.cc
@@ -285,7 +285,8 @@ TEST_P(ErrorPropagationTest, ConnectFailureCarriesCorrectStatus) {
                                           IREE_ASYNC_SOCKET_OPTION_NONE,
                                           &socket));
 
-  iree_async_address_t address = CreateRefusedAddress();
+  iree_async_socket_t* guard = nullptr;
+  iree_async_address_t address = CreateRefusedAddress(&guard);
 
   iree_async_socket_connect_operation_t connect_op;
   CompletionTracker tracker;
@@ -301,6 +302,7 @@ TEST_P(ErrorPropagationTest, ConnectFailureCarriesCorrectStatus) {
   IREE_EXPECT_NOT_OK(tracker.ConsumeStatus())
       << "Connect to non-listening port should fail";
 
+  iree_async_socket_release(guard);
   iree_async_socket_release(socket);
 }
 
@@ -359,7 +361,8 @@ TEST_P(ErrorPropagationTest, ConnectFailurePropagatesThroughLinkedChain) {
                                           IREE_ASYNC_SOCKET_OPTION_NONE,
                                           &socket));
 
-  iree_async_address_t address = CreateRefusedAddress();
+  iree_async_socket_t* guard = nullptr;
+  iree_async_address_t address = CreateRefusedAddress(&guard);
 
   iree_async_socket_connect_operation_t connect_op;
   CompletionTracker connect_tracker;
@@ -393,6 +396,7 @@ TEST_P(ErrorPropagationTest, ConnectFailurePropagatesThroughLinkedChain) {
   EXPECT_EQ(send_tracker.call_count, 1);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, send_tracker.ConsumeStatus());
 
+  iree_async_socket_release(guard);
   iree_async_socket_release(socket);
 }
 

--- a/runtime/src/iree/async/cts/core/sequence_test.cc
+++ b/runtime/src/iree/async/cts/core/sequence_test.cc
@@ -537,7 +537,8 @@ TEST_P(SequenceTest, LinkedConnectFailurePropagates) {
                                           &client));
 
   // Connect to a port with no listener — should get ECONNREFUSED.
-  iree_async_address_t bad_address = CreateRefusedAddress();
+  iree_async_socket_t* guard = nullptr;
+  iree_async_address_t bad_address = CreateRefusedAddress(&guard);
 
   CompletionTracker connect_tracker, send_tracker;
 
@@ -578,6 +579,7 @@ TEST_P(SequenceTest, LinkedConnectFailurePropagates) {
   EXPECT_EQ(send_tracker.call_count, 1);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_CANCELLED, send_tracker.ConsumeStatus());
 
+  iree_async_socket_release(guard);
   iree_async_socket_release(client);
 }
 

--- a/runtime/src/iree/async/cts/socket/lifecycle_test.cc
+++ b/runtime/src/iree/async/cts/socket/lifecycle_test.cc
@@ -404,7 +404,8 @@ TEST_P(SocketTest, StickyFailure_ReleaseAfterError) {
                                           &client));
 
   // Trigger failure via connect to a port with no listener.
-  iree_async_address_t address = CreateRefusedAddress();
+  iree_async_socket_t* guard = nullptr;
+  iree_async_address_t address = CreateRefusedAddress(&guard);
 
   iree_async_socket_connect_operation_t connect_op;
   CompletionTracker tracker;
@@ -420,6 +421,7 @@ TEST_P(SocketTest, StickyFailure_ReleaseAfterError) {
   iree_async_socket_release(client);
 
   // Final release - should cleanup properly.
+  iree_async_socket_release(guard);
   iree_async_socket_release(client);
 }
 
@@ -603,7 +605,8 @@ TEST_P(SocketTest, ConnectRefused) {
                                           &client));
 
   // Connect to a port with no listener — should fail with ECONNREFUSED.
-  iree_async_address_t address = CreateRefusedAddress();
+  iree_async_socket_t* guard = nullptr;
+  iree_async_address_t address = CreateRefusedAddress(&guard);
 
   iree_async_socket_connect_operation_t connect_op;
   CompletionTracker connect_tracker;
@@ -621,6 +624,7 @@ TEST_P(SocketTest, ConnectRefused) {
   IREE_EXPECT_STATUS_IS(IREE_STATUS_UNAVAILABLE,
                         connect_tracker.ConsumeStatus());
 
+  iree_async_socket_release(guard);
   iree_async_socket_release(client);
 }
 

--- a/runtime/src/iree/async/cts/util/socket_test_base.h
+++ b/runtime/src/iree/async/cts/util/socket_test_base.h
@@ -66,17 +66,39 @@ class SocketTestBase : public CtsTestBase<BaseType> {
   }
 
   // Returns a loopback address where nothing is listening, guaranteed to
-  // produce ECONNREFUSED on any platform. Works by binding a listener to an
-  // ephemeral port, recording the address, then closing the listener. The
-  // kernel knows this port was just in LISTEN state and sends RST immediately.
+  // produce ECONNREFUSED on any platform.
   //
-  // This is portable across firewalls, macOS stealth mode, Docker/bwrap
-  // sandboxes, and FreeBSD tcp.blackhole — environments where connecting to a
-  // hardcoded well-known port (like port 1) may silently drop SYN packets
-  // instead of sending RST, causing the connect to hang.
-  iree_async_address_t CreateRefusedAddress() {
+  // On POSIX: create a listener on an ephemeral port, record the address,
+  // close the listener. The kernel sends RST to subsequent SYN packets on
+  // the recently-listened port. No guard is needed because POSIX ephemeral
+  // port allocators do not immediately reassign recently-closed ports.
+  //
+  // On Windows: the same close-then-connect pattern races because the OS
+  // ephemeral port allocator can reassign the port between close and
+  // ConnectEx, causing the connect to succeed against a different listener.
+  // To prevent this, a guard socket is co-bound (via SO_REUSEADDR, which on
+  // Windows allows co-binding) to the same port without calling listen().
+  // Connections to a bound-but-not-listening port are refused on Windows.
+  //
+  // On Windows, the guard socket is returned via |out_guard| and MUST be
+  // released by the caller after the connect attempt completes. On POSIX,
+  // |*out_guard| is set to NULL.
+  iree_async_address_t CreateRefusedAddress(iree_async_socket_t** out_guard) {
     iree_async_address_t address;
     iree_async_socket_t* listener = CreateListener(&address);
+
+#if defined(IREE_PLATFORM_WINDOWS)
+    // Co-bind a guard to hold the port after the listener closes.
+    iree_async_socket_t* guard = nullptr;
+    IREE_CHECK_OK(
+        iree_async_socket_create(this->proactor_, IREE_ASYNC_SOCKET_TYPE_TCP,
+                                 IREE_ASYNC_SOCKET_OPTION_REUSE_ADDR, &guard));
+    IREE_CHECK_OK(iree_async_socket_bind(guard, &address));
+    *out_guard = guard;
+#else
+    *out_guard = nullptr;
+#endif  // IREE_PLATFORM_WINDOWS
+
     iree_async_socket_release(listener);
     return address;
   }


### PR DESCRIPTION
CreateRefusedAddress() created a listener on an ephemeral port, recorded the address, then closed the listener before the caller's ConnectEx. On Windows the OS ephemeral port allocator can reassign that port between close and ConnectEx causing the connect to succeed against an unrelated listener instead of failing with WSAECONNREFUSED.

Fix: on Windows, co-bind a guard socket (via SO_REUSEADDR, which allows co-binding on Windows) to the same port without calling listen(). The guard holds the port after the listener closes, preventing reassignment. Callers release the guard after their connect completes.

On POSIX no guard is needed: the close-then-connect pattern is reliable because POSIX ephemeral allocators do not immediately reassign recently-closed ports, and macOS requires the port to have been in LISTEN state to send RST (a bound-but-not-listening guard causes silent SYN drop under stealth mode).