### PR TITLE
[Codegen][GPU] Remove the single-iteration workaround and distribute pad-fused copies

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -455,9 +455,88 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
       }
 
       if (validPad) {
-        // Use pad.getSource() directly as the DMA source.
-        // This is the tensor.extract_slice result (e.g., tensor<?x64xf32>).
-        source = pad.getSource();
+        Value preSource = pad.getSource();
+
+        // Find the extract_slice closest to the pad output. This is the
+        // subgroup-level tiling's extract_slice, whose offsets tell us
+        // where this warp's tile starts within the padded tensor.
+        tensor::ExtractSliceOp tilingES;
+        {
+          Value trace = input;
+          while (auto es = trace.getDefiningOp<tensor::ExtractSliceOp>()) {
+            trace = es.getSource();
+            if (trace.getDefiningOp<tensor::PadOp>() == pad) {
+              tilingES = es;
+              break;
+            }
+          }
+        }
+
+        if (tilingES) {
+          // Subgroup tiling applied — create a sub-slice of the pre-pad
+          // source at the warp's tiling offset with sizes clamped to
+          // source bounds. Since pad has low=[0,0], the coordinate
+          // systems of the padded output and pre-pad source are aligned.
+          // The DMA's in_bounds attribute handles the case where the
+          // clamped source is smaller than the warp's init tile (the
+          // fat_raw_buffer returns zero for OOB reads).
+          rewriter.setInsertionPoint(inParallelOp);
+
+          SmallVector<OpFoldResult> warpOffsets = tilingES.getMixedOffsets();
+          SmallVector<OpFoldResult> warpSizes = tilingES.getMixedSizes();
+          auto preSourceType = cast<RankedTensorType>(preSource.getType());
+          int64_t rank = preSourceType.getRank();
+
+          SmallVector<OpFoldResult> subOffsets, subSizes, subStrides;
+          for (int64_t i = 0; i < rank; i++) {
+            subStrides.push_back(rewriter.getIndexAttr(1));
+
+            bool dimHasPadding =
+                !isConstantIntValue(pad.getMixedHighPad()[i], 0);
+
+            if (dimHasPadding) {
+              // Source may be smaller than the padded dimension. Clamp
+              // offset and size to stay within source bounds.
+              Value offsetVal = getValueOrCreateConstantIndexOp(rewriter, loc,
+                                                                warpOffsets[i]);
+              Value tileSizeVal =
+                  getValueOrCreateConstantIndexOp(rewriter, loc, warpSizes[i]);
+
+              int64_t staticDim = preSourceType.getShape()[i];
+              Value sourceDimSize;
+              if (ShapedType::isDynamic(staticDim)) {
+                sourceDimSize =
+                    tensor::DimOp::create(rewriter, loc, preSource, i);
+              } else {
+                sourceDimSize =
+                    arith::ConstantIndexOp::create(rewriter, loc, staticDim);
+              }
+
+              Value clampedOffset = arith::MinSIOp::create(
+                  rewriter, loc, offsetVal, sourceDimSize);
+              Value remaining = arith::SubIOp::create(
+                  rewriter, loc, sourceDimSize, clampedOffset);
+              Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+              Value clampedRemaining =
+                  arith::MaxSIOp::create(rewriter, loc, remaining, zero);
+              Value clampedSize = arith::MinSIOp::create(
+                  rewriter, loc, clampedRemaining, tileSizeVal);
+
+              subOffsets.push_back(clampedOffset);
+              subSizes.push_back(clampedSize);
+            } else {
+              subOffsets.push_back(warpOffsets[i]);
+              subSizes.push_back(warpSizes[i]);
+            }
+          }
+
+          source = tensor::ExtractSliceOp::create(
+              rewriter, loc, preSource, subOffsets, subSizes, subStrides);
+        } else {
+          // No subgroup tiling (single-warp case) — use full pre-pad
+          // source directly.
+          source = preSource;
+        }
 
         // Check if source tensor's innermost row size is DWORD (4-byte)
         // aligned. On AMD CDNA, per-component range checking is performed for
@@ -619,13 +698,24 @@ protected:
   }
 };
 
-/// Pattern to convert tensor.pad fusion cases directly without requiring
-/// warp-mapped forall parent.
+/// Fallback pattern to convert tensor.pad fusion cases directly without
+/// requiring warp-mapped forall parent. This handles edge cases where
+/// subgroup tiling was unable to distribute the pad-fused copy across warps
+/// (e.g., if computeSubgroupTileSizes fails). Copies that were already
+/// successfully distributed into warp-mapped foralls are handled by
+/// ConvertCopyToCoalescedDMA instead.
 struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
+    // Skip if already inside a warp-mapped forall — those are handled by
+    // ConvertCopyToCoalescedDMA with proper source offset propagation.
+    auto forallOp = copyOp->getParentOfType<scf::ForallOp>();
+    if (hasWarpMapping(forallOp)) {
+      return failure();
+    }
+
     // Only match copies with use_global_load_dma config.
     auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp);
     if (!config) {
@@ -1054,44 +1144,13 @@ private:
       return failure();
     }
 
-    // Check if this is a tensor.pad fusion case.
-    bool isPadFusion = false;
-    if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
-      if (tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0])) {
-        // Check if padding exists (non-zero low/high pad).
-        for (auto [low, high] :
-             llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
-          if (!isConstantIntValue(low, 0) || !isConstantIntValue(high, 0)) {
-            isPadFusion = true;
-            break;
-          }
-        }
-      }
-    }
-
     SmallVector<OpFoldResult> tileSizes;
     int64_t numTiledDims = 0;
 
-    if (isPadFusion) {
-      // TODO(#23365): Tile to subgroups for pad fusion by propagating source
-      // offsets through tiling. Currently, after subgroup tiling each warp's
-      // DMA gets the full pre-pad source but a sub-tiled init, and the DMA
-      // lowering has no way to offset into the source. This requires adding
-      // source offset support to CoalescedGatherDMAOp. For now, create a
-      // single-iteration wrapper forall so the DMA sees the full buffer.
-      // Bail out if any dimension is dynamic since we need static tile sizes.
-      if (llvm::any_of(shape, ShapedType::isDynamic)) {
-        return failure();
-      }
-      for (int64_t i = 0; i < rank; ++i) {
-        tileSizes.push_back(rewriter.getIndexAttr(shape[i]));
-        ++numTiledDims;
-      }
-    } else {
-      // Compute tile sizes for subgroup-level distribution.
-      std::tie(tileSizes, numTiledDims) =
-          computeSubgroupTileSizes(rewriter, shape, numWarps);
-    }
+    // Distribute across subgroups (warps) for both pad fusion and non-pad
+    // cases.
+    std::tie(tileSizes, numTiledDims) =
+        computeSubgroupTileSizes(rewriter, shape, numWarps);
 
     if (numTiledDims == 0) {
       return failure();
@@ -1143,10 +1202,9 @@ private:
       }
     });
 
