### PR TITLE
[Tokenizer] Fix INTERNAL deadlock when output buffer fills before special token emit

### DIFF
--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -2633,13 +2633,39 @@ iree_status_t iree_tokenizer_encode_state_feed(
   // buffer is smaller than max_token_length (configuration error).
   if (iree_status_is_ok(status) && chunk.size > 0 && *out_bytes_consumed == 0 &&
       total_tokens == 0) {
+    // Distinguish between two failure modes:
+    //
+    // (a) Output buffer is full (output.capacity == 0 on entry to this feed
+    //     call). A pending special token cannot be emitted because there is no
+    //     room, so the trailing input byte is stuck. This is a recoverable
+    //     condition: the caller should retry with a larger output buffer.
+    //
+    // (b) True deadlock: ring buffer too small for max_token_length, or an
+    //     unhandled edge case in the segment/normalizer state machine. This
+    //     is a programming error and should not happen in practice.
+    if (output.capacity == 0) {
+      return iree_make_status(
+          IREE_STATUS_RESOURCE_EXHAUSTED,
+          "encode output buffer full with %" PRIhsz
+          " bytes of input still pending; retry with a larger token buffer",
+          chunk.size);
+    }
     return iree_make_status(
         IREE_STATUS_INTERNAL,
         "encode deadlock: no progress despite partial segment handling "
         "(logical_capacity=%" PRIhsz " bytes, used=%" PRIhsz
-        " bytes, pending_input=%" PRIhsz " bytes, has_partial=%" PRIu32 ")",
+        " bytes, pending_input=%" PRIhsz " bytes, has_partial=%" PRIu32
+        " segment_count=%" PRIhsz " segments_consumed=%" PRIhsz
+        " pending_special=%" PRId32
+        " normalizer_pending=%d model_pending=%d)",
         state->capacity_mask + 1, state->write_position - state->read_position,
-        chunk.size, (uint32_t)state->has_partial_segment);
+        chunk.size, (uint32_t)state->has_partial_segment,
+        state->segment_count, state->segments_consumed,
+        (int32_t)state->pending_special_token,
+        (state->normalizer_state &&
+         iree_tokenizer_normalizer_state_has_pending(state->normalizer_state))
+            ? 1 : 0,
+        iree_tokenizer_model_state_has_pending(state->model_state) ? 1 : 0);
   }
 
   return status;


### PR DESCRIPTION
## Summary

`iree_tokenizer_encode_state_feed` fires `IREE_STATUS_INTERNAL` ("encode
deadlock") whenever a feed call makes no progress.  One legitimate
trigger is when the **output token buffer is completely full** on entry
to a feed call.  This is recoverable — the caller simply needs a larger
output buffer — but today it is mis-classified as an unrecoverable
programming error.

### Root cause

`iree_tokenizer_encode` (one-shot path) estimates an initial output
buffer of `text.size() / 2 + 16` tokens.  For text that contains a
long run of characters with no word-boundary (e.g. base64), the BPE
model can produce close to 1 token per character, exhausting the buffer
before a trailing special token gets a chance to emit.  The sequence is:

1. **Feed call N** — long "word" consumed, tokens fill output to
   capacity, `pending_special_token` is set for the immediately
   following special token.
2. **Feed call N+1** — `output.capacity == 0`; the special token
   cannot be emitted (no room); pending_special_token blocks
   normalization of the trailing byte; no progress; `INTERNAL` fires.

The one-shot encode path already handles `IREE_STATUS_RESOURCE_EXHAUSTED`
by retrying with capacity `text.size() + 64` — enough for any real
vocabulary.  The fix makes the feed function return `RESOURCE_EXHAUSTED`
instead of `INTERNAL` when the root cause is a full output buffer
(`output.capacity == 0`), allowing the existing retry to succeed.

The `INTERNAL` path is kept for the genuinely unrecoverable case (ring
buffer smaller than `max_token_length`) and now includes extended
diagnostics to help diagnose any future occurrences.

### Trigger pattern

```
<continuous-alphanum ≥ ~100 chars> + <pre-norm special token> + <any single byte>
```

Verified with HuggingFace BPE tokenizers that use `added_tokens` with
`special: false` (token content appears literally in text and is matched
before normalization).

### Verification

Tested with a patched local build on three independently-collected
real-world inputs that previously triggered the deadlock.  All three now
produce token sequences that exactly match the HuggingFace reference
tokenizer (`iree_ids == hf_ids`).

### Performance

Measured on NVIDIA B200, single-threaded, 30 iterations, same machine:

| Input tokens | Unpatched local | Patched local | Delta |
|-------------:|----------------:|--------------:|------:|
|          5 K |        0.26 ms  |      0.26 ms  |  0.0% |
|         30 K |        1.57 ms  |      1.59 ms  | +1.3% |
|         50 K |        2.63 ms  |      2.66 ms  | +1.1% |
|        100 K |        5.23 ms  |      5.31 ms  | +1.5% |
|        180 K |        9.61 ms  |      9.77 ms  | +1.7% |

The new branch is on a cold code path (only reachable when the output
buffer is already exhausted) and is never executed on normal inputs.