### PR TITLE
[MetalSPIRV] Add external executable serialization for Metal target

### DIFF
--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -121,9 +121,148 @@ public:
     buildCodegenTranslationPostProcessingPassPipeline(passManager);
   }
 
+  // Serialize an externally-provided Metal executable (.metallib or .metal MSL).
+  // This is the Metal equivalent of VulkanSPIRVTarget::serializeExternalExecutable
+  // (VulkanSPIRVTarget.cpp:399) and CUDATarget.cpp:496. It enables
+  // --iree-hal-substitute-executable-object with pre-compiled .metallib binaries
+  // or raw .metal MSL source files.
+  //
+  // The runtime already supports both formats:
+  //   - .metallib via [MTLDevice newLibraryWithData:] (executable.m:242)
+  //   - .metal MSL via [MTLDevice newLibraryWithSource:] (executable.m:211)
+  LogicalResult
+  serializeExternalExecutable(const SerializationOptions &serOptions,
+                              IREE::HAL::ExecutableVariantOp variantOp,
+                              OpBuilder &executableBuilder) {
+    if (!variantOp.getObjects().has_value() ||
+        variantOp.getObjects()->getValue().empty()) {
+      return variantOp.emitOpError()
+             << "no objects defined for external variant";
+    } else if (variantOp.getObjects()->getValue().size() != 1) {
+      // For now we assume there will be exactly one object file.
+      // TODO(#7824): support multiple .metallib files in a single flatbuffer
+      // archive so that we can combine executables.
+      return variantOp.emitOpError() << "only one object reference is "
+                                        "supported for external variants";
+    }
+
+    // Load the external object (.metallib or .metal MSL source).
+    auto objectAttr = cast<IREE::HAL::ExecutableObjectAttr>(
+        variantOp.getObjects()->getValue().front());
+    std::string objectData;
+    if (auto data = objectAttr.loadData()) {
+      objectData = data.value();
+    } else {
+      return variantOp.emitOpError()
+             << "object file could not be loaded: " << objectAttr;
+    }
+
+    FlatbufferBuilder builder;
+    iree_hal_metal_ExecutableDef_start_as_root(builder);
+
+    // Attach embedded source file contents for debugging.
+    auto sourceFilesRef = createSourceFilesVec(
+        serOptions.debugLevel, variantOp.getSourcesAttr(), builder);
+
+    // Compiled .metallib files start with the "MTLB" magic bytes (Apple's
+    // metallib binary format). If detected, embed as pre-compiled binary;
+    // otherwise treat as MSL source text for runtime JIT compilation.
+    bool isMetalLib = objectData.size() >= 4 &&
+                      memcmp(objectData.data(), "MTLB", 4) == 0;
+
+    iree_hal_metal_LibraryDef_start(builder);
+    if (isMetalLib) {
+      auto metallibRef = builder.createString(objectData);
+      iree_hal_metal_LibraryDef_metallib_add(builder, metallibRef);
+    } else {
+      auto sourceStrRef = builder.createString(objectData);
+      // MTLLanguageVersion3_0 = 196608 (0x00030000), matching the normal
+      // codegen path (serializeExecutable, ~line 357).
+      constexpr unsigned kMTLLanguageVersion3_0 = 196608;
+      auto sourceRef = iree_hal_metal_MSLSourceDef_create(
+          builder, kMTLLanguageVersion3_0, sourceStrRef);
+      iree_hal_metal_LibraryDef_source_add(builder, sourceRef);
+    }
+    auto libraryRef = iree_hal_metal_LibraryDef_end(builder);
+    SmallVector<iree_hal_metal_LibraryDef_ref_t> libraryRefs = {libraryRef};
+    auto librariesRef = builder.createOffsetVecDestructive(libraryRefs);
+
+    // Build pipeline definitions from export ops. This mirrors the pipeline
+    // construction in the normal codegen path (~line 381) and CUDATarget's
+    // ExportDef construction (~line 640).
+    auto exportOps = llvm::to_vector_of<IREE::HAL::ExecutableExportOp>(
+        variantOp.getExportOps());
+    auto exportDebugInfos =
+        createExportDefs(serOptions.debugLevel, exportOps, builder);
+
+    SmallVector<iree_hal_metal_PipelineDef_ref_t> pipelineRefs;
+    for (auto [i, exportOp] :
+         llvm::enumerate(exportOps)) {
+      auto entryPointRef = builder.createString(exportOp.getName());
+
+      // Read threadgroup size from the export op's workgroup_size attribute,
+      // following the same convention as CUDATarget.cpp:653.
+      iree_hal_metal_ThreadgroupSize_t threadgroupSize = {0, 0, 0};
+      if (auto workgroupSizeAttr = exportOp.getWorkgroupSize()) {
+        auto workgroupSize = workgroupSizeAttr->getValue();
+        threadgroupSize.x = cast<IntegerAttr>(workgroupSize[0]).getInt();
+        threadgroupSize.y = cast<IntegerAttr>(workgroupSize[1]).getInt();
+        threadgroupSize.z = cast<IntegerAttr>(workgroupSize[2]).getInt();
+      }
+
+      auto layoutAttr = exportOp.getLayoutAttr();
+      uint32_t constantCount = static_cast<uint32_t>(layoutAttr.getConstants());
+      SmallVector<iree_hal_metal_BindingBits_enum_t> bindingFlags;
+      for (auto bindingAttr : layoutAttr.getBindings()) {
+        iree_hal_metal_BindingBits_enum_t flags = 0;
+        if (allEnumBitsSet(bindingAttr.getFlags(),
+                           IREE::HAL::DescriptorFlags::ReadOnly)) {
+          flags |= iree_hal_metal_BindingBits_IMMUTABLE;
+        }
+        bindingFlags.push_back(flags);
+      }
+      auto bindingFlagsRef = iree_hal_metal_BindingBits_vec_create(
+          builder, bindingFlags.data(), bindingFlags.size());
+
+      iree_hal_metal_PipelineDef_start(builder);
+      iree_hal_metal_PipelineDef_library_ordinal_add(builder, 0);
+      iree_hal_metal_PipelineDef_entry_point_add(builder, entryPointRef);
+      iree_hal_metal_PipelineDef_threadgroup_size_add(builder,
+                                                      &threadgroupSize);
+      iree_hal_metal_PipelineDef_constant_count_add(builder, constantCount);
+      iree_hal_metal_PipelineDef_binding_flags_add(builder, bindingFlagsRef);
+      iree_hal_metal_PipelineDef_debug_info_add(builder, exportDebugInfos[i]);
+      pipelineRefs.push_back(iree_hal_metal_PipelineDef_end(builder));
+    }
+    auto pipelinesRef = builder.createOffsetVecDestructive(pipelineRefs);
+
+    iree_hal_metal_ExecutableDef_pipelines_add(builder, pipelinesRef);
+    iree_hal_metal_ExecutableDef_libraries_add(builder, librariesRef);
+    if (sourceFilesRef)
+      iree_hal_metal_ExecutableDef_source_files_add(builder, sourceFilesRef);
+    iree_hal_metal_ExecutableDef_end_as_root(builder);
+
+    auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
+        executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
+        variantOp.getTarget().getFormat(),
+        builder.getHeaderPrefixedBufferAttr(
+            executableBuilder.getContext(),
+            /*magic=*/iree_hal_metal_ExecutableDef_file_identifier,
+            /*version=*/0));
+    binaryOp.setMimeTypeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
+    return success();
+  }
+
   LogicalResult serializeExecutable(const SerializationOptions &serOptions,
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) final {
+    // Handle external .metallib/.metal objects (substitute mechanism).
+    if (variantOp.isExternal()) {
+      return serializeExternalExecutable(serOptions, variantOp,
+                                         executableBuilder);
+    }
+
     ModuleOp innerModuleOp = variantOp.getInnerModule();
 
     // TODO: rework this to compile all modules into the same metallib and

--- a/compiler/plugins/target/MetalSPIRV/test/BUILD.bazel
+++ b/compiler/plugins/target/MetalSPIRV/test/BUILD.bazel
@@ -16,7 +16,10 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         # keep sorted
-        ["smoketest.mlir"],
+        [
+            "external_executable.mlir",
+            "smoketest.mlir",
+        ],
         include = ["*.mlir"],
     ),
     cfg = "//compiler:lit.cfg.py",

