### PR TITLE
[Codegen][MXFP4] Add PartialDataTiledScaledMMAAttr to enable scales preshuffling (preshuffling prs 2/3)

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -211,13 +211,18 @@ Attribute TensorUKernelProviderAttr::getDataLayoutForUKernel(
         continue;
       }
     } else if (opType == IREE::Encoding::EncodingOpType::scaled_matmul) {
-      auto dtScaledMma = dyn_cast<GPU::DataTiledScaledMMAAttr>(mma);
-      if (!dtScaledMma) {
+      auto scaledIntrinsic =
+          llvm::TypeSwitch<Attribute, std::optional<GPU::ScaledMMAIntrinsic>>(
+              mma)
+              .Case<GPU::DataTiledScaledMMAAttr,
+                    GPU::PartialDataTiledScaledMMAAttr>(
+                  [](auto attr) { return attr.getIntrinsic(); })
+              .Default([](auto) { return std::nullopt; });
+      if (!scaledIntrinsic) {
         continue;
       }
-      // Scaled MMA intrinsic.
       auto intrinsicAttr = GPU::ScaledMMAAttr::get(
-          matchTypes.getContext(), dtScaledMma.getIntrinsic(),
+          matchTypes.getContext(), *scaledIntrinsic,
           /*lhs_elem_type=*/types[0], /*rhs_elem_type=*/types[1],
           /*acc_elem_type=*/types[4], /*col_major=*/false);
       if (!llvm::is_contained(targetAttr.getWgp().getScaledMma(),

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -495,6 +495,16 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                               mTotalTileToDistribute % splitFactor == 0;
   bool canNDistributeEvenly = nTotalTileToDistribute > splitFactor &&
                               nTotalTileToDistribute % splitFactor == 0;
+
+  // PartialDataTiledScaledMMAAttr needs more subgroups on N than M so that the
+  // scale-operand swizzle encodes correctly. When both dimensions can
+  // distribute evenly, suppress M so the N-first branch is taken.
+  if (canMDistributeEvenly && canNDistributeEvenly &&
+      isa_and_nonnull<IREE::GPU::PartialDataTiledScaledMMAAttr>(
+          intrinsic.mmaKind)) {
+    canMDistributeEvenly = false;
+  }
+
   if (canMDistributeEvenly) {
     LDBG() << "Distributing seed evenly to M dim";
     distributeSqrtForDim(true, subgroupSqrt, tileSqrt, mTotalTileToDistribute,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -495,16 +495,6 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
                               mTotalTileToDistribute % splitFactor == 0;
   bool canNDistributeEvenly = nTotalTileToDistribute > splitFactor &&
                               nTotalTileToDistribute % splitFactor == 0;
-
-  // PartialDataTiledScaledMMAAttr needs more subgroups on N than M so that the
-  // scale-operand swizzle encodes correctly. When both dimensions can
-  // distribute evenly, suppress M so the N-first branch is taken.
-  if (canMDistributeEvenly && canNDistributeEvenly &&
-      isa_and_nonnull<IREE::GPU::PartialDataTiledScaledMMAAttr>(
-          intrinsic.mmaKind)) {
-    canMDistributeEvenly = false;
-  }
-
   if (canMDistributeEvenly) {
     LDBG() << "Distributing seed evenly to M dim";
     distributeSqrtForDim(true, subgroupSqrt, tileSqrt, mTotalTileToDistribute,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -188,6 +188,48 @@ struct GPUMMASchedule {
   }
 };
 
+/// Pads a dimension bound to a favorable alignment for the MMA heuristic.
+/// The heuristic uses power-of-2 split factors, so odd tile counts (e.g.,
+/// ceil(1000/16) = 63) cannot distribute evenly. Padding to a multiple of
+/// |alignment| avoids this. Returns the original bound if already aligned
+/// or dynamic.
+inline int64_t padBoundForHeuristic(int64_t bound, int64_t alignment) {
+  if (ShapedType::isDynamic(bound)) {
+    return bound;
+  }
+  int64_t remainder = bound % alignment;
+  if (remainder == 0) {
+    return bound;
+  }
+  return bound + alignment - remainder;
+}
+
+/// Pads M and N sizes in a GPUMatmulShapeType so that the MMA heuristic sees
+/// power-of-2-friendly tile counts. This matches the padding applied by the
+/// TileAndFuse config path in ConfigUtils.cpp. Dimensions <= 32 are left
+/// unpadded; dimensions > 128 are padded to 128; dimensions in (32, 128] are
+/// padded to 32.
+inline void padProblemForHeuristic(GPUMatmulShapeType &problem) {
+  auto padDim = [](int64_t bound) -> int64_t {
+    if (ShapedType::isDynamic(bound)) {
+      return bound;
+    }
+    if (bound > 128) {
+      return padBoundForHeuristic(bound, 128);
+    }
+    if (bound > 32) {
+      return padBoundForHeuristic(bound, 32);
+    }
+    return bound;
+  };
+  for (int64_t &m : problem.mSizes) {
+    m = padDim(m);
+  }
+  for (int64_t &n : problem.nSizes) {
+    n = padDim(n);
+  }
+}
+
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
 /// When |target| is provided, architecture-specific seed adjustments (e.g.,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -394,6 +394,104 @@ func.func @swizzle_operand_no_promote_fill(%b: tensor<128x128xf32>) -> tensor<4x
 
 // -----
 
+#lowering_config_swizzle_transpose = #iree_gpu.lowering_config<{
+  promote_operands = [0, 1],
+  promotion_types = [
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>]}>
+
+#transpose_map = affine_map<(d0, d1) -> (d1, d0)>
+#identity_map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @swizzle_operand_transpose_producer(
+    %a_transposed: tensor<64x32xf32>, %b: tensor<64x128xf32>) -> tensor<32x128xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty_a = tensor.empty() : tensor<32x64xf32>
+  %transpose_a = linalg.generic {
+    indexing_maps = [#transpose_map, #identity_map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%a_transposed : tensor<64x32xf32>) outs(%empty_a : tensor<32x64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<32x64xf32>
+  %empty = tensor.empty() : tensor<32x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x128xf32>) -> tensor<32x128xf32>
+  %mm = linalg.matmul {lowering_config = #lowering_config_swizzle_transpose}
+    ins(%transpose_a, %b : tensor<32x64xf32>, tensor<64x128xf32>)
+    outs(%fill : tensor<32x128xf32>) -> tensor<32x128xf32>
+  return %mm : tensor<32x128xf32>
+}
+
+// Transpose linalg.generic producers are not given a lowering_config early
+// return — they fall through to the swizzle promotion path so XOR swizzle
+// hints are applied to their output buffer.
+// CHECK-LABEL: func.func @swizzle_operand_transpose_producer
+//  CHECK-SAME:   %[[A_T:[A-Za-z0-9]+]]: tensor<64x32xf32>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<64x128xf32>
+//       CHECK:   %[[TRANSPOSE:.+]] = linalg.generic {{.*}} ins(%[[A_T]] : tensor<64x32xf32>)
+//       CHECK:   %[[EMPTY_A:.+]] = tensor.empty() : tensor<2048xf32>
+//       CHECK:   %[[SWIZZLE_A:.+]] = iree_codegen.swizzle_hint %[[EMPTY_A]][#iree_codegen.xor_shuffle<256, 32>] : tensor<2048xf32>
+//       CHECK:   %[[EXPAND_A:.+]] = tensor.expand_shape %[[SWIZZLE_A]] {{\[\[}}0, 1{{\]\]}} output_shape [32, 64] : tensor<2048xf32> into tensor<32x64xf32>
+//       CHECK:   %[[COPY_A:.+]] = linalg.copy
+//  CHECK-SAME:     lowering_config = #iree_gpu.derived_thread_config
+//  CHECK-SAME:     ins(%[[TRANSPOSE]] : tensor<32x64xf32>) outs(%[[EXPAND_A]] : tensor<32x64xf32>)
+//       CHECK:   %[[EMPTY_B:.+]] = tensor.empty() : tensor<8192xf32>
+//       CHECK:   %[[SWIZZLE_B:.+]] = iree_codegen.swizzle_hint %[[EMPTY_B]][#iree_codegen.xor_shuffle<256, 32>] : tensor<8192xf32>
+//       CHECK:   %[[EXPAND_B:.+]] = tensor.expand_shape %[[SWIZZLE_B]] {{\[\[}}0, 1{{\]\]}} output_shape [64, 128] : tensor<8192xf32> into tensor<64x128xf32>
+//       CHECK:   %[[COPY_B:.+]] = linalg.copy
+//  CHECK-SAME:     lowering_config = #iree_gpu.derived_thread_config
+//  CHECK-SAME:     ins(%[[B]] : tensor<64x128xf32>) outs(%[[EXPAND_B]] : tensor<64x128xf32>)
+//       CHECK:   linalg.matmul {{.*}} ins(%[[COPY_A]], %[[COPY_B]] : tensor<32x64xf32>, tensor<64x128xf32>)
+
+// -----
+
+#lowering_config_swizzle_non_transpose = #iree_gpu.lowering_config<{
+  promote_operands = [0, 1],
+  promotion_types = [
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>]}>
+
+#elementwise_map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @swizzle_operand_non_transpose_generic_producer(
+    %a_raw: tensor<32x64xf32>, %b: tensor<64x128xf32>) -> tensor<32x128xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty_a = tensor.empty() : tensor<32x64xf32>
+  %negated_a = linalg.generic {
+    indexing_maps = [#elementwise_map, #elementwise_map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%a_raw : tensor<32x64xf32>) outs(%empty_a : tensor<32x64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %neg = arith.negf %in : f32
+    linalg.yield %neg : f32
+  } -> tensor<32x64xf32>
+  %empty = tensor.empty() : tensor<32x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x128xf32>) -> tensor<32x128xf32>
+  %mm = linalg.matmul {lowering_config = #lowering_config_swizzle_non_transpose}
+    ins(%negated_a, %b : tensor<32x64xf32>, tensor<64x128xf32>)
+    outs(%fill : tensor<32x128xf32>) -> tensor<32x128xf32>
+  return %mm : tensor<32x128xf32>
+}
+
+// Non-transpose linalg.generic producers get a lowering_config stamped on them
+// directly and skip swizzle promotion — no swizzle_hint is created for them.
+// CHECK-LABEL: func.func @swizzle_operand_non_transpose_generic_producer
+//  CHECK-SAME:   %[[A_RAW:[A-Za-z0-9]+]]: tensor<32x64xf32>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<64x128xf32>
+//       CHECK:   %[[NEGATED:.+]] = linalg.generic
+//  CHECK-SAME:     ins(%[[A_RAW]] : tensor<32x64xf32>)
+//       CHECK:     lowering_config = #iree_gpu.derived_thread_config
+//   CHECK-NOT:   iree_codegen.swizzle_hint {{.*}} tensor<2048xf32>
+//       CHECK:   %[[EMPTY_B:.+]] = tensor.empty() : tensor<8192xf32>
+//       CHECK:   %[[SWIZZLE_B:.+]] = iree_codegen.swizzle_hint %[[EMPTY_B]][#iree_codegen.xor_shuffle<256, 32>] : tensor<8192xf32>
+//       CHECK:   %[[EXPAND_B:.+]] = tensor.expand_shape %[[SWIZZLE_B]] {{\[\[}}0, 1{{\]\]}} output_shape [64, 128] : tensor<8192xf32> into tensor<64x128xf32>
+//       CHECK:   %[[COPY_B:.+]] = linalg.copy
+//  CHECK-SAME:     lowering_config = #iree_gpu.derived_thread_config
+//  CHECK-SAME:     ins(%[[B]] : tensor<64x128xf32>) outs(%[[EXPAND_B]] : tensor<64x128xf32>)
+//       CHECK:   linalg.matmul {{.*}} ins(%[[NEGATED]], %[[COPY_B]] : tensor<32x64xf32>, tensor<64x128xf32>)
+
+// -----
+
 // Im2colOp has no DMA conversion path in GPUConvertToCoalescedDMA, so
 // promotionImpl must never stamp use_global_load_dma on it — it always falls
 // back to derived_thread_config regardless of the requested promotion type.

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -97,6 +97,7 @@ iree_lit_test_suite(
             "materialize_encoding_gfx950.mlir",
             "materialize_encoding_into_nop.mlir",
             "materialize_encoding_into_padding.mlir",
+            "materialize_encoding_partial_dt_gfx950.mlir",
             "materialize_encoding_riscv.mlir",
             "materialize_encoding_vmvx.mlir",
             "materialize_encoding_x86_64.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_lit_test_suite(
     "materialize_encoding_gfx950.mlir"
     "materialize_encoding_into_nop.mlir"
     "materialize_encoding_into_padding.mlir"
+    "materialize_encoding_partial_dt_gfx950.mlir"
     "materialize_encoding_riscv.mlir"
     "materialize_encoding_vmvx.mlir"
     "materialize_encoding_x86_64.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_partial_dt_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_partial_dt_gfx950.mlir
@@ -1,0 +1,169 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding{test-gpu-encoding-resolver=gpu_data_tiling}))" \
+// RUN:   --iree-gpu-test-target=gfx950 \
+// RUN:   --iree-gpu-partial-dt-scaled-mma \
+// RUN:   --split-input-file %s | FileCheck %s
+
+// Tests for PartialDataTiledScaledMMAAttr materialization:
+//   - Data operands (LHS, RHS) produce linalg.pack + expand_shape (no transpose)
+//   - Scale operands produce full pack + expand_shape + transpose
+//   - Scaled matmul lowers to inner_tiled with partial_data_tiled_scaled_mma_layout kind
+
+//-----------------------------------------------------------------------------
+// LHS data operand (operand_index=0): pack + expand_shape, no transpose
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<
+  operand_index = 0 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [256, 512, 128, 32]>
+
+func.func @partial_dt_set_encoding_LHS_data(%arg0: tensor<256x128x32xf4E2M1FN>) -> tensor<256x128x32xf4E2M1FN, #encoding_lhs> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<256x128x32xf4E2M1FN> -> tensor<256x128x32xf4E2M1FN, #encoding_lhs>
+  return %0 : tensor<256x128x32xf4E2M1FN, #encoding_lhs>
+}
+
+// CHECK-LABEL: func.func @partial_dt_set_encoding_LHS_data(
+// CHECK:         %[[PACK:.*]] = linalg.pack
+// CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-NOT:     linalg.transpose
+// CHECK:         return %[[EXPANDED]]
+
+// -----
+
+//-----------------------------------------------------------------------------
+// RHS data operand (operand_index=1): pack + expand_shape, no transpose
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_rhs = #iree_encoding.encoding<
+  operand_index = 1 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [256, 512, 128, 32]>
+
+func.func @partial_dt_set_encoding_RHS_data(%arg0: tensor<512x128x32xf4E2M1FN>) -> tensor<512x128x32xf4E2M1FN, #encoding_rhs> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<512x128x32xf4E2M1FN> -> tensor<512x128x32xf4E2M1FN, #encoding_rhs>
+  return %0 : tensor<512x128x32xf4E2M1FN, #encoding_rhs>
+}
+
+// CHECK-LABEL: func.func @partial_dt_set_encoding_RHS_data(
+// CHECK:         %[[PACK:.*]] = linalg.pack
+// CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-NOT:     linalg.transpose
+// CHECK:         return %[[EXPANDED]]
+
+// -----
+
+//-----------------------------------------------------------------------------
+// LHS scale operand (operand_index=2): full pack + expand + transpose
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs_scales = #iree_encoding.encoding<
+  operand_index = 2 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [256, 512, 128, 32]>
+
+func.func @partial_dt_set_encoding_LHS_scales(%arg0: tensor<256x128xf8E8M0FNU>) -> tensor<256x128xf8E8M0FNU, #encoding_lhs_scales> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<256x128xf8E8M0FNU> -> tensor<256x128xf8E8M0FNU, #encoding_lhs_scales>
+  return %0 : tensor<256x128xf8E8M0FNU, #encoding_lhs_scales>
+}
+
+// CHECK-LABEL: func.func @partial_dt_set_encoding_LHS_scales(
+// CHECK:         linalg.pack
+// CHECK:         tensor.expand_shape
+// CHECK:         linalg.transpose
+// CHECK:         return
+
+// -----
+
+//-----------------------------------------------------------------------------
+// RHS scale operand (operand_index=3): full pack + expand + transpose
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_rhs_scales = #iree_encoding.encoding<
+  operand_index = 3 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [256, 512, 128, 32]>
+
+func.func @partial_dt_set_encoding_RHS_scales(%arg0: tensor<512x128xf8E8M0FNU>) -> tensor<512x128xf8E8M0FNU, #encoding_rhs_scales> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<512x128xf8E8M0FNU> -> tensor<512x128xf8E8M0FNU, #encoding_rhs_scales>
+  return %0 : tensor<512x128xf8E8M0FNU, #encoding_rhs_scales>
+}
+
+// CHECK-LABEL: func.func @partial_dt_set_encoding_RHS_scales(
+// CHECK:         linalg.pack
+// CHECK:         tensor.expand_shape
+// CHECK:         linalg.transpose
+// CHECK:         return
+
+// -----
+
+//-----------------------------------------------------------------------------
+// Scaled matmul inner_tiled formation with PartialDataTiledScaledMMAAttr kind
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [256, 512, 128, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [256, 512, 128, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [256, 512, 128, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [256, 512, 128, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [256, 512, 128, 32]>
+
+func.func @partial_dt_scaled_matmul_inner_tiled(
+    %arg0: tensor<256x128x32xf4E2M1FN, #encoding_lhs>,
+    %arg1: tensor<512x128x32xf4E2M1FN, #encoding_rhs>,
+    %arg2: tensor<256x128xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<512x128xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<256x512xf32, #encoding_result>
+) -> tensor<256x512xf32, #encoding_result> {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<256x128x32xf4E2M1FN, #encoding_lhs>, tensor<512x128x32xf4E2M1FN, #encoding_rhs>,
+             tensor<256x128xf8E8M0FNU, #encoding_lhs_scales>, tensor<512x128xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<256x512xf32, #encoding_result>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f4E2M1FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f4E2M1FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<256x512xf32, #encoding_result>
+  return %0 : tensor<256x512xf32, #encoding_result>
+}
+
+// CHECK:     func.func @partial_dt_scaled_matmul_inner_tiled(
+// CHECK:       iree_codegen.inner_tiled
+// CHECK-SAME:    kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -253,6 +253,19 @@ TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
   return getSwizzleImpl(scaledMma, operandIdx);
 }
 
+TileSwizzle getSwizzle(IREE::GPU::PartialDataTiledScaledMMAAttr partialMma,
+                       unsigned operandIdx) {
+  TileSwizzle swizzle = getSwizzleImpl(partialMma, operandIdx);
+  using MMAIntrinsicTy = IREE::GPU::ScaledMMAIntrinsic;
+  const bool isLhs = isIntrinsicLhs<MMAIntrinsicTy>(operandIdx);
+  const bool isRhs = isIntrinsicRhs<MMAIntrinsicTy>(operandIdx);
+  if (isLhs || isRhs) {
+    auto &perm = swizzle.permutation();
+    std::iota(perm.begin(), perm.end(), 0);
+  }
+  return swizzle;
+}
+
 TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma, int operandIndex) {
   return getSwizzleImpl(mma, operandIndex);
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
@@ -23,6 +23,14 @@ Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
 Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
                                 unsigned operandIdx);
 
+/// Returns the swizzle for the partial-data-tiled-scaled-mma tile. For data
+/// operands (LHS, RHS), returns the standard swizzle with an identity
+/// permutation (pack-only, row-major within tile). For scale/acc operands,
+/// returns the standard permuted swizzle.
+Codegen::TileSwizzle
+getSwizzle(IREE::GPU::PartialDataTiledScaledMMAAttr partialMma,
+           unsigned operandIdx);
+
 /// Returns the swizzle for the data-tiled-mma tile, based on the `fragment`
 /// and contraction dimensions required from the `encoding`.
 FailureOr<Codegen::TileSwizzle>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -835,6 +835,10 @@ getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
         smmaAttr.getIntrinsic(), operandIndex,
         operandIndex == kScaledMMAOperandAcc && smmaAttr.getColMajor());
   }
