### PR TITLE
[Codegen] Deprecate the old ExportOp path from PropagateDispatchSizeBounds

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -1007,12 +1007,6 @@ def PropagateDispatchSizeBoundsPass :
     InterfacePass<"iree-codegen-propagate-dispatch-size-bounds", "mlir::FunctionOpInterface"> {
   let summary = "Pass to annotate workitem and workgroup IDs with known bounds";
   let dependentDialects = ["::mlir::arith::ArithDialect"];
-  let options = [
-    Option<"useDispatchConfig", "use-dispatch-config", "bool",
-           /*default=*/"false",
-           "Read workgroup size/count from dispatch_config op instead of "
-           "hal.executable.export.">,
-  ];
 }
 
 def PropagateReshapesByExpansionPass :

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchSizeBounds.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchSizeBounds.cpp
@@ -160,35 +160,14 @@ struct PropagateDispatchSizeBoundsPass final
     // Check if a specific subgroup size has been explicitly chosen via the
     // codegen pipeline configuration.
     std::optional<int64_t> staticSubgroupSize = getSubgroupSize(funcOp);
-
-    IREE::Codegen::DispatchConfigOp configOp;
-    if (useDispatchConfig) {
-      configOp = getDispatchConfigOp(funcOp);
-      if (configOp) {
-        if (std::optional<ArrayRef<int64_t>> wgSize =
-                configOp.getWorkgroupSize()) {
-          staticWorkgroupSize = llvm::to_vector(wgSize.value());
-        }
-        if (std::optional<uint64_t> sgSize = configOp.getSubgroupSize()) {
-          staticSubgroupSize = static_cast<int64_t>(*sgSize);
-        }
+    IREE::Codegen::DispatchConfigOp configOp = getDispatchConfigOp(funcOp);
+    if (configOp) {
+      if (std::optional<ArrayRef<int64_t>> wgSize =
+              configOp.getWorkgroupSize()) {
+        staticWorkgroupSize = llvm::to_vector(wgSize.value());
       }
-    } else {
-      // Late in codegen, we've reconciled the workgroup size onto the export
-      // op.
-      if (std::optional<IREE::HAL::ExecutableExportOp> exportOp =
-              getEntryPoint(funcOp)) {
-        if (std::optional<ArrayAttr> exportWorkgroupSize =
-                exportOp->getWorkgroupSize()) {
-          staticWorkgroupSize = llvm::map_to_vector(
-              exportWorkgroupSize->getAsRange<IntegerAttr>(),
-              [](IntegerAttr a) { return a.getInt(); });
-        }
-
-        if (std::optional<uint64_t> exportSubgroupSize =
-                exportOp->getSubgroupSizeAsUInt()) {
-          staticSubgroupSize = static_cast<int64_t>(*exportSubgroupSize);
-        }
+      if (std::optional<uint64_t> sgSize = configOp.getSubgroupSize()) {
+        staticSubgroupSize = static_cast<int64_t>(*sgSize);
       }
     }
 
@@ -219,10 +198,8 @@ struct PropagateDispatchSizeBoundsPass final
       }
     }
     SmallVector<int64_t> staticWorkgroupCounts;
-    if (useDispatchConfig && configOp) {
+    if (configOp) {
       staticWorkgroupCounts = configOp.getStaticNumWorkgroups();
-    } else {
-      staticWorkgroupCounts = getStaticNumWorkgroups(funcOp);
     }
     assert(staticWorkgroupCounts.size() <= 3 &&
            "workgroup counts are 3D at most");

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
@@ -1,120 +1,101 @@
 // RUN: iree-opt %s --split-input-file \
-// RUN:     --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-propagate-dispatch-size-bounds)))))" \
+// RUN:     --pass-pipeline="builtin.module(func.func(iree-codegen-propagate-dispatch-size-bounds))" \
 // RUN:  | FileCheck %s
-// RUN: iree-opt %s --split-input-file \
-// RUN:     --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-propagate-dispatch-size-bounds{use-dispatch-config=true})))))" \
-// RUN:  | FileCheck %s --check-prefix=DISPATCH-CONFIG
 
 // Note: not the real target definition, missing types
-#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
-  wgp = <compute = fp32,
-    storage = b32,
-    subgroup = arithmetic,
-    subgroup_size_choices = [32, 64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
+    wgp = <compute = fp32, storage = b32, subgroup = arithmetic,
+      subgroup_size_choices = [32, 64],
+      max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024,
+      max_workgroup_memory_bytes = 65536,
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 
-hal.executable private @static {
-  hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @static ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %c32 = arith.constant 32 : index
-      %c8 = arith.constant 8 : index
-      %c1 = arith.constant 1 : index
-      hal.return %c32, %c8, %c1 : index, index, index
-    } attributes {workgroup_size = [64 : index, 2 : index, 1 : index]}
-    builtin.module {
 // CHECK-LABEL: func.func @static()
 // CHECK-SAME: gpu.known_block_size = array<i32: 64, 2, 1>
-      func.func @static() {
+func.func @static() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
-        %lane_id = gpu.lane_id
+  %lane_id = gpu.lane_id
 
 // CHECK-NEXT: gpu.subgroup_id upper_bound 4 : index
-        %subgroup_id = gpu.subgroup_id : index
+  %subgroup_id = gpu.subgroup_id : index
 
 // CHECK-NEXT: gpu.thread_id x upper_bound 64
 // CHECK-NEXT: gpu.thread_id y upper_bound 2
 // CHECK-NEXT: gpu.thread_id z upper_bound 1
-        %thread_id_x = gpu.thread_id x
-        %thread_id_y = gpu.thread_id y
-        %thread_id_z = gpu.thread_id z
+  %thread_id_x = gpu.thread_id x
+  %thread_id_y = gpu.thread_id y
+  %thread_id_z = gpu.thread_id z
 
 // CHECK-NEXT: arith.constant 64 : index
 // CHECK-NEXT: arith.constant 2 : index
 // CHECK-NEXT: arith.constant 1 : index
-        %block_dim_x = gpu.block_dim x
-        %block_dim_y = gpu.block_dim y
-        %block_dim_z = gpu.block_dim z
+  %block_dim_x = gpu.block_dim x
+  %block_dim_y = gpu.block_dim y
+  %block_dim_z = gpu.block_dim z
 
 // CHECK-NEXT: arith.constant 64 : index
 // CHECK-NEXT: arith.constant 2 : index
 // CHECK-NEXT: arith.constant 1 : index
-        %workgroup_size_x = hal.interface.workgroup.size[0] : index
-        %workgroup_size_y = hal.interface.workgroup.size[1] : index
-        %workgroup_size_z = hal.interface.workgroup.size[2] : index
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_size_y = hal.interface.workgroup.size[1] : index
+  %workgroup_size_z = hal.interface.workgroup.size[2] : index
 
 // CHECK-NEXT: hal.interface.workgroup.id[0] upper_bound 32
 // CHECK-NEXT: hal.interface.workgroup.id[1] upper_bound 8
 // CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
 // CHECK-NEXT: arith.constant 32 : index
 // CHECK-NEXT: arith.constant 8 : index
 // CHECK-NEXT: arith.constant 1 : index
-        %workgroup_conut_x = hal.interface.workgroup.count[0] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %workgroup_count_z = hal.interface.workgroup.count[2] : index
 
-        return
-      }
-    }
-  }
+  return
+}
+iree_codegen.dispatch_config @static workgroup_size = [64, 2, 1] {
+  %c32 = arith.constant 32 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c32, %c8, %c1 : index, index, index
 }
 
 // -----
 
 // Note: not the real target definition, missing types
-#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
-  wgp = <compute = fp32,
-    storage = b32,
-    subgroup = arithmetic,
-    subgroup_size_choices = [32, 64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
+    wgp = <compute = fp32, storage = b32, subgroup = arithmetic,
+      subgroup_size_choices = [32, 64],
+      max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024,
+      max_workgroup_memory_bytes = 65536,
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 
-hal.executable private @manual_subgroup_size {
-  hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @manual_subgroup_size ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %c32 = arith.constant 32 : index
-      %c8 = arith.constant 8 : index
-      %c1 = arith.constant 1 : index
-      hal.return %c32, %c8, %c1 : index, index, index
-    } attributes {subgroup_size = 32 : index}
-    builtin.module {
 // CHECK-LABEL: func.func @manual_subgroup_size()
-      func.func @manual_subgroup_size() {
+func.func @manual_subgroup_size() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: gpu.lane_id upper_bound 32
-        %lane_id = gpu.lane_id
+  %lane_id = gpu.lane_id
 
 // No workgroup_size; bound from max_thread_count_per_workgroup (1024) / subgroup_size (32) = 32.
 // CHECK-NEXT: gpu.subgroup_id upper_bound 32 : index
-        %subgroup_id = gpu.subgroup_id : index
+  %subgroup_id = gpu.subgroup_id : index
 
 // CHECK-NEXT: arith.constant 32 : index
-        %subgroup_size = gpu.subgroup_size : index
+  %subgroup_size = gpu.subgroup_size : index
 
-        return
-      }
-    }
-  }
+  return
+}
+iree_codegen.dispatch_config @manual_subgroup_size subgroup_size = 32 {
+  %c32 = arith.constant 32 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c32, %c8, %c1 : index, index, index
 }
 
 // -----
