### PR TITLE
[Codegen][GPU] Guard multi-buffering behind pipelining pre-flight check

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1254,10 +1254,6 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
       LDBG() << "Async copy mode supports at most 3 stages, got " << numStages;
       return failure();
     }
-    // Apply multi-buffering: numStages buffers for N-stage pipelining
-    if (failed(multiBufferLDSAllocations(forOp, /*numBuffers=*/numStages))) {
-      return failure();
-    }
   } else {
     // Stream copy: no buffering, just validate numStages
     // No prefetching needed for single-stage pipelining.
@@ -1274,7 +1270,25 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
     }
   }
 
-  // Compute stage classification using the refactored approach
+  // Pre-flight: validate that pipelining will succeed before mutating the IR.
+  // computeStageClassification is pure analysis that checks loop iterations,
+  // identifies root operations, computes backward slices, and classifies
+  // operations into pipeline stages. If it fails, we bail out before
+  // multi-buffering touches the IR, preventing half-transformed state (e.g.,
+  // doubled LDS allocations with no actual pipelining).
+  if (failed(computeStageClassification(forOp, mode, numStages))) {
+    return forOp;
+  }
+
+  if (mode == PipelineMode::AsyncCopy) {
+    // Apply multi-buffering: numStages buffers for N-stage pipelining.
+    if (failed(multiBufferLDSAllocations(forOp, /*numBuffers=*/numStages))) {
+      return failure();
+    }
+  }
+
+  // Re-run classification on the (potentially multi-buffered) IR to capture
+  // any new operations introduced by multi-buffering in the schedule.
   auto stagesOr = computeStageClassification(forOp, mode, numStages);
   if (failed(stagesOr)) {
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -519,6 +519,58 @@ func.func @gather_to_lds_inside_if_not_multibuffered(
 
 // -----
 
+// Test: gather_to_lds with two operands where one is inside scf.if.
+// The scf.if blocks pipelining in async copy mode. The pre-flight guard
+// should skip both multi-buffering and pipelining, leaving the IR untouched.
+// CHECK-LABEL: @gather_to_lds_two_operands_one_predicated
+func.func @gather_to_lds_two_operands_one_predicated(
+    %A_global: memref<128x128xf32>,
+    %B_global: memref<128x128xf32>,
+    %output: memref<128xf32>,
+    %bound: index) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+
+  // No multi-buffering: both allocs stay as memref<1xf32, ...>.
+  // CHECK: memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+  // CHECK: memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+  // CHECK-NOT: memref<2x1xf32
+  %A_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+  %B_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+
+  // CHECK: scf.for
+  %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
+    // First DMA is unconditional.
+    // CHECK: amdgpu.gather_to_lds
+    amdgpu.gather_to_lds %A_global[%c0, %k], %A_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+
+    // Second DMA is predicated — blocks pipelining.
+    %in_bounds = arith.cmpi slt, %k, %bound : index
+    // CHECK: scf.if
+    // CHECK: amdgpu.gather_to_lds
+    scf.if %in_bounds {
+      amdgpu.gather_to_lds %B_global[%k, %c0], %B_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    }
+
+    // CHECK-NOT: rocdl.asyncmark
+    // CHECK-NOT: rocdl.wait.asyncmark
+    %a_val = vector.transfer_read %A_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %b_val = vector.transfer_read %B_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %prod = arith.mulf %a_val, %b_val : vector<1xf32>
+    %sum = arith.addf %prod, %acc : vector<1xf32>
+    // CHECK: scf.yield
+    scf.yield %sum : vector<1xf32>
+  }
+
+  vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  return
+}
+
+// -----
+
 // CHECK-ALL-LABEL: @gather_to_lds_mixed_with_stream_copy
 // CHECK-ALL-SAME: (%[[GLOBAL:.*]]: memref<128x128xf32>, %[[OUTPUT:.*]]: memref<128xf32>)
 func.func @gather_to_lds_mixed_with_stream_copy(


### PR DESCRIPTION
Move computeStageClassification before multiBufferLDSAllocations as a pre-flight validation. If stage classification fails (e.g. gather_to_lds inside scf.if, insufficient loop iterations), bail out before mutating the IR. This prevents doubled LDS allocations with no actual pipelining.

After multi-buffering succeeds, re-run classification on the mutated IR to capture the correct double buffered schedule.