### PR TITLE
Fix generic RISC-V build: skip coordinated_test on Generic CMake

### DIFF
--- a/runtime/src/iree/testing/CMakeLists.txt
+++ b/runtime/src/iree/testing/CMakeLists.txt
@@ -78,42 +78,44 @@ iree_cc_library(
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
-iree_cc_library(
-  NAME
-    coordinated_test
-  HDRS
-    "coordinated_test.h"
-  SRCS
-    "coordinated_test.c"
-  DEPS
-    iree::base
-  PUBLIC
-)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Generic")
+  iree_cc_library(
+    NAME
+      coordinated_test
+    HDRS
+      "coordinated_test.h"
+    SRCS
+      "coordinated_test.c"
+    DEPS
+      iree::base
+    PUBLIC
+  )
 
-iree_cc_library(
-  NAME
-    coordinated_test_main
-  SRCS
-    "coordinated_test_main.cc"
-  DEPS
-    ::coordinated_test
-    ::gtest
-    gtest
-    iree::base
-    iree::base::tooling::flags
-  TESTONLY
-  PUBLIC
-)
+  iree_cc_library(
+    NAME
+      coordinated_test_main
+    SRCS
+      "coordinated_test_main.cc"
+    DEPS
+      ::coordinated_test
+      ::gtest
+      gtest
+      iree::base
+      iree::base::tooling::flags
+    TESTONLY
+    PUBLIC
+  )
 
-iree_cc_test(
-  NAME
-    coordinated_test_test
-  SRCS
-    "coordinated_test_test.cc"
-  DEPS
-    ::coordinated_test
-    ::coordinated_test_main
-    ::gtest
-  LABELS
-    "noriscv"
-)
+  iree_cc_test(
+    NAME
+      coordinated_test_test
+    SRCS
+      "coordinated_test_test.cc"
+    DEPS
+      ::coordinated_test
+      ::coordinated_test_main
+      ::gtest
+    LABELS
+      "noriscv"
+  )
+endif()


### PR DESCRIPTION
Commit 3a4c9919ba3a8e81b47fb10bbccc0b45be8e0fab added the coordinated multi-process test harness as part of the async / cross-process shared memory infrastructure. That implementation assumes a host OS with POSIX (or Windows) process and filesystem support and pulls in <dirent.h>, nanosleep, mkdtemp, etc.

Fix this by teaching runtime/src/iree/testing/CMakeLists.txt to skip building coordinated_test, coordinated_test_main, and coordinated_test_test when CMAKE_SYSTEM_NAME is "Generic".