### PR TITLE
Bump LLVM at llvm/llvm-project@93dce0bf4332

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -78,6 +78,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:BufferizationTransformOps",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:GPUTransformOps",
+        "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransformOps",
         "@llvm-project//mlir:MemRefDialect",

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     MLIRBufferizationTransformOps
     MLIRGPUDialect
     MLIRGPUTransformOps
+    MLIRGPUTransforms
     MLIRIR
     MLIRLinalgDialect
     MLIRLinalgTransformOps

--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Dialect/Bufferization/TransformOps/BufferizationTransformOps.h"
 #include "mlir/Dialect/GPU/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
+#include "mlir/Dialect/GPU/Transforms/IndexedAccessOpInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
@@ -107,6 +108,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   affine::registerValueBoundsOpInterfaceExternalModels(registry);
   arith::registerValueBoundsOpInterfaceExternalModels(registry);
   bufferization::registerTransformDialectExtension(registry);
+  gpu::registerIndexedAccessOpInterfaceExternalModels(registry);
   gpu::registerValueBoundsOpInterfaceExternalModels(registry);
   gpu::registerTransformDialectExtension(registry);
   gpu::registerValueBoundsOpInterfaceExternalModels(registry);


### PR DESCRIPTION
- Add fixes for https://github.com/llvm/llvm-project/commit/0dd5054d850e that removed the hard-coded `gpu.subgroup_mma_*` handling in` FoldMemRefAliasOp`s and moved it to the new `IndexedAccessOpInterface` external model.