### PR TITLE
[tools] Avoid noisy failures in IREE bash completion.

### DIFF
--- a/tools/scripts/iree-tools-argcomplete.bash
+++ b/tools/scripts/iree-tools-argcomplete.bash
@@ -8,10 +8,23 @@ _iree_tools_autocomplete() {
     local commands
     local cur
 
-    # Get the list of commands from the appropriate tool's `--help-list`
-    commands=$($tool --help-list | awk '{print $1}' | grep -v '^ *=' | sed 's/[=<].*//')
-
     cur=${COMP_WORDS[COMP_CWORD]}
+
+    # If the tool is not available yet, avoid noisy shell errors.
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      case "$cur" in
+        -*)
+          COMPREPLY=()
+          ;;
+        *)
+          COMPREPLY=($(compgen -f -- "${cur}"))
+          ;;
+      esac
+      return 0
+    fi
+
+    # Get the list of options from the tool's `--help-list`.
+    commands=$("$tool" --help-list 2>/dev/null | awk '{print $1}' | grep -v '^ *=' | sed 's/[=<].*//')
 
     case "$cur" in
       -*)


### PR DESCRIPTION
Guard completion for missing IREE tools to avoid "command not found" output clobbering the current command line before the tools are built.