### PR TITLE
[Codegen] Fix iree-compile --debug crash on CPU/GPU codegen pass options

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -9,6 +9,24 @@
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::CPUCodegenOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
+// Defines the out-of-line parser methods declared by
+// IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION. Paired with the declaration macro
+// in CodegenOptions.h.
+#define IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(TYPE)                          \
+  namespace llvm::cl {                                                         \
+  template class basic_parser<TYPE>;                                           \
+  bool parser<TYPE>::parse(Option &, StringRef, StringRef, TYPE &) {           \
+    return false;                                                              \
+  }                                                                            \
+  void parser<TYPE>::printOptionDiff(const Option &, TYPE, const OptVal &,     \
+                                     size_t) const {}                          \
+  void parser<TYPE>::anchor() {}                                               \
+  } /* namespace llvm::cl */
+
+IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::CPUCodegenOptions)
+IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::GPUCodegenOptions)
+#undef IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION
+
 namespace mlir::iree_compiler {
 
 std::string CodegenOptions::tuningSpecPath = "";

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -9,6 +9,24 @@
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::CPUCodegenOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
+// Defines the out-of-line parser methods declared by
+// IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION. Paired with the declaration macro
+// in CodegenOptions.h.
+#define IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(TYPE)                          \
+  namespace llvm::cl {                                                         \
+  template class basic_parser<TYPE>;                                           \
+  bool parser<TYPE>::parse(Option &, StringRef, StringRef, TYPE &) {           \
+    return false;                                                              \
+  }                                                                            \
+  void parser<TYPE>::printOptionDiff(const Option &, TYPE, const OptVal &,     \
+                                     size_t) const {}                          \
+  void parser<TYPE>::anchor() {}                                               \
+  } /* namespace llvm::cl */
+
+IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::CPUCodegenOptions)
+IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::GPUCodegenOptions)
+#undef IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION
+
 namespace mlir::iree_compiler {
 
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -9,23 +9,31 @@
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::CPUCodegenOptions);
 IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
-// Defines the out-of-line parser methods declared by
-// IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION. Paired with the declaration macro
+// Out-of-line definitions for the `llvm::cl::parser` specializations declared
 // in CodegenOptions.h.
-#define IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(TYPE)                          \
-  namespace llvm::cl {                                                         \
-  template class basic_parser<TYPE>;                                           \
-  bool parser<TYPE>::parse(Option &, StringRef, StringRef, TYPE &) {           \
-    return false;                                                              \
-  }                                                                            \
-  void parser<TYPE>::printOptionDiff(const Option &, TYPE, const OptVal &,     \
-                                     size_t) const {}                          \
-  void parser<TYPE>::anchor() {}                                               \
-  } /* namespace llvm::cl */
+namespace llvm::cl {
 
-IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::CPUCodegenOptions)
-IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::GPUCodegenOptions)
-#undef IREE_DEFINE_CODEGEN_OPTIONS_PASS_OPTION
+template class basic_parser<mlir::iree_compiler::CPUCodegenOptions>;
+bool parser<mlir::iree_compiler::CPUCodegenOptions>::parse(
+    Option &, StringRef, StringRef, mlir::iree_compiler::CPUCodegenOptions &) {
+  return false;
+}
+void parser<mlir::iree_compiler::CPUCodegenOptions>::printOptionDiff(
+    const Option &, mlir::iree_compiler::CPUCodegenOptions, const OptVal &,
+    size_t) const {}
+void parser<mlir::iree_compiler::CPUCodegenOptions>::anchor() {}
+
+template class basic_parser<mlir::iree_compiler::GPUCodegenOptions>;
+bool parser<mlir::iree_compiler::GPUCodegenOptions>::parse(
+    Option &, StringRef, StringRef, mlir::iree_compiler::GPUCodegenOptions &) {
+  return false;
+}
+void parser<mlir::iree_compiler::GPUCodegenOptions>::printOptionDiff(
+    const Option &, mlir::iree_compiler::GPUCodegenOptions, const OptVal &,
+    size_t) const {}
+void parser<mlir::iree_compiler::GPUCodegenOptions>::anchor() {}
+
+} // namespace llvm::cl
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -67,4 +67,44 @@ struct GPUCodegenOptions : CodegenOptions {
 
 } // namespace mlir::iree_compiler
 
