### PR TITLE
[LinalgExt] Add optional logsumexp output to AttentionOp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -798,6 +798,9 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(IREE::LinalgExt::createDecomposeAttentionPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  // Remove dead per-tile logsumexp values produced by decomposeOperation
+  // that are superseded by mergeReductions' logsumexp computation.
+  funcPassManager.addPass(mlir::createRemoveDeadValuesPass());
 
   // Convert convolutions to matmuls by tiling filter dimensions.
   funcPassManager.addPass(createGPUTileAndConvertConvToMatmulPass());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -23,6 +23,8 @@
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+
+#include <cmath>
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
@@ -619,6 +621,35 @@ OnlineAttentionOp::decomposeOperation(OpBuilder &b) {
   newAcc = computeMatmul(b, loc, pMap, getValueMap(), accMap, p, value, newAcc);
   if (pvAttrs) {
     newAcc.getDefiningOp()->setDiscardableAttrs(pvAttrs);
+  }
+
+  // If logsumexp output is requested, compute from max and sum.
+  // When useExp2=true: logsumexp = max * ln(2) + ln(sum)
+  // When useExp2=false: logsumexp = max + ln(sum)
+  if (hasLogsumexp()) {
+    AffineMap maxMap = getMaxMap();
+    AffineMap sumMap = getSumMap();
+    SmallVector<AffineMap> lseMaps =
+        compressUnusedDims(SmallVector<AffineMap>{maxMap, sumMap, maxMap});
+    SmallVector<utils::IteratorType> lseIterTypes(
+        lseMaps[0].getNumDims(), utils::IteratorType::parallel);
+
+    auto lseOp = linalg::GenericOp::create(
+        b, loc, getLogsumexp().getType(), ValueRange{newMax, newSum},
+        getLogsumexp(), lseMaps, lseIterTypes,
+        [&](OpBuilder &nb, Location nloc, ValueRange args) {
+          Value maxVal = args[0];
+          if (useExp2) {
+            Value ln2 = arith::ConstantOp::create(
+                nb, nloc, nb.getFloatAttr(args[0].getType(), M_LN2));
+            maxVal = arith::MulFOp::create(nb, nloc, maxVal, ln2);
+          }
+          Value logSum = math::LogOp::create(nb, nloc, args[1]);
+          Value lse = arith::AddFOp::create(nb, nloc, maxVal, logSum);
+          linalg::YieldOp::create(nb, nloc, lse);
+        });
+
+    return SmallVector<Value>{newAcc, newMax, newSum, lseOp.getResult(0)};
   }
 
   return SmallVector<Value>{newAcc, newMax, newSum};

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1752,21 +1752,24 @@ LogicalResult WinogradOutputTransformOp::reifyResultShapes(
 void AttentionOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                         TypeRange results, Value query, Value key, Value value,
                         Value scale, Value output, ArrayAttr indexingMaps,
-                        std::optional<Value> mask) {
+                        std::optional<Value> mask,
+                        std::optional<Value> logsumexp) {
   Value maskIn = mask.value_or(Value());
+  Value lseIn = logsumexp.value_or(Value());
   build(odsBuilder, odsState, results, query, key, value, scale, maskIn, output,
-        indexingMaps, DictionaryAttr());
+        lseIn, indexingMaps, DictionaryAttr());
 }
 
 void AttentionOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                         TypeRange results, ValueRange inputOperands,
                         ValueRange initOperands, ArrayAttr indexingMaps) {
   assert(inputOperands.size() < 6);
-  assert(initOperands.size() == 1);
+  assert(initOperands.size() >= 1 && initOperands.size() <= 2);
   Value mask = inputOperands.size() > 4 ? inputOperands[4] : Value();
+  Value logsumexp = initOperands.size() > 1 ? initOperands[1] : Value();
   build(odsBuilder, odsState, results, inputOperands[0], inputOperands[1],
-        inputOperands[2], inputOperands[3], mask, initOperands[0], indexingMaps,
-        DictionaryAttr());
+        inputOperands[2], inputOperands[3], mask, initOperands[0], logsumexp,
+        indexingMaps, DictionaryAttr());
 }
 
 LogicalResult AttentionOp::verify() {
@@ -1881,8 +1884,11 @@ LogicalResult AttentionOp::verify() {
 }
 
 MutableOperandRange AttentionOp::getDpsInitsMutable() {
-  return MutableOperandRange(*this, /*numInputs=*/getMask() ? 5 : 4,
-                             /*numInits=*/1);
+  // output is operand index 5 in the ODS definition (query=0, key=1,
+  // value=2, scale=3, mask=4, output=5, logsumexp=6).
+  auto [outputStart, outputLen] = getODSOperandIndexAndLength(5);
+  int numInits = hasLogsumexp() ? 2 : 1;
+  return MutableOperandRange(*this, outputStart, numInits);
 }
 
 LogicalResult AttentionOp::reifyResultShapes(
@@ -1951,10 +1957,12 @@ void OnlineAttentionOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                               TypeRange results, Value query, Value key,
                               Value value, Value scale, Value output, Value max,
                               Value sum, ArrayAttr indexingMaps,
-                              std::optional<Value> mask) {
+                              std::optional<Value> mask,
+                              std::optional<Value> logsumexp) {
   Value maskIn = mask.value_or(Value());
-  build(odsBuilder, odsState, results, query, key, value, maskIn, scale, output,
-        max, sum, indexingMaps, DictionaryAttr());
+  Value lseIn = logsumexp.value_or(Value());
+  build(odsBuilder, odsState, results, query, key, value, scale, maskIn, output,
+        max, sum, lseIn, indexingMaps, DictionaryAttr());
 }
 
 LogicalResult OnlineAttentionOp::verify() {
@@ -2067,8 +2075,11 @@ LogicalResult OnlineAttentionOp::verify() {
 }
 
 MutableOperandRange OnlineAttentionOp::getDpsInitsMutable() {
-  return MutableOperandRange(*this, /*numInputs=*/getMask() ? 5 : 4,
-                             /*numInits=*/3);
+  // output is operand index 5 in the ODS definition (query=0, key=1,
+  // value=2, scale=3, mask=4, output=5, max=6, sum=7, logsumexp=8).
+  auto [outputStart, outputLen] = getODSOperandIndexAndLength(5);
+  int numInits = hasLogsumexp() ? 4 : 3;
+  return MutableOperandRange(*this, outputStart, numInits);
 }
 
 LogicalResult OnlineAttentionOp::reifyResultShapes(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -856,7 +856,8 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
 //===----------------------------------------------------------------------===//
 
 def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
-    [DeclareOpInterfaceMethods<LinalgFusionInterface,
+    [AttrSizedOperandSegments,
+     DeclareOpInterfaceMethods<LinalgFusionInterface,
       ["getIndexingMapsForResults", "getIndexingMapsForOperands",
        "getStaticLoopRanges"]>,
      DeclareOpInterfaceMethods<IndexingMapOpInterface, ["getMatchingIndexingMap"]>,
@@ -880,6 +881,15 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     If an additional mask argument M is included, the result of the first matmul is modified according to:
 
     Q @ K.T += M
+
+    An optional logsumexp output can be requested by providing a logsumexp
+    init tensor. When present, the op also computes the log-sum-exp of the
+    attention scores per row:
+
+    logsumexp = max(S) + log(sum(exp(S - max(S))))
+
+    where S = Q @ K.T * scale. This is needed for the backward pass of
+    attention (training).
   }];
 
   let arguments = (ins AnyShaped:$query,
@@ -888,6 +898,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
                        AnyFloat:$scale,
                        Optional<AnyShaped>:$mask,
                        AnyShaped:$output,
+                       Optional<AnyShaped>:$logsumexp,
                        AffineMapArrayAttr:$indexing_maps,
                        OptionalAttr<DictionaryAttr>:$decomposition_config
   );
@@ -899,7 +910,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
   let assemblyFormat = [{
     attr-dict
     `ins` `(` $query `,` $key `,` $value `,` $scale (`,` $mask^)?  `:` type($query) `,` type($key) `,` type($value) `,` type($scale) (`,` type($mask)^ )?`)`
-    `outs` `(` $output `:` type($output) `)`
+    `outs` `(` $output (`,` $logsumexp^)? `:` type($output) (`,` type($logsumexp)^)? `)`
     $region
     (`->` type($results)^)?
   }];
@@ -912,7 +923,8 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
       "Value":$scale,
       "Value":$output,
       "ArrayAttr":$indexing_maps,
-      CArg<"std::optional<Value>", "std::nullopt">:$mask)>,
+      CArg<"std::optional<Value>", "std::nullopt">:$mask,
+      CArg<"std::optional<Value>", "std::nullopt">:$logsumexp)>,
     OpBuilder<(ins "TypeRange":$results,
       "ValueRange":$inputOperands,
       "ValueRange":$initOperands,
@@ -925,6 +937,9 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     MutableOperandRange getDpsInitsMutable();
 
     SmallVector<AffineMap> getIndexingMapsArray();
+
+    // Whether logsumexp output is requested.
+    bool hasLogsumexp() { return getLogsumexp() != Value(); }
 
     AffineMap getQueryMap() {
       return cast<AffineMap>(getIndexingMapsArray()[0]);
@@ -947,6 +962,13 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     AffineMap getOutputMap() {
       return cast<AffineMap>(getIndexingMapsArray()[getNumDpsInputs()]);
     }
+    std::optional<AffineMap> getLogsumexpMap() {
+      if (hasLogsumexp()) {
+        return cast<AffineMap>(
+            getIndexingMapsArray()[getNumDpsInputs() + 1]);
+      }
+      return std::nullopt;
+    }
     int64_t getIterationDomainRank() {
       return getQueryMap().getNumDims();
     }
@@ -966,7 +988,8 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
 //===----------------------------------------------------------------------===//
 
 def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
-    [IndexingMapOpInterface,
+    [AttrSizedOperandSegments,
+     IndexingMapOpInterface,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<AggregatedOpInterface, ["decomposeOperation"]>,
      DeclareOpInterfaceMethods<TilingInterface,
@@ -1025,6 +1048,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
                        AnyShaped:$output,
                        AnyShaped:$max,
                        AnyShaped:$sum,
+                       Optional<AnyShaped>:$logsumexp,
                        AffineMapArrayAttr:$indexing_maps,
                        OptionalAttr<DictionaryAttr>:$decomposition_config
   );
@@ -1036,7 +1060,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
   let assemblyFormat = [{
     attr-dict
     `ins` `(` $query `,` $key `,` $value `,` $scale (`,` $mask^)?  `:` type($query) `,` type($key) `,` type($value) `,` type($scale) (`,` type($mask)^ )?`)`
-    `outs` `(` $output `,` $max `,` $sum `:` type($output) `,` type($max) `,` type($sum) `)`
+    `outs` `(` $output `,` $max `,` $sum (`,` $logsumexp^)? `:` type($output) `,` type($max) `,` type($sum) (`,` type($logsumexp)^)? `)`
     $region
     (`->` type($results)^)?
   }];
@@ -1051,7 +1075,8 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
     "Value":$max,
     "Value":$sum,
     "ArrayAttr":$indexing_maps,
-    CArg<"std::optional<Value>", "std::nullopt">:$mask)>
+    CArg<"std::optional<Value>", "std::nullopt">:$mask,
+    CArg<"std::optional<Value>", "std::nullopt">:$logsumexp)>
   ];
 
 
@@ -1088,6 +1113,15 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
     }
     AffineMap getSumMap() {
       return cast<AffineMap>(getIndexingMapsArray()[getNumDpsInputs() + 2]);
+    }
+    // Whether logsumexp output is requested.
+    bool hasLogsumexp() { return getLogsumexp() != Value(); }
+    std::optional<AffineMap> getLogsumexpMap() {
+      if (hasLogsumexp()) {
+        return cast<AffineMap>(
+            getIndexingMapsArray()[getNumDpsInputs() + 3]);
+      }
+      return std::nullopt;
     }
 
     int64_t getIterationDomainRank() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -22,6 +22,8 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/OpDefinition.h"
 
