### PR TITLE
[SPIRV] Add native shapes for step op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -284,7 +284,7 @@ SmallVector<int64_t> getNativeVectorShapeImpl(vector::ReductionOp op) {
 }
 
 SmallVector<int64_t> getNativeVectorShapeImpl(vector::StepOp op) {
-  VectorType srcVectorType = static_cast<VectorType>(op.getType());
+  VectorType srcVectorType = op.getType();
   assert(srcVectorType.getRank() == 1); // Guaranteed by semantics
   int64_t vectorSize = getComputeVectorSize(srcVectorType.getDimSize(0));
   return {vectorSize};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -283,6 +283,13 @@ SmallVector<int64_t> getNativeVectorShapeImpl(vector::ReductionOp op) {
   return {vectorSize};
 }
 
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::StepOp op) {
+  VectorType srcVectorType = static_cast<VectorType>(op.getType());
+  assert(srcVectorType.getRank() == 1); // Guaranteed by semantics
+  int64_t vectorSize = getComputeVectorSize(srcVectorType.getDimSize(0));
+  return {vectorSize};
+}
+
 SmallVector<int64_t> getNativeVectorShapeImpl(vector::TransposeOp op) {
   VectorType vectorType = op.getResultVectorType();
   SmallVector<int64_t> nativeSize(vectorType.getRank(), 1);
@@ -312,7 +319,8 @@ getNativeVectorShape(Operation *op, bool targetSupportsDotProd) {
 
   return TypeSwitch<Operation *, std::optional<SmallVector<int64_t>>>(op)
       .Case<VectorTransferOpInterface, vector::MultiDimReductionOp,
-            vector::ReductionOp, vector::TransposeOp, vector::GatherOp>(
+            vector::ReductionOp, vector::TransposeOp, vector::GatherOp,
+            vector::StepOp>(
           [](auto typedOp) { return getNativeVectorShapeImpl(typedOp); })
       .Case([=](vector::ContractionOp contract) {
         return getNativeVectorShapeImpl(contract, targetSupportsDotProd);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/initial_vector_lowering_index_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/initial_vector_lowering_index_type.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --pass-pipeline='builtin.module(func.func(iree-spirv-initial-vector-lowering))' \
+// RUN: iree-opt %s --split-input-file --pass-pipeline='builtin.module(func.func(iree-spirv-initial-vector-lowering))' \
 // RUN:  | FileCheck %s
 
 // Verify that vector unrolling does not crash on index element types.
@@ -10,4 +10,32 @@ func.func @transfer_read_index_type(%mem: memref<64xindex>) -> vector<4xindex> {
   %idx = arith.constant 0 : index
   %0 = vector.transfer_read %mem[%c0], %idx {in_bounds = [true]} : memref<64xindex>, vector<4xindex>
   return %0 : vector<4xindex>
+}
+
+// -----
+
+// Verify that vector.step is unrolled to the native vector size.
+// getComputeVectorSize(5) == 1 since 5 is not divisible by 4, 3, or 2.
+
+// CHECK-LABEL: func.func @step_unroll
+//   CHECK-DAG:   %[[CST4:.+]] = arith.constant dense<4> : vector<1xindex>
+//   CHECK-DAG:   %[[CST3:.+]] = arith.constant dense<3> : vector<1xindex>
+//   CHECK-DAG:   %[[CST2:.+]] = arith.constant dense<2> : vector<1xindex>
+//   CHECK-DAG:   %[[CST1:.+]] = arith.constant dense<1> : vector<1xindex>
+//       CHECK:   %[[STEP:.+]] = vector.step : vector<1xindex>
+//       CHECK:   %[[INS0:.+]] = vector.insert_strided_slice %[[STEP]], %{{.+}} {offsets = [0], strides = [1]} : vector<1xindex> into vector<5xindex>
+//       CHECK:   %[[ADD1:.+]] = arith.addi %[[STEP]], %[[CST1]] : vector<1xindex>
+//       CHECK:   %[[INS1:.+]] = vector.insert_strided_slice %[[ADD1]], %[[INS0]] {offsets = [1], strides = [1]} : vector<1xindex> into vector<5xindex>
+//       CHECK:   %[[ADD2:.+]] = arith.addi %[[STEP]], %[[CST2]] : vector<1xindex>
+//       CHECK:   %[[INS2:.+]] = vector.insert_strided_slice %[[ADD2]], %[[INS1]] {offsets = [2], strides = [1]} : vector<1xindex> into vector<5xindex>
+//       CHECK:   %[[ADD3:.+]] = arith.addi %[[STEP]], %[[CST3]] : vector<1xindex>
+//       CHECK:   %[[INS3:.+]] = vector.insert_strided_slice %[[ADD3]], %[[INS2]] {offsets = [3], strides = [1]} : vector<1xindex> into vector<5xindex>
+//       CHECK:   %[[ADD4:.+]] = arith.addi %[[STEP]], %[[CST4]] : vector<1xindex>
+//       CHECK:   %[[INS4:.+]] = vector.insert_strided_slice %[[ADD4]], %[[INS3]] {offsets = [4], strides = [1]} : vector<1xindex> into vector<5xindex>
+//       CHECK:   vector.store %[[INS4]], %{{.+}}[%{{.+}}] : memref<5xindex>, vector<5xindex>
+func.func @step_unroll(%dest: memref<5xindex>) {
+  %c0 = arith.constant 0 : index
+  %v0 = vector.step : vector<5xindex>
+  vector.store %v0, %dest[%c0] : memref<5xindex>, vector<5xindex>
+  return
 }


### PR DESCRIPTION
SPIRV's TypeConverter failed with the following debug message:

>  illegal: not a valid composite type

which for vectors and composite types means that the vector had an invalid size.
`SPIRVInitialVectorLoweringPass` includes the upstream VectorUnroll patterns which themselves can unroll vector.step.
However, vector.step was skipped from unrolling since it lacked a target shaped defined in the VectorUnroll options.

```
[vector-unroll VectorUnroll.cpp:92 1] Get unroll shape for op vector.step
[vector-unroll VectorUnroll.cpp:110 1] --vector op shape: 5
[vector-unroll VectorUnroll.cpp:114 1] --no unrolling target shape defined 
%20 = vector.step : vector<5xindex>-> SKIP
```

To fix this we simply define a target shape for vector.step following the established conventions for other operations.

Fixes #24035
