### PR TITLE
[LLVMGPU] Modernize GPU pipeline tests.

### DIFF
--- a/compiler/plugins/target/ROCM/test/emit_debug_info.mlir
+++ b/compiler/plugins/target/ROCM/test/emit_debug_info.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --mlir-print-debuginfo --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline{preserve-debug-info}))))" %s | FileCheck %s --check-prefix=WITH-DEBUG
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --mlir-print-debuginfo --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=WITHOUT-DEBUG
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --mlir-print-debuginfo --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline='preserve-debug-info' %s | FileCheck %s --check-prefix=WITH-DEBUG
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --mlir-print-debuginfo --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=WITHOUT-DEBUG
 
 // Test that debug location information is preserved when the pipeline
 // `preserve-debug-info` option is used, and stripped otherwise.
@@ -9,28 +9,21 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-hal.executable @debug_test {
-  hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @debug_test layout(#pipeline_layout)
-    builtin.module {
-      func.func @debug_test() {
-        %c0 = arith.constant 0 : index loc("test.mlir":1:1)
-        %c2 = arith.constant 2.0 : f32 loc("test.mlir":2:1)
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> loc("test.mlir":3:1)
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>> loc("test.mlir":4:1)
-        %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[4], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> -> tensor<4xf32> loc("test.mlir":5:1)
-        %3 = tensor.empty() : tensor<4xf32> loc("test.mlir":6:1)
-        %4 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
-             ins(%2 : tensor<4xf32>) outs(%3 : tensor<4xf32>) {
-        ^bb0(%in: f32 loc("test.mlir":8:1), %out: f32 loc("test.mlir":8:2)):
-          %5 = arith.mulf %in, %c2 : f32 loc("test.mlir":9:1)
-          linalg.yield %5 : f32 loc("test.mlir":10:1)
-        } -> tensor<4xf32> loc("test.mlir":7:1)
-        iree_tensor_ext.dispatch.tensor.store %4, %1, offsets=[0], sizes=[4], strides=[1] : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>> loc("test.mlir":11:1)
-        return loc("test.mlir":12:1)
-      }
-    }
-  }
+func.func @debug_test() {
+  %c0 = arith.constant 0 : index loc("test.mlir":1:1)
+  %c2 = arith.constant 2.0 : f32 loc("test.mlir":2:1)
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> loc("test.mlir":3:1)
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>> loc("test.mlir":4:1)
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[4], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> -> tensor<4xf32> loc("test.mlir":5:1)
+  %3 = tensor.empty() : tensor<4xf32> loc("test.mlir":6:1)
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+       ins(%2 : tensor<4xf32>) outs(%3 : tensor<4xf32>) {
+  ^bb0(%in: f32 loc("test.mlir":8:1), %out: f32 loc("test.mlir":8:2)):
+    %5 = arith.mulf %in, %c2 : f32 loc("test.mlir":9:1)
+    linalg.yield %5 : f32 loc("test.mlir":10:1)
+  } -> tensor<4xf32> loc("test.mlir":7:1)
+  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets=[0], sizes=[4], strides=[1] : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>> loc("test.mlir":11:1)
+  return loc("test.mlir":12:1)
 }
 
 // WITH-DEBUG: loc("test.mlir":9:1

--- a/compiler/src/iree/compiler/Codegen/Common/MathTransform.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MathTransform.cpp
@@ -161,9 +161,6 @@ public:
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     auto target = IREE::HAL::ExecutableTargetAttr::lookup(getOperation());
-    if (!target) {
-      return signalPassFailure();
-    }
     populateMathFunctionsRewritePatterns(patterns, [target](StringRef name) {
       return predicateRewrite(name, target);
     });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1242,8 +1242,8 @@ void registerCodegenLLVMGPUPasses() {
   // Generated.
   common::registerPasses();
 
-  struct LLVMGPUPipelineOptions final
-      : PassPipelineOptions<LLVMGPUPipelineOptions> {
+  struct LLVMGPULoweringPipelineOptions final
+      : PassPipelineOptions<LLVMGPULoweringPipelineOptions> {
     Option<bool> preserveDebugInfo{
         *this, "preserve-debug-info",
         llvm::cl::desc("Preserve debug information (do not strip)")};
@@ -1257,23 +1257,25 @@ void registerCodegenLLVMGPUPasses() {
         buildLLVMGPUCodegenConfigurationPassPipelineImpl(modulePassManager);
       });
 
-  static PassPipelineRegistration<LLVMGPUPipelineOptions> LinalgNVVMPipeline(
-      "iree-codegen-linalg-to-nvvm-pipeline",
-      "Runs the progressive lowering pipeline from Linalg to NVVM",
-      [](OpPassManager &modulePassManager,
-         const LLVMGPUPipelineOptions &options) {
-        buildLLVMGPUCodegenPassPipeline(modulePassManager, false,
-                                        options.preserveDebugInfo);
-      });
+  static PassPipelineRegistration<LLVMGPULoweringPipelineOptions>
+      LLVMGPUNVVMLoweringPipeline(
+          "iree-codegen-llvmgpu-nvvm-lowering-pipeline",
+          "Runs the LLVMGPU NVVM lowering pipeline",
+          [](OpPassManager &modulePassManager,
+             const LLVMGPULoweringPipelineOptions &options) {
+            buildLLVMGPUCodegenPassPipeline(modulePassManager, false,
+                                            options.preserveDebugInfo);
+          });
 
-  static PassPipelineRegistration<LLVMGPUPipelineOptions> LinalgROCDLPipeline(
-      "iree-codegen-linalg-to-rocdl-pipeline",
-      "Runs the progressive lowering pipeline from Linalg to ROCDL",
-      [](OpPassManager &modulePassManager,
-         const LLVMGPUPipelineOptions &options) {
-        buildLLVMGPUCodegenPassPipeline(modulePassManager, true,
-                                        options.preserveDebugInfo);
-      });
+  static PassPipelineRegistration<LLVMGPULoweringPipelineOptions>
+      LLVMGPUROCDLLoweringPipeline(
+          "iree-codegen-llvmgpu-rocdl-lowering-pipeline",
+          "Runs the LLVMGPU ROCDL lowering pipeline",
+          [](OpPassManager &modulePassManager,
+             const LLVMGPULoweringPipelineOptions &options) {
+            buildLLVMGPUCodegenPassPipeline(modulePassManager, true,
+                                            options.preserveDebugInfo);
+          });
 
   static PassPipelineRegistration<> LLVMGPULinkingPipeline(
       "iree-codegen-llvmgpu-linking-pipeline",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAnnotateKernelForTranslation.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAnnotateKernelForTranslation.cpp
@@ -95,16 +95,17 @@ annotateKernelForTranslation(LLVM::LLVMFuncOp funcOp,
         builder.getStringAttr(Twine(flatWgSize) + "," + Twine(flatWgSize)));
   }
 
-  IREE::HAL::ExecutableTargetAttr targetAttr =
-      IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
-  if (IntegerAttr attr =
-          getConfigWavesPerEuAttr(targetAttr.getConfiguration())) {
-    rocdlDialect->getWavesPerEuAttrHelper().setAttr(funcOp, attr);
-  }
-  if (IREE::Codegen::DenormalFpMathAttr attr =
-          getConfigDenormalFpMathF32Attr(targetAttr.getConfiguration());
-      attr && attr.getValue() != IREE::Codegen::DenormalFpMath::None) {
-    setDenormalFpenvForF32(funcOp, toLLVMDenormalModeKind(attr.getValue()));
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+  if (targetAttr && targetAttr.getConfiguration()) {
+    if (IntegerAttr attr =
+            getConfigWavesPerEuAttr(targetAttr.getConfiguration())) {
+      rocdlDialect->getWavesPerEuAttrHelper().setAttr(funcOp, attr);
+    }
+    if (IREE::Codegen::DenormalFpMathAttr attr =
+            getConfigDenormalFpMathF32Attr(targetAttr.getConfiguration());
+        attr && attr.getValue() != IREE::Codegen::DenormalFpMath::None) {
+      setDenormalFpenvForF32(funcOp, toLLVMDenormalModeKind(attr.getValue()));
+    }
   }
 
   // Check if the `denormal_fp_math_f32` dictionary is set and process it.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
@@ -1,12 +1,12 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=CDNA3
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=CDNA3
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
 
 // With --iree-llvmgpu-enable-small-float-emulation, unsupported chips use software emulation.
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=EMULATED
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=EMULATED
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-llvmgpu-enable-small-float-emulation --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-llvmgpu-enable-small-float-emulation --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --iree-llvmgpu-enable-small-float-emulation --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=EMULATED
 
 #map = affine_map<(d0) -> (d0)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -14,48 +14,36 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @ext_fp8_dispatch {
-  hal.executable.variant @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @ext_fp8_dispatch layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @ext_fp8_dispatch() {
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FNUZ>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2FNUZ>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
-        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FNUZ>> -> tensor<4096xf8E4M3FNUZ>
-        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2FNUZ>> -> tensor<4096xf8E5M2FNUZ>
-        %5 = tensor.empty() : tensor<4096xf32>
-        %6 = linalg.generic {indexing_maps = [#map, #map, #map],
-                             iterator_types = ["parallel"]}
-                             ins(%3, %4 : tensor<4096xf8E4M3FNUZ>, tensor<4096xf8E5M2FNUZ>)
-                             outs(%5 : tensor<4096xf32>) {
-        ^bb0(%in0: f8E4M3FNUZ, %in1: f8E5M2FNUZ, %out: f32):
-          %7 = arith.extf %in0 : f8E4M3FNUZ to f32
-          %8 = arith.extf %in1 : f8E5M2FNUZ to f32
-          %9 = arith.addf %7, %8 : f32
-          linalg.yield %9 : f32
-        } -> tensor<4096xf32>
-        iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
-        return
-      }
-    }
-  }
+func.func @ext_fp8_dispatch() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FNUZ>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2FNUZ>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FNUZ>> -> tensor<4096xf8E4M3FNUZ>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2FNUZ>> -> tensor<4096xf8E5M2FNUZ>
+  %5 = tensor.empty() : tensor<4096xf32>
+  %6 = linalg.generic {indexing_maps = [#map, #map, #map],
+                       iterator_types = ["parallel"]}
+                       ins(%3, %4 : tensor<4096xf8E4M3FNUZ>, tensor<4096xf8E5M2FNUZ>)
+                       outs(%5 : tensor<4096xf32>) {
+  ^bb0(%in0: f8E4M3FNUZ, %in1: f8E5M2FNUZ, %out: f32):
+    %7 = arith.extf %in0 : f8E4M3FNUZ to f32
+    %8 = arith.extf %in1 : f8E5M2FNUZ to f32
+    %9 = arith.addf %7, %8 : f32
+    linalg.yield %9 : f32
+  } -> tensor<4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+  return
 }
 
 // ERRORS: F8E5M2FNUZ and F8E4M3FNUZ types are not supported on non-gfx942 (MI-300) chipsets; try F8E5M2 or F8E4M3FN instead, or use --iree-llvmgpu-enable-small-float-emulation
 
-//   CDNA3-LABEL: hal.executable public @ext_fp8_dispatch {
-//         CDNA3:   hal.executable.variant public @rocm
-// CDNA3-COUNT-8:     rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
-// CDNA3-COUNT-8:     rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
-//         CDNA3:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
-//         CDNA3:     llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
+//   CDNA3-LABEL: llvm.func @ext_fp8_dispatch
+// CDNA3-COUNT-8:   rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
+// CDNA3-COUNT-8:   rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
+//         CDNA3:   %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
+//         CDNA3:   llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
 
-// EMULATED-LABEL: hal.executable public @ext_fp8_dispatch {
-//       EMULATED:   hal.executable.variant public @rocm
-//       EMULATED:     llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
-//       EMULATED:     llvm.store %{{.*}}, %{{.*}} : vector<16xf32>, !llvm.ptr<7>
+// EMULATED-LABEL: llvm.func @ext_fp8_dispatch
+//       EMULATED:   llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
+//       EMULATED:   llvm.store %{{.*}}, %{{.*}} : vector<16xf32>, !llvm.ptr<7>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8ocp.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8ocp.mlir
@@ -1,12 +1,12 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=OCP
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=OCP
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=OCP
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=OCP
 
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
-// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
+// RUN: not iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline -o /dev/null 2>&1 %s | FileCheck %s --check-prefix=ERRORS
 
 // With --iree-llvmgpu-enable-small-float-emulation, unsupported chips use software emulation.
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=EMULATED
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-llvmgpu-enable-small-float-emulation --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-llvmgpu-enable-small-float-emulation --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=EMULATED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-llvmgpu-enable-small-float-emulation --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s --check-prefix=EMULATED
 
 #map = affine_map<(d0) -> (d0)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -14,48 +14,36 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @ext_fp8_dispatch {
-  hal.executable.variant @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @ext_fp8_dispatch layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @ext_fp8_dispatch() {
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FN>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
-        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FN>> -> tensor<4096xf8E4M3FN>
-        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2>> -> tensor<4096xf8E5M2>
-        %5 = tensor.empty() : tensor<4096xf32>
-        %6 = linalg.generic {indexing_maps = [#map, #map, #map],
-                             iterator_types = ["parallel"]}
-                             ins(%3, %4 : tensor<4096xf8E4M3FN>, tensor<4096xf8E5M2>)
-                             outs(%5 : tensor<4096xf32>) {
-        ^bb0(%in0: f8E4M3FN, %in1: f8E5M2, %out: f32):
-          %7 = arith.extf %in0 : f8E4M3FN to f32
-          %8 = arith.extf %in1 : f8E5M2 to f32
-          %9 = arith.addf %7, %8 : f32
-          linalg.yield %9 : f32
-        } -> tensor<4096xf32>
-        iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
-        return
-      }
-    }
-  }
+func.func @ext_fp8_dispatch() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FN>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E4M3FN>> -> tensor<4096xf8E4M3FN>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf8E5M2>> -> tensor<4096xf8E5M2>
+  %5 = tensor.empty() : tensor<4096xf32>
+  %6 = linalg.generic {indexing_maps = [#map, #map, #map],
+                       iterator_types = ["parallel"]}
+                       ins(%3, %4 : tensor<4096xf8E4M3FN>, tensor<4096xf8E5M2>)
+                       outs(%5 : tensor<4096xf32>) {
+  ^bb0(%in0: f8E4M3FN, %in1: f8E5M2, %out: f32):
+    %7 = arith.extf %in0 : f8E4M3FN to f32
+    %8 = arith.extf %in1 : f8E5M2 to f32
+    %9 = arith.addf %7, %8 : f32
+    linalg.yield %9 : f32
+  } -> tensor<4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+  return
 }
 
 // ERRORS: F8E5M2 and F8E4M3FN types are not supported on gfx942 (MI-300) or older chipsets; try F8E5M2FNUZ or F8E4M3FNUZ instead, or use --iree-llvmgpu-enable-small-float-emulation
 
-//   OCP-LABEL: hal.executable public @ext_fp8_dispatch {
-//         OCP:   hal.executable.variant public @rocm
-// OCP-COUNT-8:     rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
-// OCP-COUNT-8:     rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
-//         OCP:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
-//         OCP:     llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
+//   OCP-LABEL: llvm.func @ext_fp8_dispatch
+// OCP-COUNT-8:   rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
+// OCP-COUNT-8:   rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
+//         OCP:   %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
+//         OCP:   llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
 
-// EMULATED-LABEL: hal.executable public @ext_fp8_dispatch {
-//       EMULATED:   hal.executable.variant public @rocm
-//       EMULATED:     llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
-//       EMULATED:     llvm.store %{{.*}}, %{{.*}} : vector<16xf32>, !llvm.ptr<7>
+// EMULATED-LABEL: llvm.func @ext_fp8_dispatch
+//       EMULATED:   llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
+//       EMULATED:   llvm.store %{{.*}}, %{{.*}} : vector<16xf32>, !llvm.ptr<7>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_truncation_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_scaled_truncation_gfx950.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline), iree-hal-hoist-executable-objects, iree-codegen-propagate-dispatch-config)))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline %s | FileCheck %s
 
 // This pipeline-level test exists because there are fragile pattern matches
 // needed to generate efficient calls to scaling truncation
@@ -12,70 +12,58 @@
     #hal.pipeline.binding<storage_buffer>,
     #hal.pipeline.binding<storage_buffer>
   ]>
-hal.executable @fp4_dynamic_quantt {
-  hal.executable.variant @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @fp4_dynamic_quant layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @fp4_dynamic_quant() {
-        %c0 = arith.constant 0 : index
-        %cst_0.25 = arith.constant 2.500000e-01 : f32
-        %cst_neg_inf = arith.constant 0xff800000 : f32
-        %len_i32 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-        %cast = arith.index_castui %len_i32 : i32 to index
-        %len = iree_tensor_ext.dispatch.workload.ordinal %cast, 0 : index
-        %input.bind = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x32xf32>>{%len}
-        %trunc.bind = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%len}
-        %scales.bind = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xi8>>{%len}
+func.func @fp4_dynamic_quant() {
+  %c0 = arith.constant 0 : index
+  %cst_0.25 = arith.constant 2.500000e-01 : f32
+  %cst_neg_inf = arith.constant 0xff800000 : f32
+  %len_i32 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %cast = arith.index_castui %len_i32 : i32 to index
+  %len = iree_tensor_ext.dispatch.workload.ordinal %cast, 0 : index
+  %input.bind = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x32xf32>>{%len}
+  %trunc.bind = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%len}
+  %scales.bind = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xi8>>{%len}
 
-        %input = iree_tensor_ext.dispatch.tensor.load %input.bind, offsets = [0, 0], sizes = [%len, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x32xf32>>{%len} -> tensor<?x32xf32>
-        %abs.max.empty = tensor.empty(%len) : tensor<?xf32>
-        %abs.max.init = linalg.fill ins(%cst_neg_inf : f32) outs(%abs.max.empty : tensor<?xf32>) -> tensor<?xf32>
-        %abs.max = linalg.generic {indexing_maps = [#map, #map1],
-                                   iterator_types = ["parallel", "reduction"]}
-                                   ins(%input : tensor<?x32xf32>)
-                                   outs(%abs.max.init : tensor<?xf32>) {
-        ^bb0(%in: f32, %out: f32):
-          %abs = math.absf %in : f32
-          %max = arith.maximumf %abs, %out : f32
-          linalg.yield %max : f32
-        } -> tensor<?xf32>
-        %scales.init = tensor.empty(%len) : tensor<?xi8>
-        %scales = linalg.generic {indexing_maps = [#map2, #map2],
-                                   iterator_types = ["parallel"]}
-                                   ins(%abs.max : tensor<?xf32>)
-                                   outs(%scales.init : tensor<?xi8>) {
-        ^bb0(%in0: f32, %out: i8):
-          %normalized = arith.mulf %in0, %cst_0.25 : f32
-          %only.exp = arith.truncf %normalized : f32 to f8E8M0FNU
-          %scale.byte = arith.bitcast %only.exp : f8E8M0FNU to i8
-          linalg.yield %scale.byte : i8
-        } -> tensor<?xi8>
-        %trunc.empty = tensor.empty(%len) : tensor<?x32xf4E2M1FN>
-        %trunc = linalg.generic {indexing_maps = [#map, #map1, #map],
-                                   iterator_types = ["parallel", "parallel"]}
-                                   ins(%input, %abs.max : tensor<?x32xf32>, tensor<?xf32>)
-                                   outs(%trunc.empty : tensor<?x32xf4E2M1FN>) {
-        ^bb0(%in1: f32, %scale: f32, %out: f4E2M1FN):
-          %normalized2 = arith.mulf %scale, %cst_0.25 : f32
-          %scaling.trunc = arith.scaling_truncf %in1, %normalized2 : f32, f32 to f4E2M1FN
-          linalg.yield %scaling.trunc : f4E2M1FN
-        } -> tensor<?x32xf4E2M1FN>
+  %input = iree_tensor_ext.dispatch.tensor.load %input.bind, offsets = [0, 0], sizes = [%len, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x32xf32>>{%len} -> tensor<?x32xf32>
+  %abs.max.empty = tensor.empty(%len) : tensor<?xf32>
+  %abs.max.init = linalg.fill ins(%cst_neg_inf : f32) outs(%abs.max.empty : tensor<?xf32>) -> tensor<?xf32>
+  %abs.max = linalg.generic {indexing_maps = [#map, #map1],
+                             iterator_types = ["parallel", "reduction"]}
+                             ins(%input : tensor<?x32xf32>)
+                             outs(%abs.max.init : tensor<?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %abs = math.absf %in : f32
+    %max = arith.maximumf %abs, %out : f32
+    linalg.yield %max : f32
+  } -> tensor<?xf32>
+  %scales.init = tensor.empty(%len) : tensor<?xi8>
+  %scales = linalg.generic {indexing_maps = [#map2, #map2],
+                             iterator_types = ["parallel"]}
+                             ins(%abs.max : tensor<?xf32>)
+                             outs(%scales.init : tensor<?xi8>) {
+  ^bb0(%in0: f32, %out: i8):
+    %normalized = arith.mulf %in0, %cst_0.25 : f32
+    %only.exp = arith.truncf %normalized : f32 to f8E8M0FNU
+    %scale.byte = arith.bitcast %only.exp : f8E8M0FNU to i8
+    linalg.yield %scale.byte : i8
+  } -> tensor<?xi8>
+  %trunc.empty = tensor.empty(%len) : tensor<?x32xf4E2M1FN>
+  %trunc = linalg.generic {indexing_maps = [#map, #map1, #map],
+                             iterator_types = ["parallel", "parallel"]}
+                             ins(%input, %abs.max : tensor<?x32xf32>, tensor<?xf32>)
+                             outs(%trunc.empty : tensor<?x32xf4E2M1FN>) {
+  ^bb0(%in1: f32, %scale: f32, %out: f4E2M1FN):
+    %normalized2 = arith.mulf %scale, %cst_0.25 : f32
+    %scaling.trunc = arith.scaling_truncf %in1, %normalized2 : f32, f32 to f4E2M1FN
+    linalg.yield %scaling.trunc : f4E2M1FN
+  } -> tensor<?x32xf4E2M1FN>
 
-        iree_tensor_ext.dispatch.tensor.store %scales, %scales.bind, offsets = [0], sizes = [%len], strides = [1] : tensor<?xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xi8>>{%len}
-        iree_tensor_ext.dispatch.tensor.store %trunc, %trunc.bind, offsets = [0, 0], sizes = [%len, 32], strides = [1, 1] : tensor<?x32xf4E2M1FN> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%len}
-        return
-      }
-    }
-  }
+  iree_tensor_ext.dispatch.tensor.store %scales, %scales.bind, offsets = [0], sizes = [%len], strides = [1] : tensor<?xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xi8>>{%len}
+  iree_tensor_ext.dispatch.tensor.store %trunc, %trunc.bind, offsets = [0, 0], sizes = [%len, 32], strides = [1, 1] : tensor<?x32xf4E2M1FN> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%len}
+  return
 }
 
-// CHECK-LABEL: hal.executable public @fp4_dynamic_quant
-// CHECK: hal.executable.variant public @rocm
+// CHECK-LABEL: llvm.func @fp4_dynamic_quant
 // (Note to editors: this mainly shouldn't be 1)
-// CHECK: workgroup_size = [64 : index
 // CHECK: llvm.intr.vector.reduce.fmax
 // CHECK-COUNT-4: rocdl.cvt.scalef32.pk.fp4.f32 {{.*}} -> %{{.*}}[3] : i32
 // CHECK-NOT: rocdl.cvt.scalef32.pk.fp4.f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1,81 +1,61 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-nvvm-pipeline))))" %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-nvvm-pipeline))))" %s | FileCheck %s --check-prefix=SM80
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-nvvm-lowering-pipeline %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-nvvm-lowering-pipeline %s | FileCheck %s --check-prefix=SM80
 
 // Verify that a simple element wise op gets lowered successfully all the way to
 // nvvm/llvm dialect.
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @simpleMath_ex_dispatch_0 {
-  hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @add_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @add_dispatch_0() {
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
-      %3 = tensor.empty() : tensor<16xf32>
-      %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
-      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %7 = arith.addf %arg0, %arg1 : f32
-          linalg.yield %7 : f32
-        } -> tensor<16xf32>
-        iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
-        return
-      }
-    }
-  }
+func.func @add_dispatch_0() attributes {hal.executable.target = #executable_target_cuda} {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+  %3 = tensor.empty() : tensor<16xf32>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
+  %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+      %7 = arith.addf %arg0, %arg1 : f32
+      linalg.yield %7 : f32
+    } -> tensor<16xf32>
+    iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+    return
 }
 
-// CHECK-LABEL: hal.executable public @simpleMath_ex_dispatch_0
-//       CHECK:   hal.executable.variant public @cuda
+// CHECK-LABEL: llvm.func @add_dispatch_0
 //       CHECK:   llvm.fadd
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @dot_dispatch_0 {
-  hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @dot_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @dot_dispatch_0() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
-        %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
-        %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
-        %15 = tensor.empty() : tensor<1024x1024xf32>
-        %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-        %17 = linalg.matmul ins(%8, %10 : tensor<1024x1024xf32>, tensor<1024x1024xf32>)
-            outs(%16 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-        iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
-        return
-      }
-    }
-  }
+func.func @dot_dispatch_0() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+  %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
+  %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
+  %15 = tensor.empty() : tensor<1024x1024xf32>
+  %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  %17 = linalg.matmul ins(%8, %10 : tensor<1024x1024xf32>, tensor<1024x1024xf32>)
+      outs(%16 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+  return
 }
 
