### PR TITLE
[CI] Enable sccache on windows.

### DIFF
--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -17,7 +17,7 @@ jobs:
       BASE_BUILD_DIR_POWERSHELL: B:\tmpbuild
       SCCACHE_AZURE_CONNECTION_STRING: "${{ secrets.AZURE_CCACHE_CONNECTION_STRING }}"
       SCCACHE_AZURE_BLOB_CONTAINER: ccache-container
-      SCCACHE_CCACHE_ZSTD_LEVEL: 10
+      SCCACHE_CACHE_ZSTD_LEVEL: 10
       SCCACHE_AZURE_KEY_PREFIX: "ci_windows_x64_msvc"
     steps:
       - name: "Checking out repository"
@@ -59,8 +59,10 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
       - name: "Building IREE"
+        shell: bash
         run: |
           echo "Building in ${{ env.BUILD_DIR_BASH }}"
+          source ./build_tools/cmake/setup_sccache.sh
           bash ./build_tools/cmake/build_all.sh ${{ env.BUILD_DIR_BASH }}
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh ${{ env.BUILD_DIR_BASH }}

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -76,6 +76,12 @@ declare -a CMAKE_ARGS=(
   "-DIREE_TARGET_BACKEND_WEBGPU_SPIRV=${IREE_TARGET_BACKEND_WEBGPU_SPIRV}"
 )
 
+# sccache doesn't work with MSVC's /Zi (shared PDB files). Use /Z7 to embed
+# debug info in each .obj instead, avoiding PDB contention across parallel jobs.
+if [[ "${OSTYPE}" =~ ^msys ]] && (( ${IREE_USE_SCCACHE:-0} == 1 )); then
+  CMAKE_ARGS+=("-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded")
+fi
+
 "$CMAKE_BIN" "${CMAKE_ARGS[@]}"
 
 if (( IREE_CONFIGURE_ONLY == 1 )); then


### PR DESCRIPTION
* Fixes environment variable SCCACHE_CACHE_ZSTD_LEVEL
* calls set up sccache script before building
* Adds CMAKE_ARGS+=("-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded") to avoid contention across parallel jobs.

* [Before this change: completes in 22 minutes](https://github.com/iree-org/iree/actions/runs/24362105079/job/71144255284)
```
+ sccache --show-stats
Compile requests                   6739
Compile requests executed          6739
Cache hits                            0
Cache misses                       6693
Cache misses (C/C++)               6693
Cache hits rate                    0.00 %
Cache hits rate (C/C++)            0.00 %
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Cache errors                         33
Cache errors (C/C++)                 33
Compilations                       6693
Compilation failures                 13
Non-cacheable compilations            0
Non-cacheable calls                   0
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.057 s
Average compiler                  9.639 s
Average cache read hit            0.000 s
Failed distributed compilations       0
```

*[ After this change](https://github.com/iree-org/iree/actions/runs/24363450279/job/71149608012): completes in 10 minutes
```
+ sccache --show-stats
Compile requests                   6739
Compile requests executed          6739
Cache hits                         6640
Cache hits (C/C++)                 6640
Cache misses                         53
Cache misses (C/C++)                 53
Cache hits rate                   99.21 %
Cache hits rate (C/C++)           99.21 %
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Cache errors                         33
Cache errors (C/C++)                 33
Compilations                         53
Compilation failures                 13
Non-cacheable compilations            0
Non-cacheable calls                   0
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.012 s
Average compiler                  0.240 s
Average cache read hit            0.044 s
Failed distributed compilations       0
```

Please note that this only works on PRs from the repository itself, not from forks.