### PR TITLE
[SPIRV][nfc] Adapt pipeline tests on module-scope.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -646,20 +646,27 @@ void buildSPIRVCodegenConfigurationPassPipeline(
   buildSPIRVCodegenConfigurationPassPipelineImpl(modulePassManager);
 }
 
-void buildSPIRVCodegenPassPipeline(OpPassManager &modulePassManager) {
+void buildSPIRVCodegenPassPipeline(OpPassManager &modulePassManager,
+                                   bool includeSPIRVLowering) {
   modulePassManager.addPass(
       createSPIRVLowerExecutableUsingTransformDialectPass());
   FunctionLikeNest(modulePassManager)
       .addPass(createSPIRVLowerExecutableTargetPass)
       .addPass(createVerifyWorkgroupDistributionPass);
-  addMemRefLoweringPasses(modulePassManager);
-  FunctionLikeNest(modulePassManager).addPass(createGpuEliminateBarriers);
+
+  if (includeSPIRVLowering) {
+    addMemRefLoweringPasses(modulePassManager);
+    FunctionLikeNest(modulePassManager).addPass(createGpuEliminateBarriers);
+  }
+
   modulePassManager.addPass(createReconcileTranslationInfoPass());
   modulePassManager.addPass(createResolveWorkgroupCountHintsPass());
   modulePassManager.addPass(IREE::Util::createDropCompilerHintsPass(
       IREE::Util::DropCompilerHintsPassOptions{/*keepAssumeInt=*/true}));
 
-  addSPIRVLoweringPasses(modulePassManager);
+  if (includeSPIRVLowering) {
+    addSPIRVLoweringPasses(modulePassManager);
+  }
 
   LLVM_DEBUG({
     llvm::dbgs() << "Using SPIR-V pass pipeline:\n";
@@ -759,12 +766,23 @@ void registerCodegenSPIRVPasses() {
         buildSPIRVCodegenConfigurationPassPipelineImpl(modulePassManager);
       });
 
-  static PassPipelineRegistration<> LinalgSPIRVPipeline(
-      "iree-codegen-linalg-to-spirv-pipeline",
-      "Runs the progressive lowering pipeline from linalg to SPIR-V",
-      [](OpPassManager &modulePassManager) {
-        buildSPIRVCodegenPassPipeline(modulePassManager);
-      });
+  struct SPIRVLoweringPipelineOptions final
+      : PassPipelineOptions<SPIRVLoweringPipelineOptions> {
+    Option<bool> includeSPIRVLowering{
+        *this, "include-spirv-lowering",
+        llvm::cl::desc("Include the lowering to SPIR-V dialect."),
+        llvm::cl::init(true)};
+  };
+
+  static PassPipelineRegistration<SPIRVLoweringPipelineOptions>
+      LinalgSPIRVPipeline(
+          "iree-codegen-linalg-to-spirv-pipeline",
+          "Runs the progressive lowering pipeline from linalg to SPIR-V",
+          [](OpPassManager &modulePassManager,
+             const SPIRVLoweringPipelineOptions &options) {
+            buildSPIRVCodegenPassPipeline(modulePassManager,
+                                          options.includeSPIRVLowering);
+          });
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -61,8 +61,11 @@ void buildSPIRVCodegenConfigurationPassPipeline(
     OpPassManager &modulePassManager);
 
 /// Populates passes needed to lower linalg/arith/math ops to SPIR-V ops via
-/// the structured ops path.
-void buildSPIRVCodegenPassPipeline(OpPassManager &modulePassManager);
+/// the structured ops path. When `includeSPIRVLowering` is false, the MemRef
+/// lowering and SPIR-V conversion passes are skipped, leaving the output at
+/// the vector/memref level.
+void buildSPIRVCodegenPassPipeline(OpPassManager &modulePassManager,
+                                   bool includeSPIRVLowering = true);
 
 /// Populates passes needed to link HAL executables across SPIRV targets.
 void buildSPIRVLinkingPassPipeline(OpPassManager &modulePassManager);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
@@ -1,4 +1,7 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=cdna2@vulkan --pass-pipeline='builtin.module(iree-codegen-spirv-configuration-pipeline, func.func(iree-spirv-lower-executable-target-pass))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=cdna2@vulkan \
+// RUN:   --iree-codegen-spirv-configuration-pipeline \
+// RUN:   --iree-codegen-linalg-to-spirv-pipeline='include-spirv-lowering=false' \
+// RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -1,8 +1,7 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=volta@vulkan --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-spirv-configuration-pipeline, func.func(iree-spirv-lower-executable-target-pass)))))' %s | FileCheck %s
-
-// TODO (MaheshRavishankar): This test should be modified to run just on the inner module/func.func. Blocked
-// today since `TileAndDistributeToWorkgroups` runs the `FoldAffineMinOverWorkgroupIds` pattern that
-// doesnt work without the entry point.
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=volta@vulkan \
+// RUN:   --iree-codegen-spirv-configuration-pipeline \
+// RUN:   --iree-codegen-linalg-to-spirv-pipeline='include-spirv-lowering=false' \
+// RUN:   %s | FileCheck %s
 
 // Verify pipelining + multi-buffering.
 
@@ -16,44 +15,32 @@
     lowering_config  = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 16]]>,
     translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize> workgroup_size = [16, 8, 1], {pipeline_depth = 2, store_stage = 1}>>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-hal.executable @matmul_f32_128x256x64 {
-  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_f32_128x256x64() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
-        %7 = tensor.empty() : tensor<128x256xf32>
-        %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
-        %9 = linalg.matmul {compilation_info = #compilation}
-           ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
-        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
-                ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
-        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %11 = arith.divf %arg0, %arg1 : f32
-          linalg.yield %11 : f32
-        } -> tensor<128x256xf32>
-        iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
-        return
-      }
-    }
-  }
+func.func @matmul_f32_128x256x64() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+  %7 = tensor.empty() : tensor<128x256xf32>
+  %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  %9 = linalg.matmul {compilation_info = #compilation}
+     ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+          ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %11 = arith.divf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<128x256xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
+  return
 }
 
 //       CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 2)>
