### PR TITLE
[SPIRV] Switch SPIR-V to module-scope pipeline.

### DIFF
--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -7,6 +7,7 @@
 #include "compiler/plugins/target/MetalSPIRV/MSLToMetalLib.h"
 #include "compiler/plugins/target/MetalSPIRV/MetalTargetPlatform.h"
 #include "compiler/plugins/target/MetalSPIRV/SPIRVToMSL.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
@@ -110,12 +111,14 @@ public:
   void
   buildConfigurationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                  OpPassManager &passManager) final {
-    buildSPIRVCodegenConfigurationPassPipeline(passManager);
+    buildCodegenConfigurationPreProcessingPassPipeline(passManager);
+    buildSPIRVCodegenConfigurationPassPipeline(passManager.nest<ModuleOp>());
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                     OpPassManager &passManager) final {
-    buildSPIRVCodegenPassPipeline(passManager);
+    buildSPIRVCodegenPassPipeline(passManager.nest<ModuleOp>());
+    buildCodegenTranslationPostProcessingPassPipeline(passManager);
   }
 
   LogicalResult serializeExecutable(const SerializationOptions &serOptions,

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
@@ -214,12 +215,14 @@ public:
   void
   buildConfigurationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                  OpPassManager &passManager) final {
-    buildSPIRVCodegenConfigurationPassPipeline(passManager);
+    buildCodegenConfigurationPreProcessingPassPipeline(passManager);
+    buildSPIRVCodegenConfigurationPassPipeline(passManager.nest<ModuleOp>());
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                     OpPassManager &passManager) final {
-    buildSPIRVCodegenPassPipeline(passManager);
+    buildSPIRVCodegenPassPipeline(passManager.nest<ModuleOp>());
+    buildCodegenTranslationPostProcessingPassPipeline(passManager);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) final {

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "compiler/plugins/target/WebGPUSPIRV/SPIRVToWGSL.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
@@ -104,12 +105,14 @@ public:
   void
   buildConfigurationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                  OpPassManager &passManager) final {
-    buildSPIRVCodegenConfigurationPassPipeline(passManager);
+    buildCodegenConfigurationPreProcessingPassPipeline(passManager);
+    buildSPIRVCodegenConfigurationPassPipeline(passManager.nest<ModuleOp>());
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                     OpPassManager &passManager) final {
-    buildSPIRVCodegenPassPipeline(passManager);
+    buildSPIRVCodegenPassPipeline(passManager.nest<ModuleOp>());
+    buildCodegenTranslationPostProcessingPassPipeline(passManager);
 
     // Prepare SPIR-V for WebGPU by expanding or removing unsupported ops.
     // For example,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRV.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRV.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <tuple>
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/SPIRV/Passes.h"
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -290,13 +291,8 @@ struct HALInterfaceLoadConstantConverter final
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceConstantLoadOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // TODO(#1519): this conversion should look up the entry point information
-    // to get the total push constant count.
-    auto variantOp = loadOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
-    auto exportOps = llvm::to_vector<1>(variantOp.getExportOps());
-    assert(exportOps.size() == 1);
-    auto layoutAttr = exportOps.front().getLayout();
-
+    // Get the push constant count from the layout attribute on the op itself.
+    auto layoutAttr = loadOp.getLayout();
     uint64_t elementCount = layoutAttr.getConstants();
     unsigned index = loadOp.getOrdinal().getZExtValue();
 
@@ -569,35 +565,38 @@ void ConvertToSPIRVPass::runOnOperation() {
 
   bool useIndirectBindings = usesIndirectBindingsAttr(moduleOp);
 
+  // Build a map from function name to dispatch_config for workgroup_size
+  // and subgroup_size lookup.
+  DenseMap<StringRef, IREE::Codegen::DispatchConfigOp> configMap;
+  for (auto configOp : moduleOp.getOps<IREE::Codegen::DispatchConfigOp>()) {
+    configMap[configOp.getFunctionRef()] = configOp;
+  }
+
   for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {
-    auto exportOp = getEntryPoint(funcOp);
-    if (!exportOp) {
+    if (!configMap.contains(funcOp.getName())) {
       continue;
     }
+    IREE::Codegen::DispatchConfigOp configOp = configMap[funcOp.getName()];
     if (funcOp->hasAttr(spirv::getEntryPointABIAttrName())) {
       continue;
     }
-    std::optional<ArrayAttr> workgroupSize = exportOp->getWorkgroupSize();
-    if (!workgroupSize) {
-      exportOp->emitOpError(
-          "expected workgroup_size attribute to be set for SPIR-V lowering");
+    SmallVector<int> workgroupSize;
+    if (std::optional<ArrayRef<int64_t>> wgSize = configOp.getWorkgroupSize()) {
+      workgroupSize = llvm::map_to_vector(wgSize.value(),
+                                          [](int64_t v) -> int { return v; });
+    }
+    if (workgroupSize.empty()) {
+      funcOp->emitOpError(
+          "expected workgroup_size to be set for SPIR-V lowering");
       return signalPassFailure();
     }
-    auto workgroupSize32 =
-        llvm::map_to_vector(workgroupSize.value(), [](Attribute v) {
-          return static_cast<int32_t>(
-              cast<IntegerAttr>(v).getValue().getZExtValue());
-        });
-
-    std::optional<APInt> subgroupSize = exportOp->getSubgroupSize();
-    std::optional<int> subgroupSize32;
-    if (subgroupSize && subgroupSize->isNonNegative()) {
-      subgroupSize32 = subgroupSize->getZExtValue();
+    std::optional<int> subgroupSize;
+    if (std::optional<uint64_t> sg = configOp.getSubgroupSize()) {
+      subgroupSize = sg.value();
     }
-
     funcOp->setAttr(
         spirv::getEntryPointABIAttrName(),
-        spirv::getEntryPointABIAttr(context, workgroupSize32, subgroupSize32));
+        spirv::getEntryPointABIAttr(context, workgroupSize, subgroupSize));
   }
 
   for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -642,38 +642,28 @@ static void buildSPIRVCodegenConfigurationPassPipelineImpl(
 }
 
 void buildSPIRVCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager) {
-  variantPassManager.addPass(createSpecializeExportsPass());
-  variantPassManager.addPass(createCreateDispatchConfigPass());
-  OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
+    OpPassManager &modulePassManager) {
   buildSPIRVCodegenConfigurationPassPipelineImpl(modulePassManager);
 }
 
-void buildSPIRVCodegenPassPipeline(OpPassManager &variantPassManager) {
-  {
-    OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
-    modulePassManager.addPass(
-        createSPIRVLowerExecutableUsingTransformDialectPass());
-    FunctionLikeNest(modulePassManager)
-        .addPass(createSPIRVLowerExecutableTargetPass)
-        .addPass(createVerifyWorkgroupDistributionPass);
-    addMemRefLoweringPasses(modulePassManager);
-    FunctionLikeNest(modulePassManager).addPass(createGpuEliminateBarriers);
-    modulePassManager.addPass(createReconcileTranslationInfoPass());
-    modulePassManager.addPass(createResolveWorkgroupCountHintsPass());
-  }
-  variantPassManager.addPass(createPropagateDispatchConfigPass());
-  variantPassManager.addPass(IREE::Util::createDropCompilerHintsPass(
+void buildSPIRVCodegenPassPipeline(OpPassManager &modulePassManager) {
+  modulePassManager.addPass(
+      createSPIRVLowerExecutableUsingTransformDialectPass());
+  FunctionLikeNest(modulePassManager)
+      .addPass(createSPIRVLowerExecutableTargetPass)
+      .addPass(createVerifyWorkgroupDistributionPass);
+  addMemRefLoweringPasses(modulePassManager);
+  FunctionLikeNest(modulePassManager).addPass(createGpuEliminateBarriers);
+  modulePassManager.addPass(createReconcileTranslationInfoPass());
+  modulePassManager.addPass(createResolveWorkgroupCountHintsPass());
+  modulePassManager.addPass(IREE::Util::createDropCompilerHintsPass(
       IREE::Util::DropCompilerHintsPassOptions{/*keepAssumeInt=*/true}));
 
-  {
-    OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
-    addSPIRVLoweringPasses(modulePassManager);
-  }
+  addSPIRVLoweringPasses(modulePassManager);
 
   LLVM_DEBUG({
     llvm::dbgs() << "Using SPIR-V pass pipeline:\n";
-    variantPassManager.printAsTextualPipeline(llvm::dbgs());
+    modulePassManager.printAsTextualPipeline(llvm::dbgs());
     llvm::dbgs() << "\n";
   });
 }
@@ -772,8 +762,8 @@ void registerCodegenSPIRVPasses() {
   static PassPipelineRegistration<> LinalgSPIRVPipeline(
       "iree-codegen-linalg-to-spirv-pipeline",
       "Runs the progressive lowering pipeline from linalg to SPIR-V",
-      [](OpPassManager &variantPassManager) {
-        buildSPIRVCodegenPassPipeline(variantPassManager);
+      [](OpPassManager &modulePassManager) {
+        buildSPIRVCodegenPassPipeline(modulePassManager);
       });
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -58,11 +58,11 @@ void addSPIRVWinogradVectorizePassPipeline(OpPassManager &funcPassManager);
 /// Populates passes needed to preprocess the input variant before lowering
 /// and select lowering strategies.
 void buildSPIRVCodegenConfigurationPassPipeline(
-    OpPassManager &variantPassManager);
+    OpPassManager &modulePassManager);
 
 /// Populates passes needed to lower linalg/arith/math ops to SPIR-V ops via
 /// the structured ops path.
-void buildSPIRVCodegenPassPipeline(OpPassManager &variantPassManager);
+void buildSPIRVCodegenPassPipeline(OpPassManager &modulePassManager);
 
 /// Populates passes needed to link HAL executables across SPIRV targets.
 void buildSPIRVLinkingPassPipeline(OpPassManager &modulePassManager);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -1,13 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=volta@vulkan \
-// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)' \
 // RUN:   %s | FileCheck %s
 
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna3@vulkan \
-// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)' \
 // RUN:   %s | FileCheck %s --check-prefix=RDNA3
 
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna4@vulkan \
-// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)' \
 // RUN:   %s | FileCheck %s --check-prefix=RDNA4
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -17,45 +17,34 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-
-hal.executable public @matmul_256x1024x128_div_exp {
-  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_256x1024x128_div_exp layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module  {
-      func.func @matmul_256x1024x128_div_exp() {
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>>
-        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-        %11 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
-        %14 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
-        %17 = tensor.empty() : tensor<256x1024xf16>
-        %19 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>> -> tensor<256x128xf16>
-        %21 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [128, 1204], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>> -> tensor<128x1024xf16>
-        %24 = tensor.empty() : tensor<256x1024xf16>
-        %25 = linalg.fill ins(%cst : f16) outs(%24 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-        %26 = linalg.matmul ins(%19, %21 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%25 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-        %27 = linalg.generic {
-            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
-            iterator_types = ["parallel", "parallel"]}
-          ins(%26, %11, %14 : tensor<256x1024xf16>, tensor<256x1024xf16>, tensor<256x1024xf16>)
-          outs(%17 : tensor<256x1024xf16>) {
-        ^bb0(%arg2: f16, %arg3: f16, %arg4: f16, %arg5: f16):
-          %28 = arith.divf %arg2, %arg3 : f16
-          // spirv.GL.FAbs is not permitted to use cooperative matrix types per the spec.
-          %29 = math.absf %28 : f16
-          linalg.yield %29 : f16
-        } -> tensor<256x1024xf16>
-        iree_tensor_ext.dispatch.tensor.store %27, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-        return
-      }
-    }
-  }
+func.func @matmul_256x1024x128_div_exp() {
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>>
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
+  %11 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
+  %14 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
+  %17 = tensor.empty() : tensor<256x1024xf16>
+  %19 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>> -> tensor<256x128xf16>
+  %21 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [128, 1204], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>> -> tensor<128x1024xf16>
+  %24 = tensor.empty() : tensor<256x1024xf16>
+  %25 = linalg.fill ins(%cst : f16) outs(%24 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  %26 = linalg.matmul ins(%19, %21 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%25 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  %27 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+    ins(%26, %11, %14 : tensor<256x1024xf16>, tensor<256x1024xf16>, tensor<256x1024xf16>)
+    outs(%17 : tensor<256x1024xf16>) {
+  ^bb0(%arg2: f16, %arg3: f16, %arg4: f16, %arg5: f16):
+    %28 = arith.divf %arg2, %arg3 : f16
+    // spirv.GL.FAbs is not permitted to use cooperative matrix types per the spec.
+    %29 = math.absf %28 : f16
+    linalg.yield %29 : f16
+  } -> tensor<256x1024xf16>
+  iree_tensor_ext.dispatch.tensor.store %27, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
+  return
 }
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
@@ -203,39 +192,29 @@ hal.executable public @matmul_256x1024x128_div_exp {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable public @batch_matmul_16x128x256x512_div {
-  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @batch_matmul_16x128x256x512_div layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2, %arg3)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @batch_matmul_16x128x256x512_div() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 128, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>> -> tensor<16x128x512xf16>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 512, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>> -> tensor<16x512x256xf16>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>> -> tensor<16x128x256xf16>
-        %7 = tensor.empty() : tensor<16x128x256xf16>
-        %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
-        %9 = linalg.batch_matmul ins(%4, %5 : tensor<16x128x512xf16>, tensor<16x512x256xf16>) outs(%8 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
-        %10 = linalg.generic {
-            indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
-            iterator_types = ["parallel", "parallel", "parallel"]}
-          ins(%9, %6 : tensor<16x128x256xf16>, tensor<16x128x256xf16>) outs(%7 : tensor<16x128x256xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %11 = arith.divf %in, %in_0 : f16
-          linalg.yield %11 : f16
-        } -> tensor<16x128x256xf16>
-        iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : tensor<16x128x256xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
-        return
-      }
-    }
-  }
+func.func @batch_matmul_16x128x256x512_div() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 128, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>> -> tensor<16x128x512xf16>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 512, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>> -> tensor<16x512x256xf16>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>> -> tensor<16x128x256xf16>
+  %7 = tensor.empty() : tensor<16x128x256xf16>
+  %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
+  %9 = linalg.batch_matmul ins(%4, %5 : tensor<16x128x512xf16>, tensor<16x512x256xf16>) outs(%8 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
+  %10 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%9, %6 : tensor<16x128x256xf16>, tensor<16x128x256xf16>) outs(%7 : tensor<16x128x256xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %11 = arith.divf %in, %in_0 : f16
+    linalg.yield %11 : f16
+  } -> tensor<16x128x256xf16>
+  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : tensor<16x128x256xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
+  return
 }
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
@@ -327,39 +306,29 @@ hal.executable public @batch_matmul_16x128x256x512_div {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-hal.executable public @matmul_32x32x32_div {
-  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_32x32x32_div layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module  {
-      func.func @matmul_32x32x32_div() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x32xf16>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>> -> tensor<32x32xf16>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>> -> tensor<32x32xf16>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>> -> tensor<32x32xf16>
-        %7 = tensor.empty() : tensor<32x32xf16>
-        %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<32x32xf16>) -> tensor<32x32xf16>
-        %9 = linalg.matmul ins(%4, %5 : tensor<32x32xf16>, tensor<32x32xf16>) outs(%8 : tensor<32x32xf16>) -> tensor<32x32xf16>
-        %10 = linalg.generic {
-            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
-            iterator_types = ["parallel", "parallel"]}
-        ins(%9, %6 : tensor<32x32xf16>, tensor<32x32xf16>) outs(%7 : tensor<32x32xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %11 = arith.divf %in, %in_0 : f16
-          linalg.yield %11 : f16
-        } -> tensor<32x32xf16>
-        iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : tensor<32x32xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x32xf16>>
-        return
-      }
-    }
-  }
+func.func @matmul_32x32x32_div() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x32xf16>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>> -> tensor<32x32xf16>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>> -> tensor<32x32xf16>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x32xf16>> -> tensor<32x32xf16>
+  %7 = tensor.empty() : tensor<32x32xf16>
+  %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<32x32xf16>) -> tensor<32x32xf16>
+  %9 = linalg.matmul ins(%4, %5 : tensor<32x32xf16>, tensor<32x32xf16>) outs(%8 : tensor<32x32xf16>) -> tensor<32x32xf16>
+  %10 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+  ins(%9, %6 : tensor<32x32xf16>, tensor<32x32xf16>) outs(%7 : tensor<32x32xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %11 = arith.divf %in, %in_0 : f16
+    linalg.yield %11 : f16
+  } -> tensor<32x32xf16>
+  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : tensor<32x32xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x32xf16>>
+  return
 }
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
@@ -379,37 +348,27 @@ hal.executable public @matmul_32x32x32_div {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-hal.executable public @generic_batch_matmul_32x128x512x64 {
-  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @generic_batch_matmul_32x128x512x64 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2, %arg3, %arg4)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module  {
-      func.func @generic_batch_matmul_32x128x512x64() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128x64xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x512xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
-        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [32, 128, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128x64xf16>> -> tensor<32x128x64xf16>
-        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [64, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x512xf16>> -> tensor<64x512xf16>
-        %5 = tensor.empty() : tensor<32x128x512xf16>
-        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<32x128x512xf16>) -> tensor<32x128x512xf16>
-        %7 = linalg.generic {
-            indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
-            iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
-        ins(%3, %4 : tensor<32x128x64xf16>, tensor<64x512xf16>) outs(%6 : tensor<32x128x512xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %8 = arith.mulf %in, %in_0 : f16
-          %9 = arith.addf %out, %8 : f16
-          linalg.yield %9 : f16
-        } -> tensor<32x128x512xf16>
-        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [32, 128, 512], strides = [1, 1, 1] : tensor<32x128x512xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
-        return
-      }
-    }
-  }
+func.func @generic_batch_matmul_32x128x512x64() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128x64xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x512xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [32, 128, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128x64xf16>> -> tensor<32x128x64xf16>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [64, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x512xf16>> -> tensor<64x512xf16>
+  %5 = tensor.empty() : tensor<32x128x512xf16>
+  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<32x128x512xf16>) -> tensor<32x128x512xf16>
+  %7 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+  ins(%3, %4 : tensor<32x128x64xf16>, tensor<64x512xf16>) outs(%6 : tensor<32x128x512xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %8 = arith.mulf %in, %in_0 : f16
+    %9 = arith.addf %out, %8 : f16
+    linalg.yield %9 : f16
+  } -> tensor<32x128x512xf16>
+  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [32, 128, 512], strides = [1, 1, 1] : tensor<32x128x512xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
+  return
 }
 
 // With pipelining + multi-buffering the loop here gets completely unrolled.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -1,4 +1,6 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=pascal@vulkan --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=pascal@vulkan \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)' \
+// RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -7,38 +9,27 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-
-hal.executable @matmul_f32_128x256x64 {
-  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_f32_128x256x64() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
-        %7 = tensor.empty() : tensor<128x256xf32>
-        %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
-        %9 = linalg.matmul ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
-        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
-                ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
-        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %11 = arith.divf %arg0, %arg1 : f32
-          linalg.yield %11 : f32
-        } -> tensor<128x256xf32>
-        iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
-        return
-      }
-    }
-  }
+func.func @matmul_f32_128x256x64() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+  %7 = tensor.empty() : tensor<128x256xf32>
+  %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  %9 = linalg.matmul ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+          ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %11 = arith.divf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<128x256xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
+  return
 }
 
 // Default promotion requires 1024 x vector<4xf32>, however padding to avoid bank conflicts
@@ -79,38 +70,27 @@ hal.executable @matmul_f32_128x256x64 {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-
-hal.executable @matmul_f16_128x256x64 {
-  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f16_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_f16_128x256x64() {
-        %cst = arith.constant 0.0 : f16
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf16>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>> -> tensor<512x256xf16>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf16>> -> tensor<128x256xf16>
-        %7 = tensor.empty() : tensor<128x256xf16>
-        %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<128x256xf16>) -> tensor<128x256xf16>
-        %9 = linalg.matmul ins(%4, %5 : tensor<128x512xf16>, tensor<512x256xf16>) outs(%8 : tensor<128x256xf16>) -> tensor<128x256xf16>
-        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
-                ins(%9, %6 : tensor<128x256xf16>, tensor<128x256xf16>) outs(%7 : tensor<128x256xf16>) {
-        ^bb0(%arg0: f16, %arg1: f16, %arg2: f16):
-          %11 = arith.divf %arg0, %arg1 : f16
-          linalg.yield %11 : f16
-        } -> tensor<128x256xf16>
-        iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf16>>
-        return
-      }
-    }
-  }
+func.func @matmul_f16_128x256x64() {
+  %cst = arith.constant 0.0 : f16
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf16>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>> -> tensor<512x256xf16>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf16>> -> tensor<128x256xf16>
+  %7 = tensor.empty() : tensor<128x256xf16>
+  %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<128x256xf16>) -> tensor<128x256xf16>
+  %9 = linalg.matmul ins(%4, %5 : tensor<128x512xf16>, tensor<512x256xf16>) outs(%8 : tensor<128x256xf16>) -> tensor<128x256xf16>
+  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+          ins(%9, %6 : tensor<128x256xf16>, tensor<128x256xf16>) outs(%7 : tensor<128x256xf16>) {
+  ^bb0(%arg0: f16, %arg1: f16, %arg2: f16):
+    %11 = arith.divf %arg0, %arg1 : f16
+    linalg.yield %11 : f16
+  } -> tensor<128x256xf16>
+  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf16>>
+  return
 }
 
 // Ditto on the above but without bank conflict padding for f16.
@@ -155,30 +135,20 @@ hal.executable @matmul_f16_128x256x64 {
   lowering_config = #iree_codegen.lowering_config<tile_sizes = [[16, 128, 16]]>,
   translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize> workgroup_size = [16, 8, 1], {pipeline_depth = 0, store_stage = 1}>>
 
-hal.executable @matmul_f16_32x1280x1280 {
-  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f16_32x1280x1280 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2, %arg3)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_f16_32x1280x1280() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1280xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x1280xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1280xf16>>
-        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1280xf16>> -> tensor<32x1280xf16>
-        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1280, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x1280xf16>> -> tensor<1280x1280xf16>
-        %5 = tensor.empty() : tensor<32x1280xf16>
-        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<32x1280xf16>) -> tensor<32x1280xf16>
-        %7 = linalg.matmul {compilation_info = #user_config}
-             ins(%3, %4 : tensor<32x1280xf16>, tensor<1280x1280xf16>) outs(%6 : tensor<32x1280xf16>) -> tensor<32x1280xf16>
-        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [32, 1280], strides = [1, 1] : tensor<32x1280xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1280xf16>>
-        return
-      }
-    }
-  }
+func.func @matmul_f16_32x1280x1280() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1280xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x1280xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1280xf16>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1280xf16>> -> tensor<32x1280xf16>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1280, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x1280xf16>> -> tensor<1280x1280xf16>
+  %5 = tensor.empty() : tensor<32x1280xf16>
+  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<32x1280xf16>) -> tensor<32x1280xf16>
+  %7 = linalg.matmul {compilation_info = #user_config}
+       ins(%3, %4 : tensor<32x1280xf16>, tensor<1280x1280xf16>) outs(%6 : tensor<32x1280xf16>) -> tensor<32x1280xf16>
+  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [32, 1280], strides = [1, 1] : tensor<32x1280xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1280xf16>>
+  return
 }
 
 //   CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<2176 x f16>)>, Workgroup>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -1,32 +1,22 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=valhall1 --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=valhall1 --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable private @fuse_and_vectorize_fill_matmul {
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @fuse_and_vectorize_fill_matmul layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2, %arg3)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @fuse_and_vectorize_fill_matmul() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf32>>
-        %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>> -> tensor<4096x4096xf32>
-        %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>> -> tensor<4096x4096xf32>
-        %15 = tensor.empty() : tensor<4096x4096xf32>
-        %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
-        %17 = linalg.matmul ins(%8, %10 : tensor<4096x4096xf32>, tensor<4096x4096xf32>) outs(%16 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
-        iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : tensor<4096x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf32>>
-        return
-      }
-    }
-  }
+func.func @fuse_and_vectorize_fill_matmul() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf32>>
+  %8 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>> -> tensor<4096x4096xf32>
+  %10 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x4096xf32>> -> tensor<4096x4096xf32>
+  %15 = tensor.empty() : tensor<4096x4096xf32>
+  %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+  %17 = linalg.matmul ins(%8, %10 : tensor<4096x4096xf32>, tensor<4096x4096xf32>) outs(%16 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : tensor<4096x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf32>>
+  return
 }
 
 //    CHECK-LABEL: spirv.func @fuse_and_vectorize_fill_matmul
