### PR TITLE
[CPU] Factor thread utilization into mmt4d lowering tile selection

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1894,20 +1894,21 @@ getMmt4dLoweringConfig(linalg::LinalgOp op, DictionaryAttr targetConfig) {
   const SmallVector<std::pair<int64_t, int64_t>> divisorsOfM1 = getDivisors(M1);
   const SmallVector<std::pair<int64_t, int64_t>> divisorsOfN1 = getDivisors(N1);
 
-  // Helper to associate a cost to a candidate pair or tile sizes along the M
-  // and N dimensions.
-  auto evalTraversalCost = [=](int64_t numTilesM,
-                               int64_t numTilesN) -> int64_t {
-    // The cost model is a lower bound on the amount of data
-    // that will need to be loaded over the entire matmul. Note that each matrix
-    // (LHS, RHS) is traversed a number of times equal to the number of tiles
-    // of the opposite (RHS, LHS) matrix.
-    return numTilesN * M * lhsTypeBits + numTilesM * N * rhsTypeBits;
+  // Cost model.
+  auto evalCost = [=](int64_t numTilesM, int64_t numTilesN) -> int64_t {
+    // Note that each matrix (LHS, RHS) is traversed a number of times equal to
+    // the number of tiles of the opposite (RHS, LHS) matrix.
+    int64_t traversalCost =
+        numTilesN * M * lhsTypeBits + numTilesM * N * rhsTypeBits;
+    // Penalize failing to use the requested number of threads due to few tiles.
+    int64_t underutilizationCost = std::max<int64_t>(
+        1, clNumberOfRuntimeThreads / (numTilesM * numTilesN));
+    return traversalCost * underutilizationCost;
   };
 
   int64_t selectedTileM = 1;
   int64_t selectedTileN = 1;
-  int64_t selectedCost = evalTraversalCost(M1, N1);
+  int64_t selectedCost = evalCost(M1, N1);
 
   // Iterate over all candidate tile shapes, which are the divisors of (M1, N1).
   for (auto [tileM, numTilesM] : divisorsOfM1) {
@@ -1931,7 +1932,7 @@ getMmt4dLoweringConfig(linalg::LinalgOp op, DictionaryAttr targetConfig) {
         continue;
       }
       // Evaluate the cost model and retain the better candidate.
-      int64_t candidateCost = evalTraversalCost(numTilesM, numTilesN);
+      int64_t candidateCost = evalCost(numTilesM, numTilesN);
       if (candidateCost < selectedCost) {
         selectedCost = candidateCost;
         selectedTileM = tileM;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1015,7 +1015,7 @@ func.func @batch_mmt4d(%17: tensor<128x10x32x8x1xf32>, %18: tensor<128x80x32x4x1
   return %21 : tensor<128x10x80x8x4xf32>
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 10, 80, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 0, 8, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 10, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 0, 8, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 1]>
 //      CHECK: func.func @batch_mmt4d(
 //      CHECK:   linalg.batch_mmt4d
 // CHECK-SAME:     lowering_config = #[[CONFIG]]


### PR DESCRIPTION
Extend the mmt4d distribution cost model with a penalty when the M×N tile count is too small to use the configured runtime parallelism, so we prefer shapes that keep more workgroups active.

[Benchmark](https://docs.google.com/spreadsheets/d/1q0pY8uAI4ApGSUndJYAdSq7CKGRzTJgaWlEzMkvSL9A/edit?usp=sharing) (3 PRs together: #24107, #24108, #24109) showing no regression across many matmul shapes and slight improvement to scaling SDXL-clip to many threads.

The point is not the tiny perf improvement per se, but ensuring that existing parameters have the intended semantics.

Made-with: Cursor