### PR TITLE
[Codegen][NFC] Add full pipeline smoke tests for each backend.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
 
 namespace mlir::iree_compiler {
 
@@ -46,5 +47,21 @@ namespace {
 void registerCodegenCommonPasses() {
   // Generated.
   registerPasses();
+
+  static PassPipelineRegistration<> CodegenConfigurationPreProcessingPipeline(
+      "iree-codegen-configuration-preprocessing-pipeline",
+      "Runs the variant-scope pre-processing pipeline that precedes the "
+      "codegen configuration pipeline",
+      [](OpPassManager &variantPassManager) {
+        buildCodegenConfigurationPreProcessingPassPipeline(variantPassManager);
+      });
+
+  static PassPipelineRegistration<> CodegenTranslationPostProcessingPipeline(
+      "iree-codegen-translation-postprocessing-pipeline",
+      "Runs the variant-scope post-processing pipeline that follows the "
+      "codegen translation pipeline",
+      [](OpPassManager &variantPassManager) {
+        buildCodegenTranslationPostProcessingPassPipeline(variantPassManager);
+      });
 }
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -40,6 +40,7 @@ iree_lit_test_suite(
             "peel.mlir",
             "pipeline_arm_sme_streaming_mode_tests.mlir",
             "pipeline_disable_distribution_tests.mlir",
+            "pipeline_full_smoketests.mlir",
             "pipeline_pack_unpack_tests.mlir",
             "pipeline_pad_conv_tests.mlir",
             "pipeline_pad_tests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "peel.mlir"
     "pipeline_arm_sme_streaming_mode_tests.mlir"
     "pipeline_disable_distribution_tests.mlir"
+    "pipeline_full_smoketests.mlir"
     "pipeline_pack_unpack_tests.mlir"
     "pipeline_pad_conv_tests.mlir"
     "pipeline_pad_tests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_full_smoketests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_full_smoketests.mlir
@@ -1,0 +1,131 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-configuration-preprocessing-pipeline, builtin.module(iree-codegen-llvmcpu-configuration-pipeline, iree-codegen-llvmcpu-lowering-pipeline), iree-codegen-translation-postprocessing-pipeline)))" %s \
+// RUN: | FileCheck %s
+
+// Smoketest: the full LLVMCPU codegen pipeline — variant-scope pre-processing
+// (specialize-exports, create-dispatch-config), module-scope configuration and
+// lowering, and variant-scope post-processing (propagate-dispatch-config) — all
+// drive a simple elementwise add to the LLVM dialect.
+
+#executable_target_embedded_elf_x86_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  cpu_features = "",
+  native_vector_size = 16 : index,
+  target_triple = "x86_64-none-elf"
+}>
+
+#pipeline_layout_static = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// Static add over 4096 elements.
+hal.executable private @add_static {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_x86_64) {
+    hal.executable.export public @add_static ordinal(0) layout(#pipeline_layout_static)
+        count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_static() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %empty = tensor.empty() : tensor<4096xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<4096xf32>, tensor<4096xf32>) outs(%empty : tensor<4096xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [4096], strides = [1]
+            : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_static
+//       CHECK:   hal.executable.export public @add_static
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     llvm.func @add_static
+//       CHECK:       llvm.fadd
+//   CHECK-NOT:   iree_codegen.dispatch_config
+
+// -----
+
+#executable_target_embedded_elf_x86_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  cpu_features = "",
+  native_vector_size = 16 : index,
+  target_triple = "x86_64-none-elf"
+}>
+
+#pipeline_layout_dynamic = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_dynamic {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_x86_64) {
+    hal.executable.export public @add_dynamic ordinal(0) layout(#pipeline_layout_dynamic)
+        count(%device: !hal.device, %w0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_dynamic() {
+        %c0 = arith.constant 0 : index
+        %dim_i32 = hal.interface.constant.load layout(#pipeline_layout_dynamic) ordinal(0) : i32
+        %dim = arith.index_castui %dim_i32 : i32 to index
+        %n = iree_tensor_ext.dispatch.workload.ordinal %dim, 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %empty = tensor.empty(%n) : tensor<?xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<?xf32>, tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [%n], strides = [1]
+            : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_dynamic
+//       CHECK:   hal.executable.export public @add_dynamic
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     llvm.func @add_dynamic
+//       CHECK:       llvm.fadd
+//   CHECK-NOT:   iree_codegen.dispatch_config

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "config_tile_and_fuse_sm80.mlir",
             "config_vector_distribute_sm80.mlir",
+            "pipeline_full_smoketests.mlir",
             "pipeline_tile_and_fuse_sm80.mlir",
             "pipeline_vector_distribute_sm80.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "config_tile_and_fuse_sm80.mlir"
     "config_vector_distribute_sm80.mlir"
+    "pipeline_full_smoketests.mlir"
     "pipeline_tile_and_fuse_sm80.mlir"
     "pipeline_vector_distribute_sm80.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_full_smoketests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_full_smoketests.mlir
@@ -1,0 +1,120 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-configuration-preprocessing-pipeline, builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-llvmgpu-nvvm-lowering-pipeline), iree-codegen-translation-postprocessing-pipeline)))" %s \
+// RUN: | FileCheck %s
+
+// Smoketest: the full LLVMGPU (NVVM) codegen pipeline — variant-scope
+// pre-processing (specialize-exports, create-dispatch-config), module-scope
+// configuration and NVVM lowering, and variant-scope post-processing
+// (propagate-dispatch-config) — all drive a simple elementwise add to the LLVM
+// dialect.
+
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#pipeline_layout_static = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_static {
+  hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
+    hal.executable.export public @add_static ordinal(0) layout(#pipeline_layout_static)
+        count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_static() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %empty = tensor.empty() : tensor<4096xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<4096xf32>, tensor<4096xf32>) outs(%empty : tensor<4096xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [4096], strides = [1]
+            : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_static
+//       CHECK:   hal.executable.export public @add_static
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     llvm.func @add_static
+//       CHECK:       llvm.fadd
+//   CHECK-NOT:   iree_codegen.dispatch_config
+
+// -----
+
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#pipeline_layout_dynamic = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_dynamic {
+  hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
+    hal.executable.export public @add_dynamic ordinal(0) layout(#pipeline_layout_dynamic)
+        count(%device: !hal.device, %w0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_dynamic() {
+        %c0 = arith.constant 0 : index
+        %dim_i32 = hal.interface.constant.load layout(#pipeline_layout_dynamic) ordinal(0) : i32
+        %dim = arith.index_castui %dim_i32 : i32 to index
+        %n = iree_tensor_ext.dispatch.workload.ordinal %dim, 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %empty = tensor.empty(%n) : tensor<?xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<?xf32>, tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [%n], strides = [1]
+            : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_dynamic
+//       CHECK:   hal.executable.export public @add_dynamic
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     llvm.func @add_dynamic
+//       CHECK:       llvm.fadd
+//   CHECK-NOT:   iree_codegen.dispatch_config

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "pipeline_direct_conv_tile_and_fuse.mlir",
             "pipeline_elementwise_f8fnuz.mlir",
             "pipeline_elementwise_f8ocp.mlir",
+            "pipeline_full_smoketests.mlir",
             "pipeline_igemm_tile_and_fuse.mlir",
             "pipeline_igemm_tile_and_fuse_gfx950.mlir",
             "pipeline_lower_to_llvmgpu.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     "pipeline_direct_conv_tile_and_fuse.mlir"
     "pipeline_elementwise_f8fnuz.mlir"
     "pipeline_elementwise_f8ocp.mlir"
+    "pipeline_full_smoketests.mlir"
     "pipeline_igemm_tile_and_fuse.mlir"
     "pipeline_igemm_tile_and_fuse_gfx950.mlir"
     "pipeline_lower_to_llvmgpu.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_full_smoketests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_full_smoketests.mlir
@@ -1,0 +1,120 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-configuration-preprocessing-pipeline, builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-llvmgpu-rocdl-lowering-pipeline), iree-codegen-translation-postprocessing-pipeline)))" %s \
+// RUN: | FileCheck %s
+
+// Smoketest: the full LLVMGPU (ROCDL) codegen pipeline — variant-scope
+// pre-processing (specialize-exports, create-dispatch-config), module-scope
+// configuration and ROCDL lowering, and variant-scope post-processing
+// (propagate-dispatch-config) — all drive a simple elementwise add to the LLVM
+// dialect.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout_static = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_static {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @add_static ordinal(0) layout(#pipeline_layout_static)
+        count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_static() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %empty = tensor.empty() : tensor<4096xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<4096xf32>, tensor<4096xf32>) outs(%empty : tensor<4096xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [4096], strides = [1]
+            : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_static
+//       CHECK:   hal.executable.export public @add_static
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     llvm.func @add_static
+//       CHECK:       llvm.fadd
+//   CHECK-NOT:   iree_codegen.dispatch_config
+
+// -----
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout_dynamic = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_dynamic {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @add_dynamic ordinal(0) layout(#pipeline_layout_dynamic)
+        count(%device: !hal.device, %w0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_dynamic() {
+        %c0 = arith.constant 0 : index
+        %dim_i32 = hal.interface.constant.load layout(#pipeline_layout_dynamic) ordinal(0) : i32
+        %dim = arith.index_castui %dim_i32 : i32 to index
+        %n = iree_tensor_ext.dispatch.workload.ordinal %dim, 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %empty = tensor.empty(%n) : tensor<?xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<?xf32>, tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [%n], strides = [1]
+            : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_dynamic
+//       CHECK:   hal.executable.export public @add_dynamic
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     llvm.func @add_dynamic
+//       CHECK:       llvm.fadd
+//   CHECK-NOT:   iree_codegen.dispatch_config

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -58,6 +58,7 @@ iree_lit_test_suite(
             "map_memref_storage_class.mlir",
             "materialize_executable_conditions.mlir",
             "physical_storage_buffer_addresses.mlir",
+            "pipeline_full_smoketests.mlir",
             "pipeline_matmul_cooperative_ops.mlir",
             "pipeline_matmul_promotion.mlir",
             "pipeline_matmul_vectorization.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_lit_test_suite(
     "map_memref_storage_class.mlir"
     "materialize_executable_conditions.mlir"
     "physical_storage_buffer_addresses.mlir"
+    "pipeline_full_smoketests.mlir"
     "pipeline_matmul_cooperative_ops.mlir"
     "pipeline_matmul_promotion.mlir"
     "pipeline_matmul_vectorization.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_full_smoketests.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_full_smoketests.mlir
@@ -1,0 +1,141 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-configuration-preprocessing-pipeline, builtin.module(iree-codegen-spirv-configuration-pipeline, iree-codegen-linalg-to-spirv-pipeline), iree-codegen-translation-postprocessing-pipeline)))" %s \
+// RUN: | FileCheck %s
+
+// Smoketest: the full SPIR-V codegen pipeline — variant-scope pre-processing
+// (specialize-exports, create-dispatch-config), module-scope configuration and
+// linalg-to-SPIR-V lowering, and variant-scope post-processing
+// (propagate-dispatch-config) — all drive a simple elementwise add to the
+// spirv dialect.
+
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+  iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
+    compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
+    subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [65535, 65535, 65535]>>
+}>
+
+#pipeline_layout_static = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// Static add over 4096 elements.
+hal.executable private @add_static {
+  hal.executable.variant public @vulkan_spirv_fb target(#executable_target_vulkan_spirv_fb) {
+    hal.executable.export public @add_static ordinal(0) layout(#pipeline_layout_static)
+        count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_static() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %empty = tensor.empty() : tensor<4096xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<4096xf32>, tensor<4096xf32>) outs(%empty : tensor<4096xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [4096], strides = [1]
+            : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_static
+//       CHECK:   hal.executable.export public @add_static
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     spirv.module
+//       CHECK:       spirv.func @add_static
+//       CHECK:         spirv.FAdd
+//   CHECK-NOT:   iree_codegen.dispatch_config
+
+// -----
+
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+  iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
+    compute = fp32|fp16|int32, storage = b32|b16, subgroup = shuffle|arithmetic,
+    subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [65535, 65535, 65535]>>
+}>
+
+#pipeline_layout_dynamic = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// Dynamic add: workload dim threaded through a workload.ordinal, with a matching
+// count region on the export.
+hal.executable private @add_dynamic {
+  hal.executable.variant public @vulkan_spirv_fb target(#executable_target_vulkan_spirv_fb) {
+    hal.executable.export public @add_dynamic ordinal(0) layout(#pipeline_layout_dynamic)
+        count(%device: !hal.device, %w0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_dynamic() {
+        %c0 = arith.constant 0 : index
+        %dim_i32 = hal.interface.constant.load layout(#pipeline_layout_dynamic) ordinal(0) : i32
+        %dim = arith.index_castui %dim_i32 : i32 to index
+        %n = iree_tensor_ext.dispatch.workload.ordinal %dim, 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %empty = tensor.empty(%n) : tensor<?xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<?xf32>, tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [%n], strides = [1]
+            : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_dynamic
+//       CHECK:   hal.executable.export public @add_dynamic
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     spirv.module
+//       CHECK:       spirv.func @add_dynamic
+//       CHECK:         spirv.FAdd
+//   CHECK-NOT:   iree_codegen.dispatch_config

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "link_executables.mlir",
             "lower_linalg_microkernels.mlir",
             "pipeline.mlir",
+            "pipeline_full_smoketests.mlir",
             "select_lowering_strategy.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "link_executables.mlir"
     "lower_linalg_microkernels.mlir"
     "pipeline.mlir"
+    "pipeline_full_smoketests.mlir"
     "select_lowering_strategy.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline_full_smoketests.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline_full_smoketests.mlir
@@ -1,0 +1,119 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-configuration-preprocessing-pipeline, builtin.module(iree-codegen-vmvx-configuration-pipeline, iree-codegen-vmvx-lowering-pipeline), iree-codegen-translation-postprocessing-pipeline)))" %s \
+// RUN: | FileCheck %s
+
+// Smoketest: the full VMVX codegen pipeline — variant-scope pre-processing
+// (specialize-exports, create-dispatch-config), module-scope configuration and
+// lowering, and variant-scope post-processing (propagate-dispatch-config) — all
+// drive a simple elementwise add to buffers.
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
+#pipeline_layout_static = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_static {
+  hal.executable.variant public @vmvx_bytecode_fb target(#executable_target_vmvx_bytecode_fb) {
+    hal.executable.export public @add_static ordinal(0) layout(#pipeline_layout_static)
+        count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_static() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>>
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_static) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [4096], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf32>> -> tensor<4096xf32>
+        %empty = tensor.empty() : tensor<4096xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<4096xf32>, tensor<4096xf32>) outs(%empty : tensor<4096xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<4096xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [4096], strides = [1]
+            : tensor<4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf32>>
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_static
+//       CHECK:   hal.executable.export public @add_static
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     func.func @add_static
+//       CHECK:       arith.addf
+//   CHECK-NOT:   iree_codegen.dispatch_config
+
+// -----
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
+#pipeline_layout_dynamic = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @add_dynamic {
+  hal.executable.variant public @vmvx_bytecode_fb target(#executable_target_vmvx_bytecode_fb) {
+    hal.executable.export public @add_dynamic ordinal(0) layout(#pipeline_layout_dynamic)
+        count(%device: !hal.device, %w0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%w0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_dynamic() {
+        %c0 = arith.constant 0 : index
+        %dim_i32 = hal.interface.constant.load layout(#pipeline_layout_dynamic) ordinal(0) : i32
+        %dim = arith.index_castui %dim_i32 : i32 to index
+        %n = iree_tensor_ext.dispatch.workload.ordinal %dim, 0 : index
+        %lhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(0)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %rhs = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(1)
+            alignment(64) offset(%c0) flags(ReadOnly)
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n}
+        %out = hal.interface.binding.subspan layout(#pipeline_layout_dynamic) binding(2)
+            alignment(64) offset(%c0)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        %lhs_t = iree_tensor_ext.dispatch.tensor.load %lhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %rhs_t = iree_tensor_ext.dispatch.tensor.load %rhs, offsets = [0], sizes = [%n], strides = [1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%n} -> tensor<?xf32>
+        %empty = tensor.empty(%n) : tensor<?xf32>
+        %sum = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%lhs_t, %rhs_t : tensor<?xf32>, tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+        ^bb0(%a: f32, %b: f32, %o: f32):
+          %s = arith.addf %a, %b : f32
+          linalg.yield %s : f32
+        } -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %sum, %out, offsets = [0], sizes = [%n], strides = [1]
+            : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%n}
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @add_dynamic
+//       CHECK:   hal.executable.export public @add_dynamic
+//       CHECK:     hal.return
+//       CHECK:   builtin.module
+//       CHECK:     func.func @add_dynamic
+//       CHECK:       arith.addf
+//   CHECK-NOT:   iree_codegen.dispatch_config


### PR DESCRIPTION
After making codegen pipeline in module-scope, there are preprocessing (before configuration) and postprocessing (after translation). The revision creates the pipelines for each, and adds full smoketests for each backend.