-//      CHECK-LABEL: hal.executable public @dot_dispatch_0
-//            CHECK:   hal.executable.variant public @cuda
+//      CHECK-LABEL: llvm.func @dot_dispatch_0
 //        CHECK-NOT:   llvm.store
 //            CHECK:   llvm.br
 //            CHECK:    llvm.load {{.*}} : !llvm.ptr<1> -> vector<32xf32>
@@ -97,87 +77,67 @@ hal.executable @dot_dispatch_0 {
   ],
   iterator_types = ["parallel", "parallel", "reduction"]
 }
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @dot_dispatch_0 {
-  hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @dot_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @dot_dispatch_0() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
-        %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
-        %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
-        %15 = tensor.empty() : tensor<1024x1024xf32>
-        %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-        %17 = linalg.generic #matmul_trait
-            ins(%8, %10 : tensor<1024x1024xf32>, tensor<1024x1024xf32>) outs(%16 : tensor<1024x1024xf32>)  {
-          ^bb(%a: f32, %b: f32, %c: f32) :
-            %d = arith.mulf %a, %b: f32
-            %e = arith.addf %c, %d: f32
-            linalg.yield %e : f32
-          } -> (tensor<1024x1024xf32>)
-        iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
-        return
-      }
-    }
-  }
+func.func @dot_dispatch_0() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+  %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
+  %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
+  %15 = tensor.empty() : tensor<1024x1024xf32>
+  %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  %17 = linalg.generic #matmul_trait
+      ins(%8, %10 : tensor<1024x1024xf32>, tensor<1024x1024xf32>) outs(%16 : tensor<1024x1024xf32>)  {
+    ^bb(%a: f32, %b: f32, %c: f32) :
+      %d = arith.mulf %a, %b: f32
+      %e = arith.addf %c, %d: f32
+      linalg.yield %e : f32
+    } -> (tensor<1024x1024xf32>)
+  iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+  return
 }
 
