### PR TITLE
[LinalgExt] Verify input/output indices element types match in topk_v2

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1366,6 +1366,12 @@ LogicalResult TopkV2Op::verify() {
     if (failed(verifyCompatibleShape(inputValuesType, inputIndicesType))) {
       return emitOpError("input values/indices shape must match");
     }
+    auto outputIndicesType = cast<ShapedType>(getOutputIndices().getType());
+    if (inputIndicesType.getElementType() !=
+        outputIndicesType.getElementType()) {
+      return emitOpError(
+          "expected input/output indices element types to be identical");
+    }
   }
 
   if (Value outputIndices = getOutputIndices()) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1242,6 +1242,24 @@ func.func @topk_v2_input_indices_without_output_indices(
 
 // -----
 
+func.func @topk_v2_indices_element_type_mismatch(
+    %arg0: tensor<4x128xf32>, %arg1: tensor<4x128xi32>)
+    -> (tensor<4x128xf32>, tensor<4x128xi64>) {
+  %out_values = tensor.empty() : tensor<4x128xf32>
+  %out_indices = tensor.empty() : tensor<4x128xi64>
+  // expected-error@+1 {{expected input/output indices element types to be identical}}
+  %0:2 = iree_linalg_ext.topk_v2 dimension(1)
+      ins(%arg0, %arg1 : tensor<4x128xf32>, tensor<4x128xi32>)
+      outs(%out_values, %out_indices : tensor<4x128xf32>, tensor<4x128xi64>) {
+      ^bb0(%lhs: f32, %rhs: f32):
+        %cmp = arith.cmpf oge, %lhs, %rhs : f32
+        iree_linalg_ext.yield %cmp : i1
+      } -> tensor<4x128xf32>, tensor<4x128xi64>
+  return %0#0, %0#1 : tensor<4x128xf32>, tensor<4x128xi64>
+}
+
+// -----
+
 func.func @exp_reduction_non_zero(%S: tensor<2x3xf32>) -> tensor<2xf32> {
   %M = tensor.empty() : tensor<2xf32>
   %out = tensor.empty() : tensor<2xf32>


### PR DESCRIPTION
Per https://github.com/iree-org/iree/pull/24129#issuecomment-4264485479, this PR adds a verifier check that ensures input and output indices have matching element types when both are present.