-    // Apply subgroup-level tiling to each op.
-    // For tensor.pad fusion cases, tileAtSubgroupLevel creates a
-    // single-iteration wrapper forall to maintain the expected structure while
-    // allowing the DMA to operate on the full buffer.
+    // Apply subgroup-level tiling to each op. If tiling fails (e.g., dynamic
+    // shapes, alignment mismatch), the op is left untiled and handled by the
+    // fallback pattern ConvertPadFusionCopyToCoalescedDMA in Phase 2.
     IRRewriter rewriter(context);
     for (Operation *op : opsToTile) {
       FailureOr<scf::SCFTilingResult> tilingResult =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -448,6 +448,84 @@ tileToThreadLevel(OpTy op, PatternRewriter &rewriter,
   return threadForallOp;
 }
 
+/// Create a sub-slice from the pre-pad source that corresponds to the tiled
+/// view of the padded tensor. Sizes on padded dims are clamped to source
+/// bounds; the DMA in_bounds attribute handles zero-fill for the remaining
+/// padded area.
+static Value createClampedSourceSliceFromPad(PatternRewriter &rewriter,
+                                             Location loc, tensor::PadOp pad,
+                                             scf::InParallelOp inParallelOp) {
+  Value preSource = pad.getSource();
+
+  // The per-tile view of the padded tensor is the (single) extract_slice user
+  // of the pad, created either by `tileAtSubgroupLevel` (warp tile) or by
+  // `tileToThreadLevel` in the `ConvertPadFusionCopyToCoalescedDMA` fallback
+  // (thread tile). Either way, after tiling the copy's input always traces
+  // through this slice, so it must exist.
+  tensor::ExtractSliceOp tilingES;
+  for (Operation *user : pad->getUsers()) {
+    if (auto es = dyn_cast<tensor::ExtractSliceOp>(user)) {
+      tilingES = es;
+      break;
+    }
+  }
+  assert(tilingES && "pad output must have an extract_slice user after tiling");
+
+  // Build a sub-slice of the pre-pad source at this tile's offset, with sizes
+  // clamped to source bounds on padded dims. Pad uses low=[0,...], so padded
+  // and pre-pad coordinates align.
+  rewriter.setInsertionPoint(inParallelOp);
+
+  SmallVector<OpFoldResult> warpOffsets = tilingES.getMixedOffsets();
+  SmallVector<OpFoldResult> warpSizes = tilingES.getMixedSizes();
+  auto preSourceType = cast<RankedTensorType>(preSource.getType());
+  int64_t rank = preSourceType.getRank();
+
+  SmallVector<OpFoldResult> subOffsets, subSizes, subStrides;
+  for (int64_t i = 0; i < rank; i++) {
+    subStrides.push_back(rewriter.getIndexAttr(1));
+
+    bool dimHasPadding = !isConstantIntValue(pad.getMixedHighPad()[i], 0);
+    if (!dimHasPadding) {
+      subOffsets.push_back(warpOffsets[i]);
+      subSizes.push_back(warpSizes[i]);
+      continue;
+    }
+
+    // Source may be smaller than the padded dimension. Clamp offset and size to
+    // stay within source bounds.
+    Value offsetVal =
+        getValueOrCreateConstantIndexOp(rewriter, loc, warpOffsets[i]);
+    Value tileSizeVal =
+        getValueOrCreateConstantIndexOp(rewriter, loc, warpSizes[i]);
+
+    int64_t staticDim = preSourceType.getShape()[i];
+    Value sourceDimSize;
+    if (ShapedType::isDynamic(staticDim)) {
+      sourceDimSize = tensor::DimOp::create(rewriter, loc, preSource, i);
+    } else {
+      sourceDimSize = arith::ConstantIndexOp::create(rewriter, loc, staticDim);
+    }
+
+    Value clampedOffset =
+        arith::MinSIOp::create(rewriter, loc, offsetVal, sourceDimSize);
+    Value remaining =
+        arith::SubIOp::create(rewriter, loc, sourceDimSize, clampedOffset);
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value clampedRemaining =
+        arith::MaxSIOp::create(rewriter, loc, remaining, zero);
+    Value clampedSize =
+        arith::MinSIOp::create(rewriter, loc, clampedRemaining, tileSizeVal);
+
+    subOffsets.push_back(clampedOffset);
+    subSizes.push_back(clampedSize);
+  }
+
+  auto sourceSlice = tensor::ExtractSliceOp::create(
+      rewriter, loc, preSource, subOffsets, subSizes, subStrides);
+  return sourceSlice.getResult();
+}
+
 /// Create a coalesced DMA operation in the in_parallel region.
 /// Handles both copy and gather operations.
 template <typename OpTy>
@@ -493,78 +571,8 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     // We need to trace through extract_slice to find if source is tensor.pad.
     tensor::PadOp pad = traceToTensorPad(input);
     if (pad && isValidPadForDMA(pad)) {
-      Value preSource = pad.getSource();
-
-      // The per-tile view of the padded tensor is the (single) extract_slice
-      // user of the pad — created by `tileAtSubgroupLevel` (warp tile) or by
-      // `tileToThreadLevel` in the `ConvertPadFusionCopyToCoalescedDMA`
-      // fallback (thread tile). Either way, after tiling the copy's input
-      // always traces through this slice, so it must exist.
-      tensor::ExtractSliceOp tilingES;
-      for (Operation *user : pad->getUsers()) {
-        if (auto es = dyn_cast<tensor::ExtractSliceOp>(user)) {
-          tilingES = es;
-          break;
-        }
-      }
-      assert(tilingES &&
-             "pad output must have an extract_slice user after tiling");
-
-      // Build a sub-slice of the pre-pad source at this tile's offset, with
-      // sizes clamped to source bounds on padded dims. Pad uses low=[0,...]
-      // so padded and pre-pad coordinates align. The DMA's in_bounds attr
-      // handles the case where the clamped source is smaller than the init
-      // tile (fat_raw_buffer returns zero for OOB reads).
-      rewriter.setInsertionPoint(inParallelOp);
-
-      SmallVector<OpFoldResult> warpOffsets = tilingES.getMixedOffsets();
-      SmallVector<OpFoldResult> warpSizes = tilingES.getMixedSizes();
-      auto preSourceType = cast<RankedTensorType>(preSource.getType());
-      int64_t rank = preSourceType.getRank();
-
-      SmallVector<OpFoldResult> subOffsets, subSizes, subStrides;
-      for (int64_t i = 0; i < rank; i++) {
-        subStrides.push_back(rewriter.getIndexAttr(1));
-
-        bool dimHasPadding = !isConstantIntValue(pad.getMixedHighPad()[i], 0);
-
-        if (dimHasPadding) {
-          // Source may be smaller than the padded dimension. Clamp offset
-          // and size to stay within source bounds.
-          Value offsetVal =
-              getValueOrCreateConstantIndexOp(rewriter, loc, warpOffsets[i]);
-          Value tileSizeVal =
-              getValueOrCreateConstantIndexOp(rewriter, loc, warpSizes[i]);
-
-          int64_t staticDim = preSourceType.getShape()[i];
-          Value sourceDimSize;
-          if (ShapedType::isDynamic(staticDim)) {
-            sourceDimSize = tensor::DimOp::create(rewriter, loc, preSource, i);
-          } else {
-            sourceDimSize =
-                arith::ConstantIndexOp::create(rewriter, loc, staticDim);
-          }
-
-          Value clampedOffset =
-              arith::MinSIOp::create(rewriter, loc, offsetVal, sourceDimSize);
-          Value remaining = arith::SubIOp::create(rewriter, loc, sourceDimSize,
-                                                  clampedOffset);
-          Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-          Value clampedRemaining =
-              arith::MaxSIOp::create(rewriter, loc, remaining, zero);
-          Value clampedSize = arith::MinSIOp::create(
-              rewriter, loc, clampedRemaining, tileSizeVal);
-
-          subOffsets.push_back(clampedOffset);
-          subSizes.push_back(clampedSize);
-        } else {
-          subOffsets.push_back(warpOffsets[i]);
-          subSizes.push_back(warpSizes[i]);
-        }
-      }
-
-      source = tensor::ExtractSliceOp::create(rewriter, loc, preSource,
-                                              subOffsets, subSizes, subStrides);
+      source =
+          createClampedSourceSliceFromPad(rewriter, loc, pad, inParallelOp);
 
       // Compute in_bounds based on whether padding was added per dimension.
       for (auto [low, high] :

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -473,7 +473,88 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     // We need to trace through extract_slice to find if source is tensor.pad.
     tensor::PadOp pad = traceToTensorPad(input);
     if (pad && isValidPadForDMA(pad)) {
-      source = pad.getSource();
+      Value preSource = pad.getSource();
+
+      // Find the extract_slice closest to the pad output. This is the
+      // subgroup-level tiling's extract_slice, whose offsets tell us where
+      // this warp's tile starts within the padded tensor.
+      tensor::ExtractSliceOp tilingES;
+      {
+        Value trace = input;
+        while (auto es = trace.getDefiningOp<tensor::ExtractSliceOp>()) {
+          trace = es.getSource();
+          if (trace.getDefiningOp<tensor::PadOp>() == pad) {
+            tilingES = es;
+            break;
+          }
+        }
+      }
+
+      if (tilingES) {
+        // Subgroup tiling applied — create a sub-slice of the pre-pad source
+        // at the warp's tiling offset with sizes clamped to source bounds.
+        // Since pad has low=[0,0], the coordinate systems of the padded
+        // output and pre-pad source are aligned.  The DMA's in_bounds
+        // attribute handles the case where the clamped source is smaller
+        // than the warp's init tile (the fat_raw_buffer returns zero for OOB
+        // reads).
+        rewriter.setInsertionPoint(inParallelOp);
+
+        SmallVector<OpFoldResult> warpOffsets = tilingES.getMixedOffsets();
+        SmallVector<OpFoldResult> warpSizes = tilingES.getMixedSizes();
+        auto preSourceType = cast<RankedTensorType>(preSource.getType());
+        int64_t rank = preSourceType.getRank();
+
+        SmallVector<OpFoldResult> subOffsets, subSizes, subStrides;
+        for (int64_t i = 0; i < rank; i++) {
+          subStrides.push_back(rewriter.getIndexAttr(1));
+
+          bool dimHasPadding = !isConstantIntValue(pad.getMixedHighPad()[i], 0);
+
+          if (dimHasPadding) {
+            // Source may be smaller than the padded dimension. Clamp offset
+            // and size to stay within source bounds.
+            Value offsetVal =
+                getValueOrCreateConstantIndexOp(rewriter, loc, warpOffsets[i]);
+            Value tileSizeVal =
+                getValueOrCreateConstantIndexOp(rewriter, loc, warpSizes[i]);
+
+            int64_t staticDim = preSourceType.getShape()[i];
+            Value sourceDimSize;
+            if (ShapedType::isDynamic(staticDim)) {
+              sourceDimSize =
+                  tensor::DimOp::create(rewriter, loc, preSource, i);
+            } else {
+              sourceDimSize =
+                  arith::ConstantIndexOp::create(rewriter, loc, staticDim);
+            }
+
+            Value clampedOffset =
+                arith::MinSIOp::create(rewriter, loc, offsetVal, sourceDimSize);
+            Value remaining = arith::SubIOp::create(
+                rewriter, loc, sourceDimSize, clampedOffset);
+            Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+            Value clampedRemaining =
+                arith::MaxSIOp::create(rewriter, loc, remaining, zero);
+            Value clampedSize = arith::MinSIOp::create(
+                rewriter, loc, clampedRemaining, tileSizeVal);
+
+            subOffsets.push_back(clampedOffset);
+            subSizes.push_back(clampedSize);
+          } else {
+            subOffsets.push_back(warpOffsets[i]);
+            subSizes.push_back(warpSizes[i]);
+          }
+        }
+
+        source = tensor::ExtractSliceOp::create(
+            rewriter, loc, preSource, subOffsets, subSizes, subStrides);
+      } else {
+        // No subgroup tiling (single-warp case) — use full pre-pad source
+        // directly.
+        source = preSource;
+      }
+
       // Compute in_bounds based on whether padding was added per dimension.
       for (auto [low, high] :
            llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
@@ -623,13 +704,24 @@ protected:
   }
 };
 
-/// Pattern to convert tensor.pad fusion cases directly without requiring
-/// warp-mapped forall parent.
+/// Fallback pattern to convert tensor.pad fusion cases directly without
+/// requiring warp-mapped forall parent. This handles edge cases where
+/// subgroup tiling was unable to distribute the pad-fused copy across warps
+/// (e.g., if computeSubgroupTileSizes fails). Copies that were already
+/// successfully distributed into warp-mapped foralls are handled by
+/// ConvertCopyToCoalescedDMA instead.
 struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
+    // Skip if already inside a warp-mapped forall — those are handled by
+    // ConvertCopyToCoalescedDMA with proper source offset propagation.
+    auto forallOp = copyOp->getParentOfType<scf::ForallOp>();
+    if (hasWarpMapping(forallOp)) {
+      return failure();
+    }
+
     // Only match copies with use_global_load_dma config.
     auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp);
     if (!config) {
@@ -1066,44 +1158,13 @@ private:
       return failure();
     }
 
-    // Check if this is a tensor.pad fusion case.
-    bool isPadFusion = false;
-    if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
-      if (tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0])) {
-        // Check if padding exists (non-zero low/high pad).
-        for (auto [low, high] :
-             llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
-          if (!isConstantIntValue(low, 0) || !isConstantIntValue(high, 0)) {
-            isPadFusion = true;
-            break;
-          }
-        }
-      }
-    }
-
     SmallVector<OpFoldResult> tileSizes;
     int64_t numTiledDims = 0;
 