-//   CHECK-LABEL: hal.executable public @dot_dispatch_0
-//            CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @dot_dispatch_0
 //            CHECK:  llvm.br
 //   CHECK-COUNT-512:  llvm.call @__nv_fmaf({{.*}}) : (f32, f32, f32) -> f32
 //            CHECK:    llvm.store {{.*}} : vector<16xf32>, !llvm.ptr<1>
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @conv2d_dispatch_0 {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @conv2d_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @conv2d_dispatch_0() {
-      %cst = arith.constant 0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4x4x2xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x2x2x1xf32>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x2x3x1xf32>>
-      %11 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0 ,0, 0], sizes = [1, 4, 4, 2], strides = [1, 1, 1, 1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4x4x2xf32>> -> tensor<1x4x4x2xf32>
-      %13 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 2, 2, 1], strides = [1, 1, 1, 1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x2x2x1xf32>> -> tensor<3x2x2x1xf32>
-      %20 = tensor.empty() : tensor<1x2x3x1xf32>
-      %21 = linalg.fill ins(%cst : f32) outs(%20 : tensor<1x2x3x1xf32>) -> tensor<1x2x3x1xf32>
-      %22 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-          ins(%11, %13 : tensor<1x4x4x2xf32>, tensor<3x2x2x1xf32>) outs(%21 : tensor<1x2x3x1xf32>) -> tensor<1x2x3x1xf32>
-      iree_tensor_ext.dispatch.tensor.store %22, %2, offsets = [0, 0, 0, 0], sizes = [1, 2, 3, 1], strides = [1, 1, 1, 1]
-          : tensor<1x2x3x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x2x3x1xf32>>
-      return
-    }
-  }
-}
+func.func @conv2d_dispatch_0() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4x4x2xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x2x2x1xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x2x3x1xf32>>
+  %11 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0 ,0, 0], sizes = [1, 4, 4, 2], strides = [1, 1, 1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4x4x2xf32>> -> tensor<1x4x4x2xf32>
+  %13 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 2, 2, 1], strides = [1, 1, 1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x2x2x1xf32>> -> tensor<3x2x2x1xf32>
+  %20 = tensor.empty() : tensor<1x2x3x1xf32>
+  %21 = linalg.fill ins(%cst : f32) outs(%20 : tensor<1x2x3x1xf32>) -> tensor<1x2x3x1xf32>
+  %22 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+      ins(%11, %13 : tensor<1x4x4x2xf32>, tensor<3x2x2x1xf32>) outs(%21 : tensor<1x2x3x1xf32>) -> tensor<1x2x3x1xf32>
+  iree_tensor_ext.dispatch.tensor.store %22, %2, offsets = [0, 0, 0, 0], sizes = [1, 2, 3, 1], strides = [1, 1, 1, 1]
+      : tensor<1x2x3x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x2x3x1xf32>>
+  return
 }
 
