### PR TITLE
[Codegen] Move codegen pipelines to work on online_attention

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -36,15 +36,18 @@ transform.named_sequence
   -> (!transform.any_op, !transform.any_param, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %attention : !transform.any_op
 
-  %batch, %m, %k1, %k2, %n =
-    transform.iree.match.attention %attention,
-      query_type = f16, key_type = f16, value_type = f16, output_type = f16,
+  %batch, %m, %n, %k1, %k2 =
+    transform.iree.match.online_attention %attention,
+      query_type = f16, key_type = f16, value_type = f16, scale_type = f16,
+      output_type = f32, max_type = f32, sum_type = f32,
       indexing_maps = [
         affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, M, K1)>,
         affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, K2, K1)>,
         affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, N, K2)>,
         affine_map<(B0, B1, M, N, K1, K2) -> ()>,
-        affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, M, N)>
+        affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, M, N)>,
+        affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, M)>,
+        affine_map<(B0, B1, M, N, K1, K2) -> (B0, B1, M)>
       ] : !transform.any_op -> !transform.param<i64>
 
   %query = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value

--- a/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
@@ -68,11 +68,11 @@ hal.executable public @main {
 // -----
 
 // CHECK-LABEL:  func.func @attention_2x10x4096x64x64x64_f16
-// CHECK:          iree_linalg_ext.attention
+// CHECK:          iree_linalg_ext.online_attention
 // CHECK-SAME:       __tuning_spec_applied__
 
 // MI300X-LABEL:  func.func @attention_2x10x4096x64x64x64_f16
-// MI300X:          iree_linalg_ext.attention
+// MI300X:          iree_linalg_ext.online_attention
 // MI300X-SAME:       __tuning_spec_applied__
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
@@ -80,6 +80,7 @@ hal.executable public @main {
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
 #map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -100,22 +101,23 @@ hal.executable public @main {
         %query: tensor<2x10x4096x64xf16>,
         %key: tensor<2x10x64x64xf16>,
         %value: tensor<2x10x64x64xf16>
-      ) -> tensor<2x10x4096x64xf16> {
+      ) -> tensor<2x10x4096x64xf32> {
 
         %cst = arith.constant 1.250000e-01 : f16
-        %output = tensor.empty() : tensor<2x10x4096x64xf16>
+        %output = tensor.empty() : tensor<2x10x4096x64xf32>
+        %max = tensor.empty() : tensor<2x10x4096xf32>
+        %sum = tensor.empty() : tensor<2x10x4096xf32>
 
-        // Apply the attention operation directly to function inputs.
-        %result = iree_linalg_ext.attention {
-            indexing_maps = [#map, #map1, #map2, #map3, #map4]
+        %result:3 = iree_linalg_ext.online_attention {
+            indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]
         } ins(%query, %key, %value, %cst :
             tensor<2x10x4096x64xf16>, tensor<2x10x64x64xf16>, tensor<2x10x64x64xf16>, f16)
-          outs(%output : tensor<2x10x4096x64xf16>) {
+          outs(%output, %max, %sum : tensor<2x10x4096x64xf32>, tensor<2x10x4096xf32>, tensor<2x10x4096xf32>) {
             ^bb0(%arg0: f32):
               iree_linalg_ext.yield %arg0 : f32
-          } -> tensor<2x10x4096x64xf16>
+          } -> tensor<2x10x4096x64xf32>, tensor<2x10x4096xf32>, tensor<2x10x4096xf32>
 
-        return %result : tensor<2x10x4096x64xf16>
+        return %result#0 : tensor<2x10x4096x64xf32>
       }
     }
   }
@@ -124,11 +126,11 @@ hal.executable public @main {
 // -----
 
 // CHECK-LABEL:  func.func @attention_3x10x4096x64x64x32_f16
-// CHECK:          iree_linalg_ext.attention
+// CHECK:          iree_linalg_ext.online_attention
 // CHECK-NOT:       __tuning_spec_applied__
 
 // MI300X-LABEL:  func.func @attention_3x10x4096x64x64x32_f16
-// MI300X:          iree_linalg_ext.attention
+// MI300X:          iree_linalg_ext.online_attention
 // MI300X-NOT:       __tuning_spec_applied__
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
@@ -136,6 +138,7 @@ hal.executable public @main {
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
 #map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -156,22 +159,23 @@ hal.executable public @main {
         %query: tensor<3x10x4096x64xf16>,
         %key: tensor<3x10x32x64xf16>,
         %value: tensor<3x10x64x32xf16>
-      ) -> tensor<3x10x4096x64xf16> {
+      ) -> tensor<3x10x4096x64xf32> {
 
         %cst = arith.constant 1.250000e-01 : f16
-        %output = tensor.empty() : tensor<3x10x4096x64xf16>
+        %output = tensor.empty() : tensor<3x10x4096x64xf32>
+        %max = tensor.empty() : tensor<3x10x4096xf32>
+        %sum = tensor.empty() : tensor<3x10x4096xf32>
 
-        // Apply the attention operation directly to function inputs.
-        %result = iree_linalg_ext.attention {
-            indexing_maps = [#map, #map1, #map2, #map3, #map4]
+        %result:3 = iree_linalg_ext.online_attention {
+            indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]
         } ins(%query, %key, %value, %cst :
             tensor<3x10x4096x64xf16>, tensor<3x10x32x64xf16>, tensor<3x10x64x32xf16>, f16)
-          outs(%output : tensor<3x10x4096x64xf16>) {
+          outs(%output, %max, %sum : tensor<3x10x4096x64xf32>, tensor<3x10x4096xf32>, tensor<3x10x4096xf32>) {
             ^bb0(%arg0: f32):
               iree_linalg_ext.yield %arg0 : f32
-          } -> tensor<3x10x4096x64xf16>
+          } -> tensor<3x10x4096x64xf32>, tensor<3x10x4096xf32>, tensor<3x10x4096xf32>
 
-        return %result : tensor<3x10x4096x64xf16>
+        return %result#0 : tensor<3x10x4096x64xf32>
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -279,11 +279,11 @@ blockDynamicDimensions(RewriterBase &rewriter,
   return success();
 }
 
-/// Block dynamic dimensions in operands of `AttentionOp`.
+/// Block dynamic dimensions in operands of `OnlineAttentionOp`.
 static LogicalResult
 blockDynamicDimensions(RewriterBase &rewriter,
                        const TensorDynamicDimAnalysis &dynamicDimAnalysis,
-                       IREE::LinalgExt::AttentionOp attentionOp) {
+                       IREE::LinalgExt::OnlineAttentionOp attentionOp) {
   // Only block the q and k values.
   llvm::SmallDenseSet<int64_t> prunedOperandsList, prunedResultsList;
   prunedOperandsList.insert(attentionOp.getQueryMutable().getOperandNumber());
@@ -298,7 +298,7 @@ blockDynamicDimensions(RewriterBase &rewriter,
                        const TensorDynamicDimAnalysis &dynamicDimAnalysis,
                        Operation *operation) {
   return TypeSwitch<Operation *, LogicalResult>(operation)
-      .Case([&](IREE::LinalgExt::AttentionOp attentionOp) {
+      .Case([&](IREE::LinalgExt::OnlineAttentionOp attentionOp) {
         return blockDynamicDimensions(rewriter, dynamicDimAnalysis,
                                       attentionOp);
       })

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/PassUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/PassManager.h"
 
@@ -29,7 +30,8 @@ void addCommonTargetExecutablePreprocessingPasses(
       .addPass(createBufferizeCopyOnlyDispatchesPass)
       .addPass([&]() {
         return createDecomposeSoftmaxPass(useDecomposeSoftmaxFusion);
-      });
+      })
+      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -26,7 +26,7 @@ func.func @block_attention_dims() {
   %mask_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect")
       : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x?x?xf16>>{%m, %k2}
   %output_in = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) flags(Indirect)
-      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x?x32x128xf16>>{%m}
+      : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x?x32x128xf32>>{%m}
   %q = iree_tensor_ext.dispatch.tensor.load %q_in, offsets = [0, 0, 0, 0], sizes = [4, %m, 32, 128], strides = [1, 1, 1, 1]
       : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?x32x128xf16>>{%m} -> tensor<4x?x32x128xf16>
   %key = iree_tensor_ext.dispatch.tensor.load %key_in, offsets = [0, 0, 0, 0], sizes = [4, %k2, 32, 128], strides = [1, 1, 1, 1]
@@ -35,30 +35,39 @@ func.func @block_attention_dims() {
       : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?x32x128xf16>>{%k2} -> tensor<4x?x32x128xf16>
   %mask = iree_tensor_ext.dispatch.tensor.load %mask_in, offsets = [0, 0, 0, 0], sizes = [4, 32, %m, %k2], strides = [1, 1, 1, 1]
       : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x?x?xf16>>{%m, %k2} -> tensor<4x32x?x?xf16>
-  %1 = tensor.empty(%m) : tensor<4x?x32x128xf16>
-  %2 = tensor.empty(%m) : tensor<4x32x?x128xf16>
-  %attn = iree_linalg_ext.attention {
+  %1 = tensor.empty(%m) : tensor<4x?x32x128xf32>
+  %2 = tensor.empty(%m) : tensor<4x32x?x128xf32>
+  %3 = tensor.empty(%m) : tensor<4x32x?xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %4 = linalg.fill ins(%cst_0 : f32) outs(%2 : tensor<4x32x?x128xf32>) -> tensor<4x32x?x128xf32>
+  %5 = linalg.fill ins(%cst_1 : f32) outs(%3 : tensor<4x32x?xf32>) -> tensor<4x32x?xf32>
+  %6 = linalg.fill ins(%cst_2 : f32) outs(%3 : tensor<4x32x?xf32>) -> tensor<4x32x?xf32>
+  %attn:3 = iree_linalg_ext.online_attention {
       indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d4)>,
                        affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d4)>,
                        affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d3)>,
                        affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
                        affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
-                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]}
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>]}
       ins(%q, %key, %value, %cst, %mask : tensor<4x?x32x128xf16>, tensor<4x?x32x128xf16>, tensor<4x?x32x128xf16>, f16, tensor<4x32x?x?xf16>)
-      outs(%2 : tensor<4x32x?x128xf16>) {
-    ^bb0(%b0 : f16) :
-      iree_linalg_ext.yield %b0 : f16
-  }-> tensor<4x32x?x128xf16>
+      outs(%4, %5, %6 : tensor<4x32x?x128xf32>, tensor<4x32x?xf32>, tensor<4x32x?xf32>) {
+    ^bb0(%b0 : f32) :
+      iree_linalg_ext.yield %b0 : f32
+  }-> tensor<4x32x?x128xf32>, tensor<4x32x?xf32>, tensor<4x32x?xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
                        affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>],
       iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-      ins(%attn : tensor<4x32x?x128xf16>) outs(%1 : tensor<4x?x32x128xf16>) {
-  ^bb0(%in: f16, %out: f16):
-    linalg.yield %in : f16
-  } -> tensor<4x?x32x128xf16>
+      ins(%attn#0 : tensor<4x32x?x128xf32>) outs(%1 : tensor<4x?x32x128xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<4x?x32x128xf32>
   iree_tensor_ext.dispatch.tensor.store %result, %output_in, offsets = [0, 0, 0, 0], sizes = [4, %m, 32, 128], strides = [1, 1, 1, 1]
-      : tensor<4x?x32x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x?x32x128xf16>>{%m}
+      : tensor<4x?x32x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x?x32x128xf32>>{%m}
   return
 }
 // CHECK-LABEL: func @block_attention_dims()
@@ -83,7 +92,7 @@ func.func @block_attention_dims() {
 //       CHECK:   %[[M_DYNAMIC2:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 16)>()[%[[M]]]
 //       CHECK:   %[[OUTPUT_BINDING:.+]] = hal.interface.binding.subspan
 //  CHECK-SAME:       binding(4)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x?x16x32x128xf16>>{%[[M_DYNAMIC2]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x?x16x32x128xf32>>{%[[M_DYNAMIC2]]}
 //       CHECK:   %[[Q:.+]] = iree_tensor_ext.dispatch.tensor.load %[[Q_BINDING]]
 //  CHECK-SAME:       sizes = [4, %[[M_DYNAMIC]], 16, 32, 128]
 //  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?x16x32x128xf16>>{%[[M_DYNAMIC]]}
@@ -96,7 +105,7 @@ func.func @block_attention_dims() {
 //       CHECK:   %[[MASK:.+]] = iree_tensor_ext.dispatch.tensor.load %[[MASK_BINDING]]
 //  CHECK-SAME:       sizes = [4, 32, %[[M_DYNAMIC]], 16, %[[K2_DYNAMIC]], 32]
 //  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x?x16x?x32xf16>>{%[[M_DYNAMIC]], %[[K2_DYNAMIC]]}
-//       CHECK:   %[[ATTENTION:.+]] = iree_linalg_ext.attention
+//       CHECK:   %[[ATTENTION:.+]]:3 = iree_linalg_ext.online_attention
 //       CHECK:       ins(%[[Q]], %[[K]], %[[V]], %{{.+}}, %[[MASK]] :
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[GENERIC]], %[[OUTPUT_BINDING]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
@@ -175,7 +175,7 @@ module @td_module attributes { transform.with_named_sequence } {
         }
 
         transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
-            transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+            transform.match.operation_name %attention ["iree_linalg_ext.online_attention"] : !transform.any_op
             %config = transform.param.constant {key = "attn_config"} -> !transform.any_param
             %decomposition_config = transform.param.constant {key = "decomp_config"} -> !transform.any_param
             transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2150,7 +2150,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
 }
 
 static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
-                                   IREE::LinalgExt::AttentionOp attnOp) {
+                                   IREE::LinalgExt::OnlineAttentionOp attnOp) {
   FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
       IREE::LinalgExt::AttentionOpDetail::get(
           attnOp.getQueryMap(), attnOp.getKeyMap(), attnOp.getValueMap(),
@@ -2161,7 +2161,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   SmallVector<int64_t> lbs, ubs;
   getRangeBounds(attnOp, lbs, ubs);
 
-  LDBG() << "Attention Detail:";
+  LDBG() << "Online Attention Detail:";
   LDBG() << "Batch: " << llvm::interleaved_array(opInfo.getBatchDims());
   LDBG() << "M: " << llvm::interleaved_array(opInfo.getMDims());
   LDBG() << "K1: " << llvm::interleaved_array(opInfo.getK1Dims());
@@ -2271,7 +2271,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   generator.setVectorTileSizes(vecTileSizes);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG() << "Set lowering_config for attnOp: " << loweringConfig;
+  LDBG() << "Set lowering_config for online attnOp: " << loweringConfig;
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, attnOp, loweringConfig,
       getCPUTranslationInfo(attnOp.getContext(),
@@ -3030,7 +3030,7 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
             return setDefaultCustomOpLoweringConfig(entryPointFn, op,
                                                     initCPULaunchConfig);
           })
-          .Case<IREE::LinalgExt::AttentionOp, IREE::LinalgExt::FftOp,
+          .Case<IREE::LinalgExt::OnlineAttentionOp, IREE::LinalgExt::FftOp,
                 IREE::LinalgExt::GatherOp, linalg::PackOp, tensor::PadOp,
                 linalg::UnPackOp, linalg::Mmt4DOp, linalg::BatchMmt4DOp>(
               [&](auto op) { return setRootConfig(entryPointFn, op); })

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -151,7 +151,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   // functionality, though the performance may be suboptimal.
   auto hasAttentionOp = [](FunctionOpInterface funcOp) {
     bool hasAttention = false;
-    funcOp.walk([&](IREE::LinalgExt::AttentionOp) {
+    funcOp.walk([&](IREE::LinalgExt::OnlineAttentionOp) {
       hasAttention = true;
       return WalkResult::interrupt();
     });

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -427,8 +427,6 @@ void addCPULinalgExtTileAndVectorizePipeline(
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
   funcPassManager.addPass(createLLVMCPUTileAndFuseProducerConsumerPass(
       IREE::CPU::TilingLevel::VectorCommonParallelTiles));
-  funcPassManager.addPass(
-      IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
       IREE::CPU::TilingLevel::VectorReductionTiles));
   funcPassManager.addPass(
@@ -638,6 +636,8 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.
       .addPass(createEraseHALDescriptorTypeFromMemRefPass);
+  FunctionLikeNest(modulePassManager)
+      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
 
   modulePassManager.addPass(createLLVMCPUSelectLoweringStrategyPass());
   LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -636,9 +636,6 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.
       .addPass(createEraseHALDescriptorTypeFromMemRefPass);
-  FunctionLikeNest(modulePassManager)
-      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
-
   modulePassManager.addPass(createLLVMCPUSelectLoweringStrategyPass());
   LLVM_DEBUG({
     llvm::dbgs() << "LLVMCPU codegen configuration pass pipeline:\n";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
@@ -226,7 +226,7 @@ func.func @gather_attention(
     %key_table: tensor<?x4x16x32xf16>, %indices: tensor<32x?xi64>,
     %value_table: tensor<?x4x16x32xf16>, %query: tensor<32x4x2x32xf16>,
     %mask: tensor<32x4x2x?x16xf16>, %dim0: index, %dim1: index,
-    %dim2: index, %dim3: index) -> tensor<32x4x2x32xf16>
+    %dim2: index, %dim3: index) -> tensor<32x4x2x32xf32>
     attributes {hal.executable.target = #executable_target} {
   %cst = arith.constant 1.767580e-01 : f16
   %empty = tensor.empty(%dim1) : tensor<32x?x4x16x32xf16>
@@ -236,29 +236,39 @@ func.func @gather_attention(
   %v_gather = iree_linalg_ext.gather dimension_map = [0]
       ins(%value_table, %indices : tensor<?x4x16x32xf16>, tensor<32x?xi64>)
       outs(%empty : tensor<32x?x4x16x32xf16>) -> tensor<32x?x4x16x32xf16>
-  %out = tensor.empty() : tensor<32x4x2x32xf16>
-  %result = iree_linalg_ext.attention {
+  %acc = tensor.empty() : tensor<32x4x2x32xf32>
+  %max = tensor.empty() : tensor<32x4x2xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %fill_acc = linalg.fill ins(%cst_0 : f32) outs(%acc : tensor<32x4x2x32xf32>) -> tensor<32x4x2x32xf32>
+  %fill_max = linalg.fill ins(%cst_1 : f32) outs(%max : tensor<32x4x2xf32>) -> tensor<32x4x2xf32>
+  %fill_sum = linalg.fill ins(%cst_2 : f32) outs(%max : tensor<32x4x2xf32>) -> tensor<32x4x2xf32>
+  %result:3 = iree_linalg_ext.online_attention {
       indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4)>,
                        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d1, d6, d4)>,
                        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d1, d6, d3)>,
                        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>,
                        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d5, d6)>,
-                       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>]}
+                       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2)>]}
       ins(%query, %k_gather, %v_gather, %cst, %mask
           : tensor<32x4x2x32xf16>, tensor<32x?x4x16x32xf16>,
             tensor<32x?x4x16x32xf16>, f16, tensor<32x4x2x?x16xf16>)
-      outs(%out : tensor<32x4x2x32xf16>) {
+      outs(%fill_acc, %fill_max, %fill_sum
+          : tensor<32x4x2x32xf32>, tensor<32x4x2xf32>, tensor<32x4x2xf32>) {
   ^bb0(%arg0: f32):
     iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<32x4x2x32xf16>
-  return %result : tensor<32x4x2x32xf16>
+  } -> tensor<32x4x2x32xf32>, tensor<32x4x2xf32>, tensor<32x4x2xf32>
+  return %result#0 : tensor<32x4x2x32xf32>
 }
 // Gather ops should have vector_reduction set for dims mapping to attention
 // reduction dims (d5, d6). This is critical for correct vectorization.
 //  CHECK-DAG: #[[GATHER_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 0, 1, 0, {{[0-9]+}}], vector_reduction = [0, 1, 0, 4, 0]>
-//  CHECK-DAG: #[[ATTN_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 2, 32, 0, 0, 0], vector_common_parallel = [1, 1, 1, 2, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 1, 4]>
+//  CHECK-DAG: #[[ATTN_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 2, 32, 0, 0, 0], vector_common_parallel = [1, 1, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 1, 4]>
 //      CHECK: func.func @gather_attention(
 //      CHECK:   iree_linalg_ext.gather
 // CHECK-SAME:     lowering_config = #[[GATHER_CONFIG]]
-//      CHECK:   iree_linalg_ext.attention
+//      CHECK:   iree_linalg_ext.online_attention
 // CHECK-SAME:     lowering_config = #[[ATTN_CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -311,12 +311,12 @@ func.func @conv_nchw_static(%3: tensor<1x128x30x30xf32>, %4: tensor<128x128x3x3x
   %7 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%6 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
   return %7 : tensor<1x128x28x28xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 14, 28, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 64, 28, 4, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      CHECK: func.func @conv_nchw_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nchw_fchw
-//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 14, 28, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 64, 28, 4, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
 //  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      GENERIC: func.func @conv_nchw_static(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
@@ -333,13 +333,13 @@ func.func @depthwise_conv_static(%3: tensor<1x161x161x240xf32>, %4: tensor<3x3x2
   %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x161x161x240xf32>, tensor<3x3x240xf32>) outs(%6 : tensor<1x80x80x240xf32>) -> tensor<1x80x80x240xf32>
   return %7 : tensor<1x80x80x240xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 48, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 16, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      CHECK: func.func @depthwise_conv_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
-//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 48, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 16, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      GENERIC: func.func @depthwise_conv_static(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
@@ -380,13 +380,13 @@ func.func @pooling_nchw_max(%2: tensor<1x64x114x114xf32>) -> tensor<1x64x56x56xf
   %6 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%2, %4 : tensor<1x64x114x114xf32>, tensor<3x3xf32>) outs(%5 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
   return %6 : tensor<1x64x56x56xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 8, 28, 56, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 32, 56, 8, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      CHECK: func.func @pooling_nchw_max(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.pooling_nchw_max
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
-//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 8, 28, 56, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 32, 56, 8, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      GENERIC: func.func @pooling_nchw_max(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
@@ -713,7 +713,7 @@ func.func @pack_many_elements(%2: tensor<1200x500000xf32>) -> tensor<31250x1200x
   %pack = linalg.pack %2 outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 1] into %3 : tensor<1200x500000xf32> -> tensor<31250x1200x16x1xf32>
   return %pack : tensor<31250x1200x16x1xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 48], vector_common_parallel = [1, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 3], vector_common_parallel = [1, 1]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
 //      CHECK: func.func @pack_many_elements(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -952,7 +952,7 @@ func.func @quant_model(%4: tensor<2304x24xi8>, %5: tensor<24x144xi8>, %6: tensor
   } -> tensor<2304x144xi8>
   return %11 : tensor<2304x144xi8>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 48, 0], distribution = [64, 48, 0], vector_common_parallel = [1, 1, 0], vector_reduction = [0, 0, 4]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 16, 0], distribution = [64, 16, 0], vector_common_parallel = [1, 1, 0], vector_reduction = [0, 0, 4]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @quant_model(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1015,7 +1015,7 @@ func.func @batch_mmt4d(%17: tensor<128x10x32x8x1xf32>, %18: tensor<128x80x32x4x1
   return %21 : tensor<128x10x80x8x4xf32>
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 10, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 0, 8, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 10, 80, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 0, 8, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 1]>
 //      CHECK: func.func @batch_mmt4d(
 //      CHECK:   linalg.batch_mmt4d
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -1118,27 +1118,47 @@ func.func @winograd_filter_transform(%2: tensor<3x3x64x128xf32>) -> tensor<8x8x6
       cpu = "generic", cpu_features = "",
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
-func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6: tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+//      CHECK: #[[ATTN_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16]>
+//      CHECK: #[[ATTN_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
+//      CHECK: #[[ATTN_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 1, 0, 0, 16], vector_reduction = [0, 0, 0, 1, 0]>
+//      CHECK: #[[ATTN_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+//      CHECK: #[[ATTN_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+//      CHECK: #[[ATTN_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+//      CHECK: #[[ATTN_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
+//      CHECK: #[[ATTN_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+//      CHECK: #[[ATTN_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+//      CHECK: #[[ATTN_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
+func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6: tensor<20x4096x64xf16>) -> tensor<20x4096x64xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %scale = arith.constant 0.125 : f16
-  %7 = tensor.empty() : tensor<20x4096x64xf16>
-  %8 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-    affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-    affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-    affine_map<(d0, d1, d2, d3, d4) -> ()>,
-    affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+  %8 = tensor.empty() : tensor<20x4096x64xf32>
+  %9 = tensor.empty() : tensor<20x4096xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant -3.40282347E+38 : f32
+  %cst_1 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst : f32) outs(%8 : tensor<20x4096x64xf32>) -> tensor<20x4096x64xf32>
+  %11 = linalg.fill ins(%cst_0 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %12 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]}
     ins(%4, %5, %6, %scale : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16)
-    outs(%7 : tensor<20x4096x64xf16>) {
+    outs(%10, %11, %12 : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
      ^bb0(%score: f32):
        iree_linalg_ext.yield %score : f32
-    } -> tensor<20x4096x64xf16>
-  return %8 : tensor<20x4096x64xf16>
+    } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+  return %13#0 : tensor<20x4096x64xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 1, 0, 0, 32], vector_reduction = [0, 0, 0, 2, 0]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention(
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//     CHECK:   iree_linalg_ext.attention
-// CHECK-SAME:    lowering_config = #[[CONFIG]]
+// CHECK-SAME:     translation_info = #[[ATTN_TRANSLATION]]
+//     CHECK:   iree_linalg_ext.online_attention
+// CHECK-SAME:    indexing_maps = [#[[ATTN_MAP0]], #[[ATTN_MAP1]], #[[ATTN_MAP2]], #[[ATTN_MAP3]], #[[ATTN_MAP4]], #[[ATTN_MAP5]], #[[ATTN_MAP5]]]
+// CHECK-SAME:    lowering_config = #[[ATTN_CONFIG2]]
 
 // -----
 