-//       CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize> workgroup_size = [16, 8, 1]
 //     CHECK-LABEL: func.func @matmul_f32_128x256x64()
-//      CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //           CHECK:   %[[PV:.+]] = ub.poison : f32
 //           CHECK:   memref.alloc() : memref<2x64x20xf32, #gpu.address_space<workgroup>>
 //           CHECK:   memref.alloc() : memref<2x16x68xf32, #gpu.address_space<workgroup>>
@@ -101,44 +88,32 @@ hal.executable @matmul_f32_128x256x64 {
     lowering_config  = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 16]]>,
     translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize> workgroup_size = [16, 8, 1], {pipeline_depth = 2, store_stage = 0}>>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-hal.executable @matmul_f32_128x256x64 {
-  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_f32_128x256x64() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
-        %7 = tensor.empty() : tensor<128x256xf32>
-        %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
-        %9 = linalg.matmul {compilation_info = #compilation}
-                ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
-        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
-                ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
-        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
-          %11 = arith.divf %arg0, %arg1 : f32
-          linalg.yield %11 : f32
-        } -> tensor<128x256xf32>
-        iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
-        return
-      }
-    }
-  }
+func.func @matmul_f32_128x256x64() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+  %7 = tensor.empty() : tensor<128x256xf32>
+  %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  %9 = linalg.matmul {compilation_info = #compilation}
+          ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+          ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %11 = arith.divf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<128x256xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256xf32>>
+  return
 }
 
 //       CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 3)>
-//       CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize> workgroup_size = [16, 8, 1]
 //     CHECK-LABEL: func.func @matmul_f32_128x256x64()
-//      CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //           CHECK:   %[[PV:.+]] = ub.poison : f32
 //           CHECK:   memref.alloc() : memref<3x64x20xf32, #gpu.address_space<workgroup>>
 //           CHECK:   memref.alloc() : memref<3x16x68xf32, #gpu.address_space<workgroup>>
