### PR TITLE
[CI] Updating torch vae test golden time

### DIFF
--- a/tests/external/iree-test-suites/torch_models/sdxl/vae_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/vae_benchmark_mi325.json
@@ -26,5 +26,5 @@
             "value": "1x4x128x128xf16"
         }
     ],
-    "golden_time_ms": 60.0
+    "golden_time_ms": 67.9
 }


### PR DESCRIPTION
Adjusting the golden time of vae test in torch to be 110% of observed benchmark time instead of ~100%. Small margins were causing false negatives.

See [discord discussion](https://discord.com/channels/689900678990135345/689957613152239638/1491465547370729633) for context.