### PR TITLE
[TensorExt] Add LinearizeRaggedDimsOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -50,12 +50,11 @@ static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
                                          ValueRange dynamicDims) {
   unsigned requiredCount = 0;
   for (auto value : values) {
-    if (auto shapedType = dyn_cast<ShapedType>(value.getType())) {
-      requiredCount += shapedType.getNumDynamicDims();
-    } else if (auto tensorType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
-                   value.getType())) {
-      requiredCount += tensorType.getNumDynamicDims();
-    }
+    requiredCount +=
+        TypeSwitch<Type, int64_t>(value.getType())
+            .Case<ShapedType, IREE::TensorExt::DispatchTensorType>(
+                [&](auto type) { return type.getNumDynamicDims(); })
+            .Default([&](Type /*type*/) { return 0; });
   }
   if (dynamicDims.size() != requiredCount) {
     return op->emitOpError()
@@ -1001,13 +1000,12 @@ LogicalResult LinearizeRaggedDimsOp::reifyResultShapes(
 }
 
 LogicalResult LinearizeRaggedDimsOp::verify() {
-  ShapedType sourceType = cast<ShapedType>(getSource().getType());
-  ShapedType resultType = cast<ShapedType>(getResult().getType());
+  auto sourceType = cast<ShapedType>(getSource().getType());
+  auto resultType = cast<ShapedType>(getResult().getType());
 
   // 1. Verify source has ragged tensor encoding.
   auto raggedAttr =
       dyn_cast_if_present<RaggedShapeAttr>(getEncodingOrLayout(sourceType));
-
   if (!raggedAttr) {
     return emitOpError("expected source type to have a ragged tensor encoding");
   }
@@ -1020,12 +1018,11 @@ LogicalResult LinearizeRaggedDimsOp::verify() {
 
   // Get the sparse dimensions from the encoding.
   SmallVector<int64_t> sparseDims = raggedAttr.getSparseDimensions();
-
   if (sparseDims.empty()) {
     return emitOpError("ragged tensor encoding has no sparse dimensions");
   }
 
-  // Verify sparse dimensions are contiguous
+  // Verify sparse dimensions are contiguous.
   for (size_t i = 1; i < sparseDims.size(); ++i) {
     if (sparseDims[i] != sparseDims[i - 1] + 1) {
       return emitOpError("sparse dimensions must be contiguous, but got ")
@@ -1037,7 +1034,7 @@ LogicalResult LinearizeRaggedDimsOp::verify() {
   int64_t resultRank = resultType.getRank();
 
   // 2. Verify result rank: sparse dimensions are linearized into one dimension
-  // Result rank = source rank - number of sparse dimensions + 1
+  // Result rank = source rank - number of sparse dimensions + 1.
   int64_t expectedResultRank = sourceRank - sparseDims.size() + 1;
   if (resultRank != expectedResultRank) {
     return emitOpError("expected result rank to be ")
@@ -1047,11 +1044,11 @@ LogicalResult LinearizeRaggedDimsOp::verify() {
   }
 
   // 3. Build a set of sparse dimensions and a map from non-sparse source
-  // dimensions to result dimensions
+  // dimensions to result dimensions.
   llvm::SmallDenseSet<int64_t> sparseDimSet(sparseDims.begin(),
                                             sparseDims.end());
 
-  // Build mapping: non-sparse source dims -> result dims
+  // Build mapping: non-sparse source dims -> result dims.
   int64_t resultDimIndex = 0;
   for (int64_t sourceDim = 0; sourceDim < sourceRank; ++sourceDim) {
     if (sparseDimSet.contains(sourceDim)) {
@@ -1068,9 +1065,8 @@ LogicalResult LinearizeRaggedDimsOp::verify() {
 
     int64_t sourceSize = sourceType.getDimSize(sourceDim);
     int64_t resultSize = resultType.getDimSize(resultDimIndex);
-    bool sourceDynamic = ShapedType::isDynamic(sourceSize);
-    bool resultDynamic = ShapedType::isDynamic(resultSize);
-    if (!sourceDynamic && !resultDynamic && sourceSize != resultSize) {
+    if (ShapedType::isStatic(sourceSize) && ShapedType::isStatic(resultSize) &&
+        sourceSize != resultSize) {
       return emitOpError("expected source dimension ")
              << sourceDim << " with size " << sourceSize
              << " to be preserved in result dimension " << resultDimIndex
@@ -1081,18 +1077,9 @@ LogicalResult LinearizeRaggedDimsOp::verify() {
   }
 
   // 4. Verify the correct number of dynamic dimensions are provided
-  int64_t numResultDynamicDims = getResultDynamicDims().size();
-  int64_t numExpectedDynamicDims = 0;
-  for (int64_t i = 0; i < resultRank; ++i) {
-    if (resultType.isDynamicDim(i)) {
-      numExpectedDynamicDims++;
-    }
-  }
-
-  if (numResultDynamicDims != numExpectedDynamicDims) {
-    return emitOpError("expected ")
-           << numExpectedDynamicDims << " dynamic dimension values, but got "
-           << numResultDynamicDims;
+  if (failed(verifyOpDynamicDims(getOperation(), getResult(),
+                                 getResultDynamicDims()))) {
+    return failure();
   }
 
   return success();

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -66,6 +66,23 @@ static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
   return success();
 }
 
+static Attribute getEncodingOrLayout(ShapedType type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+    return tensorType.getEncoding();
+  }
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
+    return memrefType.getLayout();
+  }
+  return {};
+}
+
+static bool hasEncodingOrNonIdentityLayout(ShapedType type) {
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
+    return memrefType.getLayout() && !memrefType.getLayout().isIdentity();
+  }
+  return getEncodingOrLayout(type) != nullptr;
+}
+
 // Gets the dropped dimensions for `iree_tensor_ext.dispatch.tensor.load/store`.
 static llvm::SmallBitVector
 getDroppedDimsImpl(RankedTensorType slicedObjectType,
@@ -966,6 +983,119 @@ llvm::BitVector CastToRaggedShapeOp::getDistributionInfoForSparseDimensions() {
     result.set(0); // Only first sparse dimension is distributable.
   }
   return result;
+}
+
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.linearize_ragged_dims
+//===----------------------------------------------------------------------===//
+
+LogicalResult LinearizeRaggedDimsOp::reifyResultShapes(
+    OpBuilder &builder, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  ArrayRef<int64_t> resultShape =
+      cast<ShapedType>(getResult().getType()).getShape();
+  ValueRange dynamicDims = getResultDynamicDims();
+  SmallVector<OpFoldResult> mixedResultShapes =
+      getMixedValues(resultShape, dynamicDims, builder);
+  reifiedReturnShapes.emplace_back(std::move(mixedResultShapes));
+  return success();
+}
+
+LogicalResult LinearizeRaggedDimsOp::verify() {
+  ShapedType sourceType = cast<ShapedType>(getSource().getType());
+  ShapedType resultType = cast<ShapedType>(getResult().getType());
+
+  // 1. Verify source has ragged tensor encoding.
+  auto raggedAttr =
+      dyn_cast_if_present<RaggedShapeAttr>(getEncodingOrLayout(sourceType));
+
+  if (!raggedAttr) {
+    return emitOpError("expected source type to have a ragged tensor encoding");
+  }
+
+  // Verify result does not have ragged encoding.
+  if (hasEncodingOrNonIdentityLayout(resultType)) {
+    return emitOpError(
+        "expected result type to have no encoding or identity layout");
+  }
+
+  // Get the sparse dimensions from the encoding.
+  SmallVector<int64_t> sparseDims = raggedAttr.getSparseDimensions();
+
+  if (sparseDims.empty()) {
+    return emitOpError("ragged tensor encoding has no sparse dimensions");
+  }
+
+  // Verify sparse dimensions are contiguous
+  for (size_t i = 1; i < sparseDims.size(); ++i) {
+    if (sparseDims[i] != sparseDims[i - 1] + 1) {
+      return emitOpError("sparse dimensions must be contiguous, but got ")
+             << sparseDims[i - 1] << " and " << sparseDims[i];
+    }
+  }
+
+  int64_t sourceRank = sourceType.getRank();
+  int64_t resultRank = resultType.getRank();
+
+  // 2. Verify result rank: sparse dimensions are linearized into one dimension
+  // Result rank = source rank - number of sparse dimensions + 1
+  int64_t expectedResultRank = sourceRank - sparseDims.size() + 1;
+  if (resultRank != expectedResultRank) {
+    return emitOpError("expected result rank to be ")
+           << expectedResultRank
+           << " (source rank - number of sparse dimensions + 1), but got "
+           << resultRank;
+  }
+
+  // 3. Build a set of sparse dimensions and a map from non-sparse source
+  // dimensions to result dimensions
+  llvm::SmallDenseSet<int64_t> sparseDimSet(sparseDims.begin(),
+                                            sparseDims.end());
+
+  // Build mapping: non-sparse source dims -> result dims
+  int64_t resultDimIndex = 0;
+  for (int64_t sourceDim = 0; sourceDim < sourceRank; ++sourceDim) {
+    if (sparseDimSet.contains(sourceDim)) {
+      if (sourceDim == sparseDims[0]) {
+        resultDimIndex++;
+      }
+      continue;
+    }
+
+    if (resultDimIndex >= resultRank) {
+      return emitOpError("result rank too small to accommodate all non-sparse "
+                         "source dimensions");
+    }
+
+    int64_t sourceSize = sourceType.getDimSize(sourceDim);
+    int64_t resultSize = resultType.getDimSize(resultDimIndex);
+    bool sourceDynamic = ShapedType::isDynamic(sourceSize);
+    bool resultDynamic = ShapedType::isDynamic(resultSize);
+    if (!sourceDynamic && !resultDynamic && sourceSize != resultSize) {
+      return emitOpError("expected source dimension ")
+             << sourceDim << " with size " << sourceSize
+             << " to be preserved in result dimension " << resultDimIndex
+             << " but got size " << resultSize;
+    }
+
+    resultDimIndex++;
+  }
+
+  // 4. Verify the correct number of dynamic dimensions are provided
+  int64_t numResultDynamicDims = getResultDynamicDims().size();
+  int64_t numExpectedDynamicDims = 0;
+  for (int64_t i = 0; i < resultRank; ++i) {
+    if (resultType.isDynamicDim(i)) {
+      numExpectedDynamicDims++;
+    }
+  }
+
+  if (numResultDynamicDims != numExpectedDynamicDims) {
+    return emitOpError("expected ")
+           << numExpectedDynamicDims << " dynamic dimension values, but got "
+           << numResultDynamicDims;
+  }
+
+  return success();
 }
 
 } // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -606,4 +606,35 @@ def IREETensorExt_CastToRaggedShapeOp :
   let hasVerifier = 1;
 }
 
+def IREETensorExt_LinearizeRaggedDimsOp :
+    IREETensorExt_PureOp<"linearize_ragged_dims", [
+      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface,
+        ["reifyResultShapes"]>
+    ]> {
+  let summary = [{Linearizes the sparse dimensions of a ragged shaped value.}];
+  let description = [{
+    Linearizes the contiguous sparse dimensions of a tensor or memref with a
+    `#iree_tensor_ext.ragged_shape` encoding/layout into a single dense
+    dimension. The result has the same element type, preserves all non-sparse
+    dimensions, removes the ragged encoding/layout, and has rank:
+
+    ```
+    rank(source) - num_sparse_dimensions + 1
+    ```
+
+    Dynamic result dimensions are provided by `resultDynamicDims`.
+  }];
+
+  let arguments = (ins
+    AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$source,
+    Variadic<Index>:$resultDynamicDims
+  );
+  let results = (outs AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$result);
+
+  let assemblyFormat = [{
+    $source attr-dict `:` type($source) `->` type($result)(`{` $resultDynamicDims^ `}`)?
+  }];
+
+  let hasVerifier = 1;
+}
 #endif  // IREE_DIALECT_TENSOR_EXT_OPS

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -423,7 +423,7 @@ util.func public @dimensionNotPreserved(%source : tensor<10x3x?x30xf32, #iree_te
 util.func public @wrongDynamicDimCount(%source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>,
     %d0 : index, %d1 : index, %d2 : index, %d3 : index)
     -> tensor<?x?x?xf32> {
-  // expected-error @+1 {{expected 3 dynamic dimension values, but got 4}}
+  // expected-error @+1 {{value set has 3 dynamic dimensions but only 4 dimension values are attached}}
   %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?x?x?xf32>{%d0, %d1, %d2, %d3}
   util.return %0 : tensor<?x?x?xf32>
 }
@@ -434,7 +434,7 @@ util.func public @wrongDynamicDimCount(%source : tensor<?x3x?x?xf32, #iree_tenso
 
 util.func public @missingDynamicDims(%source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>)
     -> tensor<?x?x?xf32> {
-  // expected-error @+1 {{expected 3 dynamic dimension values, but got 0}}
+  // expected-error @+1 {{value set has 3 dynamic dimensions but only 0 dimension values are attached}}
   %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?x?x?xf32>
   util.return %0 : tensor<?x?x?xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -363,3 +363,78 @@ util.func public @extraSourceDynamicDims(%source : tensor<2x?x5xf32>,
       : (tensor<2x?x5xf32>{%d0, %d1}, tensor<4xindex>) -> tensor<2x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
   util.return %0 : tensor<2x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
 }
+
+// -----
+
+// Error if source does not have ragged tensor encoding
+
+util.func public @noRaggedEncoding(%source : tensor<10x3x8x30xf32>)
+    -> tensor<10x240xf32> {
+  // expected-error @+1 {{expected source type to have a ragged tensor encoding}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<10x3x8x30xf32> -> tensor<10x240xf32>
+  util.return %0 : tensor<10x240xf32>
+}
+
+// -----
+
+// Error if result has encoding
+
+util.func public @resultHasEncoding(%source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>)
+    -> tensor<10x30xf32, #iree_tensor_ext.ragged_shape<0>> {
+  // expected-error @+1 {{expected result type to have no encoding or identity layout}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<10x30xf32, #iree_tensor_ext.ragged_shape<0>>
+  util.return %0 : tensor<10x30xf32, #iree_tensor_ext.ragged_shape<0>>
+}
+
+// -----
+
+// Error if result rank is incorrect
+
+util.func public @wrongResultRank(%source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>, %d0 : index) -> tensor<?xf32> {
+  // expected-error @+1 {{expected result rank to be 3 (source rank - number of sparse dimensions + 1), but got 1}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?xf32>{%d0}
+  util.return %0 : tensor<?xf32>
+}
+
+// -----
+
+// Error if result rank is too high
+
+util.func public @resultRankTooHigh(%source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>) -> tensor<10x3x?x30xf32> {
+  // expected-error @+1 {{expected result rank to be 3 (source rank - number of sparse dimensions + 1), but got 4}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<10x3x?x30xf32>
+  util.return %0 : tensor<10x3x?x30xf32>
+}
+
+// -----
+
+// Error if non-ragged dimensions are not preserved
+
+util.func public @dimensionNotPreserved(%source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>) -> tensor<5x?x30xf32> {
+  // expected-error @+1 {{expected source dimension 0 with size 10 to be preserved in result dimension 0 but got size 5}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<5x?x30xf32>
+  util.return %0 : tensor<5x?x30xf32>
+}
+
+// -----
+
+// Error if incorrect number of dynamic dimensions provided
+
+util.func public @wrongDynamicDimCount(%source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>,
+    %d0 : index, %d1 : index, %d2 : index, %d3 : index)
+    -> tensor<?x?x?xf32> {
+  // expected-error @+1 {{expected 3 dynamic dimension values, but got 4}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?x?x?xf32>{%d0, %d1, %d2, %d3}
+  util.return %0 : tensor<?x?x?xf32>
+}
+
+// -----
+
+// Error if missing dynamic dimensions
+
+util.func public @missingDynamicDims(%source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>)
+    -> tensor<?x?x?xf32> {
+  // expected-error @+1 {{expected 3 dynamic dimension values, but got 0}}
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?x?x?xf32>
+  util.return %0 : tensor<?x?x?xf32>
+}

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -179,6 +179,54 @@ util.func public @staticAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
 
 // -----
 
+// Check static iree_tensor_ext.linearize_ragged_dims
+
+util.func public @staticLinearizeRaggedDims(%source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>,
+    %d0 : index) -> tensor<10x?x30xf32> {
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<10x?x30xf32>{%d0}
+  util.return %0 : tensor<10x?x30xf32>
+}
+// CHECK-LABEL: @staticLinearizeRaggedDims
+// CHECK: iree_tensor_ext.linearize_ragged_dims %{{.*}} : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<10x?x30xf32>{%{{.*}}}
+
+// -----
+
+// Check dynamic iree_tensor_ext.linearize_ragged_dims
+
+util.func public @dynamicLinearizeRaggedDims(%source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?xf32> {
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?x?x?xf32>{%d0, %d1, %d2}
+  util.return %0 : tensor<?x?x?xf32>
+}
+// CHECK-LABEL: @dynamicLinearizeRaggedDims
+// CHECK: iree_tensor_ext.linearize_ragged_dims %{{.*}} : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> tensor<?x?x?xf32>{%{{.*}}, %{{.*}}, %{{.*}}}
+
+// -----
+
+// Check memref-type iree_tensor_ext.linearize_ragged_dims
+
+util.func public @memrefLinearizeRaggedDims(%source : memref<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>,
+    %d0 : index, %d1 : index, %d2 : index) -> memref<?x?x?xf32> {
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : memref<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> memref<?x?x?xf32>{%d0, %d1, %d2}
+  util.return %0 : memref<?x?x?xf32>
+}
+// CHECK-LABEL: @memrefLinearizeRaggedDims
+// CHECK: iree_tensor_ext.linearize_ragged_dims %{{.*}} : memref<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> -> memref<?x?x?xf32>{%{{.*}}, %{{.*}}, %{{.*}}}
+
+// -----
+
+// Check iree_tensor_ext.linearize_ragged_dims with ragged_shape<0>
+
+util.func public @linearizeRaggedDims0(%source : tensor<?x?xf32, #iree_tensor_ext.ragged_shape<0>>,
+    %linearized_size : index) -> tensor<?xf32> {
+  %0 = iree_tensor_ext.linearize_ragged_dims %source : tensor<?x?xf32, #iree_tensor_ext.ragged_shape<0>> -> tensor<?xf32>{%linearized_size}
+  util.return %0 : tensor<?xf32>
+}
+// CHECK-LABEL: @linearizeRaggedDims0
+// CHECK: iree_tensor_ext.linearize_ragged_dims %{{.*}} : tensor<?x?xf32, #iree_tensor_ext.ragged_shape<0>> -> tensor<?xf32>{%{{.*}}}
+
+// -----
+
 // Round trip test for SparseIterationDimsAttr
 func.func @sparseIterationDimsAttr() {
   scf.forall (%i, %j) = (0, 0) to (10, 20) step (1, 1) {


### PR DESCRIPTION
This is PR 3/N of landing block sparse changes that are captured in this
branch :

https://github.com/MaheshRavishankar/iree/tree/users/MaheshRavishankar/blockSparseCommits

Add `iree_tensor_ext.linearize_ragged_dims` to linearize the ragged dimensions of a tensor (memref) value, resulting in a tensor (memref) that has no ragged/sparse encodings.