### PR TITLE
[CI] Fix BYO LLVM build

### DIFF
--- a/build_tools/llvm/llvm_config.cmake
+++ b/build_tools/llvm/llvm_config.cmake
@@ -50,9 +50,11 @@ set(LLVM_INSTALL_TOOLCHAIN_ONLY OFF CACHE BOOL "")
 
 ### Distributions ###
 
+# Order matters: Toolchain must come before Development so that the LLVM shared
+# library target is defined before Development exports reference it.
 set(LLVM_DISTRIBUTIONS
-      Development
       Toolchain
+      Development
     CACHE STRING "")
 
 set(LLVM_TOOLCHAIN_TOOLS

--- a/tests/e2e/attention/CMakeLists.txt
+++ b/tests/e2e/attention/CMakeLists.txt
@@ -184,6 +184,8 @@ iree_generated_e2e_runner_test(
   LABELS
     "hostonly"
     "local"
+  TIMEOUT
+    300
 )
 
 # To distinguish between CDNA(gfx9) and RDNA3(gfx11)


### PR DESCRIPTION
Two fixes:

- https://github.com/iree-org/iree/pull/23708 alphabetically sorted `LLVM_DISTRIBUTIONS` in `llvm_config.cmake`, changing the order from`Toolchain, Development` to `Development, Toolchain`. This order controls the include order of export files in the generated `LLVMConfig.cmake`. `LLVMDevelopmentExports.cmake` references the `LLVM` shared library target defined in `LLVMToolchainExports.cmake`, so Toolchain must be loaded first.
- `e2e_attention_cpu_f16_f16_f16_prefill_medium` (introduced by #23342) exceeds the default 60s timeout on the `ubuntu-24.04` GitHub-hosted runner (actual runtime ~127s). Increase its timeout to 300s.


ci-extra: linux_x64_clang_byollvm
Assisted-by: Cursor (Claude)