+  if (auto pdtsmma = dyn_cast<PartialDataTiledScaledMMAAttr>(mmaKind)) {
+    return IREE::GPU::getSingleSubgroupLayout(pdtsmma.getIntrinsic(),
+                                              operandIndex);
+  }
   assert(false && "unhandled MMA Interface type.");
   return {};
 }
@@ -1344,6 +1348,21 @@ LogicalResult MMAAttr::populateOperandOffsetsSizesStrides(
 //===----------------------------------------------------------------------===//
 // DataTiledMMA Attributes
 //===----------------------------------------------------------------------===//
+
+void DataTiledMMAAttr::getDistributedTileTypes(
+    SmallVectorImpl<VectorType> &result) const {
+  return cast<DataTiledMMAInterfaceAttr>(*this).getDistributedTileTypes(result);
+}
+
+LogicalResult DataTiledMMAAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) const {
+  return cast<DataTiledMMAInterfaceAttr>(*this)
+      .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
+                                          permutation, offsets, sizes, strides);
+}
 
 int64_t DataTiledMMAAttr::getExpectedNumInputs() const { return 2; }
 
@@ -2515,24 +2534,39 @@ int64_t getKbSize(ScaledMMAIntrinsic intrinsic) {
   return std::get<3>(getMNKKbShapeFromScaledIntrinsic(intrinsic));
 }
 
