### PR TITLE
[LinalgExt] Add scalar implementation for TopkV2Op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -711,7 +711,13 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 def IREELinalgExt_TopkV2Op : IREELinalgExt_Op<"topk_v2",[
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
-  DeclareOpInterfaceMethods<LinalgExtInterface>
+  DeclareOpInterfaceMethods<LinalgExtInterface>,
+  DeclareOpInterfaceMethods<TilingInterface,
+    ["generateScalarImplementation",
+     "getIterationDomain",
+     "getLoopIteratorTypes",
+     "getResultTilePosition",
+     "getTiledImplementation"]>
 ]>{
   let summary = [{Top-K v2 operator.}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -913,12 +913,69 @@ LogicalResult SortOp::getResultTilePosition(
   return success();
 }
 
+/// Emit one bubble-sort sweep: compare adjacent elements along sortDim and
+/// conditionally swap. compareOperands are fed to the comparator region (as
+/// interleaved pairs); carryOperands are swapped in lockstep but not compared.
+/// Convention: comparator returning true means keep current order (no swap).
+static void emitBubbleSortSweep(OpBuilder &b, Location loc, Value zero,
+                                Value one, Value ub, int64_t sortDim,
+                                ValueRange ivs, ValueRange compareOperands,
+                                ValueRange carryOperands,
+                                Region &comparatorRegion) {
+  Block &cmpBlock = comparatorRegion.front();
+  scf::ForOp::create(
+      b, loc, zero, ub, one, /*iterArgs=*/ValueRange{},
+      [&](OpBuilder &b, Location loc, Value j, ValueRange) {
+        // Compare adjacent elements at positions j (lhs) and j+1 (rhs).
+        Value jPlusOne = arith::AddIOp::create(b, loc, j, one);
+        SmallVector<Value> lhsIndices(ivs);
+        lhsIndices[sortDim] = j;
+        SmallVector<Value> rhsIndices(ivs);
+        rhsIndices[sortDim] = jPlusOne;
+
+        SmallVector<Value> cmpArgs;
+        SmallVector<Value> lhsVals, rhsVals;
+        for (Value operand : compareOperands) {
+          Value lhs = memref::LoadOp::create(b, loc, operand, lhsIndices);
+          Value rhs = memref::LoadOp::create(b, loc, operand, rhsIndices);
+          cmpArgs.push_back(lhs);
+          cmpArgs.push_back(rhs);
+          lhsVals.push_back(lhs);
+          rhsVals.push_back(rhs);
+        }
+
+        for (Value operand : carryOperands) {
+          lhsVals.push_back(
+              memref::LoadOp::create(b, loc, operand, lhsIndices));
+          rhsVals.push_back(
+              memref::LoadOp::create(b, loc, operand, rhsIndices));
+        }
+
+        IRMapping sortMap;
+        sortMap.map(cmpBlock.getArguments(), cmpArgs);
+        for (auto &blockOp : cmpBlock.without_terminator()) {
+          b.clone(blockOp, sortMap);
+        }
+        Value keepOrder =
+            sortMap.lookup(cmpBlock.getTerminator()->getOperand(0));
+
+        SmallVector<Value> allOps;
+        allOps.append(compareOperands.begin(), compareOperands.end());
+        allOps.append(carryOperands.begin(), carryOperands.end());
+        for (auto [operand, lhs, rhs] :
+             llvm::zip_equal(allOps, lhsVals, rhsVals)) {
+          Value newLhs = arith::SelectOp::create(b, loc, keepOrder, lhs, rhs);
+          Value newRhs = arith::SelectOp::create(b, loc, keepOrder, rhs, lhs);
+          memref::StoreOp::create(b, loc, newLhs, operand, lhsIndices);
+          memref::StoreOp::create(b, loc, newRhs, operand, rhsIndices);
+        }
+        scf::YieldOp::create(b, loc, /*operands=*/ValueRange{});
+      });
+}
+
 LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange ivs) {
   auto sortDim = getDimension();
-  SmallVector<Value> indices, sortBlkArgs;
-  indices.append(ivs.begin(), ivs.end());
-  // Bubble sort innermost loop.
   Value zero = arith::ConstantIndexOp::create(b, loc, 0);
   Value one = arith::ConstantIndexOp::create(b, loc, 1);
   Value ub;
@@ -929,61 +986,10 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                         getOperandType(0).getDimSize(sortDim));
   }
   ub = arith::SubIOp::create(b, loc, ub, one);