-//   CHECK-LABEL: hal.executable public @conv2d_dispatch_0
-//         CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @conv2d_dispatch_0
 // CHECK-COUNT-3:   llvm.load %{{.*}} : !llvm.ptr<1> -> f32
 //         CHECK:   llvm.fmul %{{.*}}, %{{.*}}  : f32
 //         CHECK:   llvm.fadd %{{.*}}, %{{.*}}  : f32
@@ -185,122 +145,92 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @simpleMath_ex_dispatch_0 {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @add_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @add_dispatch_0() {
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
-      %3 = tensor.empty() : tensor<16xf32>
-      %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %5 = arith.constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
-      %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
-      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %7 = arith.addf %arg0, %arg1 : f32
-          linalg.yield %7 : f32
-      } -> tensor<16xf32>
-      iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
-      return
-    }
-  }
-}
+func.func @add_dispatch_0() attributes {hal.executable.target = #executable_target_cuda} {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+  %3 = tensor.empty() : tensor<16xf32>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
+  %5 = arith.constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
+  %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+      %7 = arith.addf %arg0, %arg1 : f32
+      linalg.yield %7 : f32
+  } -> tensor<16xf32>
+  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+  return
 }
 
-// CHECK-LABEL: hal.executable public @simpleMath_ex_dispatch_0
-//       CHECK:   hal.executable.variant public @cuda
-//       CHECK:   llvm.mlir.global private constant @{{.*}}(dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01]> : tensor<16xf32>)
+// CHECK: llvm.mlir.global private constant @{{.*}}(dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01]> : tensor<16xf32>)
+// CHECK-LABEL: llvm.func @add_dispatch_0
 //       CHECK:   llvm.fadd
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @reduction_dispatch {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @reduction layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @reduction() {
-      %cst = arith.constant 0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<14x14x96xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<96xf32>>
-      %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [14, 14, 96], strides = [1, 1, 1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<14x14x96xf32>> -> tensor<14x14x96xf32>
-      %8 = tensor.empty() : tensor<96xf32>
-      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<96xf32>) -> tensor<96xf32>
-      %10 = linalg.generic {
-            indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2, d0)>, affine_map<(d0, d1, d2) -> (d0)>],
-            iterator_types = ["parallel", "reduction", "reduction"]}
-            ins(%5 : tensor<14x14x96xf32>) outs(%9 : tensor<96xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):
-          %11 = arith.addf %arg1, %arg2 : f32
-          linalg.yield %11 : f32
-        } -> tensor<96xf32>
-      iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0], sizes = [96], strides = [1]
-          : tensor<96xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<96xf32>>
-      return
-    }
-  }
-}
+func.func @reduction() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<14x14x96xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<96xf32>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [14, 14, 96], strides = [1, 1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<14x14x96xf32>> -> tensor<14x14x96xf32>
+  %8 = tensor.empty() : tensor<96xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<96xf32>) -> tensor<96xf32>
+  %10 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2, d0)>, affine_map<(d0, d1, d2) -> (d0)>],
+        iterator_types = ["parallel", "reduction", "reduction"]}
+        ins(%5 : tensor<14x14x96xf32>) outs(%9 : tensor<96xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg1, %arg2 : f32
+      linalg.yield %11 : f32
+    } -> tensor<96xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0], sizes = [96], strides = [1]
+      : tensor<96xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<96xf32>>
+  return
 }
 