-IREE::Codegen::TileMxNxKxKb DataTiledScaledMMAAttr::getTileMNKKb() const {
+static IREE::Codegen::TileMxNxKxKb
+getScaledTileMNKKb(ScaledMMAIntrinsic intrinsic, int64_t intrinsicsM,
+                   int64_t subgroupsM, int64_t intrinsicsN, int64_t subgroupsN,
+                   int64_t intrinsicsK, int64_t subgroupsK) {
   IREE::Codegen::TileMxNxKxKb innerTile;
   std::tie(innerTile.M, innerTile.N, innerTile.K, innerTile.KB) =
-      getMNKKbShapeFromScaledIntrinsic(getIntrinsic());
-  innerTile.M *= getIntrinsicsM() * getSubgroupsM();
-  innerTile.N *= getIntrinsicsN() * getSubgroupsN();
-  innerTile.K *= getIntrinsicsK() * getSubgroupsK();
+      getMNKKbShapeFromScaledIntrinsic(intrinsic);
+  innerTile.M *= intrinsicsM * subgroupsM;
+  innerTile.N *= intrinsicsN * subgroupsN;
+  innerTile.K *= intrinsicsK * subgroupsK;
   return innerTile;
+}
+
+IREE::Codegen::TileMxNxKxKb DataTiledScaledMMAAttr::getTileMNKKb() const {
+  return getScaledTileMNKKb(getIntrinsic(), getIntrinsicsM(), getSubgroupsM(),
+                            getIntrinsicsN(), getSubgroupsN(), getIntrinsicsK(),
+                            getSubgroupsK());
+}
+
+static void getScaledElementTypes(MLIRContext *ctx, Type lhsElemType,
+                                  Type rhsElemType, Type accElemType,
+                                  SmallVectorImpl<Type> &result) {
+  result.push_back(lhsElemType);
+  result.push_back(rhsElemType);
+  result.push_back(Float8E8M0FNUType::get(ctx));
+  result.push_back(Float8E8M0FNUType::get(ctx));
+  result.push_back(accElemType);
 }
 
 void DataTiledScaledMMAAttr::getElementTypes(
     SmallVectorImpl<Type> &result) const {
-  result.push_back(getLhsElemType());
-  result.push_back(getRhsElemType());
-  result.push_back(Float8E8M0FNUType::get(getContext()));
-  result.push_back(Float8E8M0FNUType::get(getContext()));
-  result.push_back(getAccElemType());
-  return;
+  getScaledElementTypes(getContext(), getLhsElemType(), getRhsElemType(),
+                        getAccElemType(), result);
 }
 
 static Value createScaledMmaOp(OpBuilder &builder, Location loc,
@@ -2565,59 +2599,35 @@ static Value createScaledMmaOp(OpBuilder &builder, Location loc,
                                       /*scalesIdxB=*/0);
 }
 
-LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
+static LogicalResult buildScaledMmaUnderlyingOperationsImpl(
     OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
-    SmallVectorImpl<Value> &results) const {
-  // Validation. Similar to MMAAttr::buildMmaOperation.
-  if (inputs.size() != 4) {
-    return failure();
-  }
-  if (outputs.size() != 1) {
-    return failure();
-  }
-  SmallVector<VectorType> regTypes;
-  getDistributedTileTypes(regTypes);
-  if (!llvm::equal(regTypes,
-                   llvm::concat<Type>(inputs.getTypes(), outputs.getTypes()))) {
-    return failure();
-  }
+    SmallVectorImpl<Value> &results, ArrayRef<TileSwizzle> swizzles,
+    ScaledMMAIntrinsic intrinsic, int64_t intrinsicsM, int64_t intrinsicsN,
+    int64_t intrinsicsK) {
+  TileSwizzle lhsSwizzle = swizzles[0];
+  TileSwizzle rhsSwizzle = swizzles[1];
+  TileSwizzle lhsScalesSwizzle = swizzles[2];
+  TileSwizzle rhsScalesSwizzle = swizzles[3];
+  TileSwizzle accSwizzle = swizzles[4];
 
-  // Prepare Lhs/Rhs/Acc operand slices to feed the intrinsic.
-  const unsigned lhsIdx = 0;
-  const unsigned rhsIdx = 1;
-  const unsigned lhsScalesIdx = 2;
-  const unsigned rhsScalesIdx = 3;
-  const unsigned accIdx = 4;
-  TileSwizzle lhsSwizzle = getSwizzle(*this, lhsIdx);
-  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
   LDBG() << "    lhsSwizzle: " << lhsSwizzle;
   SmallVector<Value> intrinsicsLhs =
       distributeMmaFragmentToIntrinsics(builder, loc, inputs[0], lhsSwizzle);
 
-  TileSwizzle rhsSwizzle = getSwizzle(*this, rhsIdx);
-  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
   LDBG() << "    rhsSwizzle: " << rhsSwizzle;
   SmallVector<Value> intrinsicsRhs =
       distributeMmaFragmentToIntrinsics(builder, loc, inputs[1], rhsSwizzle);
 
-  TileSwizzle lhsScalesSwizzle = getSwizzle(*this, lhsScalesIdx);
-  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
   LDBG() << "    lhsScalesSwizzle: " << lhsScalesSwizzle;
   SmallVector<Value> intrinsicsLhsScales = distributeMmaFragmentToIntrinsics(
       builder, loc, inputs[2], lhsScalesSwizzle);
 
-  TileSwizzle rhsScalesSwizzle = getSwizzle(*this, rhsScalesIdx);
-  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
   LDBG() << "    rhsScalesSwizzle: " << rhsScalesSwizzle;
   SmallVector<Value> intrinsicsRhsScales = distributeMmaFragmentToIntrinsics(
       builder, loc, inputs[3], rhsScalesSwizzle);
 
-  TileSwizzle accSwizzle = getSwizzle(*this, accIdx);
-  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
   LDBG() << "    accSwizzle: " << accSwizzle;
 
-  // Distribute the accumulator into per-intrinsic slices; the reassembly
-  // conversion will be hoisted out of the reduction loop.
   auto distributeOp = IREE::Util::HoistableConversionOp::create(
       builder, loc, /*tag=*/kDataTiledAccDistribute,
       /*inverseTag=*/kDataTiledAccReassemble, ValueRange{outputs[0]},
@@ -2626,25 +2636,22 @@ LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
       });
   SmallVector<Value> intrinsicsAcc(distributeOp.getResults());
 
-  ScaledMMAIntrinsic intrinsic = getIntrinsic();
   auto intrinCType = cast<VectorType>(intrinsicsAcc.front().getType());
 
-  // Loop over the 3 unroll_{m,n,k} dimensions to create the intrinsics.
-  for (int64_t mu = 0; mu < getIntrinsicsM(); ++mu) {
-    for (int64_t nu = 0; nu < getIntrinsicsN(); ++nu) {
-      for (int64_t ku = 0; ku < getIntrinsicsK(); ++ku) {
-        Value lhs = intrinsicsLhs[mu * getIntrinsicsK() + ku];
-        Value rhs = intrinsicsRhs[nu * getIntrinsicsK() + ku];
-        Value lhsScales = intrinsicsLhsScales[mu * getIntrinsicsK() + ku];
-        Value rhsScales = intrinsicsRhsScales[nu * getIntrinsicsK() + ku];
-        Value &acc = intrinsicsAcc[mu * getIntrinsicsN() + nu];
+  for (int64_t mu = 0; mu < intrinsicsM; ++mu) {
+    for (int64_t nu = 0; nu < intrinsicsN; ++nu) {
+      for (int64_t ku = 0; ku < intrinsicsK; ++ku) {
+        Value lhs = intrinsicsLhs[mu * intrinsicsK + ku];
+        Value rhs = intrinsicsRhs[nu * intrinsicsK + ku];
+        Value lhsScales = intrinsicsLhsScales[mu * intrinsicsK + ku];
+        Value rhsScales = intrinsicsRhsScales[nu * intrinsicsK + ku];
+        Value &acc = intrinsicsAcc[mu * intrinsicsN + nu];
         acc = createScaledMmaOp(builder, loc, intrinsic, intrinCType, lhs, rhs,
                                 lhsScales, rhsScales, acc);
       }
     }
   }
 
-  // Insert the results into the destination accumulator.
   SmallVector<int64_t> accCrossIntrinsicShape =
       Codegen::sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
         return dim.kind() == TileSwizzle::Dim::Kind::CrossIntrinsic;
@@ -2684,6 +2691,43 @@ LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
   return success();
 }
 
+LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
+    OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
+    SmallVectorImpl<Value> &results) const {
+  if (inputs.size() != 4 || outputs.size() != 1) {
+    return failure();
+  }
+  SmallVector<VectorType> regTypes;
+  getDistributedTileTypes(regTypes);
+  if (!llvm::equal(regTypes,
+                   llvm::concat<Type>(inputs.getTypes(), outputs.getTypes()))) {
+    return failure();
+  }
+  SmallVector<TileSwizzle, 5> swizzles;
+  for (unsigned i = 0, e = getExpectedNumInputs() + getExpectedNumOutputs();
+       i < e; ++i) {
+    swizzles.push_back(getSwizzle(*this, i));
+  }
+  return buildScaledMmaUnderlyingOperationsImpl(
+      builder, loc, inputs, outputs, results, swizzles, getIntrinsic(),
+      getIntrinsicsM(), getIntrinsicsN(), getIntrinsicsK());
+}
+
+void DataTiledScaledMMAAttr::getDistributedTileTypes(
+    SmallVectorImpl<VectorType> &result) const {
+  return cast<DataTiledMMAInterfaceAttr>(*this).getDistributedTileTypes(result);
+}
+
+LogicalResult DataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) const {
+  return cast<DataTiledMMAInterfaceAttr>(*this)
+      .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
+                                          permutation, offsets, sizes, strides);
+}
+
 int64_t DataTiledScaledMMAAttr::getExpectedNumInputs() const { return 4; }
 
 int64_t DataTiledScaledMMAAttr::getExpectedNumOutputs() const { return 1; }
