### PR TITLE
[DMA][Swizzle] Apply inverse source swizzle in DMA lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -30,6 +31,7 @@
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
@@ -144,6 +146,19 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
   return segments;
 }
 
+/// Trace a memref value through view-like ops to find a SwizzleHintOp.
+/// Returns the swizzle attribute if found, std::nullopt otherwise.
+static std::optional<IREE::Codegen::SwizzleAttrInterface>
+getDestSwizzleAttr(Value dest) {
+  while (auto viewOp = dest.getDefiningOp<mlir::ViewLikeOpInterface>()) {
+    dest = viewOp.getViewSource();
+  }
+  if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
+    return hintOp.getSwizzle();
+  }
+  return std::nullopt;
+}
+
 /// Generates source and destination indices for a GatherToLDS operation.
 ///
 /// The gather_to_lds instruction requires:
@@ -222,6 +237,8 @@ struct LowerCoalescedGatherDMAPattern final
 
     Value source = dmaOp.getSource();
     Value dest = dmaOp.getInit();
+    std::optional<IREE::Codegen::SwizzleAttrInterface> destSwizzle =
+        getDestSwizzleAttr(dest);
 
     auto sourceType = cast<MemRefType>(source.getType());
     auto destType = cast<MemRefType>(dest.getType());
@@ -320,7 +337,7 @@ struct LowerCoalescedGatherDMAPattern final
 
     emitTransfers(rewriter, loc, source, dest, destShape, numLinearDims,
                   elementType, indices, segments, segmentLaneOffsets,
-                  dmaOp.getInBounds());
+                  dmaOp.getInBounds(), destSwizzle);
 
     rewriter.eraseOp(dmaOp);
     return success();
@@ -341,20 +358,25 @@ private:
   ///   - Source indices: per-lane divergent (include lane offset)
   ///   - Destination indices: subgroup-uniform (exclude lane offset)
   ///
+  /// When a destination swizzle is present (e.g., XOR swizzle for LDS bank
+  /// conflict avoidance), an inverse swizzle is applied to the source indices.
+  /// The destination writes linearly into LDS, and the swizzled source read
+  /// pattern ensures data arrives in the correct swizzled layout.
+  ///
   /// We generate two delinearizations:
-  ///   1. With lane offset: for source index computation (divergent)
+  ///   1. With lane offset (and optional inverse swizzle): for source indices
   ///   2. Without lane offset: for destination index computation (uniform)
   ///
   /// Example: shape [16, 64] with 32 lanes, 4 elements/lane:
   ///   - Lane 16: srcLinearOffset = 0 + 16*4 = 64
   ///   - delinearize(64, [16, 64]) → [1, 0] (for source)
   ///   - delinearize(0, [16, 64])  → [0, 0] (for destination, uniform)
