### PR TITLE
[Codegen] Move scatter DPS fill into workgroup forall

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -9,17 +9,20 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Support/WalkResult.h"
@@ -225,6 +228,88 @@ static bool isUsedAsInit(Operation *producer, Operation *user) {
   });
 }
 
+/// When workgroup `scf.forall` contains `iree_linalg_ext.scatter`, the scatter
+/// init may be produced by `linalg.fill` over `tensor.empty`. Tile-and-fuse
+/// cannot pull that fill into the forall (DPS init fusion is skipped), so the
+/// fill stays in the sequential region and bufferizes to a global write before
+/// the workgroup loop, which fails
+/// `iree-codegen-verify-workgroup-distribution`. Move the fill to the start of
+/// the forall body and wire `shared_outs` to the `tensor.empty` instead of the
+/// filled tensor.
+static void moveInitFillIntoWorkgroupForallWithScatter(RewriterBase &rewriter,
+                                                       scf::ForallOp forallOp) {
+  std::optional<ArrayAttr> mapping = forallOp.getMapping();
+  if (!mapping || mapping.value().empty() ||
+      !llvm::isa<IREE::Codegen::WorkgroupMappingAttr>(
+          *mapping.value().begin())) {
+    return;
+  }
+
+  bool hasScatter = false;
+  forallOp.getBody()->walk([&](IREE::LinalgExt::ScatterOp) {
+    hasScatter = true;
+    return WalkResult::interrupt();
+  });
+  if (!hasScatter) {
+    return;
+  }
+
+  Block::BlockArgListType iterArgs = forallOp.getRegionIterArgs();
+  SmallVector<Value> originalOutputs(llvm::to_vector(forallOp.getOutputs()));
+  if (originalOutputs.size() != iterArgs.size()) {
+    return;
+  }
+
+  SmallVector<Value> newOutputs = originalOutputs;
+
+  Operation *lastInsertedFill = nullptr;
+  for (auto [idx, iterArg] : llvm::enumerate(iterArgs)) {
+    auto fillOp = newOutputs[idx].getDefiningOp<linalg::FillOp>();
+    if (!fillOp) {
+      continue;
+    }
+    Value emptyTensor = fillOp.getDpsInitOperand(0)->get();
+    if (!emptyTensor.getDefiningOp<tensor::EmptyOp>()) {
+      continue;
+    }
+    auto bbArg = cast<BlockArgument>(iterArg);
+
+    IRMapping mapper;
+    mapper.map(fillOp.getDpsInitOperand(0)->get(), bbArg);
+    if (lastInsertedFill) {
+      rewriter.setInsertionPointAfter(lastInsertedFill);
+    } else {
+      rewriter.setInsertionPointToStart(forallOp.getBody());
+    }
+    Operation *clonedFill = rewriter.clone(*fillOp, mapper);
+    lastInsertedFill = clonedFill;
+    Value filled = clonedFill->getResult(0);
+
+    rewriter.replaceUsesWithIf(bbArg, filled, [&](OpOperand &operand) {
+      if (operand.getOwner() == clonedFill) {
+        return false;
+      }
+      if (auto pis =
+              dyn_cast<tensor::ParallelInsertSliceOp>(operand.getOwner())) {
+        if (pis.getDest() == bbArg) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    newOutputs[idx] = emptyTensor;
+
+    if (fillOp->use_empty()) {
+      rewriter.eraseOp(fillOp);
+    }
+  }
+
+  if (newOutputs != originalOutputs) {
+    forallOp.getOutputsMutable().assign(newOutputs);
+  }
+}
+
 void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
   auto *context = &getContext();
@@ -409,6 +494,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
         forallOp.setMappingAttr(ArrayAttr::get(context, mappingAttrs));
       }
     }
+    moveInitFillIntoWorkgroupForallWithScatter(rewriter, forallOp);
   }
 
   // Cleanup patterns for tile and distribute

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -668,6 +668,35 @@ func.func @consumer_fuse_scatter(%arg0: tensor<3x2048x2048xf32>,
 
 // -----
 
+// Scatter init is linalg.fill(tensor.empty); tile-and-fuse leaves the fill outside the workgroup
+// forall, which breaks workgroup distribution verification after bufferization. The pass should
+// move the fill into the forall body and use tensor.empty as shared_outs init.
+func.func @scatter_fill_shared_init_into_forall(
+    %updates: tensor<3x2048x2048xf32>,
+    %indices: tensor<3x1xi32>) -> tensor<3x2048x2048xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<3x2048x2048xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<3x2048x2048xf32>) -> tensor<3x2048x2048xf32>
+  %2 = iree_linalg_ext.scatter {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1, 256]]>}
+      dimension_map = [0] unique_indices(true)
+      ins(%updates, %indices : tensor<3x2048x2048xf32>, tensor<3x1xi32>) outs(%1 : tensor<3x2048x2048xf32>) {
+  ^bb0(%a: f32, %b: f32):
+    iree_linalg_ext.yield %a : f32
+  } -> tensor<3x2048x2048xf32>
+  return %2 : tensor<3x2048x2048xf32>
+}
+
+// CHECK-LABEL: func @scatter_fill_shared_init_into_forall
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty()
+//       CHECK:   %[[RESULT:.+]] = scf.forall
+//  CHECK-SAME:       shared_outs(%{{.+}} = %[[EMPTY]])
+// Tile/fuse may slice the shared tensor before the moved fill; fill must still
+// appear inside the forall before scatter (not between tensor.empty and forall).
+//       CHECK:     linalg.fill
+//       CHECK:     iree_linalg_ext.scatter
+
+// -----
+
 func.func @dont_transpose_dynamic(%0 : tensor<?x?xf32>, %1 : tensor<?x?xf32>, %2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %3 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0]]>}
       ins(%0, %1 : tensor<?x?xf32>, tensor<?x?xf32>)


### PR DESCRIPTION
For iree_linalg_ext.scatter with a DPS init from linalg.fill(tensor.empty), TileAndDistributeToWorkgroupsUsingForallOpPass places the scatter in a workgroup-mapped scf.forall while tile-and-fuse skips fusing producers that are only DPS inits (isUsedAsInit). The fill then stays in the sequential region before the forall; after bufferization it writes the dispatch output outside any workgroup loop and fails iree-codegen-verify-workgroup-distribution.

ScatterOp tiling slices updates/indices but the tiled output position comes from getResultTilePosition; with scalar updates (update_slice_rank == 0), common when dimension_map covers all output ranks, there is no tensor.extract_slice chain from the fill for fusion to pull into the forall.

After building the workgroup forall, if it is workgroup-mapped and contains ScatterOp, rewrite each shared_out init defined by linalg.fill(tensor.empty): clone the fill to the start of the forall body using the shared block argument as the DPS destination, retarget consumers, set shared_outs to tensor.empty, and erase the outer fill.

Adds scatter_fill_shared_init_into_forall to
tile_and_distribute_workgroups_using_forall.mlir.