### PR TITLE
[IO] Add IREE_IO_FILE_MODE_SHARE_READ to internal read-only callers

### DIFF
--- a/runtime/src/iree/io/file_contents.c
+++ b/runtime/src/iree/io/file_contents.c
@@ -213,8 +213,9 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_read(
   // Open the file for reading.
   iree_io_file_handle_t* handle = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_io_file_handle_open(IREE_IO_FILE_MODE_READ, path, host_allocator,
-                                   &handle));
+      z0, iree_io_file_handle_open(
+              IREE_IO_FILE_MODE_READ | IREE_IO_FILE_MODE_SHARE_READ, path,
+              host_allocator, &handle));
 
   // Get an stdio FILE* for the handle.
   // This will need to be closed as its lifetime is separate from our file
@@ -300,7 +301,8 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_map(
   *out_contents = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_io_file_mode_t mode = IREE_IO_FILE_MODE_READ;
+  iree_io_file_mode_t mode =
+      IREE_IO_FILE_MODE_READ | IREE_IO_FILE_MODE_SHARE_READ;
   if (iree_all_bits_set(access, IREE_IO_FILE_ACCESS_WRITE)) {
     mode |= IREE_IO_FILE_MODE_WRITE;
   }

--- a/runtime/src/iree/io/file_contents_test.cc
+++ b/runtime/src/iree/io/file_contents_test.cc
@@ -130,6 +130,41 @@ TEST(FileContents, ReadWriteContentsMmap) {
   iree_io_file_contents_free(read_contents);
 }
 
+// Tests that a file opened for reading can be opened again concurrently.
+// Validates FILE_SHARE_READ behavior on Windows — without it, the second
+// open fails with ERROR_SHARING_VIOLATION.
+TEST(FileContents, ConcurrentReadOpens) {
+  constexpr const char* kUniqueName = "ConcurrentReadOpens";
+  auto path = GetUniquePath(kUniqueName);
+
+  // Write a file to open.
+  auto contents = GetUniqueContents(kUniqueName, 4096);
+  IREE_ASSERT_OK(iree_io_file_contents_write(
+      iree_make_string_view(path.data(), path.size()),
+      iree_make_const_byte_span(contents.data(), contents.size()),
+      iree_allocator_system()));
+
+  // Open the file twice for reading — both should succeed.
+  iree_io_file_contents_t* read1 = NULL;
+  IREE_ASSERT_OK(iree_io_file_contents_map(
+      iree_make_string_view(path.data(), path.size()), IREE_IO_FILE_ACCESS_READ,
+      iree_allocator_system(), &read1));
+
+  iree_io_file_contents_t* read2 = NULL;
+  IREE_ASSERT_OK(iree_io_file_contents_map(
+      iree_make_string_view(path.data(), path.size()), IREE_IO_FILE_ACCESS_READ,
+      iree_allocator_system(), &read2));
+
+  // Both should have the same contents.
+  EXPECT_EQ(read1->const_buffer.data_length, read2->const_buffer.data_length);
+  EXPECT_EQ(memcmp(read1->const_buffer.data, read2->const_buffer.data,
+                   read1->const_buffer.data_length),
+            0);
+
+  iree_io_file_contents_free(read2);
+  iree_io_file_contents_free(read1);
+}
+
 }  // namespace
 }  // namespace io
 }  // namespace iree

--- a/runtime/src/iree/tooling/parameter_util.c
+++ b/runtime/src/iree/tooling/parameter_util.c
@@ -37,11 +37,13 @@ static iree_status_t iree_io_open_parameter_file(
   iree_status_t status = iree_ok_status();
   iree_io_file_handle_t* file_handle = NULL;
   if (strcmp(FLAG_parameter_mode, "preload") == 0) {
-    status = iree_io_file_handle_preload(IREE_IO_FILE_MODE_READ, path,
-                                         host_allocator, &file_handle);
+    status = iree_io_file_handle_preload(
+        IREE_IO_FILE_MODE_READ | IREE_IO_FILE_MODE_SHARE_READ, path,
+        host_allocator, &file_handle);
   } else if (strcmp(FLAG_parameter_mode, "file") == 0) {
-    status = iree_io_file_handle_open(IREE_IO_FILE_MODE_READ, path,
-                                      host_allocator, &file_handle);
+    status = iree_io_file_handle_open(
+        IREE_IO_FILE_MODE_READ | IREE_IO_FILE_MODE_SHARE_READ, path,
+        host_allocator, &file_handle);
   } else {
     status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "unrecognized --parameter_mode= value '%s'",


### PR DESCRIPTION
On Windows, opening the same file for reading from multiple places fails with ERROR_SHARING_VIOLATION. Fix internal callers to pass IREE_IO_FILE_MODE_SHARE_READ when opening files for reading.

Fixed callers:
- file_contents.c: iree_io_file_contents_read, iree_io_file_contents_map
- parameter_util.c: parameter file loading (preload and mmap modes)

Add a test that opens the same file twice for reading concurrently, validating the fix on all platforms. See test failing on windows without this fix: https://github.com/iree-org/iree/actions/runs/23940576218/job/69825870972