-  void emitTransfers(PatternRewriter &rewriter, Location loc, Value source,
-                     Value dest, ArrayRef<int64_t> destShape,
-                     int64_t numLinearDims, Type elementType,
-                     OperandRange indices, ArrayRef<TransferSegment> segments,
-                     ArrayRef<Value> segmentLaneOffsets,
-                     std::optional<ArrayAttr> inBoundsAttr) const {
+  void emitTransfers(
+      PatternRewriter &rewriter, Location loc, Value source, Value dest,
+      ArrayRef<int64_t> destShape, int64_t numLinearDims, Type elementType,
+      OperandRange indices, ArrayRef<TransferSegment> segments,
+      ArrayRef<Value> segmentLaneOffsets, std::optional<ArrayAttr> inBoundsAttr,
+      std::optional<IREE::Codegen::SwizzleAttrInterface> destSwizzle) const {
     int64_t destRank = destShape.size();
     int64_t numOuterDims = destRank - numLinearDims;
     LDBG() << "Emitting transfers: " << numOuterDims << " outer dims, "
@@ -401,6 +423,14 @@ private:
           // Source indices: add lane offset before delinearization (divergent).
           Value srcLinearOffset =
               arith::AddIOp::create(rewriter, loc, linearOffsetVal, laneOffset);
+          // Apply inverse source swizzle when destination has XOR swizzle.
+          // XOR swizzle is self-inverse, so swizzle(swizzle(x)) = x.
+          if (destSwizzle) {
+            srcLinearOffset = getValueOrCreateConstantIndexOp(
+                rewriter, loc,
+                destSwizzle->swizzleOffset(rewriter, loc, srcLinearOffset,
+                                           dest));
+          }
           auto srcDelinearize = affine::AffineDelinearizeIndexOp::create(
               rewriter, loc, srcLinearOffset, basis, /*hasOuterBound=*/true);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -147,14 +147,21 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
 }
 
 /// Trace a memref value through view-like ops to find a SwizzleHintOp.
-/// Returns the swizzle attribute if found, std::nullopt otherwise.
+/// Returns the swizzle attribute if it is an XOR swizzle (which is
+/// self-inverse), std::nullopt otherwise.
 static std::optional<IREE::Codegen::SwizzleAttrInterface>
 getDestSwizzleAttr(Value dest) {
   while (auto viewOp = dest.getDefiningOp<mlir::ViewLikeOpInterface>()) {
     dest = viewOp.getViewSource();
   }
   if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
-    return hintOp.getSwizzle();
+    auto swizzle = hintOp.getSwizzle();
+    // Only XOR swizzle is self-inverse (swizzle(swizzle(x)) = x), so it can
+    // be applied to source addresses as the inverse transformation. Other
+    // swizzle types (e.g. rotate_rows) are not self-inverse.
+    if (isa<IREE::Codegen::XORShuffleAttr>(swizzle)) {
+      return swizzle;
+    }
   }
   return std::nullopt;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -180,6 +180,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:VectorToSCF",
         "@llvm-project//mlir:VectorTransforms",
         "@llvm-project//mlir:VectorUtils",
+        "@llvm-project//mlir:ViewLikeInterface",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -144,6 +144,7 @@ iree_cc_library(
     MLIRVectorToSCF
     MLIRVectorTransforms
     MLIRVectorUtils
+    MLIRViewLikeInterface
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1581,3 +1581,123 @@ func.func @no_lower_oob_without_fat_raw_buffer(
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return
 }
+
+// -----
+
+// Test: Inverse source swizzle when destination has swizzle_hint.
+// The destination traces through expand_shape -> swizzle_hint -> alloc.
+// Source indices should be swizzled, destination indices should be linear.
+//
+// Shape: 4x128 f32 dest. With 64 lanes, 128-bit DMA = 4 elements/lane.
+// 256 elements/transfer, 512 total = 2 transfers.
+// XOR swizzle with row_width=128, access_width=16 permutes source offsets.
+
+#executable_target_rocm_hsaco_fb_swizzle = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [],
+    subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_swizzle = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @lower_dma_with_dest_swizzle
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>
+func.func @lower_dma_with_dest_swizzle(
+    %source: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_swizzle,
+    translation_info = #translation_swizzle} {
+  %alloc = memref.alloc() : memref<512xf32, #gpu.address_space<workgroup>>
+  %swizzled = iree_codegen.swizzle_hint %alloc[#iree_codegen.xor_shuffle<128, 16>]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+  %dest = memref.expand_shape %swizzled [[0, 1]]
+      output_shape [4, 128]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+      into memref<4x128xf32, #gpu.address_space<workgroup>>
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (64)
+  scf.forall (%lane) in (64) {
+    // CHECK: %[[C4:.+]] = arith.constant 4 : index
+    // CHECK: %[[LANE_OFFSET:.+]] = arith.muli %[[LANE_ID]], %[[C4]]
+    //
+    // Transfer 1: linearOffset = 0, source gets XOR-swizzled offset.
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
+    // XOR swizzle: extractCol, extractRow, xori, updateCol, diff, add.
+    // CHECK: %[[COL0:.+]] = affine.apply
+    // CHECK: %[[ROW0:.+]] = affine.apply
+    // CHECK: %[[XOR0:.+]] = arith.xori %[[ROW0]], %[[COL0]]
+    // CHECK: %[[UCOL0:.+]] = affine.apply
+    // CHECK: %[[DIFF0:.+]] = arith.subi %[[UCOL0]], %[[SRC_LIN0]]
+    // CHECK: %[[SWIZZLED0:.+]] = arith.addi %[[SRC_LIN0]], %[[DIFF0]]
+    // Source delinearized from swizzled offset.
+    // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SWIZZLED0]] into (4, 128)
+    // Destination delinearized from unswizzled offset (no xori).
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
+    // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[SRC_DELIN0]]#0, %[[SRC_DELIN0]]#1], %{{.+}}[%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
+    //
+    // Remaining 1 transfer also has XOR swizzle on source.
+    // CHECK-COUNT-1: amdgpu.gather_to_lds
+    // CHECK-NOT: amdgpu.gather_to_lds
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)
+        : memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>,
+          memref<4x128xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#iree_gpu.lane_id<0>]}
+  return
+}
+
+// -----
+
+// Test: Swizzle trace through chained view-like ops.
+// Destination traces: subview -> expand_shape -> swizzle_hint -> alloc.
+// The swizzle should still be detected through the chain.
+
+#executable_target_rocm_hsaco_fb_swizzle_chain = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [],
+    subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_swizzle_chain = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+// CHECK-LABEL: func.func @lower_dma_with_chained_view_ops
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<2x128xf32, #amdgpu.address_space<fat_raw_buffer>>
+func.func @lower_dma_with_chained_view_ops(
+    %source: memref<2x128xf32, #amdgpu.address_space<fat_raw_buffer>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_swizzle_chain,
+    translation_info = #translation_swizzle_chain} {
+  %alloc = memref.alloc() : memref<512xf32, #gpu.address_space<workgroup>>
+  %swizzled = iree_codegen.swizzle_hint %alloc[#iree_codegen.xor_shuffle<128, 16>]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+  %expanded = memref.expand_shape %swizzled [[0, 1]]
+      output_shape [4, 128]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+      into memref<4x128xf32, #gpu.address_space<workgroup>>
+  %dest = memref.subview %expanded[0, 0] [2, 128] [1, 1]
+      : memref<4x128xf32, #gpu.address_space<workgroup>>
+      to memref<2x128xf32, strided<[128, 1]>, #gpu.address_space<workgroup>>
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (64)
+  scf.forall (%lane) in (64) {
+    // XOR swizzle should still be applied through the subview+expand chain.
+    // CHECK: arith.xori
+    // CHECK: amdgpu.gather_to_lds
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)
+        : memref<2x128xf32, #amdgpu.address_space<fat_raw_buffer>>,
+          memref<2x128xf32, strided<[128, 1]>, #gpu.address_space<workgroup>>, index
+  } {mapping = [#iree_gpu.lane_id<0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -10,11 +10,11 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 namespace mlir::iree_compiler {
 
@@ -139,26 +139,6 @@ static void swizzleStore(RewriterBase &rewriter, vector::StoreOp store,
   rewriter.eraseOp(store);
 }
 
-/// Swizzles:
-///  amdgpu.gather_to_lds
-///    (iree_codegen.swizzle_hint, srcIndices, dst, dstIndices, transferType)
-///
-/// For now, only support gather_to_lds width == accessWidth.
-static void swizzleGatherToLDS(RewriterBase &rewriter,
-                               amdgpu::GatherToLDSOp gatherOp,
-                               IREE::Codegen::SwizzleHintOp hintOp) {
-  Location hintLoc = hintOp.getLoc();
-  Value memrefOffset = gatherOp.getSrcIndices()[0];
-  Value newOffset = getValueOrCreateConstantIndexOp(
-      rewriter, hintLoc,
-      hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(), memrefOffset,
-                                        hintOp.getOperand()));
-  rewriter.modifyOpInPlace(gatherOp, [&]() {
-    gatherOp.getSrcMutable().assign(hintOp.getOperand());
-    gatherOp.getSrcIndicesMutable().assign(newOffset);
-  });
-}
-
 static LogicalResult
 verifyFlatContiguousSwizzleHintOp(IREE::Codegen::SwizzleHintOp hintOp) {
   auto memrefType = cast<MemRefType>(hintOp.getOperand().getType());
@@ -182,7 +162,6 @@ static void resolveHintOp(RewriterBase &rewriter,
                           IREE::Codegen::SwizzleHintOp hintOp) {
   SmallVector<vector::LoadOp> loads;
   SmallVector<vector::StoreOp> stores;
-  SmallVector<amdgpu::GatherToLDSOp> gatherToLDSOps;
   int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
   for (Operation *user : hintOp->getUsers()) {
     if (auto load = dyn_cast<vector::LoadOp>(user)) {
@@ -205,35 +184,11 @@ static void resolveHintOp(RewriterBase &rewriter,
       stores.push_back(store);
       continue;
     }
-    if (auto gatherToLDSOp = dyn_cast<amdgpu::GatherToLDSOp>(user)) {
-      // Ignore swizzleHint on Dst Operand. Gather_to_lds writes elements of a
-      // subgroup contiguously in order of lane ID.
-      if (gatherToLDSOp.getDst() == hintOp) {
-        continue;
-      }
-      int64_t accessBitWidth = cast<MemRefType>(hintOp.getOperand().getType())
-                                   .getElementTypeBitWidth() *
-                               accessWidth;
-      auto transferBitWidth = [&]() -> int64_t {
-        if (auto vectorType =
-                dyn_cast<VectorType>(gatherToLDSOp.getTransferType())) {
-          return vectorType.getElementTypeBitWidth() *
-                 vectorType.getNumElements();
-        }
-        return gatherToLDSOp.getTransferType().getIntOrFloatBitWidth();
-      }();
-      if (accessBitWidth != transferBitWidth) {
-        return;
-      }
-      gatherToLDSOps.push_back(gatherToLDSOp);
-      continue;
-    }
-    // Treat reshape/subview ops as transparent users. When a swizzle_hint is
-    // used as the destination (via expand_shape/collapse_shape/subview) of a
-    // gather_to_lds, the swizzle is applied at the source-side in the DMA
-    // lowering pass, so these ops just pass through the swizzled allocation.
-    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp, memref::SubViewOp>(
-            user)) {
+    // Gather_to_lds destination-side swizzle is handled by
+    // AMDGPULowerCoalescedDMAToGatherLDS, which applies the inverse swizzle
+    // to source indices. Treat gather_to_lds and view-like ops as transparent
+    // users that pass through the swizzled allocation.
+    if (isa<amdgpu::GatherToLDSOp, ViewLikeOpInterface>(user)) {
       continue;
     }
     // Throw if we can't rewrite all users.
@@ -248,10 +203,6 @@ static void resolveHintOp(RewriterBase &rewriter,
   for (vector::StoreOp store : stores) {
     rewriter.setInsertionPoint(store);
     swizzleStore(rewriter, store, hintOp);
-  }
-  for (amdgpu::GatherToLDSOp gatherToLDSOp : gatherToLDSOps) {
-    rewriter.setInsertionPoint(gatherToLDSOp);
-    swizzleGatherToLDS(rewriter, gatherToLDSOp, hintOp);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/AffineExpr.h"
@@ -225,6 +226,14 @@ static void resolveHintOp(RewriterBase &rewriter,
         return;
       }
       gatherToLDSOps.push_back(gatherToLDSOp);
+      continue;
+    }
+    // Treat reshape/subview ops as transparent users. When a swizzle_hint is
+    // used as the destination (via expand_shape/collapse_shape/subview) of a
+    // gather_to_lds, the swizzle is applied at the source-side in the DMA
+    // lowering pass, so these ops just pass through the swizzled allocation.
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp, memref::SubViewOp>(
+            user)) {
       continue;
     }
     // Throw if we can't rewrite all users.

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -196,7 +196,9 @@ func.func @swizzle_adjust_add_offset(%src: memref<?xf32>, %vec: vector<4xf32>, %
 
 // -----
 
-func.func @swizzle_gather_to_lds(%src: memref<?xf32>, %offset: index) {
+// Gather_to_lds source-side swizzle is handled by
+// AMDGPULowerCoalescedDMAToGatherLDS. ResolveSwizzleHints just drops the hint.
+func.func @gather_to_lds_passthrough(%src: memref<?xf32>, %offset: index) {
   %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
   %lds = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
@@ -204,46 +206,12 @@ func.func @swizzle_gather_to_lds(%src: memref<?xf32>, %offset: index) {
   return
 }
 
-// CHECK-LABEL: func @swizzle_gather_to_lds
+// CHECK-LABEL: func @gather_to_lds_passthrough
 //  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
 //  CHECK-SAME:   %[[OFFSET:[A-Za-z0-9]+]]: index
-//   CHECK-DAG:   %[[ROW_WIDTH:.+]] = arith.constant 64 : index
-//   CHECK-DAG:   %[[GROUP_COUNT:.+]] = arith.constant 16 : index
-//   CHECK-DAG:   %[[GROUP_WIDTH:.+]] = arith.constant 4 : index
 //   CHECK-DAG:   %[[DSTOFFSET:.+]] = arith.constant 0 : index
 //       CHECK:   %[[LDS:.+]] = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
-//       CHECK:   %[[I:.+]] = arith.divui %[[OFFSET]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[JELEM:.+]] = arith.remui %[[OFFSET]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[J:.+]] = arith.divui %[[JELEM]], %[[GROUP_WIDTH]] : index
-//       CHECK:   %[[ADD:.+]] = arith.addi %[[I]], %[[J]] : index
-//       CHECK:   %[[ROTATEJ:.+]] = arith.remui %[[ADD]], %[[GROUP_COUNT]] : index
-//       CHECK:  %[[ROTATEJELEM:.+]] = arith.muli %[[ROTATEJ]], %[[GROUP_WIDTH]] : index
-//       CHECK:   %[[IELEM:.+]] = arith.muli %[[I]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[SWOFF:.+]] = arith.addi %[[ROTATEJELEM]], %[[IELEM]] : index
-//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[SWOFF]]], %[[LDS]][%[[DSTOFFSET]]]
-
-// -----
-func.func @swizzle_gather_to_lds_scalar(%src: memref<?xf32>, %offset: index) {
-  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 1>] : memref<?xf32>
-  %lds = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
-  %c0 = arith.constant 0 : index
-  amdgpu.gather_to_lds %0[%offset], %lds[%c0] : f32, memref<?xf32>, memref<256xf32, #gpu.address_space<workgroup>>
-  return
-}
-
-// CHECK-LABEL: func @swizzle_gather_to_lds_scalar
-//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
-//  CHECK-SAME:   %[[OFFSET:[A-Za-z0-9]+]]: index
-//   CHECK-DAG:   %[[ROW_WIDTH:.+]] = arith.constant 64 : index
-//   CHECK-DAG:   %[[DSTOFFSET:.+]] = arith.constant 0 : index
-//       CHECK:   %[[LDS:.+]] = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
-//       CHECK:   %[[I:.+]] = arith.divui %[[OFFSET]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[JELEM:.+]] = arith.remui %[[OFFSET]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[J:.+]] = arith.addi %[[I]], %[[JELEM]] : index
-//       CHECK:   %[[ROTATEJ:.+]] = arith.remui %[[J]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[IELEM:.+]] = arith.muli %[[I]], %[[ROW_WIDTH]] : index
-//       CHECK:   %[[SWOFF:.+]] = arith.addi %[[ROTATEJ]], %[[IELEM]] : index
-//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[SWOFF]]], %[[LDS]][%[[DSTOFFSET]]]
+//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[OFFSET]]], %[[LDS]][%[[DSTOFFSET]]]
 
 // -----
 
@@ -281,9 +249,11 @@ func.func @swizzle_load_xor_phase2(%src: memref<?xi8>) -> vector<16xi8> {
 // -----
 
 
-func.func @swizzle_raw_buffer_to_lds(%global : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>) {
+// Gather_to_lds source-side swizzle is handled by
+// AMDGPULowerCoalescedDMAToGatherLDS. ResolveSwizzleHints just drops the hint
+// without modifying source indices.
+func.func @gather_to_lds_src_passthrough(%global : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>) {
   %c0 = arith.constant 0 : index
-  //1 row, 3rd tile : 1*8192+2*128 = 8448 -> (0 XOR 1)*16+8448 = 8464
   %offset = arith.constant 8448 : index
   %lds = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
   %globalSwizzle = iree_codegen.swizzle_hint %global[#iree_codegen.xor_shuffle<128, 16, 8192>] : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>
@@ -293,19 +263,18 @@ func.func @swizzle_raw_buffer_to_lds(%global : memref<32768xi8, #amdgpu.address_
   func.return
 }
 
-// CHECK-LABEL: func @swizzle_raw_buffer_to_lds
+// CHECK-LABEL: func @gather_to_lds_src_passthrough
 //  CHECK-SAME:   %[[SRC:.+]]: memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>
-//   CHECK:   %[[SWOFF:.+]] = arith.constant 8464 : index
-//   CHECK:   %[[LDSOFFSET:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[OFFSET:.+]] = arith.constant 8448 : index
+//   CHECK-DAG:   %[[LDSOFFSET:.+]] = arith.constant 0 : index
 //       CHECK:   %[[LDS:.+]] = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
-//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[SWOFF]]], %[[LDS]][%[[LDSOFFSET]]]
+//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[OFFSET]]], %[[LDS]][%[[LDSOFFSET]]]
 
 // -----
 
-
-func.func @swizzle_raw_buffer_to_lds_ignore_dst_op(%global : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>) {
+// Dst-side swizzle hint on gather_to_lds is treated as transparent.
+func.func @gather_to_lds_dst_passthrough(%global : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>) {
   %c0 = arith.constant 0 : index
-  //1 row, 3rd tile : 1*8192+2*128 = 8448 -> (0 XOR 1)*16+8448 = 8464
   %offset = arith.constant 8448 : index
   %lds = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
   %ldsSwizzle = iree_codegen.swizzle_hint %lds[#iree_codegen.xor_shuffle<128, 16>] : memref<32768xi8, #gpu.address_space<workgroup>>
@@ -316,12 +285,12 @@ func.func @swizzle_raw_buffer_to_lds_ignore_dst_op(%global : memref<32768xi8, #a
   func.return
 }
 
-// CHECK-LABEL: func @swizzle_raw_buffer_to_lds_ignore_dst_op
+// CHECK-LABEL: func @gather_to_lds_dst_passthrough
 //  CHECK-SAME:   %[[SRC:.+]]: memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>
-//   CHECK:   %[[SWOFF:.+]] = arith.constant 8464 : index
-//   CHECK:   %[[LDSOFFSET:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[OFFSET:.+]] = arith.constant 8448 : index
+//   CHECK-DAG:   %[[LDSOFFSET:.+]] = arith.constant 0 : index
 //       CHECK:   %[[LDS:.+]] = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
-//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[SWOFF]]], %[[LDS]][%[[LDSOFFSET]]]
+//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[OFFSET]]], %[[LDS]][%[[LDSOFFSET]]]
 
 // -----
 


### PR DESCRIPTION
* Add `getDestSwizzleAttr` helper that traces destination memref through view-like ops to find SwizzleHintOp.
* Apply the swizzle attribute's offset transformation to source linear offsets in `gather_to_lds` lowering. XOR swizzle is self-inverse, so applying it to source addresses produces the correct swizzled layout in LDS without violating `gather_to_lds`'s uniform-destination constraint.