@@ -2704,6 +2748,205 @@ DataTiledScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
 
 SmallVector<SmallVector<utils::IteratorType>>
 DataTiledScaledMMAAttr::getOperandIteratorTypes() const {
+  return {{utils::IteratorType::parallel, utils::IteratorType::reduction,
+           utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::reduction,
+           utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::reduction},
+          {utils::IteratorType::reduction, utils::IteratorType::parallel},
+          {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+}
+
+//===----------------------------------------------------------------------===//
+// PartialDataTiledScaledMMA Attributes
+//===----------------------------------------------------------------------===//
+
+TileSwizzle
+PartialDataTiledScaledMMAAttr::getTileSwizzle(unsigned operandIndex) const {
+  return getSwizzle(*this, operandIndex);
+}
+
+IREE::Codegen::TileMxNxKxKb
+PartialDataTiledScaledMMAAttr::getTileMNKKb() const {
+  return getScaledTileMNKKb(getIntrinsic(), getIntrinsicsM(), getSubgroupsM(),
+                            getIntrinsicsN(), getSubgroupsN(), getIntrinsicsK(),
+                            getSubgroupsK());
+}
+
+void PartialDataTiledScaledMMAAttr::getElementTypes(
+    SmallVectorImpl<Type> &result) const {
+  getScaledElementTypes(getContext(), getLhsElemType(), getRhsElemType(),
+                        getAccElemType(), result);
+}
+
+LogicalResult PartialDataTiledScaledMMAAttr::buildUnderlyingOperations(
+    OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
+    SmallVectorImpl<Value> &results) const {
+  if (inputs.size() != 4 || outputs.size() != 1) {
+    return failure();
+  }
+  SmallVector<VectorType> regTypes;
+  getDistributedTileTypes(regTypes);
+  if (!llvm::equal(regTypes,
+                   llvm::concat<Type>(inputs.getTypes(), outputs.getTypes()))) {
+    return failure();
+  }
+  int64_t numOperands = getExpectedNumInputs() + getExpectedNumOutputs();
+  SmallVector<TileSwizzle, 5> swizzles;
+  for (int64_t i = 0; i < numOperands; ++i) {
+    swizzles.push_back(getSwizzle(*this, i));
+  }
+  return buildScaledMmaUnderlyingOperationsImpl(
+      builder, loc, inputs, outputs, results, swizzles, getIntrinsic(),
+      getIntrinsicsM(), getIntrinsicsN(), getIntrinsicsK());
+}
+
+void PartialDataTiledScaledMMAAttr::getDistributedTileTypes(
+    SmallVectorImpl<VectorType> &result) const {
+  return cast<DataTiledMMAInterfaceAttr>(*this).getDistributedTileTypes(result);
+}
+
+LogicalResult PartialDataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) const {
+
+  // Scale operands are handled by the generic swizzle-based approach.
+  TileSwizzle swizzle = getTileSwizzle(operandIndex);
+  bool isDataOperand = (operandIndex == kScaledMMAOperandLhs ||
+                        operandIndex == kScaledMMAOperandRhs);
+  if (!isDataOperand) {
+    return populateSwizzleBasedOffsetsSizesStrides(
+        builder, loc, swizzle, laneId, permutation, offsets, sizes, strides);
+  }
+
+  // Data operands must be manually handled because unlike the fully data-tiled
+  // case, the fastest moving dimensions haven't been permuted to be the
+  // innermost dimensions. So set the offsets and sizes manually.
+  int64_t subgroupSize = getSubgroupSize();
+  Value laneIdVal = getValueOrCreateConstantIndexOp(builder, loc, laneId);
+  Value subgroupSizeVal =
+      arith::ConstantIndexOp::create(builder, loc, subgroupSize);
+  Value withinSubgroupId =
+      arith::RemUIOp::create(builder, loc, laneIdVal, subgroupSizeVal);
+  Value subgroupId =
+      arith::DivUIOp::create(builder, loc, laneIdVal, subgroupSizeVal);
+
+  // Decompose subgroupId into (sgM, sgN).
+  // Linearization: subgroupId = sgM * subgroupsN + sgN.
+  int64_t sgN = getSubgroupsN();
+  Value sgNVal = arith::ConstantIndexOp::create(builder, loc, sgN);
+  Value subgroupM = arith::DivUIOp::create(builder, loc, subgroupId, sgNVal);
+  Value subgroupN = arith::RemUIOp::create(builder, loc, subgroupId, sgNVal);
+
+  MMASingleSubgroupLayout layout =
+      getSingleSubgroupLayout(getIntrinsic(), operandIndex);
+
+  // The swizzle construction (getIntrinsicSwizzle) rotates [K, Kb, N] → [N,
+  // K, Kb] for RHS so that the parallel dim is first. We must apply the same
+  // rotation to the layout fields so that vtids[srcIdx] lines up with the
+  // swizzle's expandShape source indices.
+  if (operandIndex == kScaledMMAOperandRhs) {
+    auto rotateRight = [](MutableArrayRef<int64_t> v) {
+      std::rotate(v.begin(), v.end() - 1, v.end());
+    };
+    rotateRight(layout.outer);
+    rotateRight(layout.thread);
+    rotateRight(layout.tstrides);
+    rotateRight(layout.element);
+  }
+
+  SmallVector<int64_t> vtidBasis;
+  SmallVector<size_t> dimToVtid;
+  if (failed(basisFromSizesStrides(layout.thread, layout.tstrides, vtidBasis,
+                                   dimToVtid))) {
+    return failure();
+  }
+  auto splitLaneId = affine::AffineDelinearizeIndexOp::create(
+      builder, loc, withinSubgroupId, vtidBasis, /*hasOuterBound=*/false);
+
+  size_t numSrcDims = layout.thread.size();
+  SmallVector<Value> vtids(numSrcDims);
+  for (size_t d = 0; d < numSrcDims; ++d) {
+    vtids[d] = splitLaneId.getResult(dimToVtid[d]);
+  }
+
+  Value sgParallel =
+      (operandIndex == kScaledMMAOperandLhs) ? subgroupM : subgroupN;
+
+  // If we have distribution across subgroups, then there will be
+  // an additional CrossThread dimension in the first index of the first group.
+  // The offset for this dimension will be the subgroup ID.
+  int64_t parallelSubgroups = (operandIndex == kScaledMMAOperandLhs)
+                                  ? getSubgroupsM()
+                                  : getSubgroupsN();
+  bool distributeAcrossSubgroups = (parallelSubgroups > 1);
+
+  OpFoldResult zero = builder.getIndexAttr(0);
+  OpFoldResult one = builder.getIndexAttr(1);
+  SmallVector<OpFoldResult> tileOffsets;
+  SmallVector<OpFoldResult> tileSizes;
+  for (auto [srcIdx, group] : llvm::enumerate(swizzle.expandShape())) {
+    for (TileSwizzle::Dim d : group) {
+      OpFoldResult tileOffset = zero;
+      OpFoldResult tileSize = one;
+      switch (d.kind()) {
+      case TileSwizzle::Dim::Kind::Internal:
+      case TileSwizzle::Dim::Kind::CrossIntrinsic:
+        tileSize = builder.getIndexAttr(d.size());
+        break;
+      case TileSwizzle::Dim::Kind::CrossThread:
+        tileOffset = vtids[srcIdx];
+        break;
+      }
+      tileOffsets.push_back(tileOffset);
+      tileSizes.push_back(tileSize);
+    }
+  }
+
+  if (distributeAcrossSubgroups) {
+    assert(swizzle.expandShape()[0][0].kind() ==
+               TileSwizzle::Dim::Kind::CrossThread &&
+           "CrossThread subgroup dimension should be the first dimension in "
+           "the first group");
+    tileOffsets[0] = sgParallel;
+  }
+
+  tileOffsets.assign(applyPermutation(tileOffsets, permutation));
+  tileSizes.assign(applyPermutation(tileSizes, permutation));
+  SmallVector<OpFoldResult> tileStrides(tileSizes.size(),
+                                        builder.getIndexAttr(1));
+  offsets.append(tileOffsets);
+  sizes.append(tileSizes);
+  strides.append(tileStrides);
+  return success();
+}
+
+int64_t PartialDataTiledScaledMMAAttr::getExpectedNumInputs() const {
+  return 4;
+}
+
+int64_t PartialDataTiledScaledMMAAttr::getExpectedNumOutputs() const {
+  return 1;
+}
+
+int64_t PartialDataTiledScaledMMAAttr::getSubgroupSize() const {
+  return getIntrinsicSubgroupSize(getIntrinsic());
+}
+
+int64_t PartialDataTiledScaledMMAAttr::getFlatWorkgroupSize() const {
+  return getSubgroupSize() * getSubgroupsM() * getSubgroupsN() *
+         getSubgroupsK();
+}
+
+LogicalResult PartialDataTiledScaledMMAAttr::verifyIndexingMaps(
+    ArrayRef<AffineMap> maps) const {
+  return IREE::LinalgExt::inferScaledContractionDims(maps);
+}
+
+SmallVector<SmallVector<utils::IteratorType>>
+PartialDataTiledScaledMMAAttr::getOperandIteratorTypes() const {
   return {{utils::IteratorType::parallel, utils::IteratorType::reduction,
            utils::IteratorType::reduction},
           {utils::IteratorType::reduction, utils::IteratorType::reduction,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -339,6 +339,10 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
     // Define interface methods for InnerTileDescAttrInterface with shared
     // implementation among DataTiledMMAInterfaceAttr. The implementations
     // are defined in IREEGPUInterfaces.cpp.
+    //
+    // getDistributedTileTypes and populateOperandOffsetsSizesStrides are NOT
+    // generated here; each concrete class provides its own definition so that
+    // PartialDataTiledScaledMMAAttr can override them.
     //========================================================================//
 
     void $cppClass::getUndistributedTileTypes(
@@ -347,28 +351,11 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
           .getUndistributedTileTypes(result);
     }
 
-    void $cppClass::getDistributedTileTypes(
-        SmallVectorImpl<VectorType>& result) const {
-      return cast<DataTiledMMAInterfaceAttr>(*this)
-          .getDistributedTileTypes(result);
-    }
-
     std::optional<::mlir::SmallVector<int64_t, 2>>
     $cppClass::getUndistributedTileDimExpansion(int64_t operandIndex,
                                                 int64_t logicalDim) const {
       return cast<DataTiledMMAInterfaceAttr>(*this)
           .getUndistributedTileDimExpansion(operandIndex, logicalDim);
-    }
-
-    LogicalResult $cppClass::populateOperandOffsetsSizesStrides(
-        OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
-        ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
-        SmallVectorImpl<OpFoldResult> &sizes,
-        SmallVectorImpl<OpFoldResult> &strides) const {
-      return cast<DataTiledMMAInterfaceAttr>(*this)
-          .populateOperandOffsetsSizesStrides(builder, loc, operandIndex,
-                                              laneId, permutation, offsets,
-                                              sizes, strides);
     }
 
     Attribute $cppClass::getDistributionMappingKind() const {
@@ -483,6 +470,63 @@ def IREEGPU_DataTiledScaledMMAAttr :
     specified on the attribute.
 
     The other fields are similar to DataTiledMMAAttr, refer to its documentation.
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let parameters =
+      (ins EnumParameter<IREEGPU_ScaledMMAIntrinsic>:$intrinsic,
+          "::mlir::Type":$lhs_elem_type, "::mlir::Type":$rhs_elem_type,
+          "::mlir::Type":$acc_elem_type,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Intrinsic count along the M dimension.">:$intrinsics_m,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Subgroup count along the M dimension.">:$subgroups_m,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Intrinsic count along the N dimension.">:$intrinsics_n,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Subgroup count along the N dimension.">:$subgroups_n,
+          DefaultValuedParameter<"int64_t", "1",
+                                 "Intrinsic count along the K dimension.">:$intrinsics_k,
+          DefaultValuedParameter<
+              "int64_t", "1",
+              "Subgroup count along the K dimension.">:$subgroups_k,
+          OptionalParameter<
+              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_m,
+          OptionalParameter<
+              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_n,
+          OptionalParameter<
+              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k);
+}
+
+def IREEGPU_PartialDataTiledScaledMMAAttr :
+    IREEGPU_DataTiledMMAInnerTileDescAttr<"PartialDataTiledScaledMMA", [
+  DeclareAttrInterfaceMethods<IREECodegen_InnerTileDescAttrInterface, [
+    "getExpectedNumInputs",
+    "getExpectedNumOutputs",
+    "verifyIndexingMaps",
+    "buildUnderlyingOperations"
+  ]>
+]> {
+  let mnemonic = "partial_data_tiled_scaled_mma_layout";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  let description = [{
+    Like DataTiledScaledMMAAttr but with "partial" data-tiling: data operands
+    (LHS, RHS) are only packed (linalg.pack) without the expand_shape/transpose
+    that full data-tiling applies, so they remain in row-major layout within each
+    packed tile. Scale operands are fully shuffled as usual.
+
+    This avoids both the extra dispatch needed to preshuffle data operands and
+    the strided memory access caused by fusing the transpose into the GEMM load
+    pattern. The buildUnderlyingOperations implementation accounts for the
+    row-major data layout when extracting per-intrinsic fragments.
+
+    All other fields are identical to DataTiledScaledMMAAttr.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -87,17 +87,12 @@ DataTiledMMAInterfaceAttr::getUndistributedTileDimExpansion(
   return std::nullopt;
 }
 
-LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
-    OpBuilder &builder, Location loc, uint32_t operandIndex, Value threadId,
-    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+LogicalResult populateSwizzleBasedOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, const TileSwizzle &swizzle,
+    Value threadId, ArrayRef<int64_t> permutation,
+    SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) {
-  TileSwizzle swizzle = getTileSwizzle(operandIndex);
-
-  LDBG() << "DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides\n"
-         << "    operand: " << operandIndex << "\n"
-         << "    swizzle: " << swizzle << "\n";
-
   SmallVector<int64_t> distributionThreadSizes =
       getSwizzledDistributionShape(swizzle);
 
@@ -151,6 +146,21 @@ LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
   strides.append(tileStrides);
 
   return success();
+}
+
+LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value threadId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) {
+  TileSwizzle swizzle = getTileSwizzle(operandIndex);
+
+  LDBG() << "DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides\n"
+         << "    operand: " << operandIndex << "\n"
+         << "    swizzle: " << swizzle << "\n";
+
+  return populateSwizzleBasedOffsetsSizesStrides(
+      builder, loc, swizzle, threadId, permutation, offsets, sizes, strides);
 }
 
 Attribute DataTiledMMAInterfaceAttr::getDistributionMappingKind() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
@@ -19,6 +19,17 @@
 namespace mlir::iree_compiler::IREE::GPU {
 Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
                            Attribute attr);
+
+/// Computes offsets, sizes, and strides for a single thread's slice of a
+/// swizzle-based (data-tiled) operand tile. This is the standard distribution
+/// logic shared by DataTiledMMAInterfaceAttr and the non-data operand path of
+/// PartialDataTiledScaledMMAAttr.
+LogicalResult populateSwizzleBasedOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, const Codegen::TileSwizzle &swizzle,
+    Value threadId, ArrayRef<int64_t> permutation,
+    SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides);
 } // namespace mlir::iree_compiler::IREE::GPU
 
 // clang-format off

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
@@ -76,8 +76,13 @@ static std::optional<Value> promotionImpl(OpBuilder &builder,
     }
 
     if (isa<linalg::LinalgOp>(producer.getOperation())) {
-      setLoweringConfig(producer, attr);
-      return operand.get();
+      // Don't skip promotion for transpose producers — they need to go through
+      // the swizzle path so XOR swizzle hints are applied.
+      if (auto generic = dyn_cast<linalg::GenericOp>(producer.getOperation());
+          !generic || !linalg::isaTransposeOpInterface(generic)) {
+        setLoweringConfig(producer, attr);
+        return operand.get();
+      }
     }
     // Im2colOp has no DMA conversion path in GPUConvertToCoalescedDMA, so
     // always use derived_thread_config regardless of the requested attr.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -263,6 +263,24 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4, operands_interleaving_intrinsics_k = [2, 3]>
 
 module {
+  func.func @test_partial_data_tiled_scaled_mfma_F32_16x16x128_B32_defaults() attributes {
+      mma_types = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_partial_data_tiled_scaled_mfma_F32_16x16x128_B32_defaults
+//  CHECK-SAME:   mma_types = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
+
+module {
+  func.func @test_partial_data_tiled_scaled_mfma_F32_16x16x128_B32_multi() attributes {
+      mma_types = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_k = [2, 3]>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_partial_data_tiled_scaled_mfma_F32_16x16x128_B32_multi
+//  CHECK-SAME:   mma_types = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_k = [2, 3]>
+
+module {
   func.func @test_any_lowering_config() attributes {
       lowering_config = #iree_gpu.lowering_config<{workgroup = [16, 16], thread = [0, 4]}>} {
     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
@@ -340,6 +340,46 @@ func.func @data_tiled_scaled_1x1x1_tensor_multi_mma(
 
 // -----
 
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @partial_data_tiled_scaled_1x1x1_tensor_multi_mma(
+    %lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %rhs: tensor<?x?x1x16x4x32xf4E2M1FN>,
+    %lhs_scales: tensor<?x?x4x16xf8E8M0FNU>, %rhs_scales: tensor<?x?x4x16xf8E8M0FNU>,
+    %acc: tensor<?x?x4x16x4xf32>) -> tensor<?x?x4x16x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+  } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>
+  return %0 : tensor<?x?x4x16x4xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @partial_data_tiled_scaled_1x1x1_tensor_multi_mma
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG4:[a-zA-Z0-9_]+]]
+//       CHECK:   iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]]) outs(%[[ARG4]])
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
+//  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>
+//  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>
+
+// -----
+
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -111,6 +111,26 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
   };
   if (ukernelConfig) {
     op->setAttr(kUkernelAttrName, ukernelConfig);
+  } else if (auto partialDT = dyn_cast<GPU::PartialDataTiledScaledMMAAttr>(
+                 dataTiledMmaAttr)) {
+    // PartialDataTiledScaledMMAAttr keeps data in row-major layout (no
+    // transpose), which causes LDS bank conflicts. Apply XOR swizzle on the
+    // promoted data operands to avoid them.
+    auto defaultCfg = GPU::DerivedThreadConfigAttr::get(context);
+    FailureOr<Attribute> lhsSwizzle =
+        getXorShuffleAttr(context, defaultCfg, target, partialDT,
+                          /*reductionTileSizes=*/{}, kScaledMMAOperandLhs);
+    FailureOr<Attribute> rhsSwizzle =
+        getXorShuffleAttr(context, defaultCfg, target, partialDT,
+                          /*reductionTileSizes=*/{}, kScaledMMAOperandRhs);
+    if (succeeded(lhsSwizzle) && succeeded(rhsSwizzle)) {
+      SmallVector<Attribute> promotionArray = {*lhsSwizzle, *rhsSwizzle,
+                                               defaultCfg, defaultCfg};
+      GPU::appendPromotedOperandsList(context, attrs, {0, 1, 2, 3},
+                                      promotionArray);
+    } else {
+      GPU::appendPromotedOperandsList(context, attrs, {0, 1, 2, 3});
+    }
   } else {
     // Promote operands to use shared memory for LHS and RHS.
     // Don't do that with ukernels: their untiled reduction dimension is too
@@ -123,9 +143,13 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   // By default, don't add any special padding or prefetching, since the
-  // data-tiled layout is already what we want.
+  // data-tiled layout is already what we want. For
+  // PartialDataTiledScaledMMAAttr default to 2 prefetch stages to enable
+  // software pipelining.
   SmallVector<NamedAttribute, 1> pipelineAttrs;
-  int64_t prefetchStages = prefetchNumStages.value_or(0);
+  int64_t defaultPrefetch =
+      isa<GPU::PartialDataTiledScaledMMAAttr>(dataTiledMmaAttr) ? 2 : 0;
+  int64_t prefetchStages = prefetchNumStages.value_or(defaultPrefetch);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       context, /*prefetchNumStages=*/prefetchStages,
       /*no_reduce_shared_memory_bank_conflicts=*/true,
@@ -299,11 +323,11 @@ getContractionHeuristicSeeds(IREE::GPU::TargetAttr target,
 /// When `doCPromotion` is true, the accumulator uses shared memory. This can be
 /// due to padding requirements or because the operation has an existing
 /// accumulator that needs to be loaded from global memory (matmul_accumulate).
-static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
+std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
     IREE::GPU::TargetAttr target, GPUMatmulShapeType problem, Location loc,
     bool transposedLhs, bool transposedRhs, bool isGemm, bool scaled,
-    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned = true,
-    bool doCPromotion = false, int64_t splitReductionTripCnt = 0) {
+    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned,
+    bool doCPromotion, int64_t splitReductionTripCnt) {
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
   SmallVector<GPUIntrinsicType> intrinsics;
   if (scaled) {
@@ -720,16 +744,6 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
       cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
   bool couldNeedPadding = false;
 
-  // Helper to pad bounds to a preferred alignment.
-  auto maybePaddedBounds = [&](int64_t originalBound,
-                               int64_t alignment) -> int64_t {
-    int64_t remainder = originalBound % alignment;
-    if (remainder == 0) {
-      return originalBound;
-    }
-    couldNeedPadding = true;
-    return originalBound + alignment - remainder;
-  };
   // Since the TileAndFuse (I)GEMM pipeline can support padding we can align
   // the bounds of our problem so that we get favorable tile sizes.
   // Please see the document linked in
@@ -744,17 +758,15 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                           bool paddingCanBeExpensive) -> SmallVector<int64_t> {
     return llvm::map_to_vector(dims, [&](int64_t dim) {
       if (ShapedType::isDynamic(bounds[dim]) || !canSupportUnaligned ||
-          paddingCanBeExpensive) {
+          paddingCanBeExpensive || bounds[dim] <= 32) {
         return bounds[dim];
       }
-      if (bounds[dim] > 128) {
-        return maybePaddedBounds(bounds[dim], 128);
+      int64_t alignment = bounds[dim] > 128 ? 128 : 32;
+      int64_t padded = padBoundForHeuristic(bounds[dim], alignment);
+      if (padded != bounds[dim]) {
+        couldNeedPadding = true;
       }
-      if (bounds[dim] > 32) {
-        return maybePaddedBounds(bounds[dim], 32);
-      }
-
-      return bounds[dim];
+      return padded;
     });
   };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -7,12 +7,21 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 
+#include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir::iree_compiler::IREE::GPU {
+
+/// Given a target and a matmul problem, try to find an MMA schedule for the
+/// problem based on the available mma intrinsics and heuristic seeds.
+std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
+    IREE::GPU::TargetAttr target, GPUMatmulShapeType problem, Location loc,
+    bool transposedLhs, bool transposedRhs, bool isGemm, bool scaled,
+    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned = true,
+    bool doCPromotion = false, int64_t splitReductionTripCnt = 0);
 
 /// Helper for setting up a data tiled multi-MMA inner_tiled config based on the
 /// specified target.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -939,6 +939,55 @@ func.func @data_tiled_scaled_2x2x4_tensor_interleave_m_n_and_k(
 
 // -----
 
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @partial_data_tiled_scaled_1x1x1_distribute(
+    %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
+    %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+    %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+  } : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+  return %0 : tensor<1x1x4x16x4xf32>
+}
+
+// CHECK-LABEL: func @partial_data_tiled_scaled_1x1x1_distribute
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]
+//       CHECK:   scf.forall (%[[THREAD_ID:.+]]) in (64) shared_outs(%[[ACC_ARG:.+]] = %[[ACC]]) -> (tensor<1x1x4x16x4xf32>)
+//   CHECK-DAG:     %[[DATA_IDS:.+]]:3 = affine.delinearize_index {{.*}} into (4, 16)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[DATA_IDS]]#2, %[[DATA_IDS]]#1, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[DATA_IDS]]#2, %[[DATA_IDS]]#1, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[SCALE_IDS:.+]]:3 = affine.delinearize_index %[[THREAD_ID]] into (4, 16)
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[SCALE_IDS]]#1, %[[SCALE_IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[SCALE_IDS]]#1, %[[SCALE_IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[SCALE_IDS]]#1, %[[SCALE_IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>
+//  CHECK-SAME:       : tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1xf8E8M0FNU>, tensor<1x1x1x1xf8E8M0FNU> into tensor<1x1x1x1x4xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[SCALE_IDS]]#1, %[[SCALE_IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]
+
+// -----
+
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
  affine_map<(i, j, k) -> (k, j)>,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:ConfigUtils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:KnownTargets",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms",

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
+    iree::compiler::Codegen::Dialect::GPU::TargetUtils::ConfigUtils
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::KnownTargets
     iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Dialect::PCF::Transforms

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -34,12 +34,14 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
 #include "iree/compiler/Codegen/ExternalInterfaces/Utils.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
@@ -51,6 +53,13 @@
 #include <numeric>
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
+
+static llvm::cl::opt<bool> clPartialDTScaledMMA(
+    "iree-gpu-partial-dt-scaled-mma",
+    llvm::cl::desc(
+        "Use PartialDataTiledScaledMMAAttr for scaled matmuls: data operands "
+        "are pack-only (row-major), scales are fully shuffled."),
+    llvm::cl::init(false));
 
 namespace mlir::iree_compiler::IREE::GPU {
 
@@ -363,6 +372,48 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   auto scaledMmaInterleaveK = DenseI64ArrayAttr::get(
       ctx, {kScaledMMAOperandLhsScale, kScaledMMAOperandRhsScale});
   auto intrinsicScaledMma = cast<ScaledMMAAttr>(intrinsicAttr);
+
+  if (clPartialDTScaledMMA) {
+    if (succeeded(matmulSizes) && !ShapedType::isDynamic(matmulSizes->M) &&
+        !ShapedType::isDynamic(matmulSizes->N) &&
+        !ShapedType::isDynamic(matmulSizes->K)) {
+      GPUMatmulShapeType problem(
+          {matmulSizes->M}, {matmulSizes->N}, {matmulSizes->K, matmulSizes->Kb},
+          /*batch=*/{}, eTypes[kScaledMMAOperandLhs],
+          eTypes[kScaledMMAOperandRhs], eTypes[kScaledMMAOperandAcc],
+          eTypes[kScaledMMAOperandLhsScale], eTypes[kScaledMMAOperandRhsScale]);
+      padProblemForHeuristic(problem);
+      auto schedule = getMmaScheduleFromProblemAndTarget(
+          target, problem, UnknownLoc::get(ctx),
+          /*transposedLhs=*/false, /*transposedRhs=*/false,
+          /*isGemm=*/true, /*scaled=*/true,
+          /*useDirectLoad=*/false, /*prefetchNumStages=*/2);
+      if (schedule) {
+        intrinsicsM = schedule->getTotalMTileSize();
+        intrinsicsN = schedule->getTotalNTileSize();
+        subgroupsM = schedule->getTotalMSubgroupCount();
+        subgroupsN = schedule->getTotalNSubgroupCount();
+        intrinsicsK = schedule->getTotalKTileSize();
+        subgroupsK = 1;
+      } else {
+        intrinsicsK = 2;
+      }
+    }
+    auto scaledMmaInterleaveM =
+        DenseI64ArrayAttr::get(ctx, {kScaledMMAOperandLhsScale});
+    auto scaledMmaInterleaveN =
+        DenseI64ArrayAttr::get(ctx, {kScaledMMAOperandRhsScale});
+    return PartialDataTiledScaledMMAAttr::get(
+        ctx, intrinsicScaledMma.getIntrinsic(),
+        intrinsicScaledMma.getLhsElemType(),
+        intrinsicScaledMma.getRhsElemType(),
+        intrinsicScaledMma.getAccElemType(), intrinsicsM, subgroupsM,
+        intrinsicsN, subgroupsN, intrinsicsK, subgroupsK,
+        /*operands_interleaving_intrinsics_m=*/scaledMmaInterleaveM,
+        /*operands_interleaving_intrinsics_n=*/scaledMmaInterleaveN,
+        /*operands_interleaving_intrinsics_k=*/scaledMmaInterleaveK);
+  }
+
   return DataTiledScaledMMAAttr::get(
       ctx, intrinsicScaledMma.getIntrinsic(),
       intrinsicScaledMma.getLhsElemType(), intrinsicScaledMma.getRhsElemType(),
@@ -541,7 +592,7 @@ static Operation *lowerContractionOrScaledContractionOpToInnerTiledOp(
     return Codegen::InnerTiledOp::create(
         builder, loc, operands.take_front(inputs.size()),
         operands.take_back(outputs.size()), indexingMaps, iteratorTypes,
-        cast<IREE::GPU::DataTiledScaledMMAAttr>(dataTiledAttr), semantics);
+        cast<Codegen::InnerTileDescAttrInterface>(dataTiledAttr), semantics);
   }
   default: {
     assert(false && "unexpected encoding op type");
@@ -590,8 +641,10 @@ struct GPUEncodingPackedLayoutMaterializerAttr
       return info;
     }
     info = std::move(maybeEncodingInfo.value());
+
+    unsigned opIdx = encoding.getOperandIndex().getInt();
     FailureOr<IREE::Codegen::TileSwizzle> maybeSwizzle =
-        getEncodingSwizzle(encoding, mma, encoding.getOperandIndex().getInt());
+        getEncodingSwizzle(encoding, mma, opIdx);
     if (failed(maybeSwizzle)) {
       return info;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -629,7 +629,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     // Disable redundant vector transfer hoisting because it does not
     // properly consider distributed code on memrefs.
     options.redundantHoisting = false;
-    funcPassManager.addPass(createOptimizeVectorTransferPass(options));
+    funcPassManager.addPass(createOptimizeVectorTransferPass());
   }
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -629,7 +629,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     // Disable redundant vector transfer hoisting because it does not
     // properly consider distributed code on memrefs.
     options.redundantHoisting = false;
-    funcPassManager.addPass(createOptimizeVectorTransferPass());
+    funcPassManager.addPass(createOptimizeVectorTransferPass(options));
   }
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -305,6 +305,36 @@ func.func @data_tiled_scaled_mma_inner_tiled_with_copy(
 
 // -----
 
+module {
+  func.func @partial_data_tiled_scaled_mma_inner_tiled(
+      %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
+      %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+      %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32> {
+    %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+      indexing_maps = [affine_map<(m, n, k, kb) -> (m, k, kb)>,
+                       affine_map<(m, n, k, kb) -> (n, k, kb)>,
+                       affine_map<(m, n, k, kb) -> (m, k)>,
+                       affine_map<(m, n, k, kb) -> (n, k)>,
+                       affine_map<(m, n, k, kb) -> (m, n)>],
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>,
+      semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
+      : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+      return %0 : tensor<1x1x4x16x4xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @partial_data_tiled_scaled_mma_inner_tiled
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
+//       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+//  CHECK-SAME:     reduction = [0, 0, 1, 1]
+//  CHECK-SAME:     workgroup = [1, 1, 0, 0]
+
+// -----
+
 // Test that scaled matmul with an existing accumulator (matmul_accumulate)
 // gets smaller tiles than a zero-initialized matmul to account for accumulator
 // memory in workgroup memory (LDS). Without this, 256x256 tiles would be

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -416,3 +416,104 @@ hal.executable public @matmul_i8 {
 //          CHECK:     }
 //          CHECK:     vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xi32>, memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
 //          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+// PartialDataTiledScaledMMAAttr pipeline test: verifies XOR swizzle hints on
+// data operands, software pipelining, and amdgpu.scaled_mfma generation.
+
+#pipeline_layout_pdt = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, Indirect>],
+  flags = Indirect
+>
+#translation_info_pdt = #iree_codegen.translation_info<pipeline =
+  #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64,
+  {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      prefetch_num_stages = 2,
+      no_reduce_shared_memory_bank_conflicts = true>
+  }
+>
+#config_pdt = #iree_gpu.lowering_config<{
+  workgroup = [1, 1, 0, 0],
+  reduction = [0, 0, 1, 1],
+  promote_operands = [0, 1, 2, 3],
+  promotion_types = [
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config,
+      swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config,
+      swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.derived_thread_config,
+    #iree_gpu.derived_thread_config]
+}>
+hal.executable public @pdt_main {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @partial_dt_scaled_mma ordinal(0) layout(#pipeline_layout_pdt) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @partial_dt_scaled_mma()
+        attributes {translation_info = #translation_info_pdt} {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>>
+        %4 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(4) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
+        %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 16, 4, 32], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>> -> tensor<9x9x1x16x4x32xf4E2M1FN>
+        %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 16, 4, 32], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>> -> tensor<9x9x1x16x4x32xf4E2M1FN>
+        %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [9, 9, 4, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>> -> tensor<9x9x4x16xf8E8M0FNU>
+        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [9, 9, 4, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>> -> tensor<9x9x4x16xf8E8M0FNU>
+        %9 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>> -> tensor<9x9x4x16x4xf32>
+        %10 = iree_codegen.inner_tiled ins(%5, %6, %7, %8) outs(%9) {
+          lowering_config = #config_pdt,
+          indexing_maps = [
+            affine_map<(m, n, k, kb) -> (m, k, kb)>,
+            affine_map<(m, n, k, kb) -> (n, k, kb)>,
+            affine_map<(m, n, k, kb) -> (m, k)>,
+            affine_map<(m, n, k, kb) -> (n, k)>,
+            affine_map<(m, n, k, kb) -> (m, n)>],
+          iterator_types = [
+            #linalg.iterator_type<parallel>,
+            #linalg.iterator_type<parallel>,
+            #linalg.iterator_type<reduction>,
+            #linalg.iterator_type<reduction>],
+          kind = #iree_gpu.partial_data_tiled_scaled_mma_layout<
+            intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+            lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32,
+            operands_interleaving_intrinsics_m = [2],
+            operands_interleaving_intrinsics_n = [3],
+            operands_interleaving_intrinsics_k = [2, 3]>,
+          semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
+          : tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x4x16xf8E8M0FNU>, tensor<9x9x4x16xf8E8M0FNU> into tensor<9x9x4x16x4xf32>
+        iree_tensor_ext.dispatch.tensor.store %10, %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : tensor<9x9x4x16x4xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @partial_dt_scaled_mma()
+// CHECK-DAG:  %[[PDT_C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:  %[[PDT_C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:  %[[PDT_C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:  %[[PDT_BUFFER_A:.+]] = amdgpu.fat_raw_buffer_cast %{{.*}} : memref<9x9x1x16x4x32xf4E2M1FN{{.*}}> to memref<9x9x1x16x4x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-DAG:  %[[PDT_BUFFER_B:.+]] = amdgpu.fat_raw_buffer_cast %{{.*}} : memref<9x9x1x16x4x32xf4E2M1FN{{.*}}> to memref<9x9x1x16x4x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-DAG:  %[[PDT_A_ALLOC:.+]] = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 32>} : memref<2048xf4E2M1FN, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[PDT_B_ALLOC:.+]] = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 32>} : memref<2048xf4E2M1FN, #gpu.address_space<workgroup>>
+//     CHECK:  gpu.barrier memfence [#gpu.address_space<workgroup>]
+//     CHECK:  %[[PDT_LOOP:.+]] = scf.for {{.*}} %[[PDT_C0]] to %[[PDT_C8]] step %[[PDT_C1]] iter_args({{.*}}) -> (vector<4xf32>)
+// CHECK-DAG:    vector.transfer_read %[[PDT_BUFFER_A]]{{.*}} vector<32xf4E2M1FN>
+// CHECK-DAG:    vector.transfer_read %[[PDT_BUFFER_B]]{{.*}} vector<32xf4E2M1FN>
+//     CHECK:    gpu.barrier
+//     CHECK:    amdgpu.scaled_mfma 16x16x128
+//     CHECK:    scf.yield
+//     CHECK:  }
+//     CHECK:  amdgpu.scaled_mfma 16x16x128

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -814,6 +814,16 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
       return failure();
     }
   }
+  if (auto pdtsmma =
+          dyn_cast<IREE::GPU::PartialDataTiledScaledMMAAttr>(intrinsic)) {
+    switch (pdtsmma.getIntrinsic()) {
+    case IREE::GPU::ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+      return XorShuffleParams({/*rowElems=*/256,
+                               /*accessElems=*/32});
+    default:
+      return failure();
+    }
+  }
   return failure();
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -344,6 +344,23 @@ void HoistEncodingOpsPass::runOnOperation() {
       }
     }
     if (isHoistable) {
+      // In partial-dt-scaled-mma mode, only hoist scale operand encodings
+      // (operand_index 2 or 3). Data and accumulator encodings stay inside.
+      if (partialDTScaledMMA) {
+        auto encodingAttr =
+            dyn_cast_if_present<IREE::Encoding::EncodingAttr>(encoding);
+        if (encodingAttr) {
+          auto opIdx = encodingAttr.getOperandIndex();
+          if (opIdx) {
+            int64_t idx = cast<IntegerAttr>(opIdx).getInt();
+            if (idx != 2 && idx != 3) {
+              LDBG() << "Skipping non-scale operand (idx=" << idx
+                     << ") in partial-dt-scaled-mma mode: " << setEncodingOp;
+              return;
+            }
+          }
+        }
+      }
       candidates.push_back(llvm::to_vector(llvm::reverse(opsWithinDispatch)));
       return;
     }

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -50,6 +50,13 @@ static llvm::cl::opt<bool> clExperimentalMultiUseEncodingFusion(
         "Enable encoding op fusion if the producer has more than one use"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clPartialDTScaledMMA(
+    "iree-dispatch-creation-partial-dt-scaled-mma",
+    llvm::cl::desc(
+        "Only hoist scale operand encodings; keep data operand encodings "
+        "inside dispatches (for PartialDataTiledScaledMMAAttr path)."),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<DispatchCreation::EncodingOptions> clSetEncodingStrategy(
     "iree-dispatch-creation-set-encoding-strategy",
     llvm::cl::desc("Set the encoding strategy for operations."),
@@ -273,7 +280,12 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
     // op, so hoist them out of their current dispatch regions. Also, bubble
     // SetEncodingOps through special operations like bit-extending ops and
     // broadcasting ops.
-    passManager.addPass(DispatchCreation::createHoistEncodingOpsPass());
+    {
+      HoistEncodingOpsPassOptions hoistOpts;
+      hoistOpts.partialDTScaledMMA = clPartialDTScaledMMA;
+      passManager.addPass(
+          DispatchCreation::createHoistEncodingOpsPass(hoistOpts));
+    }
   }
   FunctionLikeNest(passManager)
       .addPass([&]() {

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -381,6 +381,12 @@ def HoistEncodingOpsPass : Pass<"iree-dispatch-creation-hoist-encoding-ops", "ml
     "IREE::Flow::FlowDialect",
     "IREE::Encoding::IREEEncodingDialect",
   ];
+  let options = [
+    Option<"partialDTScaledMMA", "partial-dt-scaled-mma", "bool",
+    /*default=*/"false",
+    "Only hoist scale operand encodings (operand_index 2,3); "
+    "keep data operand encodings inside dispatches.">,
+  ];
 }
 
 def HoistUniformScalarComputePass :

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2666,6 +2666,40 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cdna4_mxfp4_partial_dt
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=easy_large_static"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    --iree-dispatch-creation-data-tiling=true
+    --iree-rocm-encoding-layout-resolver=data-tiling
+    --iree-gpu-partial-dt-scaled-mma
+    --iree-dispatch-creation-partial-dt-scaled-mma
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_cdna4_mxfp4_dt_tensor_ukernel_medium
   TEST_TYPE
     matmul


### PR DESCRIPTION
This PR is the second in a series of PRs meant to enable preshuffling for scaled gemms.

We introduce a new kind called `PartialDataTiledScaledMMAAttr` which is meant to be identical to `DataTiledScaledMMAAttr` in every way except three:
1) We do not use the default heuristic in `chooseDataTiledMMAAttr` to choose tiling config, instead use `getMmaScheduleFromProblemAndTarget`.
2) Perform shuffling on scale operands only; Do not hoist data operands to a separate dispatch and importantly, do not apply any permutations to these operands.
3) Add ability to handle row-major (non-permuted) data operands in `populateOperandOffsetsSizesStrides`.

These changes allow us to only create separate dispatches to preshuffle scale operands. This provides an immediate 31.5% geomean improvement in throughput across 50 shapes tested.