@@ -1146,28 +1166,58 @@ func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6:
       cpu = "generic", cpu_features = "",
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
-func.func @attention_transpose_distribute_4d(%29: index, %37: tensor<4x4x?x128xf16>, %38: tensor<4x4x?x1x1x128xf16>, %39: tensor<4x4x?x1x1x128xf16>, %40: tensor<4x4x?x?x1x1xf16>) -> tensor<4x?x4x128xf16> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d3)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d5, d6, d7)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2)>
+#map7 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map8 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
+//      CHECK: #[[ATTN4D_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 1, 4]>
+//      CHECK: #[[ATTN4D_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 1]>
+//      CHECK: #[[ATTN4D_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 4, 0, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 1, 1, 1]>
+//      CHECK: #[[ATTN4D_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>
+//      CHECK: #[[ATTN4D_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d4)>
+//      CHECK: #[[ATTN4D_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d3)>
+//      CHECK: #[[ATTN4D_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>
+//      CHECK: #[[ATTN4D_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d5, d6, d7)>
+//      CHECK: #[[ATTN4D_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>
+//      CHECK: #[[ATTN4D_MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2)>
+//      CHECK: #[[ATTN4D_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
+func.func @attention_transpose_distribute_4d(%29: index, %37: tensor<4x4x?x128xf16>, %38: tensor<4x4x?x1x1x128xf16>, %39: tensor<4x4x?x1x1x128xf16>, %40: tensor<4x4x?x?x1x1xf16>) -> tensor<4x?x4x128xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %cst = arith.constant 8.837890e-02 : f16
   %30 = util.assume.int %29<umin = 16, umax = 131056, udiv = 16> : index
   %31 = iree_tensor_ext.dispatch.workload.ordinal %30, 0 : index
-  %41 = tensor.empty(%31) : tensor<4x?x4x128xf16>
-  %42 = tensor.empty(%31) : tensor<4x4x?x128xf16>
-  %43 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d3)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d5, d6, d7)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>]} ins(%37, %38, %39, %cst, %40 : tensor<4x4x?x128xf16>, tensor<4x4x?x1x1x128xf16>, tensor<4x4x?x1x1x128xf16>, f16, tensor<4x4x?x?x1x1xf16>) outs(%42 : tensor<4x4x?x128xf16>) {
+  %41 = tensor.empty(%31) : tensor<4x?x4x128xf32>
+  %42 = tensor.empty(%31) : tensor<4x4x?x128xf32>
+  %c2 = arith.constant 2 : index
+  %dim = tensor.dim %37, %c2 : tensor<4x4x?x128xf16>
+  %43 = tensor.empty(%dim) : tensor<4x4x?x128xf32>
+  %44 = tensor.empty(%dim) : tensor<4x4x?xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %45 = linalg.fill ins(%cst_0 : f32) outs(%43 : tensor<4x4x?x128xf32>) -> tensor<4x4x?x128xf32>
+  %46 = linalg.fill ins(%cst_1 : f32) outs(%44 : tensor<4x4x?xf32>) -> tensor<4x4x?xf32>
+  %47 = linalg.fill ins(%cst_2 : f32) outs(%44 : tensor<4x4x?xf32>) -> tensor<4x4x?xf32>
+  %48:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map6, #map6]} ins(%37, %38, %39, %cst, %40 : tensor<4x4x?x128xf16>, tensor<4x4x?x1x1x128xf16>, tensor<4x4x?x1x1x128xf16>, f16, tensor<4x4x?x?x1x1xf16>) outs(%45, %46, %47 : tensor<4x4x?x128xf32>, tensor<4x4x?xf32>, tensor<4x4x?xf32>) {
   ^bb0(%arg0: f32):
     iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<4x4x?x128xf16>
-  %44 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%43 : tensor<4x4x?x128xf16>) outs(%41 : tensor<4x?x4x128xf16>) {
-  ^bb0(%in: f16, %out: f16):
-    linalg.yield %in : f16
-  } -> tensor<4x?x4x128xf16>
-  return %44 : tensor<4x?x4x128xf16>
+  } -> tensor<4x4x?x128xf32>, tensor<4x4x?xf32>, tensor<4x4x?xf32>
+  %49 = linalg.generic {indexing_maps = [#map8, #map9], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%48#0 : tensor<4x4x?x128xf32>) outs(%41 : tensor<4x?x4x128xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<4x?x4x128xf32>
+  return %49 : tensor<4x?x4x128xf32>
 }
-// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 2, 0, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 1, 1, 1]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention_transpose_distribute_4d
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//     CHECK:   iree_linalg_ext.attention
-// CHECK-SAME:    lowering_config = #[[CONFIG]]
+// CHECK-SAME:     translation_info = #[[ATTN4D_TRANSLATION]]
+//     CHECK:   iree_linalg_ext.online_attention
+// CHECK-SAME:    indexing_maps = [#[[ATTN4D_MAP0]], #[[ATTN4D_MAP1]], #[[ATTN4D_MAP2]], #[[ATTN4D_MAP3]], #[[ATTN4D_MAP4]], #[[ATTN4D_MAP5]], #[[ATTN4D_MAP6]], #[[ATTN4D_MAP6]]]
+// CHECK-SAME:    lowering_config = #[[ATTN4D_CONFIG2]]
 
 // -----
 
@@ -1441,62 +1491,124 @@ func.func @decode_reduction_f32(%arg0: tensor<32x262144xf16>, %arg1: tensor<32xf
 // -----
 
 #executable_target_embedded_elf_x86_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", native_vector_size = 64 : i64, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
-func.func @attention_reshape_pack(%arg0: index, %arg1: tensor<4x2x?x32xf16>, %arg2: tensor<?x4x32xf16>, %arg3: tensor<?x4x32xf16>, %arg4: tensor<4x2x?x?xf16>) -> tensor<?x256x1x1xf16> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
-  %cst = arith.constant 0.000000e+00 : f16
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d3)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+#map7 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map8 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d2, d0, d1, d3)>
+//      CHECK: #[[RESHAPE_GENERIC_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, 16]>
+//      CHECK: #[[RESHAPE_FILL_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8]>
+//      CHECK: #[[RESHAPE_ROOT_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 16, 0, 0], vector_common_parallel = [1, 1, 8, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 16]>
+//      CHECK: #[[RESHAPE_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+//      CHECK: #[[RESHAPE_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d4)>
+//      CHECK: #[[RESHAPE_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d3)>
+//      CHECK: #[[RESHAPE_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+//      CHECK: #[[RESHAPE_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+//      CHECK: #[[RESHAPE_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+//      CHECK: #[[RESHAPE_MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+//      CHECK: #[[RESHAPE_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
+func.func @attention_reshape_pack(%arg0: index, %arg1: tensor<4x2x?x32xf16>, %arg2: tensor<?x4x32xf16>, %arg3: tensor<?x4x32xf16>, %arg4: tensor<4x2x?x?xf16>) -> tensor<?x256x1x1xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
+  %cst = arith.constant 0.000000e+00 : f32
   %cst_0 = arith.constant 1.767580e-01 : f16
-  %0 = tensor.empty(%arg0) : tensor<?x4x2x32xf16>
-  %1 = tensor.empty(%arg0) : tensor<4x2x?x32xf16>
-  %2 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d4)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d3)>, affine_map<(d0, d1, d2, d3, d4, d5) -> ()>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]} ins(%arg1, %arg2, %arg3, %cst_0, %arg4 : tensor<4x2x?x32xf16>, tensor<?x4x32xf16>, tensor<?x4x32xf16>, f16, tensor<4x2x?x?xf16>) outs(%1 : tensor<4x2x?x32xf16>) {
+  %0 = tensor.empty(%arg0) : tensor<?x4x2x32xf32>
+  %c2 = arith.constant 2 : index
+  %dim = tensor.dim %arg1, %c2 : tensor<4x2x?x32xf16>
+  %2 = tensor.empty(%dim) : tensor<4x2x?x32xf32>
+  %3 = tensor.empty(%dim) : tensor<4x2x?xf32>
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %cst_3 = arith.constant -3.40282347E+38 : f32
+  %cst_4 = arith.constant 0.000000e+00 : f32
+  %4 = linalg.fill ins(%cst_2 : f32) outs(%2 : tensor<4x2x?x32xf32>) -> tensor<4x2x?x32xf32>
+  %5 = linalg.fill ins(%cst_3 : f32) outs(%3 : tensor<4x2x?xf32>) -> tensor<4x2x?xf32>
+  %6 = linalg.fill ins(%cst_4 : f32) outs(%3 : tensor<4x2x?xf32>) -> tensor<4x2x?xf32>
+  %7:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map6, #map6]} ins(%arg1, %arg2, %arg3, %cst_0, %arg4 : tensor<4x2x?x32xf16>, tensor<?x4x32xf16>, tensor<?x4x32xf16>, f16, tensor<4x2x?x?xf16>) outs(%4, %5, %6 : tensor<4x2x?x32xf32>, tensor<4x2x?xf32>, tensor<4x2x?xf32>) {
   ^bb0(%arg5: f32):
     iree_linalg_ext.yield %arg5 : f32
-  } -> tensor<4x2x?x32xf16>
-  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d2, d0, d1, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<4x2x?x32xf16>) outs(%0 : tensor<?x4x2x32xf16>) {
-  ^bb0(%in: f16, %out: f16):
-    linalg.yield %in : f16
-  } -> tensor<?x4x2x32xf16>
-  %collapsed = tensor.collapse_shape %3 [[0], [1, 2, 3]] : tensor<?x4x2x32xf16> into tensor<?x256xf16>
-  %4 = tensor.empty(%arg0) : tensor<?x256x1x1xf16>
-  %pack = linalg.pack %collapsed padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [1, 1] into %4 : tensor<?x256xf16> -> tensor<?x256x1x1xf16>
-  return %pack : tensor<?x256x1x1xf16>
+  } -> tensor<4x2x?x32xf32>, tensor<4x2x?xf32>, tensor<4x2x?xf32>
+  %8 = linalg.generic {indexing_maps = [#map8, #map9], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%7#0 : tensor<4x2x?x32xf32>) outs(%0 : tensor<?x4x2x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<?x4x2x32xf32>
+  %collapsed = tensor.collapse_shape %8 [[0], [1, 2, 3]] : tensor<?x4x2x32xf32> into tensor<?x256xf32>
+  %13 = tensor.empty(%arg0) : tensor<?x256x1x1xf32>
+  %pack = linalg.pack %collapsed padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [1, 1] into %13 : tensor<?x256xf32> -> tensor<?x256x1x1xf32>
+  return %pack : tensor<?x256x1x1xf32>
 }
-//  CHECK-DAG: #[[CONFIG0:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 32, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 32]>
-//  CHECK-DAG: #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 4, 16]>
-//  CHECK-NOT: #iree_cpu.lowering_config
 //      CHECK: func.func @attention_reshape_pack
-//      CHECK:   iree_linalg_ext.attention
-// CHECK-SAME:       lowering_config = #[[CONFIG0]]
+// CHECK-SAME:     translation_info = #[[RESHAPE_TRANSLATION]]
+//      CHECK:   iree_linalg_ext.online_attention
+// CHECK-SAME:       indexing_maps = [#[[RESHAPE_MAP0]], #[[RESHAPE_MAP1]], #[[RESHAPE_MAP2]], #[[RESHAPE_MAP3]], #[[RESHAPE_MAP4]], #[[RESHAPE_MAP5]], #[[RESHAPE_MAP6]], #[[RESHAPE_MAP6]]]
+// CHECK-SAME:       lowering_config = #[[RESHAPE_ROOT_CONFIG]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:       lowering_config = #[[CONFIG1]]
+// CHECK-SAME:       lowering_config = #[[RESHAPE_GENERIC_CONFIG]]
 
 // -----
 
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", native_vector_size = 64 : i64, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+//      CHECK: #[[DYN_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 16, 16]>
+//      CHECK: #[[DYN_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 16]>
+//      CHECK: #[[DYN_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 16, 0, 0, 16], vector_reduction = [0, 0, 16, 16, 0]>
+//      CHECK: #[[DYN_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+//      CHECK: #[[DYN_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+//      CHECK: #[[DYN_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+//      CHECK: #[[DYN_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
+//      CHECK: #[[DYN_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+//      CHECK: #[[DYN_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+//      CHECK: #[[DYN_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 func.func @attention_dynamic_3d(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value: tensor<?x?x?xf32>, %dim0: index, %dim1: index, %dim2: index) -> tensor<?x?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %scale = arith.constant 0.125 : f32
-  %out = tensor.empty(%dim0, %dim1, %dim2) : tensor<?x?x?xf32>
-  %result = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-    affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-    affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-    affine_map<(d0, d1, d2, d3, d4) -> ()>,
-    affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %query, %c0 : tensor<?x?x?xf32>
+  %c1 = arith.constant 1 : index
+  %dim_0 = tensor.dim %query, %c1 : tensor<?x?x?xf32>
+  %c2 = arith.constant 2 : index
+  %dim_1 = tensor.dim %query, %c2 : tensor<?x?x?xf32>
+  %c1_2 = arith.constant 1 : index
+  %dim_3 = tensor.dim %key, %c1_2 : tensor<?x?x?xf32>
+  %c2_4 = arith.constant 2 : index
+  %dim_5 = tensor.dim %value, %c2_4 : tensor<?x?x?xf32>
+  %1 = tensor.empty(%dim, %dim_0, %dim_5) : tensor<?x?x?xf32>
+  %2 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant -3.40282347E+38 : f32
+  %cst_1 = arith.constant 0.000000e+00 : f32
+  %3 = linalg.fill ins(%cst : f32) outs(%1 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  %4 = linalg.fill ins(%cst_0 : f32) outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %5 = linalg.fill ins(%cst_1 : f32) outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %6:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]}
     ins(%query, %key, %value, %scale : tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, f32)
-    outs(%out : tensor<?x?x?xf32>) {
+    outs(%3, %4, %5 : tensor<?x?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) {
      ^bb0(%score: f32):
        iree_linalg_ext.yield %score : f32
-    } -> tensor<?x?x?xf32>
-  return %result : tensor<?x?x?xf32>
+    } -> tensor<?x?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>
+  return %6#0 : tensor<?x?x?xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 16, 0, 0, 16], vector_reduction = [0, 0, 16, 16, 0]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention_dynamic_3d(
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK:   iree_linalg_ext.attention
-// CHECK-SAME:    lowering_config = #[[CONFIG]]
+// CHECK-SAME:     translation_info = #[[DYN_TRANSLATION]]
+//      CHECK:   iree_linalg_ext.online_attention
+// CHECK-SAME:    indexing_maps = [#[[DYN_MAP0]], #[[DYN_MAP1]], #[[DYN_MAP2]], #[[DYN_MAP3]], #[[DYN_MAP4]], #[[DYN_MAP5]], #[[DYN_MAP5]]]
+// CHECK-SAME:    lowering_config = #[[DYN_CONFIG2]]
 
 // -----
 
 #executable_target_embedded_elf_x86_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", native_vector_size = 64 : i64, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+//      CHECK: #[[MMT_FILL_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16, 16]>
+//      CHECK: #[[MMT_MMT4D_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+//      CHECK: #[[MMT_UNPACK_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
 func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tensor<640x4096x16x1xf16>) -> tensor<5x10240x16x1xf16> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
   %cst = arith.constant 0.000000e+00 : f16
   %cst_0 = arith.constant 0.000000e+00 : f32
@@ -1515,18 +1627,15 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
   %pack = linalg.pack %unpack padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %6 : tensor<77x10240xf16> -> tensor<5x10240x16x1xf16>
   return %pack : tensor<5x10240x16x1xf16>
 }
-// CHECK-DAG:   #[[$CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16, 16]>
-// CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, 16, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
-// CHECK-DAG:   #[[$CONFIG2:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
-// CHECK-LABEL: func.func @mmt4d_generic_unpack_pack(
+//      CHECK: func.func @mmt4d_generic_unpack_pack(
 // CHECK:         linalg.fill
-// CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
+// CHECK:              {lowering_config = #[[MMT_FILL_CONFIG]]}
 // CHECK:         linalg.mmt4d
-// CHECK-SAME:      {lowering_config = #[[$CONFIG1]]}
+// CHECK:              {lowering_config = #[[MMT_MMT4D_CONFIG]]}
 // CHECK:         linalg.generic
-// CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
+// CHECK:              {lowering_config = #[[MMT_FILL_CONFIG]]}
 // CHECK:         linalg.unpack
-// CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
+// CHECK:              {lowering_config = #[[MMT_UNPACK_CONFIG]]}
 // CHECK:         linalg.pack
 // CHECK-NOT:      lowering_config
 
@@ -1536,6 +1645,7 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4, d5)>
+// CHECK:       #[[BATCH_MMT_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 10, 20, 0, 8, 4, 0], vector_common_parallel = [1, 1, 1, 0, 1, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 0]>
 func.func @batch_mmt4d_generic_form(%lhs: tensor<128x10x32x8x1xf32>, %rhs: tensor<128x80x32x4x1xf32>, %acc: tensor<128x10x80x8x4xf32>) -> tensor<128x10x80x8x4xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
     ins(%lhs, %rhs : tensor<128x10x32x8x1xf32>, tensor<128x80x32x4x1xf32>)
@@ -1547,10 +1657,9 @@ func.func @batch_mmt4d_generic_form(%lhs: tensor<128x10x32x8x1xf32>, %rhs: tenso
   } -> tensor<128x10x80x8x4xf32>
   return %0 : tensor<128x10x80x8x4xf32>
 }
-// CHECK:       #[[$CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 10, 20, 0, 8, 4, 0], vector_common_parallel = [1, 1, 1, 0, 1, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 0]>
-// CHECK-LABEL: func.func @batch_mmt4d_generic_form(
+//      CHECK: func.func @batch_mmt4d_generic_form(
 // CHECK:         linalg.generic
-// CHECK-SAME:      {lowering_config = #[[$CONFIG]]}
+// CHECK-SAME:      {lowering_config = #[[BATCH_MMT_CONFIG]]}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -311,12 +311,12 @@ func.func @conv_nchw_static(%3: tensor<1x128x30x30xf32>, %4: tensor<128x128x3x3x
   %7 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<1x128x30x30xf32>, tensor<128x128x3x3xf32>) outs(%6 : tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
   return %7 : tensor<1x128x28x28xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 64, 28, 4, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 14, 28, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      CHECK: func.func @conv_nchw_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nchw_fchw
-//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 64, 28, 4, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 16, 14, 28, 0, 0, 0], vector_common_parallel = [1, 4, 1, 4, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 8, 1, 1]>
 //  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      GENERIC: func.func @conv_nchw_static(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
@@ -333,13 +333,13 @@ func.func @depthwise_conv_static(%3: tensor<1x161x161x240xf32>, %4: tensor<3x3x2
   %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x161x161x240xf32>, tensor<3x3x240xf32>) outs(%6 : tensor<1x80x80x240xf32>) -> tensor<1x80x80x240xf32>
   return %7 : tensor<1x80x80x240xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 16, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 48, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      CHECK: func.func @depthwise_conv_static(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
-//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 16, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 40, 40, 48, 0, 0], vector_common_parallel = [1, 1, 4, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      GENERIC: func.func @depthwise_conv_static(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
@@ -380,13 +380,13 @@ func.func @pooling_nchw_max(%2: tensor<1x64x114x114xf32>) -> tensor<1x64x56x56xf
   %6 = linalg.pooling_nchw_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%2, %4 : tensor<1x64x114x114xf32>, tensor<3x3xf32>) outs(%5 : tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
   return %6 : tensor<1x64x56x56xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 32, 56, 8, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 8, 28, 56, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      CHECK: func.func @pooling_nchw_max(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.pooling_nchw_max
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
-//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 32, 56, 8, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
+//  GENERIC-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [0, 8, 28, 56, 0, 0], vector_common_parallel = [1, 8, 1, 8, 0, 0], vector_reduction = [0, 0, 0, 0, 1, 3]>
 //  GENERIC-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<ConvTileAndDecomposeExpert>>
 //      GENERIC: func.func @pooling_nchw_max(
 // GENERIC-SAME:     translation_info = #[[TRANSLATION]]
@@ -713,7 +713,7 @@ func.func @pack_many_elements(%2: tensor<1200x500000xf32>) -> tensor<31250x1200x
   %pack = linalg.pack %2 outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 1] into %3 : tensor<1200x500000xf32> -> tensor<31250x1200x16x1xf32>
   return %pack : tensor<31250x1200x16x1xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 3], vector_common_parallel = [1, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 48], vector_common_parallel = [1, 1]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
 //      CHECK: func.func @pack_many_elements(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -952,7 +952,7 @@ func.func @quant_model(%4: tensor<2304x24xi8>, %5: tensor<24x144xi8>, %6: tensor
   } -> tensor<2304x144xi8>
   return %11 : tensor<2304x144xi8>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 16, 0], distribution = [64, 16, 0], vector_common_parallel = [1, 1, 0], vector_reduction = [0, 0, 4]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 48, 0], distribution = [64, 48, 0], vector_common_parallel = [1, 1, 0], vector_reduction = [0, 0, 4]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @quant_model(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1015,7 +1015,7 @@ func.func @batch_mmt4d(%17: tensor<128x10x32x8x1xf32>, %18: tensor<128x80x32x4x1
   return %21 : tensor<128x10x80x8x4xf32>
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 10, 80, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 0, 8, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 1]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 10, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 0, 8, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 1]>
 //      CHECK: func.func @batch_mmt4d(
 //      CHECK:   linalg.batch_mmt4d
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -1126,16 +1126,6 @@ func.func @winograd_filter_transform(%2: tensor<3x3x64x128xf32>) -> tensor<8x8x6
 #map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
 #map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-//      CHECK: #[[ATTN_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16]>
-//      CHECK: #[[ATTN_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
-//      CHECK: #[[ATTN_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 1, 0, 0, 16], vector_reduction = [0, 0, 0, 1, 0]>
-//      CHECK: #[[ATTN_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
-//      CHECK: #[[ATTN_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
-//      CHECK: #[[ATTN_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
-//      CHECK: #[[ATTN_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
-//      CHECK: #[[ATTN_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
-//      CHECK: #[[ATTN_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
-//      CHECK: #[[ATTN_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6: tensor<20x4096x64xf16>) -> tensor<20x4096x64xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %scale = arith.constant 0.125 : f16
   %8 = tensor.empty() : tensor<20x4096x64xf32>
@@ -1154,6 +1144,16 @@ func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6:
     } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
   return %13#0 : tensor<20x4096x64xf32>
 }
+//      CHECK: #[[ATTN_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16]>
+//      CHECK: #[[ATTN_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
+//      CHECK: #[[ATTN_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 1, 0, 0, 16], vector_reduction = [0, 0, 0, 1, 0]>
+//      CHECK: #[[ATTN_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+//      CHECK: #[[ATTN_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+//      CHECK: #[[ATTN_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+//      CHECK: #[[ATTN_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
+//      CHECK: #[[ATTN_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+//      CHECK: #[[ATTN_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+//      CHECK: #[[ATTN_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention(
 // CHECK-SAME:     translation_info = #[[ATTN_TRANSLATION]]
 //     CHECK:   iree_linalg_ext.online_attention
@@ -1176,17 +1176,6 @@ func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6:
 #map7 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map8 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map9 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
-//      CHECK: #[[ATTN4D_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 1, 4]>
-//      CHECK: #[[ATTN4D_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 1]>
-//      CHECK: #[[ATTN4D_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 4, 0, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 1, 1, 1]>
-//      CHECK: #[[ATTN4D_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>
-//      CHECK: #[[ATTN4D_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d4)>
-//      CHECK: #[[ATTN4D_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d3)>
-//      CHECK: #[[ATTN4D_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>
-//      CHECK: #[[ATTN4D_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d5, d6, d7)>
-//      CHECK: #[[ATTN4D_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>
-//      CHECK: #[[ATTN4D_MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2)>
-//      CHECK: #[[ATTN4D_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 func.func @attention_transpose_distribute_4d(%29: index, %37: tensor<4x4x?x128xf16>, %38: tensor<4x4x?x1x1x128xf16>, %39: tensor<4x4x?x1x1x128xf16>, %40: tensor<4x4x?x?x1x1xf16>) -> tensor<4x?x4x128xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %cst = arith.constant 8.837890e-02 : f16
   %30 = util.assume.int %29<umin = 16, umax = 131056, udiv = 16> : index
@@ -1213,6 +1202,17 @@ func.func @attention_transpose_distribute_4d(%29: index, %37: tensor<4x4x?x128xf
   } -> tensor<4x?x4x128xf32>
   return %49 : tensor<4x?x4x128xf32>
 }
+//      CHECK: #[[ATTN4D_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 1, 4]>
+//      CHECK: #[[ATTN4D_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 1]>
+//      CHECK: #[[ATTN4D_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 64, 0, 0, 0, 0], vector_common_parallel = [1, 1, 1, 4, 0, 0, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 1, 1, 1]>
+//      CHECK: #[[ATTN4D_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>
+//      CHECK: #[[ATTN4D_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d4)>
+//      CHECK: #[[ATTN4D_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d3)>
+//      CHECK: #[[ATTN4D_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>
+//      CHECK: #[[ATTN4D_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d5, d6, d7)>
+//      CHECK: #[[ATTN4D_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>
+//      CHECK: #[[ATTN4D_MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2)>
+//      CHECK: #[[ATTN4D_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention_transpose_distribute_4d
 // CHECK-SAME:     translation_info = #[[ATTN4D_TRANSLATION]]
 //     CHECK:   iree_linalg_ext.online_attention