-// CHECK-LABEL: hal.executable public @reduction_dispatch
-//       CHECK:   hal.executable.variant public @cuda
+// CHECK-LABEL: llvm.func @reduction
 //       CHECK:     "llvm.intr.vector.reduce.fadd"({{.*}}) {{.*}} : (f32, vector<4xf32>) -> f32
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @vector_add_dispatch {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @vector_add_dispatch layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @vector_add_dispatch() {
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
-      %6 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [16384], strides = [1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>> -> tensor<16384xf32>
-      %8 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [16384], strides = [1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>> -> tensor<16384xf32>
-      %10 = tensor.empty() : tensor<16384xf32>
-      %11 = linalg.generic {
-          indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
-          iterator_types = ["parallel"]}
-          ins(%6, %8 : tensor<16384xf32>, tensor<16384xf32>) outs(%10 : tensor<16384xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
-          %12 = arith.addf %arg1, %arg2 : f32
-          linalg.yield %12 : f32
-        } -> tensor<16384xf32>
-      iree_tensor_ext.dispatch.tensor.store %11, %2, offsets = [0], sizes = [16384], strides = [1]
-          : tensor<16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
-      return
-    }
-  }
-}
+func.func @vector_add_dispatch() attributes {hal.executable.target = #executable_target_cuda} {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  %6 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [16384], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>> -> tensor<16384xf32>
+  %8 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [16384], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16384xf32>> -> tensor<16384xf32>
+  %10 = tensor.empty() : tensor<16384xf32>
+  %11 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%6, %8 : tensor<16384xf32>, tensor<16384xf32>) outs(%10 : tensor<16384xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
+      %12 = arith.addf %arg1, %arg2 : f32
+      linalg.yield %12 : f32
+    } -> tensor<16384xf32>
+  iree_tensor_ext.dispatch.tensor.store %11, %2, offsets = [0], sizes = [16384], strides = [1]
+      : tensor<16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  return
 }
 
-//   CHECK-LABEL: hal.executable public @vector_add_dispatch
-//         CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @vector_add_dispatch
 //         CHECK:   llvm.fadd %{{.*}}, %{{.*}}  : vector<4xf32
 //         CHECK:   llvm.store %{{.*}} : vector<4xf32>, !llvm.ptr<1>
 
@@ -308,123 +238,91 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 
 #map3 = affine_map<(d0, d1) -> (d1, d0)>
 #map4 = affine_map<(d0, d1) -> (d0)>
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @vector_reduction_dispatch {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @vector_reduction_dispatch layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @vector_reduction_dispatch() {
-      %cst = arith.constant 1.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x16384xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
-      %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 16384], strides = [1, 1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x16384xf32>> -> tensor<512x16384xf32>
-      %8 = tensor.empty() : tensor<16384xf32>
-      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<16384xf32>) -> tensor<16384xf32>
-      %10 = linalg.generic {
-          indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
-          ins(%5 : tensor<512x16384xf32>) outs(%9 : tensor<16384xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):
-          %11 = arith.addf %arg1, %arg2 : f32
-          linalg.yield %11 : f32
-        } -> tensor<16384xf32>
-      iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0], sizes = [16384], strides = [1]
-          : tensor<16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
-      return
-    }
-  }
-}
+func.func @vector_reduction_dispatch() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 1.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x16384xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 16384], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x16384xf32>> -> tensor<512x16384xf32>
+  %8 = tensor.empty() : tensor<16384xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<16384xf32>) -> tensor<16384xf32>
+  %10 = linalg.generic {
+      indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
+      ins(%5 : tensor<512x16384xf32>) outs(%9 : tensor<16384xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg1, %arg2 : f32
+      linalg.yield %11 : f32
+    } -> tensor<16384xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0], sizes = [16384], strides = [1]
+      : tensor<16384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16384xf32>>
+  return
 }
 
