### PR TITLE
[LinalgExt] Fix FuseTransposeWithAttentionOp skipping valid operands

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TransposeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TransposeFusion.cpp
@@ -8,10 +8,8 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
-#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
@@ -38,11 +36,17 @@ struct FuseTransposeWithAttentionOp final
       }
 
       auto maybeProducer = input->get().getDefiningOp<linalg::GenericOp>();
-      if (maybeProducer && maybeProducer.isSingleYieldOp()) {
-        producer = maybeProducer;
-        operand = input;
-        break;
+      if (!maybeProducer || !maybeProducer.isSingleYieldOp()) {
+        continue;
       }
+      auto producerMaps = maybeProducer.getIndexingMapsArray();
+      if (!producerMaps[0].isProjectedPermutation() ||
+          !producerMaps[1].isPermutation()) {
+        continue;
+      }
+      producer = maybeProducer;
+      operand = input;
+      break;
     }
     if (!operand) {
       return rewriter.notifyMatchFailure(attentionOp, "no operand found");
@@ -53,10 +57,6 @@ struct FuseTransposeWithAttentionOp final
     auto producerMaps = producer.getIndexingMapsArray();
     AffineMap producerInputMap = producerMaps[0];
     AffineMap producerResultMap = producerMaps[1];
-    if (!producerInputMap.isProjectedPermutation() ||
-        !producerResultMap.isPermutation()) {
-      return failure();
-    }
 
     rewriter.modifyOpInPlace(attentionOp, [&]() {
       SmallVector<AffineMap> newIndexingMaps =

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -316,6 +316,63 @@ util.func public @fuse_attention_with_broadcast_transpose(%arg0: tensor<4x?x8x12
 
 // -----
 
+// Verify that when Q's producer has a non-projected-permutation input map
+// (constant 0), the pattern skips it and fuses K's transpose instead.
+util.func public @skip_non_projected_permutation_producer(
+    %q: tensor<1x32x64x128xf16>,
+    %k: tensor<4x64x32x128xf16>,
+    %v: tensor<4x32x64x128xf16>,
+    %scale: f16) -> tensor<4x32x64x128xf16> {
+  %empty_q = tensor.empty() : tensor<4x32x64x128xf16>
+  %q_prod = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%q : tensor<1x32x64x128xf16>) outs(%empty_q : tensor<4x32x64x128xf16>) {
+  ^bb0(%in: f16, %out: f16):
+    linalg.yield %in : f16
+  } -> tensor<4x32x64x128xf16>
+  %empty_k = tensor.empty() : tensor<4x32x64x128xf16>
+  %k_transposed = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%k : tensor<4x64x32x128xf16>) outs(%empty_k : tensor<4x32x64x128xf16>) {
+  ^bb0(%in: f16, %out: f16):
+    linalg.yield %in : f16
+  } -> tensor<4x32x64x128xf16>
+  %empty_out = tensor.empty() : tensor<4x32x64x128xf16>
+  %attention = iree_linalg_ext.attention {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>]}
+      ins(%q_prod, %k_transposed, %v, %scale :
+          tensor<4x32x64x128xf16>, tensor<4x32x64x128xf16>,
+          tensor<4x32x64x128xf16>, f16)
+      outs(%empty_out : tensor<4x32x64x128xf16>) {
+  ^bb0(%score: f16):
+    iree_linalg_ext.yield %score : f16
+  } -> tensor<4x32x64x128xf16>
+  util.return %attention : tensor<4x32x64x128xf16>
+}
+// CHECK-LABEL: util.func public @skip_non_projected_permutation_producer
+//  CHECK-SAME:     %[[Q:[a-zA-Z0-9]+]]:
+//  CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]:
+//  CHECK-SAME:     %[[V:[a-zA-Z0-9]+]]:
+//  CHECK-SAME:     %[[SCALE:[a-zA-Z0-9]+]]:
+//       CHECK:   %[[Q_PROD:.+]] = linalg.generic
+//       CHECK:   %[[ATTENTION:.+]] = iree_linalg_ext.attention
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d1, d3)>
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+//  CHECK-SAME:     ins(%[[Q_PROD]], %[[K]], %[[V]], %[[SCALE]] :
+
+// -----
+
 util.func public @gather_fusion(%arg0: tensor<2x64x64x640xf16>, %arg1: tensor<2x64x64x640xf16>, %arg2: tensor<2xi64>, %arg3: tensor<640xi64>, %arg4: tensor<128xi64>, %arg5: tensor<640xf16>, %arg6: tensor<f32>) -> tensor<2x128x128x640xi8> {
   %cst = arith.constant -1.280000e+02 : f16
   %cst_0 = arith.constant 1.270000e+02 : f16


### PR DESCRIPTION
Move the projected permutation check for the producer's indexing maps inside the operand search loop. Previously, the loop selected the first input with a single-yield generic producer, then validated its indexing maps outside the loop. If validation failed, the pattern returned failure without considering subsequent inputs that may have had valid producers.