--- a/compiler/plugins/target/MetalSPIRV/test/CMakeLists.txt
+++ b/compiler/plugins/target/MetalSPIRV/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "external_executable.mlir"
     "smoketest.mlir"
   TOOLS
     FileCheck

--- a/compiler/plugins/target/MetalSPIRV/test/external_executable.mlir
+++ b/compiler/plugins/target/MetalSPIRV/test/external_executable.mlir
@@ -1,0 +1,109 @@
+// RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline %s | FileCheck %s
+
+// Test that external Metal executables (with hal.executable.objects) are
+// serialized correctly, producing a valid metal-msl-fb binary.
+// This mirrors the Vulkan external executable test pattern.
+
+module attributes {
+  hal.device.targets = [
+    #hal.device.target<"metal", [
+      #hal.executable.target<"metal-spirv", "metal-msl-fb", {
+        iree_codegen.target_info = #iree_gpu.target<arch = "apple", features = "spirv:v1.3,cap:Shader", wgp = <
+          compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
+          subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
+          max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 32768,
+          max_workgroup_counts = [65535, 65535, 65535]>>
+      }>
+    ]> : !hal.device
+  ]
+} {
+
+// External executable with an MSL source object.
+// The compiler should embed the MSL source in the flatbuffer without
+// attempting SPIR-V codegen.
+hal.executable public @extern_dispatch {
+  hal.executable.variant public @metal_msl_fb target(<"metal-spirv", "metal-msl-fb", {
+    iree_codegen.target_info = #iree_gpu.target<arch = "apple", features = "spirv:v1.3,cap:Shader", wgp = <
+      compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
+      subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 32768,
+      max_workgroup_counts = [65535, 65535, 65535]>>
+  }>) objects([
+    #hal.executable.object<{
+      // Inline MSL source as data.
+      data = dense<[
+        // "#include <metal_stdlib>\nusing namespace metal;\n"
+        // "kernel void entry(device float* a [[buffer(0)]]) { a[0] = 1.0; }\n"
+        0x23, 0x69, 0x6E, 0x63, 0x6C, 0x75, 0x64, 0x65
+      ]> : vector<8xi8>
+    }>
+  ]) {
+    hal.executable.export public @entry ordinal(0)
+      layout(#hal.pipeline.layout<bindings = [
+        #hal.pipeline.binding<storage_buffer, Indirect>
+      ], flags = Indirect>)
+      attributes {
+        workgroup_size = [32 : index, 1 : index, 1 : index]
+      }
+  }
+}
+
+// CHECK:        hal.executable.binary public @metal_msl_fb attributes {
+// CHECK-SAME:     data = dense
+// CHECK-SAME:     format = "metal-msl-fb"
+
+}
+
+// -----
+
+// Test external executable with a pre-compiled .metallib binary object.
+// The compiler should detect the "MTLB" magic and embed it as a metallib
+// (not MSL source) in the flatbuffer.
+
+module attributes {
+  hal.device.targets = [
+    #hal.device.target<"metal", [
+      #hal.executable.target<"metal-spirv", "metal-msl-fb", {
+        iree_codegen.target_info = #iree_gpu.target<arch = "apple", features = "spirv:v1.3,cap:Shader", wgp = <
+          compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
+          subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
+          max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 32768,
+          max_workgroup_counts = [65535, 65535, 65535]>>
+      }>
+    ]> : !hal.device
+  ]
+} {
+
+// External executable with a metallib-like binary object (MTLB magic header).
+hal.executable public @extern_metallib {
+  hal.executable.variant public @metal_msl_fb target(<"metal-spirv", "metal-msl-fb", {
+    iree_codegen.target_info = #iree_gpu.target<arch = "apple", features = "spirv:v1.3,cap:Shader", wgp = <
+      compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
+      subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
+      max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 32768,
+      max_workgroup_counts = [65535, 65535, 65535]>>
+  }>) objects([
+    #hal.executable.object<{
+      // Bytes starting with "MTLB" magic (0x4D544C42) to trigger metallib path.
+      data = dense<[
+        0x4D, 0x54, 0x4C, 0x42, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+      ]> : vector<16xi8>
+    }>
+  ]) {
+    hal.executable.export public @entry ordinal(0)
+      layout(#hal.pipeline.layout<bindings = [
+        #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+        #hal.pipeline.binding<storage_buffer, Indirect>
+      ], flags = Indirect>)
+      attributes {
+        workgroup_size = [64 : index, 1 : index, 1 : index]
+      }
+  }
+}
+
+// CHECK:        hal.executable.binary public @metal_msl_fb attributes {
+// CHECK-SAME:     data = dense
+// CHECK-SAME:     format = "metal-msl-fb"
+
+}


