### PR TITLE
[Codegen][DMA] Defer no_reduce_shared_memory_bank_conflicts setting until DMA convertibility is verified

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -311,6 +311,10 @@ static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
     return false;
   }
 
+  if (!sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
+    return false;
+  }
+
   auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
   int64_t rank = outputType.getRank();
   ArrayRef<int64_t> shape = outputType.getShape();
@@ -615,9 +619,6 @@ protected:
   SmallVector<OpFoldResult>
   computeThreadNumThreads(OpBuilder &builder,
                           linalg::CopyOp copyOp) const override {
-    if (!sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
-      return {};
-    }
     auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
     return computeThreadNumThreadsImpl(builder, copyOp, outputType);
   }
@@ -633,11 +634,6 @@ struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
     // Only match copies with use_global_load_dma config.
     auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp);
     if (!config) {
-      return failure();
-    }
-
-    // Skip if source is not from fat_raw_buffer.
-    if (!sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
       return failure();
     }
 
@@ -858,6 +854,49 @@ struct ConvertGatherToCoalescedDMA
   }
 };
 
+/// Set no_reduce_shared_memory_bank_conflicts in the function's pipeline
+/// options. Rebuilds the immutable attribute chain.
+static void setNoReduceBankConflicts(FunctionOpInterface funcOp, bool value) {
+  IREE::Codegen::TranslationInfoAttr translationInfo =
+      getTranslationInfo(funcOp);
+  if (!translationInfo) {
+    return;
+  }
+  DictionaryAttr config = translationInfo.getConfiguration();
+  if (!config) {
+    return;
+  }
+
+  MLIRContext *context = funcOp->getContext();
+  StringRef key = IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName();
+  auto oldOptions =
+      dyn_cast_if_present<IREE::GPU::GPUPipelineOptionsAttr>(config.get(key));
+  if (!oldOptions) {
+    return;
+  }
+
+  auto newOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+      context, oldOptions.getPrefetchNumStages(),
+      Builder(context).getBoolAttr(value), oldOptions.getUseIgemmConvolution(),
+      oldOptions.getReorderWorkgroupsStrategy());
+
+  SmallVector<NamedAttribute> entries(config.getValue());
+  for (NamedAttribute &entry : entries) {
+    if (entry.getName() == key) {
+      entry = NamedAttribute(entry.getName(), newOptions);
+      break;
+    }
+  }
+
+  (void)setTranslationInfo(funcOp,
+                           IREE::Codegen::TranslationInfoAttr::get(
+                               context, translationInfo.getPassPipeline(),
+                               translationInfo.getCodegenSpec(),
+                               translationInfo.getWorkgroupSize(),
+                               translationInfo.getSubgroupSize(),
+                               DictionaryAttr::get(context, entries)));
+}
+
 struct GPUConvertToCoalescedDMAPass final
     : impl::GPUConvertToCoalescedDMAPassBase<GPUConvertToCoalescedDMAPass> {
   using GPUConvertToCoalescedDMAPassBase::GPUConvertToCoalescedDMAPassBase;
@@ -900,6 +939,8 @@ struct GPUConvertToCoalescedDMAPass final
         if (allConvertible) {
           setLoweringConfig(copyOp,
                             IREE::GPU::UseGlobalLoadDMAAttr::get(context));
+          // When DMA is used, skip bank conflict padding.
+          setNoReduceBankConflicts(funcOp, /*value=*/true);
         } else {
           setLoweringConfig(copyOp,
                             IREE::GPU::DerivedThreadConfigAttr::get(context));
@@ -1137,7 +1178,7 @@ private:
     funcOp->walk([&](Operation *op) {
       if (auto copyOp = dyn_cast<linalg::CopyOp>(op)) {
         auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(op);
-        if (!config || !sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
+        if (!config) {
           return;
         }
         auto parentForall = op->getParentOfType<scf::ForallOp>();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
@@ -167,6 +169,24 @@ struct GPUReduceBankConflictsPass final
 
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
+
+    // Check if bank conflict reduction was explicitly disabled at runtime
+    // (e.g., by GPUConvertToCoalescedDMA after verifying DMA convertibility).
+    if (IREE::Codegen::TranslationInfoAttr translationInfo =
+            getTranslationInfo(funcOp)) {
+      if (DictionaryAttr config = translationInfo.getConfiguration()) {
+        auto pipelineOptionsAttr =
+            dyn_cast_if_present<IREE::GPU::GPUPipelineOptionsAttr>(config.get(
+                IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()));
+        if (pipelineOptionsAttr) {
+          BoolAttr noReduce =
+              pipelineOptionsAttr.getNoReduceSharedMemoryBankConflicts();
+          if (noReduce && noReduce.getValue()) {
+            return;
+          }
+        }
+      }
+    }
 
     IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
     unsigned sharedMemLimit =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -9,8 +9,9 @@
 >>
 
 #exec_target_copy = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_copy}>
-#translation_copy = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 512, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_copy = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 512, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = true
 // CHECK-LABEL: func.func @copy
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x512xf32>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x512xf32>
@@ -58,8 +59,9 @@ func.func @copy(%source: tensor<64x512xf32>, %init: tensor<64x512xf32>) -> tenso
 >>
 
 #exec_target_gather = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_gather}>
-#translation_gather = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1024, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_gather = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1024, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = false
 // CHECK-LABEL: func.func @gather
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x512xf32>
 // CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]: tensor<64xi32>
@@ -112,8 +114,9 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
 >>
 
 #exec_target_small_inner = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_small_inner}>
-#translation_small_inner = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_small_inner = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = false
 // CHECK-LABEL: func.func @copy_small_innermost_dim
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x32xf32>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x32xf32>
@@ -149,8 +152,9 @@ func.func @copy_small_innermost_dim(%source: tensor<64x32xf32>, %init: tensor<64
 >>
 
 #exec_target_not_aligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_not_aligned}>
-#translation_not_aligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_not_aligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = false
 // CHECK-LABEL: func.func @copy_not_aligned_to_dma
 // CHECK-SAME:    %[[SRC_BUF:[a-zA-Z0-9]+]]: memref<320xbf16, #amdgpu.address_space<fat_raw_buffer>>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<320xbf16>
@@ -185,8 +189,9 @@ func.func @copy_not_aligned_to_dma(%source_buffer: memref<320xbf16, #amdgpu.addr
 >>
 
 #exec_target_contiguous = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_contiguous}>
-#translation_contiguous = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_contiguous = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = true
 // CHECK-LABEL: func.func @copy_prefer_contiguous_subview
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x128xf32>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x128xf32>
@@ -460,8 +465,9 @@ func.func @copy_with_extract_slice_input(%large_source: tensor<256x128xf32>) -> 
 >>
 
 #exec_target_pad = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad}>
-#translation_pad = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_pad = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = true
 // CHECK-LABEL: func.func @copy_with_tensor_pad_fusion
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<121x64xf32>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x64xf32>
@@ -513,8 +519,9 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
 >>
 
 #exec_target_pad_multi_warp = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_multi_warp}>
-#translation_pad_multi_warp = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_pad_multi_warp = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = true
 // CHECK-LABEL: func.func @copy_with_tensor_pad_fusion_multi_warp
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<121x64xf32>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x64xf32>
@@ -579,8 +586,9 @@ func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %
 >>
 
 #exec_target_pad_unaligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_unaligned}>
-#translation_pad_unaligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_pad_unaligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = false
 // CHECK-LABEL: func.func @copy_with_tensor_pad_unaligned_row
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<65x121xf16>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x124xf16>
@@ -672,8 +680,9 @@ func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %
 >>
 
 #exec_target_fat_raw = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_fat_raw}>
-#translation_fat_raw = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_fat_raw = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = true
 // CHECK-LABEL: func.func @copy_from_fat_raw_buffer
 // CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<64x512xbf16, #amdgpu.address_space<fat_raw_buffer>>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x512xbf16>
@@ -714,8 +723,9 @@ func.func @copy_from_fat_raw_buffer(
 >>
 
 #exec_target_fat_raw_small = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_fat_raw_small}>
-#translation_fat_raw_small = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_fat_raw_small = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = true
 // CHECK-LABEL: func.func @copy_from_fat_raw_buffer_small
 // CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<4x256xbf16, #amdgpu.address_space<fat_raw_buffer>>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x256xbf16>
@@ -756,8 +766,9 @@ func.func @copy_from_fat_raw_buffer_small(
 >>
 
 #exec_target_storage_buf = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_storage_buf}>
-#translation_storage_buf = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_storage_buf = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = false
 // CHECK-LABEL: func.func @copy_from_non_fat_raw_buffer
 // CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<64x512xbf16, #hal.descriptor_type<storage_buffer>>
 // CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x512xbf16>
@@ -800,8 +811,9 @@ func.func @copy_from_non_fat_raw_buffer(
 >>
 
 #exec_target_dtl = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_dtl}>
-#translation_dtl = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+#translation_dtl = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 
+// CHECK: no_reduce_shared_memory_bank_conflicts = false
 // CHECK-LABEL: func.func @copy_from_dispatch_tensor_load
 func.func @copy_from_dispatch_tensor_load(%init: tensor<64x512xbf16>) -> tensor<64x512xbf16>
   attributes {hal.executable.target = #exec_target_dtl, translation_info = #translation_dtl} {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -557,6 +557,12 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
+struct GemmLoweringConfig {
+  LoweringConfigAttr loweringConfig;
+  int64_t flatWorkgroupSize;
+  bool useSwizzle;
+};
+
 /// Create a lowering config for matmul or IGEMM convolution based on iteration
 /// bounds and indexing maps for a given target. This function computes
 /// contraction dimensions and deduces an MMA intrinsic schedule to choose tile
@@ -568,8 +574,7 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
 /// global memory (matmul_accumulate) vs zero-initialized in registers. When
 /// true, the accumulator needs shared memory, similar to when padding requires
 /// C promotion.
-static FailureOr<std::pair<LoweringConfigAttr, int64_t>>
-getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
+static FailureOr<GemmLoweringConfig> getMatmulOrIGEMMLoweringConfig(
     ArrayRef<int64_t> bounds, ArrayRef<AffineMap> maps,
     ArrayRef<Value> operands, IREE::GPU::TargetAttr target, bool isGemm,
     bool scaled, bool useDirectLoad, int64_t prefetchNumStages,
@@ -876,6 +881,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   // Use global load DMA attribute (subgroup sizes will be derived from
   // translation_info).
   SmallVector<Attribute> promotionArray;
+  bool useSwizzle = false;
   if (useDirectLoad) {
     Attribute lhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
@@ -913,6 +919,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     } else {
       promotionArray = {*lhsSwizzleAttr, *rhsSwizzleAttr, defaultConfigAttr,
                         defaultConfigAttr};
+      useSwizzle = true;
     }
   }
 
@@ -952,7 +959,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
       ShapedType::getNumElements(schedule->nSubgroupCounts) *
       ShapedType::getNumElements(schedule->mSubgroupCounts);
 
-  return std::pair{loweringConfig, flatWorkgroupSize};
+  return GemmLoweringConfig{loweringConfig, flatWorkgroupSize, useSwizzle};
 }
 
 LogicalResult setIGEMMConvolutionLoweringConfig(
@@ -1027,22 +1034,21 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
       cast<DestinationStyleOpInterface>(linalgOp.getOperation()));
   // Default to 2 stages if not specified.
   int64_t prefetchStages = prefetchNumStages.value_or(2);
-  FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
-      getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
-          igemmLoopBounds, igemmContractionMaps, igemmOperands, target,
-          /*isGemm=*/false, /*scaled=*/false, useDirectLoad, prefetchStages,
-          splitReductionTripCnt, hasExistingAccumulator, convToIgemmInfo);
-  if (failed(configAndWgSize)) {
+  FailureOr<GemmLoweringConfig> info = getMatmulOrIGEMMLoweringConfig(
+      igemmLoopBounds, igemmContractionMaps, igemmOperands, target,
+      /*isGemm=*/false, /*scaled=*/false, useDirectLoad, prefetchStages,
+      splitReductionTripCnt, hasExistingAccumulator, convToIgemmInfo);
+  if (failed(info)) {
     return failure();
   }
-  std::array<int64_t, 3> workgroupSize = {configAndWgSize->second, 1, 1};
-  LoweringConfigAttr loweringConfig = configAndWgSize->first;
+  auto [loweringConfig, flatWgSize, useSwizzle] = *info;
+  std::array<int64_t, 3> workgroupSize = {flatWgSize, 1, 1};
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       linalgOp->getContext(),
       /*prefetchNumStages=*/prefetchStages,
-      /*no_reduce_shared_memory_bank_conflicts=*/useDirectLoad,
+      /*no_reduce_shared_memory_bank_conflicts=*/useSwizzle,
       /*use_igemm_convolution=*/true,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(
@@ -1094,35 +1100,33 @@ setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
   int64_t prefetchStages = prefetchNumStages.value_or(2);
 
   bool isScaled = false;
-  FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
-      getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
-          bounds, maps, operands, target, /*isGemm=*/true, isScaled,
-          useDirectLoad, prefetchStages, splitReductionTripCnt,
-          hasExistingAccumulator);
+  FailureOr<GemmLoweringConfig> info = getMatmulOrIGEMMLoweringConfig(
+      bounds, maps, operands, target, /*isGemm=*/true, isScaled, useDirectLoad,
+      prefetchStages, splitReductionTripCnt, hasExistingAccumulator);
 
   // TODO (muzasyed) : add generalization for scaled and nonscaled versions of
   // matmul lowering.
-  if (failed(configAndWgSize)) {
+  if (failed(info)) {
     // TODO (muzasyed) : Perform padding appropriately for minimizing bank
     // conflicts when dealing with scaled matmuls. For now it is disabled.
     isScaled = true;
-    configAndWgSize = getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
+    info = getMatmulOrIGEMMLoweringConfig(
         bounds, maps, operands, target, /*isGemm=*/true, isScaled,
         useDirectLoad, prefetchStages, splitReductionTripCnt,
         hasExistingAccumulator);
   }
 
-  if (failed(configAndWgSize)) {
+  if (failed(info)) {
     return failure();
   }
-  std::array<int64_t, 3> workgroupSize = {configAndWgSize->second, 1, 1};
-  LoweringConfigAttr loweringConfig = configAndWgSize->first;
+  auto [loweringConfig, flatWgSize, useSwizzle] = *info;
+  std::array<int64_t, 3> workgroupSize = {flatWgSize, 1, 1};
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       linalgOp->getContext(),
       /*prefetchNumStages=*/prefetchStages,
-      /*no_reduce_shared_memory_bank_conflicts=*/useDirectLoad || isScaled,
+      /*no_reduce_shared_memory_bank_conflicts=*/useSwizzle,
       /*use_igemm_convolution=*/false,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(


### PR DESCRIPTION
Previously, `no_reduce_shared_memory_bank_conflicts` (disable padding) was set during lowering strategy selection based on `useDirectLoad`. This caused a performance gap: when DMA was requested but later demoted silently to stream copy `GPUConvertToCoalescedDMA`. Note swizzle is not always feasible (e.g., transposed LHS), so disabling padding too early left
some kernels with no bank conflict mitigation at all.

This PR defers the padding decision until DMA convertibility is verified. Additionally, `sourceIsFromFatRawBuffer` is now part of convertibility check.

Assisted-by: Cursor (Claude)