-    if (isPadFusion) {
-      // TODO(#23365): Tile to subgroups for pad fusion by propagating source
-      // offsets through tiling. Currently, after subgroup tiling each warp's
-      // DMA gets the full pre-pad source but a sub-tiled init, and the DMA
-      // lowering has no way to offset into the source. This requires adding
-      // source offset support to CoalescedGatherDMAOp. For now, create a
-      // single-iteration wrapper forall so the DMA sees the full buffer.
-      // Bail out if any dimension is dynamic since we need static tile sizes.
-      if (llvm::any_of(shape, ShapedType::isDynamic)) {
-        return failure();
-      }
-      for (int64_t i = 0; i < rank; ++i) {
-        tileSizes.push_back(rewriter.getIndexAttr(shape[i]));
-        ++numTiledDims;
-      }
-    } else {
-      // Compute tile sizes for subgroup-level distribution.
-      std::tie(tileSizes, numTiledDims) =
-          computeSubgroupTileSizes(rewriter, shape, numWarps);
-    }
+    // Distribute across subgroups (warps) for both pad fusion and non-pad
+    // cases.
+    std::tie(tileSizes, numTiledDims) =
+        computeSubgroupTileSizes(rewriter, shape, numWarps);
 
     if (numTiledDims == 0) {
       return failure();
@@ -1155,10 +1216,9 @@ private:
       }
     });
 