@@ -1501,17 +1501,6 @@ func.func @decode_reduction_f32(%arg0: tensor<32x262144xf16>, %arg1: tensor<32xf
 #map7 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map8 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map9 = affine_map<(d0, d1, d2, d3) -> (d2, d0, d1, d3)>
-//      CHECK: #[[RESHAPE_GENERIC_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, 16]>
-//      CHECK: #[[RESHAPE_FILL_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8]>
-//      CHECK: #[[RESHAPE_ROOT_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 16, 0, 0], vector_common_parallel = [1, 1, 8, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 16]>
-//      CHECK: #[[RESHAPE_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
-//      CHECK: #[[RESHAPE_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d4)>
-//      CHECK: #[[RESHAPE_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d3)>
-//      CHECK: #[[RESHAPE_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
-//      CHECK: #[[RESHAPE_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
-//      CHECK: #[[RESHAPE_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
-//      CHECK: #[[RESHAPE_MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
-//      CHECK: #[[RESHAPE_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 func.func @attention_reshape_pack(%arg0: index, %arg1: tensor<4x2x?x32xf16>, %arg2: tensor<?x4x32xf16>, %arg3: tensor<?x4x32xf16>, %arg4: tensor<4x2x?x?xf16>) -> tensor<?x256x1x1xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
   %cst = arith.constant 0.000000e+00 : f32
   %cst_0 = arith.constant 1.767580e-01 : f16
@@ -1539,6 +1528,17 @@ func.func @attention_reshape_pack(%arg0: index, %arg1: tensor<4x2x?x32xf16>, %ar
   %pack = linalg.pack %collapsed padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [1, 1] into %13 : tensor<?x256xf32> -> tensor<?x256x1x1xf32>
   return %pack : tensor<?x256x1x1xf32>
 }
+//      CHECK: #[[RESHAPE_GENERIC_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, 16]>
+//      CHECK: #[[RESHAPE_FILL_CONFIG:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8]>
+//      CHECK: #[[RESHAPE_ROOT_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 64, 32, 0, 0], vector_common_parallel = [1, 1, 8, 16, 0, 0], vector_reduction = [0, 0, 0, 0, 0, 16]>
+//      CHECK: #[[RESHAPE_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+//      CHECK: #[[RESHAPE_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d4)>
+//      CHECK: #[[RESHAPE_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5, d0, d3)>
+//      CHECK: #[[RESHAPE_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+//      CHECK: #[[RESHAPE_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+//      CHECK: #[[RESHAPE_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+//      CHECK: #[[RESHAPE_MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+//      CHECK: #[[RESHAPE_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention_reshape_pack
 // CHECK-SAME:     translation_info = #[[RESHAPE_TRANSLATION]]
 //      CHECK:   iree_linalg_ext.online_attention
@@ -1558,16 +1558,6 @@ func.func @attention_reshape_pack(%arg0: index, %arg1: tensor<4x2x?x32xf16>, %ar
 #map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
 #map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-//      CHECK: #[[DYN_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 16, 16]>
-//      CHECK: #[[DYN_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 16]>
-//      CHECK: #[[DYN_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 16, 0, 0, 16], vector_reduction = [0, 0, 16, 16, 0]>
-//      CHECK: #[[DYN_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
-//      CHECK: #[[DYN_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
-//      CHECK: #[[DYN_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
-//      CHECK: #[[DYN_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
-//      CHECK: #[[DYN_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
-//      CHECK: #[[DYN_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
-//      CHECK: #[[DYN_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 func.func @attention_dynamic_3d(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf32>, %value: tensor<?x?x?xf32>, %dim0: index, %dim1: index, %dim2: index) -> tensor<?x?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %scale = arith.constant 0.125 : f32
   %c0 = arith.constant 0 : index
@@ -1596,6 +1586,16 @@ func.func @attention_dynamic_3d(%query: tensor<?x?x?xf32>, %key: tensor<?x?x?xf3
     } -> tensor<?x?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>
   return %6#0 : tensor<?x?x?xf32>
 }
+//      CHECK: #[[DYN_CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 16, 16]>
+//      CHECK: #[[DYN_CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 16]>
+//      CHECK: #[[DYN_CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 16, 0, 0, 16], vector_reduction = [0, 0, 16, 16, 0]>
+//      CHECK: #[[DYN_MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+//      CHECK: #[[DYN_MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+//      CHECK: #[[DYN_MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+//      CHECK: #[[DYN_MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> ()>
+//      CHECK: #[[DYN_MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+//      CHECK: #[[DYN_MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+//      CHECK: #[[DYN_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<LinalgExtTileAndVectorize>>
 //      CHECK: func.func @attention_dynamic_3d(
 // CHECK-SAME:     translation_info = #[[DYN_TRANSLATION]]
 //      CHECK:   iree_linalg_ext.online_attention

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -751,7 +751,7 @@ setAttentionPipelineAttributes(IREE::GPU::TargetAttr target,
 
 static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
     IREE::GPU::TargetAttr target, mlir::FunctionOpInterface entryPoint,
-    IREE::LinalgExt::AttentionOp op) {
+    IREE::LinalgExt::OnlineAttentionOp op) {
   if (target.getWgp().getMma().empty()) {
     return failure();
   }
@@ -933,7 +933,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   std::array<int64_t, 3> workgroupSize{flatWorkgroupSize, 1, 1};
 
   SmallVector<int64_t> workgroupTileSizes(opInfo.getDomainRank(), 0);
-  SmallVector<int64_t> reductionTileSizes(op.getNumLoops(), 0);
+  SmallVector<int64_t> reductionTileSizes(opInfo.getDomainRank(), 0);
   IREE::GPU::Basis subgroupBasis = {
       SmallVector<int64_t>(opInfo.getDomainRank(), 1),
       // Distribute subgroups from outer to inner. Mostly an arbitrary choice.
@@ -1055,10 +1055,10 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   auto pvAttrDict = b.getDictionaryAttr(pvAttrs);
 
   SmallVector<NamedAttribute, 2> decompositionConfig;
-  decompositionConfig.emplace_back(IREE::LinalgExt::AttentionOp::getQKAttrStr(),
-                                   qkAttrDict);
-  decompositionConfig.emplace_back(IREE::LinalgExt::AttentionOp::getPVAttrStr(),
-                                   pvAttrDict);
+  decompositionConfig.emplace_back(
+      IREE::LinalgExt::OnlineAttentionOp::getQKAttrStr(), qkAttrDict);
+  decompositionConfig.emplace_back(
+      IREE::LinalgExt::OnlineAttentionOp::getPVAttrStr(), pvAttrDict);
 
   DictionaryAttr decompositionConfigDict =
       b.getDictionaryAttr(decompositionConfig);
@@ -1095,7 +1095,7 @@ struct AttentionReductionHeuristicSeeds {
 
 static LogicalResult setAttentionReductionConfig(
     AttentionReductionHeuristicSeeds &seeds, IREE::GPU::TargetAttr target,
-    FunctionOpInterface entryPoint, IREE::LinalgExt::AttentionOp op) {
+    FunctionOpInterface entryPoint, IREE::LinalgExt::OnlineAttentionOp op) {
 
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
 
@@ -1344,10 +1344,10 @@ static LogicalResult setAttentionReductionConfig(
   auto pvAttrDict = b.getDictionaryAttr(pvAttrs);
 
   SmallVector<NamedAttribute, 2> decompositionConfig;
-  decompositionConfig.emplace_back(IREE::LinalgExt::AttentionOp::getQKAttrStr(),
-                                   qkAttrDict);
-  decompositionConfig.emplace_back(IREE::LinalgExt::AttentionOp::getPVAttrStr(),
-                                   pvAttrDict);
+  decompositionConfig.emplace_back(
+      IREE::LinalgExt::OnlineAttentionOp::getQKAttrStr(), qkAttrDict);
+  decompositionConfig.emplace_back(
+      IREE::LinalgExt::OnlineAttentionOp::getPVAttrStr(), pvAttrDict);
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
   setAttentionPipelineAttributes(target, pipelineAttrs);
@@ -1368,7 +1368,7 @@ static LogicalResult setAttentionReductionConfig(
 static LogicalResult
 setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
                                      FunctionOpInterface entryPoint,
-                                     IREE::LinalgExt::AttentionOp op) {
+                                     IREE::LinalgExt::OnlineAttentionOp op) {
 
   // This configuration is not really smart right now. It just makes sure that
   // attention always compiles and tries to distribute workload on threads,
@@ -1454,8 +1454,9 @@ setVectorDistributionConfig(IREE::GPU::TargetAttr target,
     }
   }
 
-  if (auto attnOp = dyn_cast<IREE::LinalgExt::AttentionOp>(computeOp)) {
-    LDBG() << "VectorDistribution: trying to find a suitable attention config";
+  if (auto attnOp = dyn_cast<IREE::LinalgExt::OnlineAttentionOp>(computeOp)) {
+    LDBG() << "VectorDistribution: trying to find a suitable online attention "
+              "config";
     if (succeeded(setAttentionIntrinsicBasedVectorDistributionConfig(
             target, entryPoint, attnOp))) {
       return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1114,8 +1114,6 @@ static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(
   buildLLVMGPUCodegenCommonConfigurationPassPipelineImpl(modulePassManager);
   modulePassManager.addPass(createMaterializeTuningSpecsPass());
   modulePassManager.addPass(createMaterializeUserConfigsPass());
-  FunctionLikeNest(modulePassManager)
-      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
   modulePassManager.addPass(createLLVMGPUSelectLoweringStrategyPass());
   if (shouldEmitPipelineConstraints()) {
     FunctionLikeNest(modulePassManager)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -745,9 +745,6 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   tileAndDistributeToWorkgroup(funcPassManager,
                                /*strategy=*/reorderStrategy);
 
-  funcPassManager.addPass(
-      IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
-
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
@@ -1117,6 +1114,8 @@ static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(
   buildLLVMGPUCodegenCommonConfigurationPassPipelineImpl(modulePassManager);
   modulePassManager.addPass(createMaterializeTuningSpecsPass());
   modulePassManager.addPass(createMaterializeUserConfigsPass());
+  FunctionLikeNest(modulePassManager)
+      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
   modulePassManager.addPass(createLLVMGPUSelectLoweringStrategyPass());
   if (shouldEmitPipelineConstraints()) {
     FunctionLikeNest(modulePassManager)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -237,6 +237,14 @@ func.func @matmul_dynamic_dim() {
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -249,21 +257,23 @@ func.func @attention_20x4096x64x4096x64() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
   %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x4096x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
-                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<20x4096x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+  %8 = tensor.empty() : tensor<20x4096x64xf32>
+  %9 = tensor.empty() : tensor<20x4096xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<20x4096x64xf32>) -> tensor<20x4096x64xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%10, %11, %12 : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
+  ^bb0(%arg0: f32):
+    iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %13#0, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
   return
 }
 
@@ -282,6 +292,14 @@ func.func @attention_20x4096x64x4096x64() {
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64_f8()
 
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -294,21 +312,23 @@ func.func @attention_20x4096x64x4096x64_f8() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
   %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
-  %7 = tensor.empty() : tensor<20x4096x64xf8E4M3FNUZ>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
-                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, f8E4M3FNUZ) outs(%7 : tensor<20x4096x64xf8E4M3FNUZ>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<20x4096x64xf8E4M3FNUZ>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf8E4M3FNUZ> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  %8 = tensor.empty() : tensor<20x4096x64xf32>
+  %9 = tensor.empty() : tensor<20x4096xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<20x4096x64xf32>) -> tensor<20x4096x64xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%4, %5, %6, %cst : tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, f8E4M3FNUZ) outs(%10, %11, %12 : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
+  ^bb0(%arg0: f32):
+    iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %13#0, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
   return
 }
 
@@ -331,6 +351,14 @@ func.func @attention_20x4096x64x4096x64_f8() {
 // Test to check if having a large head dim, which would lead to high shared
 // memory usage, can select tile sizes that fit shared memory.
 
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0)>
+#map6 = affine_map<(d0, d1) -> (d0)>
+#map7 = affine_map<(d0, d1) -> (d0, d1)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -343,21 +371,23 @@ func.func @attention_large_head_dim_shared_mem() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf16>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf32>>
   %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf16>> -> tensor<1024x512xf16>
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
-  %7 = tensor.empty() : tensor<1024x512xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d1, d2, d3, d4) -> (d1, d2)>,
-                     affine_map<(d1, d2, d3, d4) -> (d3, d2)>,
-                     affine_map<(d1, d2, d3, d4) -> (d3, d4)>,
-                     affine_map<(d1, d2, d3, d4) -> ()>,
-                     affine_map<(d1, d2, d3, d4) -> (d1, d4)>]}
-                     ins(%4, %5, %6, %cst : tensor<1024x512xf16>, tensor<128x512xf16>, tensor<128x512xf16>, f16) outs(%7 : tensor<1024x512xf16>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<1024x512xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : tensor<1024x512xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf16>>
+  %8 = tensor.empty() : tensor<1024x512xf32>
+  %9 = tensor.empty() : tensor<1024xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<1024x512xf32>) -> tensor<1024x512xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<1024xf32>) -> tensor<1024xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<1024xf32>) -> tensor<1024xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%4, %5, %6, %cst : tensor<1024x512xf16>, tensor<128x512xf16>, tensor<128x512xf16>, f16) outs(%10, %11, %12 : tensor<1024x512xf32>, tensor<1024xf32>, tensor<1024xf32>) {
+  ^bb0(%arg0: f32):
+    iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<1024x512xf32>, tensor<1024xf32>, tensor<1024xf32>
+  iree_tensor_ext.dispatch.tensor.store %13#0, %3, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : tensor<1024x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf32>>
   return
 }
 
@@ -376,6 +406,14 @@ func.func @attention_large_head_dim_shared_mem() {
 
 // Test that the config logic can handle a missing M dimension.
 
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0)>
+#map6 = affine_map<(d0, d1) -> (d0)>
+#map7 = affine_map<(d0, d1) -> (d0, d1)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -388,41 +426,52 @@ func.func @attention_20x64x4096x64_f8() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x64xf8E4M3FNUZ>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x64xf8E4M3FNUZ>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x64xf32>>
   %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x64xf8E4M3FNUZ>> -> tensor<20x64xf8E4M3FNUZ>
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
-  %7 = tensor.empty() : tensor<20x64xf8E4M3FNUZ>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d2, d3, d4) -> (d0, d2)>,
-                     affine_map<(d0, d2, d3, d4) -> (d0, d3, d2)>,
-                     affine_map<(d0, d2, d3, d4) -> (d0, d3, d4)>,
-                     affine_map<(d0, d2, d3, d4) -> ()>,
-                     affine_map<(d0, d2, d3, d4) -> (d0, d4)>]}
-                     ins(%4, %5, %6, %cst : tensor<20x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, f8E4M3FNUZ) outs(%7 : tensor<20x64xf8E4M3FNUZ>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<20x64xf8E4M3FNUZ>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [20, 64], strides = [1, 1] : tensor<20x64xf8E4M3FNUZ> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x64xf8E4M3FNUZ>>
+  %8 = tensor.empty() : tensor<20x64xf32>
+  %9 = tensor.empty() : tensor<20xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<20x64xf32>) -> tensor<20x64xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<20xf32>) -> tensor<20xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<20xf32>) -> tensor<20xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%4, %5, %6, %cst : tensor<20x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, f8E4M3FNUZ) outs(%10, %11, %12 : tensor<20x64xf32>, tensor<20xf32>, tensor<20xf32>) {
+  ^bb0(%arg0: f32):
+    iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<20x64xf32>, tensor<20xf32>, tensor<20xf32>
+  iree_tensor_ext.dispatch.tensor.store %13#0, %3, offsets = [0, 0], sizes = [20, 64], strides = [1, 1] : tensor<20x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x64xf32>>
   return
 }
 
 // -----
 
-func.func @attention_multi_m(%4 : tensor<20x256x16x64xf16>, %5 : tensor<20x4096x64xf16>, %6 : tensor<20x4096x64xf16>) -> tensor<20x256x16x64xf16> {
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+#map6 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map7 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @attention_multi_m(%arg0 : tensor<20x256x16x64xf16>, %arg1 : tensor<20x4096x64xf16>, %arg2 : tensor<20x4096x64xf16>) -> tensor<20x256x16x64xf32> {
   %cst = arith.constant 1.250000e-01 : f16
   %c0 = arith.constant 0 : index
-  %7 = tensor.empty() : tensor<20x256x16x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [
-                     affine_map<(b, m0, m1, k1, k2, n) -> (b, m0, m1, k1)>,
-                     affine_map<(b, m0, m1, k1, k2, n) -> (b, k2, k1)>,
-                     affine_map<(b, m0, m1, k1, k2, n) -> (b, k2, n)>,
-                     affine_map<(b, m0, m1, k1, k2, n) -> ()>,
-                     affine_map<(b, m0, m1, k1, k2, n) -> (b, m0, m1, n)>]}
-                     ins(%4, %5, %6, %cst : tensor<20x256x16x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x256x16x64xf16>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<20x256x16x64xf16>
-  return %8 : tensor<20x256x16x64xf16>
+  %1 = tensor.empty() : tensor<20x256x16x64xf32>
+  %2 = tensor.empty() : tensor<20x256x16xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %3 = linalg.fill ins(%cst_0 : f32) outs(%1 : tensor<20x256x16x64xf32>) -> tensor<20x256x16x64xf32>
+  %4 = linalg.fill ins(%cst_1 : f32) outs(%2 : tensor<20x256x16xf32>) -> tensor<20x256x16xf32>
+  %5 = linalg.fill ins(%cst_2 : f32) outs(%2 : tensor<20x256x16xf32>) -> tensor<20x256x16xf32>
+  %6:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%arg0, %arg1, %arg2, %cst : tensor<20x256x16x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%3, %4, %5 : tensor<20x256x16x64xf32>, tensor<20x256x16xf32>, tensor<20x256x16xf32>) {
+  ^bb0(%arg3: f32):
+    iree_linalg_ext.yield %arg3 : f32
+  } -> tensor<20x256x16x64xf32>, tensor<20x256x16xf32>, tensor<20x256x16xf32>
+  return %6#0 : tensor<20x256x16x64xf32>
 }
 
 // CHECK-LABEL: func.func @attention_multi_m
@@ -437,23 +486,34 @@ func.func @attention_multi_m(%4 : tensor<20x256x16x64xf16>, %5 : tensor<20x4096x
 
 // -----
 
-func.func @attention_multi_m_dynamic(%4 : tensor<20x8x?x16x64xf16>, %5 : tensor<20x4096x64xf16>, %6 : tensor<20x4096x64xf16>) -> tensor<20x8x?x16x64xf16> {
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d6)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d6)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+#map7 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+func.func @attention_multi_m_dynamic(%arg0 : tensor<20x8x?x16x64xf16>, %arg1 : tensor<20x4096x64xf16>, %arg2 : tensor<20x4096x64xf16>) -> tensor<20x8x?x16x64xf32> {
   %cst = arith.constant 1.250000e-01 : f16
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
-  %dim = tensor.dim %4, %c2 : tensor<20x8x?x16x64xf16>
-  %7 = tensor.empty(%dim) : tensor<20x8x?x16x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [
-                     affine_map<(b, m0, m1, m2, k1, k2, n) -> (b, m0, m1, m2, k1)>,
-                     affine_map<(b, m0, m1, m2, k1, k2, n) -> (b, k2, k1)>,
-                     affine_map<(b, m0, m1, m2, k1, k2, n) -> (b, k2, n)>,
-                     affine_map<(b, m0, m1, m2, k1, k2, n) -> ()>,
-                     affine_map<(b, m0, m1, m2, k1, k2, n) -> (b, m0, m1, m2, n)>]}
-                     ins(%4, %5, %6, %cst : tensor<20x8x?x16x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x8x?x16x64xf16>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<20x8x?x16x64xf16>
-  return %8 : tensor<20x8x?x16x64xf16>
+  %dim = tensor.dim %arg0, %c2 : tensor<20x8x?x16x64xf16>
+  %c2_0 = arith.constant 2 : index
+  %dim_1 = tensor.dim %arg0, %c2_0 : tensor<20x8x?x16x64xf16>
+  %1 = tensor.empty(%dim_1) : tensor<20x8x?x16x64xf32>
+  %2 = tensor.empty(%dim_1) : tensor<20x8x?x16xf32>
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %cst_3 = arith.constant -3.40282347E+38 : f32
+  %cst_4 = arith.constant 0.000000e+00 : f32
+  %3 = linalg.fill ins(%cst_2 : f32) outs(%1 : tensor<20x8x?x16x64xf32>) -> tensor<20x8x?x16x64xf32>
+  %4 = linalg.fill ins(%cst_3 : f32) outs(%2 : tensor<20x8x?x16xf32>) -> tensor<20x8x?x16xf32>
+  %5 = linalg.fill ins(%cst_4 : f32) outs(%2 : tensor<20x8x?x16xf32>) -> tensor<20x8x?x16xf32>
+  %6:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%arg0, %arg1, %arg2, %cst : tensor<20x8x?x16x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%3, %4, %5 : tensor<20x8x?x16x64xf32>, tensor<20x8x?x16xf32>, tensor<20x8x?x16xf32>) {
+  ^bb0(%arg3: f32):
+    iree_linalg_ext.yield %arg3 : f32
+  } -> tensor<20x8x?x16x64xf32>, tensor<20x8x?x16xf32>, tensor<20x8x?x16xf32>
+  return %6#0 : tensor<20x8x?x16x64xf32>
 }
 
 // CHECK-LABEL: func.func @attention_multi_m_dynamic

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -196,6 +196,14 @@ func.func @matmul_dynamic_dim() {
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -208,21 +216,23 @@ func.func @attention_20x4096x64x4096x64() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
   %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x4096x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
-                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
-                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<20x4096x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+  %8 = tensor.empty() : tensor<20x4096x64xf32>
+  %9 = tensor.empty() : tensor<20x4096xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<20x4096x64xf32>) -> tensor<20x4096x64xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%10, %11, %12 : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
+  ^bb0(%arg0: f32):
+    iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %13#0, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
   return
 }
 
@@ -244,6 +254,14 @@ func.func @attention_20x4096x64x4096x64() {
 // Test to check if having a large head dim, which would lead to high shared
 // memory usage, can select tile sizes that fit shared memory.
 
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0)>
+#map6 = affine_map<(d0, d1) -> (d0)>
+#map7 = affine_map<(d0, d1) -> (d0, d1)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -256,21 +274,23 @@ func.func @attention_large_head_dim_shared_mem() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf16>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf32>>
   %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf16>> -> tensor<1024x512xf16>
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
-  %7 = tensor.empty() : tensor<1024x512xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d1, d2, d3, d4) -> (d1, d2)>,
-                     affine_map<(d1, d2, d3, d4) -> (d3, d2)>,
-                     affine_map<(d1, d2, d3, d4) -> (d3, d4)>,
-                     affine_map<(d1, d2, d3, d4) -> ()>,
-                     affine_map<(d1, d2, d3, d4) -> (d1, d4)>]}
-                     ins(%4, %5, %6, %cst : tensor<1024x512xf16>, tensor<128x512xf16>, tensor<128x512xf16>, f16) outs(%7 : tensor<1024x512xf16>) {
-                      ^bb0(%score: f32):
-                        iree_linalg_ext.yield %score : f32
-                     } -> tensor<1024x512xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : tensor<1024x512xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf16>>
+  %8 = tensor.empty() : tensor<1024x512xf32>
+  %9 = tensor.empty() : tensor<1024xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<1024x512xf32>) -> tensor<1024x512xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<1024xf32>) -> tensor<1024xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<1024xf32>) -> tensor<1024xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%4, %5, %6, %cst : tensor<1024x512xf16>, tensor<128x512xf16>, tensor<128x512xf16>, f16) outs(%10, %11, %12 : tensor<1024x512xf32>, tensor<1024xf32>, tensor<1024xf32>) {
+  ^bb0(%arg0: f32):
+    iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<1024x512xf32>, tensor<1024xf32>, tensor<1024xf32>
+  iree_tensor_ext.dispatch.tensor.store %13#0, %3, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : tensor<1024x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x512xf32>>
   return
 }
 
@@ -298,12 +318,22 @@ func.func @attention_large_head_dim_shared_mem() {
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d2)>
 #map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
 #map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 func.func @attention_check_mma_accs_compatible(%arg0: f32, %arg1: tensor<960x4096x64xf8E4M3FN>, %arg2: tensor<960x4096x64xf8E4M3FN>, %arg3: tensor<960x4096x64xf8E4M3FN>, %arg4: tensor<960x4096x64xf32>, %arg5: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960x4096x64xf32>>) {
-  %0 = iree_linalg_ext.attention {indexing_maps = [#map, #map1, #map2, #map3, #map4]} ins(%arg1, %arg2, %arg3, %arg0 : tensor<960x4096x64xf8E4M3FN>, tensor<960x4096x64xf8E4M3FN>, tensor<960x4096x64xf8E4M3FN>, f32) outs(%arg4 : tensor<960x4096x64xf32>) {
+  %1 = tensor.empty() : tensor<960x4096xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant -3.40282347E+38 : f32
+  %cst_1 = arith.constant 0.000000e+00 : f32
+  %2 = linalg.fill ins(%cst : f32) outs(%arg4 : tensor<960x4096x64xf32>) -> tensor<960x4096x64xf32>
+  %3 = linalg.fill ins(%cst_0 : f32) outs(%1 : tensor<960x4096xf32>) -> tensor<960x4096xf32>
+  %4 = linalg.fill ins(%cst_1 : f32) outs(%1 : tensor<960x4096xf32>) -> tensor<960x4096xf32>
+  %5:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]} ins(%arg1, %arg2, %arg3, %arg0 : tensor<960x4096x64xf8E4M3FN>, tensor<960x4096x64xf8E4M3FN>, tensor<960x4096x64xf8E4M3FN>, f32) outs(%2, %3, %4 : tensor<960x4096x64xf32>, tensor<960x4096xf32>, tensor<960x4096xf32>) {
   ^bb0(%arg6: f32):
     iree_linalg_ext.yield %arg6 : f32
-  } -> tensor<960x4096x64xf32>
-  iree_tensor_ext.dispatch.tensor.store %0, %arg5, offsets = [0, 0, 0], sizes = [960, 4096, 64], strides = [1, 1, 1] : tensor<960x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960x4096x64xf32>>
+  } -> tensor<960x4096x64xf32>, tensor<960x4096xf32>, tensor<960x4096xf32>
+  iree_tensor_ext.dispatch.tensor.store %5#0, %arg5, offsets = [0, 0, 0], sizes = [960, 4096, 64], strides = [1, 1, 1] : tensor<960x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960x4096x64xf32>>
   return
 }
 //      CHECK: decomposition_config =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -3,7 +3,6 @@
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
 // CHECK:      #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
-// CHECK-SAME: iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -22,16 +21,19 @@ func.func @attention_20x1x64x4096x64() {
   %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %7 = tensor.empty() : tensor<20x1x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+  %8 = tensor.empty() : tensor<20x1xf16>
+  %9:3 = iree_linalg_ext.online_attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
                affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
                affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
                affine_map<(d0, d1, d2, d3, d4) -> ()>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
-               ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x1x64xf16>) {
+               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>]}
+               ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7, %8, %8 : tensor<20x1x64xf16>, tensor<20x1xf16>, tensor<20x1xf16>) {
                 ^bb0(%score: f32):
                   iree_linalg_ext.yield %score : f32
-               } -> tensor<20x1x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
+               } -> tensor<20x1x64xf16>, tensor<20x1xf16>, tensor<20x1xf16>
+  iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
   return
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_dynamic_shapes_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_dynamic_shapes_gfx942.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-gpu-test-target=gfx942 --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' \
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
 // RUN:     %s | FileCheck %s
 
 // Test that the vector distribute pipeline correctly handles the case where
@@ -7,69 +7,78 @@
 // Check the pipeline didn't fail.
 // CHECK-LABEL: func.func @kernel
 // CHECK: vector.transfer_read