@@ -123,39 +104,30 @@ hal.executable private @manual_subgroup_size {
 // with static workgroup sizes but no explicit subgroup_size selection.
 #executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
   {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
-  wgp = <compute = fp32,
-    storage = b32,
-    subgroup = arithmetic,
-    subgroup_size_choices = [32, 64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+    wgp = <compute = fp32, storage = b32, subgroup = arithmetic,
+      subgroup_size_choices = [32, 64],
+      max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024,
+      max_workgroup_memory_bytes = 65536,
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 
-hal.executable private @gfx1100_variable_subgroup {
-  hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @gfx1100_variable_subgroup ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %c128 = arith.constant 128 : index
-      %c1 = arith.constant 1 : index
-      hal.return %c128, %c1, %c1 : index, index, index
-    } attributes {workgroup_size = [128 : index, 1 : index, 1 : index]}
-    builtin.module {
 // CHECK-LABEL: func.func @gfx1100_variable_subgroup()
-      func.func @gfx1100_variable_subgroup() {
+func.func @gfx1100_variable_subgroup() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
-        %lane_id = gpu.lane_id
+  %lane_id = gpu.lane_id
 
 // CHECK-NEXT: gpu.subgroup_id upper_bound 4 : index
-        %subgroup_id = gpu.subgroup_id : index
+  %subgroup_id = gpu.subgroup_id : index
 
 // CHECK-NEXT: gpu.subgroup_size upper_bound 64 : index
-        %subgroup_size = gpu.subgroup_size : index
+  %subgroup_size = gpu.subgroup_size : index
 
-        return
-      }
-    }
-  }
+  return
+}
+iree_codegen.dispatch_config @gfx1100_variable_subgroup workgroup_size = [128, 1, 1] {
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c128, %c1, %c1 : index, index, index
 }
 
 // -----
@@ -165,236 +137,164 @@ hal.executable private @gfx1100_variable_subgroup {
 // that ever comes up.
 #executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
   {iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "",
-  wgp = <compute = fp32,
-    storage = b32,
-    subgroup = arithmetic,
-    subgroup_size_choices = [64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+    wgp = <compute = fp32, storage = b32, subgroup = arithmetic,
+      subgroup_size_choices = [64],
+      max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024,
+      max_workgroup_memory_bytes = 65536,
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 
-hal.executable private @gfx942_not_really_variable_subgroup {
-  hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @gfx942_not_really_variable_subgroup ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %c128 = arith.constant 128 : index
-      %c1 = arith.constant 1 : index
-      hal.return %c128, %c1, %c1 : index, index, index
-    } attributes {workgroup_size = [128 : index, 1 : index, 1 : index]}
-    builtin.module {
 // CHECK-LABEL: func.func @gfx942_not_really_variable_subgroup()
 // CHECK-SAME: gpu.known_block_size = array<i32: 128, 1, 1>
-      func.func @gfx942_not_really_variable_subgroup() {
+func.func @gfx942_not_really_variable_subgroup() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
-        %lane_id = gpu.lane_id
+  %lane_id = gpu.lane_id
 
 // CHECK-NEXT: gpu.subgroup_id upper_bound 2 : index
-        %subgroup_id = gpu.subgroup_id : index
+  %subgroup_id = gpu.subgroup_id : index
 
 // CHECK-NEXT: arith.constant 64 : index
-        %subgroup_size = gpu.subgroup_size : index
+  %subgroup_size = gpu.subgroup_size : index
 
-        return
-      }
-    }
-  }
+  return
+}
+iree_codegen.dispatch_config @gfx942_not_really_variable_subgroup workgroup_size = [128, 1, 1] {
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c128, %c1, %c1 : index, index, index
 }
 
 // -----
 
 #executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
   {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
-  wgp = <compute = fp32,
-    storage = b32,
-    subgroup = arithmetic,
-    subgroup_size_choices = [32, 64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+    wgp = <compute = fp32, storage = b32, subgroup = arithmetic,
+      subgroup_size_choices = [32, 64],
+      max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024,
+      max_workgroup_memory_bytes = 65536,
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
 
-hal.executable private @dynamic {
-  hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @dynamic ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-      %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 32)>()[%arg1]
-      %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%arg2]
-      %count_z = arith.constant 1 : index
-      hal.return %count_x, %count_y, %count_z : index, index, index
-    }
-    builtin.module {
 // CHECK-LABEL: func.func @dynamic()
-      func.func @dynamic() {
+func.func @dynamic() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: gpu.lane_id upper_bound 64
-        %lane_id = gpu.lane_id
+  %lane_id = gpu.lane_id
 
 // CHECK-NEXT: gpu.subgroup_id upper_bound 32 : index
-        %subgroup_id = gpu.subgroup_id : index
+  %subgroup_id = gpu.subgroup_id : index
 
 // CHECK-NEXT: gpu.subgroup_size upper_bound 64 : index
-        %subgroup_size = gpu.subgroup_size : index
+  %subgroup_size = gpu.subgroup_size : index
 
 // CHECK-NEXT: gpu.thread_id x upper_bound 1024
 // CHECK-NEXT: gpu.thread_id y upper_bound 1024
 // CHECK-NEXT: gpu.thread_id z upper_bound 1024
-        %thread_id_x = gpu.thread_id x
-        %thread_id_y = gpu.thread_id y
-        %thread_id_z = gpu.thread_id z
+  %thread_id_x = gpu.thread_id x
+  %thread_id_y = gpu.thread_id y
+  %thread_id_z = gpu.thread_id z
 
 // CHECK-NEXT: gpu.block_dim x upper_bound 1024
 // CHECK-NEXT: gpu.block_dim y upper_bound 1024
 // CHECK-NEXT: gpu.block_dim z upper_bound 1024
-        %block_dim_x = gpu.block_dim x
-        %block_dim_y = gpu.block_dim y
-        %block_dim_z = gpu.block_dim z
+  %block_dim_x = gpu.block_dim x
+  %block_dim_y = gpu.block_dim y
+  %block_dim_z = gpu.block_dim z
 
 // CHECK-NEXT: hal.interface.workgroup.size[0] upper_bound 1024
 // CHECK-NEXT: hal.interface.workgroup.size[1] upper_bound 1024
 // CHECK-NEXT: hal.interface.workgroup.size[2] upper_bound 1024
-        %workgroup_size_x = hal.interface.workgroup.size[0] : index
-        %workgroup_size_y = hal.interface.workgroup.size[1] : index
-        %workgroup_size_z = hal.interface.workgroup.size[2] : index
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_size_y = hal.interface.workgroup.size[1] : index
+  %workgroup_size_z = hal.interface.workgroup.size[2] : index
 
 // CHECK-NEXT: hal.interface.workgroup.id[0] upper_bound 2147483647
 // CHECK-NEXT: hal.interface.workgroup.id[1] upper_bound 2147483647
 // CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
 // CHECK-NEXT: hal.interface.workgroup.count[0] upper_bound 2147483647
 // CHECK-NEXT: hal.interface.workgroup.count[1] upper_bound 2147483647
 // CHECK-NEXT: arith.constant 1 : index
-        %workgroup_conut_x = hal.interface.workgroup.count[0] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %workgroup_count_z = hal.interface.workgroup.count[2] : index
 
-        return
-      }
-    }
-  }
+  return
+}
+iree_codegen.dispatch_config @dynamic {
+^bb0(%arg0: index, %arg1: index):
+  %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 32)>()[%arg0]
+  %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%arg1]
+  %count_z = arith.constant 1 : index
+  iree_codegen.yield %count_x, %count_y, %count_z : index, index, index
 }
 
 // -----
 
