### PR TITLE
[Tokenizer] Fix ByteLevel decoder: hybrid pre-decode with UTF-8 accumulator

### DIFF
--- a/runtime/src/iree/tokenizer/BUILD.bazel
+++ b/runtime/src/iree/tokenizer/BUILD.bazel
@@ -104,6 +104,7 @@ iree_runtime_cc_library(
     srcs = ["tokenizer.c"],
     hdrs = ["tokenizer.h"],
     deps = [
+        ":byte_level_tables",
         ":decoder",
         ":model",
         ":normalizer",

--- a/runtime/src/iree/tokenizer/CMakeLists.txt
+++ b/runtime/src/iree/tokenizer/CMakeLists.txt
@@ -129,6 +129,7 @@ iree_cc_library(
   SRCS
     "tokenizer.c"
   DEPS
+    ::byte_level_tables
     ::decoder
     ::model
     ::normalizer

--- a/runtime/src/iree/tokenizer/decoder.h
+++ b/runtime/src/iree/tokenizer/decoder.h
@@ -82,7 +82,7 @@ enum iree_tokenizer_decoder_capability_e {
   IREE_TOKENIZER_DECODER_CAPABILITY_NONE = 0,
   // Output for each token depends only on that token's text, not on adjacent
   // tokens or stream position. Enables full pre-decode at build time.
-  // Examples: ByteLevel, Replace, Strip.
+  // Examples: Replace, Strip, Passthrough.
   IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS = 1u << 0,
   // Output for the first token in a stream differs from subsequent tokens.
   // Typically the first token omits a leading space that "rest" tokens include.
@@ -96,6 +96,14 @@ enum iree_tokenizer_decoder_capability_e {
   // with an inline accumulator at decode time.
   // Examples: ByteFallback.
   IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_BYTE_TOKENS = 1u << 2,
+  // Stateless for most tokens (99.3% of GPT-2 vocab), but some produce
+  // partial UTF-8 bytes that must accumulate across token boundaries.
+  // Unlike BYTE_TOKENS where byte tokens are identifiable by <0xHH> syntax,
+  // partial UTF-8 tokens look like normal tokens (e.g., GPT-2's "Ã" maps to
+  // byte 0xC3 which is a UTF-8 lead byte). The build step trial-decodes each
+  // token and marks partial ones in a slab-embedded bitmap.
+  // Examples: ByteLevel (GPT-2 family).
+  IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8 = 1u << 3,
 };
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/tokenizer/decoder/BUILD.bazel
+++ b/runtime/src/iree/tokenizer/decoder/BUILD.bazel
@@ -192,6 +192,7 @@ iree_runtime_cc_test(
     srcs = ["sequence_test.cc"],
     deps = [
         ":byte_fallback",
+        ":byte_level",
         ":decoder_test_util",
         ":metaspace",
         ":passthrough",

--- a/runtime/src/iree/tokenizer/decoder/CMakeLists.txt
+++ b/runtime/src/iree/tokenizer/decoder/CMakeLists.txt
@@ -207,6 +207,7 @@ iree_cc_test(
     "sequence_test.cc"
   DEPS
     ::byte_fallback
+    ::byte_level
     ::decoder_test_util
     ::metaspace
     ::passthrough

--- a/runtime/src/iree/tokenizer/decoder/byte_level.c
+++ b/runtime/src/iree/tokenizer/decoder/byte_level.c
@@ -42,10 +42,17 @@ iree_status_t iree_tokenizer_decoder_byte_level_allocate(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(allocator, sizeof(*decoder), (void**)&decoder));
 
+  // ByteLevel produces partial UTF-8 sequences from some tokens. For example,
+  // "Ñ" (U+00D1, UTF-8: C3 91) encodes as two GPT-2 tokens:
+  //   "Ã" (U+00C3 -> byte 0xC3) and "ĳ" (U+0133 -> byte 0x91).
+  // The pending bytes [0xC3] from token "Ã" must carry over to token "ĳ" to
+  // form the valid UTF-8 sequence [0xC3, 0x91]. The PARTIAL_UTF8 capability
+  // enables a hybrid pre-decode path: tokens are trial-decoded at build time
+  // and those producing partial UTF-8 are flagged in a slab-embedded bitmap.
   iree_tokenizer_decoder_initialize(
       &decoder->base, &iree_tokenizer_decoder_byte_level_vtable,
       sizeof(iree_tokenizer_decoder_byte_level_state_t),
-      IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS);
+      IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8);
   decoder->allocator = allocator;
 
   *out_decoder = &decoder->base;

--- a/runtime/src/iree/tokenizer/decoder/byte_level_test.cc
+++ b/runtime/src/iree/tokenizer/decoder/byte_level_test.cc
@@ -509,5 +509,108 @@ TEST_F(ByteLevelDecoderTest, HF_MultipleTokens) {
                         /*expect_pending_after_process=*/false);
 }
 
+//===----------------------------------------------------------------------===//
+// Cross-Token UTF-8 with Shifted Bytes
+//===----------------------------------------------------------------------===//
+// These test multi-byte UTF-8 reconstruction where continuation bytes fall in
+// the shifted range (0x80-0x9F -> U+0122-U+0141). This is the common case for
+// non-ASCII characters like accented letters, CJK, and emoji in GPT-2.
+
+TEST_F(ByteLevelDecoderTest, CrossTokenNTilde) {
+  // "Ñ" = U+00D1, UTF-8: C3 91.
+  // GPT-2 tokens: "Ã" (U+00C3 -> byte C3) + "ĳ" (U+0133 -> byte 91).
+  // Byte 0x91 is in shifted range (0x80-0x9F -> U+0122-U+0141).
+  std::vector<std::string> tokens = {"\xC3\x83", "\xC4\xB3"};  // Ã, ĳ
+  TestWithAllBatchSizes(decoder(), tokens, "\xC3\x91",         // Ñ
+                        /*expect_pending_after_process=*/false);
+}
+
+TEST_F(ByteLevelDecoderTest, CrossTokenNTildeInWord) {
+  // "Ñoño" = Ñ + o + ñ + o.
+  // "Ñ" (C3 91): Ã (C3 83) + ĳ (C4 B3)
+  // "o" (6F): identity
+  // "ñ" (C3 B1): Ã (C3 83) + ± (C2 B1) [both identity range]
+  // "o" (6F): identity
+  // In GPT-2, BPE may merge these differently, but at the byte-level decoder
+  // layer we test the worst case: each byte-level char as a separate token.
+  std::vector<std::string> tokens = {
+      "\xC3\x83",  // Ã -> byte C3
+      "\xC4\xB3",  // ĳ -> byte 91
+      "o",         // identity
+      "\xC3\x83",  // Ã -> byte C3
+      "\xC2\xB1",  // ± -> byte B1
+      "o",         // identity
+  };
+  TestWithAllBatchSizes(decoder(), tokens,
+                        "\xC3\x91"  // Ñ
+                        "o"         //
+                        "\xC3\xB1"  // ñ
+                        "o",        //
+                        /*expect_pending_after_process=*/false);
+}
+
+TEST_F(ByteLevelDecoderTest, CrossTokenChinese) {
+  // "你好" = U+4F60 U+597D.
+  // "你" UTF-8: E4 BD A0.
+  //   byte E4 -> U+00E4 (identity, ä, C3 A4)
+  //   byte BD -> U+00BD (identity, ½, C2 BD)
+  //   byte A0 -> U+0142 (shifted, ł, C5 82)
+  // "好" UTF-8: E5 A5 BD.
+  //   byte E5 -> U+00E5 (identity, å, C3 A5)
+  //   byte A5 -> U+00A5 (identity, ¥, C2 A5)
+  //   byte BD -> U+00BD (identity, ½, C2 BD)
+  std::vector<std::string> tokens = {
+      "\xC3\xA4",  // ä -> byte E4
+      "\xC2\xBD",  // ½ -> byte BD
+      "\xC5\x82",  // ł -> byte A0
+      "\xC3\xA5",  // å -> byte E5
+      "\xC2\xA5",  // ¥ -> byte A5
+      "\xC2\xBD",  // ½ -> byte BD
+  };
+  TestWithAllBatchSizes(decoder(), tokens,
+                        "\xE4\xBD\xA0"   // 你
+                        "\xE5\xA5\xBD",  // 好
+                        /*expect_pending_after_process=*/false);
+}
+
+TEST_F(ByteLevelDecoderTest, CrossTokenEmoji) {
+  // "😀" = U+1F600, UTF-8: F0 9F 98 80.
+  //   byte F0 -> U+00F0 (identity, ð, C3 B0)
+  //   byte 9F -> U+0141 (shifted, Ł, C5 81)
+  //   byte 98 -> U+013A (shifted, ĺ, C4 BA)
+  //   byte 80 -> U+0122 (shifted, Ģ, C4 A2)
+  // Test: "hello 😀 world" with space encoded as Ġ (U+0120).
+  std::vector<std::string> tokens = {
+      "hello",
+      "\xC4\xA0",  // Ġ -> space
+      "\xC3\xB0",  // ð -> byte F0
+      "\xC5\x81",  // Ł -> byte 9F
+      "\xC4\xBA",  // ĺ -> byte 98
+      "\xC4\xA2",  // Ģ -> byte 80
+      "\xC4\xA0",  // Ġ -> space
+      "world",
+  };
+  TestWithAllBatchSizes(decoder(), tokens,
+                        "hello \xF0\x9F\x98\x80 world",  // hello 😀 world
+                        /*expect_pending_after_process=*/false);
+}
+
+TEST_F(ByteLevelDecoderTest, NotStateless) {
+  // ByteLevel must NOT be declared STATELESS because cross-token UTF-8
+  // sequences require the pending bytes accumulator to span token boundaries.
+  // Pre-decoding each token in isolation would finalize incomplete sequences
+  // as U+FFFD replacement characters.
+  iree_tokenizer_decoder_capability_t caps =
+      iree_tokenizer_decoder_capabilities(decoder());
+  EXPECT_FALSE(caps & IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS)
+      << "ByteLevel must not be STATELESS; cross-token UTF-8 requires state";
+  // ByteLevel SHOULD be declared STATELESS_EXCEPT_PARTIAL_UTF8 so the tokenizer
+  // can pre-decode non-partial tokens and use the byte accumulator only for
+  // tokens that produce incomplete UTF-8 sequences.
+  EXPECT_TRUE(caps &
+              IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8)
+      << "ByteLevel should be STATELESS_EXCEPT_PARTIAL_UTF8 for pre-decode";
+}
+
 }  // namespace
 }  // namespace iree::tokenizer

--- a/runtime/src/iree/tokenizer/decoder/sequence.c
+++ b/runtime/src/iree/tokenizer/decoder/sequence.c
@@ -91,6 +91,7 @@ iree_status_t iree_tokenizer_decoder_sequence_allocate(
   //     provided all other children are STATELESS. At most one child may have
   //     this capability (ByteFallback); if any child has NONE, the result is
   //     NONE.
+  //   STATELESS_EXCEPT_PARTIAL_UTF8 = same promotion rule as BYTE_TOKENS.
   //   POSITION_SENSITIVE = union (any child position-sensitive).
   iree_tokenizer_decoder_capability_t capabilities =
       IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS;
@@ -104,12 +105,32 @@ iree_status_t iree_tokenizer_decoder_sequence_allocate(
         iree_any_bit_set(
             child_capabilities,
             IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_BYTE_TOKENS)) {
-      // Promote sequence to STATELESS_EXCEPT_BYTE_TOKENS. This replaces
-      // STATELESS (non-byte tokens still pre-decodable) and is only valid
-      // if no other child already contributed this capability.
+      // Promote sequence to STATELESS_EXCEPT_BYTE_TOKENS. Incompatible with
+      // PARTIAL_UTF8 (different decode-time dispatch mechanisms).
+      if (iree_any_bit_set(
+              capabilities,
+              IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8)) {
+        capabilities = IREE_TOKENIZER_DECODER_CAPABILITY_NONE;
+        break;
+      }
       capabilities &= ~IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS;
       capabilities |=
           IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_BYTE_TOKENS;
+    } else if (
+        iree_any_bit_set(
+            child_capabilities,
+            IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8)) {
+      // Promote sequence to STATELESS_EXCEPT_PARTIAL_UTF8 (ByteLevel).
+      // Incompatible with BYTE_TOKENS.
+      if (iree_any_bit_set(
+              capabilities,
+              IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_BYTE_TOKENS)) {
+        capabilities = IREE_TOKENIZER_DECODER_CAPABILITY_NONE;
+        break;
+      }
+      capabilities &= ~IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS;
+      capabilities |=
+          IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8;
     } else {
       // Child has NONE — entire sequence is not pre-decodable.
       capabilities = IREE_TOKENIZER_DECODER_CAPABILITY_NONE;
@@ -120,6 +141,17 @@ iree_status_t iree_tokenizer_decoder_sequence_allocate(
             IREE_TOKENIZER_DECODER_CAPABILITY_POSITION_SENSITIVE)) {
       capabilities |= IREE_TOKENIZER_DECODER_CAPABILITY_POSITION_SENSITIVE;
     }
+  }
+
+  // POSITION_SENSITIVE + PARTIAL_UTF8 is unsupported: the first-token handler
+  // uses direct memcpy (position-sensitive space stripping) before byte-token
+  // dispatch, so a partial-UTF8 first token would bypass the accumulator.
+  // Degrade to NONE (streaming decode) for safety.
+  if (iree_all_bits_set(
+          capabilities,
+          IREE_TOKENIZER_DECODER_CAPABILITY_POSITION_SENSITIVE |
+              IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8)) {
+    capabilities = IREE_TOKENIZER_DECODER_CAPABILITY_NONE;
   }
 
   iree_tokenizer_decoder_initialize(&decoder->base,

--- a/runtime/src/iree/tokenizer/decoder/sequence_test.cc
+++ b/runtime/src/iree/tokenizer/decoder/sequence_test.cc
@@ -14,6 +14,7 @@
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 #include "iree/tokenizer/decoder/byte_fallback.h"
+#include "iree/tokenizer/decoder/byte_level.h"
 #include "iree/tokenizer/decoder/decoder_test_util.h"
 #include "iree/tokenizer/decoder/metaspace.h"
 #include "iree/tokenizer/decoder/passthrough.h"
@@ -461,6 +462,81 @@ TEST_F(SequenceDecoderTest, OverlapByteFallbackAndReplace) {
 
   TestWithAllBatchSizes(decoder.get(), tokens, " Hello World",
                         /*expect_pending_after_process=*/false);
+}
+
+//===----------------------------------------------------------------------===//
+// Capability Composition with STATELESS_EXCEPT_PARTIAL_UTF8
+//===----------------------------------------------------------------------===//
+
+TEST_F(SequenceDecoderTest, PartialUtf8PlusStatelessPromotion) {
+  // Sequence(ByteLevel, Passthrough) should promote to PARTIAL_UTF8.
+  // ByteLevel has PARTIAL_UTF8, Passthrough has STATELESS.
+  ScopedDecoder byte_level;
+  IREE_ASSERT_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), byte_level.put()));
+  ScopedDecoder passthrough;
+  IREE_ASSERT_OK(iree_tokenizer_decoder_passthrough_allocate(
+      iree_allocator_system(), passthrough.put()));
+
+  std::vector<ScopedDecoder> children;
+  children.push_back(std::move(byte_level));
+  children.push_back(std::move(passthrough));
+  auto decoder = CreateSequence(std::move(children));
+  ASSERT_NE(decoder.get(), nullptr);
+
+  iree_tokenizer_decoder_capability_t caps =
+      iree_tokenizer_decoder_capabilities(decoder.get());
+  EXPECT_TRUE(caps &
+              IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8)
+      << "Sequence(ByteLevel, Passthrough) should be PARTIAL_UTF8";
+  EXPECT_FALSE(caps & IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS)
+      << "Should not be fully STATELESS";
+}
+
+TEST_F(SequenceDecoderTest, PartialUtf8PlusPositionSensitiveDegrades) {
+  // Sequence(ByteLevel, Metaspace) should degrade to NONE because
+  // POSITION_SENSITIVE + PARTIAL_UTF8 is unsupported.
+  ScopedDecoder byte_level;
+  IREE_ASSERT_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), byte_level.put()));
+  ScopedDecoder metaspace;
+  IREE_ASSERT_OK(iree_tokenizer_decoder_metaspace_allocate(
+      0x2581,  // ▁ (LOWER ONE EIGHTH BLOCK)
+      IREE_TOKENIZER_DECODER_METASPACE_PREPEND_ALWAYS, iree_allocator_system(),
+      metaspace.put()));
+
+  std::vector<ScopedDecoder> children;
+  children.push_back(std::move(byte_level));
+  children.push_back(std::move(metaspace));
+  auto decoder = CreateSequence(std::move(children));
+  ASSERT_NE(decoder.get(), nullptr);
+
+  iree_tokenizer_decoder_capability_t caps =
+      iree_tokenizer_decoder_capabilities(decoder.get());
+  EXPECT_EQ(caps, IREE_TOKENIZER_DECODER_CAPABILITY_NONE)
+      << "PARTIAL_UTF8 + POSITION_SENSITIVE must degrade to NONE";
+}
+
+TEST_F(SequenceDecoderTest, PartialUtf8PlusByteFallbackDegrades) {
+  // Sequence(ByteLevel, ByteFallback) should degrade to NONE because
+  // the two mechanisms use incompatible detection at decode time.
+  ScopedDecoder byte_level;
+  IREE_ASSERT_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), byte_level.put()));
+  ScopedDecoder byte_fallback;
+  IREE_ASSERT_OK(iree_tokenizer_decoder_byte_fallback_allocate(
+      iree_allocator_system(), byte_fallback.put()));
+
+  std::vector<ScopedDecoder> children;
+  children.push_back(std::move(byte_level));
+  children.push_back(std::move(byte_fallback));
+  auto decoder = CreateSequence(std::move(children));
+  ASSERT_NE(decoder.get(), nullptr);
+
+  iree_tokenizer_decoder_capability_t caps =
+      iree_tokenizer_decoder_capabilities(decoder.get());
+  EXPECT_EQ(caps, IREE_TOKENIZER_DECODER_CAPABILITY_NONE)
+      << "PARTIAL_UTF8 + BYTE_TOKENS must degrade to NONE";
 }
 
 }  // namespace