-    // Apply subgroup-level tiling to each op.
-    // For tensor.pad fusion cases, tileAtSubgroupLevel creates a
-    // single-iteration wrapper forall to maintain the expected structure while
-    // allowing the DMA to operate on the full buffer.
+    // Apply subgroup-level tiling to each op. If tiling fails (e.g., dynamic
+    // shapes, alignment mismatch), the op is left untiled and handled by the
+    // fallback pattern ConvertPadFusionCopyToCoalescedDMA in Phase 2.
     IRRewriter rewriter(context);
     for (Operation *op : opsToTile) {
       FailureOr<scf::SCFTilingResult> tilingResult =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -229,6 +229,26 @@ getDMAAlignedSubgroupSize(FunctionOpInterface funcOp, Type elementType,
   return subgroupSize;
 }
 
+/// Largest numWarps in [1, totalWarps] (by repeated halving) such that
+/// `product(shape) / numWarps` satisfies the minimum DMA transfer alignment.
+/// Conservative for shapes that don't divide evenly (the real greedy in
+/// `computeSubgroupTileSizes` can sometimes pack more warps than this), but
+/// always safe. Returns 0 only if even numWarps==1 fails — the pre-check in
+/// `isCopyDMAConvertible` rejects such copies, so callers assert on 0.
+static int64_t computeMaxFeasibleNumWarps(ArrayRef<int64_t> shape,
+                                          int64_t totalWarps,
+                                          int64_t minElementsPerTransfer) {
+  int64_t totalElements = ShapedType::getNumElements(shape);
+  for (int64_t n = std::max<int64_t>(totalWarps, 1); n >= 1; n /= 2) {
+    int64_t perWarp = totalElements / n;
+    if (perWarp >= minElementsPerTransfer &&
+        perWarp % minElementsPerTransfer == 0) {
+      return n;
+    }
+  }
+  return 0;
+}
+
 /// Helper to compute thread number of threads based on translation_info.
 /// Uses the subgroup_size from translation_info for thread-level tiling.
 static SmallVector<OpFoldResult>
@@ -475,85 +495,76 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     if (pad && isValidPadForDMA(pad)) {
       Value preSource = pad.getSource();
 
-      // Find the extract_slice closest to the pad output. This is the
-      // subgroup-level tiling's extract_slice, whose offsets tell us where
-      // this warp's tile starts within the padded tensor.
+      // The per-tile view of the padded tensor is the (single) extract_slice
+      // user of the pad — created by `tileAtSubgroupLevel` (warp tile) or by
+      // `tileToThreadLevel` in the `ConvertPadFusionCopyToCoalescedDMA`
+      // fallback (thread tile). Either way, after tiling the copy's input
+      // always traces through this slice, so it must exist.
       tensor::ExtractSliceOp tilingES;
-      {
-        Value trace = input;
-        while (auto es = trace.getDefiningOp<tensor::ExtractSliceOp>()) {
-          trace = es.getSource();
-          if (trace.getDefiningOp<tensor::PadOp>() == pad) {
-            tilingES = es;
-            break;
-          }
+      for (Operation *user : pad->getUsers()) {
+        if (auto es = dyn_cast<tensor::ExtractSliceOp>(user)) {
+          tilingES = es;
+          break;
         }
       }
+      assert(tilingES &&
+             "pad output must have an extract_slice user after tiling");
 
-      if (tilingES) {
-        // Subgroup tiling applied — create a sub-slice of the pre-pad source
-        // at the warp's tiling offset with sizes clamped to source bounds.
-        // Since pad has low=[0,0], the coordinate systems of the padded
-        // output and pre-pad source are aligned.  The DMA's in_bounds
-        // attribute handles the case where the clamped source is smaller
-        // than the warp's init tile (the fat_raw_buffer returns zero for OOB
-        // reads).
-        rewriter.setInsertionPoint(inParallelOp);
+      // Build a sub-slice of the pre-pad source at this tile's offset, with
+      // sizes clamped to source bounds on padded dims. Pad uses low=[0,...]
+      // so padded and pre-pad coordinates align. The DMA's in_bounds attr
+      // handles the case where the clamped source is smaller than the init
+      // tile (fat_raw_buffer returns zero for OOB reads).
+      rewriter.setInsertionPoint(inParallelOp);
 
-        SmallVector<OpFoldResult> warpOffsets = tilingES.getMixedOffsets();
-        SmallVector<OpFoldResult> warpSizes = tilingES.getMixedSizes();
-        auto preSourceType = cast<RankedTensorType>(preSource.getType());
-        int64_t rank = preSourceType.getRank();
+      SmallVector<OpFoldResult> warpOffsets = tilingES.getMixedOffsets();
+      SmallVector<OpFoldResult> warpSizes = tilingES.getMixedSizes();
+      auto preSourceType = cast<RankedTensorType>(preSource.getType());
+      int64_t rank = preSourceType.getRank();
 
-        SmallVector<OpFoldResult> subOffsets, subSizes, subStrides;
-        for (int64_t i = 0; i < rank; i++) {
-          subStrides.push_back(rewriter.getIndexAttr(1));
+      SmallVector<OpFoldResult> subOffsets, subSizes, subStrides;
+      for (int64_t i = 0; i < rank; i++) {
+        subStrides.push_back(rewriter.getIndexAttr(1));
 
-          bool dimHasPadding = !isConstantIntValue(pad.getMixedHighPad()[i], 0);
+        bool dimHasPadding = !isConstantIntValue(pad.getMixedHighPad()[i], 0);
 
-          if (dimHasPadding) {
-            // Source may be smaller than the padded dimension. Clamp offset
-            // and size to stay within source bounds.
-            Value offsetVal =
-                getValueOrCreateConstantIndexOp(rewriter, loc, warpOffsets[i]);
-            Value tileSizeVal =
-                getValueOrCreateConstantIndexOp(rewriter, loc, warpSizes[i]);
+        if (dimHasPadding) {
+          // Source may be smaller than the padded dimension. Clamp offset
+          // and size to stay within source bounds.
+          Value offsetVal =
+              getValueOrCreateConstantIndexOp(rewriter, loc, warpOffsets[i]);
+          Value tileSizeVal =
+              getValueOrCreateConstantIndexOp(rewriter, loc, warpSizes[i]);
 
-            int64_t staticDim = preSourceType.getShape()[i];
-            Value sourceDimSize;
-            if (ShapedType::isDynamic(staticDim)) {
-              sourceDimSize =
-                  tensor::DimOp::create(rewriter, loc, preSource, i);
-            } else {
-              sourceDimSize =
-                  arith::ConstantIndexOp::create(rewriter, loc, staticDim);
-            }
-
-            Value clampedOffset =
-                arith::MinSIOp::create(rewriter, loc, offsetVal, sourceDimSize);
-            Value remaining = arith::SubIOp::create(
-                rewriter, loc, sourceDimSize, clampedOffset);
-            Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-            Value clampedRemaining =
-                arith::MaxSIOp::create(rewriter, loc, remaining, zero);
-            Value clampedSize = arith::MinSIOp::create(
-                rewriter, loc, clampedRemaining, tileSizeVal);
-
-            subOffsets.push_back(clampedOffset);
-            subSizes.push_back(clampedSize);
+          int64_t staticDim = preSourceType.getShape()[i];
+          Value sourceDimSize;
+          if (ShapedType::isDynamic(staticDim)) {
+            sourceDimSize = tensor::DimOp::create(rewriter, loc, preSource, i);
           } else {
-            subOffsets.push_back(warpOffsets[i]);
-            subSizes.push_back(warpSizes[i]);
+            sourceDimSize =
+                arith::ConstantIndexOp::create(rewriter, loc, staticDim);
           }
-        }
 
-        source = tensor::ExtractSliceOp::create(
-            rewriter, loc, preSource, subOffsets, subSizes, subStrides);
-      } else {
-        // No subgroup tiling (single-warp case) — use full pre-pad source
-        // directly.
-        source = preSource;
+          Value clampedOffset =
+              arith::MinSIOp::create(rewriter, loc, offsetVal, sourceDimSize);
+          Value remaining = arith::SubIOp::create(rewriter, loc, sourceDimSize,
+                                                  clampedOffset);
+          Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+          Value clampedRemaining =
+              arith::MaxSIOp::create(rewriter, loc, remaining, zero);
+          Value clampedSize = arith::MinSIOp::create(
+              rewriter, loc, clampedRemaining, tileSizeVal);
+
+          subOffsets.push_back(clampedOffset);
+          subSizes.push_back(clampedSize);
+        } else {
+          subOffsets.push_back(warpOffsets[i]);
+          subSizes.push_back(warpSizes[i]);
+        }
       }
+
+      source = tensor::ExtractSliceOp::create(rewriter, loc, preSource,
+                                              subOffsets, subSizes, subStrides);
 
       // Compute in_bounds based on whether padding was added per dimension.
       for (auto [low, high] :
@@ -1143,11 +1154,13 @@ private:
     // For CopyOp with output tracing to tensor.empty() (possibly through
     // swizzle promotion ops), we can linearize all dimensions.
     int64_t availableElements = innermostDim;
+    bool linearizedAvailability = false;
     if (auto copyOp = dyn_cast<linalg::CopyOp>(op.getOperation())) {
       Value output = copyOp.getOutputs()[0];
       if (tracesToTensorEmpty(output) &&
           llvm::none_of(shape, ShapedType::isDynamic)) {
         availableElements = ShapedType::getNumElements(shape);
+        linearizedAvailability = true;
       }
     }
 
@@ -1158,13 +1171,34 @@ private:
       return failure();
     }
 
+    // In the linearized-availability case the per-warp tile shrinks with more
+    // warps and can fall below the minimum DMA transfer, leaving an orphan
+    // `linalg.copy {use_global_load_dma}` inside a warp-mapped forall
+    // (issue #24139). Halve `totalWarps` until each warp's tile is aligned.
+    SmallVector<int64_t> effectiveNumWarps = numWarps;
+    int64_t feasibleNumWarps = 0;
+    if (linearizedAvailability) {
+      auto positiveWarps =
+          llvm::make_filter_range(numWarps, [](int64_t n) { return n > 0; });
+      int64_t totalWarps = llvm::product_of(positiveWarps);
+      feasibleNumWarps =
+          computeMaxFeasibleNumWarps(shape, totalWarps, minElementsPerTransfer);
+      // The whole-tile alignment check in isCopyDMAConvertible is exactly the
+      // numWarps==1 feasibility check, so reaching here with feasible==0
+      // means the pre-check is out of sync with this distribution policy.
+      assert(feasibleNumWarps >= 1 &&
+             "DMA pre-check should have rejected this copy: even a single "
+             "warp cannot satisfy the minimum DMA transfer alignment");
+      effectiveNumWarps = {feasibleNumWarps};
+    }
+
     SmallVector<OpFoldResult> tileSizes;
     int64_t numTiledDims = 0;
 
     // Distribute across subgroups (warps) for both pad fusion and non-pad
     // cases.
     std::tie(tileSizes, numTiledDims) =
-        computeSubgroupTileSizes(rewriter, shape, numWarps);
+        computeSubgroupTileSizes(rewriter, shape, effectiveNumWarps);
 
     if (numTiledDims == 0) {
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -483,14 +483,15 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
     ins(%padded : tensor<4x64xf32>)
     outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
 
-  // Key check: tensor.pad is fused - source is the extract_slice result, not the padded tensor.
-  // in_bounds = [false, true] because M dim has dynamic padding, K dim has no padding.
-  // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
-  // CHECK: scf.forall {{.*}} shared_outs(%[[OUTER_INIT:.+]] = %[[INIT]])
-  // CHECK:   scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[OUTER_INIT]])
+  // Key check: tensor.pad is fused. The DMA source is a clamped sub-slice of
+  // the pre-pad source. in_bounds = [false, true] because M dim has padding.
+  // CHECK-DAG: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
+  // CHECK: scf.forall
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK:     arith.minsi
+  // CHECK:     %[[WARP_SRC:.+]] = tensor.extract_slice %[[EXTRACTED]]
   // CHECK:     scf.forall.in_parallel {
-  // CHECK:       iree_gpu.coalesced_gather_dma %[[EXTRACTED]] into %[[INNER_INIT]] lane(%[[LANE]]) in_bounds [false, true]
-  // CHECK-SAME:     : tensor<?x64xf32>, tensor<4x64xf32>, index
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[WARP_SRC]] into {{.*}} lane(%[[LANE]]) in_bounds [false, true]
   // CHECK:     }
   // CHECK-NOT: tensor.pad
 
@@ -499,10 +500,9 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
 
 // -----
 
-// Test: tensor.pad fusion with multiple warps creates single-iteration wrapper forall.
-// When tensor.pad is fused, subgroup-level tiling is skipped to ensure the DMA
-// operates on the full padded buffer shape, not on smaller subviews.
-// This is critical for correct delinearization in the lowering pass.
+// Test: tensor.pad fusion with multiple warps distributes across warps.
+// With 4 warps and shape 4x64, the outer dimension is tiled with step=1 across
+// 4 warps. Each warp gets a clamped sub-slice of the pre-pad source.
 
 #gpu_target_pad_multi_warp = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
@@ -536,31 +536,74 @@ func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %
     ins(%padded : tensor<4x64xf32>)
     outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
 
-  // Key check: With 4 warps available, normal tiling would create a warp-level
-  // forall with step (1, 64) producing 4 iterations with 1x64 subviews.
-  // For tensor.pad fusion, we instead create a single-iteration wrapper forall
-  // with step (4, 64) - the full shape - so the DMA operates on 4x64 directly.
-  // After canonicalization, identity extract_slices are eliminated.
+  // Key check: 4 warps distribute dimension 0 with step=1 (4 iterations).
+  // Each warp's DMA source is a clamped sub-slice of the pre-pad source.
   //
-  // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
-  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (4, 64) step (4, 64)
-  // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<4x64xf32>) {
+  // CHECK-DAG: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
+  // CHECK: scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (4, 64) step (1, 64)
+  // CHECK-SAME: shared_outs({{.*}} = %[[INIT]]) -> (tensor<4x64xf32>) {
   //
-  // Thread-level forall with 64 lanes (uses outer forall's shared_out directly):
-  // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[INIT_TILE]])
+  // Thread-level forall with clamped source and DMA:
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK:     %[[CLAMPED_OFF:.+]] = arith.minsi %[[IV0]]
+  // CHECK:     %[[WARP_SRC:.+]] = tensor.extract_slice %[[EXTRACTED]][%[[CLAMPED_OFF]], 0]
   // CHECK:     scf.forall.in_parallel {
-  // CHECK:       iree_gpu.coalesced_gather_dma %[[EXTRACTED]] into %[[INNER_INIT]] lane(%[[LANE]]) in_bounds [false, true]
-  // CHECK-SAME:     : tensor<?x64xf32>, tensor<4x64xf32>, index
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[WARP_SRC]] into {{.*}} lane(%[[LANE]]) in_bounds [false, true]
   // CHECK:     }
   // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
   //
-  // CHECK:   scf.forall.in_parallel {
-  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][0, 0] [4, 64] [1, 1]
-  // CHECK:   }
   // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
   // CHECK-NOT: tensor.pad
 
   return %result : tensor<4x64xf32>
+}
+
+// -----
+
+// Test: tensor.pad fusion with padding on both dimensions (in_bounds [false, false]).
+// A larger tile (32x128) with 4 warps: dim 0 is tiled across warps.
+// Both dimensions have padding, so both get clamping and in_bounds=false.
+
+#gpu_target_pad_both_dims = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_pad_both_dims = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_both_dims}>
+#translation_pad_both_dims = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_with_tensor_pad_both_dims
+func.func @copy_with_tensor_pad_both_dims(%source: tensor<500x500xf32>, %init: tensor<32x128xf32>, %off0: index, %off1: index, %sz0: index, %sz1: index, %high0: index, %high1: index) -> tensor<32x128xf32>
+  attributes {hal.executable.target = #exec_target_pad_both_dims, translation_info = #translation_pad_both_dims} {
+  %extracted = tensor.extract_slice %source[%off0, %off1] [%sz0, %sz1] [1, 1]
+      : tensor<500x500xf32> to tensor<?x?xf32>
+
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %extracted low[0, 0] high[%high0, %high1] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : f32
+  } : tensor<?x?xf32> to tensor<32x128xf32>
+
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<32x128xf32>)
+    outs(%init : tensor<32x128xf32>) -> tensor<32x128xf32>
+
+  // 4 warps, 32x128 tile. dim 0: tiled to step=8, dim 1: kept whole (128).
+  // Both dims have padding → in_bounds = [false, false].
+  // CHECK: scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (32, 128) step (8, 128)
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK:     arith.minsi
+  // CHECK:     tensor.extract_slice
+  // CHECK:     scf.forall.in_parallel {
+  // CHECK:       iree_gpu.coalesced_gather_dma {{.*}} in_bounds [false, false]
+  // CHECK:     }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  // CHECK-NOT: tensor.pad
+
+  return %result : tensor<32x128xf32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -483,14 +483,15 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
     ins(%padded : tensor<4x64xf32>)
     outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
 
-  // Key check: tensor.pad is fused - source is the extract_slice result, not the padded tensor.
-  // in_bounds = [false, true] because M dim has dynamic padding, K dim has no padding.
-  // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
-  // CHECK: scf.forall {{.*}} shared_outs(%[[OUTER_INIT:.+]] = %[[INIT]])
-  // CHECK:   scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[OUTER_INIT]])
+  // Key check: tensor.pad is fused. The DMA source is a clamped sub-slice of
+  // the pre-pad source. in_bounds = [false, true] because M dim has padding.
+  // CHECK-DAG: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
+  // CHECK: scf.forall
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK:     arith.minsi
+  // CHECK:     %[[WARP_SRC:.+]] = tensor.extract_slice %[[EXTRACTED]]
   // CHECK:     scf.forall.in_parallel {
-  // CHECK:       iree_gpu.coalesced_gather_dma %[[EXTRACTED]] into %[[INNER_INIT]] lane(%[[LANE]]) in_bounds [false, true]
-  // CHECK-SAME:     : tensor<?x64xf32>, tensor<4x64xf32>, index
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[WARP_SRC]] into {{.*}} lane(%[[LANE]]) in_bounds [false, true]
   // CHECK:     }
   // CHECK-NOT: tensor.pad
 
@@ -499,10 +500,9 @@ func.func @copy_with_tensor_pad_fusion(%source: tensor<121x64xf32>, %init: tenso
 
 // -----
 
-// Test: tensor.pad fusion with multiple warps creates single-iteration wrapper forall.
-// When tensor.pad is fused, subgroup-level tiling is skipped to ensure the DMA
-// operates on the full padded buffer shape, not on smaller subviews.
-// This is critical for correct delinearization in the lowering pass.
+// Test: tensor.pad fusion with multiple warps distributes across warps.
+// With 4 warps and shape 4x64, the outer dimension is tiled with step=1 across
+// 4 warps. Each warp gets a clamped sub-slice of the pre-pad source.
 
 #gpu_target_pad_multi_warp = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
@@ -536,31 +536,77 @@ func.func @copy_with_tensor_pad_fusion_multi_warp(%source: tensor<121x64xf32>, %
     ins(%padded : tensor<4x64xf32>)
     outs(%init : tensor<4x64xf32>) -> tensor<4x64xf32>
 
-  // Key check: With 4 warps available, normal tiling would create a warp-level
-  // forall with step (1, 64) producing 4 iterations with 1x64 subviews.
-  // For tensor.pad fusion, we instead create a single-iteration wrapper forall
-  // with step (4, 64) - the full shape - so the DMA operates on 4x64 directly.
-  // After canonicalization, identity extract_slices are eliminated.
+  // Key check: 4 warps distribute dimension 0 with step=1 (4 iterations).
+  // Each warp's DMA source is a clamped sub-slice of the pre-pad source.
   //
-  // CHECK: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
-  // CHECK: %[[WARP_RESULT:.+]] = scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (4, 64) step (4, 64)
-  // CHECK-SAME: shared_outs(%[[INIT_TILE:.+]] = %[[INIT]]) -> (tensor<4x64xf32>) {
+  // CHECK-DAG: %[[EXTRACTED:.+]] = tensor.extract_slice %[[SRC]]
+  // CHECK: scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (4, 64) step (1, 64)
+  // CHECK-SAME: shared_outs({{.*}} = %[[INIT]]) -> (tensor<4x64xf32>) {
   //
-  // Thread-level forall with 64 lanes (uses outer forall's shared_out directly):
-  // CHECK:   %[[THREAD_RESULT:.+]] = scf.forall (%[[LANE:.+]]) in (64) shared_outs(%[[INNER_INIT:.+]] = %[[INIT_TILE]])
+  // Thread-level forall with clamped source and DMA:
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK:     %[[CLAMPED_OFF:.+]] = arith.minsi %[[IV0]]
+  // CHECK:     %[[WARP_SRC:.+]] = tensor.extract_slice %[[EXTRACTED]][%[[CLAMPED_OFF]], 0]
   // CHECK:     scf.forall.in_parallel {
-  // CHECK:       iree_gpu.coalesced_gather_dma %[[EXTRACTED]] into %[[INNER_INIT]] lane(%[[LANE]]) in_bounds [false, true]
-  // CHECK-SAME:     : tensor<?x64xf32>, tensor<4x64xf32>, index
+  // CHECK:       iree_gpu.coalesced_gather_dma %[[WARP_SRC]] into {{.*}} lane(%[[LANE]]) in_bounds [false, true]
   // CHECK:     }
   // CHECK:   } {mapping = [#iree_gpu.lane_id<0>]}
   //
-  // CHECK:   scf.forall.in_parallel {
-  // CHECK:     tensor.parallel_insert_slice %[[THREAD_RESULT]] into %[[INIT_TILE]][0, 0] [4, 64] [1, 1]
-  // CHECK:   }
   // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
   // CHECK-NOT: tensor.pad
 
   return %result : tensor<4x64xf32>
+}
+
+// -----
+
+// Test: tensor.pad fusion with padding on both dimensions (in_bounds [false, false]).
+// A larger tile (32x128) with 4 warps: dim 0 is tiled across warps.
+// Both dimensions have padding, so both get clamping and in_bounds=false.
+
+#gpu_target_pad_both_dims = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_pad_both_dims = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_both_dims}>
+#translation_pad_both_dims = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_with_tensor_pad_both_dims
+// The source's innermost dim is static (96) and DWORD-aligned (96*4=384 bytes)
+// so the dynamic-innermost rejection in `isValidPadForDMA` (PR #24132) does not
+// fire and DMA conversion can proceed.
+func.func @copy_with_tensor_pad_both_dims(%source: tensor<500x96xf32>, %init: tensor<32x128xf32>, %off0: index, %sz0: index, %high0: index) -> tensor<32x128xf32>
+  attributes {hal.executable.target = #exec_target_pad_both_dims, translation_info = #translation_pad_both_dims} {
+  %extracted = tensor.extract_slice %source[%off0, 0] [%sz0, 96] [1, 1]
+      : tensor<500x96xf32> to tensor<?x96xf32>
+
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %extracted low[0, 0] high[%high0, 32] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : f32
+  } : tensor<?x96xf32> to tensor<32x128xf32>
+
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<32x128xf32>)
+    outs(%init : tensor<32x128xf32>) -> tensor<32x128xf32>
+
+  // 4 warps, 32x128 tile. dim 0: tiled to step=8, dim 1: kept whole (128).
+  // Both dims have padding → in_bounds = [false, false].
+  // CHECK: scf.forall (%[[IV0:.+]], %[[IV1:.+]]) = (0, 0) to (32, 128) step (8, 128)
+  // CHECK:   scf.forall (%[[LANE:.+]]) in (64)
+  // CHECK:     arith.minsi
+  // CHECK:     tensor.extract_slice
+  // CHECK:     scf.forall.in_parallel {
+  // CHECK:       iree_gpu.coalesced_gather_dma {{.*}} in_bounds [false, false]
+  // CHECK:     }
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  // CHECK-NOT: tensor.pad
+
+  return %result : tensor<32x128xf32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -916,3 +916,86 @@ func.func @copy_swizzle_hint_linearized(%source: tensor<128x16xf32>) -> tensor<1
 
   return %result : tensor<128x16xf32>
 }
