### PR TITLE
[Codegen] Enable DMA by default for F16/BF16 Gemm on gfx950

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -173,21 +173,6 @@ static bool sourceIsFromFatRawBuffer(Value source) {
   return hasAMDGPUFatRawBufferAddressSpace(memrefType);
 }
 
-/// Check if the target architecture supports global load DMA.
-/// Returns true only for CDNA4+ (gfx950+) architectures.
-static bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
-  if (!target) {
-    return false;
-  }
-  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(target.getArch());
-  if (failed(chipset)) {
-    return false;
-  }
-  // CDNA4 is gfx950+ (major=9, minor>=5). Other major versions (RDNA, etc.)
-  // do not support global load DMA.
-  return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
-}
-
 /// Returns the subgroup size if the available elements are aligned to DMA
 /// transfer sizes, std::nullopt otherwise.
 static std::optional<int64_t>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -572,7 +572,7 @@ static FailureOr<std::pair<LoweringConfigAttr, int64_t>>
 getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     ArrayRef<int64_t> bounds, ArrayRef<AffineMap> maps,
     ArrayRef<Value> operands, IREE::GPU::TargetAttr target, bool isGemm,
-    bool scaled, bool useDirectLoad, int64_t prefetchNumStages,
+    bool scaled, bool &useDirectLoad, int64_t prefetchNumStages,
     int64_t splitReductionTripCnt, bool hasExistingAccumulator = false,
     std::optional<ConvToIgemmInfo> convToIgemmInfo = std::nullopt) {
   if (target.getWgp().getMma().empty()) {
@@ -750,13 +750,15 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              lhsScaleType,
                              rhsScaleType};
 
-  // TODO(#22119): We don't use global load DMA for scaled matmuls, because
-  // compilation doesn't support it. Once this is fixed, we should use global
-  // load DMA here when possible.
+  // Only enable direct load (global load DMA) for bf16 GEMMs on gfx950+.
+  // TODO: Add support for scaled matmul (#22119) and convolution (#23907).
   Location loc = operands[0].getLoc();
-  if (scaled && useDirectLoad) {
-    mlir::emitWarning(loc) << "direct load (global load DMA) is not yet "
-                              "supported for scaled matmuls, ignoring";
+  if (useDirectLoad &&
+      !(isGemm && lhsElemType.isBF16() && rhsElemType.isBF16() &&
+        targetSupportsGlobalLoadDMA(target))) {
+    mlir::emitWarning(loc) << "direct load (global load DMA) is currently only "
+                              "supported for bf16 GEMMs "
+                              "on gfx950+, falling back to stream copies";
     useDirectLoad = false;
   }
 
@@ -879,16 +881,16 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   if (useDirectLoad) {
     Attribute lhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
-    // Apply XOR swizzle for BF16 DMA operands whose reduction dim is
-    // innermost (contiguous reads) to avoid LDS bank conflicts.
-    if (lhsElemType.isBF16() && !transposedLhs) {
+    // Apply XOR swizzle for DMA operands whose reduction dim is innermost
+    // (contiguous reads) to avoid LDS bank conflicts.
+    if (!transposedLhs) {
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs);
       if (succeeded(lhsSwizzleAttr)) {
         lhsAttr = *lhsSwizzleAttr;
       }
     }
-    if (rhsElemType.isBF16() && transposedRhs) {
+    if (transposedRhs) {
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs);
       if (succeeded(rhsSwizzleAttr)) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -750,15 +750,16 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              lhsScaleType,
                              rhsScaleType};
 
-  // Only enable direct load (global load DMA) for bf16 GEMMs on gfx950+.
+  // Only enable direct load (global load DMA) for f16/bf16 GEMMs on gfx950+.
   // TODO: Add support for scaled matmul (#22119) and convolution (#23907).
+  auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
   Location loc = operands[0].getLoc();
   if (useDirectLoad &&
-      !(isGemm && lhsElemType.isBF16() && rhsElemType.isBF16() &&
+      !(isGemm && isF16OrBF16(lhsElemType) && isF16OrBF16(rhsElemType) &&
         targetSupportsGlobalLoadDMA(target))) {
     mlir::emitWarning(loc) << "direct load (global load DMA) is currently only "
-                              "supported for bf16 GEMMs "
-                              "on gfx950+, falling back to stream copies";
+                              "supported for f16/bf16 GEMMs on gfx950+, "
+                              "falling back to stream copies";
     useDirectLoad = false;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -557,6 +557,42 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
+/// Returns true if direct load DMA should be rejected, and fall back to stream
+/// copies.
+///
+/// Rejection cases:
+///   1. Target does not support DMA (requires gfx950+ / CDNA4+).
+///   2. Not a GEMM. TODO(#23907): support convolution.
+///   3. Data types are not f16 or bf16. TODO(#22119): support MXFP4.
+///   4. LHS transposed, RHS not transposed shows regressions. TODO (#24117).
+static bool shouldRejectDirectLoadDMA(IREE::GPU::TargetAttr target, bool isGemm,
+                                      Type lhsElemType, Type rhsElemType,
+                                      bool transposedLhs, bool transposedRhs) {
+  auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
+
+  // Case 1: DMA requires hardware support (gfx950+ / CDNA4+).
+  if (!targetSupportsGlobalLoadDMA(target)) {
+    return true;
+  }
+
+  // Case 2: Only GEMM are supported currently.
+  if (!isGemm) {
+    return true;
+  }
+
+  // Case 3: Only f16/bf16 are supported currently.
+  if (!isF16OrBF16(lhsElemType) || !isF16OrBF16(rhsElemType)) {
+    return true;
+  }
+
+  // Case 4: LHS transposed, RHS not transposed show regressions with DMA.
+  if (transposedLhs && !transposedRhs) {
+    return true;
+  }
+
+  return false;
+}
+
 /// Create a lowering config for matmul or IGEMM convolution based on iteration
 /// bounds and indexing maps for a given target. This function computes
 /// contraction dimensions and deduces an MMA intrinsic schedule to choose tile
@@ -750,16 +786,12 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              lhsScaleType,
                              rhsScaleType};
 
-  // Only enable direct load (global load DMA) for f16/bf16 GEMMs on gfx950+.
-  // TODO: Add support for scaled matmul (#22119) and convolution (#23907).
-  auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
   Location loc = operands[0].getLoc();
   if (useDirectLoad &&
-      !(isGemm && isF16OrBF16(lhsElemType) && isF16OrBF16(rhsElemType) &&
-        targetSupportsGlobalLoadDMA(target))) {
-    mlir::emitWarning(loc) << "direct load (global load DMA) is currently only "
-                              "supported for f16/bf16 GEMMs on gfx950+, "
-                              "falling back to stream copies";
+      shouldRejectDirectLoadDMA(target, isGemm, lhsElemType, rhsElemType,
+                                transposedLhs, transposedRhs)) {
+    mlir::emitWarning(loc) << "overriding direct load DMA, falling back to "
+                              "stream copies";
     useDirectLoad = false;
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -115,7 +115,7 @@ static llvm::cl::opt<bool> clGPUPadConvolution(
 static llvm::cl::opt<bool>
     clUseDirectLoad("iree-llvmgpu-use-direct-load",
                     llvm::cl::desc("Use global load DMA for direct load ops."),
-                    llvm::cl::Hidden, llvm::cl::init(false));
+                    llvm::cl::Hidden, llvm::cl::init(true));
 
 static llvm::cl::opt<bool> clDirectConvolution(
     "iree-codegen-llvmgpu-use-direct-convolution",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
-// RUN: --iree-codegen-llvmgpu-use-igemm=false \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=false \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
-// RUN: --iree-codegen-llvmgpu-use-igemm=false \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=false \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1304,6 +1304,18 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op) {
   return getGPUTargetAttr(op->getContext(),
                           IREE::HAL::ExecutableTargetAttr::lookup(op));
 }
+
+bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
+  if (!target) {
+    return false;
+  }
+  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(target.getArch());
+  if (failed(chipset)) {
+    return false;
+  }
+  return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
+}
+
 void addConfigGPUTarget(MLIRContext *context,
                         IREE::GPU::TargetAttr gpuTargetAttr,
                         SmallVectorImpl<NamedAttribute> &config) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -753,7 +753,7 @@ getOperandBitwidth(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                    int operandIndex) {
   SmallVector<Type> elementTypes;
   intrinsic.getElementTypes(elementTypes);
-  assert(operandIndex > 0 && "operand index must be positive");
+  assert(operandIndex >= 0 && "operand index must be non-negative");
   return elementTypes[operandIndex].getIntOrFloatBitWidth();
 }
 
@@ -816,6 +816,8 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
   }
   if (auto mma = dyn_cast<IREE::GPU::MMAAttr>(intrinsic)) {
     switch (mma.getIntrinsic()) {
+    case IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x32_F16:
+    case IREE::GPU::MMAIntrinsic::MFMA_F32_32x32x16_F16:
     case IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x32_BF16:
     case IREE::GPU::MMAIntrinsic::MFMA_F32_32x32x16_BF16:
       return XorShuffleParams({/*rowElems=*/64,

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -307,6 +307,10 @@ IREE::GPU::TargetAttr getGPUTargetAttr(MLIRContext *context,
                                        IREE::HAL::ExecutableTargetAttr attr);
 IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 
+/// Check if the target architecture supports global load DMA.
+/// Returns true only for CDNA4+ (gfx950+) architectures.
+bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target);
+
 // Methods to retrieve information association with `configuration` field
 // of `hal.executable.target` attribute used commonly in GPU codegen pipelines.
 std::optional<int64_t> getConfigWavesPerEu(DictionaryAttr targetAttr);


### PR DESCRIPTION
This PR flips the default DMA from false to true. Currently only BF16 GEMM has been properly benchmarked, but going to expand other supports as a follow-up.

Overall GEMM benchmark: **+5.9%** geomean speedup if TN (LHS transposed, RHS not transposed) cases are excluded. **+4.3%** if included.

#### Top 20 improved

| # | Op | Shape (MxNxK) | Transpose | NoDMA (us) | DMA (us) | Speedup |
|---|-----|--------------|--------|------------|----------|---------|
| 1 | mm | 7680x304x512 | NT | 14.4 | 9.7 | +32.7% |
| 2 | mm | 1280x3840x3840 | NN | 84.0 | 59.5 | +29.2% |
| 3 | mm | 24576x304x512 | NT | 33.4 | 23.8 | +28.6% |
| 4 | addmm | 256x3840x3840 | NT | 39.2 | 28.0 | +28.6% |
| 5 | mm | 1280x2304x576 | NT | 11.6 | 8.4 | +27.4% |
| 6 | mm | 1280x3840x7680 | NN | 164.4 | 119.4 | +27.3% |
| 7 | mm | 960x256x2048 | NT | 20.4 | 15.0 | +26.5% |
| 8 | mm | 4096x2048x8192 | NN | 215.5 | 159.9 | +25.8% |
| 9 | mm | 4096x2048x6144 | NN | 163.1 | 121.7 | +25.4% |
| 10 | mm | 4096x2048x4096 | NN | 112.7 | 84.4 | +25.1% |
| 11 | addmm | 5x384x384 | NT | 4.7 | 3.5 | +24.9% |
| 12 | mm | 3072x256x2048 | NT | 21.2 | 16.1 | +24.1% |
| 13 | addmm | 18928x128x512 | NT | 13.7 | 10.4 | +23.9% |
| 14 | mm | 1285x8192x2048 | NN | 76.9 | 59.4 | +22.9% |
| 15 | mm | 4112x2048x8192 | NN | 275.1 | 213.3 | +22.5% |
| 16 | mm | 256x3840x3840 | NN | 41.7 | 32.4 | +22.2% |
| 17 | mm | 1280x1152x576 | NT | 8.1 | 6.3 | +22.1% |
| 18 | mm | 4096x2048x2048 | NN | 57.0 | 44.5 | +22.0% |
| 19 | addmm | 1280x3840x3840 | NT | 83.9 | 65.5 | +22.0% |
| 20 | mm | 1280x3840x3840 | NT | 83.7 | 66.0 | +21.1% |

<details>
<summary>Reproduce commands (top 20 improved)</summary>

```
# 1. mm 7680x304x512 NT (+32.7%)
aten::mm '[[7680, 512], [512, 304]]' '["c10::BFloat16", "c10::BFloat16"]' '[[512, 1], [1, 512]]' '["", ""]'
# 2. mm 1280x3840x3840 NN (+29.2%)
aten::mm '[[1280, 3840], [3840, 3840]]' '["c10::BFloat16", "c10::BFloat16"]' '[[3840, 1], [3840, 1]]' '["", ""]'
# 3. mm 24576x304x512 NT (+28.6%)
aten::mm '[[24576, 512], [512, 304]]' '["c10::BFloat16", "c10::BFloat16"]' '[[512, 1], [1, 512]]' '["", ""]'
# 4. addmm 256x3840x3840 NT (+28.6%)
aten::addmm '[[3840], [256, 3840], [3840, 3840], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [3840, 1], [1, 3840], [], []]' '["", "", "", "1", "1"]'
# 5. mm 1280x2304x576 NT (+27.4%)
aten::mm '[[1280, 576], [576, 2304]]' '["c10::BFloat16", "c10::BFloat16"]' '[[576, 1], [1, 576]]' '["", ""]'
# 6. mm 1280x3840x7680 NN (+27.3%)
aten::mm '[[1280, 7680], [7680, 3840]]' '["c10::BFloat16", "c10::BFloat16"]' '[[7680, 1], [3840, 1]]' '["", ""]'
# 7. mm 960x256x2048 NT (+26.5%)
aten::mm '[[960, 2048], [2048, 256]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2048, 1], [1, 2048]]' '["", ""]'
# 8. mm 4096x2048x8192 NN (+25.8%)
aten::mm '[[4096, 8192], [8192, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[8192, 1], [2048, 1]]' '["", ""]'
# 9. mm 4096x2048x6144 NN (+25.4%)
aten::mm '[[4096, 6144], [6144, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[6144, 1], [2048, 1]]' '["", ""]'
# 10. mm 4096x2048x4096 NN (+25.1%)
aten::mm '[[4096, 4096], [4096, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[4096, 1], [2048, 1]]' '["", ""]'
# 11. addmm 5x384x384 NT (+24.9%)
aten::addmm '[[384], [5, 384], [384, 384], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [384, 1], [1, 384], [], []]' '["", "", "", "1", "1"]'
# 12. mm 3072x256x2048 NT (+24.1%)
aten::mm '[[3072, 2048], [2048, 256]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2048, 1], [1, 2048]]' '["", ""]'
# 13. addmm 18928x128x512 NT (+23.9%)
aten::addmm '[[128], [18928, 512], [512, 128], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [512, 1], [1, 512], [], []]' '["", "", "", "1", "1"]'
# 14. mm 1285x8192x2048 NN (+22.9%)
aten::mm '[[1285, 2048], [2048, 8192]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2048, 1], [8192, 1]]' '["", ""]'
# 15. mm 4112x2048x8192 NN (+22.5%)
aten::mm '[[4112, 8192], [8192, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[8192, 1], [2048, 1]]' '["", ""]'
# 16. mm 256x3840x3840 NN (+22.2%)
aten::mm '[[256, 3840], [3840, 3840]]' '["c10::BFloat16", "c10::BFloat16"]' '[[3840, 1], [3840, 1]]' '["", ""]'
# 17. mm 1280x1152x576 NT (+22.1%)
aten::mm '[[1280, 576], [576, 1152]]' '["c10::BFloat16", "c10::BFloat16"]' '[[576, 1], [1, 576]]' '["", ""]'
# 18. mm 4096x2048x2048 NN (+22.0%)
aten::mm '[[4096, 2048], [2048, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2048, 1], [2048, 1]]' '["", ""]'
# 19. addmm 1280x3840x3840 NT (+22.0%)
aten::addmm '[[3840], [1280, 3840], [3840, 3840], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [3840, 1], [1, 3840], [], []]' '["", "", "", "1", "1"]'
# 20. mm 1280x3840x3840 NT (+21.1%)
aten::mm '[[1280, 3840], [3840, 3840]]' '["c10::BFloat16", "c10::BFloat16"]' '[[3840, 1], [1, 3840]]' '["", ""]'
```

</details>

#### Regressions

The regression cases are strongly correlated with TN (LHS transposed, RHS not transposed) layouts — 33 out of 83 total regressions are TN, and they account for all of the severe cases (>25%). This PR disables DMA for TN cases, and they will be addressed in a follow-up.

<details>
<summary>Top 20 regressed — all layouts</summary>

| # | Op | Shape (MxNxK) | Transpose | NoDMA (us) | DMA (us) | Regression |
|---|-----|--------------|--------|------------|----------|------------|
| 1 | mm | 8192x2048x150000 | TN | 6039.3 | 14120.4 | -133.8% |
| 2 | mm | 16384x4096x150000 | TN | 24019.5 | 52548.8 | -118.8% |
| 3 | mm | 4096x16384x150000 | TN | 24946.4 | 38507.4 | -54.4% |
| 4 | mm | 2048x8192x150000 | TN | 6307.2 | 9572.7 | -51.8% |
| 5 | mm | 1024x128x150000 | TN | 190.4 | 262.3 | -37.8% |
| 6 | mm | 2048x2048x1285 | TN | 27.1 | 36.2 | -33.3% |
| 7 | mm | 128x128x2119936 | TN | 287.2 | 365.2 | -27.2% |
| 8 | mm | 576x3840x7680 | TN | 111.6 | 140.7 | -26.1% |
| 9 | mm | 1134x2048x150000 | TN | 3435.5 | 4313.4 | -25.6% |
| 10 | mm | 20x3840x21760 | TN | 42.9 | 53.7 | -25.1% |
| 11 | mm | 10x576x2304 | NN | 9.0 | 11.1 | -23.7% |
| 12 | bmm | 32x96x21x96 | NT | 4.2 | 5.1 | -23.5% |
| 13 | addmm | 5x4x384 | NT | 6.8 | 8.3 | -21.8% |
| 14 | bmm | 32x21x96x96 | NT | 4.2 | 5.1 | -21.5% |
| 15 | addmm | 150000x1134x2048 | NT | 1098.5 | 1303.2 | -18.6% |
| 16 | mm | 576x2048x24576 | TN | 167.6 | 195.8 | -16.9% |
| 17 | mm | 2048x512x24576 | TN | 142.9 | 167.0 | -16.8% |
| 18 | mm | 1024x1024x16 | TN | 4.4 | 5.1 | -16.1% |
| 19 | mm | 512x2048x24576 | TN | 136.1 | 157.9 | -16.0% |
| 20 | mm | 5x384x4 | NN | 3.5 | 4.1 | -15.2% |

<details>
<summary>Reproduce commands</summary>

```
# 1. mm 8192x2048x150000 TN (-133.8%)
aten::mm '[[8192, 150000], [150000, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 8192], [2048, 1]]' '["", ""]'
# 2. mm 16384x4096x150000 TN (-118.8%)
aten::mm '[[16384, 150000], [150000, 4096]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 16384], [4096, 1]]' '["", ""]'
# 3. mm 4096x16384x150000 TN (-54.4%)
aten::mm '[[4096, 150000], [150000, 16384]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 4096], [16384, 1]]' '["", ""]'
# 4. mm 2048x8192x150000 TN (-51.8%)
aten::mm '[[2048, 150000], [150000, 8192]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 2048], [8192, 1]]' '["", ""]'
# 5. mm 1024x128x150000 TN (-37.8%)
aten::mm '[[1024, 150000], [150000, 128]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 1024], [128, 1]]' '["", ""]'
# 6. mm 2048x2048x1285 TN (-33.3%)
aten::mm '[[2048, 1285], [1285, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 2048], [2048, 1]]' '["", ""]'
# 7. mm 128x128x2119936 TN (-27.2%)
aten::mm '[[128, 2119936], [2119936, 128]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 128], [128, 1]]' '["", ""]'
# 8. mm 576x3840x7680 TN (-26.1%)
aten::mm '[[576, 7680], [7680, 3840]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 576], [3840, 1]]' '["", ""]'
# 9. mm 1134x2048x150000 TN (-25.6%)
aten::mm '[[1134, 150000], [150000, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 1134], [2048, 1]]' '["", ""]'
# 10. mm 20x3840x21760 TN (-25.1%)
aten::mm '[[20, 21760], [21760, 3840]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 20], [3840, 1]]' '["", ""]'
# 11. mm 10x576x2304 NN (-23.7%)
aten::mm '[[10, 2304], [2304, 576]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2304, 1], [576, 1]]' '["", ""]'
# 12. bmm 32x96x21x96 (-23.5%)
aten::bmm '[[32, 96, 96], [32, 96, 21]]' '["c10::BFloat16", "c10::BFloat16"]' '[[9216, 96, 1], [2016, 1, 96]]' '["", ""]'
# 13. addmm 5x4x384 NT (-21.8%)
aten::addmm '[[4], [5, 384], [384, 4], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [384, 1], [1, 384], [], []]' '["", "", "", "1", "1"]'
# 14. bmm 32x21x96x96 (-21.5%)
aten::bmm '[[32, 21, 96], [32, 96, 96]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2016, 96, 1], [9216, 1, 96]]' '["", ""]'
# 15. addmm 150000x1134x2048 NT (-18.6%)
aten::addmm '[[1134], [150000, 2048], [2048, 1134], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [2048, 1], [1, 2048], [], []]' '["", "", "", "1", "1"]'
# 16. mm 576x2048x24576 TN (-16.9%)
aten::mm '[[576, 24576], [24576, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 576], [2048, 1]]' '["", ""]'
# 17. mm 2048x512x24576 TN (-16.8%)
aten::mm '[[2048, 24576], [24576, 512]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 2048], [512, 1]]' '["", ""]'
# 18. mm 1024x1024x16 TN (-16.1%)
aten::mm '[[1024, 16], [16, 1024]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 1024], [1024, 1]]' '["", ""]'
# 19. mm 512x2048x24576 TN (-16.0%)
aten::mm '[[512, 24576], [24576, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[1, 512], [2048, 1]]' '["", ""]'
# 20. mm 5x384x4 NN (-15.2%)
aten::mm '[[5, 4], [4, 384]]' '["c10::BFloat16", "c10::BFloat16"]' '[[4, 1], [384, 1]]' '["", ""]'
```

</details>

</details>

<details>
<summary>Top 20 regressed — excluding TN layouts</summary>

| # | Op | Shape (MxNxK) | Transpose | NoDMA (us) | DMA (us) | Regression |
|---|-----|--------------|--------|------------|----------|------------|
| 1 | mm | 10x576x2304 | NN | 9.0 | 11.1 | -23.7% |
| 2 | bmm | 32x96x21x96 | NT | 4.2 | 5.1 | -23.5% |
| 3 | addmm | 5x4x384 | NT | 6.8 | 8.3 | -21.8% |
| 4 | bmm | 32x21x96x96 | NT | 4.2 | 5.1 | -21.5% |
| 5 | addmm | 150000x1134x2048 | NT | 1098.5 | 1303.2 | -18.6% |
| 6 | mm | 5x384x4 | NN | 3.5 | 4.1 | -15.2% |
| 7 | mm | 1285x2048x8192 | NN | 154.9 | 178.0 | -14.9% |
| 8 | mm | 1285x2048x3840 | NT | 65.0 | 74.0 | -13.9% |
| 9 | mm | 16800000x134x128 | NN | 3879.0 | 4408.3 | -13.6% |
| 10 | mm | 1285x2048x2048 | NN | 43.2 | 48.9 | -13.1% |
| 11 | mm | 1285x2048x3840 | NN | 76.2 | 86.1 | -12.9% |
| 12 | mm | 24576x512x2048 | NN | 102.8 | 115.2 | -12.1% |
| 13 | bmm | 16x384x384x192 | NT | 6.4 | 7.1 | -10.9% |
| 14 | bmm | 32x96x96x21 | NN | 4.0 | 4.4 | -10.8% |
| 15 | bmm | 32x96x96x96 | NT | 4.5 | 5.0 | -10.4% |
| 16 | bmm | 32x96x96x96 | NN | 4.5 | 4.9 | -9.4% |
| 17 | mm | 528x2304x576 | NN | 9.2 | 10.1 | -8.9% |
| 18 | bmm | 32x96x96x21 | NN | 6.5 | 7.0 | -8.6% |
| 19 | addmm | 1285x2048x2048 | NT | 36.9 | 39.9 | -8.0% |
| 20 | mm | 24576x2048x512 | NN | 106.6 | 114.7 | -7.7% |

<details>
<summary>Reproduce commands</summary>

```
# 1. mm 10x576x2304 NN (-23.7%)
aten::mm '[[10, 2304], [2304, 576]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2304, 1], [576, 1]]' '["", ""]'
# 2. bmm 32x96x21x96 (-23.5%)
aten::bmm '[[32, 96, 96], [32, 96, 21]]' '["c10::BFloat16", "c10::BFloat16"]' '[[9216, 96, 1], [2016, 1, 96]]' '["", ""]'
# 3. addmm 5x4x384 NT (-21.8%)
aten::addmm '[[4], [5, 384], [384, 4], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [384, 1], [1, 384], [], []]' '["", "", "", "1", "1"]'
# 4. bmm 32x21x96x96 (-21.5%)
aten::bmm '[[32, 21, 96], [32, 96, 96]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2016, 96, 1], [9216, 1, 96]]' '["", ""]'
# 5. addmm 150000x1134x2048 NT (-18.6%)
aten::addmm '[[1134], [150000, 2048], [2048, 1134], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [2048, 1], [1, 2048], [], []]' '["", "", "", "1", "1"]'
# 6. mm 5x384x4 NN (-15.2%)
aten::mm '[[5, 4], [4, 384]]' '["c10::BFloat16", "c10::BFloat16"]' '[[4, 1], [384, 1]]' '["", ""]'
# 7. mm 1285x2048x8192 NN (-14.9%)
aten::mm '[[1285, 8192], [8192, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[8192, 1], [2048, 1]]' '["", ""]'
# 8. mm 1285x2048x3840 NT (-13.9%)
aten::mm '[[1285, 3840], [3840, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[3840, 1], [1, 3840]]' '["", ""]'
# 9. mm 16800000x134x128 NN (-13.6%)
aten::mm '[[16800000, 128], [128, 134]]' '["c10::BFloat16", "c10::BFloat16"]' '[[128, 1], [134, 1]]' '["", ""]'
# 10. mm 1285x2048x2048 NN (-13.1%)
aten::mm '[[1285, 2048], [2048, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2048, 1], [2048, 1]]' '["", ""]'
# 11. mm 1285x2048x3840 NN (-12.9%)
aten::mm '[[1285, 3840], [3840, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[3840, 1], [2048, 1]]' '["", ""]'
# 12. mm 24576x512x2048 NN (-12.1%)
aten::mm '[[24576, 2048], [2048, 512]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2048, 1], [512, 1]]' '["", ""]'
# 13. bmm 16x384x384x192 NT (-10.9%)
aten::bmm '[[16, 384, 192], [16, 192, 384]]' '["c10::BFloat16", "c10::BFloat16"]' '[[73728, 192, 1], [73728, 1, 192]]' '["", ""]'
# 14. bmm 32x96x96x21 NN (-10.8%)
aten::bmm '[[32, 96, 21], [32, 21, 96]]' '["c10::BFloat16", "c10::BFloat16"]' '[[2016, 21, 1], [2016, 96, 1]]' '["", ""]'
# 15. bmm 32x96x96x96 NT (-10.4%)
aten::bmm '[[32, 96, 96], [32, 96, 96]]' '["c10::BFloat16", "c10::BFloat16"]' '[[9216, 96, 1], [9216, 1, 96]]' '["", ""]'
# 16. bmm 32x96x96x96 NN (-9.4%)
aten::bmm '[[32, 96, 96], [32, 96, 96]]' '["c10::BFloat16", "c10::BFloat16"]' '[[9216, 96, 1], [9216, 96, 1]]' '["", ""]'
# 17. mm 528x2304x576 NN (-8.9%)
aten::mm '[[528, 576], [576, 2304]]' '["c10::BFloat16", "c10::BFloat16"]' '[[576, 1], [2304, 1]]' '["", ""]'
# 18. bmm 32x96x96x21 NN (-8.6%)
aten::bmm '[[32, 96, 21], [32, 21, 96]]' '["c10::BFloat16", "float"]' '[[2016, 21, 1], [2016, 96, 1]]' '["", ""]'
# 19. addmm 1285x2048x2048 NT (-8.0%)
aten::addmm '[[2048], [1285, 2048], [2048, 2048], [], []]' '["c10::BFloat16", "c10::BFloat16", "c10::BFloat16", "Scalar", "Scalar"]' '[[1], [2048, 1], [1, 2048], [], []]' '["", "", "", "1", "1"]'
# 20. mm 24576x2048x512 NN (-7.7%)
aten::mm '[[24576, 512], [512, 2048]]' '["c10::BFloat16", "c10::BFloat16"]' '[[512, 1], [2048, 1]]' '["", ""]'
```

</details>

</details>