--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -10,6 +10,7 @@
 
 #include "iree/base/internal/debugging.h"
 #include "iree/base/internal/unicode.h"
+#include "iree/tokenizer/byte_level_tables.h"
 #include "iree/tokenizer/decoder.h"
 #include "iree/tokenizer/decoder/byte_fallback.h"
 #include "iree/tokenizer/model.h"
@@ -41,10 +42,15 @@
 // Pre-decoded token string table. Built at tokenizer construction time when
 // the decoder has STATELESS capability, eliminating runtime decoder work.
 //
-// Single slab allocation: [offsets_array][data_blob]
+// Single slab allocation: [offsets_array][data_blob][partial_utf8_bitmap]
 //   offsets: (vocab_capacity + 1) entries, prefix-sum style.
 //   data: flat blob of decoded byte strings.
+//   partial_utf8_bitmap: (vocab_capacity + 7) / 8 bytes (only for ByteLevel).
 // Token id's decoded bytes are at data[offsets[id] .. offsets[id+1]).
+//
+// For STATELESS_EXCEPT_PARTIAL_UTF8 (ByteLevel), partial_utf8_bitmap marks
+// tokens that need the byte accumulator at decode time. Offsets are pure byte
+// positions with no flag bits.
 typedef struct iree_tokenizer_pre_decoded_t {
   // Combined allocation (NULL if not pre-decodable).
   void* slab;
@@ -59,6 +65,16 @@ typedef struct iree_tokenizer_pre_decoded_t {
   // are pre-decoded normally; byte tokens store a single raw byte value
   // in the data table.
   bool has_byte_fallback;
+  // When true, the decoder chain contains ByteLevel and some tokens produce
+  // partial UTF-8 bytes that need the inline accumulator. These tokens are
+  // identified by the partial_utf8_bitmap (not by ID range).
+  // The accumulator logic is shared with has_byte_fallback.
+  bool has_partial_utf8;
+  // Bitmap marking which tokens need the byte accumulator (ByteLevel only).
+  // Bit (id % 8) of byte (id / 8) is set for tokens requiring accumulation.
+  // Points into the slab after the data blob. NULL when has_partial_utf8 is
+  // false.
+  uint8_t* partial_utf8_bitmap;
   // Byte token ID range (inclusive). Byte tokens are nearly contiguous but
   // may have small gaps (e.g., Gemma has a literal tab token at ID 226 in
   // the middle of its byte token range 217-472). The bitmap below handles
@@ -211,13 +227,20 @@ struct iree_tokenizer_decode_state_t {
   // output.
   bool is_first_token;
 
-  // Inline byte accumulator for hybrid pre-decoded path with ByteFallback.
-  // Accumulates raw bytes from byte tokens (<0xHH>) until a complete UTF-8
-  // sequence is formed, then emits the validated bytes. Only used when
-  // pre_decoded.has_byte_fallback is true.
+  // Inline byte accumulator for hybrid pre-decoded path with ByteFallback
+  // or ByteLevel. Accumulates raw bytes from byte tokens (<0xHH>) or
+  // partial-UTF-8 ByteLevel tokens until a complete UTF-8 sequence is
+  // formed, then emits the validated bytes. Used when
+  // pre_decoded.has_byte_fallback or pre_decoded.has_partial_utf8 is true.
   uint8_t byte_fallback_pending[4];
   uint8_t byte_fallback_pending_count;
   uint8_t byte_fallback_expected_length;
+
+  // Resume position within a multi-byte ByteLevel token when the output
+  // buffer fills mid-token. Next feed call resumes from this byte offset.
+  // Zero means no partial token in progress.
+  uint32_t partial_byte_token_offset;
+  uint32_t partial_byte_token_end;
 
   // Pipeline stage state (points into state_storage).
   // NULL when using the pre-decoded fast path.
@@ -532,16 +555,112 @@ static iree_status_t iree_tokenizer_pre_decode_one_token(
   return iree_ok_status();
 }
 
+// Reverse-maps a ByteLevel token's text to raw bytes using the byte-level
+// tables. Each codepoint in the token text is mapped back to its original byte:
+//   - Shifted range (U+0100-U+0143): reverse lookup table
+//   - Identity range (U+0021-U+007E, U+00A1-U+00AC, U+00AE-U+00FF): codepoint
+//     value IS the byte
+//   - Passthrough: not a byte-level codepoint, skipped. In canonical ByteLevel
+//     vocabs (GPT-2, Llama, etc.) all tokens consist entirely of the 256
+//     byte-mapped chars, so passthrough never occurs. Custom vocabs mixing
+//     byte-mapped and non-byte-mapped chars in a single token are not
+//     supported.
+// Returns the number of raw bytes written to |out_bytes|.
+// |out_bytes| must be at least |token_text.size| bytes (max 1 byte per input
+// char, always <= input size since multi-byte UTF-8 codepoints map to 1 byte).
+static iree_host_size_t iree_tokenizer_byte_level_reverse_map_token(
+    iree_string_view_t token_text, uint8_t* out_bytes) {
+  iree_host_size_t write_count = 0;
+  iree_host_size_t pos = 0;
+  while (pos < token_text.size) {
+    uint32_t codepoint = iree_unicode_utf8_decode(token_text, &pos);
+    if (codepoint >= 0x100 && codepoint <= 0x143) {
+      out_bytes[write_count++] =
+          iree_tokenizer_byte_level_reverse_mapping[codepoint - 0x100];
+    } else if (iree_tokenizer_byte_level_is_identity(codepoint)) {
+      out_bytes[write_count++] = (uint8_t)codepoint;
+    }
+    // Passthrough codepoints (emoji, CJK, etc.) are skipped; they don't map
+    // to raw bytes.
+  }
+  return write_count;
+}
+
+// Checks if a ByteLevel token needs the cross-token byte accumulator at decode
+// time. Two checks are needed to cover both ends of a cross-token sequence:
+//
+//   Check 1 (fast, no decoder): Is the first raw byte a UTF-8 continuation
+//   byte (0x80-0xBF)? If so, this token could complete a preceding token's
+//   incomplete sequence. Example: "ĳ" → byte 0x91 (continuation). After "Ã"
+//   (byte 0xC3, a 2-byte lead), this 0x91 completes "Ñ". Pre-decoded alone,
+//   0x91 would become U+FFFD.
+//
+//   Check 2 (runs the decoder): Does the decoder have pending bytes after
+//   processing? If so, the token's last byte(s) start a multi-byte sequence
+//   that needs continuation from the next token. Example: "Ã" → byte 0xC3
+//   (2-byte lead). The decoder accumulates 0xC3 and waits for 1 more byte.
+//   has_pending returns true. Pre-decoded alone, 0xC3 would become U+FFFD.
+//   We must run the actual decoder here (not just check the raw byte) because
+//   multi-byte tokens can contain both complete and incomplete sequences —
+//   only the decoder knows what's left pending after processing all bytes.
+//
+// |reverse_map_buffer| must be at least |token_text.size| bytes.
+static bool iree_tokenizer_byte_level_token_needs_accumulator(
+    const iree_tokenizer_decoder_t* decoder, iree_string_view_t token_text,
+    void* state_storage, char* work_buffer, iree_host_size_t work_buffer_size,
+    uint8_t* reverse_map_buffer) {
+  // Check 1: does the first mapped byte start with a continuation byte?
+  iree_host_size_t raw_count = iree_tokenizer_byte_level_reverse_map_token(
+      token_text, reverse_map_buffer);
+  if (raw_count > 0 && (reverse_map_buffer[0] & 0xC0) == 0x80) {
+    return true;  // First byte is continuation -- could complete preceding seq.
+  }
+
+  // Check 2: does processing leave pending bytes (incomplete sequence at end)?
+  iree_tokenizer_decoder_state_t* state = NULL;
+  iree_status_t status =
+      iree_tokenizer_decoder_state_initialize(decoder, state_storage, &state);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return false;
+  }
+
+  iree_tokenizer_string_list_t token_list =
+      iree_tokenizer_make_string_list(&token_text, 1);
+  iree_mutable_string_view_t output =
+      iree_make_mutable_string_view(work_buffer, work_buffer_size);
+  iree_host_size_t consumed = 0;
+  iree_host_size_t written = 0;
+  status = iree_tokenizer_decoder_state_process(state, token_list, output,
+                                                &consumed, &written);
+  bool has_pending = false;
+  if (iree_status_is_ok(status)) {
+    has_pending = iree_tokenizer_decoder_state_has_pending(state);
+  } else {
+    iree_status_ignore(status);
+  }
+
+  iree_tokenizer_decoder_state_deinitialize(state);
+  return has_pending;
+}
+
 // Builds the pre-decoded token string table. Called once at tokenizer
-// construction time. If the decoder supports pre-decode (STATELESS or
-// STATELESS_EXCEPT_BYTE_TOKENS capability), this pre-computes decoded strings
-// for all vocab tokens, enabling O(1) memcpy-based decode at runtime.
+// construction time. If the decoder supports pre-decode (STATELESS,
+// STATELESS_EXCEPT_BYTE_TOKENS, or STATELESS_EXCEPT_PARTIAL_UTF8 capability),
+// this pre-computes decoded strings for all vocab tokens, enabling O(1)
+// memcpy-based decode at runtime.
 //
 // For STATELESS_EXCEPT_BYTE_TOKENS (ByteFallback models like Gemma):
 // Non-byte tokens are pre-decoded through the full chain as normal.
 // Byte tokens (<0xHH>) store their single raw byte value (1 byte each).
 // At decode time, byte tokens are handled by an inline accumulator that
 // validates UTF-8 sequences, while non-byte tokens use the memcpy fast path.
+//
+// For STATELESS_EXCEPT_PARTIAL_UTF8 (ByteLevel models like GPT-2):
+// Each token is trial-decoded. If it leaves pending (incomplete UTF-8) bytes,
+// its reverse-mapped raw bytes are stored and a bit is set in the
+// partial_utf8_bitmap. At decode time, tokens with their bitmap bit set are
+// fed through the byte accumulator; normal tokens use the memcpy fast path.
 static iree_status_t iree_tokenizer_build_pre_decoded(
     iree_tokenizer_t* tokenizer) {
   if (!tokenizer->decoder || !tokenizer->vocab) return iree_ok_status();
@@ -552,10 +671,13 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
   bool has_byte_fallback =
       !!(capabilities &
          IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_BYTE_TOKENS);
+  bool has_partial_utf8 =
+      !!(capabilities &
+         IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS_EXCEPT_PARTIAL_UTF8);
   bool is_stateless =
       !!(capabilities & IREE_TOKENIZER_DECODER_CAPABILITY_STATELESS);
 
-  if (!is_stateless && !has_byte_fallback) {
+  if (!is_stateless && !has_byte_fallback && !has_partial_utf8) {
     return iree_ok_status();  // Not pre-decodable.
   }
 
@@ -575,8 +697,14 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
   iree_host_size_t decoder_state_size =
       iree_tokenizer_decoder_state_size(tokenizer->decoder);
 
-  // Allocate temporary working memory: [state_storage][work_buffer]
-  iree_host_size_t temp_size = decoder_state_size + work_buffer_size;
+  // For partial_utf8: extra scratch space for reverse-mapped raw bytes.
+  iree_host_size_t reverse_map_buffer_size =
+      has_partial_utf8 ? max_token_length : 0;
+
+  // Allocate temporary working memory:
+  //   [state_storage][work_buffer][reverse_map_buffer]
+  iree_host_size_t temp_size =
+      decoder_state_size + work_buffer_size + reverse_map_buffer_size;
   iree_host_size_t offsets_size = 0;
   if (!iree_host_size_checked_mul(vocab_capacity + 1, sizeof(uint32_t),
                                   &offsets_size)) {
@@ -645,24 +773,44 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
     }
   }
 
+  iree_host_size_t total_data_size = 0;
+
   if (iree_status_is_ok(status)) {
     void* state_storage = temp_storage;
     char* work_buffer = (char*)temp_storage + decoder_state_size;
+    uint8_t* reverse_map_buffer =
+        has_partial_utf8 ? (uint8_t*)((char*)temp_storage + decoder_state_size +
+                                      work_buffer_size)
+                         : NULL;
 
     // Pass 1: compute total decoded size.
-    iree_host_size_t total_data_size = 0;
     for (iree_host_size_t id = 0;
          id < vocab_capacity && iree_status_is_ok(status); ++id) {
       iree_string_view_t token_text =
           iree_tokenizer_vocab_token_text(tokenizer->vocab, (int32_t)id);
 
-      // Byte tokens store 1 raw byte instead of going through the decoder.
+      // ByteFallback: byte tokens (<0xHH>) store 1 raw byte.
       uint8_t byte_value;
       if (has_byte_fallback &&
           iree_tokenizer_decoder_byte_fallback_parse_byte_token(token_text,
                                                                 &byte_value)) {
         total_data_size += 1;
         continue;
+      }
+
+      // Partial UTF-8: check if token needs the cross-token accumulator.
+      if (has_partial_utf8 && token_text.size > 0) {
+        bool needs_accum = iree_tokenizer_byte_level_token_needs_accumulator(
+            tokenizer->decoder, token_text, state_storage, work_buffer,
+            work_buffer_size, reverse_map_buffer);
+        if (needs_accum) {
+          // Reverse-map the token to raw bytes; store those instead.
+          iree_host_size_t raw_count =
+              iree_tokenizer_byte_level_reverse_map_token(token_text,
+                                                          reverse_map_buffer);
+          total_data_size += raw_count;
+          continue;
+        }
       }
 
       iree_host_size_t decoded_length = 0;
@@ -672,16 +820,23 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
       total_data_size += decoded_length;
     }
 
-    // Allocate slab: [offsets: (vocab_capacity + 1) * sizeof(uint32_t)][data]
+    // Allocate slab: [offsets][data][partial_utf8_bitmap]
+    iree_host_size_t bitmap_size =
+        has_partial_utf8 ? (vocab_capacity + 7) / 8 : 0;
     if (iree_status_is_ok(status)) {
-      status = iree_allocator_malloc(tokenizer->allocator,
-                                     offsets_size + total_data_size, &slab);
+      status = iree_allocator_malloc(
+          tokenizer->allocator, offsets_size + total_data_size + bitmap_size,
+          &slab);
     }
 
-    // Pass 2: populate data blob and offsets.
+    // Pass 2: populate data blob, offsets, and partial_utf8_bitmap.
     if (iree_status_is_ok(status)) {
       uint32_t* offsets = (uint32_t*)slab;
       uint8_t* data = (uint8_t*)slab + offsets_size;
+      uint8_t* bitmap = has_partial_utf8
+                            ? (uint8_t*)slab + offsets_size + total_data_size
+                            : NULL;
+      if (bitmap) memset(bitmap, 0, bitmap_size);
       uint32_t data_position = 0;
       for (iree_host_size_t id = 0;
            id < vocab_capacity && iree_status_is_ok(status); ++id) {
@@ -689,7 +844,7 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
         iree_string_view_t token_text =
             iree_tokenizer_vocab_token_text(tokenizer->vocab, (int32_t)id);
 
-        // Byte tokens: store the single raw byte value directly.
+        // ByteFallback: byte tokens store the single raw byte value directly.
         uint8_t byte_value;
         if (has_byte_fallback &&
             iree_tokenizer_decoder_byte_fallback_parse_byte_token(
@@ -697,6 +852,24 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
           data[data_position] = byte_value;
           data_position += 1;
           continue;
+        }
+
+        // Partial UTF-8: check if token needs the cross-token accumulator.
+        if (has_partial_utf8 && token_text.size > 0) {
+          bool needs_accum = iree_tokenizer_byte_level_token_needs_accumulator(
+              tokenizer->decoder, token_text, state_storage, work_buffer,
+              work_buffer_size, reverse_map_buffer);
+          if (needs_accum) {
+            iree_host_size_t raw_count =
+                iree_tokenizer_byte_level_reverse_map_token(token_text,
+                                                            reverse_map_buffer);
+            memcpy(data + data_position, reverse_map_buffer, raw_count);
+            // Mark this token in the bitmap as needing the byte accumulator.
+            offsets[id] = data_position;
+            bitmap[id / 8] |= (1u << (id % 8));
+            data_position += (uint32_t)raw_count;
+            continue;
+          }
         }
 
         iree_host_size_t decoded_length = 0;
@@ -718,8 +891,13 @@ static iree_status_t iree_tokenizer_build_pre_decoded(
     tokenizer->pre_decoded.slab = slab;
     tokenizer->pre_decoded.offsets = (uint32_t*)slab;
     tokenizer->pre_decoded.data = (uint8_t*)slab + offsets_size;
+    tokenizer->pre_decoded.partial_utf8_bitmap =
+        has_partial_utf8 ? (uint8_t*)slab + offsets_size + total_data_size
+                         : NULL;
     tokenizer->pre_decoded.position_sensitive = position_sensitive;
-    tokenizer->pre_decoded.has_byte_fallback = has_byte_fallback;
+    tokenizer->pre_decoded.has_byte_fallback =
+        has_byte_fallback || has_partial_utf8;
+    tokenizer->pre_decoded.has_partial_utf8 = has_partial_utf8;
     tokenizer->pre_decoded.byte_token_first_id = byte_token_first_id;
     tokenizer->pre_decoded.byte_token_last_id = byte_token_last_id;
     memcpy(tokenizer->pre_decoded.byte_token_bitmap, byte_token_bitmap,
@@ -3244,13 +3422,118 @@ static iree_host_size_t iree_tokenizer_decode_flush_pending_as_replacement(
   return written;
 }
 
-// Hybrid pre-decoded path for ByteFallback models. Non-byte tokens use the
-// O(1) memcpy fast path from the pre-decoded table. Byte tokens (<0xHH>) are
+// Feeds a single raw byte through the inline UTF-8 byte accumulator.
+// Returns true if the byte was successfully processed (output written or
+// buffered in pending). Returns false if the output buffer is full.
+// This is shared by both ByteFallback and partial-UTF8 decode paths.
+static bool iree_tokenizer_decode_feed_byte_to_accumulator(
+    iree_tokenizer_decode_state_t* state, uint8_t byte_value,
+    uint8_t* IREE_RESTRICT output, iree_host_size_t* total_written,
+    iree_host_size_t output_capacity) {
+  if (state->byte_fallback_pending_count == 0) {
+    // No pending bytes -- start a new UTF-8 sequence.
+    iree_host_size_t sequence_length =
+        iree_unicode_utf8_sequence_length(byte_value);
+
+    if (sequence_length == 1 && (byte_value & 0x80) == 0) {
+      // ASCII byte -- emit directly.
+      if (*total_written + 1 > output_capacity) {
+        return false;
+      }
+      output[(*total_written)++] = byte_value;
+      return true;
+    }
+
+    if (sequence_length == 1) {
+      // Invalid lead byte (continuation byte as lead) -- emit U+FFFD.
+      if (*total_written + 3 > output_capacity) {
+        return false;
+      }
+      int encoded_length = iree_unicode_utf8_encode(
+          IREE_UNICODE_REPLACEMENT_CHAR, (char*)(output + *total_written));
+      if (encoded_length > 0) {
+        *total_written += (iree_host_size_t)encoded_length;
+      }
+      return true;
+    }
+
+    // Multi-byte sequence -- start accumulating.
+    state->byte_fallback_pending[0] = byte_value;
+    state->byte_fallback_pending_count = 1;
+    state->byte_fallback_expected_length = (uint8_t)sequence_length;
+    return true;
+  }
+
+  // Have pending bytes -- expecting continuation.
+  if ((byte_value & 0xC0) != 0x80) {
+    // Not a continuation byte -- flush pending as replacements.
+    iree_host_size_t flushed =
+        iree_tokenizer_decode_flush_pending_as_replacement(
+            state, output, *total_written, output_capacity);
+    if (flushed == 0 && state->byte_fallback_pending_count > 0) {
+      return false;
+    }
+    *total_written += flushed;
+    // Re-process this byte as a new sequence start (recursive, max depth 1).
+    return iree_tokenizer_decode_feed_byte_to_accumulator(
+        state, byte_value, output, total_written, output_capacity);
+  }
+
+  // Valid continuation byte.
+  state->byte_fallback_pending[state->byte_fallback_pending_count++] =
+      byte_value;
+
+  if (state->byte_fallback_pending_count ==
+      state->byte_fallback_expected_length) {
+    // Sequence complete -- validate via utf8_decode.
+    iree_string_view_t pending =
+        iree_make_string_view((const char*)state->byte_fallback_pending,
+                              state->byte_fallback_pending_count);
+    iree_host_size_t decode_position = 0;
+    uint32_t codepoint = iree_unicode_utf8_decode(pending, &decode_position);
+
+    bool is_valid = (decode_position == state->byte_fallback_pending_count &&
+                     codepoint != IREE_UNICODE_REPLACEMENT_CHAR);
+
+    if (is_valid) {
+      // Valid UTF-8 -- emit accumulated bytes.
+      if (*total_written + state->byte_fallback_pending_count >
+          output_capacity) {
+        // Buffer full -- undo last byte and stop.
+        state->byte_fallback_pending_count--;
+        return false;
+      }
+      memcpy(output + *total_written, state->byte_fallback_pending,
+             state->byte_fallback_pending_count);
+      *total_written += state->byte_fallback_pending_count;
+      state->byte_fallback_pending_count = 0;
+      state->byte_fallback_expected_length = 0;
+    } else {
+      // Invalid sequence -- flush as replacements.
+      iree_host_size_t flushed =
+          iree_tokenizer_decode_flush_pending_as_replacement(
+              state, output, *total_written, output_capacity);
+      if (flushed == 0 && state->byte_fallback_pending_count > 0) {
+        state->byte_fallback_pending_count--;
+        return false;
+      }
+      *total_written += flushed;
+    }
+  }
+
+  return true;
+}
+
+// Hybrid pre-decoded path for ByteFallback/ByteLevel models. Non-byte tokens
+// use the O(1) memcpy fast path from the pre-decoded table. Byte tokens are
 // handled by an inline UTF-8 accumulator that validates sequences and emits
 // raw bytes or U+FFFD replacement characters.
 //
-// Byte tokens are identified by contiguous ID range check (O(1)).
-// Their raw byte value is stored as 1 byte in the pre-decoded data table.
+// Two detection modes:
+//   1. ByteFallback (has_partial_utf8 == false): byte tokens identified by
+//      contiguous ID range + bitmap. Each stores 1 raw byte.
+//   2. ByteLevel (has_partial_utf8 == true): byte tokens identified by
+//      partial_utf8_bitmap. Each stores N raw bytes (reverse-mapped).
 static iree_status_t
 iree_tokenizer_decode_state_feed_pre_decoded_with_byte_fallback(
     iree_tokenizer_decode_state_t* state, iree_tokenizer_token_id_list_t tokens,
@@ -3266,6 +3549,8 @@ iree_tokenizer_decode_state_feed_pre_decoded_with_byte_fallback(
       iree_tokenizer_vocab_capacity(tokenizer->vocab);
   const bool skip_special = iree_all_bits_set(
       state->flags, IREE_TOKENIZER_DECODE_FLAG_SKIP_SPECIAL_TOKENS);
+  const uint8_t* partial_utf8_bitmap = pre_decoded->partial_utf8_bitmap;
+  const bool use_partial_utf8_bitmap = (partial_utf8_bitmap != NULL);
   const int32_t byte_first = pre_decoded->byte_token_first_id;
   const int32_t byte_last = pre_decoded->byte_token_last_id;
   const uint8_t* byte_bitmap = pre_decoded->byte_token_bitmap;
@@ -3285,6 +3570,36 @@ iree_tokenizer_decode_state_feed_pre_decoded_with_byte_fallback(
     }
   }
 
+  // Resume a partially-consumed multi-byte ByteLevel token from a previous
+  // feed call that stalled on output buffer full.
+  if (state->partial_byte_token_offset > 0) {
+    uint32_t b = state->partial_byte_token_offset;
+    uint32_t end = state->partial_byte_token_end;
+    bool resumed_ok = true;
+    for (; b < end; ++b) {
+      uint8_t byte_value = src_data[b];
+      if (!iree_tokenizer_decode_feed_byte_to_accumulator(
+              state, byte_value, output, &total_written, output_capacity)) {
+        state->partial_byte_token_offset = b;
+        resumed_ok = false;
+        break;
+      }
+    }
+    if (!resumed_ok) {
+      // Still stalled — report zero tokens consumed, text written so far.
+      *out_tokens_consumed = 0;
+      *out_text_length = total_written;
+      return iree_ok_status();
+    }
+    state->partial_byte_token_offset = 0;
+    state->partial_byte_token_end = 0;
+    // The first token in this call was the partially-consumed one from last
+    // call. It's now fully processed — skip it in the main loop.
+    // Clamp to tokens.count in case the caller re-enters with an empty list
+    // (the resume consumed zero input tokens but processed pending bytes).
+    i = tokens.count > 0 ? 1 : 0;
+  }
+
   while (i < tokens.count) {
     iree_tokenizer_token_id_t id = tokens.values[i];
 
@@ -3300,101 +3615,41 @@ iree_tokenizer_decode_state_feed_pre_decoded_with_byte_fallback(
       continue;
     }
 
-    if (id >= byte_first && id <= byte_last &&
-        (byte_bitmap[(id - byte_first) / 8] &
-         (1u << ((id - byte_first) % 8)))) {
-      // Byte token: read raw byte value from pre-decoded table.
-      uint8_t byte_value = src_data[offsets[id]];
+    // Determine if this token is a "byte token" that needs the accumulator.
+    // For partial_utf8 (ByteLevel): check partial_utf8_bitmap.
+    // For byte_fallback (ByteFallback): check ID range + bitmap.
+    bool is_byte_token;
+    if (use_partial_utf8_bitmap) {
+      is_byte_token = !!(partial_utf8_bitmap[id / 8] & (1u << (id % 8)));
+    } else {
+      is_byte_token = (id >= byte_first && id <= byte_last &&
+                       (byte_bitmap[(id - byte_first) / 8] &
+                        (1u << ((id - byte_first) % 8))));
+    }
 
-      if (state->byte_fallback_pending_count == 0) {
-        // No pending bytes — start a new UTF-8 sequence.
-        iree_host_size_t sequence_length =
-            iree_unicode_utf8_sequence_length(byte_value);
+    if (is_byte_token) {
+      // Read raw byte(s) from pre-decoded table.
+      uint32_t start = offsets[id];
+      uint32_t end = offsets[id + 1];
 
-        if (sequence_length == 1 && (byte_value & 0x80) == 0) {
-          // ASCII byte — emit directly.
-          if (total_written + 1 > output_capacity) break;
-          output[total_written++] = byte_value;
-          ++i;
-          continue;
-        }
-
-        if (sequence_length == 1) {
-          // Invalid lead byte (continuation byte as lead) — emit U+FFFD.
-          if (total_written + 3 > output_capacity) break;
-          int encoded_length = iree_unicode_utf8_encode(
-              IREE_UNICODE_REPLACEMENT_CHAR, (char*)(output + total_written));
-          if (encoded_length > 0)
-            total_written += (iree_host_size_t)encoded_length;
-          ++i;
-          continue;
-        }
-
-        // Multi-byte sequence — start accumulating.
-        state->byte_fallback_pending[0] = byte_value;
-        state->byte_fallback_pending_count = 1;
-        state->byte_fallback_expected_length = (uint8_t)sequence_length;
-        ++i;
-        continue;
-      }
-
-      // Have pending bytes — expecting continuation.
-      if ((byte_value & 0xC0) != 0x80) {
-        // Not a continuation byte — flush pending as replacements, then
-        // re-process this byte token (don't advance i).
-        iree_host_size_t flushed =
-            iree_tokenizer_decode_flush_pending_as_replacement(
-                state, output, total_written, output_capacity);
-        if (flushed == 0 && state->byte_fallback_pending_count > 0) break;
-        total_written += flushed;
-        // Don't advance i — re-process this byte as a new sequence start.
-        continue;
-      }
-
-      // Valid continuation byte.
-      state->byte_fallback_pending[state->byte_fallback_pending_count++] =
-          byte_value;
-
-      if (state->byte_fallback_pending_count ==
-          state->byte_fallback_expected_length) {
-        // Sequence complete — validate via utf8_decode.
-        iree_string_view_t pending =
-            iree_make_string_view((const char*)state->byte_fallback_pending,
-                                  state->byte_fallback_pending_count);
-        iree_host_size_t decode_position = 0;
-        uint32_t codepoint =
-            iree_unicode_utf8_decode(pending, &decode_position);
-
-        bool is_valid =
-            (decode_position == state->byte_fallback_pending_count &&
-             codepoint != IREE_UNICODE_REPLACEMENT_CHAR);
-
-        if (is_valid) {
-          // Valid UTF-8 — emit accumulated bytes.
-          if (total_written + state->byte_fallback_pending_count >
-              output_capacity) {
-            // Buffer full — undo last byte and stop.
-            state->byte_fallback_pending_count--;
-            break;
-          }
-          memcpy(output + total_written, state->byte_fallback_pending,
-                 state->byte_fallback_pending_count);
-          total_written += state->byte_fallback_pending_count;
-          state->byte_fallback_pending_count = 0;
-          state->byte_fallback_expected_length = 0;
-        } else {
-          // Invalid sequence — flush as replacements.
-          iree_host_size_t flushed =
-              iree_tokenizer_decode_flush_pending_as_replacement(
-                  state, output, total_written, output_capacity);
-          if (flushed == 0 && state->byte_fallback_pending_count > 0) {
-            state->byte_fallback_pending_count--;
-            break;
-          }
-          total_written += flushed;
+      // Feed each raw byte through the accumulator.
+      uint32_t b = start;
+      for (; b < end; ++b) {
+        uint8_t byte_value = src_data[b];
+        if (!iree_tokenizer_decode_feed_byte_to_accumulator(
+                state, byte_value, output, &total_written, output_capacity)) {
+          break;  // Output buffer full — b is the unconsumed byte.
         }
       }
-
+      if (b < end) {
+        // Output buffer full mid-token. Save resume position for next call.
+        state->partial_byte_token_offset = b;
+        state->partial_byte_token_end = end;
+        break;
+      }
+      // All bytes consumed — clear resume state, advance to next token.
+      state->partial_byte_token_offset = 0;
+      state->partial_byte_token_end = 0;
       ++i;
     } else {
       // Non-byte token: flush any pending byte accumulator first.
@@ -3562,10 +3817,10 @@ iree_status_t iree_tokenizer_decode_state_finalize(
       *out_text_length = flushed;
       // Defensive: if pending bytes remain after flush, the output buffer was
       // too small for the replacement characters. Each pending byte emits one
-      // U+FFFD (3 bytes UTF-8). Only reachable with byte_fallback decoders
-      // (SentencePiece-based tokenizers) when the last fed tokens form an
-      // incomplete UTF-8 sequence and the output buffer is very small
-      // (edge case).
+      // U+FFFD (3 bytes UTF-8). Reachable with byte_fallback decoders
+      // (SentencePiece) or ByteLevel decoders (GPT-2) when the last fed
+      // tokens form an incomplete UTF-8 sequence and the output buffer is
+      // very small (edge case).
       if (state->byte_fallback_pending_count > 0) {
         return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                                 "decode finalize: output buffer too small "

--- a/runtime/src/iree/tokenizer/tokenizer_benchmark.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_benchmark.cc
@@ -218,9 +218,9 @@ static iree_tokenizer_t* BuildBenchmarkTokenizer(size_t vocab_size) {
   return tokenizer;
 }
 
-// Builds a tokenizer with a ByteLevel decoder, enabling pre-decoded fast path.
-// The ByteLevel decoder has STATELESS capability, so all vocab tokens get
-// pre-decoded at build time — decode becomes a memcpy from a flat table.
+// Builds a tokenizer with a ByteLevel decoder, enabling the hybrid pre-decoded
+// path. Most tokens (99.3% of GPT-2 vocab) are pre-decoded at build time
+// (memcpy fast path). Tokens producing partial UTF-8 use a byte accumulator.
 static iree_tokenizer_t* BuildBenchmarkTokenizerWithDecoder(size_t vocab_size) {
   iree_tokenizer_vocab_builder_t* vocab_builder = nullptr;
   IREE_CHECK_OK(iree_tokenizer_vocab_builder_allocate(
@@ -293,7 +293,7 @@ static iree_tokenizer_t* BuildBenchmarkTokenizerWithDecoder(size_t vocab_size) {
   IREE_CHECK_OK(iree_tokenizer_segmenter_whitespace_allocate(
       iree_allocator_system(), &segmenter));
 
-  // Create ByteLevel decoder (STATELESS — enables pre-decode fast path).
+  // Create ByteLevel decoder (hybrid pre-decode with byte accumulator).
   iree_tokenizer_decoder_t* decoder = nullptr;
   IREE_CHECK_OK(iree_tokenizer_decoder_byte_level_allocate(
       iree_allocator_system(), &decoder));

--- a/runtime/src/iree/tokenizer/tokenizer_decode_test.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_decode_test.cc
@@ -47,15 +47,16 @@ using testing::ScopedVocabBuilder;
 class TokenizerDecodeTest : public ::testing::Test {};
 
 //===----------------------------------------------------------------------===//
-// ByteLevel Decoder (GPT-2 style, STATELESS, not position-sensitive)
+// ByteLevel Decoder (GPT-2 style, STATELESS_EXCEPT_PARTIAL_UTF8)
 //===----------------------------------------------------------------------===//
 // GPT-2's ByteLevel decoder maps Unicode codepoints back to raw bytes.
 // The vocab stores tokens using the GPT-2 byte-to-unicode mapping:
 //   bytes 0x21-0x7E, 0xA1-0xAC, 0xAE-0xFF map to themselves as Unicode
 //   bytes 0x00-0x20, 0x7F-0xA0, 0xAD map to U+0100-U+0143 (shifted range)
 //
-// Pre-decoded: YES (STATELESS, not POSITION_SENSITIVE)
-// Each token always decodes to the same bytes regardless of position.
+// Pre-decoded: YES (STATELESS_EXCEPT_PARTIAL_UTF8)
+// Most tokens pre-decoded (99.3% of GPT-2 vocab); partial UTF-8 tokens use
+// byte accumulator.
 
 // Builds a minimal GPT-2-style tokenizer with ByteLevel decoder.
 // Tokens must use the GPT-2 byte-to-unicode encoding.
@@ -484,9 +485,287 @@ TEST_F(TokenizerDecodeTest, SequenceNotPreDecodedUsesSlowPath) {
   iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
   ASSERT_NE(tokenizer, nullptr);
 
-  // Verify decode works (uses pre-decoded path since ByteLevel is STATELESS).
+  // Verify decode works (uses hybrid pre-decoded path with byte accumulator).
   IREE_ASSERT_OK_AND_ASSIGN(std::string result, Decode(tokenizer, {0, 1}));
   EXPECT_EQ(result, "Hello world");
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Verifies the full pre-decoded pipeline (build + decode) handles cross-token
+// UTF-8 correctly. This exercises the partial_utf8_bitmap classification, the
+// iree_tokenizer_byte_level_token_needs_accumulator classification at build
+// time, and the iree_tokenizer_decode_feed_byte_to_accumulator function at
+// decode time. Unit tests in byte_level_test.cc test the decoder in isolation;
+// this test covers the end-to-end integration.
+TEST_F(TokenizerDecodeTest, ByteLevelCrossTokenUTF8) {
+  // Vocab with GPT-2 byte-level tokens for "Ñ" (UTF-8: C3 91):
+  //   id 0: "Ã" (U+00C3) — identity byte 0xC3 (UTF-8 lead byte, incomplete)
+  //   id 1: "ĳ" (U+0133) — shifted byte 0x91 (UTF-8 continuation byte)
+  //   id 2: "o"           — identity byte 0x6F (ASCII, complete)
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "\xC3\x83");  // Ã → byte C3
+  vocab_builder.AddToken(1, "\xC4\xB3");  // ĳ → byte 91
+  vocab_builder.AddToken(2, "o");         // identity
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+
+  iree_tokenizer_decoder_t* decoder = nullptr;
+  IREE_CHECK_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), &decoder));
+  iree_tokenizer_builder_set_decoder(builder.get(), decoder);
+
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // "Ñ" = tokens [0, 1] → bytes [C3, 91] → UTF-8 "Ñ" (U+00D1).
+  // Without the fix, each token is pre-decoded in isolation:
+  //   token 0 → byte C3 → incomplete → U+FFFD
+  //   token 1 → byte 91 → continuation without lead → U+FFFD
+  // With the fix, the byte accumulator carries C3 from token 0 to token 1.
+  IREE_ASSERT_OK_AND_ASSIGN(std::string result, Decode(tokenizer, {0, 1}));
+  EXPECT_EQ(result, "\xC3\x91");  // Ñ
+
+  // "Ño" = tokens [0, 1, 2] → bytes [C3, 91, 6F] → "Ño".
+  IREE_ASSERT_OK_AND_ASSIGN(std::string result2, Decode(tokenizer, {0, 1, 2}));
+  EXPECT_EQ(result2, "\xC3\x91o");  // Ño
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Tests check 2 of needs_accumulator in isolation: a multi-byte token whose
+// LAST byte is a UTF-8 lead that needs continuation from the next token.
+// Check 1 (continuation-byte first) does NOT catch this — the first byte is
+// ASCII. Only check 2 (trial-decode has_pending) identifies it.
+TEST_F(TokenizerDecodeTest, ByteLevelCheck2LeadByteAtEnd) {
+  // id 0: "oÃ" → bytes [6F, C3] (ASCII + incomplete lead)
+  //   Check 1: first byte 0x6F is ASCII → passes (not flagged)
+  //   Check 2: decoder processes 6F (emit "o"), then C3 (pending) → flagged
+  // id 1: "ĳ"  → byte 91 (continuation, completes C3+91 = "Ñ")
+  //   Check 1: first byte 0x91 is continuation → flagged
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "o\xC3\x83");  // oÃ → bytes [6F, C3]
+  vocab_builder.AddToken(1, "\xC4\xB3");   // ĳ → byte 91
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+
+  iree_tokenizer_decoder_t* decoder = nullptr;
+  IREE_CHECK_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), &decoder));
+  iree_tokenizer_builder_set_decoder(builder.get(), decoder);
+
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // tokens [0, 1] → bytes [6F, C3, 91] → "oÑ".
+  // Without check 2, token 0 would be pre-decoded as "o�" (C3 alone → U+FFFD).
+  IREE_ASSERT_OK_AND_ASSIGN(std::string result, Decode(tokenizer, {0, 1}));
+  EXPECT_EQ(result, "o\xC3\x91");  // oÑ
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Regression test: a multi-byte ByteLevel token with a small output buffer
+// must correctly resume after stalling mid-token. Token "ĳo" maps to bytes
+// [91, 6F]. With "Ã" (byte C3) preceding it, the accumulator forms "Ñ" from
+// C3+91, then must emit "o" (6F). If the output buffer fills after "Ñ" but
+// before "o", the resume must not lose the "o" byte.
+TEST_F(TokenizerDecodeTest, ByteLevelSmallBufferResume) {
+  // id 0: "Ã"  → byte C3 (lead byte, partial UTF-8)
+  // id 1: "ĳo" → bytes [91, 6F] (continuation + ASCII, multi-byte token)
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "\xC3\x83");   // Ã → byte C3
+  vocab_builder.AddToken(1, "\xC4\xB3o");  // ĳo → bytes [91, 6F]
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+
+  iree_tokenizer_decoder_t* decoder = nullptr;
+  IREE_CHECK_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), &decoder));
+  iree_tokenizer_builder_set_decoder(builder.get(), decoder);
+
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // Decode with a very small output buffer (2 bytes — enough for "Ñ" which is
+  // 2 bytes in UTF-8, but not enough for the trailing "o"). This forces
+  // a mid-token stall in the accumulator.
+  IREE_ASSERT_OK_AND_ASSIGN(auto state_storage,
+                            DecodeStateStorage::Allocate(tokenizer));
+  iree_tokenizer_decode_state_t* state = state_storage.state();
+
+  std::vector<int32_t> ids = {0, 1};
+  iree_tokenizer_token_id_list_t id_list = {ids.size(), ids.data()};
+
+  // Use a 2-byte output buffer: fits "Ñ" (C3 91) but not "o".
+  char small_buf[2];
+  iree_host_size_t tokens_consumed = 0;
+  iree_host_size_t text_length = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_feed(
+      state, id_list,
+      iree_make_mutable_string_view(small_buf, sizeof(small_buf)),
+      &tokens_consumed, &text_length));
+  std::string result(small_buf, text_length);
+
+  // Feed remaining tokens (if any) with a fresh buffer.
+  id_list.values += tokens_consumed;
+  id_list.count -= tokens_consumed;
+  char rest_buf[64];
+  iree_host_size_t rest_consumed = 0;
+  iree_host_size_t rest_length = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_feed(
+      state, id_list, iree_make_mutable_string_view(rest_buf, sizeof(rest_buf)),
+      &rest_consumed, &rest_length));
+  result.append(rest_buf, rest_length);
+
+  // Finalize.
+  char fin_buf[64];
+  iree_host_size_t fin_length = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_finalize(
+      state, iree_make_mutable_string_view(fin_buf, sizeof(fin_buf)),
+      &fin_length));
+  result.append(fin_buf, fin_length);
+
+  // Must produce "Ño" — "Ñ" from [C3, 91] + "o" from [6F].
+  // Without the resume fix, "o" would be lost.
+  EXPECT_EQ(result, "\xC3\x91o");  // Ño
+
+  iree_tokenizer_free(tokenizer);
+}
+
+// Resume with empty token list: stall mid-token, then call feed with
+// tokens.count == 0. The pending bytes should be emitted and
+// tokens_consumed must be 0 (not 1).
+TEST_F(TokenizerDecodeTest, ByteLevelResumeWithEmptyRefeed) {
+  // Same setup as ByteLevelSmallBufferResume.
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "\xC3\x83");   // Ã → byte C3
+  vocab_builder.AddToken(1, "\xC4\xB3o");  // ĳo → bytes [91, 6F]
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+
+  iree_tokenizer_decoder_t* decoder = nullptr;
+  IREE_CHECK_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), &decoder));
+  iree_tokenizer_builder_set_decoder(builder.get(), decoder);
+
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  IREE_ASSERT_OK_AND_ASSIGN(auto state_storage,
+                            DecodeStateStorage::Allocate(tokenizer));
+  iree_tokenizer_decode_state_t* state = state_storage.state();
+
+  // First feed: stall mid-token on "ĳo" (after emitting "Ñ", before "o").
+  std::vector<int32_t> ids = {0, 1};
+  iree_tokenizer_token_id_list_t id_list = {ids.size(), ids.data()};
+  char small_buf[2];
+  iree_host_size_t consumed = 0;
+  iree_host_size_t text_len = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_feed(
+      state, id_list,
+      iree_make_mutable_string_view(small_buf, sizeof(small_buf)), &consumed,
+      &text_len));
+  std::string result(small_buf, text_len);
+
+  // Second feed: EMPTY token list. Resume should emit the pending "o" byte
+  // and report tokens_consumed = 0.
+  iree_tokenizer_token_id_list_t empty_list = {0, nullptr};
+  char resume_buf[64];
+  iree_host_size_t resume_consumed = 0;
+  iree_host_size_t resume_len = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_feed(
+      state, empty_list,
+      iree_make_mutable_string_view(resume_buf, sizeof(resume_buf)),
+      &resume_consumed, &resume_len));
+  EXPECT_EQ(resume_consumed, 0u);  // No input tokens to consume.
+  result.append(resume_buf, resume_len);
+
+  // Finalize.
+  char fin_buf[64];
+  iree_host_size_t fin_len = 0;
+  IREE_ASSERT_OK(iree_tokenizer_decode_state_finalize(
+      state, iree_make_mutable_string_view(fin_buf, sizeof(fin_buf)),
+      &fin_len));
+  result.append(fin_buf, fin_len);
+
+  EXPECT_EQ(result, "\xC3\x91o");  // Ño
+  iree_tokenizer_free(tokenizer);
+}
+
+// Bitmap boundary tests: verify bit addressing in partial_utf8_bitmap for
+// IDs at byte boundaries (0, 7, 8) and the last vocab ID.
+TEST_F(TokenizerDecodeTest, ByteLevelBitmapBoundary) {
+  // Create vocab with partial-UTF8 tokens at boundary IDs:
+  //   id 0: "Ã" (byte C3, lead) — bit 0 of byte 0
+  //   id 7: "ĳ" (byte 91, continuation) — bit 7 of byte 0
+  //   id 8: "o" (byte 6F, ASCII) — bit 0 of byte 1 (should NOT be flagged)
+  //   id 9: fill to make vocab size > 8
+  ScopedVocabBuilder vocab_builder;
+  vocab_builder.AddToken(0, "\xC3\x83");  // Ã → byte C3 (lead, flagged)
+  vocab_builder.AddToken(1, "a");
+  vocab_builder.AddToken(2, "b");
+  vocab_builder.AddToken(3, "c");
+  vocab_builder.AddToken(4, "d");
+  vocab_builder.AddToken(5, "e");
+  vocab_builder.AddToken(6, "f");
+  vocab_builder.AddToken(7, "\xC4\xB3");  // ĳ → byte 91 (continuation, flagged)
+  vocab_builder.AddToken(8, "o");         // ASCII (not flagged)
+  vocab_builder.AddToken(9, "x");         // ASCII (not flagged)
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+
+  iree_tokenizer_decoder_t* decoder = nullptr;
+  IREE_CHECK_OK(iree_tokenizer_decoder_byte_level_allocate(
+      iree_allocator_system(), &decoder));
+  iree_tokenizer_builder_set_decoder(builder.get(), decoder);
+
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // id 0 (Ã) + id 7 (ĳ) → bytes [C3, 91] → "Ñ"
+  // Tests bitmap bit 0 and bit 7 of byte 0.
+  IREE_ASSERT_OK_AND_ASSIGN(std::string r1, Decode(tokenizer, {0, 7}));
+  EXPECT_EQ(r1, "\xC3\x91");  // Ñ
+
+  // id 8 (o) should be pre-decoded normally (not flagged in bitmap byte 1).
+  IREE_ASSERT_OK_AND_ASSIGN(std::string r2, Decode(tokenizer, {8}));
+  EXPECT_EQ(r2, "o");
+
+  // id 0 (Ã) + id 7 (ĳ) + id 8 (o) → "Ño"
+  // Tests transition from bitmap-flagged to non-flagged across byte boundary.
+  IREE_ASSERT_OK_AND_ASSIGN(std::string r3, Decode(tokenizer, {0, 7, 8}));
+  EXPECT_EQ(r3, "\xC3\x91o");  // Ño
 
   iree_tokenizer_free(tokenizer);
 }


### PR DESCRIPTION
The ByteLevel decoder was declared STATELESS, causing the decode pipeline to pre-decode each token in isolation. This breaks multi-byte UTF-8 reconstruction where bytes from one token combine with the next (e.g., "Ã"+"ĳ" → bytes C3 91 → "Ñ").

Add STATELESS_EXCEPT_PARTIAL_UTF8 capability: a hybrid approach that pre-decodes most vocab entries (99.3% for GPT-2) at build time, and routes partial-UTF-8 tokens through an inline byte accumulator at decode time. Partial tokens are identified by trial-decoding each token at build time and recorded in a slab-embedded bitmap (vocab_capacity/8 bytes, ~6KB for GPT-2). Offsets remain pure byte positions with no bit-packing or masking.

Decode throughput (GPT-2, ASCII text):
 - STATELESS (broken):     192M tok/s  — incorrect Unicode
 - CAPABILITY_NONE:         59M tok/s  — correct, 3.2x slower
 - PARTIAL_UTF8 (bitmap):  169M tok/s  — correct, 88% of original

HF smoketest: 1667/1667 pass. Tiktoken: 76/76 pass.
Unicode roundtrip verified: café, Ñoño, 你好世界, hello 😀 world.