### PR TITLE
[CPU] Improve splitReduction for bounded-dynamic cases.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -108,6 +108,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
+        "//compiler/src/iree/compiler/Dialect/Util/Analysis",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//compiler/src/iree/compiler/Transforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -167,6 +167,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
+    iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms
     iree::compiler::Transforms

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -108,6 +108,11 @@ LogicalResult splitReductionPrecondition(Operation *op,
 
   SmallVector<unsigned> dims;
   linalgOp.getReductionDims(dims);
+  if (dims.size() != 1) {
+    LDBG() << "expected exactly 1 reduction dimension for targets";
+    return failure();
+  }
+
   AffineMap map =
       linalgOp.getMatchingIndexingMap(linalgOp.getDpsInputOperand(0));
   unsigned lastIdx = map.getNumResults() - 1;
@@ -137,13 +142,13 @@ LogicalResult splitReductionPrecondition(Operation *op,
 /// corresponds to the single reduction iterator dimension of `op`. Fails if
 /// `op` does not have exactly one reduction dimension or if that dimension is
 /// not referenced by the input indexing map.
+/// The method assumes that the preconditions verified by
+/// `splitReductionPrecondition`.
 static FailureOr<unsigned> getReductionOperandDimPosition(linalg::LinalgOp op) {
   SmallVector<unsigned> reductionDims;
   op.getReductionDims(reductionDims);
-  if (reductionDims.size() != 1) {
-    return failure();
-  }
-
+  assert(reductionDims.size() == 1 &&
+         "precondition guarantees exactly one reduction dimension");
   AffineMap inputMap = op.getMatchingIndexingMap(op.getDpsInputOperand(0));
   for (auto [idx, dimExpr] : llvm::enumerate(inputMap.getResults())) {
     if (cast<AffineDimExpr>(dimExpr).getPosition() == reductionDims.front()) {
@@ -154,7 +159,8 @@ static FailureOr<unsigned> getReductionOperandDimPosition(linalg::LinalgOp op) {
 }
 
 /// Returns the size of the input operand along its reduction dimension. Prefers
-/// the static tensor shape when available.
+/// the static tensor shape when available. This method does not create any IR,
+/// i.e., it is safe to be used in precondition checks.
 static FailureOr<OpFoldResult> getReductionSize(linalg::LinalgOp op) {
   FailureOr<unsigned> reductionOperandDimPos =
       getReductionOperandDimPosition(op);
@@ -196,7 +202,7 @@ static FailureOr<Value> createIdentityValue(OpBuilder &builder,
 }
 
 /// Returns true if the reduction dimension size of `op` is provably a multiple
-/// of `splitSize`. For dynamic cases, returns false when  `solver` is null or
+/// of `splitSize`. For dynamic cases, returns false when `solver` is null or
 /// has no divisibility information.
 static bool canSplitReductionWithSize(linalg::LinalgOp op, int64_t splitSize,
                                       DataFlowSolver *solver) {
@@ -420,10 +426,8 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
   // splitReduction already replaces the op.
   auto tiledOp = cast<linalg::LinalgOp>(tileResFirst->tiledOps.back());
   FailureOr<OpFoldResult> reductionSize = getReductionSize(tiledOp);
-  if (failed(reductionSize)) {
-    LDBG() << "failed to determine tiled reduction size";
-    return success();
-  }
+  assert(succeeded(reductionSize) &&
+         "expected to be able to determine reduction size after tiling");
   linalg::SplitReductionResult splitRes =
       splitReduction(tiledOp, size, lastIdx, *reductionSize, rewriter);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -7,13 +7,24 @@
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/Support/DebugLog.h"
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/Utils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Pass/Pass.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-split-reduction"
@@ -25,6 +36,19 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+/// Returns the single combiner operation of the reduction body for the
+/// `initIndex`-th output of `op`. Returns nullptr if the body does not reduce
+/// with a single operation.
+static Operation *matchSingleCombinerOp(linalg::LinalgOp op,
+                                        unsigned initIndex) {
+  SmallVector<Operation *, 4> combinerOps;
+  if (!matchReduction(op.getRegionOutputArgs(), initIndex, combinerOps) ||
+      combinerOps.size() != 1) {
+    return nullptr;
+  }
+  return combinerOps.front();
+}
+
 /// Make sure that
 /// - the pass has not been applied before
 /// - has tensor semantics
@@ -35,6 +59,7 @@ namespace {
 /// - has exactly 1 input
 /// - if enableReductionReordering is not set, then operand is an int
 /// - innermost dimension of the input operand is reduction
+/// - the reduction body is a single combiner op with a known neutral element
 /// TODO: support named ops, numInputs > 1, and modify lastDim check below
 /// accordingly. If fpReductionReordering is not enabled by default, it must
 /// be an integer or index type to proceed to allow associative reordering.
@@ -92,7 +117,278 @@ LogicalResult splitReductionPrecondition(Operation *op,
     return failure();
   }
 
+  // The reduction body must consist of a single combiner op with a known
+  // neutral element, since the rewrite materializes the split using that
+  // combiner and initializes the partial accumulator with its neutral element.
+  Operation *combinerOp = matchSingleCombinerOp(linalgOp, /*initIndex=*/0);
+  if (!combinerOp) {
+    LDBG() << "cannot match a single combiner op in the reduction body";
+    return failure();
+  }
+  if (!arith::getNeutralElement(combinerOp).has_value()) {
+    LDBG() << "unknown neutral element for the reduction combiner";
+    return failure();
+  }
+
   return success();
+}
+
+/// Returns the result position in the input operand's indexing map that
+/// corresponds to the single reduction iterator dimension of `op`. Fails if
+/// `op` does not have exactly one reduction dimension or if that dimension is
+/// not referenced by the input indexing map.
+static FailureOr<unsigned> getReductionOperandDimPosition(linalg::LinalgOp op) {
+  SmallVector<unsigned> reductionDims;
+  op.getReductionDims(reductionDims);
+  if (reductionDims.size() != 1) {
+    return failure();
+  }
+
+  AffineMap inputMap = op.getMatchingIndexingMap(op.getDpsInputOperand(0));
+  for (auto [idx, dimExpr] : llvm::enumerate(inputMap.getResults())) {
+    if (cast<AffineDimExpr>(dimExpr).getPosition() == reductionDims.front()) {
+      return idx;
+    }
+  }
+  return failure();
+}
+
+/// Returns the size of the input operand along its reduction dimension. Prefers
+/// the static tensor shape when available.
+static FailureOr<OpFoldResult> getReductionSize(linalg::LinalgOp op) {
+  FailureOr<unsigned> reductionOperandDimPos =
+      getReductionOperandDimPosition(op);
+  if (failed(reductionOperandDimPos)) {
+    return failure();
+  }
+  Value input = op.getDpsInputOperand(0)->get();
+  auto inputType = cast<RankedTensorType>(input.getType());
+  int64_t staticDim = inputType.getDimSize(*reductionOperandDimPos);
+  if (ShapedType::isStatic(staticDim)) {
+    return OpFoldResult(
+        IntegerAttr::get(IndexType::get(op.getContext()), staticDim));
+  }
+  if (auto viewOp = input.getDefiningOp<OffsetSizeAndStrideOpInterface>()) {
+    return viewOp.getMixedSizes()[*reductionOperandDimPos];
+  }
+  return failure();
+}
+
+/// Creates an `arith.constant` holding the neutral element of the reduction
+/// combiner for the `initIndex`-th output of `op`. Fails if the combiner cannot
+/// be matched as a single op or if it has no known neutral element.
+static FailureOr<Value> createIdentityValue(OpBuilder &builder,
+                                            linalg::LinalgOp op,
+                                            unsigned initIndex) {
+  Operation *reductionOp = matchSingleCombinerOp(op, initIndex);
+  if (!reductionOp) {
+    return failure();
+  }
+  std::optional<TypedAttr> identityAttr = arith::getNeutralElement(reductionOp);
+  if (!identityAttr) {
+    return failure();
+  }
+  Type elementType =
+      getElementTypeOrSelf(op.getDpsInits()[initIndex].getType());
+  return arith::ConstantOp::create(builder, op.getLoc(), elementType,
+                                   *identityAttr)
+      .getResult();
+}
+
+/// Returns true if the reduction dimension size of `op` is provably a multiple
+/// of `splitSize`. For dynamic cases, returns false when  `solver` is null or
+/// has no divisibility information.
+static bool canSplitReductionWithSize(linalg::LinalgOp op, int64_t splitSize,
+                                      DataFlowSolver *solver) {
+  FailureOr<OpFoldResult> reductionSize = getReductionSize(op);
+  if (failed(reductionSize)) {
+    return false;
+  }
+  if (std::optional<int64_t> cstSize = getConstantIntValue(*reductionSize)) {
+    return *cstSize % splitSize == 0;
+  }
+
+  if (!solver) {
+    return false;
+  }
+  auto *lattice = solver->lookupState<IREE::Util::IntegerDivisibilityLattice>(
+      cast<Value>(*reductionSize));
+  if (!lattice || lattice->getValue().isUninitialized()) {
+    return false;
+  }
+  return lattice->getValue().getValue().udiv() % splitSize == 0;
+}
+
+/// Rewrites `linalgOp` by splitting its single reduction dimension into an
+/// outer reduction dimension and an inner parallel dimension of size
+/// `splitSize`, yielding a partial reduction followed by a final reduction over
+/// the new inner dimension. The split is materialized with
+/// `tensor.expand_shape`; the inner split size is static while the outer
+/// dimension may be dynamic when `reductionSize` is only bounded (not a
+/// compile-time constant). `insertSplitIndex` controls where the new parallel
+/// dimension is placed in the partial-output tensor. `reductionSize` is the
+/// size of the reduction dimension, possibly a dynamic `Value`, and is assumed
+/// to be a multiple of `splitSize`.
+///
+/// Only the inner-parallel variant is supported: the new parallel dimension is
+/// always placed inside the reduction, matching the shape
+///   `<..., outer, splitSize, ...>`
+/// where `outer` is the original reduction dimension.
+///
+/// Assumes `splitReductionPrecondition` has been verified on `linalgOp`: a
+/// single reduction dim, a single input and single output, a matchable combiner
+/// with a known neutral element, and an input indexing map whose innermost
+/// result is the reduction dim.
+static linalg::SplitReductionResult splitReduction(linalg::LinalgOp linalgOp,
+                                                   int64_t splitSize,
+                                                   unsigned insertSplitIndex,
+                                                   OpFoldResult reductionSize,
+                                                   RewriterBase &rewriter) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(linalgOp);
+
+  SmallVector<unsigned> dims;
+  linalgOp.getReductionDims(dims);
+  unsigned reductionDim = dims[0];
+  unsigned insertSplitDimension = reductionDim + 1;
+
+  Operation *reductionOp = matchSingleCombinerOp(linalgOp, /*initIndex=*/0);
+  assert(reductionOp &&
+         "precondition guarantees a single combiner op in the reduction body");
+  FailureOr<Value> identityValue =
+      createIdentityValue(rewriter, linalgOp, /*initIndex=*/0);
+  assert(succeeded(identityValue) &&
+         "precondition guarantees a known neutral element for the combiner");
+
+  Location loc = linalgOp.getLoc();
+  MLIRContext *context = linalgOp.getContext();
+
+  // Calculate the new shape and indexing map of the input operand.
+  OpOperand *inputOperand = linalgOp.getDpsInputOperand(0);
+  Value input = inputOperand->get();
+  auto inputType = cast<RankedTensorType>(input.getType());
+  AffineMap map = linalgOp.getMatchingIndexingMap(inputOperand);
+  SmallVector<OpFoldResult> newShape;
+  SmallVector<int64_t> newStaticShape;
+  SmallVector<AffineExpr> exprs;
+  SmallVector<ReassociationIndices> reassociation;
+  unsigned index = 0;
+
+  AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
+  AffineMap outerDimMap = AffineMap::get(0, 1, s0.floorDiv(splitSize), context);
+  for (unsigned idx : llvm::seq<unsigned>(0, map.getNumResults())) {
+    unsigned dim = map.getDimPosition(idx);
+    if (reductionDim == dim) {
+      OpFoldResult outerSize = affine::makeComposedFoldedAffineApply(
+          rewriter, loc, outerDimMap, ArrayRef<OpFoldResult>{reductionSize});
+      newShape.push_back(outerSize);                        // reduce
+      newShape.push_back(rewriter.getIndexAttr(splitSize)); // parallel (insert)
+      newStaticShape.push_back(
+          getConstantIntValue(outerSize).value_or(ShapedType::kDynamic));
+      newStaticShape.push_back(splitSize);
+      exprs.push_back(rewriter.getAffineDimExpr(
+          dim < insertSplitDimension ? dim : dim + 1));
+      exprs.push_back(rewriter.getAffineDimExpr(insertSplitDimension));
+      reassociation.push_back({index++, index++});
+      continue;
+    }
+    OpFoldResult dimSize = tensor::getMixedSize(rewriter, loc, input, idx);
+    newShape.push_back(dimSize);
+    newStaticShape.push_back(
+        getConstantIntValue(dimSize).value_or(ShapedType::kDynamic));
+    exprs.push_back(
+        rewriter.getAffineDimExpr(dim < insertSplitDimension ? dim : dim + 1));
+    reassociation.push_back({index++});
+  }
+  SmallVector<AffineMap> newMaps;
+  newMaps.push_back(AffineMap::get(map.getNumDims() + 1, 0, exprs, context));
+
+  auto newInputType =
+      RankedTensorType::get(newStaticShape, inputType.getElementType());
+  Value newInput = tensor::ExpandShapeOp::create(
+      rewriter, loc, newInputType, input, reassociation, newShape);
+
+  // Calculate the new output map and shape, we insert the new dimension based
+  // on `insertSplitIndex`.
+  SmallVector<OpFoldResult> newOutputShape;
+  AffineMap oldOutputMap =
+      linalgOp.getMatchingIndexingMap(linalgOp.getDpsInitOperand(0));
+  SmallVector<OpFoldResult> oldOutputShape = tensor::getMixedSizes(
+      rewriter, loc, linalgOp.getDpsInitOperand(0)->get());
+  SmallVector<AffineExpr> outputExpr;
+  for (unsigned idx : llvm::seq<unsigned>(0, oldOutputShape.size() + 1)) {
+    if (insertSplitIndex == idx) {
+      newOutputShape.push_back(rewriter.getIndexAttr(splitSize));
+      outputExpr.push_back(rewriter.getAffineDimExpr(insertSplitDimension));
+    }
+    if (idx < oldOutputShape.size()) {
+      newOutputShape.push_back(oldOutputShape[idx]);
+      unsigned dim = oldOutputMap.getDimPosition(idx);
+      outputExpr.push_back(rewriter.getAffineDimExpr(
+          dim < insertSplitDimension ? dim : dim + 1));
+    }
+  }
+  Value emptyTensor =
+      tensor::EmptyOp::create(rewriter, loc, newOutputShape,
+                              linalgOp.getRegionOutputArgs()[0].getType());
+  auto fillOp =
+      linalg::FillOp::create(rewriter, loc, *identityValue, emptyTensor);
+  Value identityTensor = fillOp.getResult(0);
+
+  newMaps.push_back(
+      AffineMap::get(oldOutputMap.getNumDims() + 1, 0, outputExpr, context));
+  SmallVector<utils::IteratorType> newIteratorTypes;
+  for (auto [index, iteratorType] :
+       llvm::enumerate(linalgOp.getIteratorTypesArray())) {
+    if (insertSplitDimension == index) {
+      newIteratorTypes.push_back(utils::IteratorType::parallel);
+    }
+    newIteratorTypes.push_back(iteratorType);
+  }
+  if (insertSplitDimension == linalgOp.getIteratorTypesArray().size()) {
+    newIteratorTypes.push_back(utils::IteratorType::parallel);
+  }
+  // Create the new op matching the original op with an extra parallel
+  // dimension.
+  auto genericOp = linalg::GenericOp::create(
+      rewriter, loc, TypeRange({emptyTensor.getType()}), ValueRange({newInput}),
+      ValueRange({identityTensor}), newMaps, newIteratorTypes);
+  rewriter.inlineRegionBefore(linalgOp->getRegion(0), genericOp.getRegion(),
+                              genericOp.getRegion().begin());
+
+  // Then create a new reduction that only reduces the newly added dimension
+  // from the previous op.
+  unsigned intermRank = newOutputShape.size();
+  AffineMap inputMap = rewriter.getMultiDimIdentityMap(intermRank);
+  SmallVector<utils::IteratorType> reductionIteratorTypes;
+  SmallVector<AffineExpr> finalExprs;
+  for (unsigned i : llvm::seq<unsigned>(0, intermRank)) {
+    if (insertSplitIndex == i) {
+      reductionIteratorTypes.push_back(utils::IteratorType::reduction);
+    } else {
+      finalExprs.push_back(rewriter.getAffineDimExpr(i));
+      reductionIteratorTypes.push_back(utils::IteratorType::parallel);
+    }
+  }
+  AffineMap outputMap = AffineMap::get(intermRank, 0, finalExprs, context);
+  SmallVector<AffineMap> reductionMaps = {inputMap, outputMap};
+
+  auto reduction = linalg::GenericOp::create(
+      rewriter, loc, linalgOp->getResultTypes(),
+      ValueRange({genericOp.getResult(0)}), linalgOp.getDpsInits(),
+      reductionMaps, reductionIteratorTypes,
+      [reductionOp](OpBuilder &b, Location nestedLoc, ValueRange inputs) {
+        Operation *clonedReductionOp = b.clone(*reductionOp);
+        clonedReductionOp->setOperand(0, inputs[0]);
+        clonedReductionOp->setOperand(1, inputs[1]);
+        linalg::YieldOp::create(b, nestedLoc, clonedReductionOp->getResult(0));
+      });
+  rewriter.replaceOp(linalgOp, reduction.getResults());
+
+  return linalg::SplitReductionResult{
+      emptyTensor.getDefiningOp(), fillOp,
+      cast<linalg::LinalgOp>(genericOp.getOperation()),
+      cast<linalg::LinalgOp>(reduction.getOperation())};
 }
 
 /// Converts an inner-reduction into outer reduction + inner-parallel dimension,
@@ -102,16 +398,10 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
   IRRewriter::InsertionGuard g(rewriter);
   rewriter.setInsertionPointAfter(op);
   linalg::LinalgOp linalgOp = cast<linalg::LinalgOp>(op);
-
   AffineMap map =
       linalgOp.getMatchingIndexingMap(linalgOp.getDpsInputOperand(0));
   unsigned lastIdx = map.getNumResults() - 1;
-  linalg::ControlSplitReductionFn fn = [size, lastIdx](linalg::LinalgOp) {
-    return linalg::SplitReductionOptions{size, lastIdx,
-                                         /*innerParallel=*/true};
-  };
-
-  auto numLoops = linalgOp.getNumLoops();
+  unsigned numLoops = linalgOp.getNumLoops();
 
   // 1) Tile to extract a single vector-length array.
   SmallVector<OpFoldResult> tileSizesSVFirst(numLoops,
@@ -128,30 +418,32 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
 
   // 2) Apply splitReduction on the single vector-length array.
   // splitReduction already replaces the op.
-  FailureOr<linalg::SplitReductionResult> splitRes = splitReduction(
-      rewriter, cast<linalg::LinalgOp>(tileResFirst->tiledOps.back()), fn);
-  if (failed(splitRes)) {
-    LDBG() << "failed on step 2 (SplitReduction)";
+  auto tiledOp = cast<linalg::LinalgOp>(tileResFirst->tiledOps.back());
+  FailureOr<OpFoldResult> reductionSize = getReductionSize(tiledOp);
+  if (failed(reductionSize)) {
+    LDBG() << "failed to determine tiled reduction size";
     return success();
   }
+  linalg::SplitReductionResult splitRes =
+      splitReduction(tiledOp, size, lastIdx, *reductionSize, rewriter);
 
   // 3) Tile the first op generated by splitReduction with tile size of 1,
   // to essentially create a reduction loop. Note that
-  // splitRes->splitLinalgOp.getNumLoops() = numLoops + 1.
-  SmallVector<OpFoldResult> tileSizesSV(splitRes->splitLinalgOp.getNumLoops(),
+  // splitRes.splitLinalgOp.getNumLoops() = numLoops + 1.
+  SmallVector<OpFoldResult> tileSizesSV(splitRes.splitLinalgOp.getNumLoops(),
                                         rewriter.getIndexAttr(0));
   // The reduction happens only in the penultimate dimension, which we now
   // tile.
   tileSizesSV[numLoops - 1] = rewriter.getIndexAttr(1);
   options = scf::SCFTilingOptions().setTileSizes(tileSizesSV);
   FailureOr<scf::SCFTilingResult> tileRes = scf::tileUsingSCF(
-      rewriter, cast<TilingInterface>(splitRes->splitLinalgOp.getOperation()),
+      rewriter, cast<TilingInterface>(splitRes.splitLinalgOp.getOperation()),
       options);
   if (failed(tileRes)) {
     LDBG() << "failed on step 3 (SCFTiling)";
     return failure();
   }
-  rewriter.replaceOp(splitRes->splitLinalgOp, tileRes->replacements);
+  rewriter.replaceOp(splitRes.splitLinalgOp, tileRes->replacements);
   return success();
 }
 
@@ -164,7 +456,9 @@ public:
     this->enableFpReductionReordering = fpReductionReordering;
   }
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect, scf::SCFDialect>();
+    registry.insert<affine::AffineDialect, arith::ArithDialect,
+                    linalg::LinalgDialect, scf::SCFDialect,
+                    tensor::TensorDialect>();
   }
   void runOnOperation() override;
 };
@@ -173,21 +467,24 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
   MLIRContext *context = &getContext();
   mlir::FunctionOpInterface funcOp = getOperation();
 
-  IRRewriter rewriter(context);
-  SmallVector<linalg::GenericOp> candidates;
-  funcOp.walk([&](linalg::GenericOp op) { candidates.push_back(op); });
-  for (auto genericOp : candidates) {
-    LDBG() << "candidate: " << genericOp;
-    if (failed(splitReductionPrecondition(genericOp,
-                                          enableFpReductionReordering))) {
-      continue;
+  struct Candidate {
+    linalg::GenericOp op;
+    int64_t splitSize;
+  };
+
+  SmallVector<Candidate> candidates;
+  SmallVector<Candidate> dynamicCandidatesNeedingProof;
+  funcOp.walk([&](linalg::GenericOp op) {
+    LDBG() << "candidate: " << op;
+    if (failed(splitReductionPrecondition(op, enableFpReductionReordering))) {
+      return;
     }
 
     IREE::Codegen::LoweringConfigAttrInterface maybeLoweringConfig =
-        getLoweringConfig(genericOp);
+        getLoweringConfig(op);
     if (!maybeLoweringConfig) {
       LDBG() << "can't find lowering_config, skip SplitReduction";
-      continue;
+      return;
     }
     auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
         maybeLoweringConfig.getTilingLevelAttr(static_cast<unsigned>(
@@ -196,16 +493,52 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
     if (scalableDims.back()) {
       LDBG() << "scalable reduction dimensions not yet supported, skip "
                 "SplitReduction";
-      continue;
+      return;
     }
     ArrayRef<int64_t> reductionSizes = attr.getSizes();
     if (reductionSizes.empty()) {
       LDBG()
           << "the list of reduction tiling sizes is empty, skip SplitReduction";
-      continue;
+      return;
     }
-    int64_t size = reductionSizes.back();
-    if (failed(splitReductionImpl(genericOp, size, rewriter))) {
+
+    Candidate candidate = {op, reductionSizes.back()};
+    FailureOr<OpFoldResult> reductionSize = getReductionSize(op);
+    if (failed(reductionSize)) {
+      return;
+    }
+    if (getConstantIntValue(*reductionSize)) {
+      if (canSplitReductionWithSize(op, candidate.splitSize,
+                                    /*solver=*/nullptr)) {
+        candidates.push_back(candidate);
+      }
+      return;
+    }
+    dynamicCandidatesNeedingProof.push_back(candidate);
+  });
+
+  std::unique_ptr<DataFlowSolver> solver;
+  if (!dynamicCandidatesNeedingProof.empty()) {
+    solver = std::make_unique<DataFlowSolver>();
+    solver->load<dataflow::SparseConstantPropagation>();
+    solver->load<dataflow::DeadCodeAnalysis>();
+    solver->load<IREE::Util::IntegerDivisibilityAnalysis>();
+    if (failed(solver->initializeAndRun(funcOp))) {
+      return signalPassFailure();
+    }
+  }
+
+  for (const Candidate &candidate : dynamicCandidatesNeedingProof) {
+    if (canSplitReductionWithSize(candidate.op, candidate.splitSize,
+                                  solver.get())) {
+      candidates.push_back(candidate);
+    }
+  }
+
+  IRRewriter rewriter(context);
+  for (const Candidate &candidate : candidates) {
+    if (failed(
+            splitReductionImpl(candidate.op, candidate.splitSize, rewriter))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -108,11 +108,6 @@ LogicalResult splitReductionPrecondition(Operation *op,
 
   SmallVector<unsigned> dims;
   linalgOp.getReductionDims(dims);
-  if (dims.size() != 1) {
-    LDBG() << "expected exactly 1 reduction dimension for targets";
-    return failure();
-  }
-
   AffineMap map =
       linalgOp.getMatchingIndexingMap(linalgOp.getDpsInputOperand(0));
   unsigned lastIdx = map.getNumResults() - 1;
@@ -142,7 +137,7 @@ LogicalResult splitReductionPrecondition(Operation *op,
 /// corresponds to the single reduction iterator dimension of `op`. Fails if
 /// `op` does not have exactly one reduction dimension or if that dimension is
 /// not referenced by the input indexing map.
-/// The method assumes that the preconditions verified by
+/// The method assumes that the preconditions are verified by
 /// `splitReductionPrecondition`.
 static FailureOr<unsigned> getReductionOperandDimPosition(linalg::LinalgOp op) {
   SmallVector<unsigned> reductionDims;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/split_reduction.mlir
@@ -144,3 +144,131 @@ func.func @dont_reassociate(%arg0 : tensor<4096xi32>, %arg1 : tensor<f32>) -> te
 //       DISABLEREASSOC:   %[[GENERIC:.+]] = linalg.generic
 //  DISABLEREASSOC-SAME:       iterator_types = ["reduction"]
 //       DISABLEREASSOC:   return %[[GENERIC]]
+
+// -----
+
+#config = #iree_cpu.lowering_config<vector_reduction = [16]>
+func.func @split_bounded_dynamic_reduction(%arg0 : tensor<256xi32>, %arg1 : tensor<i32>) -> tensor<i32> {
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %0 = scf.for %iv = %c0 to %c256 step %c128 iter_args(%acc = %arg1) -> (tensor<i32>) {
+    %size = affine.min affine_map<(d0) -> (-d0 + 256, 128)>(%iv)
+    %slice = tensor.extract_slice %arg0[%iv] [%size] [1] : tensor<256xi32> to tensor<?xi32>
+    %reduced = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
+        iterator_types = ["reduction"]}
+      ins(%slice : tensor<?xi32>) outs(%acc : tensor<i32>) attrs = {lowering_config = #config} {
+      ^bb0(%in : i32, %out : i32):
+        %sum = arith.addi %in, %out : i32
+        linalg.yield %sum : i32
+    } -> tensor<i32>
+    scf.yield %reduced : tensor<i32>
+  }
+  return %0 : tensor<i32>
+}
+// CHECK-LABEL: func.func @split_bounded_dynamic_reduction
+// CHECK:         %[[SIZE:.+]] = affine.min
+// CHECK:         %[[OUTER:.+]] = affine.apply
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape {{.*}} output_shape [%[[OUTER]], 16]
+// CHECK:         %[[INIT:.+]] = linalg.fill
+// CHECK:         %[[DIM:.+]] = tensor.dim %[[EXPANDED]]
+// CHECK:         %[[PARTIAL_LOOP:.+]] = scf.for {{.*}} iter_args(%[[ACC:.+]] = %[[INIT]]) -> (tensor<16xi32>)
+// CHECK:           %[[PARTIAL:.+]] = linalg.generic
+// CHECK-SAME:        iterator_types = ["reduction", "parallel"]
+// CHECK:           scf.yield %[[PARTIAL]]
+// CHECK:         %[[FINAL:.+]] = linalg.generic
+// CHECK-SAME:        iterator_types = ["reduction"]
+// CHECK:         scf.yield %[[FINAL]]
+
+// -----
+
+#config = #iree_cpu.lowering_config<vector_reduction = [16]>
+func.func @dont_split_unproven_dynamic_reduction(%arg0 : tensor<250xi32>, %arg1 : tensor<i32>) -> tensor<i32> {
+  %c0 = arith.constant 0 : index
+  %c125 = arith.constant 125 : index
+  %c250 = arith.constant 250 : index
+  %0 = scf.for %iv = %c0 to %c250 step %c125 iter_args(%acc = %arg1) -> (tensor<i32>) {
+    %size = affine.min affine_map<(d0) -> (-d0 + 250, 125)>(%iv)
+    %slice = tensor.extract_slice %arg0[%iv] [%size] [1] : tensor<250xi32> to tensor<?xi32>
+    %reduced = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
+        iterator_types = ["reduction"]}
+      ins(%slice : tensor<?xi32>) outs(%acc : tensor<i32>) attrs = {lowering_config = #config} {
+      ^bb0(%in : i32, %out : i32):
+        %sum = arith.addi %in, %out : i32
+        linalg.yield %sum : i32
+    } -> tensor<i32>
+    scf.yield %reduced : tensor<i32>
+  }
+  return %0 : tensor<i32>
+}
+// CHECK-LABEL: func.func @dont_split_unproven_dynamic_reduction
+// CHECK-NOT:     tensor.expand_shape
+// CHECK:         %[[GENERIC:.+]] = linalg.generic
+// CHECK-SAME:      iterator_types = ["reduction"]
+// CHECK:         scf.yield %[[GENERIC]]
+
+// -----
+
+#config = #iree_cpu.lowering_config<vector_reduction = [16]>
+func.func @split_bounded_dynamic_maximumf(%arg0 : tensor<256xf32>, %arg1 : tensor<f32>) -> tensor<f32> {
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %0 = scf.for %iv = %c0 to %c256 step %c128 iter_args(%acc = %arg1) -> (tensor<f32>) {
+    %size = affine.min affine_map<(d0) -> (-d0 + 256, 128)>(%iv)
+    %slice = tensor.extract_slice %arg0[%iv] [%size] [1] : tensor<256xf32> to tensor<?xf32>
+    %reduced = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
+        iterator_types = ["reduction"]}
+      ins(%slice : tensor<?xf32>) outs(%acc : tensor<f32>) attrs = {lowering_config = #config} {
+      ^bb0(%in : f32, %out : f32):
+        %max = arith.maximumf %in, %out : f32
+        linalg.yield %max : f32
+    } -> tensor<f32>
+    scf.yield %reduced : tensor<f32>
+  }
+  return %0 : tensor<f32>
+}
+// CHECK-LABEL: func.func @split_bounded_dynamic_maximumf
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<16xf32>
+// CHECK:         %[[FILL:.+]] = linalg.fill {{.*}} outs(%[[INIT]] : tensor<16xf32>) -> tensor<16xf32>
+// CHECK:         %[[PARTIAL:.+]] = linalg.generic
+// CHECK-SAME:      iterator_types = ["reduction", "parallel"]
+// CHECK:             %[[MAX0:.+]] = arith.maximumf
+// CHECK:         %[[FINAL:.+]] = linalg.generic
+// CHECK-SAME:      iterator_types = ["reduction"]
+// CHECK:             %[[MAX1:.+]] = arith.maximumf
+
+// -----
+
+#config = #iree_cpu.lowering_config<vector_reduction = [16]>
+func.func @split_bounded_dynamic_with_linalg_index(%arg0 : tensor<256xf32>, %arg1 : tensor<i32>) -> tensor<i32> {
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %0 = scf.for %iv = %c0 to %c256 step %c128 iter_args(%acc = %arg1) -> (tensor<i32>) {
+    %size = affine.min affine_map<(d0) -> (-d0 + 256, 128)>(%iv)
+    %slice = tensor.extract_slice %arg0[%iv] [%size] [1] : tensor<256xf32> to tensor<?xf32>
+    %reduced = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
+        iterator_types = ["reduction"]}
+      ins(%slice : tensor<?xf32>) outs(%acc : tensor<i32>) attrs = {lowering_config = #config} {
+      ^bb0(%in : f32, %out : i32):
+        %idx = linalg.index 0 : index
+        %idx_i32 = arith.index_cast %idx : index to i32
+        %sum = arith.addi %idx_i32, %out : i32
+        linalg.yield %sum : i32
+    } -> tensor<i32>
+    scf.yield %reduced : tensor<i32>
+  }
+  return %0 : tensor<i32>
+}
+// CHECK-LABEL: func.func @split_bounded_dynamic_with_linalg_index
+// CHECK-NOT:     tensor.expand_shape
+// CHECK:         %[[GENERIC:.+]] = linalg.generic
+// CHECK-SAME:      iterator_types = ["reduction"]
+// CHECK:             %[[INDEX:.+]] = linalg.index 0 : index
+// CHECK:         scf.yield %[[GENERIC]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/split_reduction.mlir
@@ -272,3 +272,66 @@ func.func @split_bounded_dynamic_with_linalg_index(%arg0 : tensor<256xf32>, %arg
 // CHECK-SAME:      iterator_types = ["reduction"]
 // CHECK:             %[[INDEX:.+]] = linalg.index 0 : index
 // CHECK:         scf.yield %[[GENERIC]]
+
+// -----
+
+#config = #iree_cpu.lowering_config<vector_reduction = [0, 0, 16]>
+func.func @split_bounded_dynamic_3d_reduction(%arg0 : tensor<4x5x128xi32>, %arg1 : tensor<4x5xi32>) -> tensor<4x5xi32> {
+  %c0 = arith.constant 0 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %0 = scf.for %iv = %c0 to %c128 step %c64 iter_args(%acc = %arg1) -> (tensor<4x5xi32>) {
+    %size = affine.min affine_map<(d0) -> (-d0 + 128, 64)>(%iv)
+    %slice = tensor.extract_slice %arg0[0, 0, %iv] [4, 5, %size] [1, 1, 1] : tensor<4x5x128xi32> to tensor<4x5x?xi32>
+    %reduced = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                         affine_map<(d0, d1, d2) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel", "reduction"]}
+      ins(%slice : tensor<4x5x?xi32>) outs(%acc : tensor<4x5xi32>) attrs = {lowering_config = #config} {
+      ^bb0(%in : i32, %out : i32):
+        %sum = arith.addi %in, %out : i32
+        linalg.yield %sum : i32
+    } -> tensor<4x5xi32>
+    scf.yield %reduced : tensor<4x5xi32>
+  }
+  return %0 : tensor<4x5xi32>
+}
+// CHECK-LABEL: func.func @split_bounded_dynamic_3d_reduction
+// CHECK:         %[[SIZE:.+]] = affine.min
+// CHECK:         %[[OUTER:.+]] = affine.apply
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape {{.*}} output_shape [1, 1, %[[OUTER]], 16]
+// CHECK:         %[[INIT:.+]] = linalg.fill
+// CHECK:         scf.for {{.*}} iter_args({{.*}} = %[[INIT]]) -> (tensor<1x1x16xi32>)
+// CHECK:           linalg.generic
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "reduction", "parallel"]
+// CHECK:         linalg.generic
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "reduction"]
+
+// -----
+
+#config = #iree_cpu.lowering_config<vector_reduction = [16]>
+func.func @split_dynamic_reduction_with_assume_int(%arg0 : tensor<?xi32>, %arg1 : tensor<i32>) -> tensor<i32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?xi32>
+  %assumed = util.assume.int %dim<udiv = 16> : index
+  %slice = tensor.extract_slice %arg0[0] [%assumed] [1] : tensor<?xi32> to tensor<?xi32>
+  %reduced = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
+      iterator_types = ["reduction"]}
+    ins(%slice : tensor<?xi32>) outs(%arg1 : tensor<i32>) attrs = {lowering_config = #config} {
+    ^bb0(%in : i32, %out : i32):
+      %sum = arith.addi %in, %out : i32
+      linalg.yield %sum : i32
+  } -> tensor<i32>
+  return %reduced : tensor<i32>
+}
+// CHECK-LABEL: func.func @split_dynamic_reduction_with_assume_int
+// CHECK:         util.assume.int
+// CHECK:         %[[OUTER:.+]] = affine.apply
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape {{.*}} output_shape [%[[OUTER]], 16]
+// CHECK:         %[[INIT:.+]] = linalg.fill
+// CHECK:         scf.for {{.*}} iter_args({{.*}} = %[[INIT]]) -> (tensor<16xi32>)
+// CHECK:           linalg.generic
+// CHECK-SAME:        iterator_types = ["reduction", "parallel"]
+// CHECK:         linalg.generic
+// CHECK-SAME:        iterator_types = ["reduction"]


### PR DESCRIPTION
The revision reworks the upstream `splitReduction` within IREE and supports the bounded-dynamic cases.

The structure of splitReduction function mirrors the inner-parallel path of upstream `mlir::linalg::splitReduction` as closely as possible to keep the port easy to maintain. The only intentional deltas are:
  1. Uses `OpFoldResult` + `tensor::getMixedSize(s)` so non-reduction dims and the outer reduction dim can be dynamic.
  2. Computes the outer reduction size with `affine.apply floorDiv splitSize` instead of dividing a static shape at compile time.
  3. Passes `output_shape` to `tensor.expand_shape` so the outer dim can be a dynamic value.
  4. Single-input / single-output only (no outer loop over input operands).
  5. Inner-parallel only (no outer-parallel branch, no `useAlloc`).

Fixes https://github.com/iree-org/iree/issues/24010