### PR TITLE
[DMA] Reject invalid pads early in DMA convertible check

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -591,7 +591,17 @@ struct ConvertToCoalescedDMABase : OpRewritePattern<OpTy> {
       return failure();
     }
 
-    return createDMAInForall<OpTy>(threadForallOp, rewriter);
+    // createDMAInForall must not fail after tileToThreadLevel, because
+    // tileToThreadLevel already erased the original op via replaceOp.
+    // Failing here would leave a dangling reference (use-after-free).
+    // All eligibility checks must happen before this point (e.g., in
+    // isCopyDMAConvertible / computeThreadNumThreads).
+    [[maybe_unused]] LogicalResult result =
+        createDMAInForall<OpTy>(threadForallOp, rewriter);
+    assert(succeeded(result) &&
+           "createDMAInForall must not fail after tileToThreadLevel erased "
+           "the original op");
+    return success();
   }
 
 protected:
@@ -667,7 +677,12 @@ struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
       return failure();
     }
 
-    return createDMAInForall<linalg::CopyOp>(threadForallOp, rewriter);
+    [[maybe_unused]] LogicalResult result =
+        createDMAInForall<linalg::CopyOp>(threadForallOp, rewriter);
+    assert(succeeded(result) &&
+           "createDMAInForall must not fail after tileToThreadLevel erased "
+           "the original op");
+    return success();
   }
 };
 
@@ -756,9 +771,8 @@ struct ConvertGatherToCoalescedDMA
       return WalkResult::interrupt();
     });
 
-    if (!tiledGatherOp) {
-      return failure();
-    }
+    assert(tiledGatherOp &&
+           "tiled gather op must exist after tileToThreadLevel");
 
     Block *forallBody = threadForallOp.getBody();
     Value sharedOut = forallBody->getArguments().back();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -272,8 +272,41 @@ computeThreadNumThreadsImpl(OpBuilder &builder, Operation *op,
   return {builder.getIndexAttr(*subgroupSize)};
 }
 
