### PR TITLE
Integrates/llvm@20260403

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -92,6 +92,8 @@ struct ConvertToNVVMPass final
             return static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared);
           case gpu::AddressSpace::Private:
             return 0;
+          case gpu::AddressSpace::Constant:
+            return static_cast<unsigned>(NVVM::NVVMMemorySpace::Constant);
           }
           llvm_unreachable("unknown address space enum value");
           return 0;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -273,6 +273,8 @@ struct ConvertToROCDLPass final
             return 3;
           case gpu::AddressSpace::Private:
             return 5;
+          case gpu::AddressSpace::Constant:
+            return 4;
           }
           llvm_unreachable("unknown address space enum value");
           return 0;


### PR DESCRIPTION
Carry local reverts https://github.com/iree-org/llvm-project/commit/12d53fd227f353e20e5b2c83037f8f6a19262590 and https://github.com/iree-org/llvm-project/commit/fd32048b7e1991ffbad05dcacf6b628b6f0cefca.

Drop local revert https://github.com/iree-org/llvm-project/commit/a36ca642f072b21c50eb6a868ea1055ed0f78c5c after upstream revert.

Bump to https://github.com/llvm/llvm-project/commit/c80443cd37b2e2788cba67ffa180a6331e5f0791.

Update two switch cases to include GPU address space `constant` to avoid `Werror` on incomplete switch-case.