### PR TITLE
[IO] Add FILE_SHARE_READ for read-only opens on Windows

### DIFF
--- a/runtime/src/iree/io/file_contents_test.cc
+++ b/runtime/src/iree/io/file_contents_test.cc
@@ -130,6 +130,41 @@ TEST(FileContents, ReadWriteContentsMmap) {
   iree_io_file_contents_free(read_contents);
 }
 
+// Tests that a file opened for reading can be opened again concurrently.
+// Validates FILE_SHARE_READ behavior on Windows — without it, the second
+// open fails with ERROR_SHARING_VIOLATION.
+TEST(FileContents, ConcurrentReadOpens) {
+  constexpr const char* kUniqueName = "ConcurrentReadOpens";
+  auto path = GetUniquePath(kUniqueName);
+
+  // Write a file to open.
+  auto contents = GetUniqueContents(kUniqueName, 4096);
+  IREE_ASSERT_OK(iree_io_file_contents_write(
+      iree_make_string_view(path.data(), path.size()),
+      iree_make_const_byte_span(contents.data(), contents.size()),
+      iree_allocator_system()));
+
+  // Open the file twice for reading — both should succeed.
+  iree_io_file_contents_t* read1 = NULL;
+  IREE_ASSERT_OK(iree_io_file_contents_map(
+      iree_make_string_view(path.data(), path.size()), IREE_IO_FILE_ACCESS_READ,
+      iree_allocator_system(), &read1));
+
+  iree_io_file_contents_t* read2 = NULL;
+  IREE_ASSERT_OK(iree_io_file_contents_map(
+      iree_make_string_view(path.data(), path.size()), IREE_IO_FILE_ACCESS_READ,
+      iree_allocator_system(), &read2));
+
+  // Both should have the same contents.
+  EXPECT_EQ(read1->const_buffer.data_length, read2->const_buffer.data_length);
+  EXPECT_EQ(memcmp(read1->const_buffer.data, read2->const_buffer.data,
+                   read1->const_buffer.data_length),
+            0);
+
+  iree_io_file_contents_free(read2);
+  iree_io_file_contents_free(read1);
+}
+
 }  // namespace
 }  // namespace io
 }  // namespace iree

--- a/runtime/src/iree/io/file_handle.c
+++ b/runtime/src/iree/io/file_handle.c
@@ -205,13 +205,13 @@ static iree_status_t iree_io_file_handle_platform_open(
   if (iree_all_bits_set(mode, IREE_IO_FILE_MODE_SHARE_WRITE)) {
     share_mode |= FILE_SHARE_WRITE;
   }
-  // TODO(#NNN): Read-only opens should default to FILE_SHARE_READ to match
-  // POSIX behavior. Without this, opening the same file for reading twice on
-  // Windows fails with ERROR_SHARING_VIOLATION. Uncomment to fix:
-  // if (iree_all_bits_set(mode, IREE_IO_FILE_MODE_READ) &&
-  //     !iree_all_bits_set(mode, IREE_IO_FILE_MODE_WRITE)) {
-  //   share_mode |= FILE_SHARE_READ;
-  // }
+  // Read-only opens default to FILE_SHARE_READ to match POSIX behavior.
+  // Without this, opening the same file for reading twice on Windows fails
+  // with ERROR_SHARING_VIOLATION.
+  if (iree_all_bits_set(mode, IREE_IO_FILE_MODE_READ) &&
+      !iree_all_bits_set(mode, IREE_IO_FILE_MODE_WRITE)) {
+    share_mode |= FILE_SHARE_READ;
+  }
 
   DWORD creation_disposition =
       iree_all_bits_set(mode, IREE_IO_FILE_MODE_OVERWRITE) ? CREATE_ALWAYS

--- a/runtime/src/iree/io/file_handle.c
+++ b/runtime/src/iree/io/file_handle.c
@@ -205,6 +205,13 @@ static iree_status_t iree_io_file_handle_platform_open(
   if (iree_all_bits_set(mode, IREE_IO_FILE_MODE_SHARE_WRITE)) {
     share_mode |= FILE_SHARE_WRITE;
   }
+  // TODO(#NNN): Read-only opens should default to FILE_SHARE_READ to match
+  // POSIX behavior. Without this, opening the same file for reading twice on
+  // Windows fails with ERROR_SHARING_VIOLATION. Uncomment to fix:
+  // if (iree_all_bits_set(mode, IREE_IO_FILE_MODE_READ) &&
+  //     !iree_all_bits_set(mode, IREE_IO_FILE_MODE_WRITE)) {
+  //   share_mode |= FILE_SHARE_READ;
+  // }
 
   DWORD creation_disposition =
       iree_all_bits_set(mode, IREE_IO_FILE_MODE_OVERWRITE) ? CREATE_ALWAYS


### PR DESCRIPTION
On Windows, files opened for reading cannot be opened again by another reader — the second open fails with ERROR_SHARING_VIOLATION. This breaks workflows where multiple IREE sessions load the same parameter file (.irpa).

The first commit adds a test that reproduces the failure — confirmed on Windows CI: https://github.com/iree-org/iree/actions/runs/23940576218/job/69825870972

The second commit enables the fix: add FILE_SHARE_READ to read-only opens, matching POSIX behavior where multiple readers are always allowed.