-/// Check if a linalg.copy is viable for DMA conversion based on alignment and
-/// size constraints. This does NOT modify the IR.
+/// Check if a tensor.pad is valid for DMA conversion.
+/// Requires: zero low padding, zero pad value, and DWORD-aligned source rows.
+static bool isValidPadForDMA(tensor::PadOp pad) {
+  // Verify pad constraints: low padding must be all zeros, pad value must be 0.
+  // TODO(#23365): Support non-zero pad values (e.g., -inf, 1) by emitting a
+  // select on the loaded values from LDS to replace OOB zeros with the desired
+  // padding element.
+  for (OpFoldResult low : pad.getMixedLowPad()) {
+    if (!isConstantIntValue(low, 0)) {
+      return false;
+    }
+  }
+  Value padVal = pad.getConstantPaddingValue();
+  if (!padVal || !(matchPattern(padVal, m_AnyZeroFloat()) ||
+                   matchPattern(padVal, m_Zero()))) {
+    return false;
+  }
+
+  // Check if source tensor's innermost row size is DWORD (4-byte) aligned. On
+  // AMD CDNA, per-component range checking is performed for each DWORD. If a
+  // DWORD is partially out-of-bounds, the entire DWORD returns zero, causing
+  // incorrect results. Additionally, partial OOB triggers the slow path with
+  // multi-cycling and instruction issue penalties.
+  auto sourceType = cast<RankedTensorType>(pad.getSource().getType());
+  int64_t innermostDim = sourceType.getShape().back();
+  if (ShapedType::isDynamic(innermostDim)) {
+    return false;
+  }
+  Type elemType = sourceType.getElementType();
+  int64_t rowBytes = innermostDim * (elemType.getIntOrFloatBitWidth() / 8);
+  return rowBytes % 4 == 0;
+}
+
+/// Check if a linalg.copy is viable for DMA conversion based on alignment,
+/// size and padding constraints. This does NOT modify the IR.
 static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
   auto funcOp = copyOp->getParentOfType<FunctionOpInterface>();
   if (!funcOp) {
@@ -296,6 +329,11 @@ static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
   if (tracesToTensorEmpty(output) &&
       llvm::none_of(shape, ShapedType::isDynamic)) {
     availableElements = ShapedType::getNumElements(shape);
+  }
+
+  tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0]);
+  if (pad && !isValidPadForDMA(pad)) {
+    return false;
   }
 
   return getDMAAlignedSubgroupSize(funcOp, outputType.getElementType(),
@@ -435,57 +473,15 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     // After tiling, the input is typically:
     //   tensor.extract_slice %padded[...] [...] [1, 1]
     // We need to trace through extract_slice to find if source is tensor.pad.
-    if (tensor::PadOp pad = traceToTensorPad(input)) {
-      // Verify pad constraints: low padding must be all zeros, pad value must
-      // be 0.
-      // TODO(#23365): Support non-zero pad values (e.g., -inf, 1) by emitting
-      // a select on the loaded values from LDS to replace OOB zeros with the
-      // desired padding element.
-      bool validPad = true;
-      for (OpFoldResult low : pad.getMixedLowPad()) {
-        if (!isConstantIntValue(low, 0)) {
-          validPad = false;
-          break;
-        }
-      }
-      Value padVal = pad.getConstantPaddingValue();
-      if (!padVal || !(matchPattern(padVal, m_AnyZeroFloat()) ||
-                       matchPattern(padVal, m_Zero()))) {
-        validPad = false;
-      }
-
-      if (validPad) {
-        // Use pad.getSource() directly as the DMA source.
-        // This is the tensor.extract_slice result (e.g., tensor<?x64xf32>).
-        source = pad.getSource();
-
-        // Check if source tensor's innermost row size is DWORD (4-byte)
-        // aligned. On AMD CDNA, per-component range checking is performed for
-        // each DWORD. If a DWORD is partially out-of-bounds, the entire DWORD
-        // returns zero, causing incorrect results. Additionally, partial OOB
-        // triggers the slow path with multi-cycling and instruction issue
-        // penalties.
-        auto sourceType = cast<RankedTensorType>(source.getType());
-        int64_t innermostDim = sourceType.getShape().back();
-        if (!ShapedType::isDynamic(innermostDim)) {
-          Type elemType = sourceType.getElementType();
-          int64_t elemBytes = elemType.getIntOrFloatBitWidth() / 8;
-          int64_t rowBytes = innermostDim * elemBytes;
-          if (rowBytes % 4 != 0) {
-            LLVM_DEBUG(llvm::dbgs()
-                       << "Skipping DMA: row size " << rowBytes
-                       << " bytes not DWORD-aligned (slow path)\n");
-            return failure();
-          }
-        }
-
-        // Compute in_bounds based on whether padding was added per dimension.
-        for (auto [low, high] :
-             llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
-          bool isInBounds =
-              isConstantIntValue(low, 0) && isConstantIntValue(high, 0);
-          inBoundsVec.push_back(isInBounds);
-        }
+    tensor::PadOp pad = traceToTensorPad(input);
+    if (pad && isValidPadForDMA(pad)) {
+      source = pad.getSource();
+      // Compute in_bounds based on whether padding was added per dimension.
+      for (auto [low, high] :
+           llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
+        bool isInBounds =
+            isConstantIntValue(low, 0) && isConstantIntValue(high, 0);
+        inBoundsVec.push_back(isInBounds);
       }
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -274,11 +274,9 @@ computeThreadNumThreadsImpl(OpBuilder &builder, Operation *op,
 
 /// Check if a tensor.pad is valid for DMA conversion.
 /// Requires: zero low padding, zero pad value, and DWORD-aligned source rows.
+/// TODO(#24156): Relax these checks by supporting individual cases.
 static bool isValidPadForDMA(tensor::PadOp pad) {
   // Verify pad constraints: low padding must be all zeros, pad value must be 0.
-  // TODO(#23365): Support non-zero pad values (e.g., -inf, 1) by emitting a
-  // select on the loaded values from LDS to replace OOB zeros with the desired
-  // padding element.
   for (OpFoldResult low : pad.getMixedLowPad()) {
     if (!isConstantIntValue(low, 0)) {
       return false;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -605,12 +605,56 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
 
   // Source row size (121 * 2 = 242 bytes) is not DWORD-aligned.
   // Coalesced DMA bails out to avoid partial OOB in per-DWORD range checking.
-  // The linalg.copy should remain unchanged.
+  // The copy is downgraded from use_global_load_dma to derived_thread_config.
   // CHECK: tensor.pad
-  // CHECK: linalg.copy
+  // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
   // CHECK-NOT: iree_gpu.coalesced_gather_dma
 
   return %result : tensor<4x124xf16>
+}
+
+// -----
+
+// Negative test: Dynamic innermost dimension fails DWORD alignment check.
+
+#gpu_target_pad_dynamic_inner = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128]
+>>
+
+#exec_target_pad_dynamic_inner = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_dynamic_inner}>
+#translation_pad_dynamic_inner = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+
+// CHECK-LABEL: func.func @copy_with_tensor_pad_dynamic_inner_dim
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<457x330xi8>
+// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x256xi8>
+func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %init: tensor<4x256xi8>, %off: index, %sz_m: index, %sz_k: index, %high_m: index, %high_k: index) -> tensor<4x256xi8>
+  attributes {hal.executable.target = #exec_target_pad_dynamic_inner, translation_info = #translation_pad_dynamic_inner} {
+  // Extract a dynamic slice where both dimensions are dynamic.
+  %extracted = tensor.extract_slice %source[%off, 0] [%sz_m, %sz_k] [1, 1]
+      : tensor<457x330xi8> to tensor<?x?xi8>
+
+  // Pad to static size.
+  %cst = arith.constant 0 : i8
+  %padded = tensor.pad %extracted low[0, 0] high[%high_m, %high_k] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : i8
+  } : tensor<?x?xi8> to tensor<4x256xi8>
+
+  // Copy from padded tensor.
+  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+    ins(%padded : tensor<4x256xi8>)
+    outs(%init : tensor<4x256xi8>) -> tensor<4x256xi8>
+
+  // The copy is downgraded from use_global_load_dma to derived_thread_config.
+  // CHECK: tensor.pad
+  // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
+  // CHECK-NOT: iree_gpu.coalesced_gather_dma
+
+  return %result : tensor<4x256xi8>
 }
 
 // -----


### PR DESCRIPTION
Extracts pad validation into a standalone `isValidPadForDMA` helper and calls it in `isCopyDMAConvertible`, so copies with invalid pads are rejected early and gracefully downgraded to `derived_thread_config` instead of failing deep in `createDMAInForall`.

As part of the refactoring, also fixes a bug where pads with dynamic innermost source dimensions were incorrectly assumed to be DWORD-aligned.

Assisted-by: Cursor (Claude)