-// CHECK: iree_codegen.dispatch_config @kernel workgroup_size = [512, 1, 1] subgroup_size = 64
-func.func @kernel() attributes {
-    translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [512, 1, 1] subgroup_size = 64, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>} {
-  %cst = arith.constant 0.0721687824 : f32
-  %c32 = arith.constant 32 : index
-  %cst_0 = arith.constant 0xFF800000 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
-  %1 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
-  %2 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(2) : i32
-  %3 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(3) : i32
-  %4 = arith.index_castui %0 : i32 to index
-  %5 = arith.index_castui %1 : i32 to index
-  %6 = arith.index_castui %2 : i32 to index
-  %7 = arith.index_castui %3 : i32 to index
-  %8:4 = util.assume.int
-      %4<umin = 1982976, umax = 13880832>,
-      %5<umin = 1589760, umax = 11128320>,
-      %6<umin = 2376192, umax = 16633344>,
-      %7<umin = 32, umax = 224, udiv = 32>
-    : index, index, index, index
-  %9 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4xi64, #hal.descriptor_type<storage_buffer>>
-  %10 = amdgpu.fat_raw_buffer_cast %9 resetOffset : memref<4xi64, #hal.descriptor_type<storage_buffer>> to memref<4xi64, #amdgpu.address_space<fat_raw_buffer>>
-  %11 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<f32, #hal.descriptor_type<storage_buffer>>
-  %12 = amdgpu.fat_raw_buffer_cast %11 resetOffset : memref<f32, #hal.descriptor_type<storage_buffer>> to memref<f32, #amdgpu.address_space<fat_raw_buffer>>
-  %13 = iree_tensor_ext.dispatch.workload.ordinal %8#3, 0 : index
-  %14 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%8#0) flags("ReadOnly|Indirect") : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>{%13}
-  %15 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%8#1) flags("ReadOnly|Indirect") : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>{%13}
-  %16 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%8#2) flags("ReadOnly|Indirect") : memref<4x?x4x192xf32, strided<[?, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>{%13}
-  %17 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags(Indirect) : memref<4x4x?x192xf32, #hal.descriptor_type<storage_buffer>>{%13}
-  %18 = iree_codegen.load_from_buffer %10 : memref<4xi64, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4xi64>
-  %19 = iree_codegen.load_from_buffer %12 : memref<f32, #amdgpu.address_space<fat_raw_buffer>> -> tensor<f32>
-  %20 = affine.apply affine_map<()[s0] -> (s0 floordiv 32)>()[%13]
-  %21 = tensor.empty(%20, %20) : tensor<4x?x32x?x32xf32>
-  %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0)>, affine_map<(d0, d1, d2, d3, d4) -> ()>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%18, %19 : tensor<4xi64>, tensor<f32>) outs(%21 : tensor<4x?x32x?x32xf32>) {
-  ^bb0(%in: i64, %in_4: f32, %out: f32):
-    %28 = linalg.index 4 : index
-    %29 = linalg.index 3 : index
-    %30 = affine.apply affine_map<()[s0, s1] -> (s0 + s1 * 32)>()[%28, %29]
-    %31 = arith.index_cast %30 : index to i64
-    %32 = arith.cmpi sge, %31, %in : i64
-    %33 = linalg.index 2 : index
-    %34 = linalg.index 1 : index
-    %35 = affine.apply affine_map<()[s0, s1] -> (s0 + s1 * 32)>()[%33, %34]
-    %36 = arith.index_cast %35 : index to i64
-    %37 = arith.cmpi sgt, %31, %36 : i64
-    %38 = arith.ori %37, %32 : i1
-    %39 = arith.select %38, %cst_0, %in_4 : f32
-    linalg.yield %39 : f32
-  } -> tensor<4x?x32x?x32xf32>
-  %nval = arith.divsi %13, %c32 : index
-  %expand_shape = memref.expand_shape %17 [[0], [1], [2, 3], [4]] output_shape [4, 4, %20, 32, 192] : memref<4x4x?x192xf32, #hal.descriptor_type<storage_buffer>> into memref<4x4x?x32x192xf32, #hal.descriptor_type<storage_buffer>>
-  %expand_shape_1 = memref.expand_shape %14 [[0], [1], [2, 3], [4]] output_shape [192, 4, %20, 32, 4] : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> into memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-  %expand_shape_2 = memref.expand_shape %16 [[0], [1, 2], [3], [4]] output_shape [4, %20, 32, 4, 192] : memref<4x?x4x192xf32, strided<[?, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> into memref<4x?x32x4x192xf32, strided<[?, 24576, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-  %expand_shape_3 = memref.expand_shape %15 [[0], [1], [2, 3], [4]] output_shape [192, 4, %20, 32, 4] : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> into memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-  %23 = iree_codegen.load_from_buffer %expand_shape_1 : memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<192x4x?x32x4xf32>
-  %24 = iree_codegen.load_from_buffer %expand_shape_3 : memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<192x4x?x32x4xf32>
-  %25 = iree_codegen.load_from_buffer %expand_shape_2 : memref<4x?x32x4x192xf32, strided<[?, 24576, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<4x?x32x4x192xf32>
-  %26 = tensor.empty(%20) : tensor<4x4x?x32x192xf32>
-  %27 = iree_linalg_ext.attention {decomposition_config = {pv_attrs = {lowering_config = #iree_gpu.lowering_config<{lane_basis = [[1, 1, 1, 1, 1, 8, 1, 8], [2, 3, 0, 1, 5, 6, 7]], subgroup_basis = [[1, 1, 1, 1, 1, 1, 2, 4], [0, 1, 2, 3, 5, 6, 7]], thread = [0, 0, 0, 0, 4, 0, 0]}>}, qk_attrs = {lowering_config = #iree_gpu.lowering_config<{lane_basis = [[1, 1, 1, 1, 1, 8, 1, 8], [2, 3, 0, 1, 5, 6, 7]], subgroup_basis = [[1, 1, 1, 1, 1, 1, 2, 4], [0, 1, 2, 3, 4, 6, 7]], thread = [0, 0, 0, 0, 4, 0, 0]}>}}, indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d0, d2, d3, d1)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d0, d6, d7, d1)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d6, d7, d1, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d3, d6, d7)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>], lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 0, 0, 0, 0, 2, 32], workgroup = [1, 1, 1, 1, 64, 0, 0, 0]}>} ins(%23, %24, %25, %cst, %22 : tensor<192x4x?x32x4xf32>, tensor<192x4x?x32x4xf32>, tensor<4x?x32x4x192xf32>, f32, tensor<4x?x32x?x32xf32>) outs(%26 : tensor<4x4x?x32x192xf32>) {
-  ^bb0(%arg0: f32):
-    iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<4x4x?x32x192xf32>
-  iree_codegen.store_to_buffer %27, %expand_shape : tensor<4x4x?x32x192xf32> into memref<4x4x?x32x192xf32, #hal.descriptor_type<storage_buffer>>
-  return
+hal.executable private @kernel {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>, iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>) {
+    hal.executable.export public @kernel ordinal(0) layout(#hal.pipeline.layout<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @kernel() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [512, 1, 1] subgroup_size = 64, {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">}>} {
+        %cst = arith.constant 0.0721687824 : f32
+        %c32 = arith.constant 32 : index
+        %cst_0 = arith.constant 0xFF800000 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
+        %1 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
+        %2 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(2) : i32
+        %3 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(3) : i32
+        %4 = arith.index_castui %0 : i32 to index
+        %5 = arith.index_castui %1 : i32 to index
+        %6 = arith.index_castui %2 : i32 to index
+        %7 = arith.index_castui %3 : i32 to index
+        %8:4 = util.assume.int
+            %4<umin = 1982976, umax = 13880832>,
+            %5<umin = 1589760, umax = 11128320>,
+            %6<umin = 2376192, umax = 16633344>,
+            %7<umin = 32, umax = 224, udiv = 32>
+          : index, index, index, index
+        %9 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4xi64, #hal.descriptor_type<storage_buffer>>
+        %10 = amdgpu.fat_raw_buffer_cast %9 resetOffset : memref<4xi64, #hal.descriptor_type<storage_buffer>> to memref<4xi64, #amdgpu.address_space<fat_raw_buffer>>
+        %11 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<f32, #hal.descriptor_type<storage_buffer>>
+        %12 = amdgpu.fat_raw_buffer_cast %11 resetOffset : memref<f32, #hal.descriptor_type<storage_buffer>> to memref<f32, #amdgpu.address_space<fat_raw_buffer>>
+        %13 = iree_tensor_ext.dispatch.workload.ordinal %8#3, 0 : index
+        %14 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%8#0) flags("ReadOnly|Indirect") : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>{%13}
+        %15 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%8#1) flags("ReadOnly|Indirect") : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>{%13}
+        %16 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%8#2) flags("ReadOnly|Indirect") : memref<4x?x4x192xf32, strided<[?, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>{%13}
+        %17 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags(Indirect) : memref<4x4x?x192xf32, #hal.descriptor_type<storage_buffer>>{%13}
+        %18 = iree_codegen.load_from_buffer %10 : memref<4xi64, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4xi64>
+        %19 = iree_codegen.load_from_buffer %12 : memref<f32, #amdgpu.address_space<fat_raw_buffer>> -> tensor<f32>
+        %20 = affine.apply affine_map<()[s0] -> (s0 floordiv 32)>()[%13]
+        %21 = tensor.empty(%20, %20) : tensor<4x?x32x?x32xf32>
+        %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0)>, affine_map<(d0, d1, d2, d3, d4) -> ()>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%18, %19 : tensor<4xi64>, tensor<f32>) outs(%21 : tensor<4x?x32x?x32xf32>) {
+        ^bb0(%in: i64, %in_4: f32, %out: f32):
+          %28 = linalg.index 4 : index
+          %29 = linalg.index 3 : index
+          %30 = affine.apply affine_map<()[s0, s1] -> (s0 + s1 * 32)>()[%28, %29]
+          %31 = arith.index_cast %30 : index to i64
+          %32 = arith.cmpi sge, %31, %in : i64
+          %33 = linalg.index 2 : index
+          %34 = linalg.index 1 : index
+          %35 = affine.apply affine_map<()[s0, s1] -> (s0 + s1 * 32)>()[%33, %34]
+          %36 = arith.index_cast %35 : index to i64
+          %37 = arith.cmpi sgt, %31, %36 : i64
+          %38 = arith.ori %37, %32 : i1
+          %39 = arith.select %38, %cst_0, %in_4 : f32
+          linalg.yield %39 : f32
+        } -> tensor<4x?x32x?x32xf32>
+        %nval = arith.divsi %13, %c32 : index
+        %expand_shape = memref.expand_shape %17 [[0], [1], [2, 3], [4]] output_shape [4, 4, %20, 32, 192] : memref<4x4x?x192xf32, #hal.descriptor_type<storage_buffer>> into memref<4x4x?x32x192xf32, #hal.descriptor_type<storage_buffer>>
+        %expand_shape_1 = memref.expand_shape %14 [[0], [1], [2, 3], [4]] output_shape [192, 4, %20, 32, 4] : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> into memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+        %expand_shape_2 = memref.expand_shape %16 [[0], [1, 2], [3], [4]] output_shape [4, %20, 32, 4, 192] : memref<4x?x4x192xf32, strided<[?, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> into memref<4x?x32x4x192xf32, strided<[?, 24576, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+        %expand_shape_3 = memref.expand_shape %15 [[0], [1], [2, 3], [4]] output_shape [192, 4, %20, 32, 4] : memref<192x4x?x4xf32, strided<[?, ?, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> into memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+        %23 = iree_codegen.load_from_buffer %expand_shape_1 : memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<192x4x?x32x4xf32>
+        %24 = iree_codegen.load_from_buffer %expand_shape_3 : memref<192x4x?x32x4xf32, strided<[?, ?, 128, 4, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<192x4x?x32x4xf32>
+        %25 = iree_codegen.load_from_buffer %expand_shape_2 : memref<4x?x32x4x192xf32, strided<[?, 24576, 768, 192, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<4x?x32x4x192xf32>
+        %26 = tensor.empty(%20) : tensor<4x4x?x32x192xf32>
+        %27 = tensor.empty(%20) : tensor<4x4x?x32xf32>
+        %28:3 = iree_linalg_ext.online_attention {decomposition_config = {pv_attrs = {lowering_config = #iree_gpu.lowering_config<{lane_basis = [[1, 1, 1, 1, 1, 8, 1, 8], [2, 3, 0, 1, 5, 6, 7]], subgroup_basis = [[1, 1, 1, 1, 1, 1, 2, 4], [0, 1, 2, 3, 5, 6, 7]], thread = [0, 0, 0, 0, 4, 0, 0]}>}, qk_attrs = {lowering_config = #iree_gpu.lowering_config<{lane_basis = [[1, 1, 1, 1, 1, 8, 1, 8], [2, 3, 0, 1, 5, 6, 7]], subgroup_basis = [[1, 1, 1, 1, 1, 1, 2, 4], [0, 1, 2, 3, 4, 6, 7]], thread = [0, 0, 0, 0, 4, 0, 0]}>}}, indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d0, d2, d3, d1)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d0, d6, d7, d1)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d6, d7, d1, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d3, d6, d7)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>], lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 0, 0, 0, 0, 2, 32], workgroup = [1, 1, 1, 1, 64, 0, 0, 0]}>} ins(%23, %24, %25, %cst, %22 : tensor<192x4x?x32x4xf32>, tensor<192x4x?x32x4xf32>, tensor<4x?x32x4x192xf32>, f32, tensor<4x?x32x?x32xf32>) outs(%26, %27, %27 : tensor<4x4x?x32x192xf32>, tensor<4x4x?x32xf32>, tensor<4x4x?x32xf32>) {
+        ^bb0(%arg0: f32):
+          iree_linalg_ext.yield %arg0 : f32
+        } -> tensor<4x4x?x32x192xf32>, tensor<4x4x?x32xf32>, tensor<4x4x?x32xf32>
+        iree_codegen.store_to_buffer %28#0, %expand_shape : tensor<4x4x?x32x192xf32> into memref<4x4x?x32x192xf32, #hal.descriptor_type<storage_buffer>>
+        return
+      }
+    }
+  }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -1,12 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
-// RUN:   --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" \
 // RUN:   %s | FileCheck %s
 
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
-// RUN:   --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" \
 // RUN:   %s | FileCheck %s --check-prefix=MEMORY
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -15,19 +16,29 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_f16_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x256_f16_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_256x256x256_f16_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_f16_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Basic pipeline test to make sure it generates the instructions we expect.
@@ -39,11 +50,9 @@ func.func @matmul_256x256x256_f16_f32() attributes {hal.executable.target = #exe
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 //          CHECK:     scf.yield
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_f16_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -52,19 +61,29 @@ func.func @matmul_256x256x256_f16_f32() attributes {hal.executable.target = #exe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_f16_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x256_f16_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_256x256x256_f16_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_f16_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f16_f32()
@@ -72,11 +91,9 @@ func.func @matmul_256x256x256_f16_f32() attributes {hal.executable.target = #exe
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 //          CHECK:     scf.yield
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_f16_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -85,41 +102,51 @@ func.func @matmul_256x256x256_f16_f32() attributes {hal.executable.target = #exe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @expanded_matmul_transpose_b() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 64, 2048], strides = [1, 1, 1]
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>> -> tensor<2x64x2048xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [10, 64, 2048], strides = [1, 1, 1]
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>> -> tensor<10x64x2048xf16>
+hal.executable @expanded_matmul_transpose_b_executable {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @expanded_matmul_transpose_b layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @expanded_matmul_transpose_b() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0)
+          : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 64, 2048], strides = [1, 1, 1]
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>> -> tensor<2x64x2048xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [10, 64, 2048], strides = [1, 1, 1]
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>> -> tensor<10x64x2048xf16>
 
-  %5 = tensor.empty() : tensor<2x10x64x64xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
-  %7 = linalg.generic {
-    indexing_maps = [
-      affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
-      affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
-      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
-    ],
-    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
-    lowering_config = #config
-  } ins(%3, %4 : tensor<2x64x2048xf16>, tensor<10x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) {
-  ^bb0(%lhs: f16, %rhs: f16, %out: f32):
-    %mul = arith.mulf %lhs, %rhs : f16
-    %ext = arith.extf %mul : f16 to f32
-    %add = arith.addf %ext, %out : f32
-    linalg.yield %add : f32
-  } -> tensor<2x10x64x64xf32>
+        %5 = tensor.empty() : tensor<2x10x64x64xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
+        %7 = linalg.generic {
+          indexing_maps = [
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+          ],
+          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
+          lowering_config = #config
+        } ins(%3, %4 : tensor<2x64x2048xf16>, tensor<10x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) {
+        ^bb0(%lhs: f16, %rhs: f16, %out: f32):
+          %mul = arith.mulf %lhs, %rhs : f16
+          %ext = arith.extf %mul : f16 to f32
+          %add = arith.addf %ext, %out : f32
+          linalg.yield %add : f32
+        } -> tensor<2x10x64x64xf32>
 
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1]
-    : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  return
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1]
+          : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 //          CHECK: func @expanded_matmul_transpose_b
@@ -130,36 +157,44 @@ func.func @expanded_matmul_transpose_b() attributes {hal.executable.target = #ex
 //          CHECK:     scf.yield
 // CHECK-COUNT-32:   amdgpu.mfma
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf32>, memref<2x10x64x64xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @expanded_matmul_transpose_b workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-func.func @matmul_multiple_k() attributes {hal.executable.target = #executable_target_rocm, translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>>
-  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>>
-  %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>> -> tensor<2x128x64x2048xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [10, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>> -> tensor<10x128x64x2048xf16>
-  %5 = tensor.empty() : tensor<2x10x64x64xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<2x128x64x2048xf16>, tensor<10x128x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 0, 1, 128], workgroup = [1, 1, 64, 64, 0, 0], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1, 1], [0, 1, 2, 3, 4, 5]]}>} {
-  ^bb0(%in: f16, %in_0: f16, %out: f32):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.extf %8 : f16 to f32
-    %10 = arith.addf %9, %out : f32
-    linalg.yield %10 : f32
-  } -> tensor<2x10x64x64xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1] : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  return
+hal.executable @matmul_multiple_k {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_multiple_k layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_multiple_k() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>>
+        %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>>
+        %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>> -> tensor<2x128x64x2048xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [10, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>> -> tensor<10x128x64x2048xf16>
+        %5 = tensor.empty() : tensor<2x10x64x64xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<2x128x64x2048xf16>, tensor<10x128x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 0, 1, 128], workgroup = [1, 1, 64, 64, 0, 0], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1, 1], [0, 1, 2, 3, 4, 5]]}>} {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.extf %8 : f16 to f32
+          %10 = arith.addf %9, %out : f32
+          linalg.yield %10 : f32
+        } -> tensor<2x10x64x64xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1] : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 // Check if we can handle multiple reduction dimensions and that they generate
@@ -171,11 +206,9 @@ func.func @matmul_multiple_k() attributes {hal.executable.target = #executable_t
 // CHECK-COUNT-32:   amdgpu.mfma
 // CHECK:            scf.yield
 // CHECK-COUNT-4:  vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf32>, memref<2x10x64x64xf32, #amdgpu.address_space<fat_raw_buffer>>
-// CHECK:          iree_codegen.dispatch_config @matmul_multiple_k workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 16, n = 16, k = 32)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -186,19 +219,29 @@ func.func @matmul_multiple_k() attributes {hal.executable.target = #executable_t
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_16x16x32_f8_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x256_16x16x32_f8_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_256x256x256_16x16x32_f8_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_16x16x32_f8_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for f8 inputs.
@@ -208,11 +251,9 @@ func.func @matmul_256x256x256_16x16x32_f8_f32() attributes {hal.executable.targe
 // along the K dimension. So in total 32 mfma ops.
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf8E4M3FNUZ>, vector<8xf8E4M3FNUZ>, vector<4xf32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_16x16x32_f8_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // Basic i8, i8 -> i32 matmul.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -223,19 +264,29 @@ func.func @matmul_256x256x256_16x16x32_f8_f32() attributes {hal.executable.targe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_i8_i32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0 : i32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %5 = tensor.empty() : tensor<256x256xi32>
-  %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  return
+hal.executable @matmul_256x256x256_i8_i32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_256x256x256_i8_i32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_i8_i32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0 : i32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %5 = tensor.empty() : tensor<256x256xi32>
+      %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for integer inputs.
@@ -245,11 +296,9 @@ func.func @matmul_256x256x256_i8_i32() attributes {hal.executable.target = #exec
 // along the K dimension. So in total 32 mfma ops.
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xi8>, vector<8xi8>, vector<4xi32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xi32>, memref<256x256xi32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_i8_i32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 32, n = 32, k = 16)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -260,19 +309,29 @@ func.func @matmul_256x256x256_i8_i32() attributes {hal.executable.target = #exec
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_32x32x16_f8_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x256_32x32x16_f8_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_256x256x256_32x32x16_f8_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_32x32x16_f8_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for f8 inputs.
@@ -282,11 +341,9 @@ func.func @matmul_256x256x256_32x32x16_f8_f32() attributes {hal.executable.targe
 // along the K dimension. So in total 16 mfma ops.
 //  CHECK-COUNT-16:     amdgpu.mfma 32x32x16 {{.*}} blgp =  none : vector<8xf8E4M3FNUZ>, vector<8xf8E4M3FNUZ>, vector<16xf32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_32x32x16_f8_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // Basic i8, i8 -> i32 matmul_transpose_b.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -297,26 +354,36 @@ func.func @matmul_256x256x256_32x32x16_f8_f32() attributes {hal.executable.targe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0 : i32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %5 = tensor.empty() : tensor<256x256xi32>
-  %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  %7 = linalg.matmul
-    indexing_maps = [
-      affine_map<(d0, d1, d2) -> (d0, d2)>,
-      affine_map<(d0, d1, d2) -> (d1, d2)>,
-      affine_map<(d0, d1, d2) -> (d0, d1)>
-    ]
-    {lowering_config = #config}
-    ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  return
+hal.executable @matmul_transpose_b_256x256x256_i8_i32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_transpose_b_256x256x256_i8_i32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0 : i32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %5 = tensor.empty() : tensor<256x256xi32>
+      %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      %7 = linalg.matmul
+        indexing_maps = [
+          affine_map<(d0, d1, d2) -> (d0, d2)>,
+          affine_map<(d0, d1, d2) -> (d1, d2)>,
+          affine_map<(d0, d1, d2) -> (d0, d1)>
+        ]
+        {lowering_config = #config}
+        ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for integer inputs.
@@ -326,11 +393,9 @@ func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {hal.executable.ta
 // along the K dimension. So in total 32 mfma ops.
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xi8>, vector<8xi8>, vector<4xi32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xi32>, memref<256x256xi32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_transpose_b_256x256x256_i8_i32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 128, 0, 0, 0], reduction = [0, 0, 0, 0, 1, 1, 32], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -339,19 +404,29 @@ func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {hal.executable.ta
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @conv_nhwc() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x258x514x768xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x768x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x256x512x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 258, 514, 768], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x258x514x768xf16>> -> tensor<2x258x514x768xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 768, 256], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x768x256xf16>> -> tensor<3x3x768x256xf16>
-  %5 = tensor.empty() : tensor<2x256x512x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x256x512x256xf32>) -> tensor<2x256x512x256xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, lowering_config = #config} ins(%3, %4 : tensor<2x258x514x768xf16>, tensor<3x3x768x256xf16>) outs(%6 : tensor<2x256x512x256xf32>) -> tensor<2x256x512x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 256, 512, 256], strides = [1, 1, 1, 1] : tensor<2x256x512x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x256x512x256xf32>>
-  return
+hal.executable @conv_nhwc_dispatch_0 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @conv_nhwc layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @conv_nhwc() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x258x514x768xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x768x256xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x256x512x256xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 258, 514, 768], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x258x514x768xf16>> -> tensor<2x258x514x768xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 768, 256], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x768x256xf16>> -> tensor<3x3x768x256xf16>
+        %5 = tensor.empty() : tensor<2x256x512x256xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x256x512x256xf32>) -> tensor<2x256x512x256xf32>
+        %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, lowering_config = #config} ins(%3, %4 : tensor<2x258x514x768xf16>, tensor<3x3x768x256xf16>) outs(%6 : tensor<2x256x512x256xf32>) -> tensor<2x256x512x256xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 256, 512, 256], strides = [1, 1, 1, 1] : tensor<2x256x512x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x256x512x256xf32>>
+        return
+      }
+    }
+  }
 }
 
 //    CHECK-LABEL: func.func @conv_nhwc
@@ -360,7 +435,6 @@ func.func @conv_nhwc() attributes {hal.executable.target = #executable_target_ro
 //          CHECK:     scf.yield
 // CHECK-COUNT-16:   amdgpu.mfma
 //  CHECK-COUNT-8:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf32>, memref<2x256x512x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @conv_nhwc workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
@@ -376,35 +450,46 @@ func.func @conv_nhwc() attributes {hal.executable.target = #executable_target_ro
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
-func.func @generic_2x1024x20x64x1280_f16() attributes {hal.executable.target = #executable_target_rocm_hsaco_fb, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-  %2 = arith.index_castui %0 : i32 to index
-  %3 = arith.index_castui %1 : i32 to index
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%2) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1024x1280xf16>>
-  %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x64x1280xf16>>
-  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%3) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1024x20x64xf32>>
-  %7 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0], sizes = [2, 1024, 1280], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1024x1280xf16>> -> tensor<2x1024x1280xf16>
-  %8 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0, 0], sizes = [20, 64, 1280], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x64x1280xf16>> -> tensor<20x64x1280xf16>
-  %9 = tensor.empty() : tensor<2x1024x20x64xf32>
-  %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<2x1024x20x64xf32>) -> tensor<2x1024x20x64xf32>
-  %11 = linalg.generic {
-    indexing_maps = [#map, #map1, #map2],
-    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
-    lowering_config = #config
-  } ins(%7, %8 : tensor<2x1024x1280xf16>, tensor<20x64x1280xf16>)
-    outs(%10 : tensor<2x1024x20x64xf32>) {
-  ^bb0(%in: f16, %in_0: f16, %out: f32):
-    %12 = arith.mulf %in, %in_0 : f16
-    %13 = arith.extf %12 : f16 to f32
-    %14 = arith.addf %out, %13 : f32
-    linalg.yield %14 : f32
-  } -> tensor<2x1024x20x64xf32>
-  iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0, 0, 0], sizes = [2, 1024, 20, 64], strides = [1, 1, 1, 1] : tensor<2x1024x20x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1024x20x64xf32>>
-  return
+hal.executable public @main_dispatch_expanded_matmul {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @generic_2x1024x20x64x1280_f16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @generic_2x1024x20x64x1280_f16() attributes {translation_info = #translation} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+        %2 = arith.index_castui %0 : i32 to index
+        %3 = arith.index_castui %1 : i32 to index
+        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%2) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1024x1280xf16>>
+        %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x64x1280xf16>>
+        %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%3) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1024x20x64xf32>>
+        %7 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0], sizes = [2, 1024, 1280], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1024x1280xf16>> -> tensor<2x1024x1280xf16>
+        %8 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0, 0], sizes = [20, 64, 1280], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x64x1280xf16>> -> tensor<20x64x1280xf16>
+        %9 = tensor.empty() : tensor<2x1024x20x64xf32>
+        %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<2x1024x20x64xf32>) -> tensor<2x1024x20x64xf32>
+        %11 = linalg.generic {
+          indexing_maps = [#map, #map1, #map2],
+          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
+          lowering_config = #config
+        } ins(%7, %8 : tensor<2x1024x1280xf16>, tensor<20x64x1280xf16>)
+          outs(%10 : tensor<2x1024x20x64xf32>) {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %12 = arith.mulf %in, %in_0 : f16
+          %13 = arith.extf %12 : f16 to f32
+          %14 = arith.addf %out, %13 : f32
+          linalg.yield %14 : f32
+        } -> tensor<2x1024x20x64xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0, 0, 0], sizes = [2, 1024, 20, 64], strides = [1, 1, 1, 1] : tensor<2x1024x20x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1024x20x64xf32>>
+        return
+      }
+    }
+  }
 }
