### PR TITLE
[LLVMGPU] Outer Reductions should use TileAndFuse Pipeline for better performance

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -122,6 +122,12 @@ static llvm::cl::opt<bool> clDirectConvolution(
     llvm::cl::desc("Use direct convolution in tile and fuse pipeline"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clGPUEnableOuterReductionTileAndFuse(
+    "iree-codegen-llvmgpu-enable-outer-reduction-tile-and-fuse",
+    llvm::cl::desc(
+        "Enable usage of tile and fuse pipeline for outer reduction"),
+    llvm::cl::init(true));
+
 // Custom parser for llvm::cl::opt<std::optional<uint64_t>>. Allows a flag to
 // be truly optional: unset on the command line means std::nullopt, while a
 // user-provided non-negative integer is stored in the optional.
@@ -2338,6 +2344,32 @@ static LogicalResult setConvolutionConfig(
 // Pipeline Configuration
 //====---------------------------------------------------------------------===//
 
+static bool isOuterReduction(linalg::LinalgOp op) {
+  if (!op.getNumReductionLoops()) {
+    return false;
+  }
+  SmallVector<unsigned> reductionDims;
+  op.getReductionDims(reductionDims);
+  for (OpOperand *input : op.getDpsInputOperands()) {
+    AffineMap map = op.getMatchingIndexingMap(input);
+    if (map.getNumResults() == 0) {
+      continue;
+    }
+    if (!map.isPermutation()) {
+      continue;
+    }
+    auto firstResult = dyn_cast<AffineDimExpr>(map.getResult(0));
+    if (!firstResult) {
+      continue;
+    }
+    unsigned dimPos = firstResult.getPosition();
+    if (llvm::is_contained(reductionDims, dimPos)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
                                    mlir::FunctionOpInterface entryPointFn,
                                    Operation *computeOp) {
@@ -2391,6 +2423,15 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
     if (succeeded(setContractConfig(target, entryPointFn, linalgOp))) {
       LDBG() << "Contract Config";
       return success();
+    }
+    if (clGPUEnableOuterReductionTileAndFuse) {
+      if (isOuterReduction(linalgOp)) {
+        if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(
+                target, entryPointFn, linalgOp))) {
+          LDBG() << "Outer reduction Tile and Fuse Config";
+          return success();
+        }
+      }
     }
     if (clGPUEnableReductionVectorDistribution) {
       LDBG() << "ReductionVectorDistribution: finding a suitable config...";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "config_tile_and_fuse.mlir",
             "config_tile_and_fuse_gfx1201.mlir",
             "config_tile_and_fuse_gfx950.mlir",
+            "config_tile_and_fuse_outer_reduction.mlir",
             "config_user_vector_distribute.mlir",
             "config_vector_distribute_gfx1100.mlir",
             "config_vector_distribute_gfx942.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "config_tile_and_fuse.mlir"
     "config_tile_and_fuse_gfx1201.mlir"
     "config_tile_and_fuse_gfx950.mlir"
+    "config_tile_and_fuse_outer_reduction.mlir"
     "config_user_vector_distribute.mlir"
     "config_vector_distribute_gfx1100.mlir"
     "config_vector_distribute_gfx942.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_outer_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_outer_reduction.mlir
@@ -1,0 +1,70 @@
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d1, d0)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @outer_reduction() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x16384xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  %in = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 16384], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x16384xf32>> -> tensor<512x16384xf32>
+  %init = tensor.empty() : tensor<16384xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<16384xf32>) -> tensor<16384xf32>
+  %result = linalg.generic {
+      indexing_maps = [#map0, #map1], iterator_types = ["parallel", "reduction"]}
+      ins(%in : tensor<512x16384xf32>) outs(%fill : tensor<16384xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      %add = arith.addf %arg0, %arg1 : f32
+      linalg.yield %add : f32
+  } -> tensor<16384xf32>
+  iree_tensor_ext.dispatch.tensor.store %result, %1, offsets = [0], sizes = [16384], strides = [1]
+      : tensor<16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  return
+}
+// CHECK-LABEL: func.func @outer_reduction
+//  CHECK-SAME:    #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     reduction = [0, 4]
+//  CHECK-SAME:     thread = [4, 0]
+//  CHECK-SAME:     workgroup = [256, 0]
+
+// -----
+
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> (d0)>
+#pipeline_layout_inner = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @inner_reduction() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_inner) binding(0) alignment(64) offset(%c0)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384x512xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_inner) binding(1) alignment(64) offset(%c0)
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  %in = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [16384, 512], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384x512xf32>> -> tensor<16384x512xf32>
+  %init = tensor.empty() : tensor<16384xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<16384xf32>) -> tensor<16384xf32>
+  %result = linalg.generic {
+      indexing_maps = [#map2, #map3], iterator_types = ["parallel", "reduction"]}
+      ins(%in : tensor<16384x512xf32>) outs(%fill : tensor<16384xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      %add = arith.addf %arg0, %arg1 : f32
+      linalg.yield %add : f32
+  } -> tensor<16384xf32>
+  iree_tensor_ext.dispatch.tensor.store %result, %1, offsets = [0], sizes = [16384], strides = [1]
+      : tensor<16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  return
+}
+// CHECK-LABEL: func.func @inner_reduction
+//   CHECK-NOT: TileAndFuse

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -264,7 +264,8 @@ func.func @vector_reduction_dispatch() attributes {hal.executable.target = #exec
 }
 
 //   CHECK-LABEL: llvm.func @vector_reduction_dispatch
-// CHECK-COUNT-5:     nvvm.shfl.sync bfly
+// CHECK-COUNT-4:     "llvm.intr.vector.reduce.fadd"({{.*}}) {{.*}} : (f32, vector<4xf32>) -> f32
+//         CHECK:     llvm.store %{{.*}} : vector<4xf32>, !llvm.ptr<1>
 
 // -----
 


### PR DESCRIPTION
This PR adds a check to select LLVMGPUTileAndFuse Pipeline when dealing with an outer reduction. This change is based on observed performance improvement when using TileAndFuse against VectorDistribute for outer reductions. 

## Summary of Stats for Context

### On MI300X
- 21 shapes improved (by avg 105us)
- 0 regressions
- 10 shapes showed minimal change

### On MI355

- 20 shapes improved (by avg 101us ~43%)
- 0 regressions
- 11 shapes showed minimal change

All comparisons were made against the VectorDistribute timings on the respective machines.