### PR TITLE
[DMA][Swizzle] Enforce access_width >= elementsPerLane in DMA lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -166,6 +166,35 @@ getDestSwizzleAttr(Value dest) {
   return std::nullopt;
 }
 
+/// Verifies that every transfer segment is compatible with the destination
+/// XOR swizzle's |accessWidth|.
+///
+/// `gather_to_lds` writes |elementsPerLane| contiguous elements per lane at
+/// `dstBase + laneId * elementsPerLane`, while the inverse XOR swizzle is
+/// applied only to each lane's base offset. The lane therefore reads
+/// `src[swizzle(perLaneBase) + k]` for k in [0, elementsPerLane). For this
+/// to match the swizzled LDS layout we need
+///   swizzle(perLaneBase) + k == swizzle(perLaneBase + k)   for all k.
+/// XOR-shuffle is identity within an access_width-sized chunk and permutes
+/// between chunks, so the equation holds iff every per-lane write stays
+/// inside one chunk:
+///   elementsPerLane <= accessWidth  AND
+///   accessWidth % elementsPerLane == 0.
+///
+/// Returns the offending segment's elementsPerLane on failure, std::nullopt
+/// on success.
+static std::optional<int64_t>
+findSwizzleIncompatibleSegment(ArrayRef<TransferSegment> segments,
+                               int64_t accessWidth) {
+  for (const TransferSegment &seg : segments) {
+    if (seg.elementsPerLane > accessWidth ||
+        accessWidth % seg.elementsPerLane != 0) {
+      return seg.elementsPerLane;
+    }
+  }
+  return std::nullopt;
+}
+
 /// Generates source and destination indices for a GatherToLDS operation.
 ///
 /// The gather_to_lds instruction requires:
@@ -312,6 +341,18 @@ struct LowerCoalescedGatherDMAPattern final
                  "of supported DMA transfer sizes");
     }
     SmallVector<TransferSegment> segments = std::move(*segmentsOrFailure);
+
+    if (destSwizzle) {
+      int64_t accessWidth = destSwizzle->getAccessElementCount();
+      if (std::optional<int64_t> badEpl =
+              findSwizzleIncompatibleSegment(segments, accessWidth)) {
+        return dmaOp.emitOpError()
+               << "DMA segment elementsPerLane=" << *badEpl
+               << " incompatible with swizzle access_width=" << accessWidth
+               << " (need elementsPerLane <= access_width and "
+                  "access_width % elementsPerLane == 0)";
+      }
+    }
 
     // OOB padding requires fat_raw_buffer for hardware OOB clamping.
     if (std::optional<ArrayAttr> inBounds = dmaOp.getInBounds()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -187,8 +187,10 @@ static std::optional<int64_t>
 findSwizzleIncompatibleSegment(ArrayRef<TransferSegment> segments,
                                int64_t accessWidth) {
   for (const TransferSegment &seg : segments) {
-    if (seg.elementsPerLane > accessWidth ||
-        accessWidth % seg.elementsPerLane != 0) {
+    // When elementsPerLane > accessWidth, accessWidth % elementsPerLane
+    // equals accessWidth (!= 0), so this single check covers both the
+    // "fits in one chunk" and "evenly divides" requirements.
+    if (accessWidth % seg.elementsPerLane != 0) {
       return seg.elementsPerLane;
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1701,3 +1701,46 @@ func.func @lower_dma_with_chained_view_ops(
   } {mapping = [#iree_gpu.lane_id<0>]}
   return
 }
+
+// -----
+
+// Test: DMA lowering rejects swizzles where elementsPerLane > access_width.
+// f32 source + dma_sizes=[128] -> 128/32 = 4 elements/lane.
+// access_width=2, so the per-lane DMA write would span two swizzle chunks.
+// Per spec: require elementsPerLane <= access_width AND
+// access_width % elementsPerLane == 0.
+
+#executable_target_rocm_hsaco_fb_bad_swizzle = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [],
+    subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [128]>>}>
+
+#translation_bad_swizzle = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+func.func @lower_dma_with_incompatible_swizzle(
+    %source: memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_bad_swizzle,
+    translation_info = #translation_bad_swizzle} {
+  %alloc = memref.alloc() : memref<512xf32, #gpu.address_space<workgroup>>
+  %swizzled = iree_codegen.swizzle_hint %alloc[#iree_codegen.xor_shuffle<128, 2>]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+  %dest = memref.expand_shape %swizzled [[0, 1]]
+      output_shape [4, 128]
+      : memref<512xf32, #gpu.address_space<workgroup>>
+      into memref<4x128xf32, #gpu.address_space<workgroup>>
+  scf.forall (%lane) in (64) {
+    // expected-error @+1 {{incompatible with swizzle access_width=2}}
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)
+        : memref<4x128xf32, #amdgpu.address_space<fat_raw_buffer>>,
+          memref<4x128xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#iree_gpu.lane_id<0>]}
+  return
+}


### PR DESCRIPTION
* When a `CoalescedGatherDMAOp`'s destination carries an XOR swizzle hint, the `gather_to_lds` lowering applies the inverse swizzle only to each lane's base offset.
* Per-lane contiguous reads of `elementsPerLane` elements must stay inside one `access_width`-sized swizzle chunk, requiring `elementsPerLane <= access_width` and `access_width % elementsPerLane == 0`.

This patch adds a guard for now to emit a clear op error when the selected DMA size violates the invariant, replacing the prior silent miscompile. Adds a negative lit test covering the error path; existing positive tests already cover compatible configs.