+
 
 //    CHECK-LABEL: func.func @generic_2x1024x20x64x1280_f16
 // This has more than 2 iterations. So we have prefetching enabled for this case. Due to
@@ -416,11 +501,9 @@ func.func @generic_2x1024x20x64x1280_f16() attributes {hal.executable.target = #
 //          CHECK:     scf.yield
 // CHECK-COUNT-32:   amdgpu.mfma
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x4x1x1xf32>, memref<2x1024x20x64xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @generic_2x1024x20x64x1280_f16 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // This test ensures that we are generating contraction schedules does not only work on contraction,
 // but also will be compatible with transfer_read layouts anchors.
 // Currently the transfer_read layout anchors expects WorkgroupSize % (WgTileSize / numelPerThread) == 0.
@@ -436,24 +519,34 @@ func.func @generic_2x1024x20x64x1280_f16() attributes {hal.executable.target = #
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @contract_schedule_considering_read_layout() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
-  %3 = arith.index_castui %0 : i32 to index
-  %4 = arith.index_castui %1 : i32 to index
-  %5 = arith.index_castui %2 : i32 to index
-  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%3) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x160x1536xf16>>
-  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%4) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1536x1536xf16>>
-  %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%5) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x160x1536xf32>>
-  %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0], sizes = [2, 160, 1536], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x160x1536xf16>> -> tensor<2x160x1536xf16>
-  %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0, 0], sizes = [2, 1536, 1536], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1536x1536xf16>> -> tensor<2x1536x1536xf16>
-  %11 = tensor.empty() : tensor<2x160x1536xf32>
-  %12 = linalg.fill ins(%cst : f32) outs(%11 : tensor<2x160x1536xf32>) -> tensor<2x160x1536xf32>
-  %13 = linalg.batch_matmul {lowering_config = #config} ins(%9, %10 : tensor<2x160x1536xf16>, tensor<2x1536x1536xf16>) outs(%12 : tensor<2x160x1536xf32>) -> tensor<2x160x1536xf32>
-  iree_tensor_ext.dispatch.tensor.store %13, %8, offsets = [0, 0, 0], sizes = [2, 160, 1536], strides = [1, 1, 1] : tensor<2x160x1536xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x160x1536xf32>>
-  return
+hal.executable public @contract_schedule_considering_read_layout {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @contract_schedule_considering_read_layout ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @contract_schedule_considering_read_layout() attributes {translation_info = #translation} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+        %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
+        %3 = arith.index_castui %0 : i32 to index
+        %4 = arith.index_castui %1 : i32 to index
+        %5 = arith.index_castui %2 : i32 to index
+        %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%3) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x160x1536xf16>>
+        %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%4) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1536x1536xf16>>
+        %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%5) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x160x1536xf32>>
+        %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0], sizes = [2, 160, 1536], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x160x1536xf16>> -> tensor<2x160x1536xf16>
+        %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0, 0], sizes = [2, 1536, 1536], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1536x1536xf16>> -> tensor<2x1536x1536xf16>
+        %11 = tensor.empty() : tensor<2x160x1536xf32>
+        %12 = linalg.fill ins(%cst : f32) outs(%11 : tensor<2x160x1536xf32>) -> tensor<2x160x1536xf32>
+        %13 = linalg.batch_matmul {lowering_config = #config} ins(%9, %10 : tensor<2x160x1536xf16>, tensor<2x1536x1536xf16>) outs(%12 : tensor<2x160x1536xf32>) -> tensor<2x160x1536xf32>
+        iree_tensor_ext.dispatch.tensor.store %13, %8, offsets = [0, 0, 0], sizes = [2, 160, 1536], strides = [1, 1, 1] : tensor<2x160x1536xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x160x1536xf32>>
+        return
+      }
+    }
+  }
 }
 // Basic pipeline test to make sure it generates the instructions we expect.
 
@@ -466,11 +559,9 @@ func.func @contract_schedule_considering_read_layout() attributes {hal.executabl
 // CHECK-COUNT-16:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK:     scf.yield
 // CHECK-COUNT-16:   amdgpu.mfma
-// CHECK:   iree_codegen.dispatch_config @contract_schedule_considering_read_layout workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // This test ensures that we can generate and decompose the right instructions from V(Virtual) MFMAs.
 // (intrinsic with shape, m = 32, n = 32, k = 16)
 
@@ -482,19 +573,29 @@ func.func @contract_schedule_considering_read_layout() attributes {hal.executabl
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf16>> -> tensor<256x256xf16>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // CHECK-LABEL: func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32
@@ -518,11 +619,9 @@ func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {h
 // CHECK-COUNT-14: vector.extract_strided_slice
 // CHECK-NEXT: amdgpu.mfma
 // CHECK:     scf.yield
-// CHECK:   iree_codegen.dispatch_config @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // This test ensures we can generate correct instructions from V(Virtual) MFMAs that has only different read layouts.
 // (intrinsic with shape m = 16, n = 16, k = 32)
 
@@ -534,19 +633,29 @@ func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {h
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Basic pipeline test to make sure it generates the instructions we expect.
@@ -558,11 +667,9 @@ func.func @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32() attributes {h
 // CHECK-COUNT-8:     amdgpu.mfma 32x32x16 {{.*}} blgp =  none : vector<8xf8E4M3FNUZ>, vector<8xf8E4M3FNUZ>, vector<16xf32>
 //          CHECK:     scf.yield
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // This test ensures we can generate correct instructions from V(Virtual) MFMAs that has only different read layouts.
 
 #config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -573,19 +680,29 @@ func.func @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32() attributes {h
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FNUZ>> -> tensor<256x256xf8E4M3FNUZ>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FNUZ>, tensor<256x256xf8E4M3FNUZ>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // CHECK-LABEL: func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32
@@ -621,73 +738,79 @@ func.func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32() attributes {h
 // CHECK-COUNT-3: amdgpu.mfma
 
 // CHECK:     scf.yield
-// CHECK:   iree_codegen.dispatch_config @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>,
-                                              #hal.pipeline.binding<storage_buffer>,
-                                              #hal.pipeline.binding<storage_buffer>,
-                                              #hal.pipeline.binding<storage_buffer>,
-                                              #hal.pipeline.binding<storage_buffer>]>
+                                                    #hal.pipeline.binding<storage_buffer>,
+                                                    #hal.pipeline.binding<storage_buffer>,
+                                                    #hal.pipeline.binding<storage_buffer>,
+                                                    #hal.pipeline.binding<storage_buffer>]>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
 #config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 64], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 128, 0]}>
 
-func.func @matmul_gather_rhs() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xi64>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4096, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>> -> tensor<4096x64xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xi64>> -> tensor<4096x64xi64>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4096, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>> -> tensor<4096x64xf16>
-  %7 = tensor.empty() : tensor<4096x4096xf16>
-  %8 = tensor.empty() : tensor<4096x4096xf32>
-  %9 = tensor.empty() : tensor<4096x64xf16>
-  %10 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<4096x64xi64>) outs(%9 : tensor<4096x64xf16>) {
-  ^bb0(%in: i64, %out: f16):
-    %14 = linalg.index 0 : index
-    %15 = arith.index_cast %in : i64 to index
-    %extracted = tensor.extract %4[%14, %15] : tensor<4096x64xf16>
-    linalg.yield %extracted : f16
-  } -> tensor<4096x64xf16>
-  %11 = linalg.fill ins(%cst : f32) outs(%8 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
-  %12 = linalg.generic {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"]}
-        ins(%6, %10 : tensor<4096x64xf16>, tensor<4096x64xf16>)
-        outs(%11 : tensor<4096x4096xf32>)
-        attrs = {lowering_config = #config} {
-  ^bb0(%in: f16, %in_0: f16, %out: f32):
-    %14 = arith.extf %in : f16 to f32
-    %15 = arith.extf %in_0 : f16 to f32
-    %16 = arith.mulf %14, %15 : f32
-    %17 = arith.addf %out, %16 : f32
-    linalg.yield %17 : f32
-  } -> tensor<4096x4096xf32>
-  %13 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%12 : tensor<4096x4096xf32>) outs(%7 : tensor<4096x4096xf16>) {
-  ^bb0(%in: f32, %out: f16):
-    %14 = arith.truncf %in : f32 to f16
-    linalg.yield %14 : f16
-  } -> tensor<4096x4096xf16>
-  iree_tensor_ext.dispatch.tensor.store %13, %3, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : tensor<4096x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf16>>
-  return
+hal.executable public @matmul_gather_rhs {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_gather_rhs ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_gather_rhs() attributes {translation_info = #translation} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xi64>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf16>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4096, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>> -> tensor<4096x64xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xi64>> -> tensor<4096x64xi64>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4096, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x64xf16>> -> tensor<4096x64xf16>
+        %7 = tensor.empty() : tensor<4096x4096xf16>
+        %8 = tensor.empty() : tensor<4096x4096xf32>
+        %9 = tensor.empty() : tensor<4096x64xf16>
+        %10 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<4096x64xi64>) outs(%9 : tensor<4096x64xf16>) {
+        ^bb0(%in: i64, %out: f16):
+          %14 = linalg.index 0 : index
+          %15 = arith.index_cast %in : i64 to index
+          %extracted = tensor.extract %4[%14, %15] : tensor<4096x64xf16>
+          linalg.yield %extracted : f16
+        } -> tensor<4096x64xf16>
+        %11 = linalg.fill ins(%cst : f32) outs(%8 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+        %12 = linalg.generic {indexing_maps = [#map1, #map2, #map3],
+                              iterator_types = ["parallel", "parallel", "reduction"]}
+              ins(%6, %10 : tensor<4096x64xf16>, tensor<4096x64xf16>)
+              outs(%11 : tensor<4096x4096xf32>)
+              attrs = {lowering_config = #config} {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %14 = arith.extf %in : f16 to f32
+          %15 = arith.extf %in_0 : f16 to f32
+          %16 = arith.mulf %14, %15 : f32
+          %17 = arith.addf %out, %16 : f32
+          linalg.yield %17 : f32
+        } -> tensor<4096x4096xf32>
+        %13 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%12 : tensor<4096x4096xf32>) outs(%7 : tensor<4096x4096xf16>) {
+        ^bb0(%in: f32, %out: f16):
+          %14 = arith.truncf %in : f32 to f16
+          linalg.yield %14 : f16
+        } -> tensor<4096x4096xf16>
+        iree_tensor_ext.dispatch.tensor.store %13, %3, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : tensor<4096x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x4096xf16>>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @matmul_gather_rhs
 // CHECK: vector.gather
 // CHECK-COUNT-32: amdgpu.mfma
-// CHECK: iree_codegen.dispatch_config @matmul_gather_rhs workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [1, 64, 0, 0, 64], reduction = [0, 0, 0, 64, 0], promote_operands = [0, 1, 2]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64>
 
@@ -697,33 +820,46 @@ func.func @matmul_gather_rhs() attributes {hal.executable.target = #executable_t
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_20x4096x64x4096x64() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.250000e-01 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x4096x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-               affine_map<(d0, d1, d2, d3, d4) -> ()>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
-               lowering_config = #config,
-               decomposition_config = {
-                qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
-                pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
-               }}
-               ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
-                ^bb0(%score: f32):
-                  iree_linalg_ext.yield %score : f32
-               } -> tensor<20x4096x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
-  return
+hal.executable private @attention_20x4096x64x4096x64 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_20x4096x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_20x4096x64x4096x64() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.250000e-01 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %7 = tensor.empty() : tensor<20x4096x64xf32>
+        %8 = tensor.empty() : tensor<20x4096xf32>
+        %9:3 = iree_linalg_ext.online_attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>],
+                     lowering_config = #config,
+                     decomposition_config = {
+                      qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
+                      pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
+                     }}
+                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7, %8, %8 : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
+                      ^bb0(%score: f32):
+                        iree_linalg_ext.yield %score : f32
+                     } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 // Basic test to make sure we can handle attention
@@ -734,24 +870,20 @@ func.func @attention_20x4096x64x4096x64() attributes {hal.executable.target = #e
 // read is hoisted out.
 // CHECK: transfer_read
 // CHECK: transfer_write
-// CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
-// CHECK-SAME: -> (vector<1x2x4x1x1x1x1x1x4xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>)
 // CHECK-COUNT-48:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @attention_20x4096x64x4096x64 workgroup_size = [128, 1, 1] subgroup_size = 64
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout matches.
 // MEMORY-LABEL: func.func @attention_20x4096x64x4096x64()
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-NOT: memref.alloc()
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 0, 0, 64], reduction = [0, 0, 0, 0, 64, 0], promote_operands = [0, 1, 2]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64>
 
@@ -761,56 +893,66 @@ func.func @attention_20x4096x64x4096x64() attributes {hal.executable.target = #e
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_multiple_m_transpose() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.0 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
-  %7 = tensor.empty() : tensor<64x4608x24x128xf16>
-  %8 = tensor.empty() : tensor<24x64x4608x128xf16>
-  %9 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
-                                                   lowering_config = #config,
-                                                   decomposition_config = {
-                                                    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
-                                                    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
-                                                   }}
-  ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
-        ^bb0(%score: f32):
-          iree_linalg_ext.yield %score : f32
-       } -> tensor<24x64x4608x128xf16>
-  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%9 : tensor<24x64x4608x128xf16>) outs(%7 : tensor<64x4608x24x128xf16>) {
-  ^bb0(%in: f16, %out: f16):
-    linalg.yield %in : f16
-  } -> tensor<64x4608x24x128xf16>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
-  return
+hal.executable private @attention_multiple_m_transpose {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_multiple_m_transpose ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_multiple_m_transpose() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.0 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %7 = tensor.empty() : tensor<64x4608x24x128xf32>
+        %8 = tensor.empty() : tensor<24x64x4608x128xf32>
+        %9 = tensor.empty() : tensor<24x64x4608xf32>
+        %10:3 = iree_linalg_ext.online_attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>],
+                                                         lowering_config = #config,
+                                                         decomposition_config = {
+                                                          qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
+                                                         }}
+        ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8, %9, %9 : tensor<24x64x4608x128xf32>, tensor<24x64x4608xf32>, tensor<24x64x4608xf32>) {
+              ^bb0(%score: f32):
+                iree_linalg_ext.yield %score : f32
+             } -> tensor<24x64x4608x128xf32>, tensor<24x64x4608xf32>, tensor<24x64x4608xf32>
+        %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10#0 : tensor<24x64x4608x128xf32>) outs(%7 : tensor<64x4608x24x128xf32>) {
+        ^bb0(%in: f32, %out: f32):
+          linalg.yield %in : f32
+        } -> tensor<64x4608x24x128xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf32>>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @attention_multiple_m_transpose()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c64
-// CHECK-SAME: -> (vector<1x1x2x4x1x1x1x1x1x1x1x4xf32>, vector<1x1x2x1x1x1x1x1x1xf32>, vector<1x1x2x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-96:  amdgpu.mfma 16x16x16 {{.*}}blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @attention_multiple_m_transpose workgroup_size = [128, 1, 1] subgroup_size = 64
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout matches.
 // MEMORY-LABEL: func.func @attention_multiple_m_transpose()
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-NOT: memref.alloc()
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 64], reduction = [0, 0, 0, 0, 32, 0], promote_operands = [0, 1, 2]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
@@ -820,56 +962,66 @@ func.func @attention_multiple_m_transpose() attributes {hal.executable.target = 
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_mfma_32x32x8() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.0 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
-  %7 = tensor.empty() : tensor<64x4608x24x128xf16>
-  %8 = tensor.empty() : tensor<24x64x4608x128xf16>
-  %9 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
-                                                   lowering_config = #config,
-                                                   decomposition_config = {
-                                                    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
-                                                    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
-                                                   }}
-  ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
-        ^bb0(%score: f32):
-          iree_linalg_ext.yield %score : f32
-       } -> tensor<24x64x4608x128xf16>
-  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%9 : tensor<24x64x4608x128xf16>) outs(%7 : tensor<64x4608x24x128xf16>) {
-  ^bb0(%in: f16, %out: f16):
-    linalg.yield %in : f16
-  } -> tensor<64x4608x24x128xf16>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
-  return
+hal.executable private @attention_mfma_32x32x8 {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_mfma_32x32x8 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_mfma_32x32x8() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.0 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %7 = tensor.empty() : tensor<64x4608x24x128xf32>
+        %8 = tensor.empty() : tensor<24x64x4608x128xf32>
+        %9 = tensor.empty() : tensor<24x64x4608xf32>
+        %10:3 = iree_linalg_ext.online_attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>],
+                                                         lowering_config = #config,
+                                                         decomposition_config = {
+                                                          qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
+                                                         }}
+        ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8, %9, %9 : tensor<24x64x4608x128xf32>, tensor<24x64x4608xf32>, tensor<24x64x4608xf32>) {
+              ^bb0(%score: f32):
+                iree_linalg_ext.yield %score : f32
+             } -> tensor<24x64x4608x128xf32>, tensor<24x64x4608xf32>, tensor<24x64x4608xf32>
+        %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10#0 : tensor<24x64x4608x128xf32>) outs(%7 : tensor<64x4608x24x128xf32>) {
+        ^bb0(%in: f32, %out: f32):
+          linalg.yield %in : f32
+        } -> tensor<64x4608x24x128xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf32>>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @attention_mfma_32x32x8()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c32
-// CHECK-SAME: -> (vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-24:  amdgpu.mfma 32x32x8 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
 // CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @attention_mfma_32x32x8 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout matches.
 // MEMORY-LABEL: func.func @attention_mfma_32x32x8()
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-NOT: memref.alloc()
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 !Q = tensor<1x16x64xf16>
 !K_SK     = tensor<1x4x256x64xf16>
 !V_SK     = tensor<1x4x256x64xf16>
@@ -887,41 +1039,51 @@ func.func @attention_mfma_32x32x8() attributes {hal.executable.target = #executa
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @online_attention_split_k2() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.0 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:!Q>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:!K_SK>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:!V_SK>
-  %out_arg = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:!O_SK>
-  %max_arg = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
-  %sum_arg = hal.interface.binding.subspan layout(#pipeline_layout) binding(5) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [1, 16, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:!Q> -> !Q
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [1, 4, 256, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:!K_SK> -> !K_SK
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [1, 4, 256, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:!V_SK> -> !V_SK
-  %empty_o = tensor.empty() : !O_SK
-  %empty_rowmax = tensor.empty() : !ROWRED_SK
-  %empty_rowsum = tensor.empty() : !ROWRED_SK
-  %out:3 = iree_linalg_ext.online_attention {indexing_maps = [affine_map<(b1, b2, m, n, k1, k2) -> (b1, m, k1)>,
-                                                              affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, k2, k1)>,
-                                                              affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, k2, n)>,
-                                                              affine_map<(b1, b2, m, n, k1, k2) -> ()>,
-                                                              affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m, n)>,
-                                                              affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m)>,
-                                                              affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m)>],
-                                                            lowering_config = #config,
-                                                            decomposition_config = {
-                                                              qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [0, 1]}>},
-                                                              pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1]}>}
-                                                            }}
-  ins(%4, %5, %6, %cst : !Q, !K_SK, !V_SK, f16) outs(%empty_o, %empty_rowmax, %empty_rowsum: !O_SK, !ROWRED_SK, !ROWRED_SK) {
-        ^bb0(%score: f32):
-          iree_linalg_ext.yield %score : f32
-       } -> !O_SK, !ROWRED_SK, !ROWRED_SK
-  iree_tensor_ext.dispatch.tensor.store %out#0, %out_arg, offsets = [0, 0, 0, 0], sizes = [1, 4, 16, 64], strides = [1, 1, 1, 1] : !O_SK -> !iree_tensor_ext.dispatch.tensor<writeonly:!O_SK>
-  iree_tensor_ext.dispatch.tensor.store %out#1, %max_arg, offsets = [0, 0, 0], sizes = [1, 4, 16], strides = [1, 1, 1] : !ROWRED_SK -> !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
-  iree_tensor_ext.dispatch.tensor.store %out#2, %sum_arg, offsets = [0, 0, 0], sizes = [1, 4, 16], strides = [1, 1, 1] : !ROWRED_SK -> !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
-  return
+hal.executable private @online_attention_split_k2 {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @online_attention_split_k2 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @online_attention_split_k2() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.0 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:!Q>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:!K_SK>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:!V_SK>
+        %out_arg = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:!O_SK>
+        %max_arg = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
+        %sum_arg = hal.interface.binding.subspan layout(#pipeline_layout) binding(5) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [1, 16, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:!Q> -> !Q
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [1, 4, 256, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:!K_SK> -> !K_SK
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [1, 4, 256, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:!V_SK> -> !V_SK
+        %empty_o = tensor.empty() : !O_SK
+        %empty_rowmax = tensor.empty() : !ROWRED_SK
+        %empty_rowsum = tensor.empty() : !ROWRED_SK
+        %out:3 = iree_linalg_ext.online_attention {indexing_maps = [affine_map<(b1, b2, m, n, k1, k2) -> (b1, m, k1)>,
+                                                                    affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, k2, k1)>,
+                                                                    affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, k2, n)>,
+                                                                    affine_map<(b1, b2, m, n, k1, k2) -> ()>,
+                                                                    affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m, n)>,
+                                                                    affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m)>,
+                                                                    affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m)>],
+                                                                  lowering_config = #config,
+                                                                  decomposition_config = {
+                                                                    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [0, 1]}>},
+                                                                    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1]}>}
+                                                                  }}
+        ins(%4, %5, %6, %cst : !Q, !K_SK, !V_SK, f16) outs(%empty_o, %empty_rowmax, %empty_rowsum: !O_SK, !ROWRED_SK, !ROWRED_SK) {
+              ^bb0(%score: f32):
+                iree_linalg_ext.yield %score : f32
+             } -> !O_SK, !ROWRED_SK, !ROWRED_SK
+        iree_tensor_ext.dispatch.tensor.store %out#0, %out_arg, offsets = [0, 0, 0, 0], sizes = [1, 4, 16, 64], strides = [1, 1, 1, 1] : !O_SK -> !iree_tensor_ext.dispatch.tensor<writeonly:!O_SK>
+        iree_tensor_ext.dispatch.tensor.store %out#1, %max_arg, offsets = [0, 0, 0], sizes = [1, 4, 16], strides = [1, 1, 1] : !ROWRED_SK -> !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
+        iree_tensor_ext.dispatch.tensor.store %out#2, %sum_arg, offsets = [0, 0, 0], sizes = [1, 4, 16], strides = [1, 1, 1] : !ROWRED_SK -> !iree_tensor_ext.dispatch.tensor<writeonly:!ROWRED_SK>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @online_attention_split_k2()
@@ -929,13 +1091,12 @@ func.func @online_attention_split_k2() attributes {hal.executable.target = #exec
 // CHECK-SAME: -> (vector<1x1x1x4x1x1x1x1x1x1x1x4xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-16:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @online_attention_split_k2 workgroup_size = [64, 1, 1] subgroup_size = 64
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout matches.
 // MEMORY-LABEL: func.func @online_attention_split_k2()
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-NOT: memref.alloc()
 
 // -----
 
@@ -953,83 +1114,106 @@ func.func @online_attention_split_k2() attributes {hal.executable.target = #exec
 #pv_config = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, promote_operands = [1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 5]]}>}
 #config = #iree_gpu.lowering_config<{promote_operands = [0, 1, 2], reduction = [0, 0, 0, 0, 0, 64], workgroup = [1, 1, 64, 64, 0, 0]}>
 
-func.func @attention_gather_k() attributes {hal.executable.target = #executable_target_rocm_hsaco_fb, translation_info = #translation} {
-  %cst = arith.constant 1.250000e-01 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xi64>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x4096x64xf16>>
-  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>> -> tensor<2x10x4096x64xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xi64>> -> tensor<2x10x4096x64xi64>
-  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>> -> tensor<2x10x4096x64xf16>
-  %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>> -> tensor<2x10x4096x64xf16>
-  %9 = tensor.empty() : tensor<2x10x4096x64xf16>
-  %10 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%6 : tensor<2x10x4096x64xi64>) outs(%9 : tensor<2x10x4096x64xf16>) {
-  ^bb0(%in: i64, %out: f16):
-    %12 = linalg.index 0 : index
-    %13 = linalg.index 1 : index
-    %14 = arith.index_cast %in : i64 to index
-    %15 = linalg.index 3 : index
-    %extracted = tensor.extract %5[%12, %13, %14, %15] : tensor<2x10x4096x64xf16>
-    linalg.yield %extracted : f16
-  } -> tensor<2x10x4096x64xf16>
-  %11 = iree_linalg_ext.attention {
-      indexing_maps = [#map1, #map2, #map3, #map4, #map5],
-      decomposition_config = { qk_attrs = #qk_config, pv_attrs = #pv_config },
-      lowering_config = #config} ins(%7, %10, %8, %cst : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, f16) outs(%9 : tensor<2x10x4096x64xf16>) {
-  ^bb0(%arg0: f32):
-    iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<2x10x4096x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %11, %4, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : tensor<2x10x4096x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x4096x64xf16>>
-  return
+module {
+  hal.executable public @attention_gather_k {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @attention_gather_k ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @attention_gather_k() attributes {translation_info = #translation} {
+          %cst = arith.constant 1.250000e-01 : f16
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>>
+          %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xi64>>
+          %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>>
+          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>>
+          %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x4096x64xf32>>
+          %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>> -> tensor<2x10x4096x64xf16>
+          %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xi64>> -> tensor<2x10x4096x64xi64>
+          %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>> -> tensor<2x10x4096x64xf16>
+          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x10x4096x64xf16>> -> tensor<2x10x4096x64xf16>
+          %9 = tensor.empty() : tensor<2x10x4096x64xf16>
+          %10 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%6 : tensor<2x10x4096x64xi64>) outs(%9 : tensor<2x10x4096x64xf16>) {
+          ^bb0(%in: i64, %out: f16):
+            %12 = linalg.index 0 : index
+            %13 = linalg.index 1 : index
+            %14 = arith.index_cast %in : i64 to index
+            %15 = linalg.index 3 : index
+            %extracted = tensor.extract %5[%12, %13, %14, %15] : tensor<2x10x4096x64xf16>
+            linalg.yield %extracted : f16
+          } -> tensor<2x10x4096x64xf16>
+          %11 = tensor.empty() : tensor<2x10x4096x64xf32>
+          %12 = tensor.empty() : tensor<2x10x4096xf32>
+          %13:3 = iree_linalg_ext.online_attention {
+              indexing_maps = [#map1, #map2, #map3, #map4, #map5,
+                               affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+                               affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>],
+              decomposition_config = { qk_attrs = #qk_config, pv_attrs = #pv_config },
+              lowering_config = #config} ins(%7, %10, %8, %cst : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, f16) outs(%11, %12, %12 : tensor<2x10x4096x64xf32>, tensor<2x10x4096xf32>, tensor<2x10x4096xf32>) {
+          ^bb0(%arg0: f32):
+            iree_linalg_ext.yield %arg0 : f32
+          } -> tensor<2x10x4096x64xf32>, tensor<2x10x4096xf32>, tensor<2x10x4096xf32>
+          iree_tensor_ext.dispatch.tensor.store %13#0, %4, offsets = [0, 0, 0, 0], sizes = [2, 10, 4096, 64], strides = [1, 1, 1, 1] : tensor<2x10x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x4096x64xf32>>
+          return
+        }
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @attention_gather_k
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
 // CHECK:      vector.gather
 // CHECK-SAME: into vector<1x1x4x1x1x1x1x1x1x1x1x8xf16>
-// CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @attention_gather_k workgroup_size = [128, 1, 1] subgroup_size = 64
+// CHECK: scf.if
 
 // MEMORY-LABEL: func.func @attention_gather_k
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT:     memref.alloc
+// MEMORY-NOT:     memref.alloc()
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
-func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
-  %5 = tensor.empty() : tensor<32000x2xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
-  ^bb0(%in: f16, %in_0: f16, %out: f32):
-    %8 = arith.extf %in : f16 to f32
-    %9 = arith.extf %in_0 : f16 to f32
-    %10 = arith.mulf %8, %9 : f32
-    %11 = arith.addf %out, %10 : f32
-    linalg.yield %11 : f32
-  } -> tensor<32000x2xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [32000, 2], strides = [1, 1] : tensor<32000x2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
-  return
+hal.executable private @matvec_dispatch_0 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
+        %5 = tensor.empty() : tensor<32000x2xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %8 = arith.extf %in : f16 to f32
+          %9 = arith.extf %in_0 : f16 to f32
+          %10 = arith.mulf %8, %9 : f32
+          %11 = arith.addf %out, %10 : f32
+          linalg.yield %11 : f32
+        } -> tensor<32000x2xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [32000, 2], strides = [1, 1] : tensor<32000x2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
+        return
+      }
+    }
+  }
 }
 //   MEMORY-LABEL: func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32
 //    CHECK-LABEL: func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32
+//          CHECK:   scf.forall ({{.*}}) = (0, 0) to (32000, 2) step (16, 1)
 // CHECK-COUNT-16:     gpu.subgroup_reduce add {{.*}} cluster(size = 64) : (f32) -> f32
 // CHECK-COUNT-16:     gpu.subgroup_reduce add {{.*}} cluster(size = 2) : (f32) -> f32
-//          CHECK:     iree_codegen.dispatch_config @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32 workgroup_size = [128, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -1038,32 +1222,42 @@ func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attri
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_map_store() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %true = arith.constant true
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
-  %1 = amdgpu.fat_raw_buffer_cast %0 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
-  %3 = amdgpu.fat_raw_buffer_cast %2 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>>
-  %5 = amdgpu.fat_raw_buffer_cast %4 resetOffset : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>> to memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
-  %6 = iree_codegen.load_from_buffer %1 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
-  %7 = iree_codegen.load_from_buffer %3 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
-  %8 = tensor.empty() : tensor<256x256xf32>
-  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %10 = linalg.matmul {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 128], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 64, 0]}>} ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %11 = tensor.empty() : tensor<2x16x8x4x4x4x4xf32>
-  %12 = iree_linalg_ext.map_store %10 into %11 {
-  ^bb0(%arg0: index, %arg1: index):
-    %13:2 = affine.delinearize_index %arg0 into (2, 128) : index, index
-    %14:2 = affine.delinearize_index %arg1 into (16, 16) : index, index
-    %15:3 = affine.delinearize_index %13#1 into (4, 8, 4) : index, index, index
-    %16:2 = affine.delinearize_index %14#1 into (4, 4) : index, index
-    iree_linalg_ext.yield %13#0, %14#0, %15#1, %16#1, %15#0, %15#2, %16#0, %true : index, index, index, index, index, index, index, i1
-  } : tensor<256x256xf32> into tensor<2x16x8x4x4x4x4xf32> -> tensor<2x16x8x4x4x4x4xf32>
-  iree_codegen.store_to_buffer %12, %5 : tensor<2x16x8x4x4x4x4xf32> into memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
-  return
+hal.executable public @matmul_map_store {
+hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export public @matmul_map_store layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @matmul_map_store() attributes {translation_info = #translation} {
+      %true = arith.constant true
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
+      %1 = amdgpu.fat_raw_buffer_cast %0 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
+      %3 = amdgpu.fat_raw_buffer_cast %2 resetOffset : memref<256x256xf16, #hal.descriptor_type<storage_buffer>> to memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>>
+      %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>>
+      %5 = amdgpu.fat_raw_buffer_cast %4 resetOffset : memref<2x16x8x4x4x4x4xf32, #hal.descriptor_type<storage_buffer>> to memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
+      %6 = iree_codegen.load_from_buffer %1 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
+      %7 = iree_codegen.load_from_buffer %3 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
+      %8 = tensor.empty() : tensor<256x256xf32>
+      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %10 = linalg.matmul {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 128], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 64, 0]}>} ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %11 = tensor.empty() : tensor<2x16x8x4x4x4x4xf32>
+      %12 = iree_linalg_ext.map_store %10 into %11 {
+      ^bb0(%arg0: index, %arg1: index):
+        %13:2 = affine.delinearize_index %arg0 into (2, 128) : index, index
+        %14:2 = affine.delinearize_index %arg1 into (16, 16) : index, index
+        %15:3 = affine.delinearize_index %13#1 into (4, 8, 4) : index, index, index
+        %16:2 = affine.delinearize_index %14#1 into (4, 4) : index, index
+        iree_linalg_ext.yield %13#0, %14#0, %15#1, %16#1, %15#0, %15#2, %16#0, %true : index, index, index, index, index, index, index, i1
+      } : tensor<256x256xf32> into tensor<2x16x8x4x4x4x4xf32> -> tensor<2x16x8x4x4x4x4xf32>
+      iree_codegen.store_to_buffer %12, %5 : tensor<2x16x8x4x4x4x4xf32> into memref<2x16x8x4x4x4x4xf32, #amdgpu.address_space<fat_raw_buffer>>
+      return
+    }
+  }
+}
 }
 //    CHECK-LABEL: func.func @matmul_map_store()
 //          CHECK:   %[[OUTPUT_BINDING:.+]] = hal.interface.binding.subspan{{.*}} binding(2)