@@ -45,36 +35,26 @@ hal.executable private @fuse_and_vectorize_fill_matmul {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable private @fuse_and_vectorize_matmul_add {
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @fuse_and_vectorize_matmul_add layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @fuse_and_vectorize_matmul_add() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x256xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x256xf32>>
-        %10 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x256xf32>> -> tensor<1024x256xf32>
-        %13 = tensor.empty() : tensor<1024x256xf32>
-        %15 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
-        %17 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
-        %20 = tensor.empty() : tensor<1024x256xf32>
-        %21 = linalg.fill ins(%cst : f32) outs(%20 : tensor<1024x256xf32>) -> tensor<1024x256xf32>
-        %22 = linalg.matmul ins(%15, %17 : tensor<1024x512xf32>, tensor<512x256xf32>) outs(%21 : tensor<1024x256xf32>) -> tensor<1024x256xf32>
-        %23 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%22, %10 : tensor<1024x256xf32>, tensor<1024x256xf32>) outs(%13 : tensor<1024x256xf32>) {
-        ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
-          %24 = arith.addf %arg2, %arg3 : f32
-          linalg.yield %24 : f32
-        } -> tensor<1024x256xf32>
-        iree_tensor_ext.dispatch.tensor.store %23, %3, offsets = [0, 0], sizes = [1024, 256], strides = [1, 1] : tensor<1024x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x256xf32>>
-        return
-      }
-    }
-  }
+func.func @fuse_and_vectorize_matmul_add() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x256xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x256xf32>>
+  %10 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x256xf32>> -> tensor<1024x256xf32>
+  %13 = tensor.empty() : tensor<1024x256xf32>
+  %15 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
+  %17 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
+  %20 = tensor.empty() : tensor<1024x256xf32>
+  %21 = linalg.fill ins(%cst : f32) outs(%20 : tensor<1024x256xf32>) -> tensor<1024x256xf32>
+  %22 = linalg.matmul ins(%15, %17 : tensor<1024x512xf32>, tensor<512x256xf32>) outs(%21 : tensor<1024x256xf32>) -> tensor<1024x256xf32>
+  %23 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%22, %10 : tensor<1024x256xf32>, tensor<1024x256xf32>) outs(%13 : tensor<1024x256xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
+    %24 = arith.addf %arg2, %arg3 : f32
+    linalg.yield %24 : f32
+  } -> tensor<1024x256xf32>
+  iree_tensor_ext.dispatch.tensor.store %23, %3, offsets = [0, 0], sizes = [1024, 256], strides = [1, 1] : tensor<1024x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x256xf32>>
+  return
 }
 
 //    CHECK-LABEL: spirv.func @fuse_and_vectorize_matmul_add

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=pascal@vulkan \
-// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline)))' \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)' \
 // RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -9,66 +9,58 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @i4_dequant_unit_matmul_f16 {
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
+func.func @i4_dequant_unit_matmul_f16() attributes {
+  hal.executable.target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
     iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
       compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
       subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
       max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
       max_workgroup_counts = [65535, 65535, 65535]>>
-    }>) {
-    hal.executable.export public @i4_dequant_unit_matmul_f16 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @i4_dequant_unit_matmul_f16() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1x86x128xf16>>
-        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x4096xf16>>
-        %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>> -> tensor<4096x86x128xi4>
-        %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [4096, 86, 1], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>> -> tensor<4096x86x1xf16>
-        %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [4096, 86, 1], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>> -> tensor<4096x86x1xf16>
-        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [1, 1, 86, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1x86x128xf16>> -> tensor<1x1x86x128xf16>
-        %9 = tensor.empty() : tensor<1x1x4096xf16>
-        %10 = tensor.empty() : tensor<4096x86x128xf16>
-        %11 = linalg.fill ins(%cst : f16) outs(%9 : tensor<1x1x4096xf16>) -> tensor<1x1x4096xf16>
-        %12 = linalg.generic {
-            indexing_maps = [
-                affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
-                affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
-                affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
-                affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
-            iterator_types = ["parallel", "parallel", "parallel"]}
-        ins(%5, %6, %7 : tensor<4096x86x128xi4>, tensor<4096x86x1xf16>, tensor<4096x86x1xf16>) outs(%10 : tensor<4096x86x128xf16>) {
-        ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
-          %14 = arith.extui %in : i4 to i32
-          %15 = arith.uitofp %14 : i32 to f16
-          %16 = arith.subf %15, %in_1 : f16
-          %17 = arith.mulf %16, %in_0 : f16
-          linalg.yield %17 : f16
-        } -> tensor<4096x86x128xf16>
-        %13 = linalg.generic {
-            indexing_maps = [
-                affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>,
-                affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>,
-                affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>],
-            iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]}
-        ins(%8, %12 : tensor<1x1x86x128xf16>, tensor<4096x86x128xf16>) outs(%11 : tensor<1x1x4096xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %14 = arith.mulf %in, %in_0 : f16
-          %15 = arith.addf %14, %out : f16
-          linalg.yield %15 : f16
-        } -> tensor<1x1x4096xf16>
-        iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0, 0, 0], sizes = [1, 1, 4096], strides = [1, 1, 1] : tensor<1x1x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x4096xf16>>
-        return
-      }
-    }
-  }
+  }>
+} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1x86x128xf16>>
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x4096xf16>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>> -> tensor<4096x86x128xi4>
+  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [4096, 86, 1], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>> -> tensor<4096x86x1xf16>
+  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [4096, 86, 1], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x1xf16>> -> tensor<4096x86x1xf16>
+  %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [1, 1, 86, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1x86x128xf16>> -> tensor<1x1x86x128xf16>
+  %9 = tensor.empty() : tensor<1x1x4096xf16>
+  %10 = tensor.empty() : tensor<4096x86x128xf16>
+  %11 = linalg.fill ins(%cst : f16) outs(%9 : tensor<1x1x4096xf16>) -> tensor<1x1x4096xf16>
+  %12 = linalg.generic {
+      indexing_maps = [
+          affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+          affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
+          affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
+          affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+  ins(%5, %6, %7 : tensor<4096x86x128xi4>, tensor<4096x86x1xf16>, tensor<4096x86x1xf16>) outs(%10 : tensor<4096x86x128xf16>) {
+  ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
+    %14 = arith.extui %in : i4 to i32
+    %15 = arith.uitofp %14 : i32 to f16
+    %16 = arith.subf %15, %in_1 : f16
+    %17 = arith.mulf %16, %in_0 : f16
+    linalg.yield %17 : f16
+  } -> tensor<4096x86x128xf16>
+  %13 = linalg.generic {
+      indexing_maps = [
+          affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>,
+          affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>,
+          affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]}
+  ins(%8, %12 : tensor<1x1x86x128xf16>, tensor<4096x86x128xf16>) outs(%11 : tensor<1x1x4096xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %14 = arith.mulf %in, %in_0 : f16
+    %15 = arith.addf %14, %out : f16
+    linalg.yield %15 : f16
+  } -> tensor<1x1x4096xf16>
+  iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0, 0, 0], sizes = [1, 1, 4096], strides = [1, 1, 1] : tensor<1x1x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x4096xf16>>
+  return
 }
 
 //   CHECK-LABEL: spirv.func @i4_dequant_unit_matmul_f16
@@ -115,63 +107,54 @@ hal.executable @i4_dequant_unit_matmul_f16 {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @i4_dequant_matvec_f16_subgroup_64 {
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
+func.func @i4_dequant_matvec_f16_subgroup_64() attributes {
+  hal.executable.target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
     iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
       compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
       subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
       max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
       max_workgroup_counts = [65535, 65535, 65535]>>
-  }>) {
-    hal.executable.export public @i4_dequant_matvec_f16_subgroup_64 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @i4_dequant_matvec_f16_subgroup_64() {
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-        %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-        %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
-        %3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : i32
-        %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : i32
-        %5 = arith.index_castui %0 : i32 to index
-        %6 = arith.index_castui %1 : i32 to index
-        %7 = arith.index_castui %2 : i32 to index
-        %8 = arith.index_castui %3 : i32 to index
-        %9 = arith.index_castui %4 : i32 to index
-        %10 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%5) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
-        %11 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%6) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>>
-        %12 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%7) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>>
-        %13 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%8) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<86x128xf16>>
-        %14 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%9) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
-        %15 = iree_tensor_ext.dispatch.tensor.load %10, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>> -> tensor<4096x86x128xi4>
-        %16 = iree_tensor_ext.dispatch.tensor.load %11, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>> -> tensor<4096x86xf16>
-        %17 = iree_tensor_ext.dispatch.tensor.load %12, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>> -> tensor<4096x86xf16>
-        %18 = iree_tensor_ext.dispatch.tensor.load %13, offsets = [0, 0], sizes = [86, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<86x128xf16>> -> tensor<86x128xf16>
-        %19 = tensor.empty() : tensor<4096xf16>
-        %20 = tensor.empty() : tensor<4096x86x128xf16>
-        %21 = linalg.fill ins(%cst : f16) outs(%19 : tensor<4096xf16>) -> tensor<4096xf16>
-        %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%15, %16, %17 : tensor<4096x86x128xi4>, tensor<4096x86xf16>, tensor<4096x86xf16>) outs(%20 : tensor<4096x86x128xf16>) {
-        ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
-          %24 = arith.extui %in : i4 to i32
-          %25 = arith.uitofp %24 : i32 to f16
-          %26 = arith.subf %25, %in_1 : f16
-          %27 = arith.mulf %26, %in_0 : f16
-          linalg.yield %27 : f16
-        } -> tensor<4096x86x128xf16>
-        %23 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%18, %22 : tensor<86x128xf16>, tensor<4096x86x128xf16>) outs(%21 : tensor<4096xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %24 = arith.mulf %in, %in_0 : f16
-          %25 = arith.addf %24, %out : f16
-          linalg.yield %25 : f16
-        } -> tensor<4096xf16>
-        iree_tensor_ext.dispatch.tensor.store %23, %14, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
-        return
-
-      }
-    }
-  }
+  }>
+} {
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
+  %3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : i32
+  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : i32
+  %5 = arith.index_castui %0 : i32 to index
+  %6 = arith.index_castui %1 : i32 to index
+  %7 = arith.index_castui %2 : i32 to index
+  %8 = arith.index_castui %3 : i32 to index
+  %9 = arith.index_castui %4 : i32 to index
+  %10 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%5) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>>
+  %11 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%6) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>>
+  %12 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%7) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>>
+  %13 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%8) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<86x128xf16>>
+  %14 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%9) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
+  %15 = iree_tensor_ext.dispatch.tensor.load %10, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xi4>> -> tensor<4096x86x128xi4>
+  %16 = iree_tensor_ext.dispatch.tensor.load %11, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>> -> tensor<4096x86xf16>
+  %17 = iree_tensor_ext.dispatch.tensor.load %12, offsets = [0, 0], sizes = [4096, 86], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86xf16>> -> tensor<4096x86xf16>
+  %18 = iree_tensor_ext.dispatch.tensor.load %13, offsets = [0, 0], sizes = [86, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<86x128xf16>> -> tensor<86x128xf16>
+  %19 = tensor.empty() : tensor<4096xf16>
+  %20 = tensor.empty() : tensor<4096x86x128xf16>
+  %21 = linalg.fill ins(%cst : f16) outs(%19 : tensor<4096xf16>) -> tensor<4096xf16>
+  %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%15, %16, %17 : tensor<4096x86x128xi4>, tensor<4096x86xf16>, tensor<4096x86xf16>) outs(%20 : tensor<4096x86x128xf16>) {
+  ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
+    %24 = arith.extui %in : i4 to i32
+    %25 = arith.uitofp %24 : i32 to f16
+    %26 = arith.subf %25, %in_1 : f16
+    %27 = arith.mulf %26, %in_0 : f16
+    linalg.yield %27 : f16
+  } -> tensor<4096x86x128xf16>
+  %23 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%18, %22 : tensor<86x128xf16>, tensor<4096x86x128xf16>) outs(%21 : tensor<4096xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %24 = arith.mulf %in, %in_0 : f16
+    %25 = arith.addf %24, %out : f16
+    linalg.yield %25 : f16
+  } -> tensor<4096xf16>
+  iree_tensor_ext.dispatch.tensor.store %23, %14, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
+  return
 }
 
 //   CHECK-LABEL: spirv.func @i4_dequant_matvec_f16_subgroup_64

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
@@ -1,38 +1,28 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=valhall1 --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s --check-prefix=NOSHUFFLE
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=valhall1 --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)' %s | FileCheck %s --check-prefix=NOSHUFFLE
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable private @subgroup_reduce {
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @subgroup_reduce ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @subgroup_reduce() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x512xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2xf32>>
-        %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x512xf32>> -> tensor<2x512xf32>
-        %3 = tensor.empty() : tensor<2xf32>
-        %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<2xf32>) -> tensor<2xf32>
-        %5 = linalg.generic {
-          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
-          iterator_types = ["parallel", "reduction"]
-        } ins(%2 : tensor<2x512xf32>) outs(%4 : tensor<2xf32>) {
-        ^bb0(%arg0: f32, %arg1: f32):
-          %6 = arith.addf %arg1, %arg0 : f32
-          linalg.yield %6 : f32
-        } -> tensor<2xf32>
-        iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [2], strides = [1] : tensor<2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2xf32>>
-        return
-      }
-    }
-  }
+func.func @subgroup_reduce() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x512xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x512xf32>> -> tensor<2x512xf32>
+  %3 = tensor.empty() : tensor<2xf32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<2xf32>) -> tensor<2xf32>
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]
+  } ins(%2 : tensor<2x512xf32>) outs(%4 : tensor<2xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    %6 = arith.addf %arg1, %arg0 : f32
+    linalg.yield %6 : f32
+  } -> tensor<2xf32>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [2], strides = [1] : tensor<2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2xf32>>
+  return
 }
 
 // CHECK-LABEL: spirv.func @subgroup_reduce
