### PR TITLE
[LLVMGPU] Enable swizzle absorb/reinsert passes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -613,6 +613,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   }
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   if (forROCDL && pipelineOptions.prefetchNumStages >= 2) {
+    funcPassManager.addPass(createAbsorbSwizzleHintToAllocPass());
     funcPassManager.addPass(createFissionTransferOpsInControlFlowPass());
     funcPassManager.addPass(createRemoveSingleIterationLoopPass());
     ROCDLPrefetchSharedMemoryPassOptions prefetchOpts;
@@ -852,6 +853,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
   }
   if (forROCDL && options.prefetchNumStages >= 2) {
+    funcPassManager.addPass(createAbsorbSwizzleHintToAllocPass());
     ROCDLPrefetchSharedMemoryPassOptions prefetchOpts;
     prefetchOpts.numStages = options.prefetchNumStages;
     funcPassManager.addPass(createROCDLPrefetchSharedMemoryPass(prefetchOpts));
@@ -996,6 +998,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   funcPassManager.addPass(createLLVMGPUVectorLoweringPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass);
+  funcPassManager.addPass(createReinsertSwizzleHintsPass);
   addLowerAndOptimizeAddressComputationPasses(funcPassManager);
 
   if (forROCDL) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -271,7 +271,7 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
                                                unsigned numBuffers) {
   SetVector<memref::AllocOp> sharedAllocs;
 
-  // Find all LDS allocations used by gather_to_lds
+  // Find all LDS allocations used by gather_to_lds.
   forOp->walk([&](amdgpu::GatherToLDSOp gatherOp) {
     if (auto alloc = traceToAllocation(gatherOp.getDst())) {
       if (hasSharedMemoryAddressSpace(alloc.getType())) {
@@ -287,7 +287,7 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
 
   LDBG() << "Multi-buffering " << sharedAllocs.size() << " LDS allocations";
 
-  // First, clone view ops inside the loop for each allocation
+  // First, clone view ops inside the loop for each allocation.
   for (memref::AllocOp alloc : sharedAllocs) {
     if (failed(cloneViewOpsInsideLoop(alloc, forOp))) {
       LDBG() << "Failed to clone view ops for: " << *alloc;
@@ -295,13 +295,19 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
     }
   }
 
-  // Now apply multi-buffering
+  // Now apply multi-buffering, and copy the swizzle attribute if present.
   for (memref::AllocOp alloc : sharedAllocs) {
     Location loc = alloc.getLoc();
-    if (failed(memref::multiBuffer(alloc, numBuffers,
-                                   /*skipOverrideAnalysis=*/true))) {
+    auto swizzleAttr = alloc->getAttr("iree_codegen.swizzle");
+    FailureOr<memref::AllocOp> newAlloc =
+        memref::multiBuffer(alloc, numBuffers,
+                            /*skipOverrideAnalysis=*/true);
+    if (failed(newAlloc)) {
       LDBG() << "Failed to multi-buffer LDS allocation at " << loc;
       return failure();
+    }
+    if (swizzleAttr) {
+      (*newAlloc)->setAttr("iree_codegen.swizzle", swizzleAttr);
     }
     LDBG() << "Multi-buffered LDS allocation with " << numBuffers
            << " buffers at " << loc;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -271,7 +271,7 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
                                                unsigned numBuffers) {
   SetVector<memref::AllocOp> sharedAllocs;
 
-  // Find all LDS allocations used by gather_to_lds.
+  // Find all LDS allocations used by gather_to_lds
   forOp->walk([&](amdgpu::GatherToLDSOp gatherOp) {
     if (auto alloc = traceToAllocation(gatherOp.getDst())) {
       if (hasSharedMemoryAddressSpace(alloc.getType())) {
@@ -287,7 +287,7 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
 
   LDBG() << "Multi-buffering " << sharedAllocs.size() << " LDS allocations";
 
-  // First, clone view ops inside the loop for each allocation.
+  // First, clone view ops inside the loop for each allocation
   for (memref::AllocOp alloc : sharedAllocs) {
     if (failed(cloneViewOpsInsideLoop(alloc, forOp))) {
       LDBG() << "Failed to clone view ops for: " << *alloc;
@@ -295,19 +295,13 @@ static LogicalResult multiBufferLDSAllocations(scf::ForOp forOp,
     }
   }
 
-  // Now apply multi-buffering, and copy the swizzle attribute if present.
+  // Now apply multi-buffering
   for (memref::AllocOp alloc : sharedAllocs) {
     Location loc = alloc.getLoc();
-    auto swizzleAttr = alloc->getAttr("iree_codegen.swizzle");
-    FailureOr<memref::AllocOp> newAlloc =
-        memref::multiBuffer(alloc, numBuffers,
-                            /*skipOverrideAnalysis=*/true);
-    if (failed(newAlloc)) {
+    if (failed(memref::multiBuffer(alloc, numBuffers,
+                                   /*skipOverrideAnalysis=*/true))) {
       LDBG() << "Failed to multi-buffer LDS allocation at " << loc;
       return failure();
-    }
-    if (swizzleAttr) {
-      (*newAlloc)->setAttr("iree_codegen.swizzle", swizzleAttr);
     }
     LDBG() << "Multi-buffered LDS allocation with " << numBuffers
            << " buffers at " << loc;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -699,3 +699,29 @@ func.func @gather_to_lds_nested_loop_async(
   }
   return
 }
+
+// -----
+
+// Verify that the iree_codegen.swizzle attribute on memref.alloc is preserved
+// through multi-buffering.
+
+// CHECK-LABEL: @gather_to_lds_with_swizzle_attr
+// CHECK: memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>} : memref<2x1xf32, #gpu.address_space<workgroup>>
+func.func @gather_to_lds_with_swizzle_attr(
+    %global: memref<128x128xf32>,
+    %output: memref<128xf32>) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %lds = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>} : memref<1xf32, #gpu.address_space<workgroup>>
+  %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
+    amdgpu.gather_to_lds %global[%c0, %k], %lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    %val = vector.transfer_read %lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %sum = arith.addf %val, %acc : vector<1xf32>
+    scf.yield %sum : vector<1xf32>
+  }
+  vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  return
+}


### PR DESCRIPTION
Part 3/3 of enabling XOR swizzle with software pipelining (#23919).

**Overall plan:** `SwizzleHintOp` in the SSA chain blocks both `memref::multiBuffer` and `scf::pipelineForLoop`. The fix absorbs the hint into an alloc attribute before pipelining, preserves it through multi-buffering, then re-inserts hints at leaf users afterward.

**This PR:** Wires `AbsorbSwizzleHintToAllocPass` before and `ReinsertSwizzleHintsPass` after `ROCDLPrefetchSharedMemoryPass`.

Assisted-by: Cursor (Claude)