### PR TITLE
[runtime/python] Remove forced HOST_VISIBLE from AllocateBufferCopy

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -192,8 +192,7 @@ py::object HalAllocator::AllocateBufferCopy(
   PyBufferReleaser py_view_releaser(py_view);
 
   iree_hal_buffer_params_t params = {0};
-  // TODO: Should not require host visible :(
-  params.type = memory_type | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.type = memory_type;
   params.usage = allowed_usage;
 
   iree_hal_buffer_t* hal_buffer = nullptr;

--- a/runtime/bindings/python/invoke.cc
+++ b/runtime/bindings/python/invoke.cc
@@ -216,8 +216,8 @@ class InvokeStatics {
 
             retained_bv = c.allocator().AllocateBufferCopy(
                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-                IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING,
-                c.device(), host_array, hal_element_type);
+                IREE_HAL_BUFFER_USAGE_DEFAULT, c.device(), host_array,
+                hal_element_type);
             bv = py::cast<HalBufferView*>(retained_bv);
           }
 
@@ -420,8 +420,7 @@ class InvokeStatics {
 
       // Put it on the device.
       py::object retained_bv = c.allocator().AllocateBufferCopy(
-          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-          IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING,
+          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL, IREE_HAL_BUFFER_USAGE_DEFAULT,
           c.device(), host_array, hal_element_type);
       HalBufferView* bv = py::cast<HalBufferView*>(retained_bv);
 

--- a/runtime/src/iree/hal/cts/buffer/allocator_test.cc
+++ b/runtime/src/iree/hal/cts/buffer/allocator_test.cc
@@ -227,6 +227,23 @@ TEST_P(AllocatorTest, ImportHostAllocationWithCallback) {
   iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
 }
 
+// Requesting DEVICE_LOCAL + MAPPING (without HOST_VISIBLE) must succeed.
+// The allocator should promote the memory type so that the buffer is
+// mappable — the Python bindings produce this combination via
+// asdevicearray(allowed_usage=DEFAULT|MAPPING).
+TEST_P(AllocatorTest, DeviceLocalMappingAllocationSucceeds) {
+  iree_hal_buffer_params_t params = {0};
+  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  params.usage = IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING;
+
+  // Allocation must not fail with "mappable buffers require host pointers".
+  iree_hal_buffer_t* buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(device_allocator_, params,
+                                                    kAllocationSize, &buffer));
+  ASSERT_NE(nullptr, buffer);
+  iree_hal_buffer_release(buffer);
+}
+
 CTS_REGISTER_TEST_SUITE(AllocatorTest);
 
 }  // namespace iree::hal::cts

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -278,6 +278,18 @@ iree_hal_cuda_allocator_query_buffer_compatibility(
     }
   }
 
+  // If the caller requests mappable device-local memory but did not set
+  // HOST_VISIBLE, promote to HOST_VISIBLE so the allocation path can use
+  // managed memory (or fall back to host-local below). Without this,
+  // cuMemAlloc produces a device-only pointer that cannot satisfy mapping.
+  if (iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL) &&
+      !iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE) &&
+      iree_any_bit_set(params->usage,
+                       IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT |
+                           IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED)) {
+    params->type |= IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  }
+
   // If concurrent managed access is not supported then make device-local +
   // host-visible allocations fall back to host-local + device-visible
   // page-locked memory. This will be significantly slower for the device to

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -357,6 +357,18 @@ iree_hal_hip_allocator_query_buffer_compatibility(
     }
   }
 
