### PR TITLE
[TensorExt] Add resolveRange and getDistributionInfo to SparseCastOpInterface 

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
@@ -13,6 +13,9 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 
+static constexpr char kSparseIterationDimsAttrName[] =
+    "iree_tensor_ext.sparse_iteration_dims";
+
 // clang-format off
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp.inc" // IWYU pragma: keep
@@ -28,12 +31,17 @@ void IREETensorExtDialect::initializeAttrs() {
 }
 
 SparseIterationDimsAttr getSparseIterationDimsAttr(Operation *op) {
-  static constexpr StringLiteral kAttrName =
-      "iree_tensor_ext.sparse_iteration_dims";
-  if (auto attr = op->getAttrOfType<SparseIterationDimsAttr>(kAttrName)) {
+  if (auto attr = op->getAttrOfType<SparseIterationDimsAttr>(
+          kSparseIterationDimsAttrName)) {
     return attr;
   }
   return SparseIterationDimsAttr();
+}
+void setSparseIterationDimsAttr(Operation *op,
+                                ArrayRef<int64_t> sparseIterationDims) {
+  auto sparseIterDimsAttr = IREE::TensorExt::SparseIterationDimsAttr::get(
+      op->getContext(), sparseIterationDims);
+  op->setAttr(kSparseIterationDimsAttrName, sparseIterDimsAttr);
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h
@@ -17,8 +17,11 @@
 
 namespace mlir::iree_compiler::IREE::TensorExt {
 
-// Get the attribute that specifies sparse iteration dimensions on operations.
+// Get/Set the attribute that specifies sparse iteration dimensions on
+// operations.
 SparseIterationDimsAttr getSparseIterationDimsAttr(Operation *op);
+void setSparseIterationDimsAttr(Operation *op,
+                                ArrayRef<int64_t> sparseIterationDims);
 
 } // namespace mlir::iree_compiler::IREE::TensorExt
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
@@ -96,6 +96,39 @@ def IREETensorExt_SparseCastOpInterface :
           "::mlir::RewriterBase &":$rewriter,
           "::llvm::ArrayRef<int64_t>":$sparseDims,
           "::llvm::ArrayRef<::mlir::Range>":$givenRanges)
+    >,
+    InterfaceMethod<
+      /*description =*/[{Resolve a range in terms of the source tensor.
+
+      Given a range that represents a slice of a sparse tensor (all dimensions
+      of the result), return an equivalent range in terms of the source tensor.
+
+      The inBounds bit vector (one bit per range entry) specifies whether each dimension's
+      access is guaranteed to be in-bounds. If false for any dimension, the implementation
+      should fail, as out-of-bounds handling is not yet supported.
+
+      The optional paddingValue parameter specifies the value to use for out-of-bounds
+      accesses. This is reserved for future use when guard generation is implemented.
+      }],
+      /*retTy =*/"::llvm::FailureOr<::llvm::SmallVector<::mlir::Range>>",
+      /*methodName =*/"resolveRange",
+      /*arguments =*/(ins
+          "::mlir::RewriterBase &":$rewriter,
+          "::llvm::ArrayRef<::mlir::Range>":$givenRanges,
+          "const ::llvm::BitVector &":$inBounds,
+          "::std::optional<::mlir::Value>":$paddingValue)
+    >,
+    InterfaceMethod<
+      /*description =*/[{
+        Returns which sparse dimensions can be distributed across workgroups.
+
+        For sparse dimensions where bounds depend on outer dimensions, those
+        dimensions cannot be distributed across workgroups. This method returns
+        a BitVector where bit i is set if sparse dimension i (from
+        SparseShapeAttrInterface::getSparseDimensions()) can be distributed.
+      }],
+      /*retTy =*/"::llvm::BitVector",
+      /*methodName =*/"getDistributionInfoForSparseDimensions"
     >
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
@@ -98,7 +98,8 @@ def IREETensorExt_SparseCastOpInterface :
           "::llvm::ArrayRef<::mlir::Range>":$givenRanges)
     >,
     InterfaceMethod<