@@ -1073,4 +1267,3 @@ func.func @matmul_map_store() attributes {hal.executable.target = #executable_ta
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 //          CHECK:   %[[FLAT_OUTPUT_BUFFER:.+]] = memref.collapse_shape %[[OUTPUT_BUFFER]]
 //  CHECK-COUNT-4:   vector.scatter %[[FLAT_OUTPUT_BUFFER]]{{.*}} : memref<65536xf32, #amdgpu.address_space<fat_raw_buffer>>, vector<4xindex>, vector<4xi1>, vector<4xf32>
-//          CHECK:   iree_codegen.dispatch_config @matmul_map_store workgroup_size = [256, 1, 1] subgroup_size = 64

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942_masking.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942_masking.mlir
@@ -32,12 +32,13 @@ hal.executable private @attention_k1_unaligned {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x16x63xf16>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x63xf16>>
         %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf32>>
         %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 16, 63], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x16x63xf16>> -> tensor<20x16x63xf16>
         %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 63], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x63xf16>> -> tensor<20x4096x63xf16>
         %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-        %7 = tensor.empty() : tensor<20x16x64xf16>
-        %8 = iree_linalg_ext.attention {
+        %7 = tensor.empty() : tensor<20x16x64xf32>
+        %8 = tensor.empty() : tensor<20x16xf32>
+        %9:3 = iree_linalg_ext.online_attention {
           decomposition_config = {
             pv_attrs = {
               lowering_config = #iree_gpu.lowering_config<{lane_basis = [[1, 1, 1, 1, 64], [1, 0, 4, 3]], subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 4, 3]], thread = [0, 0, 0, 8]}>
@@ -51,14 +52,16 @@ hal.executable private @attention_k1_unaligned {
             affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
             affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
             affine_map<(d0, d1, d2, d3, d4) -> ()>,
-            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
           ],
           lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 0, 256, 0], workgroup = [1, 1, 0, 0, 16], reduction = [0, 0, 64, 0, 0]}>
-        } ins(%4, %5, %6, %cst : tensor<20x16x63xf16>, tensor<20x4096x63xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x16x64xf16>) {
+        } ins(%4, %5, %6, %cst : tensor<20x16x63xf16>, tensor<20x4096x63xf16>, tensor<20x4096x64xf16>, f16) outs(%7, %8, %8 : tensor<20x16x64xf32>, tensor<20x16xf32>, tensor<20x16xf32>) {
         ^bb0(%arg0: f32):
           iree_linalg_ext.yield %arg0 : f32
-        } -> tensor<20x16x64xf16>
-        iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 16, 64], strides = [1, 1, 1] : tensor<20x16x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf16>>
+        } -> tensor<20x16x64xf32>, tensor<20x16xf32>, tensor<20x16xf32>
+        iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 16, 64], strides = [1, 1, 1] : tensor<20x16x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf32>>
         return
       }
     }
@@ -97,12 +100,13 @@ hal.executable private @attention_k2_unaligned {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x16x64xf16>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4080x64xf16>>
         %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4080x64xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf32>>
         %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 16, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x16x64xf16>> -> tensor<20x16x64xf16>
         %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4080, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4080x64xf16>> -> tensor<20x4080x64xf16>
         %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4080, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4080x64xf16>> -> tensor<20x4080x64xf16>
-        %7 = tensor.empty() : tensor<20x16x64xf16>
-        %8 = iree_linalg_ext.attention {
+        %7 = tensor.empty() : tensor<20x16x64xf32>
+        %8 = tensor.empty() : tensor<20x16xf32>
+        %9:3 = iree_linalg_ext.online_attention {
           decomposition_config = {
             pv_attrs = {
               attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [1], subgroup_basis = [[1, 1, 1, 1, 1], [0, 1, 3, 4]]}>},
@@ -115,14 +119,16 @@ hal.executable private @attention_k2_unaligned {
             affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
             affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
             affine_map<(d0, d1, d2, d3, d4) -> ()>,
-            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
           ],
           lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1, 2], reduction = [0, 0, 0, 64, 0], workgroup = [1, 16, 0, 0, 64]}>
-        } ins(%4, %5, %6, %cst : tensor<20x16x64xf16>, tensor<20x4080x64xf16>, tensor<20x4080x64xf16>, f16) outs(%7 : tensor<20x16x64xf16>) {
+        } ins(%4, %5, %6, %cst : tensor<20x16x64xf16>, tensor<20x4080x64xf16>, tensor<20x4080x64xf16>, f16) outs(%7, %8, %8 : tensor<20x16x64xf32>, tensor<20x16xf32>, tensor<20x16xf32>) {
         ^bb0(%arg0: f32):
           iree_linalg_ext.yield %arg0 : f32
-        } -> tensor<20x16x64xf16>
-        iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 16, 64], strides = [1, 1, 1] : tensor<20x16x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf16>>
+        } -> tensor<20x16x64xf32>, tensor<20x16xf32>, tensor<20x16xf32>
+        iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 16, 64], strides = [1, 1, 1] : tensor<20x16x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x16x64xf32>>
         return
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
@@ -1,11 +1,12 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
-// RUN:   --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" \
 // RUN:   %s | FileCheck %s
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
-// RUN:   --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" \
 // RUN:   %s | FileCheck %s --check-prefix=MEMORY
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -14,19 +15,29 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x512_f16_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>> -> tensor<256x512xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>> -> tensor<512x256xf16>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x512xf16>, tensor<512x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x512_f16_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @matmul_256x256x512_f16_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x512_f16_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>> -> tensor<256x512xf16>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>> -> tensor<512x256xf16>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x512xf16>, tensor<512x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Basic pipeline test to make sure it generates the instructions we expect.
@@ -38,11 +49,14 @@ func.func @matmul_256x256x512_f16_f32() attributes {hal.executable.target = #exe
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<4xf32>
 //          CHECK:     scf.yield
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x512_f16_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -51,19 +65,29 @@ func.func @matmul_256x256x512_f16_f32() attributes {hal.executable.target = #exe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x512_f16_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>> -> tensor<256x512xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>> -> tensor<512x256xf16>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x512xf16>, tensor<512x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x512_f16_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @matmul_256x256x512_f16_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x512_f16_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x512xf16>> -> tensor<256x512xf16>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf16>> -> tensor<512x256xf16>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x512xf16>, tensor<512x256xf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 //    CHECK-LABEL: func.func @matmul_256x256x512_f16_f32()
@@ -71,13 +95,14 @@ func.func @matmul_256x256x512_f16_f32() attributes {hal.executable.target = #exe
 // CHECK-COUNT-32:     amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<4xf32>
 //          CHECK:     scf.yield
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x512_f16_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // MEMORY-LABEL: func.func @matmul_256x256x512_f16_f32()
 
+
+
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 64, 0], reduction = [0, 0, 0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>, subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = false>}>
 
@@ -86,42 +111,52 @@ func.func @matmul_256x256x512_f16_f32() attributes {hal.executable.target = #exe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @expanded_matmul_transpose_b() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 64, 2048], strides = [1, 1, 1]
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>> -> tensor<2x64x2048xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [10, 64, 2048], strides = [1, 1, 1]
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>> -> tensor<10x64x2048xf16>
+hal.executable @expanded_matmul_transpose_b_executable {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @expanded_matmul_transpose_b layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @expanded_matmul_transpose_b() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0)
+          : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 64, 2048], strides = [1, 1, 1]
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x2048xf16>> -> tensor<2x64x2048xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [10, 64, 2048], strides = [1, 1, 1]
+          : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x64x2048xf16>> -> tensor<10x64x2048xf16>
 
-  %5 = tensor.empty() : tensor<2x10x64x64xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
-  %7 = linalg.generic {
-    indexing_maps = [
-      affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
-      affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
-      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
-    ],
-    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
-    lowering_config = #config
-  } ins(%3, %4 : tensor<2x64x2048xf16>, tensor<10x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) {
-  ^bb0(%lhs: f16, %rhs: f16, %out: f32):
-    %ext_lhs = arith.extf %lhs : f16 to f32
-    %ext_rhs = arith.extf %rhs : f16 to f32
-    %mul = arith.mulf %ext_lhs, %ext_rhs : f32
-    %add = arith.addf %mul, %out : f32
-    linalg.yield %add : f32
-  } -> tensor<2x10x64x64xf32>
+        %5 = tensor.empty() : tensor<2x10x64x64xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
+        %7 = linalg.generic {
+          indexing_maps = [
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+          ],
+          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"],
+          lowering_config = #config
+        } ins(%3, %4 : tensor<2x64x2048xf16>, tensor<10x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) {
+        ^bb0(%lhs: f16, %rhs: f16, %out: f32):
+          %ext_lhs = arith.extf %lhs : f16 to f32
+          %ext_rhs = arith.extf %rhs : f16 to f32
+          %mul = arith.mulf %ext_lhs, %ext_rhs : f32
+          %add = arith.addf %mul, %out : f32
+          linalg.yield %add : f32
+        } -> tensor<2x10x64x64xf32>
 
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1]
-    : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  return
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1]
+          : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 //    CHECK-LABEL: func @expanded_matmul_transpose_b
@@ -132,39 +167,48 @@ func.func @expanded_matmul_transpose_b() attributes {hal.executable.target = #ex
 //          CHECK:     scf.yield
 // CHECK-COUNT-32:   amdgpu.mfma
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf32>, memref<2x10x64x64xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @expanded_matmul_transpose_b workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // MEMORY-LABEL: func @expanded_matmul_transpose_b
 
+
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
 
-func.func @matmul_multiple_k() attributes {hal.executable.target = #executable_target_rocm, translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>>
-  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>>
-  %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>> -> tensor<2x128x64x2048xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [10, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>> -> tensor<10x128x64x2048xf16>
-  %5 = tensor.empty() : tensor<2x10x64x64xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<2x128x64x2048xf16>, tensor<10x128x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 0, 1, 128], workgroup = [1, 1, 64, 64, 0, 0], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1, 1], [0, 1, 2, 3, 4, 5]]}>} {
-  ^bb0(%in: f16, %in_0: f16, %out: f32):
-    %ext_in = arith.extf %in : f16 to f32
-    %ext_in_0 = arith.extf %in_0 : f16 to f32
-    %8 = arith.mulf %ext_in, %ext_in_0 : f32
-    %9 = arith.addf %8, %out : f32
-    linalg.yield %9 : f32
-  } -> tensor<2x10x64x64xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1] : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
-  return
+hal.executable @matmul_multiple_k {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_multiple_k layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_multiple_k() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>>
+        %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>>
+        %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64x2048xf16>> -> tensor<2x128x64x2048xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [10, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>> -> tensor<10x128x64x2048xf16>
+        %5 = tensor.empty() : tensor<2x10x64x64xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x10x64x64xf32>) -> tensor<2x10x64x64xf32>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<2x128x64x2048xf16>, tensor<10x128x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 0, 1, 128], workgroup = [1, 1, 64, 64, 0, 0], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1, 1], [0, 1, 2, 3, 4, 5]]}>} {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %ext_in = arith.extf %in : f16 to f32
+          %ext_in_0 = arith.extf %in_0 : f16 to f32
+          %8 = arith.mulf %ext_in, %ext_in_0 : f32
+          %9 = arith.addf %8, %out : f32
+          linalg.yield %9 : f32
+        } -> tensor<2x10x64x64xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 10, 64, 64], strides = [1, 1, 1, 1] : tensor<2x10x64x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x10x64x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 // Check if we can handle multiple reduction dimensions and that they generate
@@ -176,13 +220,14 @@ func.func @matmul_multiple_k() attributes {hal.executable.target = #executable_t
 // CHECK-COUNT-32:   amdgpu.mfma
 // CHECK:            scf.yield
 // CHECK-COUNT-4:  vector.transfer_write {{.+}} {in_bounds = [true, true, true, true]} : vector<1x1x4x1xf32>, memref<2x10x64x64xf32, #amdgpu.address_space<fat_raw_buffer>>
-// CHECK:          iree_codegen.dispatch_config @matmul_multiple_k workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // MEMORY-LABEL: func.func @matmul_multiple_k
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
+
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 16, n = 16, k = 128)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 1024], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x128_F8E4M3FN>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -193,19 +238,29 @@ func.func @matmul_multiple_k() attributes {hal.executable.target = #executable_t
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_16x16x128_f8_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FN>, tensor<256x256xf8E4M3FN>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x256_16x16x128_f8_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @matmul_256x256x256_16x16x32_f8_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_16x16x128_f8_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FN>, tensor<256x256xf8E4M3FN>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for f8 inputs.
@@ -215,11 +270,15 @@ func.func @matmul_256x256x256_16x16x128_f8_f32() attributes {hal.executable.targ
 // along the K dimension. So in total 8 mfma ops.
 // CHECK-COUNT-8:     amdgpu.mfma 16x16x128 {{.*}} blgp =  none : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<4xf32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_16x16x128_f8_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
+
 // Basic i8, i8 -> i32 matmul.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 512], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -230,19 +289,29 @@ func.func @matmul_256x256x256_16x16x128_f8_f32() attributes {hal.executable.targ
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_i8_i32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0 : i32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %5 = tensor.empty() : tensor<256x256xi32>
-  %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  return
+hal.executable @matmul_256x256x256_i8_i32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @matmul_256x256x256_i8_i32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_i8_i32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0 : i32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %5 = tensor.empty() : tensor<256x256xi32>
+      %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for integer inputs.
@@ -252,11 +321,15 @@ func.func @matmul_256x256x256_i8_i32() attributes {hal.executable.target = #exec
 // along the K dimension. So in total 16 mfma ops.
 // CHECK-COUNT-16:     amdgpu.mfma 16x16x64 {{.*}} blgp =  none : vector<16xi8>, vector<16xi8>, vector<4xi32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xi32>, memref<256x256xi32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_i8_i32 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
+
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 32, n = 32, k = 64)
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 1024], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x64_F8E4M3FN>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -267,19 +340,29 @@ func.func @matmul_256x256x256_i8_i32() attributes {hal.executable.target = #exec
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_256x256x256_32x32x64_f8_f32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
-  %5 = tensor.empty() : tensor<256x256xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FN>, tensor<256x256xf8E4M3FN>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
-  return
+hal.executable @matmul_256x256x256_32x32x64_f8_f32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @matmul_256x256x256_32x32x64_f8_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_256x256x256_32x32x64_f8_f32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xf8E4M3FN>> -> tensor<256x256xf8E4M3FN>
+      %5 = tensor.empty() : tensor<256x256xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<256x256xf8E4M3FN>, tensor<256x256xf8E4M3FN>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for f8 inputs.
@@ -289,11 +372,15 @@ func.func @matmul_256x256x256_32x32x64_f8_f32() attributes {hal.executable.targe
 // along the K dimension. So in total 4 mfma ops.
 //  CHECK-COUNT-4:     amdgpu.mfma 32x32x64 {{.*}} blgp =  none : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<16xf32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_256x256x256_32x32x64_f8_f32 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
+
 // Basic i8, i8 -> i32 matmul_transpose_b.
 
 #config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 512], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
@@ -304,25 +391,35 @@ func.func @matmul_256x256x256_32x32x64_f8_f32() attributes {hal.executable.targe
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 0 : i32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %5 = tensor.empty() : tensor<256x256xi32>
-  %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  %7 = linalg.matmul
-    indexing_maps = [
-      affine_map<(d0, d1, d2) -> (d0, d2)>,
-      affine_map<(d0, d1, d2) -> (d1, d2)>,
-      affine_map<(d0, d1, d2) -> (d0, d1)>
-    ]
-    {lowering_config = #config} ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
-  return
+hal.executable @matmul_transpose_b_256x256x256_i8_i32 {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.export @matmul_transpose_b_256x256x256_i8_i32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {translation_info = #translation} {
+      %cst = arith.constant 0 : i32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>>
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+      %5 = tensor.empty() : tensor<256x256xi32>
+      %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      %7 = linalg.matmul
+        indexing_maps = [
+          affine_map<(d0, d1, d2) -> (d0, d2)>,
+          affine_map<(d0, d1, d2) -> (d1, d2)>,
+          affine_map<(d0, d1, d2) -> (d0, d1)>
+        ]
+        {lowering_config = #config} ins(%3, %4 : tensor<256x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<256x256xi32>) -> tensor<256x256xi32>
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xi32>>
+      return
+    }
+  }
+}
 }
 
 // Make sure it generates the mfma instructions we expect for integer inputs.
@@ -332,11 +429,15 @@ func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {hal.executable.ta
 // along the K dimension. So in total 16 mfma ops.
 // CHECK-COUNT-16:     amdgpu.mfma 16x16x64 {{.*}} blgp =  none : vector<16xi8>, vector<16xi8>, vector<4xi32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xi32>, memref<256x256xi32, #amdgpu.address_space<fat_raw_buffer>>
-//          CHECK:   iree_codegen.dispatch_config @matmul_transpose_b_256x256x256_i8_i32 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
+
 #config = #iree_gpu.lowering_config<{workgroup = [1, 64, 0, 0, 64], reduction = [0, 0, 0, 128, 0], promote_operands = [0, 1, 2]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64>
 
@@ -346,33 +447,46 @@ func.func @matmul_transpose_b_256x256x256_i8_i32() attributes {hal.executable.ta
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_20x4096x64x4096x64() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.250000e-01 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x4096x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-               affine_map<(d0, d1, d2, d3, d4) -> ()>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
-               lowering_config = #config,
-               decomposition_config = {
-                qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
-                pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
-               }}
-               ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
-                ^bb0(%score: f32):
-                  iree_linalg_ext.yield %score : f32
-               } -> tensor<20x4096x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
-  return
+hal.executable private @attention_20x4096x64x4096x64 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_20x4096x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index){
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_20x4096x64x4096x64() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.250000e-01 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %7 = tensor.empty() : tensor<20x4096x64xf32>
+        %8 = tensor.empty() : tensor<20x4096xf32>
+        %9:3 = iree_linalg_ext.online_attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>],
+                     lowering_config = #config,
+                     decomposition_config = {
+                      qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
+                      pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16, col_major = true>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
+                     }}
+                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7, %8, %8 : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
+                      ^bb0(%score: f32):
+                        iree_linalg_ext.yield %score : f32
+                     } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 // Basic test to make sure we can handle attention
@@ -383,25 +497,27 @@ func.func @attention_20x4096x64x4096x64() attributes {hal.executable.target = #e
 // read is hoisted out.
 // CHECK: transfer_read
 // CHECK: transfer_write
-// CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c128
-// CHECK-SAME: -> (vector<1x2x4x1x1x1x1x1x4xf32>, vector<1x2x1x1x1x1xf32>, vector<1x2x1x1x1x1xf32>)
 // CHECK-COUNT-32:  amdgpu.mfma 16x16x32 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<4xf32>
 // CHECK-COUNT-16:  amdgpu.mfma 16x16x16 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @attention_20x4096x64x4096x64 workgroup_size = [128, 1, 1] subgroup_size = 64
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout matches.
 // MEMORY-LABEL: func.func @attention_20x4096x64x4096x64()
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-NOT: memref.alloc()
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+
+
+
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 64], reduction = [0, 0, 0, 0, 64, 0], promote_operands = [0, 1, 2]}>
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
@@ -411,80 +527,106 @@ func.func @attention_20x4096x64x4096x64() attributes {hal.executable.target = #e
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_mfma_32x32x16() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.0 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
-  %7 = tensor.empty() : tensor<64x4608x24x128xf16>
-  %8 = tensor.empty() : tensor<24x64x4608x128xf16>
-  %9 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
-                                                   affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
-                                                   lowering_config = #config,
-                                                   decomposition_config = {
-                                                    qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
-                                                    pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
-                                                   }}
-  ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
-        ^bb0(%score: f32):
-          iree_linalg_ext.yield %score : f32
-       } -> tensor<24x64x4608x128xf16>
-  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%9 : tensor<24x64x4608x128xf16>) outs(%7 : tensor<64x4608x24x128xf16>) {
-  ^bb0(%in: f16, %out: f16):
-    linalg.yield %in : f16
-  } -> tensor<64x4608x24x128xf16>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
-  return
+hal.executable private @attention_mfma_32x32x16 {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_mfma_32x32x16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_mfma_32x32x16() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.0 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %7 = tensor.empty() : tensor<64x4608x24x128xf32>
+        %8 = tensor.empty() : tensor<24x64x4608x128xf32>
+        %9 = tensor.empty() : tensor<24x64x4608xf32>
+        %10:3 = iree_linalg_ext.online_attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+                                                         affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>],
+                                                         lowering_config = #config,
+                                                         decomposition_config = {
+                                                          qk_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16, col_major = true>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
+                                                         }}
+        ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8, %9, %9 : tensor<24x64x4608x128xf32>, tensor<24x64x4608xf32>, tensor<24x64x4608xf32>) {
+              ^bb0(%score: f32):
+                iree_linalg_ext.yield %score : f32
+             } -> tensor<24x64x4608x128xf32>, tensor<24x64x4608xf32>, tensor<24x64x4608xf32>
+        %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10#0 : tensor<24x64x4608x128xf32>) outs(%7 : tensor<64x4608x24x128xf32>) {
+        ^bb0(%in: f32, %out: f32):
+          linalg.yield %in : f32
+        } -> tensor<64x4608x24x128xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x4608x24x128xf32>>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @attention_mfma_32x32x16()
 // CHECK: scf.for %{{.*}} = %c0 to %c4608 step %c64
