### PR TITLE
[Codegen] Use createWriteOrMaskedWrite utility

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
@@ -913,7 +913,7 @@ func.func @masked_tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf
 //       CHECK:   %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 //  CHECK-SAME:     : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
 //       CHECK:   %[[WRITE_MASK:.+]] = vector.create_mask {{.*}} : vector<2x5x4xi1>
-//       CHECK:   vector.transfer_write %[[MMA]], %arg2{{.*}}, %[[WRITE_MASK]] {in_bounds = [false, false, true]}
+//       CHECK:   vector.transfer_write %[[MMA]], %arg2{{.*}}, %[[WRITE_MASK]] {in_bounds = [true, true, true]}
 //  CHECK-SAME:     : vector<2x5x4xf32>, tensor<?x?x4xf32>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -1146,39 +1146,13 @@ struct InnerTiledOpVectorizationModel
         tiledOp.getKind(), tiledOp.getSemantics());
 
     // Write results back to tensor, with masking if needed.
-    // TODO: Use createWriteOrMaskedWrite once it is promoted to a public
-    // utility in mlir/Dialect/Vector/Utils/VectorUtils.h.
-    auto zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     SmallVector<Value> results;
-    unsigned numInputs = tiledOp.getNumInputs();
-    for (auto [i, result, dest] :
-         llvm::enumerate(newTiledOp.getResults(), tiledOp.getOutputs())) {
-      auto destType = cast<ShapedType>(dest.getType());
-      int64_t rank = destType.getRank();
-      SmallVector<Value> indices(rank, zero);
-
-      ArrayRef<int64_t> writeShape = readShapes[numInputs + i];
-      SmallVector<bool> inBounds(rank);
-      for (int64_t d = 0; d < rank; ++d) {
-        inBounds[d] =
-            destType.isStaticDim(d) && destType.getDimSize(d) >= writeShape[d];
-      }
-
-      auto write = vector::TransferWriteOp::create(rewriter, loc, result, dest,
-                                                   indices, inBounds);
-      if (!needsMasking) {
-        results.push_back(write.getResults().front());
-        continue;
-      }
-      auto vecType = cast<VectorType>(result.getType());
-      auto maskType =
-          vecType.cloneWith(/*shape=*/std::nullopt, rewriter.getI1Type());
-      SmallVector<OpFoldResult> mixedSizes =
-          tensor::getMixedSizes(rewriter, loc, dest);
-      Value mask =
-          vector::CreateMaskOp::create(rewriter, loc, maskType, mixedSizes);
-      results.push_back(
-          mlir::vector::maskOperation(rewriter, write, mask)->getResult(0));
+    for (auto [result, dest] :
+         llvm::zip_equal(newTiledOp.getResults(), tiledOp.getOutputs())) {
+      Operation *write = vector::createWriteOrMaskedWrite(
+          rewriter, loc, result, dest, /*writeIndices=*/{},
+          /*useInBoundsInsteadOfMasking=*/!needsMasking);
+      results.push_back(write->getResult(0));
     }
     return results;
   }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/190967 made the `createWriteOrMaskedWrite` utility available for downstream use. 

This is a follow up to https://github.com/iree-org/iree/pull/23935 and replaces custom logic for masked write in the vectorization of `inner_tiled` introduced in that PR with a use of the upstream utility.

The change is mostly NFC with one small exception: The upstream utility sets all `in_bounds` attributes to `true` if it uses masking, therefore one test needed updating. 

This is part of https://github.com/iree-org/iree/issues/23415.

Assisted-by: Claude Code