### PR TITLE
[Codegen][GPU] Use gpu::AddressSpace::Constant for constants

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
@@ -278,13 +278,13 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   // data races on GPU.
   options.checkParallelRegions = false;
 
-  // GPU targets need global address space for constants to avoid issues
-  // when accessed with dynamic indexing (e.g., split reduction).
+  // Place constants in the GPU constant address space to enable
+  // backend-specific optimizations (e.g., scalar reads on AMDGPU).
   if (isGPUBackend(IREE::HAL::ExecutableTargetAttr::lookup(funcOp))) {
     options.defaultMemorySpaceFn =
         [](TensorType t) -> std::optional<Attribute> {
       return gpu::AddressSpaceAttr::get(t.getContext(),
-                                        gpu::AddressSpace::Global);
+                                        gpu::AddressSpace::Constant);
     };
   }
 
@@ -308,12 +308,12 @@ void IREEBufferizeConstantsPass::runOnOperation() {
   opt.copyBeforeWrite = true;
   opt.opFilter.allowOperation(arith::ConstantOp::getOperationName());
 
-  // GPU targets need global address space for constants to avoid issues
-  // when accessed with dynamic indexing (e.g., split reduction).
+  // Place constants in the GPU constant address space to enable
+  // backend-specific optimizations (e.g., scalar reads on AMDGPU).
   if (isGPUBackend(IREE::HAL::ExecutableTargetAttr::lookup(getOperation()))) {
     opt.defaultMemorySpaceFn = [](TensorType t) -> std::optional<Attribute> {
       return gpu::AddressSpaceAttr::get(t.getContext(),
-                                        gpu::AddressSpace::Global);
+                                        gpu::AddressSpace::Constant);
     };
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_bufferize_constants.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_bufferize_constants.mlir
@@ -1,16 +1,15 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-codegen-iree-bufferize-constants)" %s | FileCheck %s
 