-  auto scfFor = scf::ForOp::create(
-      b, loc, zero, ub, one, ValueRange{},
-      [&](OpBuilder &b, Location loc, Value iv, ValueRange iters) {
-        SmallVector<Value> indices(ivs);
-        Value ivPlusOne = arith::AddIOp::create(b, loc, iv, one);
-        for (auto output : getDpsInits()) {
-          indices[sortDim] = iv;
-          sortBlkArgs.push_back(
-              memref::LoadOp::create(b, loc, output, indices));
-          indices[sortDim] = ivPlusOne;
-          sortBlkArgs.push_back(
-              memref::LoadOp::create(b, loc, output, indices));
-        }
-      });
-
-  auto &srcBlock = getRegion().front();
-  Region &region = scfFor.getRegion();
-  IRMapping bvm;
-  {
-    OpBuilder::InsertionGuard guard(b);
-    auto &block = region.front();
-    b.setInsertionPointToEnd(&block);
-    for (auto it : llvm::zip_equal(srcBlock.getArguments(), sortBlkArgs)) {
-      bvm.map(std::get<0>(it), std::get<1>(it));
-    }
-    for (auto &blockOp : srcBlock.without_terminator()) {
-      b.clone(blockOp, bvm);
-    }
-  }
-  Value cond = bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0));
-
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPointToEnd(&region.front());
-  scf::IfOp::create(
-      b, loc, cond,
-      [&](OpBuilder &b, Location loc) {
-        // Do not swap the pairs if true.
-        scf::YieldOp::create(b, loc);
-      },
-      [&](OpBuilder &b, Location loc) {
-        // Swap the pairs if false.
-        SmallVector<Value> indices(ivs);
-        Value ivPlusOne =
-            arith::AddIOp::create(b, loc, scfFor.getInductionVar(), one);
-        for (int i = 0, e = getNumDpsInits(); i < e; ++i) {
-          Value v1 = sortBlkArgs[i * 2];
-          Value v2 = sortBlkArgs[i * 2 + 1];
-          indices[sortDim] = scfFor.getInductionVar();
-          memref::StoreOp::create(b, loc, v2, getDpsInits()[i], indices);
-          indices[sortDim] = ivPlusOne;
-          memref::StoreOp::create(b, loc, v1, getDpsInits()[i], indices);
-        }
-        scf::YieldOp::create(b, loc);
-      });
-  scf::YieldOp::create(b, loc);
+  SmallVector<Value> compareOperands(getDpsInits().begin(),
+                                     getDpsInits().end());
+  emitBubbleSortSweep(b, loc, zero, one, ub, sortDim, ivs, compareOperands,
+                      /*carryOperands=*/{}, getRegion());
   return success();
 }
 