+// Declares the machinery required to use `TYPE` as an MLIR pass option:
+//
+//   (1) `operator<<` in the type's associated namespace, so MLIR's pass-option
+//       printing (which goes through ADL via has_stream_operator) can serialize
+//       the value. We print nothing because the options are populated
+//       programmatically from a session-scoped instance, not from pass
+//       pipeline strings.
+//   (2) `llvm::cl::parser<TYPE>` specialized to inherit `basic_parser` instead
+//       of the default `generic_parser_base`. This sidesteps
+//       `GenericOptionParser::findArgStrForValue`, which `llvm_unreachable`s
+//       on struct-typed values that have no registered enum entries.
+//
+// The parse method is a no-op: these options never flow in from strings.
+#define IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(TYPE, VALUE_NAME_STR)         \
+  namespace mlir::iree_compiler {                                              \
+  inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const TYPE &) {  \
+    return os;                                                                 \
+  }                                                                            \
+  } /* namespace mlir::iree_compiler */                                        \
+                                                                               \
+  namespace llvm::cl {                                                         \
+  extern template class basic_parser<TYPE>;                                    \
+  template <>                                                                  \
+  class parser<TYPE> : public basic_parser<TYPE> {                             \
+  public:                                                                      \
+    parser(Option &O) : basic_parser(O) {}                                     \
+    bool parse(Option &O, StringRef ArgName, StringRef Arg, TYPE &Val);        \
+    StringRef getValueName() const override { return VALUE_NAME_STR; }         \
+    void printOptionDiff(const Option &O, TYPE V, const OptVal &Default,       \
+                         size_t GlobalWidth) const;                            \
+    void anchor() override;                                                    \
+  };                                                                           \
+  } /* namespace llvm::cl */
+
+IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::CPUCodegenOptions,
+                                         "cpu codegen options")
+IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::GPUCodegenOptions,
+                                         "gpu codegen options")
+#undef IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION
+
 #endif // IREE_COMPILER_CODEGEN_UTILS_CODEGENOPTIONS_H_

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -97,46 +97,58 @@ struct GPUCodegenOptions : CodegenOptions {
   static GPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
+// Provide `operator<<` in the associated namespace so MLIR's pass-option
+// printing (which goes through ADL via has_stream_operator) can serialize
+// these values. We print a placeholder because the options are populated
+// programmatically from a session-scoped instance, not from pass pipeline
+// strings; there is no meaningful textual representation to round-trip.
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const CPUCodegenOptions &) {
+  return os << "opaque";
+}
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const GPUCodegenOptions &) {
+  return os << "opaque";
+}
+
 } // namespace mlir::iree_compiler
 
-// Declares the machinery required to use `TYPE` as an MLIR pass option:
+// Specialize `llvm::cl::parser` for the codegen option structs to inherit
+// `basic_parser` instead of the default `generic_parser_base`. This sidesteps
+// `GenericOptionParser::findArgStrForValue`, which `llvm_unreachable`s on
+// struct-typed values that have no registered enum entries.
 //
-//   (1) `operator<<` in the type's associated namespace, so MLIR's pass-option
-//       printing (which goes through ADL via has_stream_operator) can serialize
-//       the value. We print nothing because the options are populated
-//       programmatically from a session-scoped instance, not from pass
-//       pipeline strings.
-//   (2) `llvm::cl::parser<TYPE>` specialized to inherit `basic_parser` instead
-//       of the default `generic_parser_base`. This sidesteps
-//       `GenericOptionParser::findArgStrForValue`, which `llvm_unreachable`s
-//       on struct-typed values that have no registered enum entries.
-//
-// The parse method is a no-op: these options never flow in from strings.
-#define IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(TYPE, VALUE_NAME_STR)         \
-  namespace mlir::iree_compiler {                                              \
-  inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const TYPE &) {  \
-    return os;                                                                 \
-  }                                                                            \
-  } /* namespace mlir::iree_compiler */                                        \
-                                                                               \
-  namespace llvm::cl {                                                         \
-  extern template class basic_parser<TYPE>;                                    \
-  template <>                                                                  \
-  class parser<TYPE> : public basic_parser<TYPE> {                             \
-  public:                                                                      \
-    parser(Option &O) : basic_parser(O) {}                                     \
-    bool parse(Option &O, StringRef ArgName, StringRef Arg, TYPE &Val);        \
-    StringRef getValueName() const override { return VALUE_NAME_STR; }         \
-    void printOptionDiff(const Option &O, TYPE V, const OptVal &Default,       \
-                         size_t GlobalWidth) const;                            \
-    void anchor() override;                                                    \
-  };                                                                           \
-  } /* namespace llvm::cl */
+// The parse methods are no-ops: these options never flow in from strings.
+namespace llvm::cl {
 
-IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::CPUCodegenOptions,
-                                         "cpu codegen options")
-IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::GPUCodegenOptions,
-                                         "gpu codegen options")
-#undef IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION
+extern template class basic_parser<mlir::iree_compiler::CPUCodegenOptions>;
+template <>
+class parser<mlir::iree_compiler::CPUCodegenOptions>
+    : public basic_parser<mlir::iree_compiler::CPUCodegenOptions> {
+public:
+  parser(Option &o) : basic_parser(o) {}
+  bool parse(Option &, StringRef, StringRef,
+             mlir::iree_compiler::CPUCodegenOptions &);
+  StringRef getValueName() const override { return "cpu codegen options"; }
+  void printOptionDiff(const Option &, mlir::iree_compiler::CPUCodegenOptions,
+                       const OptVal &, size_t) const;
+  void anchor() override;
+};
+
+extern template class basic_parser<mlir::iree_compiler::GPUCodegenOptions>;
+template <>
+class parser<mlir::iree_compiler::GPUCodegenOptions>
+    : public basic_parser<mlir::iree_compiler::GPUCodegenOptions> {
+public:
+  parser(Option &o) : basic_parser(o) {}
+  bool parse(Option &, StringRef, StringRef,
+             mlir::iree_compiler::GPUCodegenOptions &);
+  StringRef getValueName() const override { return "gpu codegen options"; }
+  void printOptionDiff(const Option &, mlir::iree_compiler::GPUCodegenOptions,
+                       const OptVal &, size_t) const;
+  void anchor() override;
+};
+
+} // namespace llvm::cl
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_CODEGENOPTIONS_H_

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -99,4 +99,44 @@ struct GPUCodegenOptions : CodegenOptions {
 
 } // namespace mlir::iree_compiler
 
