### PR TITLE
[Preprocessing] Register backward-data-conv preprocessing pipeline

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -128,6 +128,16 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
   passManager.addPass(createCSEPass());
 }
 
+static void buildBackwardDataConvPassPipeline(OpPassManager &passManager,
+                                              const TransformOptions &options) {
+  passManager.addPass(createSwapStridedInsertSliceWithContractionPass());
+  passManager.addPass(createConvertStridedInsertSliceToGenericPass());
+  FunctionLikeNest(passManager)
+      .addPass(createConvertConvFilterToChannelsLastPass);
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createCSEPass());
+}
+
 /// Pass pipeline to make the computation within a function a single dispatch.
 /// Note that this expects a `OpPassManager` nested on `FunctionOpInterface`
 /// ops.
@@ -182,6 +192,17 @@ void registerPreprocessingPasses() {
              const TransformOptions &transformOptions) {
             buildTransposeConvolutionPassPipeline(passManager,
                                                   transformOptions);
+          });
+
+  PassPipelineRegistration<TransformOptions>
+      preprocessingBackwardDataConvPassPipeline(
+          "iree-preprocessing-backward-data-conv-pipeline",
+          "Runs passes for backward-data convolutions (swap scatter with "
+          "contraction, convert strided insert_slice to generic, convert "
+          "conv filter to channels-last)",
+          [](OpPassManager &passManager,
+             const TransformOptions &transformOptions) {
+            buildBackwardDataConvPassPipeline(passManager, transformOptions);
           });
 
   PassPipelineRegistration<TransformOptions>


### PR DESCRIPTION
Register `iree-preprocessing-backward-data-conv-pipeline` that combines:
1. SwapStridedScatterWithContraction — for 1x1 non-unit stride backward data convs
2. ConvertStridedInsertSliceToGeneric — for non-unit stride and non-1x1 backward data convs
3. ConvertConvFilterToChannelsLast — transpose filter layout for optimal GPU memory access

This pipeline is intended to be used via
`--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-backward-data-conv-pipeline)`.

This is a final PR for https://github.com/iree-org/iree/issues/23976. Also ran benchmarks on RDNA4 GPU, and around 60% non-unit stride backward data convs got up to **7.11x** performance improvement.