-//   CHECK-LABEL: hal.executable public @vector_reduction_dispatch
-//         CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @vector_reduction_dispatch
 // CHECK-COUNT-5:     nvvm.shfl.sync bfly
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
-  hal.executable public @pooling_dynamic {
-    hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-      hal.executable.export public @pooling_dynamic ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1)
-        hal.return %x, %y, %z : index, index, index
-      }
-      builtin.module {
-        func.func @pooling_dynamic() {
-          %cst = arith.constant 0.000000e+00 : f32
-          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-          %cast = arith.index_cast %0 : i32 to index
-          %s = iree_tensor_ext.dispatch.workload.ordinal %cast, 0 : index
-          %14 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%s) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048x?x?xf32>>{%s, %s, %s}
-          %15 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%s) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048x1x1xf32>>{%s}
-          %16 = iree_tensor_ext.dispatch.tensor.load %14, offsets = [0, 0, 0, 0], sizes = [%s, 2048, %s, %s], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048x?x?xf32>>{%s, %s, %s} -> tensor<?x2048x?x?xf32>
-          %19 = tensor.empty(%s) : tensor<?x2048x1x1xf32>
-          %38 = tensor.empty(%s, %s) : tensor<?x?xf32>
-          %39 = linalg.fill ins(%cst : f32) outs(%19 : tensor<?x2048x1x1xf32>) -> tensor<?x2048x1x1xf32>
-          %40 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%16, %38 : tensor<?x2048x?x?xf32>, tensor<?x?xf32>) outs(%39 : tensor<?x2048x1x1xf32>) -> tensor<?x2048x1x1xf32>
-          iree_tensor_ext.dispatch.tensor.store %40, %15, offsets = [0, 0, 0, 0], sizes = [%s, 2048, 1, 1], strides = [1, 1, 1, 1] : tensor<?x2048x1x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048x1x1xf32>>{%s}
-          return
-        }
-      }
-    }
-  }
+func.func @pooling_dynamic() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %cast = arith.index_cast %0 : i32 to index
+  %s = iree_tensor_ext.dispatch.workload.ordinal %cast, 0 : index
+  %14 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%s) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048x?x?xf32>>{%s, %s, %s}
+  %15 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%s) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048x1x1xf32>>{%s}
+  %16 = iree_tensor_ext.dispatch.tensor.load %14, offsets = [0, 0, 0, 0], sizes = [%s, 2048, %s, %s], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048x?x?xf32>>{%s, %s, %s} -> tensor<?x2048x?x?xf32>
+  %19 = tensor.empty(%s) : tensor<?x2048x1x1xf32>
+  %38 = tensor.empty(%s, %s) : tensor<?x?xf32>
+  %39 = linalg.fill ins(%cst : f32) outs(%19 : tensor<?x2048x1x1xf32>) -> tensor<?x2048x1x1xf32>
+  %40 = linalg.pooling_nchw_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%16, %38 : tensor<?x2048x?x?xf32>, tensor<?x?xf32>) outs(%39 : tensor<?x2048x1x1xf32>) -> tensor<?x2048x1x1xf32>
+  iree_tensor_ext.dispatch.tensor.store %40, %15, offsets = [0, 0, 0, 0], sizes = [%s, 2048, 1, 1], strides = [1, 1, 1, 1] : tensor<?x2048x1x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048x1x1xf32>>{%s}
+  return
+}
 
 // Just check that compilation succeed.
-//     SM80-LABEL: hal.executable public @pooling_dynamic
-//           SM80:   hal.executable.variant public @cuda
+//     SM80-LABEL: llvm.func @pooling_dynamic
 
 // -----
 
 #map3 = affine_map<(d0, d1) -> (d0, d1)>
 #map4 = affine_map<(d0, d1) -> (d0)>
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @vector_distribute_dispatch {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @vector_distribute_dispatch layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @vector_distribute_dispatch() {
-      %cst = arith.constant 1.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512xf32>>
-      %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>> -> tensor<512x1024xf32>
-      %8 = tensor.empty() : tensor<512xf32>
-      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
-      %10 = linalg.generic {
-          indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
-          ins(%5 : tensor<512x1024xf32>) outs(%9 : tensor<512xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):
-          %11 = arith.addf %arg1, %arg2 : f32
-          linalg.yield %11 : f32
-        } -> tensor<512xf32>
-      iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0], sizes = [512], strides = [1]
-          : tensor<512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512xf32>>
-      return
-    }
-  }
-}
+func.func @vector_distribute_dispatch() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst = arith.constant 1.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512xf32>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>> -> tensor<512x1024xf32>
+  %8 = tensor.empty() : tensor<512xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
+  %10 = linalg.generic {
+      indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
+      ins(%5 : tensor<512x1024xf32>) outs(%9 : tensor<512xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg1, %arg2 : f32
+      linalg.yield %11 : f32
+    } -> tensor<512xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0], sizes = [512], strides = [1]
+      : tensor<512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512xf32>>
+  return
 }
 
 // Check that we generate a vector distribute code sequence.
-//   CHECK-LABEL: hal.executable public @vector_distribute_dispatch
-//         CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @vector_distribute_dispatch
 // CHECK-COUNT-5:     nvvm.shfl.sync bfly
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} : vector<1xf32>, !llvm.ptr<3>
 //         CHECK:     nvvm.barrier0