+// Declares the machinery required to use `TYPE` as an MLIR pass option:
+//
+//   (1) `operator<<` in the type's associated namespace, so MLIR's pass-option
+//       printing (which goes through ADL via has_stream_operator) can serialize
+//       the value. We print nothing because the options are populated
+//       programmatically from a session-scoped instance, not from pass
+//       pipeline strings.
+//   (2) `llvm::cl::parser<TYPE>` specialized to inherit `basic_parser` instead
+//       of the default `generic_parser_base`. This sidesteps
+//       `GenericOptionParser::findArgStrForValue`, which `llvm_unreachable`s
+//       on struct-typed values that have no registered enum entries.
+//
+// The parse method is a no-op: these options never flow in from strings.
+#define IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(TYPE, VALUE_NAME_STR)         \
+  namespace mlir::iree_compiler {                                              \
+  inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const TYPE &) {  \
+    return os;                                                                 \
+  }                                                                            \
+  } /* namespace mlir::iree_compiler */                                        \
+                                                                               \
+  namespace llvm::cl {                                                         \
+  extern template class basic_parser<TYPE>;                                    \
+  template <>                                                                  \
+  class parser<TYPE> : public basic_parser<TYPE> {                             \
+  public:                                                                      \
+    parser(Option &O) : basic_parser(O) {}                                     \
+    bool parse(Option &O, StringRef ArgName, StringRef Arg, TYPE &Val);        \
+    StringRef getValueName() const override { return VALUE_NAME_STR; }         \
+    void printOptionDiff(const Option &O, TYPE V, const OptVal &Default,       \
+                         size_t GlobalWidth) const;                            \
+    void anchor() override;                                                    \
+  };                                                                           \
+  } /* namespace llvm::cl */
+
+IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::CPUCodegenOptions,
+                                         "cpu codegen options")
+IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION(mlir::iree_compiler::GPUCodegenOptions,
+                                         "gpu codegen options")
+#undef IREE_DECLARE_CODEGEN_OPTIONS_PASS_OPTION
+
 #endif // IREE_COMPILER_CODEGEN_UTILS_CODEGENOPTIONS_H_


### PR DESCRIPTION
Using CPUCodegenOptions / GPUCodegenOptions as MLIR pass options crashes with `--debug` (or any pass-pipeline print path): the default `llvm::cl::parser<T>` inherits `generic_parser_base`, so MLIR's OptionParser alias resolves to `GenericOptionParser<T>`, whose findArgStrForValue hits `llvm_unreachable("unknown data value for option")` on struct-typed values ([mlir/include/mlir/Pass/PassOptions.h](https://github.com/llvm/llvm-project/blob/99457c368586b1debf49f55b3a0684317f5f298d/mlir/include/mlir/Pass/PassOptions.h#L158-L170)).

Fix by specializing `llvm::cl::parser<T>` to inherit `basic_parser<T>` instead, and providing `operator<<` in the type's associated namespace (`mlir::iree_compiler`) so ADL can find it. This routes printing through `printOptionValue / has_stream_operator`, which accepts our streaming that prints `opaque`. The parse path is also a no-op — these options never flow in from pass pipeline strings.

Fixes https://github.com/iree-org/iree/issues/24074

Assisted-by: Claude Code