### PR TITLE
Enable building without google benchmark dependency 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(IREE_ENABLE_RUNTIME_TRACING "Enables instrumented runtime tracing." OFF)
 option(IREE_ENABLE_COMPILER_TRACING "Enables instrumented compiler tracing." OFF)
 option(IREE_ENABLE_RENDERDOC_PROFILING "Enables profiling HAL devices with the RenderDoc tool." OFF)
 option(IREE_ENABLE_THREADING "Builds IREE in with thread library support." ON)
+option(IREE_ENABLE_THIRD_PARTY_BENCHMARK "Enables building and linking the bundled google benchmark dependency." ON)
 option(IREE_SYNCHRONIZATION_DISABLE_UNSAFE "Disables all synchronization primitives (for single-threaded bare-metal targets only)." OFF)
 option(IREE_ENABLE_CLANG_TIDY "Builds IREE in with clang tidy enabled on IREE's libraries." OFF)
 
@@ -84,6 +85,15 @@ option(IREE_BUILD_TRACY "Enables building the 'iree-tracy-capture' CLI tool and 
 option(IREE_BUILD_BUNDLED_LLVM "Builds the bundled llvm-project (vs using installed)" ON)
 option(IREE_BUILD_CLANG_TOOLS_EXTRA "Enables building the 'clang-tools-extra' LLVM targets." OFF)
 option(IREE_USE_SYSTEM_DEPS "Uses certain system libraries instead of building downloaded dependencies" OFF)
+
+if(NOT IREE_ENABLE_THIRD_PARTY_BENCHMARK)
+  if(IREE_BUILD_TESTS)
+    message(FATAL_ERROR "IREE_ENABLE_THIRD_PARTY_BENCHMARK=OFF requires IREE_BUILD_TESTS=OFF.")
+  endif()
+  if(IREE_BUILD_PYTHON_BINDINGS)
+    message(FATAL_ERROR "IREE_ENABLE_THIRD_PARTY_BENCHMARK=OFF requires IREE_BUILD_PYTHON_BINDINGS=OFF.")
+  endif()
+endif()
 
 if(IREE_USE_SYSTEM_DEPS)
   message(WARNING "IREE_USE_SYSTEM_DEPS is on. This option is untested and may find incompatible dependencies.")
@@ -982,7 +992,7 @@ if(IREE_BUILD_TESTS)
   add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 endif()
 
-if(IREE_ENABLE_THREADING)
+if(IREE_ENABLE_THREADING AND IREE_ENABLE_THIRD_PARTY_BENCHMARK)
   # Benchmark.
   iree_set_benchmark_cmake_options()
   add_subdirectory(third_party/benchmark EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ option(IREE_BUILD_BUNDLED_LLVM "Builds the bundled llvm-project (vs using instal
 option(IREE_BUILD_CLANG_TOOLS_EXTRA "Enables building the 'clang-tools-extra' LLVM targets." OFF)
 option(IREE_USE_SYSTEM_DEPS "Uses certain system libraries instead of building downloaded dependencies" OFF)
 
+# IREE_BUILD_BENCHMARKS is required when IREE_BUILD_TESTS=ON because test
+# targets transitively depend on the bundled google benchmark target.
+cmake_dependent_option(IREE_BUILD_BENCHMARKS "Builds IREE benchmarks." ON
+    "NOT IREE_BUILD_TESTS" ON)
+
 if(IREE_USE_SYSTEM_DEPS)
   message(WARNING "IREE_USE_SYSTEM_DEPS is on. This option is untested and may find incompatible dependencies.")
 endif()
@@ -984,7 +989,7 @@ if(IREE_BUILD_TESTS)
   add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 endif()
 
-if(IREE_ENABLE_THREADING)
+if(IREE_ENABLE_THREADING AND IREE_BUILD_BENCHMARKS)
   # Benchmark.
   iree_set_benchmark_cmake_options()
   add_subdirectory(third_party/benchmark EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,10 @@ option(IREE_BUILD_BUNDLED_LLVM "Builds the bundled llvm-project (vs using instal
 option(IREE_BUILD_CLANG_TOOLS_EXTRA "Enables building the 'clang-tools-extra' LLVM targets." OFF)
 option(IREE_USE_SYSTEM_DEPS "Uses certain system libraries instead of building downloaded dependencies" OFF)
 
-# IREE_BUILD_BENCHMARKS is required when IREE_BUILD_TESTS=ON because test
-# targets transitively depend on the bundled google benchmark target.
+# When IREE_BUILD_TESTS=OFF, IREE_BUILD_BENCHMARKS is ON by default but is
+# configurable. Several test targets transitively depend on the bundled google
+# benchmark target, so when IREE_BUILD_TESTS=ON, IREE_BUILD_BENCHMARKS is forced
+# ON.
 cmake_dependent_option(IREE_BUILD_BENCHMARKS "Builds IREE benchmarks." ON
     "NOT IREE_BUILD_TESTS" ON)
 

--- a/docs/website/docs/developers/building/cmake-options.md
+++ b/docs/website/docs/developers/building/cmake-options.md
@@ -50,6 +50,13 @@ Builds the IREE compiler. Defaults to `ON`.
 
 Builds IREE unit tests. Defaults to `ON`.
 
+### `IREE_BUILD_BENCHMARKS`
+
+* type: BOOL
+
+Builds IREE benchmarks. Defaults to `ON`. Forced `ON` when
+`IREE_BUILD_TESTS=ON`.
+
 ### `IREE_BUILD_DOCS`
 
 * type: BOOL

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -13,6 +13,14 @@ if(IREE_BUILD_TRACY)
   list(APPEND _EXTRA_INSTALL_TOOL_TARGETS "IREETracyCaptureServer")
 endif()
 
+if(IREE_BUILD_BENCHMARKS)
+  list(APPEND _EXTRA_INSTALL_TOOL_TARGETS
+    "iree-benchmark-executable"
+    "iree-benchmark-module"
+    "iree-benchmark-replay"
+  )
+endif()
+
 ################################################################################
 # Package
 ################################################################################
@@ -152,6 +160,7 @@ iree_symlink_tool(
   TO_EXE_NAME iree/_runtime_libs/iree-c-embed-data
 )
 
+if(IREE_BUILD_BENCHMARKS)
 iree_symlink_tool(
   TARGET runtime
   FROM_TOOL_TARGET iree-benchmark-executable
@@ -169,6 +178,7 @@ iree_symlink_tool(
   FROM_TOOL_TARGET iree-benchmark-replay
   TO_EXE_NAME iree/_runtime_libs/iree-benchmark-replay
 )
+endif()
 
 iree_symlink_tool(
   TARGET runtime
@@ -405,9 +415,6 @@ cmake_language(DEFER DIRECTORY \"${IREE_SOURCE_DIR}\"
   CALL install
   TARGETS
     iree-cpuinfo
-    iree-benchmark-executable
-    iree-benchmark-module
-    iree-benchmark-replay
     iree-c-embed-data
     iree-convert-parameters
     iree-create-parameters

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -161,23 +161,23 @@ iree_symlink_tool(
 )
 
 if(IREE_BUILD_BENCHMARKS)
-iree_symlink_tool(
-  TARGET runtime
-  FROM_TOOL_TARGET iree-benchmark-executable
-  TO_EXE_NAME iree/_runtime_libs/iree-benchmark-executable
-)
+  iree_symlink_tool(
+    TARGET runtime
+    FROM_TOOL_TARGET iree-benchmark-executable
+    TO_EXE_NAME iree/_runtime_libs/iree-benchmark-executable
+  )
 
-iree_symlink_tool(
-  TARGET runtime
-  FROM_TOOL_TARGET iree-benchmark-module
-  TO_EXE_NAME iree/_runtime_libs/iree-benchmark-module
-)
+  iree_symlink_tool(
+    TARGET runtime
+    FROM_TOOL_TARGET iree-benchmark-module
+    TO_EXE_NAME iree/_runtime_libs/iree-benchmark-module
+  )
 
-iree_symlink_tool(
-  TARGET runtime
-  FROM_TOOL_TARGET iree-benchmark-replay
-  TO_EXE_NAME iree/_runtime_libs/iree-benchmark-replay
-)
+  iree_symlink_tool(
+    TARGET runtime
+    FROM_TOOL_TARGET iree-benchmark-replay
+    TO_EXE_NAME iree/_runtime_libs/iree-benchmark-replay
+  )
 endif()
 
 iree_symlink_tool(

--- a/runtime/src/iree/testing/CMakeLists.txt
+++ b/runtime/src/iree/testing/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 iree_add_all_subdirs()
 
-if(IREE_ENABLE_THREADING)
+if(IREE_ENABLE_THREADING AND IREE_ENABLE_THIRD_PARTY_BENCHMARK)
   iree_cc_library(
     NAME
       benchmark

--- a/runtime/src/iree/testing/CMakeLists.txt
+++ b/runtime/src/iree/testing/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 iree_add_all_subdirs()
 
-if(IREE_ENABLE_THREADING)
+if(IREE_ENABLE_THREADING AND IREE_BUILD_BENCHMARKS)
   iree_cc_library(
     NAME
       benchmark

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -85,24 +85,26 @@ iree_cc_binary(
   INSTALL_COMPONENT IREETools-Runtime
 )
 
-iree_cc_binary(
-  NAME
-    iree-benchmark-module
-  SRCS
-    "iree-benchmark-module-main.cc"
-  DEPS
-    benchmark
-    iree::base
-    iree::base::tooling::flags
-    iree::hal
-    iree::modules::hal::types
-    iree::tooling::context_util
-    iree::tooling::device_util
-    iree::tooling::function_io
-    iree::vm
-  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
-  INSTALL_COMPONENT IREETools-Runtime
-)
+if(IREE_ENABLE_THIRD_PARTY_BENCHMARK)
+  iree_cc_binary(
+    NAME
+      iree-benchmark-module
+    SRCS
+      "iree-benchmark-module-main.cc"
+    DEPS
+      benchmark
+      iree::base
+      iree::base::tooling::flags
+      iree::hal
+      iree::modules::hal::types
+      iree::tooling::context_util
+      iree::tooling::device_util
+      iree::tooling::function_io
+      iree::vm
+    COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
+    INSTALL_COMPONENT IREETools-Runtime
+  )
+endif()
 
 iree_cc_binary(
   NAME

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -64,6 +64,7 @@ if(NOT IREE_ENABLE_THREADING)
   return()
 endif()
 
+if(IREE_BUILD_BENCHMARKS)
 iree_cc_binary(
   NAME
     iree-benchmark-executable
@@ -104,6 +105,7 @@ iree_cc_binary(
   COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
+endif()
 
 iree_cc_binary(
   NAME
@@ -257,6 +259,7 @@ iree_cc_binary(
   INSTALL_COMPONENT IREETools-Runtime
 )
 
+if(IREE_BUILD_BENCHMARKS)
 iree_cc_binary(
   NAME
     iree-benchmark-replay
@@ -275,6 +278,7 @@ iree_cc_binary(
   COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
+endif()
 
 iree_cc_binary(
   NAME

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -65,46 +65,46 @@ if(NOT IREE_ENABLE_THREADING)
 endif()
 
 if(IREE_BUILD_BENCHMARKS)
-iree_cc_binary(
-  NAME
-    iree-benchmark-executable
-  SRCS
-    "iree-benchmark-executable-main.c"
-  DEPS
-    iree::async::util::proactor_pool
-    iree::base
-    iree::base::threading
-    iree::base::tooling::flags
-    iree::hal
-    iree::io::file_handle
-    iree::modules::hal::types
-    iree::testing::benchmark
-    iree::tooling::device_util
-    iree::tooling::function_io
-    iree::vm
-  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
-  INSTALL_COMPONENT IREETools-Runtime
-)
+  iree_cc_binary(
+    NAME
+      iree-benchmark-executable
+    SRCS
+      "iree-benchmark-executable-main.c"
+    DEPS
+      iree::async::util::proactor_pool
+      iree::base
+      iree::base::threading
+      iree::base::tooling::flags
+      iree::hal
+      iree::io::file_handle
+      iree::modules::hal::types
+      iree::testing::benchmark
+      iree::tooling::device_util
+      iree::tooling::function_io
+      iree::vm
+    COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
+    INSTALL_COMPONENT IREETools-Runtime
+  )
 
-iree_cc_binary(
-  NAME
-    iree-benchmark-module
-  SRCS
-    "iree-benchmark-module-main.cc"
-  DEPS
-    benchmark
-    iree::base
-    iree::base::tooling::flags
-    iree::hal
-    iree::hal::replay::recorder
-    iree::modules::hal::types
-    iree::tooling::context_util
-    iree::tooling::device_util
-    iree::tooling::function_io
-    iree::vm
-  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
-  INSTALL_COMPONENT IREETools-Runtime
-)
+  iree_cc_binary(
+    NAME
+      iree-benchmark-module
+    SRCS
+      "iree-benchmark-module-main.cc"
+    DEPS
+      benchmark
+      iree::base
+      iree::base::tooling::flags
+      iree::hal
+      iree::hal::replay::recorder
+      iree::modules::hal::types
+      iree::tooling::context_util
+      iree::tooling::device_util
+      iree::tooling::function_io
+      iree::vm
+    COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
+    INSTALL_COMPONENT IREETools-Runtime
+  )
 endif()
 
 iree_cc_binary(
@@ -260,24 +260,24 @@ iree_cc_binary(
 )
 
 if(IREE_BUILD_BENCHMARKS)
-iree_cc_binary(
-  NAME
-    iree-benchmark-replay
-  SRCS
-    "iree-benchmark-replay-main.cc"
-  DEPS
-    benchmark
-    iree::async
-    iree::async::util::proactor_pool
-    iree::base
-    iree::base::tooling::flags
-    iree::hal
-    iree::hal::replay::execute
-    iree::io::file_handle
-    iree::tooling::device_util
-  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
-  INSTALL_COMPONENT IREETools-Runtime
-)
+  iree_cc_binary(
+    NAME
+      iree-benchmark-replay
+    SRCS
+      "iree-benchmark-replay-main.cc"
+    DEPS
+      benchmark
+      iree::async
+      iree::async::util::proactor_pool
+      iree::base
+      iree::base::tooling::flags
+      iree::hal
+      iree::hal::replay::execute
+      iree::io::file_handle
+      iree::tooling::device_util
+    COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
+    INSTALL_COMPONENT IREETools-Runtime
+  )
 endif()
 
 iree_cc_binary(


### PR DESCRIPTION
When building in TheRock we need to [pull the third party google benchmark dependency](https://github.com/ROCm/TheRock/blob/497af57abf59b11237b55c4ebd553b89d00d488b/build_tools/fetch_sources.py#L661) even though the build in TheRock builds [without tests](https://github.com/ROCm/TheRock/blob/497af57abf59b11237b55c4ebd553b89d00d488b/iree-libs/CMakeLists.txt#L19-L38) and does not require `iree-benchmark-module`. 

This PR adds an option to build IREE without benchmark dependency, allowing us to remove the dep from TheRock. Removing the dep limits operational risk and allows us to sidestep a configure failure coming from benchmark CMake setup in ASan builds (a compiler invocation inside a capability check fails to find the ASan runtime library).