### PR TITLE
[LLVMCPU] Implement conv heuristics in getVectorPreProcStrategy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -241,11 +241,6 @@ getVectorPreProcStrategy(linalg::LinalgOp linalgOp) {
     return clPProcStrategy;
   }
 
-  // TODO: Implement heuristics for Convs
-  if (isa<linalg::ConvolutionOpInterface>(linalgOp.getOperation())) {
-    return VectorPreProcStrategy::None;
-  }
-
   // Select a strategy based on heuristics.
   if (linalgOp.hasPureBufferSemantics()) {
     return VectorPreProcStrategy::None;
@@ -3030,10 +3025,18 @@ setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
   }
   assert(!getLoweringConfig(convOp) && "expected lowering_config is not set");
 
+  // Masking is not yet wired for convs (no pipelineConfig branch exists).
+  // TODO: wire Masking support for convs.
+  if (vecPreProcStrategy == VectorPreProcStrategy::Masking) {
+    vecPreProcStrategy = VectorPreProcStrategy::None;
+  }
+
   unsigned numLoops = convOp.getNumLoops();
   DistributionHeuristicConfig distConfig;
 
   // Give the vector size hint on OC.
+  distConfig.allowIncompleteTile =
+      vecPreProcStrategy != VectorPreProcStrategy::None;
   distConfig.vectorSizeHints.append(numLoops, 1);
   distConfig.vectorSizeHints[3] = vectorSize;
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
@@ -91,12 +91,12 @@ func.func @conv_static(%3: tensor<1x51x41x512xf32>, %4: tensor<3x3x512x512xf32>)
   return %7 : tensor<1x25x20x512xf32>
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 5, 20, 64, 0, 0, 0], vector_common_parallel = [1, 1, 2, 2, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 16]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @conv_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 //       GENERIC: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 5, 20, 64, 0, 0, 0], vector_common_parallel = [1, 1, 2, 2, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 16]>
-//       GENERIC: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>
+//       GENERIC: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //       GENERIC: func.func @conv_static(
 //  GENERIC-SAME:     translation_info = #[[TRANSLATION]]
 //       GENERIC:     linalg.generic
@@ -113,13 +113,13 @@ func.func @restrict_num_workgroups(%3: tensor<1x11x11x576xf32>, %4: tensor<5x5x5
   return %7 : tensor<1x7x7x576xf32>
 }
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 7, 7, 64, 0, 0], vector_common_parallel = [1, 1, 1, 4, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1]>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //       CHECK: func.func @restrict_num_workgroups(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
 //       GENERIC: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 7, 7, 64, 0, 0], vector_common_parallel = [1, 1, 1, 4, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1]>
-//       GENERIC: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>
+//       GENERIC: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //       GENERIC: func.func @restrict_num_workgroups(
 //  GENERIC-SAME:     translation_info = #[[TRANSLATION]]
 //       GENERIC: linalg.generic

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_lowering_strategy.mlir
@@ -107,13 +107,13 @@ func.func @thin_depthwise_conv_static(%0: tensor<1x57x57x72xf32>, %1: tensor<3x3
   return %4 : tensor<1x28x28x72xf32>
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 28, 28, 8, 0, 0], vector_common_parallel = [1, 1, 4, 4, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @thin_depthwise_conv_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
 //  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 28, 28, 8, 0, 0], vector_common_parallel = [1, 1, 4, 4, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
-//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      GENERIC: func.func @thin_depthwise_conv_static(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
 //      GENERIC:     linalg.generic

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -267,13 +267,13 @@ func.func @conv_dynamic(%0: index, %1: index, %2: index, %3: index, %4: index, %
   return %15 : tensor<?x?x?x?xf32>
 }
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_cpu.lowering_config<distribution = [64, 64, 64, 64, 0, 0, 0], vector_common_parallel = [1, 1, 1, 1, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 1]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @conv_dynamic(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 //      CHECK:         lowering_config = #[[CONFIG]]
 //  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 64, 64, 0, 0, 0], vector_common_parallel = [1, 1, 1, 1, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 1]>
-//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      GENERIC: func.func @conv_dynamic(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
 //      GENERIC:     linalg.generic
@@ -290,12 +290,12 @@ func.func @conv_static(%3: tensor<1x225x225x3xf32>, %4: tensor<3x3x3x16xf32>) ->
   return %7 : tensor<1x112x112x16xf32>
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 56, 16, 0, 0, 0], vector_common_parallel = [1, 1, 4, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 3]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @conv_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 //  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 56, 16, 0, 0, 0], vector_common_parallel = [1, 1, 4, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 1, 3]>
-//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
+//  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>, {{\{}}enable_loop_peeling}>
 //      GENERIC: func.func @conv_static(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
 //      GENERIC:     linalg.generic


### PR DESCRIPTION
## Summary

Named conv ops previously returned `VectorPreProcStrategy::None`unconditionally in `getVectorPreProcStrategy`, bypassing all target-aware heuristics. This caused two problems:

1. The peeling pipeline was never attached to conv ops.
2. `allowIncompleteTile` stayed false, forcing the tiler to find exact divisors and producing suboptimal tile sizes for odd kernel shapes (e.g. KH=3, KW=3).

Remove the early exit so named convs fall through to the existing target-aware heuristics. In `setConvRootConfig`, clamp `Masking` to `None` (not yet wired for convs) and connect `vecPreProcStrategy` to `distConfig.allowIncompleteTile`, mirroring the matmul path in `setContractionRootConfig`.

## Testing

Tested locally on AArch64 NEON. x86 (no AVX-512) and RISC-V are expected to follow the same Peeling path but rely on CI for validation. SVE (Masking) is explicitly clamped to None pending future wiring.

## Notes

- Pre-existing test failure in `select_aarch64_lowering_strategy.mlir` due to pipeline format mismatch (`CPUDoubleTilingExpert` vs `#iree_cpu.pipeline<DoubleTilingExpert>`) unrelated to this fix.
- Masking support for convs is deferred, tracked by the TODO added in `setConvRootConfig`.

Assisted-by: Claude (Anthropic)