+#include <cmath>
+
 #define DEBUG_TYPE "linalg-ext-tiling"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
@@ -2780,10 +2782,23 @@ AttentionOp::getTiledImplementation(OpBuilder &builder,
     slices.push_back(outputSliceOp);
   }
 
+  // Logsumexp (optional)
+  Value lse = getLogsumexp();
+  if (lse) {
+    auto lseMap = getLogsumexpMap();
+    SmallVector<Range> lseSlice = getPermutedRange(*lseMap, offsets, sizes);
+    Operation *lseSliceOp = getSlice(builder, loc, lse, lseSlice);
+    tiledOperands.emplace_back(lseSliceOp->getResult(0));
+    slices.push_back(lseSliceOp);
+  }
+
   SmallVector<Type> resultTypes;
   if (hasPureTensorSemantics()) {
     int64_t baseIdx = attnMask ? 5 : 4;
     resultTypes.push_back(tiledOperands[baseIdx].getType());
+    if (lse) {
+      resultTypes.push_back(tiledOperands[baseIdx + 1].getType());
+    }
   }
 
   Operation *tiledOp =
@@ -2805,6 +2820,12 @@ LogicalResult AttentionOp::getResultTilePosition(
   case 0:
     resultIndexingMap = getOutputMap();
     break;
+  case 1:
+    if (auto lseMap = getLogsumexpMap()) {
+      resultIndexingMap = *lseMap;
+      break;
+    }
+    return failure();
   default:
     return failure();
   }