@@ -1418,7 +1424,7 @@ SmallVector<utils::IteratorType> TopkOp::getLoopIteratorTypes() {
 
 LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange ivs) {
-  uint64_t kDim = getDimension();
+  int64_t kDim = getDimension();
   Value zero = arith::ConstantIndexOp::create(b, loc, 0);
   Value one = arith::ConstantIndexOp::create(b, loc, 1);
   Value initialValue = memref::LoadOp::create(b, loc, getValues(), ivs);
@@ -1467,14 +1473,10 @@ LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
     // Save previous insertion point. Continue within loop body.
     OpBuilder::InsertionGuard guard(b);
     b.setInsertionPointToEnd(&scfFor.getRegion().front());
-    SmallVector<Value> forwardValues{loopCarryValues[0], kValue};
-    SmallVector<Value> reverseValues{kValue, loopCarryValues[0]};
-    for (auto it : llvm::zip_equal(srcBlock.getArguments(), forwardValues)) {
-      bvmF.map(std::get<0>(it), std::get<1>(it));
-    }
-    for (auto it : llvm::zip_equal(srcBlock.getArguments(), reverseValues)) {
-      bvmR.map(std::get<0>(it), std::get<1>(it));
-    }
+    SmallVector<Value> forwardValues = {loopCarryValues[0], kValue};
+    SmallVector<Value> reverseValues = {kValue, loopCarryValues[0]};
+    bvmF.map(srcBlock.getArguments(), forwardValues);
+    bvmR.map(srcBlock.getArguments(), reverseValues);
     for (auto &blockOp : srcBlock.without_terminator()) {
       b.clone(blockOp, bvmF);
       b.clone(blockOp, bvmR);
@@ -1591,6 +1593,173 @@ LogicalResult TopkOp::getResultTilePosition(
                             getDimension());
   resultSizes[getDimension()] = getAsOpFoldResult(kSize);
   return success();
+}
+
+/// Emit a full bubble sort over K output positions using the shared sweep
+/// helper. The outer double loop provides the O(k^2) passes needed for a
+/// complete sort.
+static void emitBubbleSort(OpBuilder &b, Location loc, Value ub, Value zero,
+                           Value one, int64_t kDim, ValueRange ivs,
+                           Value outputValues, Value outputIndices,
+                           Region &comparatorRegion) {
+  Value kMinus1 = arith::SubIOp::create(b, loc, ub, one);
+  SmallVector<Value> carryOps;
+  if (outputIndices) {
+    carryOps.push_back(outputIndices);
+  }
+  scf::ForOp::create(
+      b, loc, zero, kMinus1, one, /*iterArgs=*/ValueRange{},
+      [&](OpBuilder &b, Location loc, Value i, ValueRange) {
+        Value innerUb = arith::SubIOp::create(b, loc, kMinus1, i);
+        emitBubbleSortSweep(b, loc, zero, one, innerUb, kDim, ivs,
+                            /*compareOperands=*/{outputValues}, carryOps,
+                            comparatorRegion);
+        scf::YieldOp::create(b, loc, /*operands=*/ValueRange{});
+      });
+}
+
+//===----------------------------------------------------------------------===//
+// TopkV2Op
+//===----------------------------------------------------------------------===//
+
+SmallVector<Range> TopkV2Op::getIterationDomain(OpBuilder &builder) {
+  unsigned rank = getInputType().getRank();
+  SmallVector<Range> loopBounds(rank);
+  Location loc = getLoc();
+  OpFoldResult zero = builder.getIndexAttr(0);
+  OpFoldResult one = builder.getIndexAttr(1);
+  Value source = getValues();
+  for (unsigned idx = 0; idx < rank; ++idx) {
+    loopBounds[idx].offset = zero;
+    loopBounds[idx].size = getDim(builder, loc, source, idx);
+    loopBounds[idx].stride = one;
+  }
+  return loopBounds;
+}
+
+SmallVector<utils::IteratorType> TopkV2Op::getLoopIteratorTypes() {
+  SmallVector<utils::IteratorType> iteratorTypes(getInputRank(),
+                                                 utils::IteratorType::parallel);
+  iteratorTypes[getDimension()] = utils::IteratorType::reduction;
+  return iteratorTypes;
+}
+
+LogicalResult TopkV2Op::generateScalarImplementation(OpBuilder &b, Location loc,
+                                                     ValueRange ivs) {
+  int64_t kDim = getDimension();
+  Value zero = arith::ConstantIndexOp::create(b, loc, 0);
+  Value one = arith::ConstantIndexOp::create(b, loc, 1);
+  Value inputValues = getValues();
+  Value outputValues = getOutputValues();
+  Value outputIndices = getOutputIndices();
+  Value initialValue = memref::LoadOp::create(b, loc, inputValues, ivs);
+
+  // Compute K (ub) from the selected dim of the output.
+  Value ub = memref::DimOp::create(b, loc, outputValues, kDim);
+
+  SmallVector<Value> initValues = {initialValue};
+  if (outputIndices) {
+    Value initialIndex;
+    Value inputIndices = getInputIndices();
+    if (inputIndices) {
+      initialIndex = memref::LoadOp::create(b, loc, inputIndices, ivs);
+    } else {
+      Type indexElemTy =
+          cast<ShapedType>(outputIndices.getType()).getElementType();
+      initialIndex = arith::IndexCastOp::create(b, loc, indexElemTy, ivs[kDim]);
+    }
+    initValues.push_back(initialIndex);
+  }
+
+  Block &srcBlock = getRegion().front();
+  scf::ForOp::create(
+      b, loc, zero, ub, one, initValues,
+      [&](OpBuilder &b, Location loc, Value iv, ValueRange loopCarryValues) {
+        SmallVector<Value> indices(ivs);
+        indices[kDim] = iv;
+        Value kValue = memref::LoadOp::create(b, loc, outputValues, indices);
+        Value kIndex;
+        if (outputIndices) {
+          kIndex = memref::LoadOp::create(b, loc, outputIndices, indices);
+        }
+
+        // Clone the comparator region with forward mapping f(x,y).
+        IRMapping bvmF;
+        SmallVector<Value> forwardValues = {loopCarryValues[0], kValue};
+        bvmF.map(srcBlock.getArguments(), forwardValues);
+        for (auto &blockOp : srcBlock.without_terminator()) {
+          b.clone(blockOp, bvmF);
+        }
+        Value forwardCmpRes =
+            bvmF.lookup(srcBlock.getTerminator()->getOperand(0));
+
+        Value resultKValue = arith::SelectOp::create(
+            b, loc, forwardCmpRes, loopCarryValues[0], kValue);
+        memref::StoreOp::create(b, loc, resultKValue, outputValues, indices);
+        Value resultCarryValue = arith::SelectOp::create(
+            b, loc, forwardCmpRes, kValue, loopCarryValues[0]);
+
+        SmallVector<Value> yieldValues = {resultCarryValue};
+
+        // With output indices, also clone the reverse mapping f(y,x) for
+        // strict weak ordering tie-breaking.
+        if (outputIndices) {
+          IRMapping bvmR;
+          SmallVector<Value> reverseValues = {kValue, loopCarryValues[0]};
+          bvmR.map(srcBlock.getArguments(), reverseValues);
+          for (auto &blockOp : srcBlock.without_terminator()) {
+            b.clone(blockOp, bvmR);
+          }
+          Value reverseCmpRes =
+              bvmR.lookup(srcBlock.getTerminator()->getOperand(0));
+
+          // Strict weak ordering tie-breaking:
+          //   f(x,y) --> forwardCmpRes.
+          //   f(y,x) --> reverseCmpRes.
+          //   If forwardCmpRes == reverseCmpRes, select which came first.
+          Value cmpValuesEqual = arith::CmpIOp::create(
+              b, loc, arith::CmpIPredicate::eq, forwardCmpRes, reverseCmpRes);
+          Value cmpFirstIndex = arith::CmpIOp::create(
+              b, loc, arith::CmpIPredicate::slt, loopCarryValues[1], kIndex);
+          Value combinedCmpEqRes =
+              arith::AndIOp::create(b, loc, cmpValuesEqual, cmpFirstIndex);
+          Value indexCmpRes =
+              arith::OrIOp::create(b, loc, forwardCmpRes, combinedCmpEqRes);
+          Value resultKIndex = arith::SelectOp::create(
+              b, loc, indexCmpRes, loopCarryValues[1], kIndex);
+          memref::StoreOp::create(b, loc, resultKIndex, outputIndices, indices);
+          Value resultCarryIndex = arith::SelectOp::create(
+              b, loc, indexCmpRes, kIndex, loopCarryValues[1]);
+          yieldValues.push_back(resultCarryIndex);
+        }
+
+        scf::YieldOp::create(b, loc, yieldValues);
+      });
+
+  // When is_sorted is true, add a bubble sort pass after each insertion to
+  // ensure the output buffer is sorted regardless of its initial state. The
+  // insertion-sort-style K loop above maintains sorted order only if the
+  // output buffer was already sorted; this pass fixes any initial disorder.
+  if (getIsSorted()) {
+    emitBubbleSort(b, loc, ub, zero, one, kDim, ivs, outputValues,
+                   outputIndices, getRegion());
+  }
+
+  return success();
+}
+
+FailureOr<TilingResult>
+TopkV2Op::getTiledImplementation(OpBuilder &builder,
+                                 ArrayRef<OpFoldResult> offsets,
+                                 ArrayRef<OpFoldResult> sizes) {
+  return failure();
+}
+
+LogicalResult TopkV2Op::getResultTilePosition(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
+    SmallVector<OpFoldResult> &resultSizes) {
+  return failure();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -21,12 +21,10 @@ func.func @sort_1d(%arg0: memref<128xi32>) {
 // CHECK:             %[[V1:.+]] = memref.load %[[BUF]][%[[ARG2]]]
 // CHECK:             %[[V2:.+]] = memref.load %[[BUF]][%[[T1]]]
 // CHECK:             %[[COND:.+]] = arith.cmpi sgt, %[[V1]], %[[V2]] : i32
-// CHECK:             scf.if %[[COND]] {
-// CHECK:             } else {
-// CHECK:               %[[T2:.+]] = arith.addi %[[ARG2]], %[[C1]] : index
-// CHECK:               memref.store %[[V2]], %[[BUF]][%[[ARG2]]]
-// CHECK:               memref.store %[[V1]], %[[BUF]][%[[T2]]]
-// CHECK:             }
+// CHECK:             %[[NEW1:.+]] = arith.select %[[COND]], %[[V1]], %[[V2]] : i32
+// CHECK:             %[[NEW2:.+]] = arith.select %[[COND]], %[[V2]], %[[V1]] : i32
+// CHECK:             memref.store %[[NEW1]], %[[BUF]][%[[ARG2]]]
+// CHECK:             memref.store %[[NEW2]], %[[BUF]][%[[T1]]]
 
 // -----
 
@@ -53,12 +51,10 @@ func.func @sort_2d(%arg0: memref<16x32xi32>) {
 // CHECK:               %[[V1:.+]] = memref.load %[[BUF]][%[[ARG3]], %[[ARG2]]]
 // CHECK:               %[[V2:.+]] = memref.load %[[BUF]][%[[T1]], %[[ARG2]]]
 // CHECK:               %[[COND:.+]] = arith.cmpi sgt, %[[V1]], %[[V2]] : i32
-// CHECK:               scf.if %[[COND]] {
-// CHECK:               } else {
-// CHECK:                 %[[T2:.+]] = arith.addi %[[ARG3]], %[[C1]] : index
-// CHECK:                 memref.store %[[V2]], %[[BUF]][%[[ARG3]], %[[ARG2]]]
-// CHECK:                 memref.store %[[V1]], %[[BUF]][%[[T2]], %[[ARG2]]]
-// CHECK:               }
+// CHECK:               %[[NEW1:.+]] = arith.select %[[COND]], %[[V1]], %[[V2]] : i32
+// CHECK:               %[[NEW2:.+]] = arith.select %[[COND]], %[[V2]], %[[V1]] : i32
+// CHECK:               memref.store %[[NEW1]], %[[BUF]][%[[ARG3]], %[[ARG2]]]
+// CHECK:               memref.store %[[NEW2]], %[[BUF]][%[[T1]], %[[ARG2]]]
 
 // -----
 
@@ -87,14 +83,14 @@ func.func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
 // CHECK:             %[[V3:.+]] = memref.load %[[BUF2]][%[[ARG2]]]
 // CHECK:             %[[V4:.+]] = memref.load %[[BUF2]][%[[T1]]]
 // CHECK:             %[[COND:.+]] = arith.cmpf ogt, %[[V1]], %[[V2]] : f32
-// CHECK:             scf.if %[[COND]] {
-// CHECK:             } else {
-// CHECK:               %[[T2:.+]] = arith.addi %[[ARG2]], %[[C1]] : index
-// CHECK:               memref.store %[[V2]], %[[BUF1]][%[[ARG2]]]
-// CHECK:               memref.store %[[V1]], %[[BUF1]][%[[T2]]]
-// CHECK:               memref.store %[[V4]], %[[BUF2]][%[[ARG2]]]
-// CHECK:               memref.store %[[V3]], %[[BUF2]][%[[T2]]]
-// CHECK:             }
+// CHECK:             %[[NEW1:.+]] = arith.select %[[COND]], %[[V1]], %[[V2]] : f32
+// CHECK:             %[[NEW2:.+]] = arith.select %[[COND]], %[[V2]], %[[V1]] : f32
+// CHECK:             memref.store %[[NEW1]], %[[BUF1]][%[[ARG2]]]
+// CHECK:             memref.store %[[NEW2]], %[[BUF1]][%[[T1]]]
+// CHECK:             %[[NEW3:.+]] = arith.select %[[COND]], %[[V3]], %[[V4]] : i32
+// CHECK:             %[[NEW4:.+]] = arith.select %[[COND]], %[[V4]], %[[V3]] : i32
+// CHECK:             memref.store %[[NEW3]], %[[BUF2]][%[[ARG2]]]
+// CHECK:             memref.store %[[NEW4]], %[[BUF2]][%[[T1]]]
 
 // -----
 
@@ -778,6 +774,256 @@ func.func @topk_memref_optional(%input_values: memref<2x10xf32>, %out_values: me
 // CHECK:               %[[D13:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG6]] : f32
 // CHECK:               %[[D14:.+]] = arith.select %[[D10]], %[[D4]], %[[ARG7]] : i32
 // CHECK:               scf.yield %[[D13]], %[[D14]] : f32, i32
+
+// -----
+
+func.func @topk_v2_memref(%input_values: memref<2x10xf32>, %input_indices: memref<2x10xi32>, %out_values: memref<2x3xf32>, %out_indices: memref<2x3xi32>) {
+  iree_linalg_ext.topk_v2
+        dimension(1)
+        ins(%input_values, %input_indices : memref<2x10xf32> , memref<2x10xi32>)
+        outs(%out_values, %out_indices : memref<2x3xf32>, memref<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func.func @topk_v2_memref
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         scf.for %[[ARG4:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:           scf.for %[[ARG5:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+// CHECK:             %[[D0:.+]] = memref.load %[[ARG0]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D1:.+]] = memref.load %[[ARG1]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D2:.+]]:2 = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[D0]], %[[ARG8:.+]] = %[[D1]])
+// CHECK:               %[[D3:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D4:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D5:.+]] = arith.cmpf ogt, %[[ARG7]], %[[D3]] : f32
+// CHECK:               %[[D6:.+]] = arith.select %[[D5]], %[[ARG7]], %[[D3]] : f32
+// CHECK:               memref.store %[[D6]], %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D7:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D8:.+]] = arith.cmpf ogt, %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D9:.+]] = arith.cmpi eq, %[[D5]], %[[D8]] : i1
+// CHECK:               %[[D10:.+]] = arith.cmpi slt, %[[ARG8]], %[[D4]] : i32
+// CHECK:               %[[D11:.+]] = arith.andi %[[D9]], %[[D10]] : i1
+// CHECK:               %[[D12:.+]] = arith.ori %[[D5]], %[[D11]] : i1
+// CHECK:               %[[D13:.+]] = arith.select %[[D12]], %[[ARG8]], %[[D4]] : i32
+// CHECK:               memref.store %[[D13]], %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D14:.+]] = arith.select %[[D12]], %[[D4]], %[[ARG8]] : i32
+// CHECK:               scf.yield %[[D7]], %[[D14]] : f32, i32
+
+// -----
+
+func.func @topk_v2_memref_values_only(%input_values: memref<2x10xf32>, %out_values: memref<2x3xf32>) {
+  iree_linalg_ext.topk_v2
+        dimension(1)
+        ins(%input_values : memref<2x10xf32>)
+        outs(%out_values : memref<2x3xf32>) {
+        ^bb0(%arg0: f32, %arg1: f32):
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func.func @topk_v2_memref_values_only
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:           scf.for %[[ARG3:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+// CHECK:             %[[D0:.+]] = memref.load %[[ARG0]][%[[ARG2]], %[[ARG3]]]
+// CHECK:             scf.for %[[ARG4:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[D0]])
+// CHECK:               %[[D1:.+]] = memref.load %[[ARG1]][%[[ARG2]], %[[ARG4]]]
+// CHECK:               %[[D2:.+]] = arith.cmpf ogt, %[[ARG5]], %[[D1]] : f32
+// CHECK:               %[[D3:.+]] = arith.select %[[D2]], %[[ARG5]], %[[D1]] : f32
+// CHECK:               memref.store %[[D3]], %[[ARG1]][%[[ARG2]], %[[ARG4]]]
+// CHECK:               %[[D4:.+]] = arith.select %[[D2]], %[[D1]], %[[ARG5]] : f32
+// CHECK:               scf.yield %[[D4]] : f32
+
+// -----
+
+func.func @topk_v2_memref_i64_indices(%input_values: memref<2x10xf32>, %input_indices: memref<2x10xi64>, %out_values: memref<2x3xf32>, %out_indices: memref<2x3xi64>) {
+  iree_linalg_ext.topk_v2
+        dimension(1)
+        ins(%input_values, %input_indices : memref<2x10xf32> , memref<2x10xi64>)
+        outs(%out_values, %out_indices : memref<2x3xf32>, memref<2x3xi64>) {
+        ^bb0(%arg0: f32, %arg1: f32):
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func.func @topk_v2_memref_i64_indices
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         scf.for %[[ARG4:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:           scf.for %[[ARG5:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+// CHECK:             %[[D0:.+]] = memref.load %[[ARG0]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D1:.+]] = memref.load %[[ARG1]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D2:.+]]:2 = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[D0]], %[[ARG8:.+]] = %[[D1]])
+// CHECK:               %[[D3:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D4:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D5:.+]] = arith.cmpf ogt, %[[ARG7]], %[[D3]] : f32
+// CHECK:               %[[D6:.+]] = arith.select %[[D5]], %[[ARG7]], %[[D3]] : f32
+// CHECK:               memref.store %[[D6]], %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D7:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D8:.+]] = arith.cmpf ogt, %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D9:.+]] = arith.cmpi eq, %[[D5]], %[[D8]] : i1
+// CHECK:               %[[D10:.+]] = arith.cmpi slt, %[[ARG8]], %[[D4]] : i64
+// CHECK:               %[[D11:.+]] = arith.andi %[[D9]], %[[D10]] : i1
+// CHECK:               %[[D12:.+]] = arith.ori %[[D5]], %[[D11]] : i1
+// CHECK:               %[[D13:.+]] = arith.select %[[D12]], %[[ARG8]], %[[D4]] : i64
+// CHECK:               memref.store %[[D13]], %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D14:.+]] = arith.select %[[D12]], %[[D4]], %[[ARG8]] : i64
+// CHECK:               scf.yield %[[D7]], %[[D14]] : f32, i64
+
+// -----
+
+func.func @topk_v2_memref_is_sorted(%input_values: memref<2x10xf32>, %input_indices: memref<2x10xi32>, %out_values: memref<2x3xf32>, %out_indices: memref<2x3xi32>) {
+  iree_linalg_ext.topk_v2
+        dimension(1) is_sorted
+        ins(%input_values, %input_indices : memref<2x10xf32> , memref<2x10xi32>)
+        outs(%out_values, %out_indices : memref<2x3xf32>, memref<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func.func @topk_v2_memref_is_sorted
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         scf.for %[[ARG4:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:           scf.for %[[ARG5:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+//                    --- K insertion loop ---
+// CHECK:             %[[D0:.+]] = memref.load %[[ARG0]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D1:.+]] = memref.load %[[ARG1]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             scf.for {{.*}} = %[[C0]] to %[[C3]] step %[[C1]] iter_args
+// CHECK:               arith.cmpf ogt
+// CHECK:               arith.select
+// CHECK:               memref.store {{.*}}, %[[ARG2]]
+// CHECK:               arith.select
+// CHECK:               memref.store {{.*}}, %[[ARG3]]
+// CHECK:               scf.yield
+//                    --- Bubble sort pass (is_sorted): kMinus1 folds to C2 ---
+// CHECK:             scf.for %[[SI:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:               %[[IUB:.+]] = arith.subi %[[C2]], %[[SI]]
+// CHECK:               scf.for %[[SJ:.+]] = %[[C0]] to %[[IUB]] step %[[C1]]
+// CHECK:                 %[[SJ1:.+]] = arith.addi %[[SJ]], %[[C1]]
+// CHECK:                 %[[VJ:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[SJ]]]
+// CHECK:                 %[[VJ1:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[SJ1]]]
+// CHECK:                 %[[IJ:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[SJ]]]
+// CHECK:                 %[[IJ1:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[SJ1]]]
+// CHECK:                 %[[CMP:.+]] = arith.cmpf ogt, %[[VJ]], %[[VJ1]] : f32
+// CHECK:                 %[[NVJ:.+]] = arith.select %[[CMP]], %[[VJ]], %[[VJ1]]
+// CHECK:                 %[[NVJ1:.+]] = arith.select %[[CMP]], %[[VJ1]], %[[VJ]]
+// CHECK:                 memref.store %[[NVJ]], %[[ARG2]][%[[ARG4]], %[[SJ]]]
+// CHECK:                 memref.store %[[NVJ1]], %[[ARG2]][%[[ARG4]], %[[SJ1]]]
+// CHECK:                 %[[NIJ:.+]] = arith.select %[[CMP]], %[[IJ]], %[[IJ1]]
+// CHECK:                 %[[NIJ1:.+]] = arith.select %[[CMP]], %[[IJ1]], %[[IJ]]
+// CHECK:                 memref.store %[[NIJ]], %[[ARG3]][%[[ARG4]], %[[SJ]]]
+// CHECK:                 memref.store %[[NIJ1]], %[[ARG3]][%[[ARG4]], %[[SJ1]]]
+
+// -----
+
+func.func @topk_v2_memref_values_only_is_sorted(%input_values: memref<2x10xf32>, %out_values: memref<2x3xf32>) {
+  iree_linalg_ext.topk_v2
+        dimension(1) is_sorted
+        ins(%input_values : memref<2x10xf32>)
+        outs(%out_values : memref<2x3xf32>) {
+        ^bb0(%arg0: f32, %arg1: f32):
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func.func @topk_v2_memref_values_only_is_sorted
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:           scf.for %[[ARG3:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+//                    --- K insertion loop ---
+// CHECK:             %[[D0:.+]] = memref.load %[[ARG0]][%[[ARG2]], %[[ARG3]]]
+// CHECK:             scf.for {{.*}} = %[[C0]] to %[[C3]] step %[[C1]] iter_args
+// CHECK:               arith.cmpf ogt
+// CHECK:               arith.select
+// CHECK:               memref.store {{.*}}, %[[ARG1]]
+// CHECK:               arith.select
+// CHECK:               scf.yield
+//                    --- Bubble sort pass (is_sorted): kMinus1 folds to C2 ---
+// CHECK:             scf.for %[[SI:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:               %[[IUB:.+]] = arith.subi %[[C2]], %[[SI]]
+// CHECK:               scf.for %[[SJ:.+]] = %[[C0]] to %[[IUB]] step %[[C1]]
+// CHECK:                 %[[SJ1:.+]] = arith.addi %[[SJ]], %[[C1]]
+// CHECK:                 %[[VJ:.+]] = memref.load %[[ARG1]][%[[ARG2]], %[[SJ]]]
+// CHECK:                 %[[VJ1:.+]] = memref.load %[[ARG1]][%[[ARG2]], %[[SJ1]]]
+// CHECK:                 %[[CMP:.+]] = arith.cmpf ogt, %[[VJ]], %[[VJ1]] : f32
+// CHECK:                 %[[NVJ:.+]] = arith.select %[[CMP]], %[[VJ]], %[[VJ1]]
+// CHECK:                 %[[NVJ1:.+]] = arith.select %[[CMP]], %[[VJ1]], %[[VJ]]
+// CHECK:                 memref.store %[[NVJ]], %[[ARG1]][%[[ARG2]], %[[SJ]]]
+// CHECK:                 memref.store %[[NVJ1]], %[[ARG1]][%[[ARG2]], %[[SJ1]]]
+
+// -----
+
+// K=1 edge case: bubble sort outer loop is [0, 0) so no sorting occurs.
+func.func @topk_v2_memref_is_sorted_k1(%input_values: memref<2x10xf32>, %out_values: memref<2x1xf32>) {
+  iree_linalg_ext.topk_v2
+        dimension(1) is_sorted
+        ins(%input_values : memref<2x10xf32>)
+        outs(%out_values : memref<2x1xf32>) {
+        ^bb0(%arg0: f32, %arg1: f32):
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func.func @topk_v2_memref_is_sorted_k1
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         scf.for
+// CHECK:           scf.for
+//                    --- K insertion loop (K=1) ---
+// CHECK:             scf.for {{.*}} iter_args
+// CHECK:               arith.cmpf ogt
+// CHECK:               scf.yield
+//                    --- Bubble sort: kMinus1 folds to C0, outer loop [0,0) is a no-op ---
+// CHECK:             scf.for {{.*}} = %[[C0]] to %[[C0]] step %[[C1]]
 
 // -----
 


### PR DESCRIPTION
This PR adds scalar lowering (`generateScalarImplementation`) for TopkV2Op, including bubble sort support for the `is_sorted `flag. This enables convert-to-loops for TopkV2Op. Also, this PR extracts a shared `emitBubbleSortSweep `helper and refactors SortOp to use it, replacing the inline `scf.if `swap logic with `arith.select`.                                                                  
  
`getTiledImplementation `and `getResultTilePosition `return failure() as placeholders; real tiling support is sent in PR #24129