-// CHECK-SAME: -> (vector<1x1x1x2x1x1x1x4x1x1x1x4xf32>, vector<1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1xf32>)
 // CHECK-COUNT-16:  amdgpu.mfma 32x32x16 {{.*}} blgp =  none : vector<8xf16>, vector<8xf16>, vector<16xf32>
 // CHECK-COUNT-8:  amdgpu.mfma 32x32x8 {{.*}} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
 // CHECK: scf.yield
-// CHECK: iree_codegen.dispatch_config @attention_mfma_32x32x16 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout matches.
 // MEMORY-LABEL: func.func @attention_mfma_32x32x16()
 // MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-NOT: memref.alloc()
+
+
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
-func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {hal.executable.target = #executable_target_rocm, translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
-  %5 = tensor.empty() : tensor<32000x2xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
-  ^bb0(%in: f16, %in_0: f16, %out: f32):
-    %8 = arith.extf %in : f16 to f32
-    %9 = arith.extf %in_0 : f16 to f32
-    %10 = arith.mulf %8, %9 : f32
-    %11 = arith.addf %out, %10 : f32
-    linalg.yield %11 : f32
-  } -> tensor<32000x2xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [32000, 2], strides = [1, 1] : tensor<32000x2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
-  return
+
+
+
+hal.executable private @matvec_dispatch_0 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
+        %5 = tensor.empty() : tensor<32000x2xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %8 = arith.extf %in : f16 to f32
+          %9 = arith.extf %in_0 : f16 to f32
+          %10 = arith.mulf %8, %9 : f32
+          %11 = arith.addf %out, %10 : f32
+          linalg.yield %11 : f32
+        } -> tensor<32000x2xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [32000, 2], strides = [1, 1] : tensor<32000x2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32000x2xf32>>
+        return
+      }
+    }
+  }
 }
 //   MEMORY-LABEL: func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32
 //    CHECK-LABEL: func.func @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32
+//          CHECK:   scf.forall ({{.*}}) = (0, 0) to (32000, 2) step (16, 1)
 // CHECK-COUNT-16:     gpu.subgroup_reduce add {{.*}} cluster(size = 64) : (f32) -> f32
 // CHECK-COUNT-16:     gpu.subgroup_reduce add {{.*}} cluster(size = 2) : (f32) -> f32
-//          CHECK:     iree_codegen.dispatch_config @matvec_dispatch_0_matmul_transpose_b_32000x2x4096_f16xf16xf32 workgroup_size = [128, 1, 1] subgroup_size = 64

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -1,41 +1,51 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
-// RUN:   --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
 // RUN:   %s | FileCheck %s
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
-                                reduction = [0, 0, 128],
-                                thread = [0, 0, 8],
-                                subgroup_basis = [[1, 1, 1], [0, 1, 2]],
-                                lane_basis = [[1, 4, 16], [0, 1, 2]]}
+                                      reduction = [0, 0, 128],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 1, 1], [0, 1, 2]],
+                                      lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                         workgroup_size = [64, 1, 1]
-                                         subgroup_size = 64, {}>
+                                               workgroup_size = [64, 1, 1]
+                                               subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matvec_fp16() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-  %5 = tensor.empty() : tensor<1x32000xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
-  ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.addf %out, %8 : f16
-    linalg.yield %9 : f16
-  } -> tensor<1x32000xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  return
+hal.executable private @matvec_fp16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
 }
 
 //     CHECK-LABEL: func.func @matvec_fp16
@@ -47,44 +57,52 @@ func.func @matvec_fp16() attributes {hal.executable.target = #executable_target_
 
 //          CHECK:      scf.yield
 //          CHECK:    vector.transfer_write
-//          CHECK:    iree_codegen.dispatch_config @matvec_fp16 workgroup_size = [64, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config< {workgroup = [1, 4, 0],
-                                reduction = [0, 0, 512],
-                                thread = [0, 0, 8],
-                                subgroup_basis = [[1, 4, 1], [0, 1, 2]],
-                                lane_basis = [[1, 1, 64], [0, 1, 2]]}
+                                      reduction = [0, 0, 512],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 4, 1], [0, 1, 2]],
+                                      lane_basis = [[1, 1, 64], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                         workgroup_size = [256, 1, 1]
-                                         subgroup_size = 64, {}>
+                                               workgroup_size = [256, 1, 1]
+                                               subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matvec_fp16_parallel_subgroup() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-  %5 = tensor.empty() : tensor<1x32000xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
-  ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.addf %out, %8 : f16
-    linalg.yield %9 : f16
-  } -> tensor<1x32000xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  return
+hal.executable private @matvec_fp16_parallel_subgroup {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16_parallel_subgroup ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16_parallel_subgroup() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
 }
 
 //     CHECK-LABEL: func.func @matvec_fp16_parallel_subgroup
@@ -96,45 +114,53 @@ func.func @matvec_fp16_parallel_subgroup() attributes {hal.executable.target = #
 
 //          CHECK:      scf.yield
 //          CHECK:    vector.transfer_write
-//          CHECK:    iree_codegen.dispatch_config @matvec_fp16_parallel_subgroup workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
-                                reduction = [0, 0, 512],
-                                thread = [0, 0, 8],
-                                subgroup_basis = [[1, 4, 1], [0, 1, 2]],
-                                lane_basis = [[1, 1, 64], [0, 1, 2]],
-                                promote_operands = [1]}
+                                      reduction = [0, 0, 512],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 4, 1], [0, 1, 2]],
+                                      lane_basis = [[1, 1, 64], [0, 1, 2]],
+                                      promote_operands = [1]}
 >
 #translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                         workgroup_size = [256, 1, 1]
-                                         subgroup_size = 64, {}>
+                                               workgroup_size = [256, 1, 1]
+                                               subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matvec_fp16_promote_rhs() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-  %5 = tensor.empty() : tensor<1x32000xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
-  ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.addf %out, %8 : f16
-    linalg.yield %9 : f16
-  } -> tensor<1x32000xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  return
+hal.executable private @matvec_fp16_promote_rhs {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16_promote_rhs ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16_promote_rhs() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
 }
 
 //     CHECK-LABEL: func.func @matvec_fp16_promote_rhs
@@ -149,11 +175,9 @@ func.func @matvec_fp16_promote_rhs() attributes {hal.executable.target = #execut
 
 //          CHECK:      scf.yield
 //          CHECK:    vector.transfer_write
-//          CHECK:    iree_codegen.dispatch_config @matvec_fp16_promote_rhs workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // Tile Sizes:
 // workgroup = [1, 1,  0,   0, 32]
 // reduction = [0, 0,  0, 128,  0]
@@ -165,22 +189,22 @@ func.func @matvec_fp16_promote_rhs() attributes {hal.executable.target = #execut
 // threads   = [1, 1,  2,  32,  1]
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 0, 0, 32],
-                               reduction = [0, 0, 0, 128, 0],
-                               promote_operands = [1, 2]}>
+                                     reduction = [0, 0, 0, 128, 0],
+                                     promote_operands = [1, 2]}>
 
 #qk_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 2, 3]],
-                                  lane_basis = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
-                                  thread         = [0, 0, 32, 4],
-                                  promote_operands = [1]}>
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
+                                        thread         = [0, 0, 32, 4],
+                                        promote_operands = [1]}>
 
 #pv_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 3, 4]],
-                                  lane_basis = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
-                                  thread         = [0, 0, 4, 4],
-                                  promote_operands = [1]}>
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
+                                        thread         = [0, 0, 4, 4],
+                                        promote_operands = [1]}>
 
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                        workgroup_size = [256, 1, 1]
-                                        subgroup_size = 64>
+                                              workgroup_size = [256, 1, 1]
+                                              subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -188,33 +212,46 @@ func.func @matvec_fp16_promote_rhs() attributes {hal.executable.target = #execut
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.250000e-01 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x1x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-               affine_map<(d0, d1, d2, d3, d4) -> ()>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
-               lowering_config = #config,
-               decomposition_config = {
-                qk_attrs = {lowering_config = #qk_config},
-                pv_attrs = {lowering_config = #pv_config}
-               }}
-               ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x1x64xf16>) {
-                ^bb0(%score: f32):
-                  iree_linalg_ext.yield %score : f32
-               } -> tensor<20x1x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
-  return
+hal.executable private @attention_20x1x64x4096x64 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_20x1x64x4096x64() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.250000e-01 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %7 = tensor.empty() : tensor<20x1x64xf32>
+        %8 = tensor.empty() : tensor<20x1xf32>
+        %9:3 = iree_linalg_ext.online_attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>],
+                     lowering_config = #config,
+                     decomposition_config = {
+                      qk_attrs = {lowering_config = #qk_config},
+                      pv_attrs = {lowering_config = #pv_config}
+                     }}
+                     ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7, %8, %8 : tensor<20x1x64xf32>, tensor<20x1xf32>, tensor<20x1xf32>) {
+                      ^bb0(%score: f32):
+                        iree_linalg_ext.yield %score : f32
+                     } -> tensor<20x1x64xf32>, tensor<20x1xf32>, tensor<20x1xf32>
+        iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @attention_20x1x64x4096x64
@@ -235,11 +272,9 @@ func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #exec
 // CHECK-COUNT-8:   gpu.subgroup_reduce add
 
 // CHECK:           scf.yield
-// CHECK:         iree_codegen.dispatch_config @attention_20x1x64x4096x64 workgroup_size = [256, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 // Tile Sizes:
 // workgroup         = [1, 1,  0,   0, 32]
 // partial_reduction = [0, 0,  0, 128,  0]
@@ -251,22 +286,22 @@ func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #exec
 // threads           = [1, 1,  2,  32,  1]
 
 #config = #iree_gpu.lowering_config<{workgroup = [1, 1, 0, 0, 32],
-                               partial_reduction = [0, 0, 0, 128, 0],
-                               promote_operands = [1, 2]}>
+                                     partial_reduction = [0, 0, 0, 128, 0],
+                                     promote_operands = [1, 2]}>
 
 #qk_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 2, 3]],
-                                  lane_basis = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
-                                  thread         = [0, 0, 32, 4],
-                                  promote_operands = [1]}>
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
+                                        thread         = [0, 0, 32, 4],
+                                        promote_operands = [1]}>
 
 #pv_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 3, 4]],
-                                  lane_basis = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
-                                  thread         = [0, 0, 4, 4],
-                                  promote_operands = [1]}>
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
+                                        thread         = [0, 0, 4, 4],
+                                        promote_operands = [1]}>
 
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                        workgroup_size = [256, 1, 1]
-                                        subgroup_size = 64>
+                                              workgroup_size = [256, 1, 1]
+                                              subgroup_size = 64>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -274,33 +309,46 @@ func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #exec
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 1.250000e-01 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x1x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-               affine_map<(d0, d1, d2, d3, d4) -> ()>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
-               lowering_config = #config,
-               decomposition_config = {
-                qk_attrs = {lowering_config = #qk_config},
-                pv_attrs = {lowering_config = #pv_config}
-               }}
-               ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x1x64xf16>) {
-                ^bb0(%score: f32):
-                  iree_linalg_ext.yield %score : f32
-               } -> tensor<20x1x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
-  return
+hal.executable private @attention_20x1x64x4096x64 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_20x1x64x4096x64() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.250000e-01 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf32>>
+        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
+        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %7 = tensor.empty() : tensor<20x1x64xf32>
+        %8 = tensor.empty() : tensor<20x1xf32>
+        %9:3 = iree_linalg_ext.online_attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>],
+                     lowering_config = #config,
+                     decomposition_config = {
+                      qk_attrs = {lowering_config = #qk_config},
+                      pv_attrs = {lowering_config = #pv_config}
+                     }}
+                     ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7, %8, %8 : tensor<20x1x64xf32>, tensor<20x1xf32>, tensor<20x1xf32>) {
+                      ^bb0(%score: f32):
+                        iree_linalg_ext.yield %score : f32
+                     } -> tensor<20x1x64xf32>, tensor<20x1xf32>, tensor<20x1xf32>
+        iree_tensor_ext.dispatch.tensor.store %9#0, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf32>>
+        return
+      }
+    }
+  }
 }
 
 // CHECK-LABEL: func.func @attention_20x1x64x4096x64
@@ -318,53 +366,56 @@ func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #exec
 // CHECK:           vector.multi_reduction <maximumf>
 // CHECK-COUNT-1:   gpu.subgroup_reduce maximumf
 
-// Sum
+// PV path
 // CHECK:           vector.multi_reduction <add>
-// CHECK-SAME:      vector<1x1x1x1x1x1x4x1x1xf32> to vector<1x1x1x1x1x1xf32>
-// CHECK-COUNT-1:   gpu.subgroup_reduce add
-
-// PV Matmul
-// CHECK:           vector.multi_reduction
-// CHECK-SAME:      vector<1x1x1x2x1x1x1x1x4x1x1x4xf32> to vector<1x1x2x1x1x1x1x1x4xf32>
 // CHECK-COUNT-8:   gpu.subgroup_reduce add
-// CHECK:         iree_codegen.dispatch_config @attention_20x1x64x4096x64 workgroup_size = [256, 1, 1] subgroup_size = 64
+
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
-                                reduction = [0, 0, 128],
-                                thread = [0, 0, 4],
-                                subgroup_basis = [[1, 1, 2], [0, 1, 2]],
-                                lane_basis = [[1, 4, 16], [0, 1, 2]]}
+                                      reduction = [0, 0, 128],
+                                      thread = [0, 0, 4],
+                                      subgroup_basis = [[1, 1, 2], [0, 1, 2]],
+                                      lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                         workgroup_size = [128, 1, 1]
-                                         subgroup_size = 64, {}>
+                                               workgroup_size = [128, 1, 1]
+                                               subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matvec_fp16_subgroup_reduction() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-  %5 = tensor.empty() : tensor<1x32000xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
-  ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.addf %out, %8 : f16
-    linalg.yield %9 : f16
-  } -> tensor<1x32000xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  return
+hal.executable private @matvec_fp16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16_subgroup_reduction() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
 }
 //     CHECK-LABEL: func.func @matvec_fp16_subgroup_reduction
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
@@ -377,50 +428,58 @@ func.func @matvec_fp16_subgroup_reduction() attributes {hal.executable.target = 
 //          CHECK:      gpu.subgroup_reduce add {{.*}} cluster(size = 2)
 //          CHECK:      scf.yield
 //          CHECK:    vector.transfer_write
-//          CHECK:    iree_codegen.dispatch_config @matvec_fp16_subgroup_reduction workgroup_size = [128, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 #config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
-                                partial_reduction = [0, 0, 128],
-                                thread = [0, 0, 8],
-                                subgroup_basis = [[1, 1, 1], [0, 1, 2]],
-                                lane_basis = [[1, 4, 16], [0, 1, 2]]}
+                                      partial_reduction = [0, 0, 128],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 1, 1], [0, 1, 2]],
+                                      lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = #iree_gpu.pipeline<VectorDistribute>
-                                         workgroup_size = [64, 1, 1]
-                                         subgroup_size = 64, {}>
+                                               workgroup_size = [64, 1, 1]
+                                               subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matvec_fp16_unaligned() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4099xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4099xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4099], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4099xf32>> -> tensor<1x4099xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4099], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4099xf16>> -> tensor<32000x4099xf16>
-  %tempty = tensor.empty() : tensor<1x4099xf16>
-  %trunc = linalg.generic { indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"] } ins(%3 : tensor<1x4099xf32>) outs(%tempty : tensor<1x4099xf16>) {
-  ^bb0(%in : f32, %out : f16):
-    %trunced = arith.truncf %in : f32 to f16
-    linalg.yield %trunced : f16
-  } -> tensor<1x4099xf16>
-  %5 = tensor.empty() : tensor<1x32000xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%trunc, %4 : tensor<1x4099xf16>, tensor<32000x4099xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
-  ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.addf %out, %8 : f16
-    linalg.yield %9 : f16
-  } -> tensor<1x32000xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-  return
+hal.executable private @matvec_fp16_unaligned {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16_unaligned ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16_unaligned() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4099xf32>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4099xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4099], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4099xf32>> -> tensor<1x4099xf32>
+        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4099], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4099xf16>> -> tensor<32000x4099xf16>
+        %tempty = tensor.empty() : tensor<1x4099xf16>
+        %trunc = linalg.generic { indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"] } ins(%3 : tensor<1x4099xf32>) outs(%tempty : tensor<1x4099xf16>) {
+        ^bb0(%in : f32, %out : f16):
+          %trunced = arith.truncf %in : f32 to f16
+          linalg.yield %trunced : f16
+        } -> tensor<1x4099xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%trunc, %4 : tensor<1x4099xf16>, tensor<32000x4099xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
 }
 
 // Test that we don't emit spurious roundtrips to (shared) memory to perform masked reads for unaligned cases.
@@ -430,11 +489,9 @@ func.func @matvec_fp16_unaligned() attributes {hal.executable.target = #executab
 //      CHECK-NOT:   vector.transfer_write
 //          CHECK:   gpu.subgroup_reduce
 //          CHECK:   vector.transfer_write
-//          CHECK:   iree_codegen.dispatch_config @matvec_fp16_unaligned workgroup_size = [64, 1, 1] subgroup_size = 64
 
 // -----
 
-#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
 /// Paged attention reduction distribution to multiple subgroups.
 /// Distribute 8x32 reduction dims across 4 subbroups with 2x32 threads shape per subgroup.
 #translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
@@ -442,75 +499,88 @@ func.func @matvec_fp16_unaligned() attributes {hal.executable.target = #executab
 #qk_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], lane_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
 #attention_lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 0, 0, 0, 8, 0], workgroup = [1, 1, 1, 0, 0, 0, 0]}>
 
+hal.executable private @attention_4xDx1x32x128xf16 {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
   // hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {abi = "hip", iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, iree_codegen.default_tuning_spec = #rocm.builtin.tuning_module<"iree_default_tuning_spec_gfx942.mlir">, ukernels = "none"}>) {
-func.func @attention_4xDx1x32x128xf16() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
-  %cst = arith.constant 8.837890e-02 : f16
-  %cst_0 = arith.constant 0.000000e+00 : f16
-  %cst_1 = arith.constant 0xFC00 : f16
-  %c32 = arith.constant 32 : index
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
-  %1 = arith.index_castui %0 : i32 to index
-  %2 = util.assume.int %1<umin = 1, umax = 512> : index
-  %3 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x1x2x1x32x128xf16>>
-  %4 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x1x128xf16>>
-  %5 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(4) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1x1x128xf16>>
-  %6 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
-  %7 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6}
-  %8 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6}
-  %9 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [4, %6], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6} -> tensor<4x?xi64>
-  %10 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [4, %6], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6} -> tensor<4x?xi64>
-  %11 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [4, 1, 1, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x1x128xf16>> -> tensor<4x1x1x128xf16>
-  %12 = tensor.empty() : tensor<4x1x1x128xf16>
-  %13 = tensor.empty(%6) : tensor<4x1x1x?x32xf16>
-  %14 = tensor.empty(%6) : tensor<4x?x1x32x128xf16>
-  %15 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0, 0, 0], sizes = [4096, 1, 1, 1, 32, 128], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x1x2x1x32x128xf16>> -> tensor<4096x1x32x128xf16>
-  %16 = iree_linalg_ext.gather dimension_map = [0] ins(%15, %9 : tensor<4096x1x32x128xf16>, tensor<4x?xi64>) outs(%14 : tensor<4x?x1x32x128xf16>) -> tensor<4x?x1x32x128xf16>
-  %17 = iree_linalg_ext.gather dimension_map = [0] ins(%15, %10 : tensor<4096x1x32x128xf16>, tensor<4x?xi64>) outs(%14 : tensor<4x?x1x32x128xf16>) -> tensor<4x?x1x32x128xf16>
-  %18 = linalg.generic {
-      indexing_maps = [
-        affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
-      ],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]
+    hal.executable.export public @attention_4xDx1x32x128xf16 ordinal(0) layout(#hal.pipeline.layout<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1)
+      hal.return %x, %y, %z : index, index, index
     }
-    outs(%13 : tensor<4x1x1x?x32xf16>) {
-      ^bb0(%out: f16):
-        %20 = linalg.index 4 : index
-        %21 = linalg.index 3 : index
-        %22 = arith.muli %21, %c32 overflow<nsw> : index
-        %23 = arith.addi %20, %22 : index
-        %24 = arith.cmpi sle, %23, %c0 : index
-        %25 = arith.select %24, %cst_0, %cst_1 : f16
-      linalg.yield %25 : f16
-  } -> tensor<4x1x1x?x32xf16>
-  %19 = iree_linalg_ext.attention {
-      decomposition_config = {
-        pv_attrs = {lowering_config = #pv_attrs_config},
-        qk_attrs = {lowering_config = #qk_attrs_config}
-      },
-      indexing_maps = [
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d1, d6, d4)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d1, d6, d3)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d5, d6)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>],
-      lowering_config = #attention_lowering_config
+    builtin.module {
+      func.func @attention_4xDx1x32x128xf16() attributes {translation_info = #translation} {
+        %cst = arith.constant 8.837890e-02 : f16
+        %cst_0 = arith.constant 0.000000e+00 : f16
+        %cst_1 = arith.constant 0xFC00 : f16
+        %c32 = arith.constant 32 : index
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
+        %1 = arith.index_castui %0 : i32 to index
+        %2 = util.assume.int %1<umin = 1, umax = 512> : index
+        %3 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x1x2x1x32x128xf16>>
+        %4 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x1x128xf16>>
+        %5 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(4) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1x1x128xf32>>
+        %6 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
+        %7 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6}
+        %8 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6}
+        %9 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [4, %6], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6} -> tensor<4x?xi64>
+        %10 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [4, %6], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x?xi64>>{%6} -> tensor<4x?xi64>
+        %11 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [4, 1, 1, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x1x128xf16>> -> tensor<4x1x1x128xf16>
+        %12 = tensor.empty() : tensor<4x1x1x128xf32>
+        %13 = tensor.empty(%6) : tensor<4x1x1x?x32xf16>
+        %14 = tensor.empty(%6) : tensor<4x?x1x32x128xf16>
+        %15 = tensor.empty() : tensor<4x1x1xf32>
+        %16 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0, 0, 0], sizes = [4096, 1, 1, 1, 32, 128], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x1x2x1x32x128xf16>> -> tensor<4096x1x32x128xf16>
+        %17 = iree_linalg_ext.gather dimension_map = [0] ins(%16, %9 : tensor<4096x1x32x128xf16>, tensor<4x?xi64>) outs(%14 : tensor<4x?x1x32x128xf16>) -> tensor<4x?x1x32x128xf16>
+        %18 = iree_linalg_ext.gather dimension_map = [0] ins(%16, %10 : tensor<4096x1x32x128xf16>, tensor<4x?xi64>) outs(%14 : tensor<4x?x1x32x128xf16>) -> tensor<4x?x1x32x128xf16>
+        %19 = linalg.generic {
+            indexing_maps = [
+              affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+            ],
+            iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]
+          }
+          outs(%13 : tensor<4x1x1x?x32xf16>) {
+            ^bb0(%out: f16):
+              %20 = linalg.index 4 : index
+              %21 = linalg.index 3 : index
+              %22 = arith.muli %21, %c32 overflow<nsw> : index
+              %23 = arith.addi %20, %22 : index
+              %24 = arith.cmpi sle, %23, %c0 : index
+              %25 = arith.select %24, %cst_0, %cst_1 : f16
+            linalg.yield %25 : f16
+        } -> tensor<4x1x1x?x32xf16>
+        %20:3 = iree_linalg_ext.online_attention {
+            decomposition_config = {
+              pv_attrs = {lowering_config = #pv_attrs_config},
+              qk_attrs = {lowering_config = #qk_attrs_config}
+            },
+            indexing_maps = [
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4)>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d1, d6, d4)>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d5, d1, d6, d3)>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d5, d6)>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2)>,
+              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2)>],
+            lowering_config = #attention_lowering_config
+          }
+           ins(%11, %17, %18, %cst, %19 : tensor<4x1x1x128xf16>, tensor<4x?x1x32x128xf16>, tensor<4x?x1x32x128xf16>, f16, tensor<4x1x1x?x32xf16>)
+          outs(%12, %15, %15 : tensor<4x1x1x128xf32>, tensor<4x1x1xf32>, tensor<4x1x1xf32>) {
+            ^bb0(%arg0: f32):
+              iree_linalg_ext.yield %arg0 : f32
+        } -> tensor<4x1x1x128xf32>, tensor<4x1x1xf32>, tensor<4x1x1xf32>
+        iree_tensor_ext.dispatch.tensor.store %20#0, %5, offsets = [0, 0, 0, 0], sizes = [4, 1, 1, 128], strides = [1, 1, 1, 1] : tensor<4x1x1x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1x1x128xf32>>
+        return
+      }
     }
-     ins(%11, %16, %17, %cst, %18 : tensor<4x1x1x128xf16>, tensor<4x?x1x32x128xf16>, tensor<4x?x1x32x128xf16>, f16, tensor<4x1x1x?x32xf16>)
-    outs(%12 : tensor<4x1x1x128xf16>) {
-      ^bb0(%arg0: f32):
-        iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<4x1x1x128xf16>
-  iree_tensor_ext.dispatch.tensor.store %19, %5, offsets = [0, 0, 0, 0], sizes = [4, 1, 1, 128], strides = [1, 1, 1, 1] : tensor<4x1x1x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1x1x128xf16>>
-  return
+  }
 }
 
 //     CHECK-LABEL: func.func @attention_4xDx1x32x128xf16