+  // If the caller requests mappable device-local memory but did not set
+  // HOST_VISIBLE, promote to HOST_VISIBLE so the allocation path can use
+  // managed memory (or fall back to host-local below). Without this,
+  // hipMalloc produces a device-only pointer that cannot satisfy mapping.
+  if (iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL) &&
+      !iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE) &&
+      iree_any_bit_set(params->usage,
+                       IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT |
+                           IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED)) {
+    params->type |= IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  }
+
   if (iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                                           IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
     // Device local and host visible in general is much more slower than device

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
@@ -212,5 +212,79 @@ TEST_F(HipAllocatorTest, ImportHostAllocationWithCallbackUnregistersOnDestroy) {
   iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
 }
 
+// Verify that requesting MAPPING on DEVICE_LOCAL memory (without HOST_VISIBLE)
+// promotes to HOST_VISIBLE so the buffer is actually mappable. This is the
+// combination the Python bindings produce via asdevicearray().
+TEST_F(HipAllocatorTest, DeviceLocalMappingPromotesToHostVisible) {
+  iree_hal_allocator_t* allocator = iree_hal_device_allocator(device_);
+
+  // Request DEVICE_LOCAL + MAPPING without HOST_VISIBLE.
+  iree_hal_buffer_params_t params = {0};
+  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  params.usage = IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING;
+
+  constexpr iree_device_size_t kSize = 4096;
+  iree_hal_buffer_params_t compat_params = params;
+  iree_device_size_t compat_size = kSize;
+  iree_hal_buffer_compatibility_t compat =
+      iree_hal_allocator_query_buffer_compatibility(
+          allocator, params, kSize, &compat_params, &compat_size);
+  ASSERT_TRUE(
+      iree_all_bits_set(compat, IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE));
+
+  // The allocator must have promoted to a type that supports mapping.
+  // On HIP this is either DEVICE_LOCAL+HOST_VISIBLE (managed) or
+  // HOST_LOCAL+DEVICE_VISIBLE (page-locked fallback).
+  EXPECT_TRUE(
+      iree_all_bits_set(compat_params.type,
+                        IREE_HAL_MEMORY_TYPE_HOST_VISIBLE) ||
+      iree_all_bits_set(compat_params.type, IREE_HAL_MEMORY_TYPE_HOST_LOCAL));
+
+  // Allocation must succeed (no "mappable buffers require host pointers").
+  iree_hal_buffer_t* buffer = nullptr;
+  iree_status_t status =
+      iree_hal_allocator_allocate_buffer(allocator, params, kSize, &buffer);
+  ASSERT_TRUE(iree_status_is_ok(status))
+      << "DEVICE_LOCAL + MAPPING allocation should succeed after promotion; "
+      << iree_status_code_string(iree_status_code(status));
+  ASSERT_NE(nullptr, buffer);
+
+  // The buffer must be mappable.
+  iree_hal_buffer_mapping_t mapping = {};
+  status = iree_hal_buffer_map_range(buffer, IREE_HAL_MAPPING_MODE_SCOPED,
+                                     IREE_HAL_MEMORY_ACCESS_READ, 0, kSize,
+                                     &mapping);
+  EXPECT_TRUE(iree_status_is_ok(status))
+      << "Promoted buffer should be mappable";
+  if (iree_status_is_ok(status)) {
+    iree_hal_buffer_unmap_range(&mapping);
+  }
+
+  iree_hal_buffer_release(buffer);
+}
+
+// Verify that DEVICE_LOCAL without MAPPING does NOT get HOST_VISIBLE
+// (remains device-only for optimal performance).
+TEST_F(HipAllocatorTest, DeviceLocalWithoutMappingStaysDeviceOnly) {
+  iree_hal_allocator_t* allocator = iree_hal_device_allocator(device_);
+
+  iree_hal_buffer_params_t params = {0};
+  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  params.usage = IREE_HAL_BUFFER_USAGE_DEFAULT;
+
+  constexpr iree_device_size_t kSize = 4096;
+  iree_hal_buffer_params_t compat_params = params;
+  iree_device_size_t compat_size = kSize;
+  iree_hal_allocator_query_buffer_compatibility(allocator, params, kSize,
+                                                &compat_params, &compat_size);
+
+  // Without MAPPING, the allocator should keep DEVICE_LOCAL without adding
+  // HOST_VISIBLE (no managed memory overhead).
+  EXPECT_TRUE(
+      iree_all_bits_set(compat_params.type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL));
+  EXPECT_FALSE(
+      iree_all_bits_set(compat_params.type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE));
+}
+
 }  // namespace
 }  // namespace iree::hal::hip


### PR DESCRIPTION
Resolves: https://github.com/iree-org/iree/issues/24092

AllocateBufferCopy forced HOST_VISIBLE and callers requested MAPPING — leftovers from before the function was refactored to use transfer_h2d().

On HIP this causes hipMallocManaged allocation + memcpy fast path in transfer_h2d (buffer_transfer.c:212), which lacks synchronization with subsequent GPU dispatches. The GPU reads stale data (zeros).

Remove HOST_VISIBLE from AllocateBufferCopy and MAPPING from callers to match iree-run-module behavior (DEVICE_LOCAL + DEFAULT, function_io.c:448). transfer_h2d then takes the command buffer path with proper sync.

Benchmark (FunctionInvoker add_one, 500 iters, gfx1100 RX 7900 XTX):

| Size | KB | HIP before | HIP after | Vulkan before | Vulkan after |
|------|---:|-----------|----------|---------------|-------------|
| 4x4 | 0 | 3.44 ms (**WRONG**) | 0.11 ms | 0.13 ms | 0.16 ms |
| 64x64 | 16 | 3.31 ms (**WRONG**) | 0.11 ms | 0.13 ms | 0.16 ms |
| 256x256 | 256 | 3.71 ms (**WRONG**) | 0.61 ms | 0.19 ms | 0.28 ms |
| 512x512 | 1024 | 4.39 ms (**WRONG**) | 1.29 ms | 0.38 ms | 0.55 ms |

HIP: all correct=False before, correct=True after. 3-30x faster. Vulkan: correct both before and after. ~1.4x slower for large buffers due to command buffer path vs memcpy, but logic matching iree-run-module now.

I don't see a good way to add tests for this as python tests aren't enabled in hip CI runs?