### PR TITLE
[CPU] Stop scaling PackOp distribution tiles by inner pack sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2039,19 +2039,13 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   for (auto pos : dimPos) {
     distConfig.vectorSizeHints[pos] = vectorSize;
   }
+  // Note that, unlike the matmul ops itself (e.g. mmt4d), we do not take the
+  // inner tile sizes into account here. As PackOp is an element-wise op, the
+  // only reason to need multiple tiles is to distribute work to multiple
+  // threads. Memory locality should not be a concern; if it were a concern,
+  // that would be a codegen bug (suboptimal traversal within the tile).
   SmallVector<int64_t> distTileSizes =
       getDefaultDistributedLevelTileSizes(op, distConfig);
-
-  // The default function aims to returns the number of workload per workgroup,
-  // but it does not know that it is working on packed domain. We need to take
-  // inner tile sizes into account and adjust the distribution tile sizes.
-  for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
-    if (distTileSizes[pos] == 0 || ShapedType::isDynamic(size)) {
-      continue;
-    }
-    distTileSizes[pos] = distTileSizes[pos] / size;
-    distTileSizes[pos] = std::max(distTileSizes[pos], int64_t{1});
-  }
 
   // Dynamic inner tiles lead to unbounded stack allocation (which is introduced
   // by tensor.pad op), so we do not decompose the cases. The x86 and risc-v

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -281,7 +281,7 @@ func.func @pack(%arg0: tensor<20x48xf32>) -> tensor<2x?x16x?xf32> attributes {ha
   %pack = linalg.pack %arg0 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [16, %c16_vscale] into %empty : tensor<20x48xf32> -> tensor<2x?x16x?xf32>
   return %pack : tensor<2x?x16x?xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 4], vector_common_parallel = [1, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 64], vector_common_parallel = [1, 1]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
 //      CHECK: func.func @pack(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -713,7 +713,7 @@ func.func @pack_many_elements(%2: tensor<1200x500000xf32>) -> tensor<31250x1200x
   %pack = linalg.pack %2 outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 1] into %3 : tensor<1200x500000xf32> -> tensor<31250x1200x16x1xf32>
   return %pack : tensor<31250x1200x16x1xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 3], vector_common_parallel = [1, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 48], vector_common_parallel = [1, 1]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
 //      CHECK: func.func @pack_many_elements(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
Undo a 3-year old tiling tweak (#11873) that should not be necessary, though if it ever helped performance, that would indicate suboptimal codegen.

The rationale, stated in a comment, is that as packing is an element-wise operation, the only reason to need multiple tiles is to distribute work to multiple threads. Memory locality should not be a concern; if it were a concern, that would be a codegen bug (suboptimal traversal within the tile).

[Benchmark](https://docs.google.com/spreadsheets/d/1q0pY8uAI4ApGSUndJYAdSq7CKGRzTJgaWlEzMkvSL9A/edit?usp=sharing) (3 PRs together: #24107, #24108, #24109) showing no regression across many matmul shapes and slight improvement to scaling SDXL-clip to many threads.

The point is not the tiny perf improvement per se, but ensuring that existing parameters have the intended semantics.

Made-with: Cursor