-#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-linux-gnu"}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64",
+  {cpu_features = "+avx512f",
+   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+   native_vector_size = 16 : index,
+   target_triple = "x86_64-unknown-linux-gnu"}>
 
-hal.executable private @static_cpu {
-  hal.executable.variant public @embedded_elf_x86_64 target(#executable_target) {
-    hal.executable.export public @static_cpu ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %c32 = arith.constant 32 : index
-      %c8 = arith.constant 8 : index
-      %c1 = arith.constant 1 : index
-      hal.return %c32, %c8, %c1 : index, index, index
-    } attributes {workgroup_size = [64 : index, 2 : index, 1 : index]}
-    builtin.module {
 // CHECK-LABEL: func.func @static_cpu()
 // CHECK-NOT: gpu.known_block_size
-      func.func @static_cpu() {
+func.func @static_cpu() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: hal.interface.workgroup.id[0] upper_bound 32
 // CHECK-NEXT: hal.interface.workgroup.id[1] upper_bound 8
 // CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
 // CHECK-NEXT: arith.constant 32 : index
 // CHECK-NEXT: arith.constant 8 : index
 // CHECK-NEXT: arith.constant 1 : index
-        %workgroup_conut_x = hal.interface.workgroup.count[0] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %workgroup_count_z = hal.interface.workgroup.count[2] : index
 
-        return
-      }
-    }
-  }
+  return
+}
+iree_codegen.dispatch_config @static_cpu workgroup_size = [64, 2, 1] {
+  %c32 = arith.constant 32 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  iree_codegen.yield %c32, %c8, %c1 : index, index, index
 }
 
 // -----
 
