### PR TITLE
[IREEGPU] Define and expand `subgroup_scan`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
@@ -44,7 +44,8 @@ static Value inlineCombiner(RewriterBase &rewriter, Location loc,
 
 /// Lower `iree_gpu.subgroup_scan` to a Hillis-Steele scan using
 /// `gpu.shuffle idx`.
-/// First computes an inclusive scan, then derives the exclusive result by
+/// Computes an inclusive scan via Hillis-Steele. For inclusive mode, the
+/// result is used directly. For exclusive mode, derives the result by
 /// shifting right by one cluster position and inserting the identity at
 /// position 0. Also computes the cluster total by shuffling from the last
 /// lane in each cluster.
@@ -58,7 +59,6 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
                                 PatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     Value val = op.getValue();
-    Value identity = op.getIdentity();
     uint32_t clusterSize = op.getClusterSize().value_or(subgroupSize);
     uint32_t clusterStride = op.getClusterStride();
     Type valTy = val.getType();
@@ -182,11 +182,19 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
                                subgroupSizeCst, gpu::ShuffleMode::IDX);
     Value total = unpackFn(totalShuffle.getShuffleResult());
 
+    if (op.getInclusive()) {
+      // Inclusive: use the Hillis-Steele result directly.
+      rewriter.replaceOp(op, {val, total});
+      return success();
+    }
+
     // Derive exclusive result: shift inclusive result right by one cluster
     // position, insert identity at position 0.
     //   predLane = laneIdI32 - clusterStride
     //   shifted = shuffle idx val, predLane
     //   scanResult = (lanePos == 0) ? identity : shifted
+    Value scanResult;
+    Value identity = op.getIdentity();
     Value predLane = arith::SubIOp::create(rewriter, loc, laneIdI32, strideCst);
     Value packedForShift = packFn(val);
     auto shiftShuffle =
@@ -198,7 +206,7 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
                                            rewriter.getI32IntegerAttr(0));
     Value isFirstLane = arith::CmpIOp::create(
         rewriter, loc, arith::CmpIPredicate::eq, lanePos, zero);
-    Value scanResult =
+    scanResult =
         arith::SelectOp::create(rewriter, loc, isFirstLane, identity, shifted);
 
     rewriter.replaceOp(op, {scanResult, total});

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
@@ -44,15 +44,10 @@ static Value inlineCombiner(RewriterBase &rewriter, Location loc,
 
 /// Lower `iree_gpu.subgroup_scan` to a Hillis-Steele scan using
 /// `gpu.shuffle idx`.
-/// For an inclusive scan over N elements, Hillis-Steele has an outer serial
-/// loop with log(N) steps and an inner parallel loop over N.
-/// The inner parallel loop can be distributed across the lanes, so we end up
-/// with the following pseudo-code:
-/// j = lane_id
-/// for i from 0 to log(N)
-///   x[i+1][j] = (j < 2^i) ?
-///                   x[i][j] :
-///                   x[i+1][j] = x[i][j] op x[i][j - 2^i]
+/// First computes an inclusive scan, then derives the exclusive result by
+/// shifting right by one cluster position and inserting the identity at
+/// position 0. Also computes the cluster total by shuffling from the last
+/// lane in each cluster.
 ///
 struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
   LowerSubgroupScan(MLIRContext *ctx, unsigned subgroupSize,
@@ -63,6 +58,7 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
                                 PatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     Value val = op.getValue();
+    Value identity = op.getIdentity();
     uint32_t clusterSize = op.getClusterSize().value_or(subgroupSize);
     uint32_t clusterStride = op.getClusterStride();
     Type valTy = val.getType();
@@ -124,6 +120,11 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
                                   rewriter.getI32IntegerAttr(subgroupSize));
 
     // Hillis-Steele inclusive scan.
+    // j = lane_id
+    // for i from 0 to log(N)
+    //   x[i+1][j] = (j < 2^i) ?
+    //                   x[i][j] :
+    //                   x[i][j] op x[i][j - 2^i]
     unsigned numSteps = llvm::Log2_32(clusterSize);
     // Serial loop over log(N) steps.
     for (unsigned step = 0; step < numSteps; ++step) {
@@ -155,17 +156,52 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
       Value threshold =
           arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
                                     rewriter.getI32IntegerAttr(1 << step));
-      // j < 2^i
+      // j >= 2^i
       Value predicate = arith::CmpIOp::create(
           rewriter, loc, arith::CmpIPredicate::uge, lanePos, threshold);
 
-      // x[i+1][j] = (j < 2^i) ?
-      //                   x[i][j] :
-      //                   x[i+1][j] = x[i][j] op x[i][j - 2^i]
+      // x[i+1][j] = (j < 2^i) ? x[i][j] : x[i][j] op x[i][j - 2^i]
       val = arith::SelectOp::create(rewriter, loc, predicate, combined, val);
     }
+    // val now holds the inclusive scan result.
 
-    rewriter.replaceOp(op, val);
+    // Compute total: shuffle from the last lane in each cluster.
+    //   baseLane = laneIdI32 - lanePos * clusterStride
+    //   lastLane = baseLane + (clusterSize - 1) * clusterStride
+    Value lastOffset = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32Type(),
+        rewriter.getI32IntegerAttr((clusterSize - 1) * clusterStride));
+    Value posTimesStride =
+        arith::MulIOp::create(rewriter, loc, lanePos, strideCst);
+    Value baseLane =
+        arith::SubIOp::create(rewriter, loc, laneIdI32, posTimesStride);
+    Value lastLane = arith::AddIOp::create(rewriter, loc, baseLane, lastOffset);
+    Value packedForTotal = packFn(val);
+    auto totalShuffle =
+        gpu::ShuffleOp::create(rewriter, loc, packedForTotal, lastLane,
+                               subgroupSizeCst, gpu::ShuffleMode::IDX);
+    Value total = unpackFn(totalShuffle.getShuffleResult());
+
+    // Derive exclusive result: shift inclusive result right by one cluster
+    // position, insert identity at position 0.
+    //   predLane = laneIdI32 - clusterStride
+    //   shifted = shuffle idx val, predLane
+    //   scanResult = (lanePos == 0) ? identity : shifted
+    Value predLane = arith::SubIOp::create(rewriter, loc, laneIdI32, strideCst);
+    Value packedForShift = packFn(val);
+    auto shiftShuffle =
+        gpu::ShuffleOp::create(rewriter, loc, packedForShift, predLane,
+                               subgroupSizeCst, gpu::ShuffleMode::IDX);
+    Value shifted = unpackFn(shiftShuffle.getShuffleResult());
+
+    Value zero = arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                           rewriter.getI32IntegerAttr(0));
+    Value isFirstLane = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, lanePos, zero);
+    Value scanResult =
+        arith::SelectOp::create(rewriter, loc, isFirstLane, identity, shifted);
+
+    rewriter.replaceOp(op, {scanResult, total});
     return success();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
