### PR TITLE
Add pattern to lower linalg.conv_2d_nchw_fchw_q to linalg.conv_2d_nchw_fchw

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -124,7 +124,8 @@ Value multiplyDims(ImplicitLocOpBuilder &builder, Value value,
 //
 // This is implementing the math explained in Section 2.3 of
 // https://arxiv.org/abs/1712.05877.
-struct QuantizedConvToConv : OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
+struct QuantizedConvNhwcToConvNhwc
+    : public OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfQOp op,
@@ -239,6 +240,125 @@ struct QuantizedConvToConv : OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
   }
 };
 
+// Pattern lowering conv_2d_nchw_fchw_q to conv_2d_nchw_fchw.
+struct QuantizedConvNchwToConvNchw
+    : public OpRewritePattern<linalg::Conv2DNchwFchwQOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwQOp op,
+                                PatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder builder(op.getLoc(), rewriter);
+    Value input = op.getInputs()[0];
+    Value filter = op.getInputs()[1];
+    Value iZp = op.getInputs()[2];
+    Value fZp = op.getInputs()[3];
+    auto inputTy = llvm::cast<RankedTensorType>(input.getType());
+    auto resultTy = llvm::cast<ShapedType>(op.getType(0));
+    auto accETy = resultTy.getElementType();
+
+    auto strides = op.getStrides();
+    auto dilations = op.getDilations();
+
+    IntegerAttr iZpConst, fZpConst;
+    bool iZpIsZero = matchPattern(iZp, m_Constant(&iZpConst)) &&
+                     iZpConst.getValue().isZero();
+    bool fZpIsZero = matchPattern(fZp, m_Constant(&fZpConst)) &&
+                     fZpConst.getValue().isZero();
+
+    // First implement the convolution without the zero point.
+    Value newConv = linalg::Conv2DNchwFchwOp::create(
+                        builder, resultTy, ValueRange{input, filter},
+                        op.getOutputs(), strides, dilations)
+                        .getResult(0);
+
+    if (iZpIsZero && fZpIsZero) {
+      rewriter.replaceOp(op, newConv);
+      return success();
+    }
+
+    // Compute the summation and correction for the filter zero point:
+    //  sum(F) = filter(F,C,KH,KW)
+    //  conv(N,F,OH,OW) -= iZp * sum(F)
+    if (!iZpIsZero) {
+      Value filterSum =
+          sumReduceDimensionSubset(builder, filter, accETy,
+                                   /*reduce_dim=*/{false, true, true, true});
+      newConv = applyZeroPoint(builder, newConv, filterSum, iZp, {1});
+    }
+
+    if (!fZpIsZero) {
+      // Reduce along the input feature dimension:
+      //   sum(a, b, c) = input(a, b, c, d)
+      Value inputSum =
+          sumReduceDimensionSubset(builder, input, accETy,
+                                   /*reduce_dim=*/{false, true, false, false});
+
+      //   [N, H, W] -> [N, 1, H, W]
+      SmallVector<ReassociationExprs> reassociationMap(3);
+      reassociationMap[0].push_back(builder.getAffineDimExpr(0));
+      reassociationMap[0].push_back(builder.getAffineDimExpr(1));
+      reassociationMap[1].push_back(builder.getAffineDimExpr(2));
+      reassociationMap[2].push_back(builder.getAffineDimExpr(3));
+
+      auto expandTy =
+          RankedTensorType::get({inputTy.getDimSize(0), 1,
+                                 inputTy.getDimSize(2), inputTy.getDimSize(3)},
+                                accETy);
+      inputSum = tensor::ExpandShapeOp::create(builder, expandTy, inputSum,
+                                               reassociationMap);
+
+      SmallVector<int64_t> poolDims;
+      SmallVector<Value> poolDynDims;
+      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 0);
+      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 1);
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 2);
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 3);
+
+      auto poolTy = RankedTensorType::get(poolDims, accETy);
+      Value poolTensor = emptyZero(builder, poolTy, poolDynDims);
+
+      // Create the empty kernel defining the shape for the pooling operation.
+      SmallVector<int64_t> kDims;
+      SmallVector<Value> kDyn;
+      GetDynamicDym(builder, kDims, kDyn, filter, 2);
+      GetDynamicDym(builder, kDims, kDyn, filter, 3);
+      Value poolInit = tensor::EmptyOp::create(builder, kDims, accETy, kDyn);
+
+      inputSum =
+          linalg::PoolingNchwSumOp::create(builder, ArrayRef<Type>{poolTy},
+                                           ValueRange{inputSum, poolInit},
+                                           poolTensor, strides, dilations)
+              .getResult(0);
+
+      // Collapse the dimension.
+      auto resultShape = resultTy.getShape();
+      SmallVector<int64_t> collapseShape = {
+          resultShape[0], // N
+          resultShape[2], // OH
+          resultShape[3]  // OW
+      };
+      auto collapseTy = RankedTensorType::get(collapseShape, accETy);
+      inputSum = tensor::CollapseShapeOp::create(builder, collapseTy, inputSum,
+                                                 reassociationMap);
+
+      // Apply the zero-point update based on the input sum.
+      newConv = applyZeroPoint(builder, newConv, inputSum, fZp, {0, 2, 3});
+    }
+
+    // Apply the final update that occurs when there are multiple zero-points.
+    if (!iZpIsZero && !fZpIsZero) {
+      Value count = multiplyDims(builder, filter, {1, 2, 3});
+      Value cast = arith::IndexCastOp::create(builder, accETy, count);
+      Value ifZp = arith::MulIOp::create(builder, iZp, fZp);
+      Value zpUpdate = arith::MulIOp::create(builder, ifZp, cast);
+      newConv = addScalar(builder, newConv, zpUpdate);
+    }
+
+    rewriter.replaceOp(op, newConv);
+    return success();
+  }
+};
+
 // Pattern lowering depthwise_conv_2d_nhwc_hwc_q to depthwise_conv_2d_nhwc_hwc.
 //
 // This is implementing the math explained in Section 2.3 of