### PR DESCRIPTION
  ## [MetalSPIRV] Add external executable serialization for Metal target                 
                                                                                           
  This fills a parity gap with Vulkan/CUDA/ROCm: the Metal-SPIRV backend was               
  missing `serializeExternalExecutable()`, causing                                         
  `--iree-hal-substitute-executable-object`                                                
  to crash when targeting `metal-spirv`.                                                 
                                                                                           
  ### What this enables                                                                    
  
  The `--iree-hal-substitute-executable-object=<name>=<file>` flag now works with          
  Metal, accepting either:                                                               
  - Pre-compiled `.metallib` files (detected via "MTLB" magic bytes)                       
  - Raw `.metal` MSL source files (runtime JIT compiles via `newLibraryWithSource:`)       
                                                                                           
  This unlocks the same executable experimentation workflow that Vulkan/CUDA/ROCm          
  have had since #12240: dump a dispatch's executable, modify it externally, and           
  substitute it back for testing.                                                          
                                                                                         
  ### Implementation                                                                       
                                                                                         
  Follows the existing patterns in VulkanSPIRVTarget.cpp:399 and CUDATarget.cpp:496:       
  - Checks `variantOp.isExternal()` to branch into the external path
  - Reads threadgroup size from `exportOp.getWorkgroupSize()` (matching CUDA:653)          
  - Reads constant count and binding flags from the layout (matching the normal codegen    
  path)                                                                                    
  - Produces a valid MTL1-prefixed flatbuffer                                              
                                                                                           
  No runtime changes needed — `executable.m` already supports both `newLibraryWithData:`   
  (metallib, line 242) and `newLibraryWithSource:` (MSL, line 211).                        
                                                                                           
  ### Testing                                                                            
                                                                                           
  - Compiler lit test with two cases: MSL source object and metallib-like binary object    
  - Verified end-to-end on M1 Max: vecadd and matmul .metallib substitutes execute
    correctly on Metal GPU                                                                 
                                 