### PR TITLE
[Codegen] Fix bufferization dropping negative strides on dispatch tensor load/store

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Interfaces/SubsetOpInterface.h"
 
 namespace mlir::iree_compiler {
@@ -32,7 +33,8 @@ static Value getBufferizedSubspanOrSubview(
   SmallVector<Value> dynamicSizes;
   std::tie(std::ignore, dynamicSizes) = decomposeMixedValues(sizes);
   if (equalTensorShape(tensorType, dynamicSizes, dispatchTensorType,
-                       subspanDynamicSizes)) {
+                       subspanDynamicSizes) &&
+      areAllConstantIntValue(strides, 1)) {
     return subspanMemref;
   }
   MemRefType subviewMemRefType = memref::SubViewOp::inferRankReducedResultType(

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_dispatch_tensor_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_dispatch_tensor_load_store.mlir
@@ -190,3 +190,35 @@ func.func @nested_dispatch_tensor_load_in_forall() {
 // CHECK:           iree_codegen.load_from_buffer %[[SUBVIEW]]
 // CHECK-SAME:          : memref<3072x512xbf16, strided<[512, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<3072x512xbf16>
 // CHECK:         iree_codegen.store_to_buffer %{{.+}}, %[[OUTPUT]]
+
+// -----
+
+// Verify that dispatch.tensor.load with negative strides is correctly
+// bufferized to a memref.subview with negative strides, not the raw buffer.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @negative_stride_load_store() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [3], sizes = [4], strides = [-1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> -> tensor<4xf32>
+  iree_tensor_ext.dispatch.tensor.store %2, %1, offsets = [0], sizes = [4], strides = [1]
+      : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  return
+}
+
+// CHECK-LABEL: func.func @negative_stride_load_store()
+// CHECK:         %[[INPUT:.+]] = hal.interface.binding.subspan
+// CHECK-SAME:        binding(0) : memref<4xf32, #hal.descriptor_type<storage_buffer>>
+// CHECK:         %[[OUTPUT:.+]] = hal.interface.binding.subspan
+// CHECK-SAME:        binding(1) : memref<4xf32, #hal.descriptor_type<storage_buffer>>
+// CHECK:         %[[SUBVIEW:.+]] = memref.subview %[[INPUT]][3] [4] [-1]
+// CHECK-SAME:        : memref<4xf32, #hal.descriptor_type<storage_buffer>> to
+// CHECK-SAME:          memref<4xf32, strided<[-1], offset: 3>, #hal.descriptor_type<storage_buffer>>
+// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[SUBVIEW]]
+// CHECK-SAME:        : memref<4xf32, strided<[-1], offset: 3>, #hal.descriptor_type<storage_buffer>> -> tensor<4xf32>
+// CHECK:         iree_codegen.store_to_buffer %[[LOAD]], %[[OUTPUT]]
+// CHECK-SAME:        : tensor<4xf32> into memref<4xf32, #hal.descriptor_type<storage_buffer>>

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3154,3 +3154,32 @@ module attributes {hal.executable.target = #executable_target_rocm} {
 // CHECK-LABEL: func.func @constant_to_buffer_rocm
 // CHECK:         %[[CST:.+]] = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
 // CHECK:         bufferization.to_buffer %[[CST]] {{.*}} : tensor<4xi32> to memref<4xi32, #gpu.address_space<constant>>
+
+// -----
+
+// Verify that dispatch.tensor.load with negative strides (tensor flip) is
+// correctly bufferized to a memref.subview with negative strides, instead of
+// being incorrectly treated as a full-tensor identity load.
+
+#pipeline_layout_neg_stride = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, Indirect>
+], flags = Indirect>
+func.func @negative_stride_dispatch_tensor_load() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_neg_stride) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_neg_stride) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [3], sizes = [4], strides = [-1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xf32>> -> tensor<4xf32>
+  iree_tensor_ext.dispatch.tensor.store %2, %1, offsets = [0], sizes = [4], strides = [1] : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  return
+}
+
+// CHECK-LABEL: func.func @negative_stride_dispatch_tensor_load()
+//  CHECK-DAG:    %[[INPUT:.+]] = hal.interface.binding.subspan {{.+}} binding(0) {{.+}} : memref<4xf32, #hal.descriptor_type<storage_buffer>>
+//  CHECK-DAG:    %[[OUTPUT:.+]] = hal.interface.binding.subspan {{.+}} binding(1) {{.+}} : memref<4xf32, #hal.descriptor_type<storage_buffer>>
+//      CHECK:    %[[SUBVIEW:.+]] = memref.subview %[[INPUT]][3] [4] [-1]
+// CHECK-SAME:      : memref<4xf32, #hal.descriptor_type<storage_buffer>>
+// CHECK-SAME:        to memref<4xf32, strided<[-1], offset: 3>, #hal.descriptor_type<storage_buffer>>
+//      CHECK:    linalg.generic
+// CHECK-SAME:      ins(%[[SUBVIEW]] : memref<4xf32, strided<[-1], offset: 3>, #hal.descriptor_type<storage_buffer>>)
+// CHECK-SAME:      outs(%[[OUTPUT]] : memref<4xf32, #hal.descriptor_type<storage_buffer>>)

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Interfaces/SubsetOpInterface.h"
 #include "mlir/Support/LLVM.h"
