### PR TITLE
[Codegen] Make CreateDispatchConfig idempotent

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
@@ -42,6 +42,17 @@ void CreateDispatchConfigPass::runOnOperation() {
       continue;
     }
 
+    // The pass may be rerun on already-configured executables (for example
+    // when recompiling a dumped `configured` executable). Keep the existing
+    // dispatch_config in that case instead of creating a duplicate.
+    if (llvm::any_of(innerModule.getOps<IREE::Codegen::DispatchConfigOp>(),
+                     [&](IREE::Codegen::DispatchConfigOp existingConfigOp) {
+                       return existingConfigOp.getFunctionRef() ==
+                              funcOp.getName();
+                     })) {
+      continue;
+    }
+
     Location loc = funcOp.getLoc();
     Block *exportBlock = exportOp.getWorkgroupCountBody();
     if (!exportBlock || exportBlock->getNumArguments() == 0) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
@@ -116,3 +116,31 @@ hal.executable private @interleaving {
 //       CHECK:   iree_codegen.dispatch_config @fn1
 //       CHECK:   func.func @fn2
 //       CHECK:   iree_codegen.dispatch_config @fn2
+
+// -----
+
+// Rerunning the pass on an already-configured executable should be a no-op.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @already_configured {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "">) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        return
+      }
+      iree_codegen.dispatch_config @entry_point {
+      ^bb0(%device: !hal.device, %arg0: index):
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+        iree_codegen.yield %x, %y, %z : index, index, index
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @already_configured
+// CHECK-COUNT-1: iree_codegen.dispatch_config @entry_point

--- a/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
@@ -144,3 +144,4 @@ hal.executable private @already_configured {
 }
 // CHECK-LABEL: hal.executable private @already_configured
 // CHECK-COUNT-1: iree_codegen.dispatch_config @entry_point
+// CHECK-NOT: iree_codegen.dispatch_config @entry_point


### PR DESCRIPTION
Recompiling a dumped configured hal.executable reruns the executable configuration pipeline. CreateDispatchConfigPass was blindly creating a new iree_codegen.dispatch_config even when one already existed, which left duplicate configs for the same entry point.

That later caused PropagateDispatchConfigPass to fail on the stale config without workgroup_size, even though reconciliation had populated the other one.

Make CreateDispatchConfigPass skip functions that already have a matching dispatch_config, and add a regression test covering rerunning the pass on an already-configured executable.

Assisted-by: Codex