@@ -2940,10 +2961,21 @@ OnlineAttentionOp::getTiledImplementation(OpBuilder &builder,
     slices.push_back(sumSliceOp);
   }
 
+  /// Logsumexp (optional)
+  Value lse = getLogsumexp();
+  if (lse) {
+    auto lseMap = getLogsumexpMap();
+    SmallVector<Range> lseSlice = getPermutedRange(*lseMap, offsets, sizes);
+    Operation *lseSliceOp = getSlice(builder, loc, lse, lseSlice);
+    tiledOperands.emplace_back(lseSliceOp->getResult(0));
+    slices.push_back(lseSliceOp);
+  }
+
+  int numInits = lse ? 4 : 3;
   SmallVector<Type> resultTypes;
-  resultTypes.push_back(tiledOperands[tiledOperands.size() - 3].getType());
-  resultTypes.push_back(tiledOperands[tiledOperands.size() - 2].getType());
-  resultTypes.push_back(tiledOperands[tiledOperands.size() - 1].getType());
+  for (int i = numInits; i > 0; --i) {
+    resultTypes.push_back(tiledOperands[tiledOperands.size() - i].getType());
+  }
 
   Operation *tiledOp =
       mlir::clone(builder, getOperation(), resultTypes, tiledOperands);
@@ -2970,6 +3002,12 @@ LogicalResult OnlineAttentionOp::getResultTilePosition(
   case 2:
     resultIndexingMap = getSumMap();
     break;
+  case 3:
+    if (auto lseMap = getLogsumexpMap()) {
+      resultIndexingMap = *lseMap;
+      break;
+    }
+    return failure();
   default:
     return failure();
   }
