### PR TITLE
Allow 128 workers per executor (just an experiment)

### DIFF
--- a/runtime/src/iree/async/util/proactor_pool.c
+++ b/runtime/src/iree/async/util/proactor_pool.c
@@ -141,7 +141,17 @@ iree_status_t iree_async_proactor_pool_create(
   // Initialize node IDs. Proactors and runners are created on-demand when
   // pool_get or pool_get_for_node is first called for each entry.
   for (iree_host_size_t i = 0; i < node_count; ++i) {
-    pool->entries[i].node_id = node_ids ? node_ids[i] : UINT32_MAX;
+    if (node_ids) {
+      pool->entries[i].node_id = node_ids[i];
+    } else if (node_count > 1) {
+      // Distinct IDs so iree_async_proactor_pool_get_for_node can route each
+      // NUMA node to its own proactor when callers pass OS node IDs (e.g. from
+      // task executors). Single-node pools keep UINT32_MAX below so poll
+      // runners stay unpinned by default.
+      pool->entries[i].node_id = (uint32_t)i;
+    } else {
+      pool->entries[i].node_id = UINT32_MAX;
+    }
   }
 
   *out_pool = pool;

--- a/runtime/src/iree/async/util/proactor_pool.h
+++ b/runtime/src/iree/async/util/proactor_pool.h
@@ -99,8 +99,10 @@ typedef struct iree_async_proactor_pool_t iree_async_proactor_pool_t;
 //
 // If |node_ids| is non-NULL, it must point to |node_count| NUMA node IDs.
 // When a runner is created on-demand, the node ID is passed to the runner
-// factory for NUMA-aware pinning. If |node_ids| is NULL, runners get no
-// affinity hint (suitable for single-node systems).
+// factory for NUMA-aware pinning. If |node_ids| is NULL and |node_count| is 1,
+// entries use UINT32_MAX so runners get no affinity hint. If |node_ids| is NULL
+// and |node_count| > 1, entries use 0..node_count-1 so pool_get_for_node can
+// match OS NUMA node IDs and runners can be pinned per node.
 //
 // The pool retains all created proactors and runners. Releasing the pool (when
 // the ref count reaches zero) stops all runners and releases all proactors.

--- a/runtime/src/iree/async/util/proactor_pool_test.cc
+++ b/runtime/src/iree/async/util/proactor_pool_test.cc
@@ -84,6 +84,33 @@ TEST_F(ProactorPoolTest, OnDemandGet) {
   iree_async_proactor_pool_release(pool);
 }
 
+TEST_F(ProactorPoolTest, CreateMultiNodeNoNodeIdsUsesSequentialNodeIds) {
+  iree_async_proactor_pool_t* pool = nullptr;
+  IREE_ASSERT_OK(iree_async_proactor_pool_create(
+      2, /*node_ids=*/nullptr, default_options(), iree_allocator_system(),
+      &pool));
+  ASSERT_NE(pool, nullptr);
+  EXPECT_EQ(iree_async_proactor_pool_node_id(pool, 0), 0u);
+  EXPECT_EQ(iree_async_proactor_pool_node_id(pool, 1), 1u);
+
+  iree_async_proactor_t* by_node_0 = nullptr;
+  iree_async_proactor_t* by_node_1 = nullptr;
+  iree_status_t status =
+      iree_async_proactor_pool_get_for_node(pool, 0, &by_node_0);
+  if (iree_status_is_unavailable(status)) {
+    iree_status_ignore(status);
+    iree_async_proactor_pool_release(pool);
+    GTEST_SKIP() << "Platform proactor unavailable";
+  }
+  IREE_ASSERT_OK(status);
+  IREE_ASSERT_OK(iree_async_proactor_pool_get_for_node(pool, 1, &by_node_1));
+  EXPECT_NE(by_node_0, nullptr);
+  EXPECT_NE(by_node_1, nullptr);
+  EXPECT_NE(by_node_0, by_node_1);
+
+  iree_async_proactor_pool_release(pool);
+}
+
 TEST_F(ProactorPoolTest, CreateWithNodeIds) {
   uint32_t node_ids[] = {0, 1};
   iree_async_proactor_pool_t* pool = nullptr;

--- a/runtime/src/iree/task/BUILD.bazel
+++ b/runtime/src/iree/task/BUILD.bazel
@@ -87,6 +87,10 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/threading",
         "//runtime/src/iree/base/threading:thread",
     ],
+    linkopts = select({
+        "@platforms//os:linux": ["-latomic"],
+        "//conditions:default": [],
+    }),
 )
 
 iree_runtime_cc_test(

--- a/runtime/src/iree/task/CMakeLists.txt
+++ b/runtime/src/iree/task/CMakeLists.txt
@@ -204,6 +204,12 @@ iree_cc_test(
 # 3. Platform-specific (Darwin, Windows, Emscripten)
 # 4. Fallback (single-threaded conservative topology)
 
+# 128-bit worker affinity masks use libatomic-provided __atomic_*_16 on Linux when
+# Clang does not emit inline lock-free sequences for _Atomic unsigned __int128.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(iree_task_task PUBLIC atomic)
+endif()
+
 if(IREE_ENABLE_CPUINFO)
   target_compile_definitions(iree_task_task PRIVATE IREE_TASK_USE_CPUINFO=1)
   message(STATUS "IREE task topology: using cpuinfo")

--- a/runtime/src/iree/task/affinity_set.h
+++ b/runtime/src/iree/task/affinity_set.h
@@ -7,8 +7,11 @@
 #ifndef IREE_TASK_AFFINITY_SET_H_
 #define IREE_TASK_AFFINITY_SET_H_
 
+#include <limits.h>
+
 #include "iree/base/internal/atomics.h"
 #include "iree/base/internal/math.h"
+#include "iree/base/target_platform.h"
 #include "iree/task/tuning.h"
 
 #ifdef __cplusplus
@@ -25,7 +28,140 @@ extern "C" {
 // iree_task_affinity_set_t
 //===----------------------------------------------------------------------===//
 
+#if IREE_TASK_EXECUTOR_MAX_WORKER_COUNT > 64
+
+typedef unsigned __int128 iree_task_affinity_set_t;
+
+static_assert(sizeof(iree_task_affinity_set_t) == 16,
+              "task affinity masks must be 128-bit when MAX_WORKER_COUNT > 64");
+static_assert(IREE_TASK_EXECUTOR_MAX_WORKER_COUNT <=
+                  sizeof(iree_task_affinity_set_t) * CHAR_BIT,
+              "worker count cannot exceed affinity mask width");
+
+// Allows for only a specific worker to be selected.
+static inline iree_task_affinity_set_t iree_task_affinity_for_worker(
+    uint8_t worker_index) {
+  return (iree_task_affinity_set_t)1 << worker_index;
+}
+
+// Allows for a range of workers to be selected.
+static inline iree_task_affinity_set_t iree_task_affinity_for_worker_range(
+    uint8_t worker_start, uint8_t worker_end) {
+  return (((iree_task_affinity_set_t)1 << (worker_start - 1)) - 1) ^
+         (((iree_task_affinity_set_t)1 << worker_end) - 1);
+}
+
+static inline iree_task_affinity_set_t iree_task_private_affinity_set_ones(
+    uint32_t count) {
+  if (count == 0) return 0;
+  if (count >= sizeof(iree_task_affinity_set_t) * CHAR_BIT) {
+    return ~(iree_task_affinity_set_t)0;
+  }
+  return ((iree_task_affinity_set_t)1 << count) - 1;
+}
+
+// Allows for any worker to be selected (all bits up to MAX_WORKER_COUNT).
+static inline iree_task_affinity_set_t iree_task_affinity_for_any_worker(void) {
+  return iree_task_private_affinity_set_ones(
+      IREE_TASK_EXECUTOR_MAX_WORKER_COUNT);
+}
+
+#define iree_task_affinity_set_ones(count) \
+  iree_task_private_affinity_set_ones(count)
+
+static inline int iree_task_private_affinity_set_count_leading_zeros_u128(
+    iree_task_affinity_set_t set) {
+  if (set == 0) return 128;
+  uint64_t lo = (uint64_t)set;
+  uint64_t hi = (uint64_t)(set >> 64);
+  if (hi) {
+    return iree_math_count_leading_zeros_u64(hi);
+  }
+  return 64 + iree_math_count_leading_zeros_u64(lo);
+}
+
+static inline int iree_task_private_affinity_set_count_trailing_zeros_u128(
+    iree_task_affinity_set_t set) {
+  if (set == 0) return 128;
+  uint64_t lo = (uint64_t)set;
+  if (lo) {
+    return iree_math_count_trailing_zeros_u64(lo);
+  }
+  return 64 + iree_math_count_trailing_zeros_u64((uint64_t)(set >> 64));
+}
+
+static inline int iree_task_private_affinity_set_count_ones_u128(
+    iree_task_affinity_set_t set) {
+  uint64_t lo = (uint64_t)set;
+  uint64_t hi = (uint64_t)(set >> 64);
+  return iree_math_count_ones_u64(lo) + iree_math_count_ones_u64(hi);
+}
+
+static inline iree_task_affinity_set_t iree_task_private_affinity_set_rotr_u128(
+    iree_task_affinity_set_t n, uint32_t c) {
+  const uint32_t mask = (uint32_t)(sizeof(n) * CHAR_BIT - 1);
+  c &= mask;
+  if (!c) return n;
+  return (n >> c) | (n << ((-c) & mask));
+}
+
+#define iree_task_affinity_set_count_leading_zeros(set) \
+  iree_task_private_affinity_set_count_leading_zeros_u128(set)
+#define iree_task_affinity_set_count_trailing_zeros(set) \
+  iree_task_private_affinity_set_count_trailing_zeros_u128(set)
+#define iree_task_affinity_set_count_ones(set) \
+  iree_task_private_affinity_set_count_ones_u128(set)
+#define iree_task_affinity_set_rotr(set, count) \
+  iree_task_private_affinity_set_rotr_u128((set), (count))
+
+//===----------------------------------------------------------------------===//
+// iree_atomic_task_affinity_set_t
+//===----------------------------------------------------------------------===//
+
+typedef _Atomic unsigned __int128 iree_atomic_task_affinity_set_t;
+
+// Clang warns about 16-byte atomics when __atomic_always_lock_free is false for
+// the translation unit's assumptions, but on x86-64 these lower to lock-free
+// instructions when the object is 16-byte aligned (which the type guarantees).
+#if defined(IREE_COMPILER_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Watomic-alignment"
+#endif  // IREE_COMPILER_CLANG
+
+static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_load(
+    iree_atomic_task_affinity_set_t* set, iree_memory_order_t order) {
+  return iree_atomic_load(set, order);
+}
+
+static inline void iree_atomic_task_affinity_set_store(
+    iree_atomic_task_affinity_set_t* set, iree_task_affinity_set_t value,
+    iree_memory_order_t order) {
+  iree_atomic_store(set, value, order);
+}
+
+static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_fetch_and(
+    iree_atomic_task_affinity_set_t* set, iree_task_affinity_set_t value,
+    iree_memory_order_t order) {
+  return iree_atomic_fetch_and(set, value, order);
+}
+
+static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_fetch_or(
+    iree_atomic_task_affinity_set_t* set, iree_task_affinity_set_t value,
+    iree_memory_order_t order) {
+  return iree_atomic_fetch_or(set, value, order);
+}
+
+#if defined(IREE_COMPILER_CLANG)
+#pragma clang diagnostic pop
+#endif  // IREE_COMPILER_CLANG
+
+#else  // IREE_TASK_EXECUTOR_MAX_WORKER_COUNT <= 64
+
 typedef uint64_t iree_task_affinity_set_t;
+
+static_assert(IREE_TASK_EXECUTOR_MAX_WORKER_COUNT <=
+                  sizeof(iree_task_affinity_set_t) * CHAR_BIT,
+              "worker count cannot exceed affinity mask width");
 
 // Allows for only a specific worker to be selected.
 static inline iree_task_affinity_set_t iree_task_affinity_for_worker(
@@ -57,7 +193,7 @@ static inline iree_task_affinity_set_t iree_task_affinity_for_any_worker(void) {
 // iree_atomic_task_affinity_set_t
 //===----------------------------------------------------------------------===//
 
-typedef iree_atomic_int64_t iree_atomic_task_affinity_set_t;
+typedef iree_atomic_uint64_t iree_atomic_task_affinity_set_t;
 
 static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_load(
     iree_atomic_task_affinity_set_t* set, iree_memory_order_t order) {
@@ -81,6 +217,8 @@ static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_fetch_or(
     iree_memory_order_t order) {
   return iree_atomic_fetch_or(set, value, order);
 }
+
+#endif  // IREE_TASK_EXECUTOR_MAX_WORKER_COUNT > 64
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -85,10 +85,14 @@ IREE_FLAG(
 
 IREE_FLAG_LIST(
     string, task_topology_cpu_ids,
-    "A list of absolute logical CPU IDs to use for a single topology. One\n"
-    "topology will be created for each repetition of the flag. CPU IDs match\n"
-    "the Linux logical CPU ID scheme (as used by lscpu/lstopo) or a flattened\n"
-    "[0, total_processor_count) range on Windows.");
+    "Comma-separated logical CPU IDs for one task executor topology (one "
+    "worker\n"
+    "per ID). Repeat the flag to create multiple executors/queues, e.g. one\n"
+    "list per NUMA node. CPU IDs follow the Linux scheme from lscpu/lstopo, "
+    "or\n"
+    "a flattened [0, total_processor_count) range on Windows. There is no\n"
+    "requirement that IDs belong to one node or one core; duplicates are\n"
+    "allowed but usually undesirable.");
 
 IREE_FLAG(
     string, task_topology_nodes, "current",
@@ -330,8 +334,9 @@ static void iree_task_flags_dump_task_topology(
                IREE_TASK_TOPOLOGY_GROUP_MASK_ALL) {
       fprintf(stdout, "(all/undefined)\n");
     } else {
-      fprintf(stdout, "%d group(s): ",
-              iree_math_count_ones_u64(group->constructive_sharing_mask));
+      fprintf(
+          stdout, "%d group(s): ",
+          iree_task_affinity_set_count_ones(group->constructive_sharing_mask));
       for (iree_host_size_t ic = 0, jc = 0;
            ic < IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT; ++ic) {
         if ((group->constructive_sharing_mask >> ic) & 1) {

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -474,7 +474,7 @@ static iree_task_t* iree_task_executor_try_steal_task_from_affinity_set(
     iree_task_executor_t* executor, iree_task_affinity_set_t victim_mask,
     uint32_t max_theft_attempts, int rotation_offset,
     iree_task_queue_t* local_task_queue) {
-  if (!victim_mask) return NULL;
+  if (victim_mask == 0) return NULL;
   max_theft_attempts = iree_min(max_theft_attempts,
                                 iree_task_affinity_set_count_ones(victim_mask));
   victim_mask = iree_task_affinity_set_rotr(victim_mask, rotation_offset);

--- a/runtime/src/iree/task/post_batch.c
+++ b/runtime/src/iree/task/post_batch.c
@@ -95,7 +95,8 @@ void iree_task_post_batch_enqueue(iree_task_post_batch_t* post_batch,
 static void iree_task_post_batch_wake_workers(
     iree_task_post_batch_t* post_batch, iree_task_affinity_set_t wake_mask) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, iree_math_count_ones_u64(wake_mask));
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(
+      z0, iree_task_affinity_set_count_ones(wake_mask));
 
   // TODO(#4016): use a FUTEX_WAKE_BITSET here to wake all of the workers that
   // have pending work in a single syscall (vs. popcnt(worker_pending_mask)

--- a/runtime/src/iree/task/task.h
+++ b/runtime/src/iree/task/task.h
@@ -165,9 +165,17 @@ struct iree_alignas(iree_max_align_t) iree_task_t {
 };
 static_assert(offsetof(iree_task_t, next_task) == 0,
               "next_task intrusive pointer must be at offset 0");
+#if IREE_TASK_EXECUTOR_MAX_WORKER_COUNT > 64
+// 128-bit affinity sets widen the header; keep a tight cap so pool footprint
+// stays predictable.
+static_assert(sizeof(iree_task_t) <= 96,
+              "the task header greatly influences pool sizes due to alignment "
+              "requirements and should be kept tiny");
+#else
 static_assert(sizeof(iree_task_t) <= 64,
               "the task header greatly influences pool sizes due to alignment "
               "requirements and should be kept tiny");
+#endif  // IREE_TASK_EXECUTOR_MAX_WORKER_COUNT
 
 // Initializes a task header with the given type.
 // Must be called on all tasks to ensure proper dependency tracking and list

--- a/runtime/src/iree/task/topology.c
+++ b/runtime/src/iree/task/topology.c
@@ -130,11 +130,12 @@ iree_status_t iree_task_topology_initialize_from_thread_affinities(
     iree_task_topology_t* out_topology) {
   // Today we have a fixed limit on the number of groups within a particular
   // topology.
-  if (group_count >= IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
+  if (group_count > IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "too many groups specified (%" PRIhsz
                             " provided for a max capacity of %zu)",
-                            group_count, IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
+                            group_count,
+                            (size_t)IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/task/topology.h
+++ b/runtime/src/iree/task/topology.h
@@ -13,7 +13,7 @@
 
 #include "iree/base/api.h"
 #include "iree/base/threading/thread.h"
-#include "iree/task/tuning.h"
+#include "iree/task/affinity_set.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,13 +41,24 @@ iree_task_topology_node_id_t iree_task_topology_query_current_node(void);
 // Topology group (worker thread(s) assigned to a processor)
 //===----------------------------------------------------------------------===//
 
-// A bitmask indicating which other groups from 0 to N may constructively share
-// caches. For example, a value of 0b1100 indicates that group 2 and 3 share.
-typedef uint64_t iree_task_topology_group_mask_t;
+// A bitmask indicating which other groups from 0 to N may constructively
+// share caches. Width matches `iree_task_affinity_set_t` / executor worker
+// indices (64-bit on most platforms, 128-bit on x86-64 with __int128).
+typedef iree_task_affinity_set_t iree_task_topology_group_mask_t;
 
-#define IREE_TASK_TOPOLOGY_GROUP_MASK_ALL UINT64_MAX
+// All bits valid for the configured maximum worker/group count.
+#define IREE_TASK_TOPOLOGY_GROUP_MASK_ALL \
+  ((iree_task_topology_group_mask_t) - 1)
+
 #define IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT \
-  (sizeof(iree_task_topology_group_mask_t) * 8)
+  (sizeof(iree_task_topology_group_mask_t) * CHAR_BIT)
+
+// Single-group bit for |group_index| in [0,
+// IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT).
+static inline iree_task_topology_group_mask_t iree_task_topology_group_bit(
+    iree_host_size_t group_index) {
+  return (iree_task_topology_group_mask_t)1 << group_index;
+}
 
 // Total cache sizes (that we care about).
 // More information may be available but we shouldn't be specializing on it

--- a/runtime/src/iree/task/topology_cpuinfo.c
+++ b/runtime/src/iree/task/topology_cpuinfo.c
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/base/internal/math.h"
 #include "iree/task/topology.h"
 
 #if defined(IREE_TASK_USE_CPUINFO)
@@ -155,15 +154,15 @@ static void iree_task_topology_group_initialize_from_core(
 }
 
 // Returns a bitset with all *processors* that share the same |cache|.
-static uint64_t iree_task_topology_calculate_cache_bits(
+static iree_task_topology_group_mask_t iree_task_topology_calculate_cache_bits(
     const struct cpuinfo_cache* cache) {
   if (!cache) return 0;
-  uint64_t mask = 0;
+  iree_task_topology_group_mask_t mask = 0;
   for (uint32_t processor_i = 0; processor_i < cache->processor_count;
        ++processor_i) {
     uint32_t i = cache->processor_start + processor_i;
     if (i < IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
-      mask |= 1ull << i;
+      mask |= (iree_task_topology_group_mask_t)1 << i;
     }
   }
   return mask;
@@ -171,9 +170,10 @@ static uint64_t iree_task_topology_calculate_cache_bits(
 
 // Constructs a constructive sharing mask for all *processors* that share the
 // same cache as the specified |processor|.
-static uint64_t iree_task_topology_calculate_constructive_sharing_mask(
+static iree_task_topology_group_mask_t
+iree_task_topology_calculate_constructive_sharing_mask(
     const struct cpuinfo_processor* processor) {
-  uint64_t mask = 0;
+  iree_task_topology_group_mask_t mask = 0;
   mask |= iree_task_topology_calculate_cache_bits(processor->cache.l1i);
   mask |= iree_task_topology_calculate_cache_bits(processor->cache.l1d);
   mask |= iree_task_topology_calculate_cache_bits(processor->cache.l2);
@@ -190,22 +190,25 @@ iree_status_t iree_task_topology_fixup_constructive_sharing_masks(
     return iree_ok_status();
   }
 
-  // O(n^2), but n is always <= 64 (and often <= 8).
+  // O(n^2), but n is modest (physical core count on the node).
   for (iree_host_size_t i = 0; i < topology->group_count; ++i) {
     iree_task_topology_group_t* group = &topology->groups[i];
 
     // Compute the processors that we can constructively share with.
-    uint64_t constructive_sharing_mask =
+    iree_task_topology_group_mask_t constructive_sharing_mask =
         iree_task_topology_calculate_constructive_sharing_mask(
             cpuinfo_get_processor(group->processor_index));
 
     iree_task_topology_group_mask_t group_mask = 0;
     for (iree_host_size_t j = 0; j < topology->group_count; ++j) {
       const iree_task_topology_group_t* other_group = &topology->groups[j];
-      uint64_t group_processor_bits =
-          iree_math_rotl_u64(1ull, other_group->processor_index);
+      if (other_group->processor_index >= IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
+        continue;
+      }
+      iree_task_topology_group_mask_t group_processor_bits =
+          (iree_task_topology_group_mask_t)1 << other_group->processor_index;
       if (constructive_sharing_mask & group_processor_bits) {
-        group_mask |= iree_math_rotl_u64(1ull, other_group->group_index);
+        group_mask |= iree_task_topology_group_bit(other_group->group_index);
       }
     }
 
@@ -226,11 +229,12 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
 
   // Today we have a fixed limit on the number of groups within a particular
   // topology.
-  if (cpu_count >= IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
+  if (cpu_count > IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "too many CPUs specified (%" PRIhsz
                             " provided for a max capacity of %zu)",
-                            cpu_count, IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
+                            cpu_count,
+                            (size_t)IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
   }
 
   // Validate the CPU IDs provided.
@@ -256,6 +260,24 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
         cpuinfo_get_processor(cpu_ids[i]);
     iree_task_topology_group_initialize_from_processor(
         i, processor, &out_topology->groups[i]);
+  }
+
+  if (cpu_count > 0) {
+    const struct cpuinfo_processor* p0 = cpuinfo_get_processor(cpu_ids[0]);
+    if (p0 && p0->cluster) {
+      uint32_t common_node = p0->cluster->cluster_id;
+      bool have_common = true;
+      for (iree_host_size_t i = 1; i < cpu_count; ++i) {
+        const struct cpuinfo_processor* p = cpuinfo_get_processor(cpu_ids[i]);
+        if (!p || !p->cluster || p->cluster->cluster_id != common_node) {
+          have_common = false;
+          break;
+        }
+      }
+      if (have_common) {
+        out_topology->node_id = common_node;
+      }
+    }
   }
 
   iree_status_t status =

--- a/runtime/src/iree/task/topology_emscripten.c
+++ b/runtime/src/iree/task/topology_emscripten.c
@@ -33,11 +33,12 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
     iree_task_topology_t* out_topology) {
   // Today we have a fixed limit on the number of groups within a particular
   // topology.
-  if (cpu_count >= IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
+  if (cpu_count > IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "too many CPUs specified (%" PRIhsz
                             " provided for a max capacity of %zu)",
-                            cpu_count, IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
+                            cpu_count,
+                            (size_t)IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/task/topology_fallback.c
+++ b/runtime/src/iree/task/topology_fallback.c
@@ -57,11 +57,12 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
     iree_task_topology_t* out_topology) {
   // Today we have a fixed limit on the number of groups within a particular
   // topology.
-  if (cpu_count >= IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
+  if (cpu_count > IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "too many CPUs specified (%" PRIhsz
                             " provided for a max capacity of %zu)",
-                            cpu_count, IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
+                            cpu_count,
+                            (size_t)IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/task/topology_sysfs.c
+++ b/runtime/src/iree/task/topology_sysfs.c
@@ -431,7 +431,7 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
 // back to L2 if L3 is not available.
 iree_status_t iree_task_topology_fixup_constructive_sharing_masks(
     iree_task_topology_t* topology) {
-  // O(n^2), but n is always <= 64 (and often <= 8).
+  // O(n^2), but n is modest (physical core count on the node).
   for (iree_host_size_t i = 0; i < topology->group_count; ++i) {
     iree_task_topology_group_t* group = &topology->groups[i];
     uint32_t processor = group->processor_index;
@@ -449,7 +449,7 @@ iree_status_t iree_task_topology_fixup_constructive_sharing_masks(
         const iree_task_topology_group_t* other_group = &topology->groups[j];
         uint32_t other_processor = other_group->processor_index;
         if (CPU_ISSET(other_processor, &processor_sharing_mask)) {
-          group_mask |= 1ull << other_group->group_index;
+          group_mask |= iree_task_topology_group_bit(other_group->group_index);
         }
       }
     }
@@ -468,7 +468,8 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "too many CPUs specified (%" PRIhsz
                             " provided for a max capacity of %zu)",
-                            cpu_count, IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
+                            cpu_count,
+                            (size_t)IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
   }
   uint32_t processor_count = iree_sysfs_query_processor_count();
   if (processor_count == 0) {
@@ -513,6 +514,33 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
       group->ideal_thread_affinity.group = cluster_id;
     }
     iree_status_ignore(cluster_status);
+  }
+
+  // When every listed CPU maps to the same sysfs cluster / package, set the
+  // topology NUMA node so each executor routes async I/O to the matching
+  // proactor (see iree_async_proactor_pool_get_for_node). Mixed-node lists keep
+  // IREE_TASK_TOPOLOGY_NODE_ID_ANY.
+  if (cpu_count > 0) {
+    uint32_t common_node = 0;
+    bool have_common = true;
+    for (iree_host_size_t i = 0; i < cpu_count; ++i) {
+      uint32_t cid = 0;
+      iree_status_t nst = iree_sysfs_query_cluster_id(cpu_ids[i], &cid);
+      if (!iree_status_is_ok(nst) || !iree_sysfs_is_valid_cluster(cid)) {
+        iree_status_ignore(nst);
+        have_common = false;
+        break;
+      }
+      if (i == 0) {
+        common_node = cid;
+      } else if (cid != common_node) {
+        have_common = false;
+        break;
+      }
+    }
+    if (have_common) {
+      out_topology->node_id = common_node;
+    }
   }
 
   iree_status_t status =

--- a/runtime/src/iree/task/topology_win32.c
+++ b/runtime/src/iree/task/topology_win32.c
@@ -161,7 +161,8 @@ static void iree_task_topology_assign_constructive_sharing(
         iree_task_topology_group_t* other = &topology->groups[group_j];
         if (other->ideal_thread_affinity.group == group_mask.Group &&
             (group_mask.Mask & (1ull << other->ideal_thread_affinity.id))) {
-          group->constructive_sharing_mask |= 1ull << group_j;
+          group->constructive_sharing_mask |=
+              iree_task_topology_group_bit(group_j);
         }
       }
     }
@@ -251,11 +252,12 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
     iree_task_topology_t* out_topology) {
   // Today we have a fixed limit on the number of groups within a particular
   // topology.
-  if (cpu_count >= IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
+  if (cpu_count > IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "too many CPUs specified (%" PRIhsz
                             " provided for a max capacity of %zu)",
-                            cpu_count, IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
+                            cpu_count,
+                            (size_t)IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT);
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/task/tuning.h
+++ b/runtime/src/iree/task/tuning.h
@@ -7,15 +7,30 @@
 #ifndef IREE_TASK_TUNING_H_
 #define IREE_TASK_TUNING_H_
 
+#include "iree/base/config.h"
+#include "iree/base/target_platform.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
 // Maximum number of workers that an executor can manage.
-// A 64 worker hard limit is based on us using uint64_t as a bitmask to select
-// workers. It's easy to go smaller (just use fewer bits) if it's known that
-// only <64 will ever be used (such as for devices with 2 cores).
+//
+// On x86-64 with GCC or Clang we use a 128-bit worker bitmask (see
+// affinity_set.h) and allow up to 128 workers. Other architectures and
+// toolchains (including MSVC, which does not expose 128-bit integer atomics in
+// C for this use) keep the prior uint64_t / 64-worker limit.
+//
+// The thread-hostile atomics-disabled configuration only implements generic
+// atomics up to 64-bit, so keep the smaller limit there even on x86-64.
+#if defined(IREE_ARCH_X86_64) && defined(__SIZEOF_INT128__) &&      \
+    __SIZEOF_INT128__ == 16 &&                                      \
+    (defined(IREE_COMPILER_CLANG) || defined(IREE_COMPILER_GCC)) && \
+    !IREE_SYNCHRONIZATION_DISABLE_UNSAFE
+#define IREE_TASK_EXECUTOR_MAX_WORKER_COUNT (128)
+#else
 #define IREE_TASK_EXECUTOR_MAX_WORKER_COUNT (64)
+#endif  // x86-64 + __int128 + GCC/Clang + real atomics
 
 // Initial number of shard tasks that are allocated in the executor pool.
 // Increasing this number will decrease initial allocation storms in cases of

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -159,7 +159,7 @@ static void iree_task_worker_mark_active(iree_task_worker_t* worker) {
   (void)old_idle_mask;
   IREE_TRACE_PLOT_VALUE_F32(
       worker->executor->trace_name,
-      old_idle_mask
+      old_idle_mask != 0
           ? (100.0f -
              100.0f * (iree_task_affinity_set_count_ones(old_idle_mask) - 1) /
                  (float)worker->executor->worker_count)


### PR DESCRIPTION
This is just to unblock explorations of whether it's still true that 64 workers "ought to be enough for anybody".

This is discardable, vibe-coded junk. Don't read too much into the specific code changes, it is AI-generated and I only iterated on it until I would be able to run a iree-benchmark-module actually running 128 threads.

Note that this isn't attempting to solve the known issues described in https://github.com/iree-org/iree/issues/23395. For now, anyone trying to benchmark with many threads should use explicit `--task_topology_cpu_ids`.

Here's a sample benchmark. Note it directly uses `linalg.mmt4d`, not `linalg.matmul`, as that scales far better to many threads at the moment.

```mlir
util.func @mmt4d_bf16(%lhs: tensor<?x?x16x2xbf16>, %rhs: tensor<?x?x16x2xbf16>, %acc: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
  %result = linalg.mmt4d ins(%lhs, %rhs : tensor<?x?x16x2xbf16>, tensor<?x?x16x2xbf16>) outs(%acc : tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32>
  util.return %result: tensor<?x?x16x16xf32>
}
```

Compile:

```
tools/iree-compile ~/mmt4d_bf16.mlir -o /tmp/mmt4d_bf16.mlir.vmfb --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu=znver5 --iree-opt-data-tiling
```

Benchmark:

```
time tools/iree-benchmark-module --module=/tmp/mmt4d_bf16.mlir.vmfb --function=mmt4d_bf16 --input=512x4096x16x2xbf16 --input=512x4096x16x2xbf16 --input=512x512x16x16xf32 --device_allocator=caching --device=local-task --benchmark_min_time=3s --task_topology_cpu_ids="$(seq -s, 0 1 127)" 
```

The `time` at the start of the command is just to get a rough confirmation of how many threads were used. The ` --benchmark_min_time=3s` is to make initialization negligible enough that the average number of threads roughly equals the specified maximum.  The interesting part is the

`--task_topology_cpu_ids="$(seq 0 1 127 | paste -sd,)"`