@@ -52,6 +53,13 @@ namespace {
 //===----------------------------------------------------------------------===//
 // IREE specific External models for BufferizableOpInterface.
 //===----------------------------------------------------------------------===//
+
+/// Returns true if the given offsets and strides represent an identity layout
+/// (all offsets are 0, all strides are 1). Non-identity layouts (e.g. negative
+/// strides for tensor reversal) require a memref.subview to preserve semantics.
+static bool hasUnitStrides(ArrayRef<OpFoldResult> strides) {
+  return areAllConstantIntValue(strides, 1);
+}
 
 struct DispatchTensorLoadOpInterface
     : BufferizableOpInterface::ExternalModel<
@@ -79,8 +87,9 @@ struct DispatchTensorLoadOpInterface
     if (equalTensorShape(loadOp.getType(), loadOp.sizes(),
                          cast<IREE::TensorExt::DispatchTensorType>(
                              loadOp.getSource().getType()),
-                         loadOp.getSourceDims())) {
-      // The entire tensor is loaded.
+                         loadOp.getSourceDims()) &&
+        hasUnitStrides(loadOp.getMixedStrides())) {
+      // The entire tensor is loaded with unit strides.
       replaceOpWithBufferizedValues(rewriter, op, source);
       return success();
     }
@@ -133,8 +142,9 @@ struct DispatchTensorStoreOpInterface
                           storeOp.getSizes(),
                           cast<IREE::TensorExt::DispatchTensorType>(
                               storeOp.getTarget().getType()),
-                          storeOp.getTargetDims())) {
-      // Writing to a part of the tensor.
+                          storeOp.getTargetDims()) ||
+        !hasUnitStrides(storeOp.getMixedStrides())) {
+      // Writing to a part of the tensor, or with non-unit strides.
       auto subviewMemRefType =
           cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
               cast<ShapedType>(storeOp.getValue().getType()).getShape(),


### PR DESCRIPTION
The `equalTensorShape` check in the bufferization interface for `DispatchTensorLoadOp` and `DispatchTensorStoreOp` only compared result shapes and dynamic dims to determine if a "whole tensor" fast path could be taken. This missed the case where strides are non-unit (e.g. `strides = [-1]` for tensor reversal via `tensor.extract_slice`), causing the fast path to replace the op with the raw binding buffer and silently drop the stride info.

For example, the following IR:
```
  %0 = iree_tensor_ext.dispatch.tensor.load %src,
       offsets = [3], sizes = [4], strides = [-1]
       : !dispatch.tensor<readonly:tensor<4xf32>> -> tensor<4xf32>
```
was incorrectly bufferized to a plain `memref<4xf32>` identity copy instead of the correct `memref.subview` with `strided<[-1], offset: 3>`.

This resulted in `tensor.extract_slice` with negative strides (which should reverse/flip a tensor) being silently turned into a no-op by IREE, while upstream MLIR's `mlir-cpu-runner` produced correct results.

The fix adds a unit-stride check (`areAllConstantIntValue(strides, 1)`) before taking the fast "whole tensor" path. When strides are non-unit (e.g. negative), we fall through to the existing `memref.subview` code path which correctly forwards the mixed offsets, sizes, and strides.