-// Test that constants are bufferized with gpu.address_space<global> for ROCM targets
-// when accessed with dynamic indexing (e.g., split reduction scenario).
+// Test that constants are bufferized with gpu.address_space<constant> for GPU targets.
 
 #executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>> = dense<[1, 2, 3, 4]>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<constant>> = dense<[1, 2, 3, 4]>
 // CHECK: func.func @constant_with_dynamic_indexing_rocm
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_rocm} {
   func.func @constant_with_dynamic_indexing_rocm() {
     %c0 = arith.constant 0 : index
@@ -40,9 +39,9 @@ module attributes {hal.executable.target = #executable_target_rocm} {
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<100x100xi32, #gpu.address_space<global>>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<100x100xi32, #gpu.address_space<constant>>
 // CHECK: func.func @large_constant_rocm
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<100x100xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<100x100xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_rocm} {
   func.func @large_constant_rocm() {
     %c0 = arith.constant 0 : index
@@ -87,16 +86,16 @@ module attributes {hal.executable.target = #executable_target_llvm} {
 
 // -----
 
-// Test splat constant (optimizes differently but should still work).
+// Test splat constant (bufferizes to the constant address space as well).
 
 #executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<10xi32, #gpu.address_space<global>>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<10xi32, #gpu.address_space<constant>>
 // CHECK: func.func @splat_constant_rocm
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<10xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<10xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_rocm} {
   func.func @splat_constant_rocm() {
     %c0 = arith.constant 0 : index
@@ -114,16 +113,16 @@ module attributes {hal.executable.target = #executable_target_rocm} {
 
 // -----
 
-// Test with CUDA target (should also use gpu.address_space<global>).
+// Test with CUDA target (should also use gpu.address_space<constant>).
 
 #executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<constant>>
 // CHECK: func.func @constant_cuda
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_cuda} {
   func.func @constant_cuda() {
     %c0 = arith.constant 0 : index
@@ -140,16 +139,16 @@ module attributes {hal.executable.target = #executable_target_cuda} {
 
 // -----
 
-// Test with Vulkan target (should use gpu.address_space<global>).
+// Test with Vulkan target (should use gpu.address_space<constant>).
 
 #executable_target_vulkan = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<constant>>
 // CHECK: func.func @constant_vulkan
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_vulkan} {
   func.func @constant_vulkan() {
     %c0 = arith.constant 0 : index
@@ -166,16 +165,16 @@ module attributes {hal.executable.target = #executable_target_vulkan} {
 
 // -----
 
-// Test with Metal target (should use gpu.address_space<global>).
+// Test with Metal target (should use gpu.address_space<constant>).
 
 #executable_target_metal = #hal.executable.target<"metal-spirv", "metal-spirv-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<constant>>
 // CHECK: func.func @constant_metal
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_metal} {
   func.func @constant_metal() {
     %c0 = arith.constant 0 : index
@@ -192,16 +191,16 @@ module attributes {hal.executable.target = #executable_target_metal} {
 
 // -----
 
-// Test with WebGPU target (should use gpu.address_space<global>).
+// Test with WebGPU target (should use gpu.address_space<constant>).
 
 #executable_target_webgpu = #hal.executable.target<"webgpu-spirv", "webgpu-spirv-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: memref.global "private" constant @[[GLOBAL:[a-zA-Z0-9_]+]] : memref<4xi32, #gpu.address_space<constant>>
 // CHECK: func.func @constant_webgpu
-// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<global>>
+// CHECK: %[[CST:.+]] = memref.get_global @[[GLOBAL]] : memref<4xi32, #gpu.address_space<constant>>
 module attributes {hal.executable.target = #executable_target_webgpu} {
   func.func @constant_webgpu() {
     %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3122,9 +3122,8 @@ func.func @map_store_mixed_semantics(%input: tensor<16xf32>, %output: memref<16x
 
 // -----
 
-// Test that constants use gpu.address_space<global> for GPU targets.
-// This is needed to avoid issues when constants are accessed with
-// dynamic indexing (e.g., split reduction).
+// Test that constants use gpu.address_space<constant> for GPU targets.
+// This enables backend-specific optimizations (e.g., scalar reads on AMDGPU).
 
 #executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -3154,4 +3153,4 @@ module attributes {hal.executable.target = #executable_target_rocm} {
 
 // CHECK-LABEL: func.func @constant_to_buffer_rocm
 // CHECK:         %[[CST:.+]] = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
-// CHECK:         bufferization.to_buffer %[[CST]] {{.*}} : tensor<4xi32> to memref<4xi32, #gpu.address_space<global>>
+// CHECK:         bufferization.to_buffer %[[CST]] {{.*}} : tensor<4xi32> to memref<4xi32, #gpu.address_space<constant>>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
@@ -45,6 +45,8 @@ mapHALDescriptorTypeForVulkan(Attribute attr) {
     switch (gpuAttr.getValue()) {
     case gpu::AddressSpace::Workgroup:
       return spirv::StorageClass::Workgroup;
+    case gpu::AddressSpace::Constant:
+      return spirv::StorageClass::UniformConstant;
     default:
       return std::nullopt;
     }
@@ -66,6 +68,8 @@ mapHALDescriptorTypeForOpenCL(Attribute attr) {
     switch (gpuAttr.getValue()) {
     case gpu::AddressSpace::Workgroup:
       return spirv::StorageClass::Workgroup;
+    case gpu::AddressSpace::Constant:
+      return spirv::StorageClass::UniformConstant;
     default:
       return std::nullopt;
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/map_memref_storage_class.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/map_memref_storage_class.mlir
@@ -21,6 +21,9 @@ func.func @vulkan_client_api() attributes {hal.executable.target = #target} {
   %3 = "dialect.memref_producer"() : () -> (memref<?x8xf32, 3>)
   "dialect.memref_consumer"(%3) : (memref<?x8xf32, 3>) -> ()
 
+  %4 = "dialect.memref_producer"() : () -> (memref<?x8xf32, #gpu.address_space<constant>>)
+  "dialect.memref_consumer"(%4) : (memref<?x8xf32, #gpu.address_space<constant>>) -> ()
+
   return
 }
 
@@ -36,6 +39,9 @@ func.func @vulkan_client_api() attributes {hal.executable.target = #target} {
 
 //       CHECK:   %[[P3:.+]] = "dialect.memref_producer"() : () -> memref<?x8xf32, #spirv.storage_class<Workgroup>>
 //       CHECK:   "dialect.memref_consumer"(%[[P3]]) : (memref<?x8xf32, #spirv.storage_class<Workgroup>>) -> ()
+
+//       CHECK:   %[[P4:.+]] = "dialect.memref_producer"() : () -> memref<?x8xf32, #spirv.storage_class<UniformConstant>>
+//       CHECK:   "dialect.memref_consumer"(%[[P4]]) : (memref<?x8xf32, #spirv.storage_class<UniformConstant>>) -> ()
 
 // -----
 
@@ -60,6 +66,9 @@ func.func @opencl_client_api() attributes {hal.executable.target = #target} {
   %3 = "dialect.memref_producer"() : () -> (memref<?x8xf32, 3>)
   "dialect.memref_consumer"(%3) : (memref<?x8xf32, 3>) -> ()
 
+  %4 = "dialect.memref_producer"() : () -> (memref<?x8xf32, #gpu.address_space<constant>>)
+  "dialect.memref_consumer"(%4) : (memref<?x8xf32, #gpu.address_space<constant>>) -> ()
+
   return
 }
 
@@ -75,3 +84,6 @@ func.func @opencl_client_api() attributes {hal.executable.target = #target} {
 
 //       CHECK:   %[[P3:.+]] = "dialect.memref_producer"() : () -> memref<?x8xf32, #spirv.storage_class<Workgroup>>
 //       CHECK:   "dialect.memref_consumer"(%[[P3]]) : (memref<?x8xf32, #spirv.storage_class<Workgroup>>) -> ()
+
+//       CHECK:   %[[P4:.+]] = "dialect.memref_producer"() : () -> memref<?x8xf32, #spirv.storage_class<UniformConstant>>
+//       CHECK:   "dialect.memref_consumer"(%[[P4]]) : (memref<?x8xf32, #spirv.storage_class<UniformConstant>>) -> ()


### PR DESCRIPTION
Now that https://github.com/llvm/llvm-project/pull/190211 has added gpu::AddressSpace::Constant to the GPU dialect, this PR is sent to use it instead of gpu::AddressSpace::Global for bufferized constants on GPU targets.