+
+// -----
+
+// Test: incremental warp-distribution halving in tileAtSubgroupLevel.
+// 32x4xf32 tile = 128 elements. Workgroup has 4 warps.  The greedy 4-warp
+// distribution would give 8x4 = 32 elements per warp, less than the
+// minimum DMA transfer (subgroup_size=64 * 1 elt/lane = 64 elements with
+// dma_sizes=[32,128] / 32-bit f32).  Halving picks numWarps=2, which gives
+// 16x4 = 64 elements per warp (== min) — DMA emit succeeds and the warp
+// forall is well-formed (preserving wave-uniformity by construction).
+// Issue #24139.
+
+#gpu_target_warp_halve = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_warp_halve = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_warp_halve}>
+#translation_warp_halve = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_warp_distribution_halving
+func.func @copy_warp_distribution_halving(%source: tensor<32x4xf32>, %off: index, %sz: index, %high: index) -> tensor<32x4xf32>
+  attributes {hal.executable.target = #exec_target_warp_halve, translation_info = #translation_warp_halve} {
+  %extracted = tensor.extract_slice %source[%off, 0] [%sz, 4] [1, 1]
+      : tensor<32x4xf32> to tensor<?x4xf32>
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %extracted low[0, 0] high[%high, 0] {
+  ^bb0(%a: index, %b: index):
+    tensor.yield %cst : f32
+  } : tensor<?x4xf32> to tensor<32x4xf32>
+  %init = tensor.empty() : tensor<32x4xf32>
+  %r = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<32x4xf32>) outs(%init : tensor<32x4xf32>) -> tensor<32x4xf32>
+
+  // 2-warp distribution (step=16 on dim 0, dim 1 kept whole).
+  // CHECK: scf.forall (%{{.+}}, %{{.+}}) = (0, 0) to (32, 4) step (16, 4)
+  // CHECK:   scf.forall (%{{.+}}) in (64)
+  // CHECK:     iree_gpu.coalesced_gather_dma
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  // CHECK-NOT: linalg.copy
+
+  return %r : tensor<32x4xf32>
+}
+
+// -----
+
+// Test: linearized-availability detection must not rely on
+// `availableElements != innermostDim`. With a 1D (or [1,...,N]) shape whose
+// output traces to tensor.empty(), linearization fires but the two values
+// are equal. The unmodified `numWarps` (4) on shape [128] yields a per-warp
+// tile of 32 elements (< min DMA transfer 64), so halving must still kick in
+// and pick numWarps=2 (per-warp tile = 64). Issue #24139.
+
+#gpu_target_warp_halve_1d = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_warp_halve_1d = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_warp_halve_1d}>
+#translation_warp_halve_1d = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_warp_distribution_halving_1d
+func.func @copy_warp_distribution_halving_1d(%source: tensor<128xf32>) -> tensor<128xf32>
+  attributes {hal.executable.target = #exec_target_warp_halve_1d, translation_info = #translation_warp_halve_1d} {
+  %init = tensor.empty() : tensor<128xf32>
+  %r = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%source : tensor<128xf32>) outs(%init : tensor<128xf32>) -> tensor<128xf32>
+
+  // 2-warp distribution (step=64 on the only dim).
+  // CHECK: scf.forall (%{{.+}}) = (0) to (128) step (64)
+  // CHECK:   scf.forall (%{{.+}}) in (64)
+  // CHECK:     iree_gpu.coalesced_gather_dma
+  // CHECK: } {mapping = [#gpu.warp<linear_dim_0>]}
+  // CHECK-NOT: linalg.copy
+
+  return %r : tensor<128xf32>
+}