-#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-linux-gnu"}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64",
+  {cpu_features = "+avx512f",
+   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+   native_vector_size = 16 : index,
+   target_triple = "x86_64-unknown-linux-gnu"}>
 
-hal.executable private @dynamic_cpu {
-  hal.executable.variant public @embedded_elf_x86_64 target(#executable_target) {
-    hal.executable.export public @dynamic_cpu ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-      %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 32)>()[%arg1]
-      %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%arg2]
-      %count_z = arith.constant 1 : index
-      hal.return %count_x, %count_y, %count_z : index, index, index
-    }
-    builtin.module {
 // CHECK-LABEL: func.func @dynamic_cpu()
-      func.func @dynamic_cpu() {
+func.func @dynamic_cpu() attributes {hal.executable.target = #executable_target} {
 // CHECK-NEXT: hal.interface.workgroup.id[0] : index
 // CHECK-NEXT: hal.interface.workgroup.id[1] : index
 // CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1 : index
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
 // CHECK-NEXT: hal.interface.workgroup.count[0] : index
 // CHECK-NEXT: hal.interface.workgroup.count[1] : index
 // CHECK-NEXT: arith.constant 1 : index
-        %workgroup_conut_x = hal.interface.workgroup.count[0] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %workgroup_count_z = hal.interface.workgroup.count[2] : index
 
-        return
-      }
-    }
-  }
+  return
 }