@@ -198,41 +173,31 @@ hal.executable @matmul_f32_128x256x64 {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = #iree_codegen.lowering_config<tile_sizes = [[64, 256, 32]]>,
     translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize> workgroup_size = [32, 8, 1], {pipeline_depth = 1, store_stage = 1}>>
-hal.executable @matmul_f16_4096x512x512 {
-  hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f16_4096x512x512 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg1, %arg2)
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_f16_4096x512x512() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x512xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x512xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x4096xf16>>
-        %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4096, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x512xf16>> -> tensor<4096x512xf16>
-        %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x512xf16>> -> tensor<512x512xf16>
-        %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0], sizes = [512], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512xf16>> -> tensor<512xf16>
-        %7 = tensor.empty() : tensor<512x4096xf16>
-        %8 = tensor.empty() : tensor<4096x512xf16>
-        %9 = linalg.fill ins(%cst : f16) outs(%8 : tensor<4096x512xf16>) -> tensor<4096x512xf16>
-        %10 = linalg.matmul {compilation_info = #compilation}
-          ins(%4, %5 : tensor<4096x512xf16>, tensor<512x512xf16>) outs(%9 : tensor<4096x512xf16>) -> tensor<4096x512xf16>
-        %11 = linalg.generic {
-          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1, d0)>],
-          iterator_types = ["parallel", "parallel"]
-        } ins(%10, %6 : tensor<4096x512xf16>, tensor<512xf16>) outs(%7 : tensor<512x4096xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %12 = arith.addf %in, %in_0 : f16
-          linalg.yield %12 : f16
-        } -> tensor<512x4096xf16>
-        iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0], sizes = [512, 4096], strides = [1, 1] : tensor<512x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x4096xf16>>
-        return
-      }
-    }
-  }
+func.func @matmul_f16_4096x512x512() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x512xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x512xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x4096xf16>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4096, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x512xf16>> -> tensor<4096x512xf16>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x512xf16>> -> tensor<512x512xf16>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0], sizes = [512], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512xf16>> -> tensor<512xf16>
+  %7 = tensor.empty() : tensor<512x4096xf16>
+  %8 = tensor.empty() : tensor<4096x512xf16>
+  %9 = linalg.fill ins(%cst : f16) outs(%8 : tensor<4096x512xf16>) -> tensor<4096x512xf16>
+  %10 = linalg.matmul {compilation_info = #compilation}
+    ins(%4, %5 : tensor<4096x512xf16>, tensor<512x512xf16>) outs(%9 : tensor<4096x512xf16>) -> tensor<4096x512xf16>
+  %11 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1, d0)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%10, %6 : tensor<4096x512xf16>, tensor<512xf16>) outs(%7 : tensor<512x4096xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %12 = arith.addf %in, %in_0 : f16
+    linalg.yield %12 : f16
+  } -> tensor<512x4096xf16>
+  iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0], sizes = [512, 4096], strides = [1, 1] : tensor<512x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x4096xf16>>
+  return
 }
 
 //     CHECK-LABEL: func.func @matmul_f16_4096x512x512()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
@@ -1,4 +1,7 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=cdna2@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass, func.func(iree-spirv-lower-executable-target-pass))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=cdna2@vulkan \
+// RUN:   --iree-codegen-spirv-configuration-pipeline \
+// RUN:   --iree-codegen-linalg-to-spirv-pipeline='include-spirv-lowering=false' \
+// RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -45,8 +48,7 @@ func.func @i4_dequant_matvec_f32() {
 
 //   CHECK-LABEL:  func.func @i4_dequant_matvec_f32()
 
-//         CHECK:   scf.forall (%arg0) in (4096)
-//         CHECK:     %[[FOR:.+]] = scf.for %arg1 = %c0 to %c86 step %c2 iter_args(%arg2 = {{.+}}) -> (vector<1x4xf32>)
+//         CHECK:     %[[FOR:.+]] = scf.for %arg0 = %c0 to %c86 step %c2 iter_args(%arg1 = {{.+}}) -> (vector<1x4xf32>)
 //         CHECK:       %[[READ0:.+]] = vector.transfer_read {{.+}} : memref<4096x86x128xi4, #hal.descriptor_type<storage_buffer>>, vector<4xi4>
 //         CHECK:       %[[READ1:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
 //         CHECK:       %[[READ2:.+]] = vector.transfer_read {{.+}} : memref<4096x86xf32, #hal.descriptor_type<storage_buffer>>, vector<1xf32>