### PR DESCRIPTION
Previously, pad-fused `linalg.copy` operations were wrapped in a single-iteration `scf.forall` (TODO #23365), restricting the DMA load to one warp. After single-iteration loop removal, this produced an `scf.if` predicated on `thread_id` which blocked software pipelining — the pipeliner cannot handle `gather_to_lds` inside conditional blocks. On a 1134×2048×150000 bf16 GEMM (LHS transposed), this caused a ~36% direct-load regression.

This PR does the following:
 1. Remove single-iteration workaround in `tileAtSubgroupLevel`: Pad-fused copies now use `computeSubgroupTileSizes` for multi-warp distribution, same as non-padded copies.
 2. Propagate source offsets in `createDMAInForall`: When a `tensor.pad` is detected, trace from the tiled `extract_slice` back to the original pad to recover warp offsets. Create a new `tensor.extract_slice` from the pre-pad source with offsets and sizes clamped to actual source bounds via `arith.minsi/maxsi/subi`. The DMA's `in_bounds` attribute signals which dimensions may read OOB, relying on hardware (`fat_raw_buffer`) to return zeros.
 3. Guard `ConvertPadFusionCopyToCoalescedDMA`: Skip copies already distributed into warp-mapped foralls, making this pattern a fallback for edge cases.

**Before** (single warp, blocks pipelining):
```
scf.forall (%warp) = (0, 0) to (4, 64) step (4, 64)   // 1 iteration
  coalesced_gather_dma %pre_pad_source into %full_init
```

**After** (all warps participate, pipelining enabled):
```
scf.forall (%warp) = (0, 0) to (4, 64) step (1, 64)   // 4 iterations
  %clamped = extract_slice %pre_pad_source[minsi(%warp, %src_dim), 0]
                                          [minsi(%remaining, 1), 64]
  coalesced_gather_dma %clamped into %warp_init in_bounds [false, true]
```