@@ -435,52 +333,42 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 
 #map3 = affine_map<(d0, d1) -> (d0, d1)>
 #map4 = affine_map<(d0, d1) -> (d0)>
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @vector_distribution_broadcast_dispatch {
-hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @vector_distribution_broadcast_dispatch layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @vector_distribution_broadcast_dispatch() {
-      %cst_0 = arith.constant 3.840000e+02 : f32
-      %cst = arith.constant 1.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x1024xf32>>
-      %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
-          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>> -> tensor<512x1024xf32>
-      %8 = tensor.empty() : tensor<512xf32>
-      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
-      %10 = linalg.generic {
-          indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
-          ins(%5 : tensor<512x1024xf32>) outs(%9 : tensor<512xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):
-          %11 = arith.addf %arg1, %arg2 : f32
-          linalg.yield %11 : f32
-        } -> tensor<512xf32>
-      %i = tensor.empty() : tensor<512x1024xf32>
-      %11 = linalg.generic {
-        indexing_maps = [#map4, #map3], iterator_types = ["parallel", "parallel"]}
-        ins(%10 : tensor<512xf32>) outs(%i : tensor<512x1024xf32>) {
-          ^bb0(%arg0: f32, %arg1: f32):
-            %12 = arith.divf %arg0, %cst_0 : f32
-            linalg.yield %12 : f32
-          } -> tensor<512x1024xf32>
-      iree_tensor_ext.dispatch.tensor.store %11, %1, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
-          : tensor<512x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x1024xf32>>
-      return
-    }
-  }
-}
+func.func @vector_distribution_broadcast_dispatch() attributes {hal.executable.target = #executable_target_cuda} {
+  %cst_0 = arith.constant 3.840000e+02 : f32
+  %cst = arith.constant 1.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x1024xf32>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x1024xf32>> -> tensor<512x1024xf32>
+  %8 = tensor.empty() : tensor<512xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
+  %10 = linalg.generic {
+      indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
+      ins(%5 : tensor<512x1024xf32>) outs(%9 : tensor<512xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg1, %arg2 : f32
+      linalg.yield %11 : f32
+    } -> tensor<512xf32>
+  %i = tensor.empty() : tensor<512x1024xf32>
+  %11 = linalg.generic {
+    indexing_maps = [#map4, #map3], iterator_types = ["parallel", "parallel"]}
+    ins(%10 : tensor<512xf32>) outs(%i : tensor<512x1024xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %12 = arith.divf %arg0, %cst_0 : f32
+        linalg.yield %12 : f32
+      } -> tensor<512x1024xf32>
+  iree_tensor_ext.dispatch.tensor.store %11, %1, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
+      : tensor<512x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x1024xf32>>
+  return
 }
 
 // Check that we generate a group reduce fused with broadcast + elementwise.
-//   CHECK-LABEL: hal.executable public @vector_distribution_broadcast_dispatch
-//         CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @vector_distribution_broadcast_dispatch
 // CHECK-COUNT-5:     nvvm.shfl.sync bfly
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} : vector<1xf32>, !llvm.ptr<3>
 //         CHECK:     nvvm.barrier0
@@ -491,81 +379,59 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 
 // -----
 
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable private @generalized_pool {
-  hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @generalized_pool ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @generalized_pool() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0xFF800000 : f32
-        %empty = tensor.empty() : tensor<14x14x480xf32>
-        %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<14x14x480xf32>) -> tensor<14x14x480xf32>
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<29x29x480xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<14x14x480xf32>>
-        %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [29, 29, 480], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<29x29x480xf32>> -> tensor<29x29x480xf32>
-        %3 = tensor.empty() : tensor<3x3xf32>
-        %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0 * 2 + d3, d1 * 2 + d4, d2)>, affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%2, %3 : tensor<29x29x480xf32>, tensor<3x3xf32>) outs(%fill : tensor<14x14x480xf32>) {
-        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %5 = arith.maximumf %arg2, %arg0 : f32
-          linalg.yield %5 : f32
-        } -> tensor<14x14x480xf32>
-        iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0], sizes = [14, 14, 480], strides = [1, 1, 1] : tensor<14x14x480xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<14x14x480xf32>>
-        return
-      }
-    }
-  }
+func.func @generalized_pool() attributes {hal.executable.target = #executable_target_cuda} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0xFF800000 : f32
+  %empty = tensor.empty() : tensor<14x14x480xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<14x14x480xf32>) -> tensor<14x14x480xf32>
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<29x29x480xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<14x14x480xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [29, 29, 480], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<29x29x480xf32>> -> tensor<29x29x480xf32>
+  %3 = tensor.empty() : tensor<3x3xf32>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0 * 2 + d3, d1 * 2 + d4, d2)>, affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%2, %3 : tensor<29x29x480xf32>, tensor<3x3xf32>) outs(%fill : tensor<14x14x480xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %5 = arith.maximumf %arg2, %arg0 : f32
+    linalg.yield %5 : f32
+  } -> tensor<14x14x480xf32>
+  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0], sizes = [14, 14, 480], strides = [1, 1, 1] : tensor<14x14x480xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<14x14x480xf32>>
+  return
 }
 
-//   CHECK-LABEL: hal.executable private @generalized_pool
-//         CHECK:   hal.executable.variant public @cuda
+//   CHECK-LABEL: llvm.func @generalized_pool
 //         CHECK:     llvm.load %{{.*}} : !llvm.ptr<1> -> f32
 //         CHECK:     llvm.call @__nv_fmaxf
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} : f32, !llvm.ptr<1>
 
 // -----
 
-#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
 #map0 = affine_map<(d0, d1) -> (d1, d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-hal.executable private @shared_mem_transpose  {
-  hal.executable.variant @cuda target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @shared_mem_transpose layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-        hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-        func.func @shared_mem_transpose() {
-          %c0 = arith.constant 0 : index
-          %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x768xf32>>
-          %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<768x2048xf32>>
-          %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 768], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x768xf32>> -> tensor<2048x768xf32>
-          %3 = tensor.empty() : tensor<768x2048xf32>
-          %4 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<2048x768xf32>) outs(%3 : tensor<768x2048xf32>) {
-          ^bb0(%arg0: f32, %arg1: f32):
-            linalg.yield %arg0 : f32
-          } -> tensor<768x2048xf32>
-          iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [768, 2048], strides = [1, 1] : tensor<768x2048xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<768x2048xf32>>
-          return
-        }
-    }
-  }
+func.func @shared_mem_transpose() attributes {hal.executable.target = #executable_target_cuda} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x768xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<768x2048xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 768], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x768xf32>> -> tensor<2048x768xf32>
+  %3 = tensor.empty() : tensor<768x2048xf32>
+  %4 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<2048x768xf32>) outs(%3 : tensor<768x2048xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    linalg.yield %arg0 : f32
+  } -> tensor<768x2048xf32>
+  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [768, 2048], strides = [1, 1] : tensor<768x2048xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<768x2048xf32>>
+  return
 }
 
 // Check that bufferization is emitting correct code for the temp shared
 // memory alloc.
-//   SM80-LABEL: hal.executable private @shared_mem_transpose
-//         SM80:   hal.executable.variant public @cuda
+//   SM80-LABEL: llvm.func @shared_mem_transpose
 //         SM80:     llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<1> -> vector<4xf32>
 //         SM80:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : vector<4xf32>, !llvm.ptr<3>
-//         SM80:     nvvm.barrier0

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=false %s | FileCheck %s --check-prefix=CDNA1
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=false %s | FileCheck %s --check-prefix=CDNA3
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-linalg-to-rocdl-pipeline))))" --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=false %s | FileCheck %s --check-prefix=RDNA3
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=false %s | FileCheck %s --check-prefix=CDNA1
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=false %s | FileCheck %s --check-prefix=CDNA3
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-rocdl-lowering-pipeline --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=false %s | FileCheck %s --check-prefix=RDNA3
 
 // Verify that a simple element wise op gets lowered successfully all the way to
 // nvvm/llvm dialect.
@@ -10,34 +10,23 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @simpleMath_ex_dispatch_0 {
-  hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @add_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @add_dispatch_0() {
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
-      %3 = tensor.empty() : tensor<16xf32>
-      %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
-      %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
-      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %7 = arith.addf %arg0, %arg1 : f32
-          linalg.yield %7 : f32
-        } -> tensor<16xf32>
-        iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
-        return
-      }
-    }
-  }
+func.func @add_dispatch_0() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+  %3 = tensor.empty() : tensor<16xf32>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
+  %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+      %7 = arith.addf %arg0, %arg1 : f32
+      linalg.yield %7 : f32
+    } -> tensor<16xf32>
+    iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+    return
 }
 
-// CDNA1-LABEL: hal.executable public @simpleMath_ex_dispatch_0
-//       CDNA1:   hal.executable.variant public @rocm
+// CDNA1-LABEL: llvm.func @add_dispatch_0
 //       CDNA1:   llvm.fadd
 
 // -----
@@ -50,39 +39,28 @@ hal.executable @simpleMath_ex_dispatch_0 {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @dot_dispatch_0 {
-  hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @dot_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @dot_dispatch_0() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %c0 = arith.constant 0 : index
-        %c1024 = arith.constant 1024 : index
-        %c1 = arith.constant 1 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
-        %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
-        %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
-        %15 = tensor.empty() : tensor<1024x1024xf32>
-        %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-        %17 = linalg.matmul ins(%8, %10 : tensor<1024x1024xf32>, tensor<1024x1024xf32>)
-            outs(%16 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
-        iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
-            : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
-        return
-      }
-    }
-  }
+func.func @dot_dispatch_0() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %c1024 = arith.constant 1024 : index
+  %c1 = arith.constant 1 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+  %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
+  %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x1024xf32>> -> tensor<1024x1024xf32>
+  %15 = tensor.empty() : tensor<1024x1024xf32>
+  %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  %17 = linalg.matmul ins(%8, %10 : tensor<1024x1024xf32>, tensor<1024x1024xf32>)
+      outs(%16 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [1024, 1024], strides = [1, 1]
+      : tensor<1024x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x1024xf32>>
+  return
 }
 