@@ -3046,7 +3084,24 @@ OnlineAttentionOp::generateInitialTensorForPartialReduction(
       linalg::FillOp::create(b, loc, ValueRange{sumInit}, partialSum)
           .getResult(0);
 
-  return SmallVector<Value>{accFill, maxFill, sumFill};
+  SmallVector<Value> results = {accFill, maxFill, sumFill};
+
+  // Logsumexp is computed after merge, so just provide an identity-filled
+  // init tensor for it during partial reduction.
+  if (hasLogsumexp()) {
+    Type lseElTy = getElementTypeOrSelf(getLogsumexp().getType());
+    SmallVector<OpFoldResult> lseSize = applyPermutationMap<OpFoldResult>(
+        getPartialResultMap(*getLogsumexpMap(), opInfo), tiledShape);
+    Value partialLse = tensor::EmptyOp::create(b, loc, lseSize, lseElTy);
+    Value lseInit =
+        arith::getIdentityValue(arith::AtomicRMWKind::addf, lseElTy, b, loc);
+    Value lseFill =
+        linalg::FillOp::create(b, loc, ValueRange{lseInit}, partialLse)
+            .getResult(0);
+    results.push_back(lseFill);
+  }
+
+  return results;
 }
 
 FailureOr<TilingResult> OnlineAttentionOp::tileToPartialReduction(
@@ -3071,6 +3126,10 @@ FailureOr<TilingResult> OnlineAttentionOp::tileToPartialReduction(
   indexingMaps[getNumDpsInputs()] = partialAccMap;
   indexingMaps[getNumDpsInputs() + 1] = partialMaxMap;
   indexingMaps[getNumDpsInputs() + 2] = partialSumMap;
+  if (hasLogsumexp()) {
+    AffineMap partialLseMap = getPartialResultMap(*getLogsumexpMap(), opInfo);
+    indexingMaps[getNumDpsInputs() + 3] = partialLseMap;
+  }
 
   SmallVector<Value> tiledOperands;
   SmallVector<Operation *> slices;
@@ -3119,9 +3178,16 @@ FailureOr<TilingResult> OnlineAttentionOp::tileToPartialReduction(
   if (failed(appendSlice(init[2], partialSumMap, initOffsets))) {
     return failure();
   }
+  if (hasLogsumexp()) {
+    AffineMap partialLseMap = getPartialResultMap(*getLogsumexpMap(), opInfo);
+    if (failed(appendSlice(init[3], partialLseMap, initOffsets))) {
+      return failure();
+    }
+  }
 
   // Get the initial values.
-  ValueRange slicedInits = ArrayRef(tiledOperands).take_back(3);
+  int numInits = hasLogsumexp() ? 4 : 3;
+  ValueRange slicedInits = ArrayRef(tiledOperands).take_back(numInits);
 
   auto tiledOp = cast<OnlineAttentionOp>(
       mlir::clone(b, getOperation(), slicedInits.getTypes(), tiledOperands));
@@ -3243,9 +3309,38 @@ FailureOr<MergeResult> OnlineAttentionOp::mergeReductions(
   linalg::ReduceOp reducedAcc = reduceOnK2<arith::AddFOp>(
       *this, partialAccMap, opInfo, b, loc, normAcc, getOutput());
 
-  return MergeResult{{reducedAcc, reducedMax, reducedSum},
-                     {reducedAcc.getResult(0), reducedMax.getResult(0),
-                      reducedSum.getResult(0)}};
+  SmallVector<Operation *> mergeOps = {reducedAcc, reducedMax, reducedSum};
+  SmallVector<Value> mergeResults = {reducedAcc.getResult(0),
+                                     reducedMax.getResult(0),
+                                     reducedSum.getResult(0)};
+
+  // Compute logsumexp from the final merged max and sum.
+  // mergeReductions always uses exp2, so: logsumexp = max * ln(2) + ln(sum).
+  if (hasLogsumexp()) {
+    AffineMap maxMap = getMaxMap();
+    AffineMap sumMap = getSumMap();
+    SmallVector<AffineMap> lseMaps =
+        compressUnusedDims(SmallVector<AffineMap>{maxMap, sumMap, maxMap});
+    SmallVector<utils::IteratorType> lseIterTypes(
+        lseMaps[0].getNumDims(), utils::IteratorType::parallel);
+
+    auto lseOp = linalg::GenericOp::create(
+        b, loc, getLogsumexp().getType(),
+        ValueRange{reducedMax.getResult(0), reducedSum.getResult(0)},
+        getLogsumexp(), lseMaps, lseIterTypes,
+        [&](OpBuilder &nb, Location nloc, ValueRange args) {
+          Value ln2 = arith::ConstantOp::create(
+              nb, nloc, nb.getFloatAttr(args[0].getType(), M_LN2));
+          Value maxNat = arith::MulFOp::create(nb, nloc, args[0], ln2);
+          Value logSum = math::LogOp::create(nb, nloc, args[1]);
+          Value lse = arith::AddFOp::create(nb, nloc, maxNat, logSum);
+          linalg::YieldOp::create(nb, nloc, lse);
+        });
+    mergeOps.push_back(lseOp);
+    mergeResults.push_back(lseOp.getResult(0));
+  }
+
+  return MergeResult{mergeOps, mergeResults};
 }
 
 LogicalResult OnlineAttentionOp::getPartialResultTilePosition(
@@ -3277,6 +3372,12 @@ LogicalResult OnlineAttentionOp::getPartialResultTilePosition(
   case 2:
     resultIndexingMap = getSumMap();
     break;
+  case 3:
+    if (auto lseMap = getLogsumexpMap()) {
+      resultIndexingMap = *lseMap;
+      break;
+    }
+    return failure();
   default:
     return failure();
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -2260,3 +2260,97 @@ func.func @map_load_memref_static(
 // CHECK:   iree_linalg_ext.yield %[[IDX0]], %[[PAD]]
 // CHECK: } : memref<16xf32> into memref<16xf32>
 // CHECK: return
+
+// -----
+
+func.func @attention_logsumexp(%query: tensor<192x1024x64xf32>, %key: tensor<192x1024x64xf32>, %value: tensor<192x1024x64xf32>) -> (tensor<192x1024x64xf32>, tensor<192x1024xf32>) {
+  %0 = tensor.empty() : tensor<192x1024x64xf32>
+  %1 = tensor.empty() : tensor<192x1024xf32>
+  %scale = arith.constant 1.0 : f32
+  %2:2 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>]}
+                     ins(%query, %key, %value, %scale : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, f32)
+                     outs(%0, %1 : tensor<192x1024x64xf32>, tensor<192x1024xf32>) {
+                        ^bb0(%arg0: f32):
+                        iree_linalg_ext.yield %arg0 : f32
+                     } -> tensor<192x1024x64xf32>, tensor<192x1024xf32>
+  return %2#0, %2#1 : tensor<192x1024x64xf32>, tensor<192x1024xf32>
+}
+
+// CHECK-DAG: #[[$MAP_Q:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+// CHECK-DAG: #[[$MAP_K:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+// CHECK-DAG: #[[$MAP_V:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+// CHECK-DAG: #[[$MAP_S:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
+// CHECK-DAG: #[[$MAP_O:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+// CHECK-DAG: #[[$MAP_LSE:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @attention_logsumexp(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
+// CHECK:         %[[D1:.+]] = tensor.empty() : tensor<192x1024xf32>
+// CHECK:         %[[SCALE:.+]] = arith.constant 1.000000e+00 : f32
+// CHECK:         %[[D2:.+]]:2 = iree_linalg_ext.attention
+// CHECK-SAME:                 {indexing_maps = [#[[$MAP_Q]], #[[$MAP_K]], #[[$MAP_V]], #[[$MAP_S]], #[[$MAP_O]], #[[$MAP_LSE]]]}
+// CHECK-SAME:                 ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[SCALE]] :
+// CHECK-SAME:      tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, f32)
+// CHECK-SAME:      outs(%[[D0]], %[[D1]] : tensor<192x1024x64xf32>, tensor<192x1024xf32>) {
+// CHECK:          ^[[BLOCK:.+]](%[[SCORE:.+]]: f32):
+// CHECK:          iree_linalg_ext.yield %[[SCORE]] : f32
+// CHECK:        } -> tensor<192x1024x64xf32>, tensor<192x1024xf32>
+// CHECK:         return %[[D2]]#0, %[[D2]]#1
+
+// -----
+
+func.func @online_attention_logsumexp(%query: tensor<192x1024x64xf32>, %key: tensor<192x1024x64xf32>, %value: tensor<192x1024x64xf32>) -> (tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>) {
+  %0 = tensor.empty() : tensor<192x1024x64xf32>
+  %1 = tensor.empty() : tensor<192x1024xf32>
+  %2 = tensor.empty() : tensor<192x1024xf32>
+  %3 = tensor.empty() : tensor<192x1024xf32>
+  %scale = arith.constant 1.0 : f32
+  %4:4 = iree_linalg_ext.online_attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>]}
+                     ins(%query, %key, %value, %scale : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, f32)
+                     outs(%0, %1, %2, %3 : tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>) {
+                        ^bb0(%arg0: f32):
+                        iree_linalg_ext.yield %arg0 : f32
+                     } -> tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>
+  return %4#0, %4#1, %4#2, %4#3 : tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>
+}
+
+// CHECK-DAG: #[[$MAP_Q:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+// CHECK-DAG: #[[$MAP_K:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+// CHECK-DAG: #[[$MAP_V:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+// CHECK-DAG: #[[$MAP_S:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
+// CHECK-DAG: #[[$MAP_O:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+// CHECK-DAG: #[[$MAP_R:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @online_attention_logsumexp(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
+// CHECK:         %[[D1:.+]] = tensor.empty() : tensor<192x1024xf32>
+// CHECK:         %[[D2:.+]] = tensor.empty() : tensor<192x1024xf32>
+// CHECK:         %[[D3:.+]] = tensor.empty() : tensor<192x1024xf32>
+// CHECK:         %[[SCALE:.+]] = arith.constant 1.000000e+00 : f32
+// CHECK:         %[[D4:.+]]:4 = iree_linalg_ext.online_attention
+// CHECK-SAME:                 {indexing_maps = [#[[$MAP_Q]], #[[$MAP_K]], #[[$MAP_V]], #[[$MAP_S]], #[[$MAP_O]], #[[$MAP_R]], #[[$MAP_R]], #[[$MAP_R]]]}
+// CHECK-SAME:                 ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[SCALE]] :
+// CHECK-SAME:      tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, f32)
+// CHECK-SAME:      outs(%[[D0]], %[[D1]], %[[D2]], %[[D3]] : tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>) {
+// CHECK:          ^[[BLOCK:.+]](%[[SCORE:.+]]: f32):
+// CHECK:          iree_linalg_ext.yield %[[SCORE]] : f32
+// CHECK:        } -> tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>
+// CHECK:         return %[[D4]]#0, %[[D4]]#1, %[[D4]]#2, %[[D4]]#3

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -1061,15 +1061,21 @@ static Operation *createCollapsedOp(AttentionOp origOp,
   SmallVector<utils::IteratorType> iteratorTypes(getCollapsedOpIteratorTypes(
       origOp.getLoopIteratorTypes(), collapsingInfo));
 
-  Value maskOperand;
+  std::optional<Value> maskOperand;
   if (inputOperands.size() > 4) {
     maskOperand = inputOperands[4];
+  }
+
+  std::optional<Value> logsumexpOperand;
+  if (outputOperands.size() > 1) {
+    logsumexpOperand = outputOperands[1];
   }
 
   auto collapsedOp = AttentionOp::create(
       rewriter, origOp.getLoc(), resultTypes, inputOperands[0],
       inputOperands[1], inputOperands[2], inputOperands[3], outputOperands[0],
-      rewriter.getAffineMapArrayAttr(indexingMaps), maskOperand);
+      rewriter.getAffineMapArrayAttr(indexingMaps), maskOperand,
+      logsumexpOperand);
   rewriter.inlineRegionBefore(origOp.getRegion(), collapsedOp.getRegion(),
                               collapsedOp.getRegion().begin());
   return collapsedOp;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
 
@@ -96,19 +97,38 @@ void convertToOnlineAttention(IREE::LinalgExt::AttentionOp attnOp,
           .getResult(0);
 
   // Create online attention op.
+  // Strip logsumexp map from attention's indexing maps (if present) and
+  // append max/sum maps (and logsumexp map if needed) for online_attention.
   SmallVector<AffineMap> indexingMaps = attnOp.getIndexingMapsArray();
+  bool hasLogsumexp = attnOp.hasLogsumexp();
+  AffineMap lseMap;
+  if (hasLogsumexp) {
+    // Save the logsumexp map, remove it, then re-add after max/sum maps.
+    lseMap = indexingMaps.back();
+    indexingMaps.pop_back();
+  }
   indexingMaps.push_back(maxMap);
   indexingMaps.push_back(sumMap);
+  if (hasLogsumexp) {
+    indexingMaps.push_back(lseMap);
+  }
 
   Value mask = attnOp.getMask() ? attnOp.getMask() : Value();
 
+  // Build result types and logsumexp init for online_attention.
+  SmallVector<Type> onlineResultTypes = {accFill.getType(), maxFill.getType(),
+                                         sumFill.getType()};
+  std::optional<Value> lseInit;
+  if (hasLogsumexp) {
+    lseInit = attnOp.getLogsumexp();
+    onlineResultTypes.push_back(attnOp.getLogsumexp().getType());
+  }
+
   OnlineAttentionOp onlineAttn = OnlineAttentionOp::create(
-      rewriter, loc,
-      TypeRange{accFill.getType(), maxFill.getType(), sumFill.getType()},
-      attnOp.getQuery(), attnOp.getKey(), attnOp.getValue(), attnOp.getScale(),
-      mask, accFill, maxFill, sumFill,
-      rewriter.getAffineMapArrayAttr(indexingMaps),
-      attnOp.getDecompositionConfigAttr());
+      rewriter, loc, TypeRange(onlineResultTypes), attnOp.getQuery(),
+      attnOp.getKey(), attnOp.getValue(), attnOp.getScale(), accFill, maxFill,
+      sumFill, rewriter.getAffineMapArrayAttr(indexingMaps), mask, lseInit);
+  onlineAttn.setDecompositionConfigAttr(attnOp.getDecompositionConfigAttr());
 
   rewriter.cloneRegionBefore(attnOp.getRegion(), onlineAttn.getRegion(),
                              onlineAttn.getRegion().begin());
@@ -145,7 +165,14 @@ void convertToOnlineAttention(IREE::LinalgExt::AttentionOp attnOp,
       });
   ops.push_back(genericOp);
 
-  rewriter.replaceOp(attnOp, genericOp);
+  // Logsumexp is computed inside OnlineAttentionOp::decomposeOperation
+  // (in DecomposeAttention pass) where use_exp2 is known.
+  if (hasLogsumexp) {
+    rewriter.replaceOp(attnOp,
+                       {genericOp.getResult(0), onlineAttn.getResult(3)});
+  } else {
+    rewriter.replaceOp(attnOp, genericOp);
+  }
 }
 
 void ConvertAttentionToOnlineAttentionPass::runOnOperation() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_online_attention.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_online_attention.mlir
