### PR TITLE
Use iree_cc_binary for dynamic_shapes and variables_and_state samples

### DIFF
--- a/samples/dynamic_shapes/CMakeLists.txt
+++ b/samples/dynamic_shapes/CMakeLists.txt
@@ -4,15 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(_NAME "iree_samples_dynamic_shapes")
-add_executable(${_NAME} "")
-target_sources(${_NAME}
-  PRIVATE
-    main.c
-)
-
-set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "dynamic-shapes")
-
-target_link_libraries(${_NAME}
-  iree_runtime_runtime
+iree_cc_binary(
+  NAME
+    dynamic_shapes
+  SRCS
+    "main.c"
+  DEPS
+    iree::runtime::runtime
 )

--- a/samples/dynamic_shapes/README.md
+++ b/samples/dynamic_shapes/README.md
@@ -138,11 +138,11 @@ them.
         dynamic_shapes.mlir -o dynamic_shapes_cpu.vmfb
     ```
 
-4. Build the `iree_samples_dynamic_shapes` CMake target
+4. Build the `samples/dynamic_shapes/all` CMake target
 
     ```
     cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DIREE_BUILD_COMPILER=OFF .
-    cmake --build ../iree-build/ --target iree_samples_dynamic_shapes
+    cmake --build ../iree-build/ --target samples/dynamic_shapes/all
     ```
 
     Alternatively if using a non-CMake build system the `Makefile` provided can
@@ -152,6 +152,6 @@ them.
 5. Run the sample binary:
 
    ```
-   ../iree-build/samples/dynamic_shapes/dynamic-shapes \
+   ../iree-build/samples/dynamic_shapes/dynamic_shapes \
        /path/to/dynamic_shapes_cpu.vmfb local-task
    ```

--- a/samples/dynamic_shapes/test.sh
+++ b/samples/dynamic_shapes/test.sh
@@ -42,10 +42,10 @@ iree-compile \
   --iree-hal-local-target-device-backends=llvm-cpu \
   ${ARTIFACTS_DIR}/dynamic_shapes.mlir -o ${ARTIFACTS_DIR}/dynamic_shapes_cpu.vmfb
 
-# 4. Build the `iree_samples_dynamic_shapes` CMake target.
+# 4. Build the `samples/dynamic_shapes/all` CMake target.
 cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DIREE_BUILD_COMPILER=OFF .
-cmake --build ${BUILD_DIR} --target iree_samples_dynamic_shapes -- -k 0
+cmake --build ${BUILD_DIR} --target samples/dynamic_shapes/all -- -k 0
 
 # 5. Run the sample binary.
-${BUILD_DIR}/samples/dynamic_shapes/dynamic-shapes \
+${BUILD_DIR}/samples/dynamic_shapes/dynamic_shapes \
   ${ARTIFACTS_DIR}/dynamic_shapes_cpu.vmfb local-task

--- a/samples/variables_and_state/CMakeLists.txt
+++ b/samples/variables_and_state/CMakeLists.txt
@@ -4,15 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(_NAME "iree_samples_variables_and_state")
-add_executable(${_NAME} "")
-target_sources(${_NAME}
-  PRIVATE
-    main.c
-)
-
-set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "variables-and-state")
-
-target_link_libraries(${_NAME}
-  iree_runtime_runtime
+iree_cc_binary(
+  NAME
+    variables_and_state
+  SRCS
+    "main.c"
+  DEPS
+    iree::runtime::runtime
 )

--- a/samples/variables_and_state/README.md
+++ b/samples/variables_and_state/README.md
@@ -61,19 +61,19 @@ functions in the compiled programs.
 1. Run the Colab notebook and download the `counter.mlir` and
    `counter_vmvx.vmfb` files it generates
 
-2. Build the `iree_samples_variables_and_state` CMake target (see
+2. Build the `samples/variables_and_state/all` CMake target (see
     [here](https://iree.dev/building-from-source/getting-started/)
     for general instructions on building using CMake)
 
     ```
     cmake -B ../iree-build/ -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo .
-    cmake --build ../iree-build/ --target iree_samples_variables_and_state
+    cmake --build ../iree-build/ --target samples/variables_and_state/all
     ```
 
 3. Run the sample binary:
 
    ```
-   ../iree-build/samples/variables_and_state/variables-and-state \
+   ../iree-build/samples/variables_and_state/variables_and_state \
        /path/to/counter_vmvx.vmfb local-task
    ```
 
@@ -101,6 +101,6 @@ and compile the imported `counter.mlir` file using `iree-compile`:
 then run the program with that new VM bytecode module:
 
 ```
-../iree-build/samples/variables_and_state/variables-and-state \
+../iree-build/samples/variables_and_state/variables_and_state \
     /path/to/counter_cpu.vmfb local-task
 ```

--- a/samples/variables_and_state/test.sh
+++ b/samples/variables_and_state/test.sh
@@ -22,10 +22,10 @@ ${ROOT_DIR}/build_tools/testing/run_python_notebook.sh \
 test -f ${ARTIFACTS_DIR}/counter.mlir && echo "counter.mlir exists"
 test -f ${ARTIFACTS_DIR}/counter_vmvx.vmfb && echo "counter_vmvx.vmfb exists"
 
-# 2. Build the `iree_samples_variables_and_state` CMake target.
+# 2. Build the `samples/variables_and_state/all` CMake target.
 cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${ROOT_DIR}
-cmake --build ${BUILD_DIR} --target iree_samples_variables_and_state -- -k 0
+cmake --build ${BUILD_DIR} --target samples/variables_and_state/all -- -k 0
 
 # 3. Run the sample binary.
-${BUILD_DIR}/samples/variables_and_state/variables-and-state \
+${BUILD_DIR}/samples/variables_and_state/variables_and_state \
   ${ARTIFACTS_DIR}/counter_vmvx.vmfb local-task


### PR DESCRIPTION
- Switch these samples from add_executable() to iree_cc_binary() so they inherit common IREE build options and feature macros (e.g. IREE_SYNCHRONIZATION_DISABLE_UNSAFE via CMake flags).
- CMake targets now use the samples/*/all convention instead of the old iree_samples_* names.