@@ -59,7 +61,7 @@ func.func @i4_dequant_matvec_f32() {
 //         CHECK:       %[[BROADCAST1:.+]] = vector.broadcast %[[EXTRACT1]] : f32 to vector<4xf32>
 //         CHECK:       %[[MUL0:.+]] = arith.mulf %[[SUB]], %[[BROADCAST1]] : vector<4xf32>
 //         CHECK:       %[[MUL1:.+]] = arith.mulf %[[READ3]], %[[MUL0]] : vector<4xf32>
-//         CHECK:       %[[SHAPE_CAST:.+]] = vector.shape_cast %arg2 : vector<1x4xf32> to vector<4xf32>
+//         CHECK:       %[[SHAPE_CAST:.+]] = vector.shape_cast %arg1 : vector<1x4xf32> to vector<4xf32>
 //         CHECK:       %[[ADD:.+]] = arith.addf %[[MUL1]], %[[SHAPE_CAST]] : vector<4xf32>
 //         CHECK:       %[[SHAPE_CAST2:.+]] = vector.shape_cast %[[ADD]] : vector<4xf32> to vector<1x4xf32>
 //         CHECK:       scf.yield %[[SHAPE_CAST2]] : vector<1x4xf32>
@@ -69,4 +71,3 @@ func.func @i4_dequant_matvec_f32() {
 //         CHECK:     gpu.subgroup_reduce add %[[REDUCE]] : (f32) -> f32
 //         CHECK:     scf.if
 //         CHECK:       vector.transfer_write
-//         CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -1,5 +1,6 @@
 // RUN: iree-opt --split-input-file \
-// RUN:   --pass-pipeline='builtin.module(func.func(iree-codegen-decompose-softmax), iree-spirv-select-lowering-strategy-pass, func.func(iree-spirv-lower-executable-target-pass))' \
+// RUN:   --iree-codegen-spirv-configuration-pipeline \
+// RUN:   --iree-codegen-linalg-to-spirv-pipeline='include-spirv-lowering=false' \
 // RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -131,7 +132,8 @@ func.func @warp_reduction_dispatch_1() attributes {hal.executable.target = #exec
 //     CHECK-DAG:    %[[SPAN1_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //     CHECK-DAG:    %[[SPAN1:.+]] = memref.assume_alignment %[[SPAN1_BINDING]], 64
 
-//         CHECK:    scf.forall (%[[WGIDY:.+]], %[[WGIDX:.+]]) in (10, 9216) {
+//         CHECK:    scf.for %{{.+}} = %{{.+}} to %{{.+}} step %{{.+}} {
+//         CHECK:      %[[DELIN:.+]]:2 = affine.delinearize_index %{{.+}} into (10, 9216)
 //         CHECK:      %[[TIDX:.+]] = gpu.thread_id  x
 //         CHECK:      gpu.barrier memfence [#gpu.address_space<workgroup>]
 //         CHECK:      %{{.+}}, %{{.+}} = gpu.shuffle  xor %{{.+}}, %[[I1]], %[[I32]] : i32
@@ -143,16 +145,16 @@ func.func @warp_reduction_dispatch_1() attributes {hal.executable.target = #exec
 //         CHECK:      %[[BROADCAST:.+]] = vector.broadcast %[[ADD1]] : f16 to vector<4xf16>
 //         CHECK:      scf.for %[[IV:.+]] = %[[C0]] to %[[C9216]] step %[[C1024]] {
 //         CHECK:        %[[OFFSET:.+]] = affine.apply {{.*}}(%[[IV]])[%[[TIDX]]]
-//         CHECK:        %[[READ:.+]] = vector.transfer_read %[[SPAN0]][%[[WGIDY]], %[[WGIDX]], %[[OFFSET]]], %[[PV]] {in_bounds = [true]} : memref<10x9216x9216xf16{{.*}}>, vector<8xf16>
+//         CHECK:        %[[READ:.+]] = vector.transfer_read %[[SPAN0]][%[[DELIN]]#0, %[[DELIN]]#1, %[[OFFSET]]], %[[PV]] {in_bounds = [true]} : memref<10x9216x9216xf16{{.*}}>, vector<8xf16>
 //         CHECK:        %[[SLICE0:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [0], sizes = [4], strides = [1]}
 //         CHECK:        %[[DIV0:.+]] = arith.divf %[[SLICE0]], %[[BROADCAST]] : vector<4xf16>
 //         CHECK:        %[[SLICE1:.+]] = vector.insert_strided_slice %[[DIV0]], %cst {offsets = [0], strides = [1]}
 //         CHECK:        %[[SLICE2:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [4], sizes = [4], strides = [1]}
 //         CHECK:        %[[DIV1:.+]] = arith.divf %[[SLICE2]], %[[BROADCAST]] : vector<4xf16>
 //         CHECK:        %[[SLICE3:.+]] = vector.insert_strided_slice %[[DIV1]], %[[SLICE1]] {offsets = [4], strides = [1]}
-//         CHECK:        vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[WGIDY]], %[[WGIDX]], %{{.*}}] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
+//         CHECK:        vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[DELIN]]#0, %[[DELIN]]#1, %{{.*}}] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
 //         CHECK:      }
-//         CHECK:    } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+//         CHECK:    }
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_scalar_dispatch.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_scalar_dispatch.mlir
@@ -1,36 +1,29 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=pascal@vulkan --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-spirv-select-lowering-strategy-pass, func.func(iree-spirv-lower-executable-target-pass)))))' -mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=pascal@vulkan \
+// RUN:   --iree-codegen-spirv-configuration-pipeline \
+// RUN:   --iree-codegen-linalg-to-spirv-pipeline='include-spirv-lowering=false' \
+// RUN:   -mlir-print-local-scope %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @scalar_dispatch {
-  hal.executable.variant public @vulkan_spirv_fb target(#hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @scalar_dispatch ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %c1 = arith.constant 1 : index
-      hal.return %c1, %c1, %c1 : index, index, index
-    }
-    builtin.module {
-      func.func @scalar_dispatch() {
-        %c0 = arith.constant 0 : index
-        %c6364136223846793005_i64 = arith.constant 6364136223846793005 : i64
-        %c1442695040888963407_i64 = arith.constant 1442695040888963407 : i64
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<i64>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i64>>
-        %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<i64>> -> tensor<i64>
-        %extracted = tensor.extract %2[] : tensor<i64>
-        %3 = arith.muli %extracted, %c6364136223846793005_i64 : i64
-        %4 = arith.addi %3, %c1442695040888963407_i64 : i64
-        %inserted = tensor.insert %4 into %2[] : tensor<i64>
-        iree_tensor_ext.dispatch.tensor.store %inserted, %1, offsets = [], sizes = [], strides = [] : tensor<i64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i64>>
-        return
-      }
-    }
-  }
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<BaseLowering> workgroup_size = [1, 1, 1]>
+func.func @scalar_dispatch() attributes {translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %c6364136223846793005_i64 = arith.constant 6364136223846793005 : i64
+  %c1442695040888963407_i64 = arith.constant 1442695040888963407 : i64
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<i64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i64>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<i64>> -> tensor<i64>
+  %extracted = tensor.extract %2[] : tensor<i64>
+  %3 = arith.muli %extracted, %c6364136223846793005_i64 : i64
+  %4 = arith.addi %3, %c1442695040888963407_i64 : i64
+  %inserted = tensor.insert %4 into %2[] : tensor<i64>
+  iree_tensor_ext.dispatch.tensor.store %inserted, %1, offsets = [], sizes = [], strides = [] : tensor<i64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i64>>
+  return
 }
 
 //       CHECK: func.func @scalar_dispatch()
-//  CHECK-SAME:     translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<BaseLowering> workgroup_size = [1, 1, 1]>
 //       CHECK:   %[[SPAN0_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //       CHECK:   %[[SPAN0:.+]] = memref.assume_alignment %[[SPAN0_BINDING]], 64
 //       CHECK:   %[[SPAN1_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)


### PR DESCRIPTION
The revision introduces `includeSPIRVLowering` to the pipeline option, and migrate all the pipeline tests to module-scope pipeline.