@@ -40,3 +40,47 @@ func.func @attention(%q: tensor<2x10x4096x128xf16>, %k: tensor<2x10x4096x128xf16
 // CHECK: arith.mulf
 // CHECK: arith.truncf
 // CHECK: linalg.yield
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d3)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+
+func.func @attention_logsumexp(%q: tensor<2x10x4096x128xf16>, %k: tensor<2x10x4096x128xf16>, %v: tensor<2x10x4096x128xf16>)
+                     -> (tensor<2x10x4096x128xf16>, tensor<2x10x4096xf32>) {
+  %scale = arith.constant 0.125 : f16
+  %acc = tensor.empty() : tensor<2x10x4096x128xf16>
+  %lse = tensor.empty() : tensor<2x10x4096xf32>
+  %out:2 = iree_linalg_ext.attention
+         {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5]}
+         ins(%q, %k, %v, %scale : tensor<2x10x4096x128xf16>, tensor<2x10x4096x128xf16>, tensor<2x10x4096x128xf16>, f16)
+         outs(%acc, %lse : tensor<2x10x4096x128xf16>, tensor<2x10x4096xf32>) {
+              ^bb0(%score: f32):
+                iree_linalg_ext.yield %score : f32
+         } -> tensor<2x10x4096x128xf16>, tensor<2x10x4096xf32>
+  func.return %out#0, %out#1 : tensor<2x10x4096x128xf16>, tensor<2x10x4096xf32>
+}
+
+// CHECK-LABEL: func.func @attention_logsumexp
+// CHECK-SAME: %[[Q:.+]]: tensor<2x10x4096x128xf16>, %[[K:.+]]: tensor<2x10x4096x128xf16>, %[[V:.+]]: tensor<2x10x4096x128xf16>
+// CHECK-DAG: %[[ACC_INIT:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[MAX_INIT:.+]] = arith.constant -3.40282347E+38 : f32
+// CHECK-DAG: %[[SUM_INIT:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[ACC_FILL:.+]] = linalg.fill ins(%[[ACC_INIT]]
+// CHECK-DAG: %[[MAX_FILL:.+]] = linalg.fill ins(%[[MAX_INIT]]
+// CHECK-DAG: %[[SUM_FILL:.+]] = linalg.fill ins(%[[SUM_INIT]]
+// CHECK: %[[OUT:.+]]:4 = iree_linalg_ext.online_attention
+// CHECK-SAME:         ins(%[[Q]], %[[K]], %[[V]]
+// CHECK-SAME:         outs(%[[ACC_FILL]], %[[MAX_FILL]], %[[SUM_FILL]]
+//      CHECK: linalg.generic
+// CHECK-SAME: ins(%[[OUT]]#2, %[[OUT]]#0
+// CHECK: arith.divf
+// CHECK: arith.mulf
+// CHECK: arith.truncf
+// CHECK: linalg.yield
+// Logsumexp is result #3, passed through to DecomposeAttention.
+// CHECK: return %{{.*}}, %[[OUT]]#3


### PR DESCRIPTION
Add an optional logsumexp DPS init operand to iree_linalg_ext.attention for training backward pass support. When present, the lowering computes logsumexp = max * ln(2) + log(sum) from online_attention's intermediate max and sum statistics.

This is needed for SDPA generate_stats support in hipDNN/fusilli (iree-org/fusilli#275).

Both `mergeReductions` and `decomposeAttention` perform the `logsumexp` from the partial results, but the GPU path eliminates the dead code from `decomposeAttention`  since `mergeReductions` also computes the same from all the partial results.