### PR TITLE
Skip dlclose under ASAN to fix LSAN module resolution

### DIFF
--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -275,8 +275,10 @@ static void iree_dynamic_library_delete(iree_dynamic_library_t* library) {
   iree_allocator_t allocator = library->allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+#if (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION) || \
+    defined(IREE_SANITIZER_ADDRESS)
   // Leak the library when tracing, since the profiler may still be reading it.
+  // Under ASAN, keep libraries mapped so LSAN can resolve module names.
   // TODO(benvanik): move to an atexit handler instead, verify with ASAN/MSAN
   // TODO(scotttodd): Make this compatible with testing:
   //     two test cases, one for each function in the same executable

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -282,8 +282,10 @@ static void iree_dynamic_library_delete(iree_dynamic_library_t* library) {
   iree_allocator_t allocator = library->allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+#if (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION) || \
+    defined(IREE_SANITIZER_ADDRESS)
   // Leak the library when tracing, since the profiler may still be reading it.
+  // Under ASAN, keep libraries mapped so LSAN can resolve module names.
   // TODO(benvanik): move to an atexit handler instead, verify with ASAN/MSAN
   // TODO(scotttodd): Make this compatible with testing:
   //     two test cases, one for each function in the same executable


### PR DESCRIPTION
When ASAN is enabled, keep dynamically loaded libraries mapped at process exit instead of closing them during teardown. This allows LeakSanitizer to resolve module names and trace pointer reachability through library globals, enabling library-name suppressions (e.g. `leak:libhsa-runtime64.so`) to work correctly.

Without this, IREE's dlclose of HIP/ROCm libraries causes LSAN to report all leaked addresses as `<unknown module>`. This was causing issues with Fusilli's gpu-asan CI iree-org/fusilli#292 (using LD_PRELOAD as a workaround).

Fusilli PR that encountered this: https://github.com/iree-org/fusilli/pull/287