@@ -343,8 +463,8 @@ public:
     MLIRContext *context = op->getContext();
     RewritePatternSet patterns(context);
     linalg::populateSimplifyDepthwiseConvPatterns(patterns);
-    patterns.add<QuantizedConvToConv, QuantizedDepthwiseConvToDepthwiseConv>(
-        context);
+    patterns.add<QuantizedConvNhwcToConvNhwc, QuantizedConvNchwToConvNchw,
+                 QuantizedDepthwiseConvToDepthwiseConv>(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
     if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
       signalPassFailure();

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -252,8 +252,10 @@ struct QuantizedConvNchwToConvNchw
     Value filter = op.getInputs()[1];
     Value iZp = op.getInputs()[2];
     Value fZp = op.getInputs()[3];
+    Value output = op.getOutputs()[0];
+
     auto inputTy = llvm::cast<RankedTensorType>(input.getType());
-    auto resultTy = llvm::cast<ShapedType>(op.getType(0));
+    auto resultTy = llvm::cast<ShapedType>(output.getType());
     auto accETy = resultTy.getElementType();
 
     auto strides = op.getStrides();
@@ -309,10 +311,10 @@ struct QuantizedConvNchwToConvNchw
 
       SmallVector<int64_t> poolDims;
       SmallVector<Value> poolDynDims;
-      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 0);
-      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 1);
-      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 2);
-      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 3);
+      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 0); // N
+      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 1); // C
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 2);  // OH
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 3);  // OW
 
       auto poolTy = RankedTensorType::get(poolDims, accETy);
       Value poolTensor = emptyZero(builder, poolTy, poolDynDims);
@@ -341,7 +343,7 @@ struct QuantizedConvNchwToConvNchw
       inputSum = tensor::CollapseShapeOp::create(builder, collapseTy, inputSum,
                                                  reassociationMap);
 
-      // Apply the zero-point update based on the input sum.
+      // Broadcast inputSum over the output-channel dim using {N=0, OH=2, OW=3}.
       newConv = applyZeroPoint(builder, newConv, inputSum, fZp, {0, 2, 3});
     }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/test/linalg_quantized_conv_to_conv.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/linalg_quantized_conv_to_conv.mlir