-//           CHECK:   scf.for {{.*}} -> (vector<1x1x1x1x1x16x1x1x1x1x1x1x1x1x1x1x1x8xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>) {
-//       CHECK-NOT:     gpu.subgroup_reduce
-//           CHECK:     scf.yield
+//           CHECK:   scf.forall ({{.*}}) in (4)
+//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x16x1x1x1x1x1x1x1x1x1x1x1x8xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1x1x1x1x1x1x1x1x1x1xf32>) {
+//       CHECK-NOT:       gpu.subgroup_reduce
+//           CHECK:       scf.yield
 //
 // Warning: the above layout_config for vector distribution on attention goes overboard on the tail part.
-// CHECK-COUNT-390:   gpu.subgroup_reduce {{.*}} : (f32) -> f32
-//           CHECK:   iree_codegen.dispatch_config @attention_4xDx1x32x128xf16 workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK:               gpu.subgroup_reduce {{.*}} : (f32) -> f32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -638,6 +638,8 @@ static void buildSPIRVCodegenConfigurationPassPipelineImpl(
     addEncodingToNopPasses(funcPassManager);
   }
   modulePassManager.addPass(createMaterializeUserConfigsPass());
+  FunctionLikeNest(modulePassManager)
+      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
   modulePassManager.addPass(createSPIRVSelectLoweringStrategyPass());
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -638,8 +638,6 @@ static void buildSPIRVCodegenConfigurationPassPipelineImpl(
     addEncodingToNopPasses(funcPassManager);
   }
   modulePassManager.addPass(createMaterializeUserConfigsPass());
-  FunctionLikeNest(modulePassManager)
-      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
   modulePassManager.addPass(createSPIRVSelectLoweringStrategyPass());
 }
 

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -43,8 +43,6 @@ static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
   funcPassManager.addPass(createConcretizePadResultShapePass());
-  funcPassManager.addPass(
-      IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
   funcPassManager.addPass(IREE::LinalgExt::createDecomposeAttentionPass());
   funcPassManager.addPass(
       IREE::LinalgExt::createDecomposeWinogradTransformPass());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2185,6 +2185,41 @@ SmallVector<AffineMap> OnlineAttentionOp::getIndexingMapsArray() {
       getIndexingMaps().getAsValueRange<AffineMapAttr>());
 }
 
+SmallVector<int64_t> OnlineAttentionOp::getStaticLoopRanges() {
+  SmallVector<int64_t> bounds(getIterationDomainRank());
+  SmallVector<bool> dimsFound(getIterationDomainRank(), false);
+
+  ArrayRef<int64_t> queryShape = getQuery().getType().getShape();
+  ArrayRef<AffineExpr> queryDims = getQueryMap().getResults();
+  ArrayRef<int64_t> valueShape = getValue().getType().getShape();
+  ArrayRef<AffineExpr> valueDims = getValueMap().getResults();
+
+  auto fillSizes = [&](ArrayRef<int64_t> sizes, ArrayRef<AffineExpr> dims) {
+    for (auto [size, dim] : llvm::zip_equal(sizes, dims)) {
+      int pos = cast<AffineDimExpr>(dim).getPosition();
+      if (dimsFound[pos]) {
+        continue;
+      }
+      bounds[pos] = size;
+      dimsFound[pos] = true;
+    }
+  };
+  fillSizes(queryShape, queryDims);
+  fillSizes(valueShape, valueDims);
+  return bounds;
+}
+
+SmallVector<AffineMap> OnlineAttentionOp::getIndexingMapsForOperands() {
+  auto maps = getIndexingMapsArray();
+  maps.resize(getNumDpsInputs());
+  return maps;
+}
+
+SmallVector<AffineMap> OnlineAttentionOp::getIndexingMapsForResults() {
+  return llvm::to_vector_of<AffineMap>(
+      llvm::drop_begin(getIndexingMapsArray(), getNumDpsInputs()));
+}
+
 void OnlineAttentionOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                     MLIRContext *ctx) {
   patterns.insert<StaticizeLinalgExtOp<OnlineAttentionOp>>(ctx);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1038,7 +1038,10 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
 //===----------------------------------------------------------------------===//
 
 def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
-    [IndexingMapOpInterface,
+    [DeclareOpInterfaceMethods<LinalgFusionInterface,
+      ["getIndexingMapsForResults", "getIndexingMapsForOperands",
+       "getStaticLoopRanges"]>,
+     IndexingMapOpInterface,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<AggregatedOpInterface, ["decomposeOperation"]>,
      DeclareOpInterfaceMethods<TilingInterface,
@@ -1165,6 +1168,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
     int64_t getIterationDomainRank() {
       return getQueryMap().getNumDims();
     }
+    int64_t getNumLoops() { return getIterationDomainRank(); }
 
     /* Decomposition control attributes */
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -379,6 +379,30 @@ getReshapeInfo(LinalgExt::AttentionOp attentionOp) {
 }
 
 static SmallVector<ReshapeOperandInfo>
+getReshapeInfo(LinalgExt::OnlineAttentionOp attentionOp) {
+  return llvm::map_to_vector(
+      attentionOp->getOpOperands(), [&](OpOperand &opOperand) {
+        ReshapeOperandInfo operandInfo;
+        auto operandType = dyn_cast<ShapedType>(opOperand.get().getType());
+        if (!operandType) {
+          assert(
+              attentionOp.getMatchingIndexingMap(&opOperand).getNumResults() ==
+                  0 &&
+              "expected non-shaped type to have no results in indexing map");
+          return operandInfo;
+        }
+
+        operandInfo.originalShape = getDimSizes(opOperand.get());
+        for (auto result :
+             attentionOp.getMatchingIndexingMap(&opOperand).getResults()) {
+          operandInfo.operandToIterationSpace.push_back(
+              cast<AffineDimExpr>(result).getPosition());
+        }
+        return operandInfo;
+      });
+}
+
+static SmallVector<ReshapeOperandInfo>
 getReshapeInfo(LinalgExt::ScatterOp scatterOp) {
   SmallVector<ReshapeOperandInfo> infos;
   auto rankOfContiguousSlice =
@@ -876,6 +900,119 @@ struct FoldWithProducerReshapeByExpansion final : OpRewritePattern<OpTy> {
   linalg::ControlFusionFn controlFoldingReshapes;
 };
 
+static std::optional<SmallVector<Value>>
+fuseOnlineAttentionWithProducerReshapeByExpansion(OnlineAttentionOp op,
+                                                  Operation *reshapeOp,
+                                                  OpOperand *fusableOpOperand,
+                                                  PatternRewriter &rewriter) {
+  Location loc = op.getLoc();
+  auto expandingReshapeOp = dyn_cast<tensor::ExpandShapeOp>(*reshapeOp);
+  auto collapsingReshapeOp = dyn_cast<tensor::CollapseShapeOp>(*reshapeOp);
+  bool isExpanding = (expandingReshapeOp != nullptr);
+  Value expandedVal = isExpanding ? expandingReshapeOp.getResult()
+                                  : collapsingReshapeOp.getSrc();
+  SmallVector<DimSize> expandedSize;
+  if (isExpanding) {
+    if (failed(moveValueDefinitions(rewriter,
+                                    expandingReshapeOp.getOutputShape(), op))) {
+      return std::nullopt;
+    }
+    llvm::append_range(expandedSize, expandingReshapeOp.getMixedOutputShape());
+  } else {
+    expandedSize = getDimSizes(expandedVal);
+  }
+
+  ExpansionInfo info;
+  if (failed(info.compute(
+          getReshapeInfo(op), op.getStaticLoopRanges(), fusableOpOperand,
+          isExpanding ? expandingReshapeOp.getReassociationIndices()
+                      : collapsingReshapeOp.getReassociationIndices(),
+          expandedSize))) {
+    return std::nullopt;
+  }
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(op);
+
+  IRMapping mapping;
+  for (OpOperand &operand : op->getOpOperands()) {
+    std::optional<Value> maybeNewOperand =
+        info.getOrCreateExpanded(loc, &operand, rewriter);
+    assert(maybeNewOperand.has_value());
+    mapping.map(operand.get(), maybeNewOperand.value());
+  }
+
+  auto newOp = cast<OnlineAttentionOp>(rewriter.clone(*op, mapping));
+  auto expandedOpIndexingMaps = llvm::to_vector_of<AffineMap>(
+      llvm::map_range(op.getIndexingMapsArray(), [&](AffineMap m) {
+        return getIndexingMapInExpandedOp(rewriter, m, info);
+      }));
+  newOp.setIndexingMapsAttr(
+      rewriter.getAffineMapArrayAttr(expandedOpIndexingMaps));
+
+  SmallVector<OpOperand *> dpsInitOperands;
+  for (OpOperand &operand : op.getDpsInitsMutable()) {
+    dpsInitOperands.push_back(&operand);
+  }
+  for (auto [i, initOperand] : llvm::enumerate(dpsInitOperands)) {
+    newOp->getResult(i).setType(mapping.lookup(initOperand->get()).getType());
+  }
+
+  SmallVector<Value> replacements;
+  replacements.reserve(op->getNumResults());
+  for (auto [i, initOperand] : llvm::enumerate(dpsInitOperands)) {
+    SmallVector<ReassociationIndices> originalReassoc =
+        info.getReassoc(initOperand);
+    Value newResult = newOp->getResult(i);
+    if (isIdentityReassoc(originalReassoc)) {
+      replacements.push_back(newResult);
+      continue;
+    }
+    replacements.push_back(tensor::CollapseShapeOp::create(
+        rewriter, loc, op.getResult(i).getType(), newResult, originalReassoc));
+  }
+  return replacements;
+}
+
+struct FoldOnlineAttentionWithProducerReshapeByExpansion final
+    : OpRewritePattern<OnlineAttentionOp> {
+  FoldOnlineAttentionWithProducerReshapeByExpansion(
+      MLIRContext *context, linalg::ControlFusionFn controlFoldingReshapes,
+      PatternBenefit benefit = 1)
+      : OpRewritePattern<OnlineAttentionOp>(context, benefit),
+        controlFoldingReshapes(std::move(controlFoldingReshapes)) {}
+
+  LogicalResult matchAndRewrite(OnlineAttentionOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.hasPureTensorSemantics()) {
+      return failure();
+    }
+
+    for (OpOperand &opOperand : op->getOpOperands()) {
+      tensor::CollapseShapeOp reshapeOp =
+          opOperand.get().getDefiningOp<tensor::CollapseShapeOp>();
+      if (!reshapeOp) {
+        continue;
+      }
+      if (!controlFoldingReshapes(&opOperand)) {
+        continue;
+      }
+
+      std::optional<SmallVector<Value>> replacementValues =
+          fuseOnlineAttentionWithProducerReshapeByExpansion(
+              op, reshapeOp, &opOperand, rewriter);
+      if (!replacementValues) {
+        return failure();
+      }
+      rewriter.replaceOp(op, *replacementValues);
+      return success();
+    }
+    return failure();
+  }
+
+  linalg::ControlFusionFn controlFoldingReshapes;
+};
+
 template <typename OpTy>
 struct FoldWithConsumerReshapeByExpansion final
     : OpRewritePattern<tensor::ExpandShapeOp> {
@@ -1104,6 +1241,7 @@ void populateFoldReshapeOpsByExpansionPatterns(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFoldingReshapes) {
   patterns.add<FoldWithProducerReshapeByExpansion<AttentionOp>,
+               FoldOnlineAttentionWithProducerReshapeByExpansion,
                FoldWithConsumerReshapeByExpansion<AttentionOp>,
                FoldWithProducerReshapeByExpansion<ScatterOp>,
                FoldWithConsumerReshapeByExpansion<ScatterOp>,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -1013,6 +1013,44 @@ struct FoldOnlineAttentionWithProducerReshapeByExpansion final
   linalg::ControlFusionFn controlFoldingReshapes;
 };
 
+struct FoldOnlineAttentionWithConsumerReshapeByExpansion final
+    : OpRewritePattern<tensor::ExpandShapeOp> {
+  FoldOnlineAttentionWithConsumerReshapeByExpansion(
+      MLIRContext *context, linalg::ControlFusionFn controlFoldingReshapes,
+      PatternBenefit benefit = 1)
+      : OpRewritePattern<tensor::ExpandShapeOp>(context, benefit),
+        controlFoldingReshapes(std::move(controlFoldingReshapes)) {}
+
+  LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
+                                PatternRewriter &rewriter) const override {
+    auto producerResult = dyn_cast<OpResult>(expandOp.getSrc());
+    if (!producerResult) {
+      return rewriter.notifyMatchFailure(expandOp,
+                                         "source not produced by an operation");
+    }
+
+    auto op = expandOp.getSrc().getDefiningOp<OnlineAttentionOp>();
+    if (!op || !op.hasPureTensorSemantics()) {
+      return failure();
+    }
+
+    if (!controlFoldingReshapes(&expandOp.getSrcMutable())) {
+      return failure();
+    }
+
+    std::optional<SmallVector<Value>> replacementValues =
+        fuseOnlineAttentionWithProducerReshapeByExpansion(
+            op, expandOp, op.getTiedOpOperand(producerResult), rewriter);
+    if (!replacementValues) {
+      return failure();
+    }
+    rewriter.replaceOp(op, *replacementValues);
+    return success();
+  }
+
+  linalg::ControlFusionFn controlFoldingReshapes;
+};
+
 template <typename OpTy>
 struct FoldWithConsumerReshapeByExpansion final
     : OpRewritePattern<tensor::ExpandShapeOp> {
@@ -1242,6 +1280,7 @@ void populateFoldReshapeOpsByExpansionPatterns(
     const linalg::ControlFusionFn &controlFoldingReshapes) {
   patterns.add<FoldWithProducerReshapeByExpansion<AttentionOp>,
                FoldOnlineAttentionWithProducerReshapeByExpansion,
+               FoldOnlineAttentionWithConsumerReshapeByExpansion,
                FoldWithConsumerReshapeByExpansion<AttentionOp>,
                FoldWithProducerReshapeByExpansion<ScatterOp>,
                FoldWithConsumerReshapeByExpansion<ScatterOp>,

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -49,6 +49,8 @@ void buildVMVXConfigurationPassPipeline(OpPassManager &variantPassManager) {
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.
       .addPass(createEraseHALDescriptorTypeFromMemRefPass);
+  FunctionLikeNest(modulePassManager)
+      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
   modulePassManager.addPass(createVMVXSelectLoweringStrategyPass());
 }
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -49,8 +49,6 @@ void buildVMVXConfigurationPassPipeline(OpPassManager &variantPassManager) {
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.
       .addPass(createEraseHALDescriptorTypeFromMemRefPass);
-  FunctionLikeNest(modulePassManager)
-      .addPass(IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass);
   modulePassManager.addPass(createVMVXSelectLoweringStrategyPass());
 }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -1055,6 +1055,72 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// Verify exact matching for the unmasked online_attention op.
+
+#map_query = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+#map_key = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+#map_value = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
+#map_scale = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map_output = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map_max = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+
+// CHECK-LABEL: func.func @online_attention_exact
+func.func @online_attention_exact(
+    %query: tensor<2x10x6x4xf16>,
+    %key: tensor<2x10x4x4xf16>,
+    %value: tensor<2x10x4x4xf16>,
+    %scale: f16,
+    %output: tensor<2x10x6x4xf32>,
+    %max: tensor<2x10x6xf32>,
+    %sum: tensor<2x10x6xf32>) -> tensor<2x10x6x4xf32> {
+
+  // CHECK: iree_linalg_ext.online_attention
+  // CHECK-SAME: match_status = "matched"
+  %res:3 = iree_linalg_ext.online_attention {
+      indexing_maps = [#map_query, #map_key, #map_value, #map_scale, #map_output, #map_max, #map_max],
+      match_status = "unmatched"}
+      ins(%query, %key, %value, %scale : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16)
+      outs(%output, %max, %sum : tensor<2x10x6x4xf32>, tensor<2x10x6xf32>, tensor<2x10x6xf32>) {
+    ^bb0(%arg: f32):
+      iree_linalg_ext.yield %arg : f32
+    } -> tensor<2x10x6x4xf32>, tensor<2x10x6xf32>, tensor<2x10x6xf32>
+
+  return %res#0 : tensor<2x10x6x4xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_online_attention(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    %batch, %m, %n, %k1, %k2 =
+      transform.iree.match.online_attention %op,
+        query_type = f16, key_type = f16, value_type = f16, scale_type = f16,
+        output_type = f32, max_type = f32, sum_type = f32,
+        indexing_maps = [#map_query, #map_key, #map_value, #map_scale, #map_output, #map_max, #map_max] :
+        !transform.any_op -> !transform.param<i64>
+
+    transform.iree.match.dims_equal %batch, [2, 10] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [6] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [4] : !transform.param<i64>
+    transform.iree.match.dims_equal %k1, [4] : !transform.param<i64>
+    transform.iree.match.dims_equal %k2, [4] : !transform.param<i64>
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "match_status" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+    transform.foreach_match in %module
+        @match_online_attention -> @annotate
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
 // Verify indexing maps mismatching for the attention op.
 
 #map_query = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -388,6 +388,119 @@ IREE::transform_dialect::MatchAttentionOp::matchOperation(
   return DiagnosedSilenceableFailure::success();
 }
 
+DiagnosedSilenceableFailure
+IREE::transform_dialect::MatchOnlineAttentionOp::matchOperation(
+    Operation *current, transform::TransformResults &results,
+    transform::TransformState &state) {
+  Location loc = current->getLoc();
+  auto attentionOp = dyn_cast<IREE::LinalgExt::OnlineAttentionOp>(current);
+  if (!attentionOp) {
+    return emitSilenceableFailure(loc)
+           << "Operation is not an online_attention operation.";
+  }
+  if (attentionOp.getMask()) {
+    return emitSilenceableFailure(loc)
+           << "Masked online_attention operations are not supported.";
+  }
+
+  Type targetQueryType = getQueryType();
+  Type currentQueryType =
+      getElementTypeOrSelf(attentionOp.getQuery().getType());
+  if (currentQueryType != targetQueryType) {
+    return emitSilenceableFailure(loc)
+           << "Query type doesn't match: expected " << targetQueryType
+           << ", got " << currentQueryType;
+  }
+
+  Type targetKeyType = getKeyType();
+  Type currentKeyType = getElementTypeOrSelf(attentionOp.getKey().getType());
+  if (currentKeyType != targetKeyType) {
+    return emitSilenceableFailure(loc)
+           << "Key type doesn't match: expected " << targetKeyType << ", got "
+           << currentKeyType;
+  }
+
+  Type targetValueType = getValueType();
+  Type currentValueType =
+      getElementTypeOrSelf(attentionOp.getValue().getType());
+  if (currentValueType != targetValueType) {
+    return emitSilenceableFailure(loc)
+           << "Value type doesn't match: expected " << targetValueType
+           << ", got " << currentValueType;
+  }
+
+  Type targetScaleType = getScaleType();
+  Type currentScaleType =
+      getElementTypeOrSelf(attentionOp.getScale().getType());
+  if (currentScaleType != targetScaleType) {
+    return emitSilenceableFailure(loc)
+           << "Scale type doesn't match: expected " << targetScaleType
+           << ", got " << currentScaleType;
+  }
+
+  Type targetOutputType = getOutputType();
+  Type currentOutputType =
+      getElementTypeOrSelf(attentionOp.getOutput().getType());
+  if (currentOutputType != targetOutputType) {
+    return emitSilenceableFailure(loc)
+           << "Output type doesn't match: expected " << targetOutputType
+           << ", got " << currentOutputType;
+  }
+
+  Type targetMaxType = getMaxType();
+  Type currentMaxType = getElementTypeOrSelf(attentionOp.getMax().getType());
+  if (currentMaxType != targetMaxType) {
+    return emitSilenceableFailure(loc)
+           << "Max type doesn't match: expected " << targetMaxType << ", got "
+           << currentMaxType;
+  }
+
+  Type targetSumType = getSumType();
+  Type currentSumType = getElementTypeOrSelf(attentionOp.getSum().getType());
+  if (currentSumType != targetSumType) {
+    return emitSilenceableFailure(loc)
+           << "Sum type doesn't match: expected " << targetSumType << ", got "
+           << currentSumType;
+  }
+
+  ArrayAttr currentIndexingMaps = attentionOp.getIndexingMaps();
+  ArrayAttr targetIndexingMaps = getIndexingMaps();
+  if (currentIndexingMaps != targetIndexingMaps) {
+    return emitSilenceableFailure(loc) << "indexing maps don't match";
+  }
+
+  FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
+      IREE::LinalgExt::AttentionOpDetail::get(
+          attentionOp.getQueryMap(), attentionOp.getKeyMap(),
+          attentionOp.getValueMap(), attentionOp.getOutputMap());
+  if (failed(maybeOpInfo)) {
+    return emitSilenceableFailure(loc)
+           << "Failed to infer online_attention dimensions";
+  }
+  IREE::LinalgExt::AttentionOpDetail opInfo = *maybeOpInfo;
+  SmallVector<int64_t> iterationDomain = attentionOp.getStaticLoopRanges();
+
+  Builder builder(getContext());
+  auto iterationSizes = [&](ArrayRef<int64_t> dimIndices) {
+    return llvm::map_to_vector(dimIndices, [&](int64_t dimIdx) -> Attribute {
+      return builder.getI64IntegerAttr(iterationDomain[dimIdx]);
+    });
+  };
+
+  results.setParams(cast<OpResult>(getBatchDims()),
+                    iterationSizes(opInfo.getBatchDims()));
+  results.setParams(cast<OpResult>(getMDims()),
+                    iterationSizes(opInfo.getMDims()));
+  results.setParams(cast<OpResult>(getNDims()),
+                    iterationSizes(opInfo.getNDims()));
+  results.setParams(cast<OpResult>(getK1Dims()),
+                    iterationSizes(opInfo.getK1Dims()));
+  results.setParams(cast<OpResult>(getK2Dims()),
+                    iterationSizes(opInfo.getK2Dims()));
+
+  return DiagnosedSilenceableFailure::success();
+}
+
 //===----------------------------------------------------------------------===//
 // MatchConvolutionOp
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -408,6 +408,93 @@ def MatchAttentionOp : Op<Transform_Dialect, "iree.match.attention",
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
+def MatchOnlineAttentionOp : Op<Transform_Dialect, "iree.match.online_attention",
+    [MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface,
+     AllTypesMatch<["batch_dims", "m_dims", "n_dims",
+                    "k1_dims", "k2_dims"]>
+     ]> {
+  let summary = [{Check whether the op is an online_attention operation.}];
+  let description = [{
+    Matches operations from the IREELinalgExt dialect that implement
+    online attention without a mask: iree_linalg_ext.online_attention.
+
+    ### Example
+
+    ```mlir
+    #map_query = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+    #map_key = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+    #map_value = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
+    #map_scale = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+    #map_output = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+    #map_max = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+    #map_sum = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+
+    %batch_dims, %m_dims, %n_dims, %k1_dims, %k2_dims =
+      transform.iree.match.online_attention %attn_op,
+        query_type = f16, key_type = f16, value_type = f16, scale_type = f16,
+        output_type = f32, max_type = f32, sum_type = f32,
+        indexing_maps = [#map_query, #map_key, #map_value, #map_scale,
+                         #map_output, #map_max, #map_sum] :
+        !transform.any_op -> !transform.param<i64>
+    ```
+
+    This succeeds when `%attn_op` is an unmasked online_attention operation
+    with the specified element types and indexing maps.
+
+    #### Return modes
+
+    Succeeds if the operation is an unmasked online_attention operation, and
+    produces a silenceable failure otherwise.
+
+    #### Results
+
+    Returns arrays of dimension sizes extracted from the iteration domain:
+    - batch_dims: Array of batch dimension sizes.
+    - m_dims: Array of query sequence length dimension sizes.
+    - n_dims: Array of number of heads dimension sizes.
+    - k1_dims: Array of key/value sequence length dimension sizes.
+    - k2_dims: Array of key embedding dimension sizes.
+  }];
+
+  let arguments = (ins
+    TransformHandleTypeInterface:$operand_handle,
+    TypeAttr:$query_type,
+    TypeAttr:$key_type,
+    TypeAttr:$value_type,
+    TypeAttr:$scale_type,
+    TypeAttr:$output_type,
+    TypeAttr:$max_type,
+    TypeAttr:$sum_type,
+    AffineMapArrayAttr:$indexing_maps
+  );
+
+  let results = (outs
+    TransformParamTypeInterface:$batch_dims,
+    TransformParamTypeInterface:$m_dims,
+    TransformParamTypeInterface:$n_dims,
+    TransformParamTypeInterface:$k1_dims,
+    TransformParamTypeInterface:$k2_dims
+  );
+
+  let assemblyFormat = [{
+    $operand_handle `,`
+    `query_type` `=` $query_type
+    `,` `key_type` `=` $key_type
+    `,` `value_type` `=` $value_type
+    `,` `scale_type` `=` $scale_type
+    `,` `output_type` `=` $output_type
+    `,` `max_type` `=` $max_type
+    `,` `sum_type` `=` $sum_type
+    `,` `indexing_maps` `=` $indexing_maps
+    attr-dict `:` type($operand_handle) `->` type($batch_dims)
+  }];
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
 def MatchDimsEqualOp : Op<Transform_Dialect, "iree.match.dims_equal",
     [DeclareOpInterfaceMethods<TransformOpInterface>,
      MatchOpInterface,

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
@@ -26,7 +26,7 @@ module attributes { transform.with_named_sequence } {
 transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %attention : !transform.any_op
 
-    transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+    transform.match.operation_name %attention ["iree_linalg_ext.online_attention"] : !transform.any_op
     %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
 
@@ -52,7 +52,7 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
 transform.named_sequence @match_attention_f8(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %attention : !transform.any_op
 
-    transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+    transform.match.operation_name %attention ["iree_linalg_ext.online_attention"] : !transform.any_op
     %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf8E4M3FNUZ> : !transform.any_value
 

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -22,7 +22,7 @@ transform.named_sequence @apply_attn_op_config(%attention: !transform.any_op {tr
 transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %attention : !transform.any_op
 
-  transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+  transform.match.operation_name %attention ["iree_linalg_ext.online_attention"] : !transform.any_op
   %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
   transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
 


### PR DESCRIPTION
This patch moves all codegen pipelines to move to working on iree_linalg_ext.online_attention instead of iree_linalg_ext.attention.

iree_linalg_ext.attention is really a legacy operation for codegen and not really the best thing to form dispatches. The main reason is that online_attention returns the "attention state" instead of the attention result. The "attention state" can be used to do split-k and is also useful for some frontends (as logsumexp).

The main changes are:

- Add/Move convertAttentionToOnlineAttention in the configuration part of the pipieline.
- Move KernelConfig.cpp to work on online_attention instead of attention.

Pipelines already handle online_attention properly, so there should be no major changes there.

Assisted-By: Codex