### PR TITLE
[VectorDistribute] Support `vector.scan` in vector layout analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -231,6 +231,24 @@ void LayoutAnalysis::propagateOneForward(Value val,
       }
     }
 
+    if (auto scanOp = dyn_cast<vector::ScanOp>(user)) {
+      if (scanOp.getSource() == val) {
+        // source to dest: same layout (shape preserved).
+        addCandidate(scanOp.getDest(), layout);
+        // source to accumulated_value: project out scan dim.
+        int64_t rank = cast<VectorType>(val.getType()).getRank();
+        SmallVector<bool> projMask(rank, false);
+        projMask[scanOp.getReductionDim()] = true;
+        addCandidate(scanOp.getAccumulatedValue(), layout.project(projMask));
+        continue;
+      }
+      if (scanOp.getInitialValue() == val) {
+        // init to accumulated_value: same layout (same shape).
+        addCandidate(scanOp.getAccumulatedValue(), layout);
+        continue;
+      }
+    }
+
     if (auto transpose = dyn_cast<vector::TransposeOp>(user)) {
       if (transpose.getVector() == val) {
         addCandidate(transpose.getResult(),
@@ -392,6 +410,20 @@ void LayoutAnalysis::fixupOp(Operation *op) {
   if (auto multiReduce = dyn_cast<vector::MultiDimReductionOp>(op)) {
     VectorLayoutInterface layout = getResolvedLayout(multiReduce.getResult());
     setLayoutOrClone(&multiReduce.getAccMutable(), layout);
+    return;
+  }
+
+  // scan: dest layout -> source gets same layout, init gets projected layout.
+  if (auto scanOp = dyn_cast<vector::ScanOp>(op)) {
+    VectorLayoutInterface layout = getResolvedLayout(scanOp.getDest());
+    if (layout) {
+      setLayoutOrClone(&scanOp.getSourceMutable(), layout);
+      int64_t rank = scanOp.getSourceType().getRank();
+      SmallVector<bool> projMask(rank, false);
+      projMask[scanOp.getReductionDim()] = true;
+      VectorLayoutInterface initLayout = layout.project(projMask);
+      setLayoutOrClone(&scanOp.getInitialValueMutable(), initLayout);
+    }
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -1059,3 +1059,61 @@ func.func @argcompare_dimension_0(%input: vector<16x16xf16>,
   } -> vector<16xf16>, vector<16xi32>
   func.return %result#0, %result#1 : vector<16xf16>, vector<16xi32>
 }
+
+// -----
+
+// Test vector.scan forward propagation from source: source layout propagates
+// to dest (same shape) and accumulated_value (scan dim projected out).
+
+#layout_scan_fwd_src = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [8, 16],
+
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @scan_source_forward_propagation(%src: vector<16x16xf16>, %init: vector<16xf16>) -> (vector<16x16xf16>, vector<16xf16>) {
+  %srcl = iree_vector_ext.to_layout %src to layout(#layout_scan_fwd_src) : vector<16x16xf16>
+  // expected-remark @below {{layout of result #0 is #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 1], outer_tile = [1, 1], thread_tile = [1, 1], element_tile = [8, 16], subgroup_strides = [0, 0], thread_strides = [0, 0]>}}
+  // expected-remark @below {{layout of result #1 is #iree_vector_ext.nested_layout<subgroup_tile = [1], batch_tile = [1], outer_tile = [1], thread_tile = [1], element_tile = [16], subgroup_strides = [0], thread_strides = [0]>}}
+  %out:2 = vector.scan <add>, %srcl, %init {inclusive = true, reduction_dim = 0 : i64}
+    : vector<16x16xf16>, vector<16xf16>
+  func.return %out#0, %out#1 : vector<16x16xf16>, vector<16xf16>
+}
+
+// -----
+
+// Test vector.scan backward propagation: result layout propagates back to
+// source (same) and initial_value (scan dim projected out).
+
+#layout_scan_bwd = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [8, 16],
+
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @scan_backward_propagation(%arr: memref<16x16xf16>, %arr_init: memref<16xf16>) -> (vector<16x16xf16>, vector<16xf16>) {
+  %c0 = arith.constant 0 : index
+  %cst_0 = arith.constant 0.0 : f16
+  // Source transfer_read gets layout from backward propagation through scan.
+  %src = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @above {{layout of result #0 is #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 1], outer_tile = [1, 1], thread_tile = [1, 1], element_tile = [8, 16], subgroup_strides = [0, 0], thread_strides = [0, 0]>}}
+  // Init transfer_read gets projected layout (dim 0 removed) from backward
+  // propagation: [2, 1] x [1, 1] x [1, 1] x [8, 16] projects to [1] x [1] x [1] x [16].
+  %init = vector.transfer_read %arr_init[%c0], %cst_0 {in_bounds = [true]} : memref<16xf16>, vector<16xf16>
+  // expected-remark @above {{layout of result #0 is #iree_vector_ext.nested_layout<subgroup_tile = [1], batch_tile = [1], outer_tile = [1], thread_tile = [1], element_tile = [16], subgroup_strides = [0], thread_strides = [0]>}}
+  // expected-remark @below {{layout of result #0 is #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 1], outer_tile = [1, 1], thread_tile = [1, 1], element_tile = [8, 16], subgroup_strides = [0, 0], thread_strides = [0, 0]>}}
+  %out:2 = vector.scan <add>, %src, %init {inclusive = false, reduction_dim = 0 : i64}
+    : vector<16x16xf16>, vector<16xf16>
+  %destl = iree_vector_ext.to_layout %out#0 to layout(#layout_scan_bwd) : vector<16x16xf16>
+  func.return %destl, %out#1 : vector<16x16xf16>, vector<16xf16>
+}


### PR DESCRIPTION
Add support for `vector.scan` in the `VectorLayoutAnalysis` to propagate layouts across `vector.scan` and later distribute associative scans to parallel implementations.

This is part of https://github.com/iree-org/iree/issues/24186.

Assisted-by: Claude Code and Codex