-      /*description =*/[{Resolve a range in terms of the source tensor.
+      /*description =*/[{
+      Resolve a range in terms of the source tensor.
 
       Given a range that represents a slice of a sparse tensor (all dimensions
       of the result), return an equivalent range in terms of the source tensor.

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 
 // clang-format off: must be included after all LLVM/MLIR headers
@@ -15,6 +16,13 @@
 // clang-format on: must be included after all LLVM/MLIR headers
 
 namespace mlir::iree_compiler::IREE::TensorExt {
+
+bool matchDimOp(Operation *op, Value &source, IntegerAttr &dimIndex) {
+  return matchPattern(op, m_Op<memref::DimOp>(matchers::m_Any(&source),
+                                              m_Constant(&dimIndex))) ||
+         matchPattern(op, m_Op<tensor::DimOp>(matchers::m_Any(&source),
+                                              m_Constant(&dimIndex)));
+}
 
 LogicalResult verifySparseCastOpInterface(SparseCastOpInterface sparseOp) {
   // Check that the operation has only one result.
@@ -71,12 +79,11 @@ std::optional<SparseRangeResolver> getSparseRangeResolver(Range range) {
   SparseCastOpInterface sparseOp;
   int64_t resultDim;
 
-  // For now just check that the defining operation of the upper bound is a
-  // `memref.dim` operation of a result of a sparse operation.
+  // Check that the defining operation of the upper bound is a
+  // `memref.dim` or `tensor.dim` operation of a result of a sparse operation.
   Value ubSource;
   IntegerAttr dim;
-  if (!matchPattern(upperBound, m_Op<memref::DimOp>(matchers::m_Any(&ubSource),
-                                                    m_Constant(&dim)))) {
+  if (!matchDimOp(upperBound.getDefiningOp(), ubSource, dim)) {
     return std::nullopt;
   }
   sparseOp = ubSource.getDefiningOp<SparseCastOpInterface>();

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h
@@ -37,6 +37,10 @@ struct SparseRangeResolver {
   int64_t resultDim;
 };
 
+/// Match a `memref.dim` or `tensor.dim` operation and return its source value
+/// and constant dimension index.
+bool matchDimOp(Operation *op, Value &source, IntegerAttr &dimIndex);
+
 /// For a given Range retrieve the SparseRangeResolver if it is defined by a
 /// sparse operation.
 std::optional<SparseRangeResolver> getSparseRangeResolver(Range range);

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/Dominance.h"
 
@@ -561,6 +562,16 @@ OpFoldResult CastToRaggedShapeOp::getNumRaggedRowsAsOfr() {
   return IntegerAttr::get(IndexType::get(getContext()), resultShape[raggedDim]);
 }
 
+// Cast `v` to index type if it's not already index type.
+static Value castToIndexTypeOrSelf(RewriterBase &rewriter, Location loc,
+                                   Value v) {
+  if (v.getType() != rewriter.getIndexType()) {
+    return arith::IndexCastOp::create(rewriter, loc, rewriter.getIndexType(),
+                                      v);
+  }
+  return v;
+}
+
 // Starting at `v`, compute a backward slice dominated by the given `sparseOp`
 // and clone the operations in the slice, replacing any occurrence of
 // `dim(%sparseOp, givenDim)` with the value returned by
@@ -584,9 +595,9 @@ static FailureOr<SmallVector<Value>> cloneAndReplaceDimInBackwardSlice(
   IRMapping mapping;
   for (auto op : slice) {
     IntegerAttr attr;
-    if (!matchPattern(
-            op, m_Op<memref::DimOp>(matchers::m_Val(sparseOp->getResult(0)),
-                                    m_Constant(&attr)))) {
+    Value dimSource;
+    if (!matchDimOp(op, dimSource, attr) ||
+        dimSource != sparseOp->getResult(0)) {
       rewriter.clone(*op, mapping);
       continue;
     }
@@ -658,10 +669,16 @@ CastToRaggedShapeOp::getEstimatedLoopRange(RewriterBase &rewriter,
       cloneAndReplaceDimInBackwardSlice(
           rewriter, loc, dominanceInfo, innerUb, *this, expectedSparseDims[1],
           [&](RewriterBase &rewriter, Location loc) {
-            OpFoldResult sourceDim =
-                memref::DimOp::create(rewriter, loc, getSource(),
-                                      expectedSparseDims[0])
-                    .getResult();
+            OpFoldResult sourceDim;
+            if (isa<MemRefType>(getSource().getType())) {
+              sourceDim = memref::DimOp::create(rewriter, loc, getSource(),
+                                                expectedSparseDims[0])
+                              .getResult();
+            } else {
+              sourceDim = tensor::DimOp::create(rewriter, loc, getSource(),
+                                                expectedSparseDims[0])
+                              .getResult();
+            }
             OpFoldResult numRaggedRows = getNumRaggedRowsAsOfr();
             AffineExpr s0, s1;
             bindSymbols(rewriter.getContext(), s0, s1);
@@ -695,8 +712,8 @@ CastToRaggedShapeOp::lowerLoopRange(RewriterBase &rewriter,
   // Check that all requested sparse dims are valid.
   for (int64_t sparseDim : sparseDims) {
     if (!llvm::is_contained(expectedSparseDims, sparseDim)) {
-      return emitOpError(
-          "cannot lower the loop range for given sparse dimensions");
+      return rewriter.notifyMatchFailure(
+          *this, "cannot lower the loop range for given sparse dimensions");
     }
   }
   assert(givenRange.size() == sparseDims.size() &&
@@ -782,19 +799,20 @@ CastToRaggedShapeOp::lowerLoopRange(RewriterBase &rewriter,
               Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
               Value plusOne =
                   arith::AddIOp::create(rewriter, loc, outerIv, one);
-              Value columnEnd =
-                  memref::LoadOp::create(rewriter, loc, columnLengths, plusOne);
-              Value columnStart =
-                  memref::LoadOp::create(rewriter, loc, columnLengths, outerIv);
-              // Cast to index type if needed before affine operations.
-              if (columnEnd.getType() != rewriter.getIndexType()) {
-                columnEnd = arith::IndexCastOp::create(
-                    rewriter, loc, rewriter.getIndexType(), columnEnd);
+              Value columnEnd, columnStart;
+              if (isa<MemRefType>(columnLengths.getType())) {
+                columnEnd = memref::LoadOp::create(rewriter, loc, columnLengths,
+                                                   plusOne);
+                columnStart = memref::LoadOp::create(rewriter, loc,
+                                                     columnLengths, outerIv);
+              } else {
+                columnEnd = tensor::ExtractOp::create(rewriter, loc,
+                                                      columnLengths, plusOne);
+                columnStart = tensor::ExtractOp::create(rewriter, loc,
+                                                        columnLengths, outerIv);
               }
-              if (columnStart.getType() != rewriter.getIndexType()) {
-                columnStart = arith::IndexCastOp::create(
-                    rewriter, loc, rewriter.getIndexType(), columnStart);
-              }
+              columnEnd = castToIndexTypeOrSelf(rewriter, loc, columnEnd);
+              columnStart = castToIndexTypeOrSelf(rewriter, loc, columnStart);
               // Compute column_lengths[outerIv+1] - column_lengths[outerIv]
               AffineExpr s0, s1;
               bindSymbols(rewriter.getContext(), s0, s1);
@@ -862,18 +880,9 @@ FailureOr<SmallVector<Range>> CastToRaggedShapeOp::resolveRange(
 
   // Verify constraints on sparse dimension ranges.
   // For the outer sparse dimension: size must be 1, stride must be 1.
-  auto isOne = [](OpFoldResult ofr) -> bool {
-    if (auto attr = dyn_cast<Attribute>(ofr)) {
-      if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
-        return intAttr.getInt() == 1;
-      }
-    }
-    return false;
-  };
-
   OpFoldResult ofrsToCheck[] = {givenRanges[sparseDims[0]].size,
                                 givenRanges[sparseDims[0]].stride};
-  if (!llvm::all_of(ofrsToCheck, isOne)) {
+  if (!llvm::all_of(ofrsToCheck, isOneInteger)) {
     return emitOpError("expected outer sparse dimension size and stride to be "
                        "1 in givenRanges");
   }
@@ -907,7 +916,7 @@ FailureOr<SmallVector<Range>> CastToRaggedShapeOp::resolveRange(
     // corresponding source dimension.
     Value columnLengths = getColumnLengths();
 
-    // column_lengths[offset_0]
+    // Extract the column_lengths[offset_0] value.
     Value offset0 = getValueOrCreateConstantIndexOp(
         rewriter, loc, givenRanges[outerSparseDim].offset);
     Value columnLengthsCurrent;
@@ -915,20 +924,15 @@ FailureOr<SmallVector<Range>> CastToRaggedShapeOp::resolveRange(
       columnLengthsCurrent =
           memref::LoadOp::create(rewriter, loc, columnLengths, offset0);
     } else {
-      // Tensor type - use tensor.extract
       columnLengthsCurrent =
           tensor::ExtractOp::create(rewriter, loc, columnLengths, offset0);
     }
-    if (columnLengthsCurrent.getType() != rewriter.getIndexType()) {
-      columnLengthsCurrent = arith::IndexCastOp::create(
-          rewriter, loc, rewriter.getIndexType(), columnLengthsCurrent);
-    }
+    columnLengthsCurrent =
+        castToIndexTypeOrSelf(rewriter, loc, columnLengthsCurrent);
 
     // Since we verified all accesses are in-bounds, we can use the requested
     // size directly without clamping.
     OpFoldResult sizeVal = givenRanges[innerSparseDim].size;
-
-    // stride = step_1
     OpFoldResult strideVal = givenRanges[innerSparseDim].stride;
 
     // offset = column_lengths[offset_0] + offset_1
@@ -954,12 +958,12 @@ llvm::BitVector CastToRaggedShapeOp::getDistributionInfoForSparseDimensions() {
       getResultSparseEncoding().getSparseDimensions();
 
   // For ragged tensors with 2 sparse dimensions:
-  // - First sparse dimension (raggedRow) CAN be distributed
+  // - First sparse dimension (raggedRow) CAN be distributed.
   // - Second sparse dimension (raggedRow + 1) CANNOT be distributed
   //   because its bounds depend on the outer dimension.
   llvm::BitVector result(sparseDims.size(), false);
   if (!sparseDims.empty()) {
-    result.set(0); // Only first sparse dimension is distributable
+    result.set(0); // Only first sparse dimension is distributable.
   }
   return result;
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -691,103 +691,277 @@ CastToRaggedShapeOp::lowerLoopRange(RewriterBase &rewriter,
       getResultSparseEncoding().getSparseDimensions();
   assert(expectedSparseDims.size() == 2 &&
          "invalid specification of op with more than two sparse dimensions");
-  if (expectedSparseDims != sparseDims) {
-    return emitOpError(
-        "cannot lower the loop range for given sparse dimensions");
+
+  // Check that all requested sparse dims are valid.
+  for (int64_t sparseDim : sparseDims) {
+    if (!llvm::is_contained(expectedSparseDims, sparseDim)) {
+      return emitOpError(
+          "cannot lower the loop range for given sparse dimensions");
+    }
   }
   assert(givenRange.size() == sparseDims.size() &&
          "expected ranges for all dims");
 
-  // Generate the loop for outer sparse dimension.
+  // Generate the loop for sparse dimensions.
   Location loc = getLoc();
 
   // The upper bounds of the range is expected to be the
   // `memref.dim`/`tensor.dim` operation of the result of this operation.
   DominanceInfo dominanceInfo(getOperation()->getParentOp());
 
-  Value outerLb =
-      getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[0].offset);
-  Value outerUb =
-      getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[0].size);
-  Value outerStep =
-      getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[0].stride);
+  SmallVector<Value> ivs;
 
-  // Replace the `memref.dim`/`tensor.dim` operation in the backward slice of
-  // the upper bound with the number of ragged rows.
-  FailureOr<SmallVector<Value>> outerDimReplacementResult =
-      cloneAndReplaceDimInBackwardSlice(
-          rewriter, loc, dominanceInfo, outerUb, *this, expectedSparseDims[0],
-          [&](RewriterBase &rewriter, Location loc) {
-            OpFoldResult numRaggedRows = getNumRaggedRowsAsOfr();
-            Value numRaggedRowsVal =
-                getValueOrCreateConstantIndexOp(rewriter, loc, numRaggedRows);
-            return numRaggedRowsVal;
-          },
-          {outerUb});
-  if (failed(outerDimReplacementResult)) {
-    return emitOpError("failed to replace outer dim in backward slice");
+  // Find indices of outer and inner sparse dims in the sparseDims array.
+  auto outerIt = llvm::find(sparseDims, expectedSparseDims[0]);
+  auto innerIt = llvm::find(sparseDims, expectedSparseDims[1]);
+
+  // Handle outer sparse dimension (row) if present.
+  Value outerIv;
+  if (outerIt != sparseDims.end()) {
+    int64_t outerIdx = std::distance(sparseDims.begin(), outerIt);
+    Value outerLb = getValueOrCreateConstantIndexOp(
+        rewriter, loc, givenRange[outerIdx].offset);
+    Value outerUb = getValueOrCreateConstantIndexOp(rewriter, loc,
+                                                    givenRange[outerIdx].size);
+    Value outerStep = getValueOrCreateConstantIndexOp(
+        rewriter, loc, givenRange[outerIdx].stride);
+
+    // Replace the `memref.dim`/`tensor.dim` operation in the backward slice of
+    // the upper bound with the number of ragged rows.
+    FailureOr<SmallVector<Value>> outerDimReplacementResult =
+        cloneAndReplaceDimInBackwardSlice(
+            rewriter, loc, dominanceInfo, outerUb, *this, expectedSparseDims[0],
+            [&](RewriterBase &rewriter, Location loc) {
+              OpFoldResult numRaggedRows = getNumRaggedRowsAsOfr();
+              Value numRaggedRowsVal =
+                  getValueOrCreateConstantIndexOp(rewriter, loc, numRaggedRows);
+              return numRaggedRowsVal;
+            },
+            {outerUb});
+    if (failed(outerDimReplacementResult)) {
+      return emitOpError("failed to replace outer dim in backward slice");
+    }
+
+    auto outerFor =
+        scf::ForOp::create(rewriter, loc, outerLb,
+                           outerDimReplacementResult.value()[0], outerStep);
+    outerIv = outerFor.getInductionVar();
+    Block *outerForBody = outerFor.getBody();
+    rewriter.setInsertionPointToStart(outerForBody);
+    ivs.push_back(outerIv);
   }
 
-  auto outerFor = scf::ForOp::create(
-      rewriter, loc, outerLb, outerDimReplacementResult.value()[0], outerStep);
-  Value outerIv = outerFor.getInductionVar();
-  Block *outerForBody = outerFor.getBody();
-  rewriter.setInsertionPointToStart(outerForBody);
+  // Handle inner sparse dimension (column) if present.
+  if (innerIt != sparseDims.end()) {
+    int64_t innerIdx = std::distance(sparseDims.begin(), innerIt);
+    // If we don't have an outer IV from this call, we cannot create the inner
+    // loop since it depends on the outer IV for computing column bounds.
+    if (!outerIv) {
+      return emitOpError(
+          "cannot lower inner sparse dimension without outer dimension");
+    }
 
-  // For the inner sparse dimension, lower to loops by creating a loop with
-  // - Lower bound being `max(givenLowerBound, column_lengths[outerIv])`
-  // - Upper bound obtained by replacing the `memref.dim %sparseOp, 1` with
-  //   `column_lengths[outerIv + 1]`
-  Value innerLb =
-      getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[1].offset);
-  Value innerUb =
-      getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[1].size);
-  Value innerStep =
-      getValueOrCreateConstantIndexOp(rewriter, loc, givenRange[1].stride);
+    Value innerLb = getValueOrCreateConstantIndexOp(
+        rewriter, loc, givenRange[innerIdx].offset);
+    Value innerUb = getValueOrCreateConstantIndexOp(rewriter, loc,
+                                                    givenRange[innerIdx].size);
+    Value innerStep = getValueOrCreateConstantIndexOp(
+        rewriter, loc, givenRange[innerIdx].stride);
 
-  // Replace the `memref.dim`/`tensor.dim` operation in the backward slice of
-  // the inner dim with the column length.
-  Value columnLengths = getColumnLengths();
-  FailureOr<SmallVector<Value>> innerDimReplacementResult =
-      cloneAndReplaceDimInBackwardSlice(
-          rewriter, loc, dominanceInfo, innerUb, *this, expectedSparseDims[1],
-          [&](RewriterBase &rewriter, Location loc) {
-            Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
-            Value plusOne = arith::AddIOp::create(rewriter, loc, outerIv, one);
-            Value columnUb =
-                memref::LoadOp::create(rewriter, loc, columnLengths, plusOne);
-            if (columnUb.getType() != innerUb.getType()) {
-              columnUb = arith::IndexCastOp::create(
-                  rewriter, loc, innerUb.getType(), columnUb);
-            }
-            return columnUb;
-          },
-          {innerLb, innerUb});
-  if (failed(innerDimReplacementResult)) {
-    return emitOpError("failed to replace inner dims in backward slice");
+    // Replace the `memref.dim`/`tensor.dim` operation in the backward slice of
+    // the inner dim with the column length range (column_lengths[outerIv+1] -
+    // column_lengths[outerIv]). This ensures the loop variable iterates in
+    // relative index space (0, 1, 2, ...) which is correct for the dense output
+    // tensor. The sparse access resolution pass will adjust load indices to add
+    // column_lengths[outerIv] to get the linearized source index.
+    Value columnLengths = getColumnLengths();
+    FailureOr<SmallVector<Value>> innerDimReplacementResult =
+        cloneAndReplaceDimInBackwardSlice(
+            rewriter, loc, dominanceInfo, innerUb, *this, expectedSparseDims[1],
+            [&](RewriterBase &rewriter, Location loc) {
+              Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
+              Value plusOne =
+                  arith::AddIOp::create(rewriter, loc, outerIv, one);
+              Value columnEnd =
+                  memref::LoadOp::create(rewriter, loc, columnLengths, plusOne);
+              Value columnStart =
+                  memref::LoadOp::create(rewriter, loc, columnLengths, outerIv);
+              // Cast to index type if needed before affine operations.
+              if (columnEnd.getType() != rewriter.getIndexType()) {
+                columnEnd = arith::IndexCastOp::create(
+                    rewriter, loc, rewriter.getIndexType(), columnEnd);
+              }
+              if (columnStart.getType() != rewriter.getIndexType()) {
+                columnStart = arith::IndexCastOp::create(
+                    rewriter, loc, rewriter.getIndexType(), columnStart);
+              }
+              // Compute column_lengths[outerIv+1] - column_lengths[outerIv]
+              AffineExpr s0, s1;
+              bindSymbols(rewriter.getContext(), s0, s1);
+              AffineMap subMap =
+                  AffineMap::get(0, 2, {s0 - s1}, rewriter.getContext());
+              OpFoldResult columnRangeOfr =
+                  affine::makeComposedFoldedAffineApply(
+                      rewriter, loc, subMap,
+                      ArrayRef<OpFoldResult>{columnEnd, columnStart});
+              return getValueOrCreateConstantIndexOp(rewriter, loc,
+                                                     columnRangeOfr);
+            },
+            {innerLb, innerUb});
+    if (failed(innerDimReplacementResult)) {
+      return emitOpError("failed to replace inner dims in backward slice");
+    }
+
+    Value clonedLb = innerDimReplacementResult.value()[0];
+    Value clonedUb = innerDimReplacementResult.value()[1];
+    // Use the cloned lower bound directly - no need to max with
+    // column_lengths[outerIv] since the loop now iterates in relative index
+    // space.
+    auto innerFor =
+        scf::ForOp::create(rewriter, loc, clonedLb, clonedUb, innerStep);
+    Block *innerForBody = innerFor.getBody();
+    rewriter.setInsertionPointToStart(innerForBody);
+    Value innerIv = innerFor.getInductionVar();
+    ivs.push_back(innerIv);
   }
 
-  Value clonedLb = innerDimReplacementResult.value()[0];
-  Value clonedUb = innerDimReplacementResult.value()[1];
-  AffineExpr s0, s1;
-  bindSymbols(rewriter.getContext(), s0, s1);
-  AffineMap maxMap = AffineMap::get(0, 2, {s0, s1}, rewriter.getContext());
-  Value columnLb =
-      memref::LoadOp::create(rewriter, loc, columnLengths, outerIv);
-  if (columnLb.getType() != clonedLb.getType()) {
-    columnLb =
-        arith::IndexCastOp::create(rewriter, loc, clonedLb.getType(), columnLb);
-  }
-  OpFoldResult newLb = affine::makeComposedFoldedAffineMax(
-      rewriter, loc, maxMap, ArrayRef<OpFoldResult>{clonedLb, columnLb});
-  Value newLbVal = getValueOrCreateConstantIndexOp(rewriter, loc, newLb);
-  auto innerFor =
-      scf::ForOp::create(rewriter, loc, newLbVal, clonedUb, innerStep);
-  Block *innerForBody = innerFor.getBody();
-  rewriter.setInsertionPointToStart(innerForBody);
-  Value innerIv = innerFor.getInductionVar();
+  return ivs;
+}
 
-  return SmallVector<Value>{outerIv, innerIv};
+FailureOr<SmallVector<Range>> CastToRaggedShapeOp::resolveRange(
+    RewriterBase &rewriter, ArrayRef<Range> givenRanges,
+    const llvm::BitVector &inBounds, std::optional<Value> paddingValue) {
+  // NOTE: paddingValue parameter is accepted for interface compatibility.
+  // Future work: Generate conditional code/guards when paddingValue is provided
+  // to handle out-of-bounds accesses by returning the padding value.
+  (void)paddingValue; // Unused for now
+
+  ShapedType resultType = getResultType();
+
+  if (givenRanges.size() != resultType.getRank()) {
+    return emitOpError("expected givenRanges to have ")
+           << resultType.getRank() << " entries, but got "
+           << givenRanges.size();
+  }
+
+  if (inBounds.size() != givenRanges.size()) {
+    return emitOpError("expected inBounds to have ")
+           << givenRanges.size() << " bits, but got " << inBounds.size();
+  }
+
+  // Check if all accesses are in-bounds. Out-of-bounds handling is not yet
+  // supported.
+  if (!inBounds.all()) {
+    return emitOpError("out-of-bounds accesses are not yet supported");
+  }
+
+  SmallVector<int64_t> sparseDims =
+      getResultSparseEncoding().getSparseDimensions();
+  assert(sparseDims.size() == 2 &&
+         "invalid specification of op with more than two sparse dimensions");
+
+  // Verify constraints on sparse dimension ranges.
+  // For the outer sparse dimension: size must be 1, stride must be 1.
+  auto isOne = [](OpFoldResult ofr) -> bool {
+    if (auto attr = dyn_cast<Attribute>(ofr)) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
+        return intAttr.getInt() == 1;
+      }
+    }
+    return false;
+  };
+
+  OpFoldResult ofrsToCheck[] = {givenRanges[sparseDims[0]].size,
+                                givenRanges[sparseDims[0]].stride};
+  if (!llvm::all_of(ofrsToCheck, isOne)) {
+    return emitOpError("expected outer sparse dimension size and stride to be "
+                       "1 in givenRanges");
+  }
+
+  Location loc = getLoc();
+  SmallVector<Range> resolvedRange;
+
+  // Process all dimensions except the sparse dimensions.
+  int64_t resultRank = resultType.getRank();
+
+  // The outer sparse dimension index.
+  int64_t outerSparseDim = sparseDims[0];
+  int64_t innerSparseDim = sparseDims[1];
+
+  // Create a set of sparse dimensions for easy lookup.
+  llvm::SmallDenseSet<int64_t> sparseDimsSet(sparseDims.begin(),
+                                             sparseDims.end());
+
+  // Build the resolved range for the source.
+  for (int64_t resultDim = 0; resultDim < resultRank; ++resultDim) {
+    if (!sparseDimsSet.contains(resultDim)) {
+      // Non-sparse dimensions are preserved.
+      resolvedRange.push_back(givenRanges[resultDim]);
+      continue;
+    }
+    if (resultDim == innerSparseDim) {
+      // Skip the inner sparse dimension - it's already handled.
+      continue;
+    }
+    // This is the outer sparse dimension - compute the range for the
+    // corresponding source dimension.
+    Value columnLengths = getColumnLengths();
+
+    // column_lengths[offset_0]
+    Value offset0 = getValueOrCreateConstantIndexOp(
+        rewriter, loc, givenRanges[outerSparseDim].offset);
+    Value columnLengthsCurrent;
+    if (isa<MemRefType>(columnLengths.getType())) {
+      columnLengthsCurrent =
+          memref::LoadOp::create(rewriter, loc, columnLengths, offset0);
+    } else {
+      // Tensor type - use tensor.extract
+      columnLengthsCurrent =
+          tensor::ExtractOp::create(rewriter, loc, columnLengths, offset0);
+    }
+    if (columnLengthsCurrent.getType() != rewriter.getIndexType()) {
+      columnLengthsCurrent = arith::IndexCastOp::create(
+          rewriter, loc, rewriter.getIndexType(), columnLengthsCurrent);
+    }
+
+    // Since we verified all accesses are in-bounds, we can use the requested
+    // size directly without clamping.
+    OpFoldResult sizeVal = givenRanges[innerSparseDim].size;
+
+    // stride = step_1
+    OpFoldResult strideVal = givenRanges[innerSparseDim].stride;
+
+    // offset = column_lengths[offset_0] + offset_1
+    // The linearized offset is the base offset from column_lengths plus the
+    // inner sparse dimension offset.
+    AffineExpr d0_offset, d1_offset;
+    bindDims(rewriter.getContext(), d0_offset, d1_offset);
+    AffineMap addMap =
+        AffineMap::get(2, 0, {d0_offset + d1_offset}, rewriter.getContext());
+    OpFoldResult linearizedOffset = affine::makeComposedFoldedAffineApply(
+        rewriter, loc, addMap,
+        ArrayRef<OpFoldResult>{columnLengthsCurrent,
+                               givenRanges[innerSparseDim].offset});
+
+    resolvedRange.push_back(Range{linearizedOffset, sizeVal, strideVal});
+  }
+
+  return resolvedRange;
+}
+
+llvm::BitVector CastToRaggedShapeOp::getDistributionInfoForSparseDimensions() {
+  SmallVector<int64_t> sparseDims =
+      getResultSparseEncoding().getSparseDimensions();
+
+  // For ragged tensors with 2 sparse dimensions:
+  // - First sparse dimension (raggedRow) CAN be distributed
+  // - Second sparse dimension (raggedRow + 1) CANNOT be distributed
+  //   because its bounds depend on the outer dimension.
+  llvm::BitVector result(sparseDims.size(), false);
+  if (!sparseDims.empty()) {
+    result.set(0); // Only first sparse dimension is distributable
+  }
+  return result;
 }
 
 } // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Passes.td
@@ -18,6 +18,11 @@ def TestSparseOpInterfaceMethodsPass :
            /*default=*/"false", "Test lowerLoopRange method">,
     Option<"testGetEstimatedLoopRange", "test-get-estimated-loop-range", "bool",
            /*default=*/"false", "Test getEstimatedLoopRange method">,
+    Option<"testResolveRange", "test-resolve-range", "bool",
+           /*default=*/"false", "Test resolveRange method">,
+    Option<"testGetDistributionInfo", "test-get-distribution-info", "bool",
+           /*default=*/"false",
+           "Test getDistributionInfoForSparseDimensions method">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/TestSparseInterfaceMethods.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/TestSparseInterfaceMethods.cpp
@@ -253,19 +253,124 @@ static LogicalResult testGetEstimatedLoopRangeImpl(scf::ForallOp forallOp) {
   return success();
 }
 
+// Test the `resolveRange` method of the SparseCastOpInterface. Finds a
+// `"test.range"` marker op whose operands are grouped in triples
+// (offset, size, stride) — one triple per result dimension. Calls
+// `resolveRange` and replaces the marker with `"test.resolved_range"`.
+static LogicalResult testResolveRangeImpl(Operation *funcOp) {
+  SmallVector<IREE::TensorExt::SparseCastOpInterface> sparseOps;
+  SmallVector<Operation *> rangeOps;
+  funcOp->walk([&](Operation *op) {
+    if (auto sparseOp = dyn_cast<IREE::TensorExt::SparseCastOpInterface>(op)) {
+      sparseOps.push_back(sparseOp);
+    }
+    if (op->getName().getStringRef() == "test.range") {
+      rangeOps.push_back(op);
+    }
+  });
+  if (sparseOps.size() != 1) {
+    return funcOp->emitError("expected exactly one SparseCastOpInterface op");
+  }
+  if (rangeOps.size() != 1) {
+    return funcOp->emitError("expected exactly one test.range op");
+  }
+  IREE::TensorExt::SparseCastOpInterface sparseOp = sparseOps[0];
+  Operation *rangeOp = rangeOps[0];
+
+  // Operands are grouped as (offset0, size0, stride0, offset1, size1, ...).
+  unsigned numOperands = rangeOp->getNumOperands();
+  if (numOperands % 3 != 0) {
+    return rangeOp->emitError(
+        "test.range operands must be a multiple of 3 (offset, size, stride)");
+  }
+
+  SmallVector<Range> allRanges;
+  for (unsigned i = 0; i < numOperands; i += 3) {
+    allRanges.push_back(Range{rangeOp->getOperand(i),
+                              rangeOp->getOperand(i + 1),
+                              rangeOp->getOperand(i + 2)});
+  }
+
+  llvm::BitVector inBounds(allRanges.size(), true);
+
+  IRRewriter rewriter(funcOp->getContext());
+  rewriter.setInsertionPoint(rangeOp);
+  Location loc = rangeOp->getLoc();
+
+  FailureOr<SmallVector<Range>> resolvedRanges =
+      sparseOp.resolveRange(rewriter, allRanges, inBounds, std::nullopt);
+  if (failed(resolvedRanges)) {
+    return failure();
+  }
+
+  // Materialize the resolved ranges as values so FileCheck can verify them.
+  SmallVector<Value> allVals;
+  for (auto &range : resolvedRanges.value()) {
+    allVals.push_back(
+        getValueOrCreateConstantIndexOp(rewriter, loc, range.offset));
+    allVals.push_back(
+        getValueOrCreateConstantIndexOp(rewriter, loc, range.size));
+    allVals.push_back(
+        getValueOrCreateConstantIndexOp(rewriter, loc, range.stride));
+  }
+  OperationState state(loc, "test.resolved_range");
+  state.addOperands(allVals);
+  rewriter.create(state);
+
+  rewriter.eraseOp(rangeOp);
+  return success();
+}
+
+// Test the `getDistributionInfoForSparseDimensions` method. For each
+// SparseCastOpInterface op, emit a `test.distribution_info` marker with the
+// result BitVector encoded as a dense bool array attribute.
+static LogicalResult testGetDistributionInfoImpl(Operation *funcOp) {
+  SmallVector<IREE::TensorExt::SparseCastOpInterface> sparseOps;
+  funcOp->walk([&](IREE::TensorExt::SparseCastOpInterface op) {
+    sparseOps.push_back(op);
+  });
+  if (sparseOps.empty()) {
+    return funcOp->emitError("expected at least one SparseCastOpInterface op");
+  }
+
+  IRRewriter rewriter(funcOp->getContext());
+  for (auto sparseOp : sparseOps) {
+    llvm::BitVector distInfo =
+        sparseOp.getDistributionInfoForSparseDimensions();
+
+    SmallVector<bool> distributable;
+    for (unsigned i = 0; i < distInfo.size(); ++i) {
+      distributable.push_back(distInfo.test(i));
+    }
+
+    rewriter.setInsertionPointAfter(sparseOp);
+    OperationState state(sparseOp->getLoc(), "test.distribution_info");
+    state.addAttribute("distributable",
+                       rewriter.getDenseBoolArrayAttr(distributable));
+    rewriter.create(state);
+  }
+  return success();
+}
+
 void TestSparseOpInterfaceMethodsPass::runOnOperation() {
   Operation *op = getOperation();
 
+  // resolveRange and getDistributionInfo use their own marker ops, not forall.
+  if (testResolveRange) {
+    if (failed(testResolveRangeImpl(op))) {
+      return signalPassFailure();
+    }
+    return;
+  }
+  if (testGetDistributionInfo) {
+    if (failed(testGetDistributionInfoImpl(op))) {
+      return signalPassFailure();
+    }
+    return;
+  }
+
   SmallVector<scf::ForallOp> forallOps;
-  SmallVector<IREE::TensorExt::SparseCastOpInterface> sparseInterfaceOps;
-  op->walk([&](Operation *op) {
-    if (auto forallOp = dyn_cast<scf::ForallOp>(op)) {
-      forallOps.push_back(forallOp);
-    }
-    if (auto sparseOp = dyn_cast<IREE::TensorExt::SparseCastOpInterface>(op)) {
-      sparseInterfaceOps.push_back(sparseOp);
-    }
-  });
+  op->walk([&](scf::ForallOp forallOp) { forallOps.push_back(forallOp); });
 
   if (!llvm::hasSingleElement(forallOps)) {
     op->emitError("expected a single ForallOp");

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/BUILD.bazel
@@ -18,8 +18,10 @@ iree_lit_test_suite(
         # keep sorted
         [
             "sparse_interface_methods.mlir",
+            "sparse_interface_methods_distribution_info.mlir",
             "sparse_interface_methods_estimated_loop_range_fail.mlir",
             "sparse_interface_methods_lower_loop_range_fail.mlir",
+            "sparse_interface_methods_resolve_range.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/CMakeLists.txt
@@ -15,8 +15,10 @@ iree_lit_test_suite(
     lit
   SRCS
     "sparse_interface_methods.mlir"
+    "sparse_interface_methods_distribution_info.mlir"
     "sparse_interface_methods_estimated_loop_range_fail.mlir"
     "sparse_interface_methods_lower_loop_range_fail.mlir"
+    "sparse_interface_methods_resolve_range.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods.mlir
@@ -31,12 +31,12 @@ func.func public @simpleTest(%source : memref<?x?xf32>, %column_lengths: memref<
 // LOWER-LOOP-RANGE:   %[[C1:.*]] = arith.constant 1 : index
 // LOWER-LOOP-RANGE:   scf.for %[[IV0:.+]] = %[[LB0]] to %[[NUM_ROWS]] step %[[STEP0]] {
 // LOWER-LOOP-RANGE:     %[[PLUSONE:.+]] = arith.addi %[[IV0]], %[[C1]]
-// LOWER-LOOP-RANGE:     %[[ROW_UB_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
-// LOWER-LOOP-RANGE:     %[[ROW_UB:.+]] = arith.index_cast %[[ROW_UB_I32]] : i32 to index
-// LOWER-LOOP-RANGE:     %[[ROW_LB_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[IV0]]]
-// LOWER-LOOP-RANGE:     %[[ROW_LB:.+]] = arith.index_cast %[[ROW_LB_I32]] : i32 to index
-// LOWER-LOOP-RANGE:     %[[LB:.+]] = affine.max affine_map<()[s0, s1] -> (s0, s1)>()[%[[LB1]], %[[ROW_LB]]]
-// LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB]] to %[[ROW_UB]] step %[[STEP1]] {
+// LOWER-LOOP-RANGE:     %[[COL_END_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
+// LOWER-LOOP-RANGE:     %[[COL_START_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[IV0]]]
+// LOWER-LOOP-RANGE:     %[[COL_END:.+]] = arith.index_cast %[[COL_END_I32]] : i32 to index
+// LOWER-LOOP-RANGE:     %[[COL_START:.+]] = arith.index_cast %[[COL_START_I32]] : i32 to index
+// LOWER-LOOP-RANGE:     %[[COL_RANGE:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 - s1)>()[%[[COL_END]], %[[COL_START]]]
+// LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB1]] to %[[COL_RANGE]] step %[[STEP1]] {
 // LOWER-LOOP-RANGE:       "some_op"(%[[IV0]], %[[IV1]])
 
 // GET-ESTIMATED-LOOP-RANGE: %[[C0:.+]] = arith.constant 0 : index
@@ -78,12 +78,12 @@ func.func public @testEstimatedColumnLength(%source : memref<?x?xf32>, %column_l
 // LOWER-LOOP-RANGE:   %[[C1:.*]] = arith.constant 1 : index
 // LOWER-LOOP-RANGE:   scf.for %[[IV0:.+]] = %[[LB0]] to %[[NUM_ROWS]] step %[[STEP0]] {
 // LOWER-LOOP-RANGE:     %[[PLUSONE:.+]] = arith.addi %[[IV0]], %[[C1]]
-// LOWER-LOOP-RANGE:     %[[ROW_UB_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
-// LOWER-LOOP-RANGE:     %[[ROW_UB:.+]] = arith.index_cast %[[ROW_UB_I32]] : i32 to index
-// LOWER-LOOP-RANGE:     %[[ROW_LB_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[IV0]]]
-// LOWER-LOOP-RANGE:     %[[ROW_LB:.+]] = arith.index_cast %[[ROW_LB_I32]] : i32 to index
-// LOWER-LOOP-RANGE:     %[[LB:.+]] = affine.max affine_map<()[s0, s1] -> (s0, s1)>()[%[[LB1]], %[[ROW_LB]]]
-// LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB]] to %[[ROW_UB]] step %[[STEP1]] {
+// LOWER-LOOP-RANGE:     %[[COL_END_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
+// LOWER-LOOP-RANGE:     %[[COL_START_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[IV0]]]
+// LOWER-LOOP-RANGE:     %[[COL_END:.+]] = arith.index_cast %[[COL_END_I32]] : i32 to index
+// LOWER-LOOP-RANGE:     %[[COL_START:.+]] = arith.index_cast %[[COL_START_I32]] : i32 to index
+// LOWER-LOOP-RANGE:     %[[COL_RANGE:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 - s1)>()[%[[COL_END]], %[[COL_START]]]
+// LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB1]] to %[[COL_RANGE]] step %[[STEP1]] {
 // LOWER-LOOP-RANGE:       "some_op"(%[[IV0]], %[[IV1]])
 
 //      GET-ESTIMATED-LOOP-RANGE: %[[EST_COLS:.+]] = affine.apply
@@ -136,12 +136,12 @@ func.func public @nonOuterMostSparseLoops(%source : memref<?x?x?xf32>, %column_l
 // LOWER-LOOP-RANGE:   scf.for %[[IV0:.+]] =
 // LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB1]] to %[[NUM_ROWS]] step %[[STEP1]] {
 // LOWER-LOOP-RANGE:       %[[PLUSONE:.+]] = arith.addi %[[IV1]], %[[C1]]
-// LOWER-LOOP-RANGE:       %[[ROW_UB_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
-// LOWER-LOOP-RANGE:       %[[ROW_UB:.+]] = arith.index_cast %[[ROW_UB_I32]] : i32 to index
-// LOWER-LOOP-RANGE:       %[[ROW_LB_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[IV1]]]
-// LOWER-LOOP-RANGE:       %[[ROW_LB:.+]] = arith.index_cast %[[ROW_LB_I32]] : i32 to index
-// LOWER-LOOP-RANGE:       %[[LB:.+]] = affine.max affine_map<()[s0, s1] -> (s0, s1)>()[%[[LB2]], %[[ROW_LB]]]
-// LOWER-LOOP-RANGE:       scf.for %[[IV2:.+]] = %[[LB]] to %[[ROW_UB]] step %[[STEP2]] {
+// LOWER-LOOP-RANGE:       %[[COL_END_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
+// LOWER-LOOP-RANGE:       %[[COL_START_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[IV1]]]
+// LOWER-LOOP-RANGE:       %[[COL_END:.+]] = arith.index_cast %[[COL_END_I32]] : i32 to index
+// LOWER-LOOP-RANGE:       %[[COL_START:.+]] = arith.index_cast %[[COL_START_I32]] : i32 to index
+// LOWER-LOOP-RANGE:       %[[COL_RANGE:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 - s1)>()[%[[COL_END]], %[[COL_START]]]
+// LOWER-LOOP-RANGE:       scf.for %[[IV2:.+]] = %[[LB2]] to %[[COL_RANGE]] step %[[STEP2]] {
 // LOWER-LOOP-RANGE:         scf.for %[[IV3:.+]] =
 // LOWER-LOOP-RANGE:           "some_op"(%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]])
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods.mlir
@@ -152,3 +152,53 @@ func.func public @nonOuterMostSparseLoops(%source : memref<?x?x?xf32>, %column_l
 // GET-ESTIMATED-LOOP-RANGE-SAME:     = (%[[LB0]], %[[LB1]], %[[LB2]], %[[LB3]]) to (%{{[a-zA-Z0-9_]+}}, %[[NUM_ROWS]], %[[UB2]], %{{[a-zA-Z0-9_]+}})
 // GET-ESTIMATED-LOOP-RANGE-SAME:     step (%[[STEP0]], %[[STEP1]], %[[STEP2]], %[[STEP3]]) {
 //      GET-ESTIMATED-LOOP-RANGE:   "some_op"(%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]])
+
+// -----
+
+// Check interface methods for tensor types (instead of memref).
+func.func public @tensorTest(%source : tensor<?x?xf32>, %column_lengths: tensor<?xi32>,
+    %num_rows: index, %lb0 : index, %lb1 : index, %step0 : index, %step1 : index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %source_d0 = tensor.dim %source, %c0 : tensor<?x?xf32>
+  %source_d1 = tensor.dim %source, %c1 : tensor<?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source
+      ragged_dim(0) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
+      : (tensor<?x?xf32>{%source_d0, %source_d1}, tensor<?xi32>)
+      -> tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  %d0 = tensor.dim %0, %c0 : tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  %d1 = tensor.dim %0, %c1 : tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  scf.forall (%i, %j) = (%lb0, %lb1) to (%d0, %d1) step (%step0, %step1) {
+    "some_op"(%i, %j) : (index, index) -> ()
+  } {iree_tensor_ext.sparse_iteration_dims = #iree_tensor_ext.sparse_iteration_dims<[0, 1]>}
+  return
+}
+// CHECK-ALL-LABEL: func public @tensorTest(
+//  CHECK-ALL-SAME:     %[[SOURCE:.+]]: tensor<?x?xf32>,
+//  CHECK-ALL-SAME:     %[[COLUMN_LENGTHS:.+]]: tensor<?xi32>,
+//  CHECK-ALL-SAME:     %[[NUM_ROWS:[a-zA-Z0-9]+]]: index,
+//  CHECK-ALL-SAME:     %[[LB0:[a-zA-Z0-9]+]]: index
+//  CHECK-ALL-SAME:     %[[LB1:[a-zA-Z0-9]+]]: index
+//  CHECK-ALL-SAME:     %[[STEP0:[a-zA-Z0-9]+]]: index,
+//  CHECK-ALL-SAME:     %[[STEP1:[a-zA-Z0-9]+]]: index) {
+
+// LOWER-LOOP-RANGE:   %[[C1:.*]] = arith.constant 1 : index
+// LOWER-LOOP-RANGE:   scf.for %[[IV0:.+]] = %[[LB0]] to %[[NUM_ROWS]] step %[[STEP0]] {
+// LOWER-LOOP-RANGE:     %[[PLUSONE:.+]] = arith.addi %[[IV0]], %[[C1]]
+// LOWER-LOOP-RANGE:     %[[COL_END_I32:.+]] = tensor.extract %[[COLUMN_LENGTHS]][%[[PLUSONE]]]
+// LOWER-LOOP-RANGE:     %[[COL_START_I32:.+]] = tensor.extract %[[COLUMN_LENGTHS]][%[[IV0]]]
+// LOWER-LOOP-RANGE:     %[[COL_END:.+]] = arith.index_cast %[[COL_END_I32]] : i32 to index
+// LOWER-LOOP-RANGE:     %[[COL_START:.+]] = arith.index_cast %[[COL_START_I32]] : i32 to index
+// LOWER-LOOP-RANGE:     %[[COL_RANGE:.+]] = affine.apply
+// LOWER-LOOP-RANGE-SAME:    affine_map<()[s0, s1] -> (s0 - s1)>()[%[[COL_END]], %[[COL_START]]]
+// LOWER-LOOP-RANGE:     scf.for %[[IV1:.+]] = %[[LB1]] to %[[COL_RANGE]] step %[[STEP1]] {
+// LOWER-LOOP-RANGE:       "some_op"(%[[IV0]], %[[IV1]])
+
+//      GET-ESTIMATED-LOOP-RANGE: %[[C0:.+]] = arith.constant 0 : index
+//      GET-ESTIMATED-LOOP-RANGE: %[[D0:.+]] = tensor.dim %[[SOURCE]], %[[C0]]
+//      GET-ESTIMATED-LOOP-RANGE: %[[UB1:.+]] = affine.apply
+// GET-ESTIMATED-LOOP-RANGE-SAME:     affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%[[D0]], %[[NUM_ROWS]]]
+//      GET-ESTIMATED-LOOP-RANGE: scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]])
+// GET-ESTIMATED-LOOP-RANGE-SAME:     = (%[[LB0]], %[[LB1]]) to (%[[NUM_ROWS]], %[[UB1]])
+// GET-ESTIMATED-LOOP-RANGE-SAME:     step (%[[STEP0]], %[[STEP1]]) {
+//      GET-ESTIMATED-LOOP-RANGE:   "some_op"(%[[IV0]], %[[IV1]])

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods_distribution_info.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods_distribution_info.mlir
@@ -1,0 +1,41 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-tensor-ext-test-sparse-op-interface-methods{test-get-distribution-info=true}))' %s --split-input-file --allow-unregistered-dialect --mlir-print-local-scope --verify-diagnostics | FileCheck %s
+
+// For ragged_dim(0): sparse dims are [0, 1].
+// Dim 0 (outer) is distributable, dim 1 (inner) is not.
+func.func public @distributionInfoRaggedDim0(
+    %source : memref<?x?xf32>, %column_lengths: memref<?xi32>,
+    %num_rows: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %source_d0 = memref.dim %source, %c0 : memref<?x?xf32>
+  %source_d1 = memref.dim %source, %c1 : memref<?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source
+      ragged_dim(0) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
+      : (memref<?x?xf32>{%source_d0, %source_d1}, memref<?xi32>)
+      -> memref<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  return
+}
+// CHECK-LABEL: func public @distributionInfoRaggedDim0
+//       CHECK:   "test.distribution_info"() {distributable = array<i1: true, false>}
+
+// -----
+
+// For ragged_dim(1): sparse dims are [1, 2].
+// Dim 1 (outer) is distributable, dim 2 (inner) is not.
+func.func public @distributionInfoRaggedDim1(
+    %source : memref<?x?x?xf32>, %column_lengths: memref<?xi32>,
+    %num_rows: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %source_d0 = memref.dim %source, %c0 : memref<?x?x?xf32>
+  %source_d1 = memref.dim %source, %c1 : memref<?x?x?xf32>
+  %source_d2 = memref.dim %source, %c2 : memref<?x?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source
+      ragged_dim(1) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
+      : (memref<?x?x?xf32>{%source_d0, %source_d1, %source_d2}, memref<?xi32>)
+      -> memref<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  return
+}
+// CHECK-LABEL: func public @distributionInfoRaggedDim1
+//       CHECK:   "test.distribution_info"() {distributable = array<i1: true, false>}

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods_lower_loop_range_fail.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods_lower_loop_range_fail.mlir
@@ -1,8 +1,9 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-tensor-ext-test-sparse-op-interface-methods{test-lower-loop-range=true}, cse))' %s --split-input-file --allow-unregistered-dialect --mlir-print-local-scope --verify-diagnostics
 
-// Test failure when the sparse loops are not resolvable. In this case it isnt resolvable since
-// the resolution is only invoked for the 1-th dimension of the `scf.forall` (instead of for the `[1, 2]`).
-func.func public @nonOuterMostSparseLoops(%source : memref<?x?x?xf32>, %column_lengths: memref<?xi32>,
+// Test failure when only the inner sparse dimension is provided without the
+// outer dimension. The inner loop depends on the outer IV for computing column
+// bounds, so it cannot be lowered independently.
+func.func public @innerWithoutOuter(%source : memref<?x?x?xf32>, %column_lengths: memref<?xi32>,
     %num_rows: index, %lb0 : index, %lb1 : index, %lb2 : index, %lb3 : index,
     %step0 : index, %step1 : index, %step2 : index, %step3 : index) {
   %c0 = arith.constant 0 : index
@@ -12,7 +13,7 @@ func.func public @nonOuterMostSparseLoops(%source : memref<?x?x?xf32>, %column_l
   %source_d0 = memref.dim %source, %c0 : memref<?x?x?xf32>
   %source_d1 = memref.dim %source, %c1 : memref<?x?x?xf32>
   %source_d2 = memref.dim %source, %c2 : memref<?x?x?xf32>
-  // expected-error @+1 {{cannot lower the loop range for given sparse dimensions}}
+  // expected-error @+1 {{cannot lower inner sparse dimension without outer dimension}}
   %0 = iree_tensor_ext.cast_to_ragged_shape %source
       ragged_dim(1) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
       : (memref<?x?x?xf32>{%source_d0, %source_d1, %source_d2}, memref<?xi32>)
@@ -23,6 +24,6 @@ func.func public @nonOuterMostSparseLoops(%source : memref<?x?x?xf32>, %column_l
   %d3 = memref.dim %0, %c3 : memref<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
   scf.forall (%i, %j, %k, %l) = (%lb0, %lb1, %lb2, %lb3) to (%d0, %d1, %d2, %d3) step (%step0, %step1, %step2, %step3) {
     "some_op"(%i, %j, %k, %l) : (index, index, index, index) -> ()
-  } {iree_tensor_ext.sparse_iteration_dims = #iree_tensor_ext.sparse_iteration_dims<[1]>}
+  } {iree_tensor_ext.sparse_iteration_dims = #iree_tensor_ext.sparse_iteration_dims<[2]>}
   return
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods_resolve_range.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/test/sparse_interface_methods_resolve_range.mlir
@@ -1,0 +1,109 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-tensor-ext-test-sparse-op-interface-methods{test-resolve-range=true}))' %s --split-input-file --allow-unregistered-dialect --mlir-print-local-scope --verify-diagnostics | FileCheck %s
+
+// Test resolveRange for a simple 2D ragged tensor (memref).
+// The test.range operands specify (offset, size, stride) triples for each
+// result dimension:
+//   dim 0 (outer sparse): offset=%row_idx, size=1, stride=1
+//   dim 1 (inner sparse): offset=%col_offset, size=%col_size, stride=1
+//   dim 2 (dense): offset=%dense_offset, size=%dense_size, stride=1
+//
+// Expected resolved range (2D source):
+//   dim 0: offset = column_lengths[row_idx] + col_offset,
+//          size = col_size, stride = 1
+//   dim 1: offset = dense_offset, size = dense_size, stride = 1
+func.func public @resolveRangeMemref(
+    %source : memref<?x?xf32>, %column_lengths: memref<?xi32>,
+    %num_rows: index, %row_idx: index, %col_offset: index,
+    %col_size: index, %dense_offset: index, %dense_size: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %source_d0 = memref.dim %source, %c0 : memref<?x?xf32>
+  %source_d1 = memref.dim %source, %c1 : memref<?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source
+      ragged_dim(0) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
+      : (memref<?x?xf32>{%source_d0, %source_d1}, memref<?xi32>)
+      -> memref<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  "test.range"(%row_idx, %c1, %c1,
+               %col_offset, %col_size, %c1,
+               %dense_offset, %dense_size, %c1)
+      : (index, index, index, index, index, index, index, index, index) -> ()
+  return
+}
+// CHECK-LABEL: func public @resolveRangeMemref(
+//  CHECK-SAME:     %[[SOURCE:.+]]: memref<?x?xf32>,
+//  CHECK-SAME:     %[[COLUMN_LENGTHS:.+]]: memref<?xi32>,
+//  CHECK-SAME:     %[[NUM_ROWS:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[ROW_IDX:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[COL_OFFSET:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[COL_SIZE:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[DENSE_OFFSET:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[DENSE_SIZE:[a-zA-Z0-9]+]]: index) {
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:   %[[COL_LEN_I32:.+]] = memref.load %[[COLUMN_LENGTHS]][%[[ROW_IDX]]]
+//       CHECK:   %[[COL_LEN:.+]] = arith.index_cast %[[COL_LEN_I32]] : i32 to index
+//       CHECK:   %[[LINEARIZED:.+]] = affine.apply
+//  CHECK-SAME:       affine_map<()[s0, s1] -> (s0 + s1)>()[%[[COL_LEN]], %[[COL_OFFSET]]]
+//       CHECK:   "test.resolved_range"(%[[LINEARIZED]], %[[COL_SIZE]], %[[C1]],
+//  CHECK-SAME:       %[[DENSE_OFFSET]], %[[DENSE_SIZE]], %[[C1]])
+
+// -----
+
+// Test resolveRange for a 2D ragged tensor with tensor types.
+func.func public @resolveRangeTensor(
+    %source : tensor<?x?xf32>, %column_lengths: tensor<?xi32>,
+    %num_rows: index, %row_idx: index, %col_offset: index,
+    %col_size: index, %dense_offset: index, %dense_size: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %source_d0 = tensor.dim %source, %c0 : tensor<?x?xf32>
+  %source_d1 = tensor.dim %source, %c1 : tensor<?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source
+      ragged_dim(0) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
+      : (tensor<?x?xf32>{%source_d0, %source_d1}, tensor<?xi32>)
+      -> tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  "test.range"(%row_idx, %c1, %c1,
+               %col_offset, %col_size, %c1,
+               %dense_offset, %dense_size, %c1)
+      : (index, index, index, index, index, index, index, index, index) -> ()
+  return
+}
+// CHECK-LABEL: func public @resolveRangeTensor(
+//  CHECK-SAME:     %[[SOURCE:.+]]: tensor<?x?xf32>,
+//  CHECK-SAME:     %[[COLUMN_LENGTHS:.+]]: tensor<?xi32>,
+//  CHECK-SAME:     %[[NUM_ROWS:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[ROW_IDX:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[COL_OFFSET:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[COL_SIZE:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[DENSE_OFFSET:[a-zA-Z0-9]+]]: index,
+//  CHECK-SAME:     %[[DENSE_SIZE:[a-zA-Z0-9]+]]: index) {
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:   %[[COL_LEN_I32:.+]] = tensor.extract %[[COLUMN_LENGTHS]][%[[ROW_IDX]]]
+//       CHECK:   %[[COL_LEN:.+]] = arith.index_cast %[[COL_LEN_I32]] : i32 to index
+//       CHECK:   %[[LINEARIZED:.+]] = affine.apply
+//  CHECK-SAME:       affine_map<()[s0, s1] -> (s0 + s1)>()[%[[COL_LEN]], %[[COL_OFFSET]]]
+//       CHECK:   "test.resolved_range"(%[[LINEARIZED]], %[[COL_SIZE]], %[[C1]],
+//  CHECK-SAME:       %[[DENSE_OFFSET]], %[[DENSE_SIZE]], %[[C1]])
+
+// -----
+
+// Test failure when the outer sparse dimension size is not 1.
+func.func public @outerSparseSizeNotOne(
+    %source : memref<?x?xf32>, %column_lengths: memref<?xi32>,
+    %num_rows: index, %row_idx: index, %col_offset: index,
+    %col_size: index, %dense_offset: index, %dense_size: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %source_d0 = memref.dim %source, %c0 : memref<?x?xf32>
+  %source_d1 = memref.dim %source, %c1 : memref<?x?xf32>
+  // expected-error @+1 {{expected outer sparse dimension size and stride to be 1 in givenRanges}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source
+      ragged_dim(0) column_lengths(%column_lengths) num_ragged_rows(%num_rows)
+      : (memref<?x?xf32>{%source_d0, %source_d1}, memref<?xi32>)
+      -> memref<?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  "test.range"(%row_idx, %c2, %c1,
+               %col_offset, %col_size, %c1,
+               %dense_offset, %dense_size, %c1)
+      : (index, index, index, index, index, index, index, index, index) -> ()
+  return
+}


### PR DESCRIPTION
This is PR 2/N of landing block sparse changes that are captured in this
branch :
https://github.com/MaheshRavishankar/iree/tree/users/MaheshRavishankar/blockSparseCommits

Extends SparseCastOpInterface with two new methods:                                                         
  - `resolveRange`: Resolves a range from sparse result space to source                                       
    tensor space by computing linearized offsets via column_lengths.                                          
    Accepts an inBounds bit vector and optional padding value for future                                      
    out-of-bounds guard generation.                                                                           
  - `getDistributionInfoForSparseDimensions`: Returns which sparse                                            
    dimensions can be distributed across workgroups. For ragged tensors,                                      
    only the outer sparse dimension is distributable since the inner                                          
    dimension bounds depend on the outer IV.                                                                  
                                                                                                              
Also refactors `lowerLoopRange` to support lowering individual sparse                                       
dimensions independently (outer-only or both), and switches the inner                                       
loop to iterate in relative index space (0..columnLength) rather than                                       
absolute linearized space.
                                                                    
Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>  