@@ -96,40 +86,30 @@ hal.executable private @subgroup_reduce {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable public @softmax{
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @softmax ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @softmax() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %cst_0 = arith.constant 1.000000e+00 : f32
-        %c786432 = arith.constant 786432 : index
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c786432) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1536x128xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1536x128xf32>>
-        %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1536, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1536x128xf32>> -> tensor<1536x128xf32>
-        %3 = tensor.empty() : tensor<1536xf32>
-        %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<1536xf32>) -> tensor<1536xf32>
-        %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<1536x128xf32>) outs(%4 : tensor<1536xf32>) {
-        ^bb0(%in: f32, %out: f32):
-          %8 = arith.addf %in, %out : f32
-          linalg.yield %8 : f32
-        } -> tensor<1536xf32>
-        %6 = tensor.empty() : tensor<1536x128xf32>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %5 : tensor<1536x128xf32>, tensor<1536xf32>) outs(%6 : tensor<1536x128xf32>) {
-        ^bb0(%in: f32, %in_1: f32, %out: f32):
-          %8 = arith.divf %cst_0, %in_1 : f32
-          %9 = arith.mulf %in, %8 : f32
-          linalg.yield %9 : f32
-        } -> tensor<1536x128xf32>
-        iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [1536, 128], strides = [1, 1] : tensor<1536x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1536x128xf32>>
-        return
-      }
-    }
-  }
+func.func @softmax() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 1.000000e+00 : f32
+  %c786432 = arith.constant 786432 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c786432) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1536x128xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1536x128xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1536, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1536x128xf32>> -> tensor<1536x128xf32>
+  %3 = tensor.empty() : tensor<1536xf32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<1536xf32>) -> tensor<1536xf32>
+  %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<1536x128xf32>) outs(%4 : tensor<1536xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %8 = arith.addf %in, %out : f32
+    linalg.yield %8 : f32
+  } -> tensor<1536xf32>
+  %6 = tensor.empty() : tensor<1536x128xf32>
+  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %5 : tensor<1536x128xf32>, tensor<1536xf32>) outs(%6 : tensor<1536x128xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %8 = arith.divf %cst_0, %in_1 : f32
+    %9 = arith.mulf %in, %8 : f32
+    linalg.yield %9 : f32
+  } -> tensor<1536x128xf32>
+  iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [1536, 128], strides = [1, 1] : tensor<1536x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1536x128xf32>>
+  return
 }
 
 // CHECK-LABEL: spirv.func @softmax

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
@@ -1,4 +1,6 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-codegen-create-dispatch-config, builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan \
+// RUN:   --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline)' \
+// RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -6,39 +8,29 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @i4_dequant {
-  hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @i4_dequant layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @i4_dequant() {
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072x128xi4>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<131072x128xf32>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [131072, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072x128xi4>> -> tensor<131072x128xi4>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [131072], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>> -> tensor<131072xf32>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0], sizes = [131072], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>> -> tensor<131072xf32>
-        %7 = tensor.empty() : tensor<131072x128xf32>
-        %8 = linalg.generic {
-               indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
-               iterator_types = ["parallel", "parallel"]
-             } ins(%4, %5, %6 : tensor<131072x128xi4>, tensor<131072xf32>, tensor<131072xf32>) outs(%7 : tensor<131072x128xf32>) {
-        ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
-          %9 = arith.extui %in : i4 to i32
-          %10 = arith.uitofp %9 : i32 to f32
-          %11 = arith.subf %10, %in_1 : f32
-          %12 = arith.mulf %11, %in_0 : f32
-          linalg.yield %12 : f32
-        } -> tensor<131072x128xf32>
-        iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [131072, 128], strides = [1, 1] : tensor<131072x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<131072x128xf32>>
-        return
-      }
-    }
-  }
+func.func @i4_dequant() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072x128xi4>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<131072x128xf32>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [131072, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072x128xi4>> -> tensor<131072x128xi4>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [131072], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>> -> tensor<131072xf32>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0], sizes = [131072], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>> -> tensor<131072xf32>
+  %7 = tensor.empty() : tensor<131072x128xf32>
+  %8 = linalg.generic {
+         indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+         iterator_types = ["parallel", "parallel"]
+       } ins(%4, %5, %6 : tensor<131072x128xi4>, tensor<131072xf32>, tensor<131072xf32>) outs(%7 : tensor<131072x128xf32>) {
+  ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
+    %9 = arith.extui %in : i4 to i32
+    %10 = arith.uitofp %9 : i32 to f32
+    %11 = arith.subf %10, %in_1 : f32
+    %12 = arith.mulf %11, %in_0 : f32
+    linalg.yield %12 : f32
+  } -> tensor<131072x128xf32>
+  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [131072, 128], strides = [1, 1] : tensor<131072x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<131072x128xf32>>
+  return
 }
 
 //   CHECK-LABEL: spirv.func @i4_dequant


### PR DESCRIPTION
The revision moves the variant-scope passes to the boundary of pipelines, and the actual codegen works on module-scope after the change. The pipeline tests are adapted, so there are no hal.variant op involved.

It also fixes a long-due TODO in HALInterfaceLoadConstantConverter.