### PR TITLE
[SPIRV] Scope SPIRVConvertGPUTarget on module op.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVConvertGPUTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVConvertGPUTarget.cpp
@@ -244,8 +244,7 @@ spirv::ResourceLimitsAttr convertLimits(IREE::GPU::TargetAttr target) {
 //===----------------------------------------------------------------------===//
 
 FailureOr<spirv::TargetEnvAttr>
-convertGPUTarget(MLIRContext *context, IREE::HAL::ExecutableVariantOp variant) {
-  IREE::HAL::ExecutableTargetAttr target = variant.getTarget();
+convertGPUTarget(MLIRContext *context, IREE::HAL::ExecutableTargetAttr target) {
   IREE::GPU::TargetAttr gpuTarget = getGPUTargetAttr(context, target);
 
   SmallVector<StringRef> features;
@@ -257,8 +256,7 @@ convertGPUTarget(MLIRContext *context, IREE::HAL::ExecutableVariantOp variant) {
 
   std::optional<Version> version = deduceVersion(features);
   if (!version) {
-    return variant.emitError("cannot deduce spirv version from target "
-                             "features; need to specify 'spirv1.x'");
+    return failure();
   }
   processCapabilities(features, caps);
   processExtensions(features, exts);
@@ -271,10 +269,14 @@ convertGPUTarget(MLIRContext *context, IREE::HAL::ExecutableVariantOp variant) {
   addDotProductFeatures(compute, wgp.getDot().getValue(), caps, exts);
   addMatrixFeatures(wgp.getMma(), caps, exts, coopMatAttrs);
 
-  auto triple = spirv::VerCapExtAttr::get(
-      *version, caps.getArrayRef(), exts.getArrayRef(), variant.getContext());
+  auto triple = spirv::VerCapExtAttr::get(*version, caps.getArrayRef(),
+                                          exts.getArrayRef(), context);
+  StringRef backend;
+  if (target) {
+    backend = target.getBackend();
+  }
   return spirv::TargetEnvAttr::get(
-      triple, convertLimits(gpuTarget), deduceClientAPI(target.getBackend()),
+      triple, convertLimits(gpuTarget), deduceClientAPI(backend),
       deduceVendor(gpuTarget), spirv::DeviceType::Unknown,
       spirv::TargetEnvAttr::kUnknownDeviceID);
 }
@@ -282,20 +284,34 @@ convertGPUTarget(MLIRContext *context, IREE::HAL::ExecutableVariantOp variant) {
 struct SPIRVConvertGPUTargetPass final
     : impl::SPIRVConvertGPUTargetPassBase<SPIRVConvertGPUTargetPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<spirv::SPIRVDialect>();
+    registry.insert<IREE::GPU::IREEGPUDialect, spirv::SPIRVDialect>();
   }
 
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
-    auto variant = moduleOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
     MLIRContext *context = &getContext();
-
+    IREE::HAL::ExecutableTargetAttr targetAttr;
+    for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+      auto attr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+      if (!attr) {
+        continue;
+      }
+      if (!targetAttr) {
+        targetAttr = attr;
+        continue;
+      }
+      if (targetAttr != attr) {
+        moduleOp->emitError()
+            << "inconsistent executable target attributes across functions";
+        return signalPassFailure();
+      }
+    }
     FailureOr<spirv::TargetEnvAttr> spirvTarget =
-        convertGPUTarget(context, variant);
+        convertGPUTarget(context, targetAttr);
     if (failed(spirvTarget)) {
+      moduleOp->emitError() << "failed to convert GPU target to SPIR-V target";
       return signalPassFailure();
     }
-
     moduleOp->setAttr(spirv::getTargetEnvAttrName(), *spirvTarget);
   }
 };

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
@@ -69,6 +69,7 @@ func.func @cli_target_without_executable_target() {
 // CHECK-SAME: spirv.target_env = #spirv.target_env<#spirv.vce<v1.6,
 
 // -----
+
 #executable_target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">
 func.func @cli_target_with_basic_executable_target() attributes { hal.executable.target = #executable_target } {
   return

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
@@ -1,26 +1,18 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-spirv-convert-gpu-target))))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=valhall1 --pass-pipeline='builtin.module(iree-spirv-convert-gpu-target)' %s | FileCheck %s
 
