### PR TITLE
[NFC] Fix GCC 11 build

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -586,7 +586,7 @@ struct FoldIndexVecAddBroadcast final : OpRewritePattern<OpTy> {
       Value remaining;
       for (auto [lhs, rhs] : {std::pair(addOp.getLhs(), addOp.getRhs()),
                               std::pair(addOp.getRhs(), addOp.getLhs())}) {
-        auto broadcast = lhs.getDefiningOp<vector::BroadcastOp>();
+        auto broadcast = lhs.template getDefiningOp<vector::BroadcastOp>();
         if (broadcast && isa<IndexType>(broadcast.getSourceType())) {
           scalarSrc = broadcast.getSource();
           remaining = rhs;


### PR DESCRIPTION
Fix GCC parsing error by adding `template` keyword before `getDefiningOp` to disambiguate the dependent template call. This should fix the GCC 11 CI.