@@ -6,11 +6,15 @@
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -23,8 +27,153 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+/// Clone the combiner region body, mapping block arguments to (lhs, rhs),
+/// and return the value produced by the yield.
+static Value inlineCombiner(RewriterBase &rewriter, Location loc,
+                            Region &combiner, Value lhs, Value rhs) {
+  Block &block = combiner.front();
+  IRMapping mapping;
+  mapping.map(block.getArgument(0), lhs);
+  mapping.map(block.getArgument(1), rhs);
+  for (auto &op : block.without_terminator()) {
+    rewriter.clone(op, mapping);
+  }
+  auto yield = cast<IREE::GPU::YieldOp>(block.getTerminator());
+  return mapping.lookupOrDefault(yield.getOperand(0));
+}
+
+/// Lower `iree_gpu.subgroup_scan` to a Hillis-Steele scan using
+/// `gpu.shuffle idx`.
+/// For an inclusive scan over N elements, Hillis-Steele has an outer serial
+/// loop with log(N) steps and an inner parallel loop over N.
+/// The inner parallel loop can be distributed across the lanes, so we end up
+/// with the following pseudo-code:
+/// j = lane_id
+/// for i from 0 to log(N)
+///   x[i+1][j] = (j < 2^i) ?
+///                   x[i][j] :
+///                   x[i+1][j] = x[i][j] op x[i][j - 2^i]
+///
+struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
+  LowerSubgroupScan(MLIRContext *ctx, unsigned subgroupSize,
+                    PatternBenefit benefit)
+      : OpRewritePattern(ctx, benefit), subgroupSize(subgroupSize) {}
+
+  LogicalResult matchAndRewrite(IREE::GPU::SubgroupScanOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value val = op.getValue();
+    uint32_t clusterSize = op.getClusterSize().value_or(subgroupSize);
+    uint32_t clusterStride = op.getClusterStride();
+    Type valTy = val.getType();
+    unsigned bitwidth = valTy.getIntOrFloatBitWidth();
+
+    constexpr unsigned shuffleBitwidth = 32;
+
+    if (!valTy.isIntOrFloat() || bitwidth > shuffleBitwidth) {
+      return rewriter.notifyMatchFailure(
+          op, "value type is not a compatible scalar");
+    }
+
+    // Validate that the cluster fits within the subgroup.
+    if (clusterSize * clusterStride > subgroupSize) {
+      return op.emitOpError()
+             << "cluster size (" << clusterSize << ") * stride ("
+             << clusterStride << ") exceeds subgroup size " << subgroupSize;
+    }
+
+    // Pack/unpack functions for types narrower than 32 bits.
+    auto shuffleIntType = rewriter.getIntegerType(shuffleBitwidth);
+    auto equivIntType = rewriter.getIntegerType(bitwidth);
+
+    auto packFn = [&](Value v) -> Value {
+      if (bitwidth == shuffleBitwidth) {
+        return v;
+      }
+      Value asInt = arith::BitcastOp::create(rewriter, loc, equivIntType, v);
+      return arith::ExtUIOp::create(rewriter, loc, shuffleIntType, asInt);
+    };
+    auto unpackFn = [&](Value v) -> Value {
+      if (bitwidth == shuffleBitwidth) {
+        return v;
+      }
+      Value asInt = arith::TruncIOp::create(rewriter, loc, equivIntType, v);
+      return arith::BitcastOp::create(rewriter, loc, valTy, asInt);
+    };
+
+    Value laneId =
+        gpu::LaneIdOp::create(rewriter, loc, /*upper_bound=*/nullptr);
+
+    // Compute logical position within cluster:
+    //   lanePos = (laneId / clusterStride) % clusterSize
+    Value strideCst =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                  rewriter.getI32IntegerAttr(clusterStride));
+    Value sizeCst =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                  rewriter.getI32IntegerAttr(clusterSize));
+    Value laneIdI32 = arith::IndexCastOp::create(rewriter, loc,
+                                                 rewriter.getI32Type(), laneId);
+    // j
+    Value lanePos = arith::RemUIOp::create(
+        rewriter, loc,
+        arith::DivUIOp::create(rewriter, loc, laneIdI32, strideCst), sizeCst);
+
+    Value subgroupSizeCst =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                  rewriter.getI32IntegerAttr(subgroupSize));
+
+    // Hillis-Steele inclusive scan.
+    unsigned numSteps = llvm::Log2_32(clusterSize);
+    // Serial loop over log(N) steps.
+    for (unsigned step = 0; step < numSteps; ++step) {
+      int64_t offset = static_cast<int64_t>(1U << step) * clusterStride;
+      Value offsetCst =
+          arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                    rewriter.getI32IntegerAttr(offset));
+
+      // The subtraction may wrap for lanes near the start of a cluster.
+      // The wrapped value will cause the shuffle to read from an arbitrary
+      // lane, but the predicate below discards the result in that case.
+      Value srcLane =
+          arith::SubIOp::create(rewriter, loc, laneIdI32, offsetCst);
+
+      // Shuffle to get neighbor's value. Because we support non-unit cluster
+      // strides, we need to use `idx` shuffle and not `up` shuffle.
+      Value packed = packFn(val);
+      auto shuffle =
+          gpu::ShuffleOp::create(rewriter, loc, packed, srcLane,
+                                 subgroupSizeCst, gpu::ShuffleMode::IDX);
+      // x[i][j - 2^i]
+      Value neighbor = unpackFn(shuffle.getShuffleResult());
+
+      // x[i][j] op x[i][j - 2^i]
+      Value combined =
+          inlineCombiner(rewriter, loc, op.getCombiner(), neighbor, val);
+
+      // Predicate: only accumulate if lanePos >= (1 << step).
+      Value threshold =
+          arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                    rewriter.getI32IntegerAttr(1 << step));
+      // j < 2^i
+      Value predicate = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::uge, lanePos, threshold);
+
+      // x[i+1][j] = (j < 2^i) ?
+      //                   x[i][j] :
+      //                   x[i+1][j] = x[i][j] op x[i][j - 2^i]
+      val = arith::SelectOp::create(rewriter, loc, predicate, combined, val);
+    }
+
+    rewriter.replaceOp(op, val);
+    return success();
+  }
+
+private:
+  unsigned subgroupSize;
+};
+
 struct ExpandGPUOpsPass final : impl::ExpandGPUOpsPassBase<ExpandGPUOpsPass> {
-  // Apply AMD GPU targeting patterns.
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
     MLIRContext *ctx = &getContext();
@@ -51,6 +200,7 @@ struct ExpandGPUOpsPass final : impl::ExpandGPUOpsPassBase<ExpandGPUOpsPass> {
         patterns, /* maxShuffleBitwidth=*/32, PatternBenefit(3));
     populateGpuLowerClusteredSubgroupReduceToShufflePatterns(
         patterns, *subgroupSize, /* shuffleBitwidth=*/32, PatternBenefit(1));
+    patterns.add<LowerSubgroupScan>(ctx, *subgroupSize, PatternBenefit(1));
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
@@ -52,8 +52,9 @@ static Value inlineCombiner(RewriterBase &rewriter, Location loc,
 ///
 struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
   LowerSubgroupScan(MLIRContext *ctx, unsigned subgroupSize,
-                    PatternBenefit benefit)
-      : OpRewritePattern(ctx, benefit), subgroupSize(subgroupSize) {}
+                    unsigned shuffleBitwidth, PatternBenefit benefit)
+      : OpRewritePattern(ctx, benefit), subgroupSize(subgroupSize),
+        shuffleBitwidth(shuffleBitwidth) {}
 
   LogicalResult matchAndRewrite(IREE::GPU::SubgroupScanOp op,
                                 PatternRewriter &rewriter) const override {
@@ -63,8 +64,6 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
     uint32_t clusterStride = op.getClusterStride();
     Type valTy = val.getType();
     unsigned bitwidth = valTy.getIntOrFloatBitWidth();
-
-    constexpr unsigned shuffleBitwidth = 32;
 
     if (!valTy.isIntOrFloat() || bitwidth > shuffleBitwidth) {
       return rewriter.notifyMatchFailure(
@@ -215,6 +214,7 @@ struct LowerSubgroupScan : OpRewritePattern<IREE::GPU::SubgroupScanOp> {
 
 private:
   unsigned subgroupSize;
+  unsigned shuffleBitwidth;
 };
 
 struct ExpandGPUOpsPass final : impl::ExpandGPUOpsPassBase<ExpandGPUOpsPass> {
@@ -244,7 +244,8 @@ struct ExpandGPUOpsPass final : impl::ExpandGPUOpsPassBase<ExpandGPUOpsPass> {
         patterns, /* maxShuffleBitwidth=*/32, PatternBenefit(3));
     populateGpuLowerClusteredSubgroupReduceToShufflePatterns(
         patterns, *subgroupSize, /* shuffleBitwidth=*/32, PatternBenefit(1));
-    patterns.add<LowerSubgroupScan>(ctx, *subgroupSize, PatternBenefit(1));
+    patterns.add<LowerSubgroupScan>(ctx, *subgroupSize, /*shuffleBitwidth=*/32,
+                                    PatternBenefit(1));
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -476,7 +476,8 @@ def ExpandGPUOpsPass :
     InterfacePass<"iree-codegen-expand-gpu-ops", "mlir::FunctionOpInterface"> {
   let summary = "Expands high-level GPU ops, such as clustered gpu.subgroup_reduce.";
   let dependentDialects = [
-    "::mlir::gpu::GPUDialect"
+    "::mlir::arith::ArithDialect",
+    "::mlir::gpu::GPUDialect",
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
         [
             "amdgpu_lower_coalesced_dma_to_gather_lds.mlir",
             "decompose_horizontally_fused_gemms.mlir",
+            "expand_gpu_ops_scan.mlir",
             "flatten_swizzle_hint_allocs.mlir",
             "gpu_alloc_private_memory_for_dps_ops.mlir",
             "gpu_apply_derived_thread_config.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "amdgpu_lower_coalesced_dma_to_gather_lds.mlir"
     "decompose_horizontally_fused_gemms.mlir"
+    "expand_gpu_ops_scan.mlir"
     "flatten_swizzle_hint_allocs.mlir"
     "gpu_alloc_private_memory_for_dps_ops.mlir"
     "gpu_apply_derived_thread_config.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/expand_gpu_ops_scan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/expand_gpu_ops_scan.mlir
@@ -1,0 +1,172 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline='builtin.module(func.func(iree-codegen-expand-gpu-ops))' %s | FileCheck %s
+
+// Basic scan with cluster_size=4, stride=1 (default), f32 addf.
+// Expects 2 shuffle steps (offsets 1, 2) with predicates and selects.
+// When stride=1, the divui-by-1 is folded away, so lanePos = remui(laneId, 4).
+
+#translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
+func.func @scan_add_f32(%x: f32) -> f32 attributes {translation_info = #translation_info} {
+  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %add = arith.addf %lhs, %rhs : f32
+    iree_gpu.yield %add : f32
+  } : f32
+  return %scan : f32
+}
+
+// CHECK-LABEL: func.func @scan_add_f32
+// CHECK-SAME:    (%[[X:.+]]: f32)
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : i32
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : i32
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : i32
+// CHECK:         %[[LANE:.+]] = gpu.lane_id
+// CHECK:         %[[LANE_I32:.+]] = arith.index_cast %[[LANE]] : index to i32
+// CHECK:         %[[POS:.+]] = arith.remui %[[LANE_I32]], %[[C4]]
+//
+// Step 0: offset=1, threshold=1
+// CHECK:         %[[SRC0:.+]] = arith.subi %[[LANE_I32]], %[[C1]]
+// CHECK:         %[[SHUF0:.+]], %{{.+}} = gpu.shuffle idx %[[X]], %[[SRC0]], %[[C32]]
+// CHECK:         %[[ADD0:.+]] = arith.addf %[[SHUF0]], %[[X]]
+// CHECK:         %[[PRED0:.+]] = arith.cmpi uge, %[[POS]], %[[C1]]
+// CHECK:         %[[SEL0:.+]] = arith.select %[[PRED0]], %[[ADD0]], %[[X]]
+//
+// Step 1: offset=2, threshold=2
+// CHECK:         %[[SRC1:.+]] = arith.subi %[[LANE_I32]], %[[C2]]
+// CHECK:         %[[SHUF1:.+]], %{{.+}} = gpu.shuffle idx %[[SEL0]], %[[SRC1]], %[[C32]]
+// CHECK:         %[[ADD1:.+]] = arith.addf %[[SHUF1]], %[[SEL0]]
+// CHECK:         %[[PRED1:.+]] = arith.cmpi uge, %[[POS]], %[[C2]]
+// CHECK:         %[[SEL1:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
+//
+// CHECK:         return %[[SEL1]]
+
+// -----
+
+// Clustered scan with cluster_size=4, stride=16.
+// Expects shuffle offsets of 16, 32. lanePos = (laneId / 16) % 4.
+
+#translation_info2 = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
+func.func @scan_add_f32_stride16(%x: f32) -> f32 attributes {translation_info = #translation_info2} {
+  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4, stride = 16) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %add = arith.addf %lhs, %rhs : f32
+    iree_gpu.yield %add : f32
+  } : f32
+  return %scan : f32
+}
+
+// CHECK-LABEL: func.func @scan_add_f32_stride16
+// CHECK-SAME:    (%[[X:.+]]: f32)
+// CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : i32
+// CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : i32
+// CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : i32
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : i32
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : i32
+// CHECK:         %[[LANE:.+]] = gpu.lane_id
+// CHECK:         %[[LANE_I32:.+]] = arith.index_cast %[[LANE]] : index to i32
+// CHECK:         %[[DIV:.+]] = arith.divui %[[LANE_I32]], %[[C16]]
+// CHECK:         %[[POS:.+]] = arith.remui %[[DIV]], %[[C4]]
+//
+// Step 0: offset=16
+// CHECK:         %[[SRC0:.+]] = arith.subi %[[LANE_I32]], %[[C16]]
+// CHECK:         %[[SHUF0:.+]], %{{.+}} = gpu.shuffle idx %[[X]], %[[SRC0]], %[[C64]]
+// CHECK:         %[[ADD0:.+]] = arith.addf %[[SHUF0]], %[[X]]
+// CHECK:         %[[PRED0:.+]] = arith.cmpi uge, %[[POS]], %[[C1]]
+// CHECK:         %[[SEL0:.+]] = arith.select %[[PRED0]], %[[ADD0]], %[[X]]
+//
+// Step 1: offset=32
+// CHECK:         %[[SRC1:.+]] = arith.subi %[[LANE_I32]], %[[C32]]
+// CHECK:         %[[SHUF1:.+]], %{{.+}} = gpu.shuffle idx %[[SEL0]], %[[SRC1]], %[[C64]]
+// CHECK:         %[[ADD1:.+]] = arith.addf %[[SHUF1]], %[[SEL0]]
+// CHECK:         %[[PRED1:.+]] = arith.cmpi uge, %[[POS]], %[[C2]]
+// CHECK:         %[[SEL1:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
+//
+// CHECK:         return %[[SEL1]]
+
+// -----
+
+// i32 scan: no bitcast needed.
+
+#translation_info3 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
+func.func @scan_add_i32(%x: i32) -> i32 attributes {translation_info = #translation_info3} {
+  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+  ^bb0(%lhs: i32, %rhs: i32):
+    %add = arith.addi %lhs, %rhs : i32
+    iree_gpu.yield %add : i32
+  } : i32
+  return %scan : i32
+}
+
+// CHECK-LABEL: func.func @scan_add_i32
+// No bitcast or extui/trunci for i32.
+// CHECK-NOT:     arith.bitcast
+// CHECK-NOT:     arith.extui
+// CHECK-NOT:     arith.trunci
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.addi
+// CHECK:         arith.select
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.addi
+// CHECK:         arith.select
+
+// -----
+
+// f16 scan: requires bitcast to i32 for shuffle.
+
+#translation_info4 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
+func.func @scan_add_f16(%x: f16) -> f16 attributes {translation_info = #translation_info4} {
+  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+  ^bb0(%lhs: f16, %rhs: f16):
+    %add = arith.addf %lhs, %rhs : f16
+    iree_gpu.yield %add : f16
+  } : f16
+  return %scan : f16
+}
+
+// CHECK-LABEL: func.func @scan_add_f16
+// Step 0: pack to i32, shuffle, unpack
+// CHECK:         arith.bitcast %{{.+}} : f16 to i16
+// CHECK:         arith.extui %{{.+}} : i16 to i32
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.trunci %{{.+}} : i32 to i16
+// CHECK:         arith.bitcast %{{.+}} : i16 to f16
+// CHECK:         arith.addf
+// CHECK:         arith.select
+// Step 1: pack to i32, shuffle, unpack
+// CHECK:         arith.bitcast %{{.+}} : f16 to i16
+// CHECK:         arith.extui %{{.+}} : i16 to i32
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.trunci %{{.+}} : i32 to i16
+// CHECK:         arith.bitcast %{{.+}} : i16 to f16
+// CHECK:         arith.addf
+// CHECK:         arith.select
+
+// -----
+
+// Full subgroup scan (no cluster clause) with subgroup_size=32.
+// Expects 5 shuffle steps (offsets 1, 2, 4, 8, 16).
+
+#translation_info5 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
+func.func @scan_full_subgroup(%x: f32) -> f32 attributes {translation_info = #translation_info5} {
+  %scan = iree_gpu.subgroup_scan(%x) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %add = arith.addf %lhs, %rhs : f32
+    iree_gpu.yield %add : f32
+  } : f32
+  return %scan : f32
+}
+
+// CHECK-LABEL: func.func @scan_full_subgroup
+// 5 steps for subgroup_size=32: offsets 1, 2, 4, 8, 16
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.select
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.select
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.select
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.select
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.select
+// CHECK-NOT:     gpu.shuffle

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/expand_gpu_ops_scan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/expand_gpu_ops_scan.mlir
@@ -6,7 +6,7 @@
 
 #translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
 func.func @scan_add_f32(%x: f32, %zero: f32) -> (f32, f32) attributes {translation_info = #translation_info} {
-  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4) {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero : f32) cluster(size = 4) {
   ^bb0(%lhs: f32, %rhs: f32):
     %add = arith.addf %lhs, %rhs : f32
     iree_gpu.yield %add : f32
@@ -61,7 +61,7 @@ func.func @scan_add_f32(%x: f32, %zero: f32) -> (f32, f32) attributes {translati
 
 #translation_info2 = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
 func.func @scan_add_f32_stride16(%x: f32, %zero: f32) -> (f32, f32) attributes {translation_info = #translation_info2} {
-  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4, stride = 16) {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero : f32) cluster(size = 4, stride = 16) {
   ^bb0(%lhs: f32, %rhs: f32):
     %add = arith.addf %lhs, %rhs : f32
     iree_gpu.yield %add : f32
@@ -118,7 +118,7 @@ func.func @scan_add_f32_stride16(%x: f32, %zero: f32) -> (f32, f32) attributes {
 
 #translation_info3 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
 func.func @scan_add_i32(%x: i32, %zero: i32) -> (i32, i32) attributes {translation_info = #translation_info3} {
-  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4) {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero : i32) cluster(size = 4) {
   ^bb0(%lhs: i32, %rhs: i32):
     %add = arith.addi %lhs, %rhs : i32
     iree_gpu.yield %add : i32
@@ -150,7 +150,7 @@ func.func @scan_add_i32(%x: i32, %zero: i32) -> (i32, i32) attributes {translati
 
 #translation_info4 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
 func.func @scan_add_f16(%x: f16, %zero: f16) -> (f16, f16) attributes {translation_info = #translation_info4} {
-  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4) {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero : f16) cluster(size = 4) {
   ^bb0(%lhs: f16, %rhs: f16):
     %add = arith.addf %lhs, %rhs : f16
     iree_gpu.yield %add : f16
@@ -189,7 +189,7 @@ func.func @scan_add_f16(%x: f16, %zero: f16) -> (f16, f16) attributes {translati
 
 #translation_info5 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
 func.func @scan_full_subgroup(%x: f32, %zero: f32) -> (f32, f32) attributes {translation_info = #translation_info5} {
-  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero : f32) {
   ^bb0(%lhs: f32, %rhs: f32):
     %add = arith.addf %lhs, %rhs : f32
     iree_gpu.yield %add : f32
@@ -215,3 +215,53 @@ func.func @scan_full_subgroup(%x: f32, %zero: f32) -> (f32, f32) attributes {tra
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.select
 // CHECK-NOT:     gpu.shuffle
+
+// -----
+
+// Inclusive scan with cluster_size=4, f32 addf.
+// Expects 2 shuffle steps for inclusive scan, then total shuffle from last
+// lane. No exclusive shift shuffle or identity select.
+
+#translation_info6 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
+func.func @scan_inclusive_add_f32(%x: f32) -> (f32, f32) attributes {translation_info = #translation_info6} {
+  %scan, %total = iree_gpu.subgroup_scan inclusive (%x) cluster(size = 4) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %add = arith.addf %lhs, %rhs : f32
+    iree_gpu.yield %add : f32
+  } : f32
+  return %scan, %total : f32, f32
+}
+
+// CHECK-LABEL: func.func @scan_inclusive_add_f32
+// CHECK-SAME:    (%[[X:.+]]: f32)
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : i32
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : i32
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : i32
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : i32
+// CHECK:         %[[LANE:.+]] = gpu.lane_id
+// CHECK:         %[[LANE_I32:.+]] = arith.index_cast %[[LANE]] : index to i32
+// CHECK:         %[[POS:.+]] = arith.remui %[[LANE_I32]], %[[C4]]
+//
+// Inclusive scan step 0: offset=1, threshold=1
+// CHECK:         %[[SRC0:.+]] = arith.subi %[[LANE_I32]], %[[C1]]
+// CHECK:         %[[SHUF0:.+]], %{{.+}} = gpu.shuffle idx %[[X]], %[[SRC0]], %[[C32]]
+// CHECK:         %[[ADD0:.+]] = arith.addf %[[SHUF0]], %[[X]]
+// CHECK:         %[[PRED0:.+]] = arith.cmpi uge, %[[POS]], %[[C1]]
+// CHECK:         %[[SEL0:.+]] = arith.select %[[PRED0]], %[[ADD0]], %[[X]]
+//
+// Inclusive scan step 1: offset=2, threshold=2
+// CHECK:         %[[SRC1:.+]] = arith.subi %[[LANE_I32]], %[[C2]]
+// CHECK:         %[[SHUF1:.+]], %{{.+}} = gpu.shuffle idx %[[SEL0]], %[[SRC1]], %[[C32]]
+// CHECK:         %[[ADD1:.+]] = arith.addf %[[SHUF1]], %[[SEL0]]
+// CHECK:         %[[PRED1:.+]] = arith.cmpi uge, %[[POS]], %[[C2]]
+// CHECK:         %[[INCL:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
+//
+// Total: shuffle from last lane in cluster
+// CHECK:         %[[BASE:.+]] = arith.subi %[[LANE_I32]], %[[POS]]
+// CHECK:         %[[LAST:.+]] = arith.addi %[[BASE]], %[[C3]]
+// CHECK:         %[[TOTAL_SHUF:.+]], %{{.+}} = gpu.shuffle idx %[[INCL]], %[[LAST]], %[[C32]]
+//
+// No exclusive shift — inclusive result used directly
+// CHECK-NOT:     gpu.shuffle
+// CHECK:         return %[[INCL]], %[[TOTAL_SHUF]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/expand_gpu_ops_scan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/expand_gpu_ops_scan.mlir
@@ -1,44 +1,58 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline='builtin.module(func.func(iree-codegen-expand-gpu-ops))' %s | FileCheck %s
 
-// Basic scan with cluster_size=4, stride=1 (default), f32 addf.
-// Expects 2 shuffle steps (offsets 1, 2) with predicates and selects.
-// When stride=1, the divui-by-1 is folded away, so lanePos = remui(laneId, 4).
+// Basic exclusive scan with cluster_size=4, stride=1 (default), f32 addf.
+// Expects 2 shuffle steps for inclusive scan, then total shuffle from last
+// lane, then exclusive shift shuffle + select identity at lane 0.
 
 #translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
-func.func @scan_add_f32(%x: f32) -> f32 attributes {translation_info = #translation_info} {
-  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+func.func @scan_add_f32(%x: f32, %zero: f32) -> (f32, f32) attributes {translation_info = #translation_info} {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4) {
   ^bb0(%lhs: f32, %rhs: f32):
     %add = arith.addf %lhs, %rhs : f32
     iree_gpu.yield %add : f32
   } : f32
-  return %scan : f32
+  return %scan, %total : f32, f32
 }
 
 // CHECK-LABEL: func.func @scan_add_f32
-// CHECK-SAME:    (%[[X:.+]]: f32)
+// CHECK-SAME:    (%[[X:.+]]: f32, %[[ZERO:.+]]: f32)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : i32
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
 // CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : i32
 // CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : i32
 // CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : i32
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : i32
 // CHECK:         %[[LANE:.+]] = gpu.lane_id
 // CHECK:         %[[LANE_I32:.+]] = arith.index_cast %[[LANE]] : index to i32
 // CHECK:         %[[POS:.+]] = arith.remui %[[LANE_I32]], %[[C4]]
 //
-// Step 0: offset=1, threshold=1
+// Inclusive scan step 0: offset=1, threshold=1
 // CHECK:         %[[SRC0:.+]] = arith.subi %[[LANE_I32]], %[[C1]]
 // CHECK:         %[[SHUF0:.+]], %{{.+}} = gpu.shuffle idx %[[X]], %[[SRC0]], %[[C32]]
 // CHECK:         %[[ADD0:.+]] = arith.addf %[[SHUF0]], %[[X]]
 // CHECK:         %[[PRED0:.+]] = arith.cmpi uge, %[[POS]], %[[C1]]
 // CHECK:         %[[SEL0:.+]] = arith.select %[[PRED0]], %[[ADD0]], %[[X]]
 //
-// Step 1: offset=2, threshold=2
+// Inclusive scan step 1: offset=2, threshold=2
 // CHECK:         %[[SRC1:.+]] = arith.subi %[[LANE_I32]], %[[C2]]
 // CHECK:         %[[SHUF1:.+]], %{{.+}} = gpu.shuffle idx %[[SEL0]], %[[SRC1]], %[[C32]]
 // CHECK:         %[[ADD1:.+]] = arith.addf %[[SHUF1]], %[[SEL0]]
 // CHECK:         %[[PRED1:.+]] = arith.cmpi uge, %[[POS]], %[[C2]]
-// CHECK:         %[[SEL1:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
+// CHECK:         %[[INCL:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
 //
-// CHECK:         return %[[SEL1]]
+// Total: shuffle from last lane in cluster
+// (muli by 1 is folded, so baseLane = laneIdI32 - lanePos)
+// CHECK:         %[[BASE:.+]] = arith.subi %[[LANE_I32]], %[[POS]]
+// CHECK:         %[[LAST:.+]] = arith.addi %[[BASE]], %[[C3]]
+// CHECK:         %[[TOTAL_SHUF:.+]], %{{.+}} = gpu.shuffle idx %[[INCL]], %[[LAST]], %[[C32]]
+//
+// Exclusive: shift right by one, insert identity at position 0
+// CHECK:         %[[PRED_LANE:.+]] = arith.subi %[[LANE_I32]], %[[C1]]
+// CHECK:         %[[SHIFT_SHUF:.+]], %{{.+}} = gpu.shuffle idx %[[INCL]], %[[PRED_LANE]], %[[C32]]
+// CHECK:         %[[IS_FIRST:.+]] = arith.cmpi eq, %[[POS]], %[[C0]]
+// CHECK:         %[[EXCL:.+]] = arith.select %[[IS_FIRST]], %[[ZERO]], %[[SHIFT_SHUF]]
+//
+// CHECK:         return %[[EXCL]], %[[TOTAL_SHUF]]
 
 // -----
 
@@ -46,21 +60,23 @@ func.func @scan_add_f32(%x: f32) -> f32 attributes {translation_info = #translat
 // Expects shuffle offsets of 16, 32. lanePos = (laneId / 16) % 4.
 
 #translation_info2 = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
-func.func @scan_add_f32_stride16(%x: f32) -> f32 attributes {translation_info = #translation_info2} {
-  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4, stride = 16) {
+func.func @scan_add_f32_stride16(%x: f32, %zero: f32) -> (f32, f32) attributes {translation_info = #translation_info2} {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4, stride = 16) {
   ^bb0(%lhs: f32, %rhs: f32):
     %add = arith.addf %lhs, %rhs : f32
     iree_gpu.yield %add : f32
   } : f32
-  return %scan : f32
+  return %scan, %total : f32, f32
 }
 
 // CHECK-LABEL: func.func @scan_add_f32_stride16
-// CHECK-SAME:    (%[[X:.+]]: f32)
+// CHECK-SAME:    (%[[X:.+]]: f32, %[[ZERO:.+]]: f32)
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : i32
 // CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : i32
 // CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : i32
 // CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : i32
 // CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : i32
+// CHECK-DAG:     %[[C48:.+]] = arith.constant 48 : i32
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : i32
 // CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : i32
 // CHECK:         %[[LANE:.+]] = gpu.lane_id
@@ -68,34 +84,46 @@ func.func @scan_add_f32_stride16(%x: f32) -> f32 attributes {translation_info = 
 // CHECK:         %[[DIV:.+]] = arith.divui %[[LANE_I32]], %[[C16]]
 // CHECK:         %[[POS:.+]] = arith.remui %[[DIV]], %[[C4]]
 //
-// Step 0: offset=16
+// Inclusive scan step 0: offset=16
 // CHECK:         %[[SRC0:.+]] = arith.subi %[[LANE_I32]], %[[C16]]
 // CHECK:         %[[SHUF0:.+]], %{{.+}} = gpu.shuffle idx %[[X]], %[[SRC0]], %[[C64]]
 // CHECK:         %[[ADD0:.+]] = arith.addf %[[SHUF0]], %[[X]]
 // CHECK:         %[[PRED0:.+]] = arith.cmpi uge, %[[POS]], %[[C1]]
 // CHECK:         %[[SEL0:.+]] = arith.select %[[PRED0]], %[[ADD0]], %[[X]]
 //
-// Step 1: offset=32
+// Inclusive scan step 1: offset=32
 // CHECK:         %[[SRC1:.+]] = arith.subi %[[LANE_I32]], %[[C32]]
 // CHECK:         %[[SHUF1:.+]], %{{.+}} = gpu.shuffle idx %[[SEL0]], %[[SRC1]], %[[C64]]
 // CHECK:         %[[ADD1:.+]] = arith.addf %[[SHUF1]], %[[SEL0]]
 // CHECK:         %[[PRED1:.+]] = arith.cmpi uge, %[[POS]], %[[C2]]
-// CHECK:         %[[SEL1:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
+// CHECK:         %[[INCL:.+]] = arith.select %[[PRED1]], %[[ADD1]], %[[SEL0]]
 //
-// CHECK:         return %[[SEL1]]
+// Total: shuffle from last lane in cluster (offset = 48)
+// CHECK:         %[[POS_X_STRIDE:.+]] = arith.muli %[[POS]], %[[C16]]
+// CHECK:         %[[BASE:.+]] = arith.subi %[[LANE_I32]], %[[POS_X_STRIDE]]
+// CHECK:         %[[LAST:.+]] = arith.addi %[[BASE]], %[[C48]]
+// CHECK:         %[[TOTAL_SHUF:.+]], %{{.+}} = gpu.shuffle idx %[[INCL]], %[[LAST]], %[[C64]]
+//
+// Exclusive: shift right by stride=16, insert identity at position 0
+// CHECK:         %[[PRED_LANE:.+]] = arith.subi %[[LANE_I32]], %[[C16]]
+// CHECK:         %[[SHIFT_SHUF:.+]], %{{.+}} = gpu.shuffle idx %[[INCL]], %[[PRED_LANE]], %[[C64]]
+// CHECK:         %[[IS_FIRST:.+]] = arith.cmpi eq, %[[POS]], %[[C0]]
+// CHECK:         %[[EXCL:.+]] = arith.select %[[IS_FIRST]], %[[ZERO]], %[[SHIFT_SHUF]]
+//
+// CHECK:         return %[[EXCL]], %[[TOTAL_SHUF]]
 
 // -----
 
 // i32 scan: no bitcast needed.
 
 #translation_info3 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
-func.func @scan_add_i32(%x: i32) -> i32 attributes {translation_info = #translation_info3} {
-  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+func.func @scan_add_i32(%x: i32, %zero: i32) -> (i32, i32) attributes {translation_info = #translation_info3} {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4) {
   ^bb0(%lhs: i32, %rhs: i32):
     %add = arith.addi %lhs, %rhs : i32
     iree_gpu.yield %add : i32
   } : i32
-  return %scan : i32
+  return %scan, %total : i32, i32
 }
 
 // CHECK-LABEL: func.func @scan_add_i32
@@ -103,11 +131,17 @@ func.func @scan_add_i32(%x: i32) -> i32 attributes {translation_info = #translat
 // CHECK-NOT:     arith.bitcast
 // CHECK-NOT:     arith.extui
 // CHECK-NOT:     arith.trunci
+// Inclusive scan shuffles
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.addi
 // CHECK:         arith.select
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.addi
+// CHECK:         arith.select
+// Total shuffle
+// CHECK:         gpu.shuffle idx
+// Exclusive shift shuffle + select
+// CHECK:         gpu.shuffle idx
 // CHECK:         arith.select
 
 // -----
@@ -115,17 +149,17 @@ func.func @scan_add_i32(%x: i32) -> i32 attributes {translation_info = #translat
 // f16 scan: requires bitcast to i32 for shuffle.
 
 #translation_info4 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
-func.func @scan_add_f16(%x: f16) -> f16 attributes {translation_info = #translation_info4} {
-  %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+func.func @scan_add_f16(%x: f16, %zero: f16) -> (f16, f16) attributes {translation_info = #translation_info4} {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) cluster(size = 4) {
   ^bb0(%lhs: f16, %rhs: f16):
     %add = arith.addf %lhs, %rhs : f16
     iree_gpu.yield %add : f16
   } : f16
-  return %scan : f16
+  return %scan, %total : f16, f16
 }
 
 // CHECK-LABEL: func.func @scan_add_f16
-// Step 0: pack to i32, shuffle, unpack
+// Inclusive scan step 0: pack to i32, shuffle, unpack
 // CHECK:         arith.bitcast %{{.+}} : f16 to i16
 // CHECK:         arith.extui %{{.+}} : i16 to i32
 // CHECK:         gpu.shuffle idx
@@ -133,32 +167,38 @@ func.func @scan_add_f16(%x: f16) -> f16 attributes {translation_info = #translat
 // CHECK:         arith.bitcast %{{.+}} : i16 to f16
 // CHECK:         arith.addf
 // CHECK:         arith.select
-// Step 1: pack to i32, shuffle, unpack
+// Inclusive scan step 1: pack to i32, shuffle, unpack
 // CHECK:         arith.bitcast %{{.+}} : f16 to i16
 // CHECK:         arith.extui %{{.+}} : i16 to i32
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.trunci %{{.+}} : i32 to i16
 // CHECK:         arith.bitcast %{{.+}} : i16 to f16
 // CHECK:         arith.addf
+// CHECK:         arith.select
+// Total shuffle (pack/unpack)
+// CHECK:         gpu.shuffle idx
+// Exclusive shift shuffle (pack/unpack) + select
+// CHECK:         gpu.shuffle idx
 // CHECK:         arith.select
 
 // -----
 
 // Full subgroup scan (no cluster clause) with subgroup_size=32.
-// Expects 5 shuffle steps (offsets 1, 2, 4, 8, 16).
+// Expects 5 shuffle steps for inclusive scan (offsets 1, 2, 4, 8, 16),
+// then total shuffle + exclusive shift.
 
 #translation_info5 = #iree_codegen.translation_info<pipeline = None workgroup_size = [32, 1, 1] subgroup_size = 32>
-func.func @scan_full_subgroup(%x: f32) -> f32 attributes {translation_info = #translation_info5} {
-  %scan = iree_gpu.subgroup_scan(%x) {
+func.func @scan_full_subgroup(%x: f32, %zero: f32) -> (f32, f32) attributes {translation_info = #translation_info5} {
+  %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero) {
   ^bb0(%lhs: f32, %rhs: f32):
     %add = arith.addf %lhs, %rhs : f32
     iree_gpu.yield %add : f32
   } : f32
-  return %scan : f32
+  return %scan, %total : f32, f32
 }
 
 // CHECK-LABEL: func.func @scan_full_subgroup
-// 5 steps for subgroup_size=32: offsets 1, 2, 4, 8, 16
+// 5 inclusive scan steps for subgroup_size=32: offsets 1, 2, 4, 8, 16
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.select
 // CHECK:         gpu.shuffle idx
@@ -167,6 +207,11 @@ func.func @scan_full_subgroup(%x: f32) -> f32 attributes {translation_info = #tr
 // CHECK:         arith.select
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.select
+// CHECK:         gpu.shuffle idx
+// CHECK:         arith.select
+// Total shuffle
+// CHECK:         gpu.shuffle idx
+// Exclusive shift shuffle + select identity
 // CHECK:         gpu.shuffle idx
 // CHECK:         arith.select
 // CHECK-NOT:     gpu.shuffle

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -118,6 +118,41 @@ LogicalResult ValueBarrierOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// SubgroupScanOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SubgroupScanOp::verify() {
+  if (std::optional<uint32_t> size = getClusterSize()) {
+    if (!llvm::isPowerOf2_32(*size)) {
+      return emitOpError("cluster_size must be a power of 2");
+    }
+  }
+  uint32_t stride = getClusterStride();
+  if (!llvm::isPowerOf2_32(stride)) {
+    return emitOpError("cluster_stride must be a power of 2");
+  }
+  return success();
+}
+
+LogicalResult SubgroupScanOp::verifyRegions() {
+  Block &block = getCombiner().front();
+  if (block.getNumArguments() != 2) {
+    return emitOpError("combiner region must have exactly 2 arguments");
+  }
+  Type valTy = getValue().getType();
+  for (auto arg : block.getArguments()) {
+    if (arg.getType() != valTy) {
+      return emitOpError("combiner argument type must match value type");
+    }
+  }
+  auto yield = cast<IREE::GPU::YieldOp>(block.getTerminator());
+  if (yield.getNumOperands() != 1 || yield.getOperand(0).getType() != valTy) {
+    return emitOpError("combiner must yield one value of the value type");
+  }
+  return success();
+}
+
 // AMD Specific Operations
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -132,6 +132,14 @@ LogicalResult SubgroupScanOp::verify() {
   if (!llvm::isPowerOf2_32(stride)) {
     return emitOpError("cluster_stride must be a power of 2");
   }
+  if (!getInclusive() && !getIdentity()) {
+    return emitOpError("exclusive scan requires an identity operand");
+  }
+  if (Value id = getIdentity()) {
+    if (id.getType() != getValue().getType()) {
+      return emitOpError("identity type must match value type");
+    }
+  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -172,7 +172,8 @@ def IREEGPU_ValueBarrierOp : Op<IREEGPU_Dialect, "value_barrier", [
 
 def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
     Pure, ReturnLike, Terminator,
-    HasParent<"::mlir::iree_compiler::IREE::GPU::BarrierRegionOp">]> {
+    ParentOneOf<["::mlir::iree_compiler::IREE::GPU::BarrierRegionOp",
+                 "::mlir::iree_compiler::IREE::GPU::SubgroupScanOp"]>]> {
   let summary = [{Yield values from a iree_gpu region.}];
   let description = [{
      This operation is used to yield values from a within a region.
@@ -183,6 +184,54 @@ def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
 
   let assemblyFormat =
       [{  attr-dict ($values^ `:` type($values))? }];
+}
+
+//===----------------------------------------------------------------------===//
+// SubgroupScanOp
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
+    SingleBlockImplicitTerminator<"mlir::iree_compiler::IREE::GPU::YieldOp">,
+    AllTypesMatch<["value", "result"]>]> {
+  let summary = "Inclusive prefix scan across subgroup lanes.";
+  let description = [{
+    Performs an inclusive prefix scan of a scalar value across lanes within
+    a subgroup cluster. The combiner is specified by the region body, which
+    takes two arguments of the value type and yields one result.
+
+    The subgroup is divided into clusters of `size` lanes starting at lane 0
+    with inter-lane `stride`. Within each cluster, lane at logical position
+    `p` receives `val_0 op val_1 op ... op val_p`, where `op` is the combiner.
+
+    The combiner must be associative. It does not need to be commutative.
+
+    Example:
+    ```mlir
+    %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4, stride = 2) {
+    ^bb0(%lhs: f32, %rhs: f32):
+      %add = arith.addf %lhs, %rhs : f32
+      iree_gpu.yield %add : f32
+    } : f32
+    ```
+  }];
+
+  let arguments = (ins
+    AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$value,
+    OptionalAttr<I32Attr>:$cluster_size,
+    DefaultValuedAttr<I32Attr, "1">:$cluster_stride
+  );
+  let results = (outs AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$result);
+  let regions = (region SizedRegion<1>:$combiner);
+
+  let assemblyFormat = [{
+    `(` $value `)`
+    (`cluster` `(` `size` `=` $cluster_size^
+      (`,` `stride` `=` $cluster_stride^)? `)`)?
+    $combiner attr-dict `:` type($value)
+  }];
+
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -192,29 +192,43 @@ def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
 
 def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
     SingleBlockImplicitTerminator<"mlir::iree_compiler::IREE::GPU::YieldOp">,
-    AllTypesMatch<["value", "identity", "result", "total"]>]> {
-  let summary = "Exclusive prefix scan across subgroup lanes with total.";
+    AllTypesMatch<["value", "result", "total"]>]> {
+  let summary = "Prefix scan across subgroup lanes with total.";
   let description = [{
-    Performs an exclusive prefix scan of a scalar value across lanes within
-    a subgroup cluster, and returns the cluster total as a second result.
+    Performs a prefix scan of a scalar value across lanes within a subgroup
+    cluster, and returns the cluster total as a second result. The scan can
+    be either inclusive or exclusive:
+
+    - **Inclusive** (`inclusive` keyword present): lane at logical position `p`
+      receives `val_0 op val_1 op ... op val_p`. No identity is needed.
+    - **Exclusive** (default, no `inclusive` keyword): lane at position `p`
+      receives `identity op val_0 op ... op val_{p-1}`. Lane 0 receives the
+      identity. The `identity` operand is required for exclusive mode.
+
     The combiner is specified by the region body, which takes two arguments
     of the value type and yields one result.
 
     The subgroup is divided into clusters of `size` lanes starting at lane 0
-    with inter-lane `stride`. Within each cluster, lane at logical position
-    `p` receives `identity op val_0 op ... op val_{p-1}` (exclusive), where
-    `op` is the combiner. Lane 0 receives the identity.
+    with inter-lane `stride`.
 
     The second result `total` is the reduction of all values in the cluster:
     `val_0 op val_1 op ... op val_{size-1}`.
 
-    The caller must supply `identity`, the identity element of the combiner.
     The combiner must be associative. It does not need to be commutative.
 
-    Example:
+    Examples:
     ```mlir
-    %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero)
+    // Exclusive scan:
+    %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero : f32)
         cluster(size = 4, stride = 2) {
+    ^bb0(%lhs: f32, %rhs: f32):
+      %add = arith.addf %lhs, %rhs : f32
+      iree_gpu.yield %add : f32
+    } : f32
+
+    // Inclusive scan:
+    %scan, %total = iree_gpu.subgroup_scan inclusive (%x)
+        cluster(size = 4) {
     ^bb0(%lhs: f32, %rhs: f32):
       %add = arith.addf %lhs, %rhs : f32
       iree_gpu.yield %add : f32
@@ -224,7 +238,8 @@ def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
 
   let arguments = (ins
     AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$value,
-    AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$identity,
+    Optional<AnyTypeOf<[AnySignlessInteger, AnyFloat]>>:$identity,
+    UnitAttr:$inclusive,
     OptionalAttr<I32Attr>:$cluster_size,
     DefaultValuedAttr<I32Attr, "1">:$cluster_stride
   );
@@ -235,7 +250,8 @@ def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
   let regions = (region SizedRegion<1>:$combiner);
 
   let assemblyFormat = [{
-    `(` $value `,` `identity` `=` $identity `)`
+    (`inclusive` $inclusive^)?
+    `(` $value (`,` `identity` `=` $identity^ `:` type($identity))? `)`
     (`cluster` `(` `size` `=` $cluster_size^
       (`,` `stride` `=` $cluster_stride^)? `)`)?
     $combiner attr-dict `:` type($value)

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -192,22 +192,29 @@ def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
 
 def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
     SingleBlockImplicitTerminator<"mlir::iree_compiler::IREE::GPU::YieldOp">,
-    AllTypesMatch<["value", "result"]>]> {
-  let summary = "Inclusive prefix scan across subgroup lanes.";
+    AllTypesMatch<["value", "identity", "result", "total"]>]> {
+  let summary = "Exclusive prefix scan across subgroup lanes with total.";
   let description = [{
-    Performs an inclusive prefix scan of a scalar value across lanes within
-    a subgroup cluster. The combiner is specified by the region body, which
-    takes two arguments of the value type and yields one result.
+    Performs an exclusive prefix scan of a scalar value across lanes within
+    a subgroup cluster, and returns the cluster total as a second result.
+    The combiner is specified by the region body, which takes two arguments
+    of the value type and yields one result.
 
     The subgroup is divided into clusters of `size` lanes starting at lane 0
     with inter-lane `stride`. Within each cluster, lane at logical position
-    `p` receives `val_0 op val_1 op ... op val_p`, where `op` is the combiner.
+    `p` receives `identity op val_0 op ... op val_{p-1}` (exclusive), where
+    `op` is the combiner. Lane 0 receives the identity.
 
+    The second result `total` is the reduction of all values in the cluster:
+    `val_0 op val_1 op ... op val_{size-1}`.
+
+    The caller must supply `identity`, the identity element of the combiner.
     The combiner must be associative. It does not need to be commutative.
 
     Example:
     ```mlir
-    %scan = iree_gpu.subgroup_scan(%x) cluster(size = 4, stride = 2) {
+    %scan, %total = iree_gpu.subgroup_scan(%x, identity = %zero)
+        cluster(size = 4, stride = 2) {
     ^bb0(%lhs: f32, %rhs: f32):
       %add = arith.addf %lhs, %rhs : f32
       iree_gpu.yield %add : f32
@@ -217,14 +224,18 @@ def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
 
   let arguments = (ins
     AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$value,
+    AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$identity,
     OptionalAttr<I32Attr>:$cluster_size,
     DefaultValuedAttr<I32Attr, "1">:$cluster_stride
   );
-  let results = (outs AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$result);
+  let results = (outs
+    AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$result,
+    AnyTypeOf<[AnySignlessInteger, AnyFloat]>:$total
+  );
   let regions = (region SizedRegion<1>:$combiner);
 
   let assemblyFormat = [{
-    `(` $value `)`
+    `(` $value `,` `identity` `=` $identity `)`
     (`cluster` `(` `size` `=` $cluster_size^
       (`,` `stride` `=` $cluster_stride^)? `)`)?
     $combiner attr-dict `:` type($value)

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -156,6 +156,18 @@ func.func @mma_inner_tiled_invalid_inner_types_distributed_nonopaque(%lhs: tenso
 
 // -----
 
+func.func @subgroup_scan_exclusive_without_identity(%x: f32) -> (f32, f32) {
+  // expected-error @+1 {{exclusive scan requires an identity operand}}
+  %scan, %total = iree_gpu.subgroup_scan(%x) cluster(size = 4) {
+  ^bb0(%lhs: f32, %rhs: f32):
+    %add = arith.addf %lhs, %rhs : f32
+    iree_gpu.yield %add : f32
+  } : f32
+  return %scan, %total : f32, f32
+}
+
+// -----
+
 func.func @vector_multi_mma_with_wrong_number_of_permutations(%lhs: vector<2x3x4xf16>, %rhs: vector<3x5x4xf16>, %acc: vector<2x5x4xf32>) -> vector<2x5x4xf32> {
   // expected-error @+1 {{op mismatch between the number of permutations (2) and the number of operands (3)}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {


### PR DESCRIPTION
The upstream GPU dialect currently does not expose a `subgroup_scan` operation as analog to `subgroup_scan`.

Having the `subgroup_scan` operation allows us to lower associative scans across the threads in incremental steps rather than doing distribution and full lowering to cross-subgroup operations in a single step. 

The associative scan semantics of the operation is similar to `vector.scan` and supports inclusive and exclusive scan. The subgroup semantics is similar to `subgroup_scan` where applicable.

The expansion of the operation into lower-level vector operations and cross-subgroup operations (e.g., shuffle) uses the [Hillis-Steele algorithm](https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel).

This is part of https://github.com/iree-org/iree/issues/24186.

Assisted-by: Claude Code and Codex