-hal.executable @dispatch {
-hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
+// --iree-gpu-test-target is the flag for test cases that do not have
+// `#iree_gpu.target` in IR. For test cases that have `#iree_gpu.target` in IR,
+// the flag is ignored and the target info in IR is used directly.
+
+#executable_target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
     iree_codegen.target_info = #iree_gpu.target<arch = "rdna3", features = "spirv:v1.6,cap:Shader",
       wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic, dot = dp4xi8toi32, mma = [<WMMAR3_F32_16x16x16_F16>, <WMMAR3_F16_16x16x16_F16>],
       subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>) {
-  hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<bindings = [
-    #hal.pipeline.binding<storage_buffer>]>
-  ) count(%arg0: !hal.device) -> (index, index, index) {
-    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @dispatch() {
-      return
-    }
-  }
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
+func.func @dispatch() attributes { hal.executable.target = #executable_target } {
+  return
 }
-}
-
-//      CHECK: builtin.module attributes
+//      CHECK: module attributes
 // CHECK-SAME: spirv.target_env = #spirv.target_env<#spirv.vce<v1.6,
 // CHECK-SAME:   [Shader, Float64, Float16, Int64, Int16, Int8,
 // CHECK-SAME:    StorageBuffer16BitAccess, StorageUniform16, StoragePushConstant16,
@@ -44,29 +36,17 @@ hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-s
 // Check that we filter out types not supported by VK_KHR_cooperative_matrix,
 // e.g., bf16 and various versions of f8.
 
-hal.executable @dispatch_with_unsupported_types {
-hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
+#executable_target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
     iree_codegen.target_info = #iree_gpu.target<arch = "rdna4", features = "spirv:v1.6,cap:Shader",
       wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b32, subgroup = none,
              mma = [<WMMAR4_F32_16x16x16_F16>, <WMMAR4_F16_16x16x16_F16>, <WMMAR4_BF16_16x16x16_BF16>, <WMMAR4_F32_16x16x16_BF16>,
                     <WMMAR4_F32_16x16x16_F8E5M2>, <WMMAR4_F32_16x16x16_F8E4M3FN_F8E5M2>, <WMMAR4_I32_16x16x16_I8>],
       subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>) {
-  hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<bindings = [
-    #hal.pipeline.binding<storage_buffer>]>
-  ) count(%arg0: !hal.device) -> (index, index, index) {
-    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @dispatch() {
-      return
-    }
-  }
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
+func.func @dispatch_with_unsupported_types() attributes { hal.executable.target = #executable_target } {
+  return
 }
-}
-
-//      CHECK: builtin.module attributes
+//      CHECK: module attributes
 // CHECK-SAME: spirv.target_env = #spirv.target_env<#spirv.vce<v1.6,
 // CHECK-SAME:   [Shader, Float64, Float16, Int64, Int16, Int8, CooperativeMatrixKHR],
 // CHECK-SAME:   [SPV_KHR_cooperative_matrix]>,
@@ -79,3 +59,19 @@ hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-s
 // CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f16, result_type = f16, acc_sat = false, scope = <Subgroup>>,
 // CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = i8, b_type = i8, c_type = i32, result_type = i32, acc_sat = false, scope = <Subgroup>>
 // CHECK-SAME: ]>>
+
+// -----
+
+func.func @cli_target_without_executable_target() {
+  return
+}
+//      CHECK: module attributes
+// CHECK-SAME: spirv.target_env = #spirv.target_env<#spirv.vce<v1.6,
+
+// -----
+#executable_target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">
+func.func @cli_target_with_basic_executable_target() attributes { hal.executable.target = #executable_target } {
+  return
+}
+//      CHECK: module attributes
+// CHECK-SAME: spirv.target_env = #spirv.target_env<#spirv.vce<v1.6,


### PR DESCRIPTION
The revision gathers the executable target from func ops, instead of assuming hal.executab.variant op exists. It also improves the pass to accept CLI GPUTarget testing flags and avoid crashes when target is not available.