-//   RDNA3-LABEL: hal.executable public @dot_dispatch_0
-//         RDNA3:   hal.executable.variant public @rocm
+//   RDNA3-LABEL: llvm.func @dot_dispatch_0
 //       RDNA3-NOT:   llvm.store
 //           RDNA3:   llvm.br
 //   RDNA3-COUNT-1:    llvm.load {{.*}} : !llvm.ptr<7> -> vector<32xf32>
@@ -101,35 +79,24 @@ hal.executable @dot_dispatch_0 {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @ceildiv_expand_dispatch {
-  hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @ceildiv_expand layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-  builtin.module {
-    func.func @ceildiv_expand() {
-      %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xi32>>
-      %3 = tensor.empty() : tensor<16xi32>
-      %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>> -> tensor<16xi32>
-      %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>> -> tensor<16xi32>
-      %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xi32>, tensor<16xi32>) outs(%3 : tensor<16xi32>) {
-      ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
-          %7 = arith.ceildivsi %arg0, %arg1 : i32
-          linalg.yield %7 : i32
-        } -> tensor<16xi32>
-        iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xi32>>
-        return
-      }
-    }
-  }
+func.func @ceildiv_expand() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xi32>>
+  %3 = tensor.empty() : tensor<16xi32>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>> -> tensor<16xi32>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>> -> tensor<16xi32>
+  %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xi32>, tensor<16xi32>) outs(%3 : tensor<16xi32>) {
+  ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
+      %7 = arith.ceildivsi %arg0, %arg1 : i32
+      linalg.yield %7 : i32
+    } -> tensor<16xi32>
+    iree_tensor_ext.dispatch.tensor.store %6, %2, offsets=[0], sizes=[16], strides=[1] : tensor<16xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xi32>>
+    return
 }
 
-//   CDNA3-LABEL: hal.executable public @ceildiv_expand_dispatch
-//         CDNA3:   hal.executable.variant public @rocm
+//   CDNA3-LABEL: llvm.func @ceildiv_expand
 //     CDNA3-NOT:     arith.ceildivsi
 // CDNA3-COUNT-1:     llvm.sdiv {{.*}} : vector<1xi32>
 // CDNA3-COUNT-1:     llvm.mul {{.*}} : vector<1xi32>
@@ -146,47 +113,36 @@ hal.executable @ceildiv_expand_dispatch {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable public @matmul_map_store {
-hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @matmul_map_store layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @matmul_map_store() {
-      %true = arith.constant true
-      %cst = arith.constant 0.000000e+00 : f32
-      %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
-      %1 = amdgpu.fat_raw_buffer_cast %0 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
-      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
-      %3 = amdgpu.fat_raw_buffer_cast %2 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
-      %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>>
-      %5 = amdgpu.fat_raw_buffer_cast %4 resetOffset : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>> to memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
-      %6 = iree_codegen.load_from_buffer %1 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
-      %7 = iree_codegen.load_from_buffer %3 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
-      %8 = tensor.empty() : tensor<256x256xf32>
-      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<256x256xf32>) -> tensor<256x256xf32>
-      %10 = linalg.matmul ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
-      %11 = tensor.empty() : tensor<2x16x8x4x4x4x4xf32>
-      %12 = iree_linalg_ext.map_store %10 into %11 {
-      ^bb0(%arg0: index, %arg1: index):
-        %13:2 = affine.delinearize_index %arg0 into (2, 128) : index, index
-        %14:2 = affine.delinearize_index %arg1 into (16, 16) : index, index
-        %15:3 = affine.delinearize_index %13#1 into (4, 8, 4) : index, index, index
-        %16:2 = affine.delinearize_index %14#1 into (4, 4) : index, index
-        iree_linalg_ext.yield %13#0, %14#0, %15#1, %16#1, %15#0, %15#2, %16#0, %true : index, index, index, index, index, index, index, i1
-      } : tensor<256x256xf32> into tensor<2x16x8x4x4x4x4xf32> -> tensor<2x16x8x4x4x4x4xf32>
-      iree_codegen.store_to_buffer %12, %5 : tensor<2x16x8x4x4x4x4xf32> into memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
-      return
-    }
-  }
-}
+func.func @matmul_map_store() {
+  %true = arith.constant true
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
+  %1 = amdgpu.fat_raw_buffer_cast %0 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
+  %3 = amdgpu.fat_raw_buffer_cast %2 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>>
+  %5 = amdgpu.fat_raw_buffer_cast %4 resetOffset : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>> to memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %6 = iree_codegen.load_from_buffer %1 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
+  %7 = iree_codegen.load_from_buffer %3 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
+  %8 = tensor.empty() : tensor<256x256xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<256x256xf32>) -> tensor<256x256xf32>
+  %10 = linalg.matmul ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
+  %11 = tensor.empty() : tensor<2x16x8x4x4x4x4xf32>
+  %12 = iree_linalg_ext.map_store %10 into %11 {
+  ^bb0(%arg0: index, %arg1: index):
+    %13:2 = affine.delinearize_index %arg0 into (2, 128) : index, index
+    %14:2 = affine.delinearize_index %arg1 into (16, 16) : index, index
+    %15:3 = affine.delinearize_index %13#1 into (4, 8, 4) : index, index, index
+    %16:2 = affine.delinearize_index %14#1 into (4, 4) : index, index
+    iree_linalg_ext.yield %13#0, %14#0, %15#1, %16#1, %15#0, %15#2, %16#0, %true : index, index, index, index, index, index, index, i1
+  } : tensor<256x256xf32> into tensor<2x16x8x4x4x4x4xf32> -> tensor<2x16x8x4x4x4x4xf32>
+  iree_codegen.store_to_buffer %12, %5 : tensor<2x16x8x4x4x4x4xf32> into memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
+  return
 }
 // Verify that the map_store indexing arithmetic has been optimized to i32
 
-// CDNA3-LABEL: hal.executable public @matmul_map_store
-//       CDNA3:   hal.executable.variant public @rocm
+// CDNA3-LABEL: llvm.func @matmul_map_store
 //   CDNA3-NOT:     llvm.add {{.*}} : vector<{{[0-9x]*}}xi64>
 //   CDNA3-NOT:     llvm.mul {{.*}} : vector<{{[0-9x]*}}xi64>
 //   CDNA3-NOT:     llvm.urem {{.*}} : vector<{{[0-9x]*}}xi64>


### PR DESCRIPTION
- Rename pipelines: `iree-codegen-linalg-to-nvvm-pipeline` → `iree-codegen-llvmgpu-nvvm-lowering-pipeline` `iree-codegen-linalg-to-rocdl-pipeline` → `iree-codegen-llvmgpu-rocdl-lowering-pipeline` with `LLVMGPULoweringPipelineOptions`.
- Remove `hal.executable` / `hal.executable.variant` wrapping from pipeline test IR and use `hal.executable.target` attribute on `func.func` instead.
- Update RUN lines to use direct pipeline flags instead of nested `--pass-pipeline` syntax.
- Update CHECK lines to match flattened output (llvm.func labels).
- Fix two exposed issue.
  * The MathTransformPass should not fail if executable target is not found. It means that the device library function or hardware intrinsic may not exist, so it is safer to enable approximation.
  * ROCDLAnnotateKernelForTranslation should check the configuration before access.