@@ -344,6 +344,352 @@ func.func @conv2d_all_dyn(%arg0: tensor<?x?x?x?xi8>, %arg1: tensor<?x?x?x?xi8>, 
 
 // -----
 
+// CHECK-LABEL: func.func @nchw_conv2d_zp
+func.func @nchw_conv2d_zp(%arg0: tensor<1x5x14x16xi8>, %arg1: tensor<1024x5x3x4xi8>, %arg2: tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 0 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+  // CHECK-SAME:  dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  strides = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  ins(%arg0, %arg1 : tensor<1x5x14x16xi8>, tensor<1024x5x3x4xi8>)
+  // CHECK-SAME:  outs(%arg2 : tensor<1x1024x12x13xi32>)
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x5x14x16xi8>, tensor<1024x5x3x4xi8>, i32, i32) outs(%arg2 : tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32>
+
+  // CHECK: return %[[CONV]]
+  return %0 : tensor<1x1024x12x13xi32>
+}
+
+// -----
+
+// CHECK: #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d1)>
+
+// CHECK-LABEL: func.func @nchw_conv2d_filter_zp
+func.func @nchw_conv2d_filter_zp(%arg0: tensor<1x5x14x16xi8>, %arg1: tensor<1024x5x3x4xi8>, %arg2: tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32> {
+  %iZp = arith.constant 42 : i32
+  %fZp = arith.constant 0 : i32
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42
+  // CHECK-DAG: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+  // CHECK-DAG: %[[SUM_INIT:.+]] = tensor.empty() : tensor<1024xi32>
+  // CHECK-DAG: %[[SUM_FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%1 : tensor<1024xi32>) -> tensor<1024xi32>
+
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map, #map1]
+  // CHECK-SAME:  iterator_types = ["parallel", "reduction", "reduction", "reduction"]}
+  // CHECK-SAME:  ins(%arg1 : tensor<1024x5x3x4xi8>)
+  // CHECK-SAME:  outs(%[[SUM_FILL]] : tensor<1024xi32>)
+  // CHECK:   ^bb0(%[[IN:.+]]: i8, %[[OUT:.+]]: i32):
+  // CHECK:   %[[EXT:.+]] = arith.extsi %[[IN]] : i8 to i32
+  // CHECK:   %[[ADD:.+]] = arith.addi %[[EXT]], %[[OUT]] : i32
+  // CHECK:   linalg.yield %[[ADD]]
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x1024x12x13xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map, #map2, #map]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:  ins(%[[CONV]], %[[SUM]] : tensor<1x1024x12x13xi32>, tensor<1024xi32>)
+  // CHECK-SAME:  outs(%[[INIT]] : tensor<1x1024x12x13xi32>)
+  // CHECK:   ^bb0(%[[A0:.+]]: i32, %[[A1:.+]]: i32, %[[A2:.+]]: i32):
+  // CHECK:   %[[MUL:.+]] = arith.muli %[[A1]], %[[C42]] : i32
+  // CHECK:   %[[SUB:.+]] = arith.subi %[[A0]], %[[MUL]] : i32
+  // CHECK:   linalg.yield %[[SUB]]
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x5x14x16xi8>, tensor<1024x5x3x4xi8>, i32, i32) outs(%arg2 : tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32>
+
+  // CHECK: return %[[GENERIC]] : tensor<1x1024x12x13xi32>
+  return %0 : tensor<1x1024x12x13xi32>
+}
+
+// -----
+
+// CHECK: #map = affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+
+// CHECK-LABEL: func.func @nchw_conv2d_input_zp
+func.func @nchw_conv2d_input_zp(%arg0: tensor<1x5x14x16xi8>, %arg1: tensor<1024x5x3x4xi8>, %arg2: tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 42 : i32
+
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+
+  // CHECK: %[[INIT0:.+]] = tensor.empty() : tensor<1x14x16xi32>
+  // CHECK: %[[FILL0:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT0]] : tensor<1x14x16xi32>)
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map, #map1]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+  // CHECK-SAME:  ins(%arg0 : tensor<1x5x14x16xi8>)
+  // CHECK-SAME:  outs(%[[FILL0]] : tensor<1x14x16xi32>)
+
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SUM]] {{\[\[0, *1\], *\[2\], *\[3\]\]}}
+  // CHECK: %[[INIT1:.+]] = tensor.empty()
+  // CHECK: %[[FILL1:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT1]] : tensor<1x1x12x13xi32>)
+  // CHECK: %[[KERNEL:.+]] = tensor.empty() : tensor<3x4xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nchw_sum
+  // CHECK-SAME:  dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  strides = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  ins(%[[EXPAND]], %[[KERNEL]] : tensor<1x1x14x16xi32>, tensor<3x4xi32>)
+  // CHECK-SAME:  outs(%[[FILL1]] : tensor<1x1x12x13xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]] {{\[\[0, *1\], *\[2\], *\[3\]\]}}
+
+  // CHECK: %[[INIT2:.+]] = tensor.empty() : tensor<1x1024x12x13xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map2, #map3, #map2]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:  ins(%[[CONV]], %[[COLLAPSE]] : tensor<1x1024x12x13xi32>, tensor<1x12x13xi32>)
+  // CHECK-SAME:  outs(%[[INIT2]] : tensor<1x1024x12x13xi32>)
+  // CHECK:   ^bb0(%[[A0:.+]]: i32, %[[A1:.+]]: i32, %[[A2:.+]]: i32):
+  // CHECK:   %[[MUL:.+]] = arith.muli %[[A1]], %[[C42]]
+  // CHECK:   %[[SUB:.+]] = arith.subi %[[A0]], %[[MUL]]
+  // CHECK:   linalg.yield %[[SUB]]
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x5x14x16xi8>, tensor<1024x5x3x4xi8>, i32, i32) outs(%arg2 : tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32>
+
+  // CHECK: return %[[GENERIC]]
+  return %0 : tensor<1x1024x12x13xi32>
+}
+
+// -----
+
+// CHECK: #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d1)>
+// CHECK: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>
+// CHECK: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK: #map5 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+func.func @nchw_conv2d_full(%arg0: tensor<1x5x14x16xi8>, %arg1: tensor<1024x5x3x4xi8>, %arg2: tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32> {
+  %iZp = arith.constant 17 : i32
+  %fZp = arith.constant 42 : i32
+
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C42840:.+]] = arith.constant 42840 : i32
+  // CHECK-DAG: %[[C17:.+]] = arith.constant 17 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+
+  // CHECK: %[[SUM:.+]] = linalg.generic {indexing_maps = [#map, #map1]
+  // CHECK-SAME:  ins(%arg1 : tensor<1024x5x3x4xi8>)
+  // CHECK: %[[IZP:.+]] = linalg.generic {indexing_maps = [#map, #map2, #map]
+  // CHECK-SAME:  ins(%[[CONV]], %[[SUM]] : tensor<1x1024x12x13xi32>, tensor<1024xi32>)
+
+  // CHECK: %[[SUM:.+]] = linalg.generic {indexing_maps = [#map3, #map4]
+  // CHECK-SAME:  ins(%arg0 : tensor<1x5x14x16xi8>)
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SUM]]
+  // CHECK: %[[KERNEL:.+]] = tensor.empty() : tensor<3x4xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nchw_sum
+  // CHECK-SAME:  ins(%[[EXPAND]], %[[KERNEL]] : tensor<1x1x14x16xi32>, tensor<3x4xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]]
+  // CHECK: %[[FZP:.+]] = linalg.generic {indexing_maps = [#map, #map5, #map]
+  // CHECK-SAME:  ins(%[[IZP]], %[[COLLAPSE]] : tensor<1x1024x12x13xi32>, tensor<1x12x13xi32>)
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x1024x12x13xi32>
+  // CHECK: %[[FINAL:.+]] = linalg.generic {indexing_maps = [#map, #map]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:  ins(%[[FZP]] : tensor<1x1024x12x13xi32>)
+  // CHECK-SAME:  outs(%[[INIT]] : tensor<1x1024x12x13xi32>)
+  // CHECK:   ^bb0(%[[A0:.+]]: i32, %[[A1:.+]]: i32):
+  // CHECK:   %[[ADD:.+]] = arith.addi %[[A0]], %[[C42840]] : i32
+  // CHECK:   linalg.yield %[[ADD]]
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x5x14x16xi8>, tensor<1024x5x3x4xi8>, i32, i32) outs(%arg2 : tensor<1x1024x12x13xi32>) -> tensor<1x1024x12x13xi32>
+
+  // CHECK: return %[[FINAL]]
+  return %0 : tensor<1x1024x12x13xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @nchw_conv2d_dyn
+func.func @nchw_conv2d_dyn(%arg0: tensor<?x5x?x?xi8>, %arg1: tensor<1024x5x3x4xi8>, %arg2: tensor<?x1024x?x?xi32>) -> tensor<?x1024x?x?xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 0 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<?x5x?x?xi8>, tensor<1024x5x3x4xi8>, i32, i32) outs(%arg2 : tensor<?x1024x?x?xi32>) -> tensor<?x1024x?x?xi32>
+
+  // CHECK: return %[[CONV]]
+  return %0 : tensor<?x1024x?x?xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @nchw_conv2d_dyn_filter_zp
+func.func @nchw_conv2d_dyn_filter_zp(%arg0: tensor<1x5x14x16xi8>, %arg1: tensor<1024x5x?x?xi8>, %arg2: tensor<1x1024x?x?xi32>) -> tensor<1x1024x?x?xi32> {
+  // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C3:.+]] = arith.constant 3 : index
+
+  %iZp = arith.constant 42 : i32
+  %fZp = arith.constant 0 : i32
+
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME: ins(%arg1 : tensor<1024x5x?x?xi8>)
+
+  // CHECK: %[[DIMH:.+]] = tensor.dim %arg2, %[[C2]] : tensor<1x1024x?x?xi32>
+  // CHECK: %[[DIMW:.+]] = tensor.dim %arg2, %[[C3]] : tensor<1x1024x?x?xi32>
+  // CHECK: %[[INIT:.+]] = tensor.empty(%[[DIMH]], %[[DIMW]]) : tensor<1x1024x?x?xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic
+  // CHECK-SAME: ins(%[[CONV]], %[[SUM]] : tensor<1x1024x?x?xi32>, tensor<1024xi32>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x1024x?x?xi32>)
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x5x14x16xi8>, tensor<1024x5x?x?xi8>, i32, i32) outs(%arg2 : tensor<1x1024x?x?xi32>) -> tensor<1x1024x?x?xi32>
+
+  // CHECK: return %[[GENERIC]]
+  return %0 : tensor<1x1024x?x?xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @nchw_conv2d_dyn_input_zp
+func.func @nchw_conv2d_dyn_input_zp(%arg0: tensor<1x5x14x16xi8>, %arg1: tensor<1024x5x?x?xi8>, %arg2: tensor<1x1024x?x?xi32>) -> tensor<1x1024x?x?xi32> {
+  %fZp = arith.constant 42 : i32
+  %iZp = arith.constant 0 : i32
+
+  // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C3:.+]] = arith.constant 3 : index
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x14x16xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT]] : tensor<1x14x16xi32>)
+  // CHECK: %[[GENERIC:.+]] = linalg.generic
+  // CHECK-SAME: ins(%arg0 : tensor<1x5x14x16xi8>) outs(%[[FILL]] : tensor<1x14x16xi32>)
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[GENERIC]]
+
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[C2]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[C3]]
+  // CHECK: %[[INIT:.+]] = tensor.empty(%[[DIM1]], %[[DIM2]]) : tensor<1x1x?x?xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT]] : tensor<1x1x?x?xi32>)
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[C2]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[C3]]
+  // CHECK: %[[KERNEL:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nchw_sum
+  // CHECK-SAME: ins(%[[EXPAND]], %[[KERNEL]] : tensor<1x1x14x16xi32>, tensor<?x?xi32>)
+  // CHECK-SAME: outs(%[[FILL]] : tensor<1x1x?x?xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]]
+
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[C2]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[C3]]
+  // CHECK: %[[INIT:.+]] = tensor.empty(%[[DIM1]], %[[DIM2]]) : tensor<1x1024x?x?xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic
+  // CHECK-SAME: ins(%[[CONV]], %[[COLLAPSE]] : tensor<1x1024x?x?xi32>, tensor<1x?x?xi32>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x1024x?x?xi32>)
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x5x14x16xi8>, tensor<1024x5x?x?xi8>, i32, i32) outs(%arg2 : tensor<1x1024x?x?xi32>) -> tensor<1x1024x?x?xi32>
+
+  // CHECK: return %[[GENERIC]]
+  return %0 : tensor<1x1024x?x?xi32>
+}
+
+// -----
+
+// CHECK: #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d1)>
+// CHECK: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>
+// CHECK: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK: #map5 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+
+// CHECK-LABEL: @nchw_conv2d_all_dyn
+func.func @nchw_conv2d_all_dyn(%arg0: tensor<?x?x?x?xi8>, %arg1: tensor<?x?x?x?xi8>, %arg2: tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32> {
+  %fZp = arith.constant 42 : i32
+  %iZp = arith.constant 13 : i32
+
+  // CHECK-DAG: %[[I3:.+]] = arith.constant 3 : index
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[I0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[I1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[I2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C546:.+]] = arith.constant 546 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[C13:.+]] = arith.constant 13 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+  // CHECK-SAME:  ins(%arg0, %arg1 : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>)
+  // CHECK-SAME:  outs(%arg2 : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM3:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM3]]) : tensor<?xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<?xi32>)
+  // CHECK: %[[FSUM:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map, #map1]
+  // CHECK-SAME:  iterator_types = ["parallel", "reduction", "reduction", "reduction"]
+  // CHECK-SAME:  ins(%arg1 : tensor<?x?x?x?xi8>)
+  // CHECK-SAME:  outs(%[[FILL]] : tensor<?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[DIM3:.+]] = tensor.dim %arg2, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]])
+  // CHECK: %[[CONV_SUMF:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map, #map2, #map]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  // CHECK-SAME:  ins(%[[CONV]], %[[FSUM]] : tensor<?x?x?x?xi32>, tensor<?xi32>)
+  // CHECK-SAME:  outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg0, %[[I2]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg0, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]])
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<?x?x?xi32>)
+  // CHECK: %[[SUMI:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map3, #map4]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+  // CHECK-SAME:  ins(%arg0 : tensor<?x?x?x?xi8>)
+  // CHECK-SAME:  outs(%[[FILL]] : tensor<?x?x?xi32>)
+  // CHECK: %[[DIM00:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SUMI]] {{\[\[0, *1\], *\[2\], *\[3\]\]}}
+
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg2, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM00]], %[[DIM1]], %[[DIM2]])
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%9 : tensor<?x1x?x?xi32>)
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg1, %[[I2]] : tensor<?x?x?x?xi8>
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg1, %[[I3]] : tensor<?x?x?x?xi8>
+  // CHECK: %[[KERNEL:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nchw_sum
+  // CHECK-SAME: dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME: strides = dense<1> : tensor<2xi64>}
+  // CHECK-SAME: ins(%[[EXPAND]], %[[KERNEL]] : tensor<?x1x?x?xi32>, tensor<?x?xi32>)
+  // CHECK-SAME: outs(%[[FILL]] : tensor<?x1x?x?xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]] {{\[\[0, *1\], *\[2\], *\[3\]\]}}
+
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK-DAG: %[[DIM3:.+]] = tensor.dim %arg2, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]])
+  // CHECK: %[[CONV_SUMIF:.+]] = linalg.generic
+  // CHECK-SAME: indexing_maps = [#map, #map5, #map]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[CONV_SUMF]], %[[COLLAPSE]] : tensor<?x?x?x?xi32>, tensor<?x?x?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[I1]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg1, %[[I2]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg1, %[[I3]]
+  // CHECK-DAG: %[[MUL1:.+]] = arith.muli %[[DIM0]], %[[DIM1]]
+  // CHECK-DAG: %[[MUL2:.+]] = arith.muli %[[MUL1]], %[[DIM2]]
+  // CHECK-DAG: %[[CAST:.+]] = arith.index_cast %[[MUL2]] : index to i32
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK-DAG: %[[DIM3:.+]] = tensor.dim %arg2, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
+  // CHECK: %[[RESULT:.+]] = linalg.generic
+  // CHECK-SAME: indexing_maps = [#map, #map]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[CONV_SUMIF]] : tensor<?x?x?x?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>, i32, i32) outs(%arg2 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+
+  // CHECK: return %[[RESULT]]
+  return %0 : tensor<?x?x?x?xi32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @dconv2d
 func.func @dconv2d(%arg0 : tensor<1x64x64x16xi8>, %arg1 : tensor<4x4x16xi8>, %arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32> {
   %iZp = arith.constant 0 : i32


### PR DESCRIPTION
This PR extends LinalgQuantizedConvToConvPass `(iree-global-opt-quantized-conv-to-conv)` to support the **NCHW/FCHW** quantized conv2d op by lowering `linalg.conv_2d_nchw_fchw_q` to `linalg.conv_2d_nchw_fchw`. It also adds MLIR tests mirroring the existing NHWC tests.

The reason for this pattern is that if quantized_nchw_conv was not converted by this pass, it will not be lowered when the `img2col` pass runs, resulting in unoptimized MLIR generation.

Compilation Command (x86):
```
./iree_build/tools/iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-global-opt-quantized-conv-to-conv, iree-global-opt-conv2d-to-img2col))"  \
  --iree-hal-target-device=local     --iree-hal-local-target-device-backends=llvm-cpu  \
  --iree-llvmcpu-target-cpu=host --iree-llvmcpu-target-cpu-features=host  \
  conv2d_nchw.mlir -o conv2d_nchw.vmfb
```

Test Run:
```
ctest -R iree/compiler/GlobalOptimization/test/linalg_quantized_conv_to_conv.mlir.test --output-on-failure
```