-
-// -----
-
-// Test that use-dispatch-config reads bounds from dispatch_config instead of
-// hal.executable.export.
-
-// Note: not the real target definition, missing types
-#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<arch = "gfx1100", features = "",
-  wgp = <compute = fp32,
-    storage = b32,
-    subgroup = arithmetic,
-    subgroup_size_choices = [32, 64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
-
-hal.executable private @dispatch_config_static {
-  hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @dispatch_config_static ordinal(0) layout(#pipeline_layout)
-    builtin.module {
-// DISPATCH-CONFIG-LABEL: func.func @dispatch_config_static()
-// DISPATCH-CONFIG-SAME: gpu.known_block_size = array<i32: 64, 2, 1>
-      func.func @dispatch_config_static() {
-// DISPATCH-CONFIG-NEXT: gpu.thread_id x upper_bound 64
-// DISPATCH-CONFIG-NEXT: gpu.thread_id y upper_bound 2
-// DISPATCH-CONFIG-NEXT: gpu.thread_id z upper_bound 1
-        %thread_id_x = gpu.thread_id x
-        %thread_id_y = gpu.thread_id y
-        %thread_id_z = gpu.thread_id z
-
-// DISPATCH-CONFIG-NEXT: hal.interface.workgroup.id[0] upper_bound 32
-// DISPATCH-CONFIG-NEXT: hal.interface.workgroup.id[1] upper_bound 8
-// DISPATCH-CONFIG-NEXT: hal.interface.workgroup.id[2] upper_bound 1
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_id_z = hal.interface.workgroup.id[2] : index
-
-        return
-      }
-      iree_codegen.dispatch_config @dispatch_config_static workgroup_size = [64, 2, 1] subgroup_size = 64 {
-        %c32 = arith.constant 32 : index
-        %c8 = arith.constant 8 : index
-        %c1 = arith.constant 1 : index
-        iree_codegen.yield %c32, %c8, %c1 : index, index, index
-      }
-    }
-  }
+iree_codegen.dispatch_config @dynamic_cpu {
+^bb0(%arg0: index, %arg1: index):
+  %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 32)>()[%arg0]
+  %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%arg1]
+  %count_z = arith.constant 1 : index
+  iree_codegen.yield %count_x, %count_y, %count_z : index, index, index
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -333,8 +333,7 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createGPUDistributePass());
 
   // Post bufferization optimizations.
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
   funcPassManager.addPass(createIREECodegenFoldMemRefAliasOpsPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -566,8 +565,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createTileLargeTensorsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
@@ -604,8 +602,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 9. Remaining post-bufferization optimizations/lowerings.
   funcPassManager.addPass(createFlattenSwizzleHintAllocsPass());
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
   funcPassManager.addPass(createUnrollAnnotatedLoopsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
@@ -669,8 +666,7 @@ void addGPUWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createGPUDistributeScfForPass(options));
 
   // Post bufferization optimizations.
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());
   funcPassManager.addPass(createIREECodegenFoldMemRefAliasOpsPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
@@ -879,8 +875,7 @@ void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
 }
 
@@ -894,8 +889,7 @@ void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCSEPass());
 
   addBufferizePasses(funcPassManager);
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
 }
 
@@ -907,8 +901,7 @@ void addGPUBaseLoweringPassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(IREE::LinalgExt::createLinalgExtToLoopsPass());
   funcPassManager.addPass(createMemrefCopyToLinalgPass());
   funcPassManager.addPass(createConvertLinalgToLoopsPass());
-  funcPassManager.addPass(
-      createPropagateDispatchSizeBoundsPass({/*useDispatchConfig=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -937,10 +930,7 @@ addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
       .addPass(createIREEExpandStridedMetadataPass)
-      .addPass([] {
-        return createPropagateDispatchSizeBoundsPass(
-            {/*useDispatchConfig=*/true});
-      })
+      .addPass(createPropagateDispatchSizeBoundsPass)
       // Hoist loop invariant variables to give affine decomposition pass the
       // right loop dependencies.
       .addPass(createIREELoopInvariantCodeMotionPass)


### PR DESCRIPTION
After the module-scope pipeline migration, all the GPU backends do not touch export op during codegen. Thus, this option can be deprecated.

The tests are updated to exclude hal ops.