### PR TITLE
Prevent incorrect folding of nested insert_slice ops in TensorExt

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -59,6 +59,11 @@ struct FoldInsertSliceWithTensorStoreOp
     if (!insertSliceOp)
       return failure();
 
+    //Take the destination of the insert slice op and check whther it is another insert slice op.Then return failure if it is not. This is to avoid folding insert slice ops that are not directly feeding into the dispatch tensor store op, which can lead to incorrect folding and potential issues in the IR.
+     auto destOfInsertSliceOp = insertSliceOp.getDest().getDefiningOp();
+    if(!destOfInsertSliceOp || isa<tensor::InsertSliceOp>(destOfInsertSliceOp))
+      return failure();
+
     SmallVector<OpFoldResult> offsets, sizes, strides;
     // `tensor.insert_slice` (i.e. the producer) folds **into**
     // `iree_tensor_ext.dispatch.tensor.store` (i.e. the consumer).


### PR DESCRIPTION
Add a guard in FoldInsertSliceWithTensorStoreOp to avoid folding insert_slice operations when their destination is not directly originating from a non-insert_slice op.

Specifically, check the defining op of the destination tensor and bail out if it is missing or another tensor::InsertSliceOp. This ensures that only insert_slice ops directly feeding into the dispatch tensor store are folded.

This prevents incorrect IR transformations and potential issues arising from folding nested or chained insert_slice operations.