### PR TITLE
Add encoding materialization for data tiling convolutions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
@@ -597,3 +597,738 @@ func.func @matmul_lowering_i8i4i32_aarch64_i8mm(
 //  CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
 //  CHECK-SAME:       outs(%[[OUTS]] :
 //       CHECK:   return %[[MMT4D]]
+
+// -----
+
+#map_in  = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh + fh, ow + fw, ic)>
+#map_f   = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (fh, fw, ic, oc)>
+#map_out = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh, ow, oc)>
+
+#encoding_conv_input = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#map_in, #map_f, #map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_input_pack(%arg0: tensor<1x16x16x4xf32>)
+    -> tensor<1x16x16x4xf32, #encoding_conv_input>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0
+       : tensor<1x16x16x4xf32> -> tensor<1x16x16x4xf32, #encoding_conv_input>
+  return %0 : tensor<1x16x16x4xf32, #encoding_conv_input>
+}
+// CHECK-LABEL: func.func @conv_input_pack
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x16x16x4xf32>
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x16x16x4xf32> -> tensor<1x1x16x16x4xf32>
+// CHECK:         return %[[PACK]]
+
+// -----
+
+#map_in  = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh + fh, ow + fw, ic)>
+#map_f   = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (fh, fw, ic, oc)>
+#map_out = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh, ow, oc)>
+
+#encoding_conv_filter = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#map_in, #map_f, #map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_filter_pack(%arg0: tensor<3x3x4x8xf32>)
+    -> tensor<3x3x4x8xf32, #encoding_conv_filter>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0
+       : tensor<3x3x4x8xf32> -> tensor<3x3x4x8xf32, #encoding_conv_filter>
+  return %0 : tensor<3x3x4x8xf32, #encoding_conv_filter>
+}
+// CHECK-LABEL: func.func @conv_filter_pack
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<3x3x4x8xf32>
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [3, 2, 0, 1]
+// CHECK-SAME:      inner_dims_pos = [3, 2]
+// CHECK-SAME:      inner_tiles = [4, 4]
+// CHECK-SAME:      : tensor<3x3x4x8xf32> -> tensor<2x1x3x3x4x4xf32>
+// CHECK:         return %[[PACK]]
+
+// -----
+
+#map_in  = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh + fh, ow + fw, ic)>
+#map_f   = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (fh, fw, ic, oc)>
+#map_out = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh, ow, oc)>
+
+#encoding_conv_output = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#map_in, #map_f, #map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_output_unset(%arg0: tensor<1x14x14x8xf32, #encoding_conv_output>)
+    -> tensor<1x14x14x8xf32>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.unset_encoding %arg0
+       : tensor<1x14x14x8xf32, #encoding_conv_output> -> tensor<1x14x14x8xf32>
+  return %0 : tensor<1x14x14x8xf32>
+}
+// CHECK-LABEL: func.func @conv_output_unset
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x2x14x14x4xf32>
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x2x14x14x4xf32> -> tensor<1x14x14x8xf32>
+// CHECK:         return %[[UNPACK]]
+
+// -----
+
+// Full conv materialization: direct-access 9D tiled generic with tensor.extract.
+//
+// Map invariant (all filter formats must produce the same canonical generics):
+//   9D filter:  (d0..d8) -> (d1, d4, d5, d6, d7, d8)
+//   9D output:  (d0..d8) -> (d0, d1, d2, d3, d7)
+//
+// CHECK: #[[$M_FLT:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d4, d5, d6, d7, d8)>
+// CHECK: #[[$M_OUT:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d7)>
+
+#map_in  = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh + fh, ow + fw, ic)>
+#map_f   = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (fh, fw, ic, oc)>
+#map_out = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh, ow, oc)>
+
+#encoding_in = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#map_in, #map_f, #map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#encoding_f = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#map_in, #map_f, #map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#encoding_out = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#map_in, #map_f, #map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv2d_nhwc_hwcf_materialize(
+    %input  : tensor<1x16x16x4xf32, #encoding_in>,
+    %filter : tensor<3x3x4x8xf32, #encoding_f>,
+    %output : tensor<1x14x14x8xf32, #encoding_out>)
+    -> tensor<1x14x14x8xf32, #encoding_out>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = linalg.conv_2d_nhwc_hwcf
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+         ins(%input, %filter
+           : tensor<1x16x16x4xf32, #encoding_in>,
+             tensor<3x3x4x8xf32, #encoding_f>)
+         outs(%output : tensor<1x14x14x8xf32, #encoding_out>)
+         -> tensor<1x14x14x8xf32, #encoding_out>
+  return %0 : tensor<1x14x14x8xf32, #encoding_out>
+}
+// CHECK-LABEL: func.func @conv2d_nhwc_hwcf_materialize
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<1x1x16x16x4xf32>
+// CHECK-SAME:    %[[FILTER:.+]]: tensor<2x1x3x3x4x4xf32>
+// CHECK-SAME:    %[[OUTPUT:.+]]: tensor<1x2x14x14x4xf32>
+//
+// Direct-access 9D tiled computation (input accessed via tensor.extract):
+// CHECK:         %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:      indexing_maps = [#[[$M_FLT]], #[[$M_OUT]]]
+// CHECK-SAME:      iterator_types = ["parallel", "parallel", "parallel", "parallel",
+// CHECK-SAME:                        "reduction", "reduction", "reduction",
+// CHECK-SAME:                        "parallel", "reduction"]
+// CHECK-SAME:      ins(%[[FILTER]]
+// CHECK-SAME:      outs(%[[OUTPUT]]
+// CHECK:           tensor.extract %[[INPUT]]
+// CHECK:           %[[MUL:.+]] = arith.mulf
+// CHECK:           %[[ADD:.+]] = arith.addf %[[MUL]]
+// CHECK:           linalg.yield %[[ADD]]
+// CHECK:         return %[[RESULT]]
+
+// -----
+
+// NCHW input: pack should canonicalize to [N, H, W, IC/c0, c0].
+
+#nchw_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>
+#nchw_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+#nchw_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_nchw_input = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_map_in, #nchw_map_f, #nchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+
+func.func @conv_nchw_input_pack(%arg0: tensor<1x4x16x16xf32>)
+    -> tensor<1x4x16x16xf32, #encoding_nchw_input>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0
+       : tensor<1x4x16x16xf32> -> tensor<1x4x16x16xf32, #encoding_nchw_input>
+  return %0 : tensor<1x4x16x16xf32, #encoding_nchw_input>
+}
+// CHECK-LABEL: func.func @conv_nchw_input_pack
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x4x16x16xf32>
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x4x16x16xf32> -> tensor<1x1x16x16x4xf32>
+// CHECK:         return %[[PACK]]
+
+// -----
+
+// FCHW filter: pack should canonicalize to [OC/k0, FH, FW, IC/c0, k0, c0].
+
+#nchw_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>
+#nchw_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+#nchw_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_fchw_filter = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_map_in, #nchw_map_f, #nchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+
+func.func @conv_fchw_filter_pack(%arg0: tensor<8x4x3x3xf32>)
+    -> tensor<8x4x3x3xf32, #encoding_fchw_filter>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0
+       : tensor<8x4x3x3xf32> -> tensor<8x4x3x3xf32, #encoding_fchw_filter>
+  return %0 : tensor<8x4x3x3xf32, #encoding_fchw_filter>
+}
+// CHECK-LABEL: func.func @conv_fchw_filter_pack
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<8x4x3x3xf32>
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [0, 1]
+// CHECK-SAME:      inner_tiles = [4, 4]
+// CHECK-SAME:      : tensor<8x4x3x3xf32> -> tensor<2x1x3x3x4x4xf32>
+// CHECK:         return %[[PACK]]
+
+// -----
+
+// NCHW output: unpack should reverse the canonical [N, OH, OW, OC/k0, k0].
+
+#nchw_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>
+#nchw_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+#nchw_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_nchw_output = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_map_in, #nchw_map_f, #nchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+
+func.func @conv_nchw_output_unset(%arg0: tensor<1x8x14x14xf32, #encoding_nchw_output>)
+    -> tensor<1x8x14x14xf32>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.unset_encoding %arg0
+       : tensor<1x8x14x14xf32, #encoding_nchw_output> -> tensor<1x8x14x14xf32>
+  return %0 : tensor<1x8x14x14xf32>
+}
+// CHECK-LABEL: func.func @conv_nchw_output_unset
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x2x14x14x4xf32>
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x2x14x14x4xf32> -> tensor<1x8x14x14xf32>
+// CHECK:         return %[[UNPACK]]
+
+// -----
+
+// Full conv_2d_nchw_fchw materialization: direct-access 9D tiled generic with tensor.extract.
+// Packing canonicalizes NCHW/FCHW to the same internal layout as NHWC/HWCF, so the
+// 9D computation generic must have identical indexing maps.
+//
+// CHECK: #[[$M_FLT:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d4, d5, d6, d7, d8)>
+// CHECK: #[[$M_OUT:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d7)>
+
+#nchw_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>
+#nchw_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+#nchw_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_nchw_in = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_map_in, #nchw_map_f, #nchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+#encoding_nchw_f = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_map_in, #nchw_map_f, #nchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+#encoding_nchw_out = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_map_in, #nchw_map_f, #nchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+
+func.func @conv2d_nchw_fchw_materialize(
+    %input  : tensor<1x4x16x16xf32, #encoding_nchw_in>,
+    %filter : tensor<8x4x3x3xf32, #encoding_nchw_f>,
+    %output : tensor<1x8x14x14xf32, #encoding_nchw_out>)
+    -> tensor<1x8x14x14xf32, #encoding_nchw_out>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = linalg.conv_2d_nchw_fchw
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+         ins(%input, %filter
+           : tensor<1x4x16x16xf32, #encoding_nchw_in>,
+             tensor<8x4x3x3xf32, #encoding_nchw_f>)
+         outs(%output : tensor<1x8x14x14xf32, #encoding_nchw_out>)
+         -> tensor<1x8x14x14xf32, #encoding_nchw_out>
+  return %0 : tensor<1x8x14x14xf32, #encoding_nchw_out>
+}
+// CHECK-LABEL: func.func @conv2d_nchw_fchw_materialize
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<1x1x16x16x4xf32>
+// CHECK-SAME:    %[[FILTER:.+]]: tensor<2x1x3x3x4x4xf32>
+// CHECK-SAME:    %[[OUTPUT:.+]]: tensor<1x2x14x14x4xf32>
+//
+// Direct-access 9D tiled computation (input accessed via tensor.extract):
+// CHECK:         %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:      indexing_maps = [#[[$M_FLT]], #[[$M_OUT]]]
+// CHECK-SAME:      iterator_types = ["parallel", "parallel", "parallel", "parallel",
+// CHECK-SAME:                        "reduction", "reduction", "reduction",
+// CHECK-SAME:                        "parallel", "reduction"]
+// CHECK-SAME:      ins(%[[FILTER]]
+// CHECK-SAME:      outs(%[[OUTPUT]]
+// CHECK:           tensor.extract %[[INPUT]]
+// CHECK:           %[[MUL:.+]] = arith.mulf
+// CHECK:           %[[ADD:.+]] = arith.addf %[[MUL]]
+// CHECK:           linalg.yield %[[ADD]]
+// CHECK:         return %[[RESULT]]
+
+// -----
+
+// FHWC filter: pack should produce canonical [OC/k0, FH, FW, IC/c0, k0, c0].
+
+#nhwc_fhwc_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#nhwc_fhwc_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#nhwc_fhwc_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_fhwc_filter = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc_map_in, #nhwc_fhwc_map_f, #nhwc_fhwc_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_fhwc_filter_pack(%arg0: tensor<8x3x3x4xf32>)
+    -> tensor<8x3x3x4xf32, #encoding_fhwc_filter>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0
+       : tensor<8x3x3x4xf32> -> tensor<8x3x3x4xf32, #encoding_fhwc_filter>
+  return %0 : tensor<8x3x3x4xf32, #encoding_fhwc_filter>
+}
+// CHECK-LABEL: func.func @conv_fhwc_filter_pack
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<8x3x3x4xf32>
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [0, 3]
+// CHECK-SAME:      inner_tiles = [4, 4]
+// CHECK-SAME:      : tensor<8x3x3x4xf32> -> tensor<2x1x3x3x4x4xf32>
+// CHECK:         return %[[PACK]]
+
+// -----
+
+// FHWC input: input packing is independent of filter layout; produces [N, H, W, IC/c0, c0].
+
+#nhwc_fhwc_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#nhwc_fhwc_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#nhwc_fhwc_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_fhwc_input = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc_map_in, #nhwc_fhwc_map_f, #nhwc_fhwc_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_fhwc_input_pack(%arg0: tensor<1x16x16x4xf32>)
+    -> tensor<1x16x16x4xf32, #encoding_fhwc_input>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0
+       : tensor<1x16x16x4xf32> -> tensor<1x16x16x4xf32, #encoding_fhwc_input>
+  return %0 : tensor<1x16x16x4xf32, #encoding_fhwc_input>
+}
+// CHECK-LABEL: func.func @conv_fhwc_input_pack
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x16x16x4xf32>
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x16x16x4xf32> -> tensor<1x1x16x16x4xf32>
+// CHECK:         return %[[PACK]]
+
+// -----
+
+// FHWC output: output unpacking is independent of filter layout; produces [N, OH, OW, OC] from [N, OH, OW, OC/k0, k0].
+
+#nhwc_fhwc_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#nhwc_fhwc_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#nhwc_fhwc_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_fhwc_output = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc_map_in, #nhwc_fhwc_map_f, #nhwc_fhwc_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_fhwc_output_unset(%arg0: tensor<1x14x14x8xf32, #encoding_fhwc_output>)
+    -> tensor<1x14x14x8xf32>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.unset_encoding %arg0
+       : tensor<1x14x14x8xf32, #encoding_fhwc_output> -> tensor<1x14x14x8xf32>
+  return %0 : tensor<1x14x14x8xf32>
+}
+// CHECK-LABEL: func.func @conv_fhwc_output_unset
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x2x14x14x4xf32>
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %[[ARG0]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x2x14x14x4xf32> -> tensor<1x14x14x8xf32>
+// CHECK:         return %[[UNPACK]]
+
+// -----
+
+// Full conv_2d_nhwc_fhwc materialization: direct-access 9D tiled generic with tensor.extract.
+// The canonical 9D computation generic must have identical indexing maps to the NHWC/HWCF case.
+//
+// CHECK: #[[$M_FLT:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d4, d5, d6, d7, d8)>
+// CHECK: #[[$M_OUT:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d7)>
+
+#nhwc_fhwc_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#nhwc_fhwc_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#nhwc_fhwc_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#encoding_nhwc_fhwc_in = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc_map_in, #nhwc_fhwc_map_f, #nhwc_fhwc_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#encoding_nhwc_fhwc_f = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc_map_in, #nhwc_fhwc_map_f, #nhwc_fhwc_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#encoding_nhwc_fhwc_out = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc_map_in, #nhwc_fhwc_map_f, #nhwc_fhwc_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv2d_nhwc_fhwc_materialize(
+    %input  : tensor<1x16x16x4xf32, #encoding_nhwc_fhwc_in>,
+    %filter : tensor<8x3x3x4xf32, #encoding_nhwc_fhwc_f>,
+    %output : tensor<1x14x14x8xf32, #encoding_nhwc_fhwc_out>)
+    -> tensor<1x14x14x8xf32, #encoding_nhwc_fhwc_out>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = linalg.conv_2d_nhwc_fhwc
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+         ins(%input, %filter
+           : tensor<1x16x16x4xf32, #encoding_nhwc_fhwc_in>,
+             tensor<8x3x3x4xf32, #encoding_nhwc_fhwc_f>)
+         outs(%output : tensor<1x14x14x8xf32, #encoding_nhwc_fhwc_out>)
+         -> tensor<1x14x14x8xf32, #encoding_nhwc_fhwc_out>
+  return %0 : tensor<1x14x14x8xf32, #encoding_nhwc_fhwc_out>
+}
+// CHECK-LABEL: func.func @conv2d_nhwc_fhwc_materialize
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<1x1x16x16x4xf32>
+// CHECK-SAME:    %[[FILTER:.+]]: tensor<2x1x3x3x4x4xf32>
+// CHECK-SAME:    %[[OUTPUT:.+]]: tensor<1x2x14x14x4xf32>
+//
+// Direct-access 9D tiled computation (input accessed via tensor.extract):
+// CHECK:         %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:      indexing_maps = [#[[$M_FLT]], #[[$M_OUT]]]
+// CHECK-SAME:      iterator_types = ["parallel", "parallel", "parallel", "parallel",
+// CHECK-SAME:                        "reduction", "reduction", "reduction",
+// CHECK-SAME:                        "parallel", "reduction"]
+// CHECK-SAME:      ins(%[[FILTER]]
+// CHECK-SAME:      outs(%[[OUTPUT]]
+// CHECK:           tensor.extract %[[INPUT]]
+// CHECK:           %[[MUL:.+]] = arith.mulf
+// CHECK:           %[[ADD:.+]] = arith.addf %[[MUL]]
+// CHECK:           linalg.yield %[[ADD]]
+// CHECK:         return %[[RESULT]]
+
+// -----
+
+// Full-pack canonicalization for conv_2d_nhwc_hwcf: verifies outer_dims_perm,
+// inner_dims_pos, and inner_tiles for all three operands together.
+// Input and output are NHWC (identity perm, tile last dim).
+// Filter is HWCF (OC promoted to front, both IC and OC tiled).
+
+#nhwc_hwcf_map_in  = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh + fh, ow + fw, ic)>
+#nhwc_hwcf_map_f   = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (fh, fw, ic, oc)>
+#nhwc_hwcf_map_out = affine_map<(n, oh, ow, oc, fh, fw, ic) -> (n, oh, ow, oc)>
+
+#enc_nhwc_hwcf_in = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_hwcf_map_in, #nhwc_hwcf_map_f, #nhwc_hwcf_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#enc_nhwc_hwcf_f = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_hwcf_map_in, #nhwc_hwcf_map_f, #nhwc_hwcf_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#enc_nhwc_hwcf_out = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_hwcf_map_in, #nhwc_hwcf_map_f, #nhwc_hwcf_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_nhwc_hwcf_pack_canonicalization(
+    %input  : tensor<1x16x16x4xf32>,
+    %filter : tensor<3x3x4x8xf32>,
+    %output : tensor<1x14x14x8xf32>)
+    -> tensor<1x14x14x8xf32>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %enc_in  = iree_encoding.set_encoding %input
+      : tensor<1x16x16x4xf32> -> tensor<1x16x16x4xf32, #enc_nhwc_hwcf_in>
+  %enc_f   = iree_encoding.set_encoding %filter
+      : tensor<3x3x4x8xf32> -> tensor<3x3x4x8xf32, #enc_nhwc_hwcf_f>
+  %enc_out = iree_encoding.set_encoding %output
+      : tensor<1x14x14x8xf32> -> tensor<1x14x14x8xf32, #enc_nhwc_hwcf_out>
+  %0 = linalg.conv_2d_nhwc_hwcf
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+         ins(%enc_in, %enc_f
+           : tensor<1x16x16x4xf32, #enc_nhwc_hwcf_in>,
+             tensor<3x3x4x8xf32, #enc_nhwc_hwcf_f>)
+         outs(%enc_out : tensor<1x14x14x8xf32, #enc_nhwc_hwcf_out>)
+         -> tensor<1x14x14x8xf32, #enc_nhwc_hwcf_out>
+  %1 = iree_encoding.unset_encoding %0
+      : tensor<1x14x14x8xf32, #enc_nhwc_hwcf_out> -> tensor<1x14x14x8xf32>
+  return %1 : tensor<1x14x14x8xf32>
+}
+// CHECK-LABEL: func.func @conv_nhwc_hwcf_pack_canonicalization
+// CHECK-SAME:    %[[IN:[a-zA-Z0-9]+]]: tensor<1x16x16x4xf32>
+// CHECK-SAME:    %[[F:[a-zA-Z0-9]+]]: tensor<3x3x4x8xf32>
+// CHECK-SAME:    %[[OUT:[a-zA-Z0-9]+]]: tensor<1x14x14x8xf32>
+//
+// Input pack: NHWC → [N, IC/c0, H, W, c0]  (NCHWc layout)
+// CHECK:         %[[PACK_IN:.+]] = linalg.pack %[[IN]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x16x16x4xf32> -> tensor<1x1x16x16x4xf32>
+//
+// Filter pack: HWCF → [OC/k0, IC/c0, FH, FW, c0, k0]  (XNNPACK convention)
+// CHECK:         %[[PACK_F:.+]] = linalg.pack %[[F]]
+// CHECK-SAME:      outer_dims_perm = [3, 2, 0, 1]
+// CHECK-SAME:      inner_dims_pos = [3, 2]
+// CHECK-SAME:      inner_tiles = [4, 4]
+// CHECK-SAME:      : tensor<3x3x4x8xf32> -> tensor<2x1x3x3x4x4xf32>
+//
+// Output pack: NHWC → [N, OC/k0, OH, OW, k0]  (NCHWc layout)
+// CHECK:         %[[PACK_OUT:.+]] = linalg.pack %[[OUT]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x14x14x8xf32> -> tensor<1x2x14x14x4xf32>
+//
+// Output unpack: [N, OC/k0, OH, OW, k0] → NHWC
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %{{[^ ]+}}
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x2x14x14x4xf32> -> tensor<1x14x14x8xf32>
+
+// -----
+
+// Full-pack canonicalization for conv_2d_nchw_fchw: packing must canonicalize
+// NCHW input/output and FCHW filter to the same internal layout as NHWC/HWCF.
+// Input/output: outer_dims_perm keeps C in-place (already NCHWc-compatible).
+// Filter: outer_dims_perm keeps dims in-place (OC, IC already in XNNPACK order).
+
+#nchw_fchw_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>
+#nchw_fchw_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+#nchw_fchw_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#enc_nchw_fchw_in = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_fchw_map_in, #nchw_fchw_map_f, #nchw_fchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+#enc_nchw_fchw_f = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_fchw_map_in, #nchw_fchw_map_f, #nchw_fchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+#enc_nchw_fchw_out = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nchw_fchw_map_in, #nchw_fchw_map_f, #nchw_fchw_map_out],
+  iteration_sizes = [1, 8, 14, 14, 4, 3, 3]>
+
+func.func @conv_nchw_fchw_pack_canonicalization(
+    %input  : tensor<1x4x16x16xf32>,
+    %filter : tensor<8x4x3x3xf32>,
+    %output : tensor<1x8x14x14xf32>)
+    -> tensor<1x8x14x14xf32>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %enc_in  = iree_encoding.set_encoding %input
+      : tensor<1x4x16x16xf32> -> tensor<1x4x16x16xf32, #enc_nchw_fchw_in>
+  %enc_f   = iree_encoding.set_encoding %filter
+      : tensor<8x4x3x3xf32> -> tensor<8x4x3x3xf32, #enc_nchw_fchw_f>
+  %enc_out = iree_encoding.set_encoding %output
+      : tensor<1x8x14x14xf32> -> tensor<1x8x14x14xf32, #enc_nchw_fchw_out>
+  %0 = linalg.conv_2d_nchw_fchw
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+         ins(%enc_in, %enc_f
+           : tensor<1x4x16x16xf32, #enc_nchw_fchw_in>,
+             tensor<8x4x3x3xf32, #enc_nchw_fchw_f>)
+         outs(%enc_out : tensor<1x8x14x14xf32, #enc_nchw_fchw_out>)
+         -> tensor<1x8x14x14xf32, #enc_nchw_fchw_out>
+  %1 = iree_encoding.unset_encoding %0
+      : tensor<1x8x14x14xf32, #enc_nchw_fchw_out> -> tensor<1x8x14x14xf32>
+  return %1 : tensor<1x8x14x14xf32>
+}
+// CHECK-LABEL: func.func @conv_nchw_fchw_pack_canonicalization
+// CHECK-SAME:    %[[IN:[a-zA-Z0-9]+]]: tensor<1x4x16x16xf32>
+// CHECK-SAME:    %[[F:[a-zA-Z0-9]+]]: tensor<8x4x3x3xf32>
+// CHECK-SAME:    %[[OUT:[a-zA-Z0-9]+]]: tensor<1x8x14x14xf32>
+//
+// Input pack: NCHW → [N, IC/c0, H, W, c0]  (identity outer perm, tile dim 1)
+// CHECK:         %[[PACK_IN:.+]] = linalg.pack %[[IN]]
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x4x16x16xf32> -> tensor<1x1x16x16x4xf32>
+//
+// Filter pack: FCHW → [OC/k0, IC/c0, FH, FW, c0, k0]  (identity outer perm, tile dims 0 and 1)
+// CHECK:         %[[PACK_F:.+]] = linalg.pack %[[F]]
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [0, 1]
+// CHECK-SAME:      inner_tiles = [4, 4]
+// CHECK-SAME:      : tensor<8x4x3x3xf32> -> tensor<2x1x3x3x4x4xf32>
+//
+// Output pack: NCHW → [N, OC/k0, OH, OW, k0]  (identity outer perm, tile dim 1)
+// CHECK:         %[[PACK_OUT:.+]] = linalg.pack %[[OUT]]
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x8x14x14xf32> -> tensor<1x2x14x14x4xf32>
+//
+// Output unpack: [N, OC/k0, OH, OW, k0] → NCHW
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %{{[^ ]+}}
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2, 3]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x2x14x14x4xf32> -> tensor<1x8x14x14xf32>
+
+// -----
+
+// Full-pack canonicalization for conv_2d_nhwc_fhwc: input and output use NHWC
+// (identical packing to HWCF variant). Filter uses FHWC: identity outer perm,
+// inner_dims_pos = [0, 3] (OC at dim 0, IC at dim 3).
+
+#nhwc_fhwc2_map_in  = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#nhwc_fhwc2_map_f   = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#nhwc_fhwc2_map_out = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#enc_nhwc_fhwc_in = #iree_encoding.encoding<operand_index = 0, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc2_map_in, #nhwc_fhwc2_map_f, #nhwc_fhwc2_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#enc_nhwc_fhwc_f = #iree_encoding.encoding<operand_index = 1, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc2_map_in, #nhwc_fhwc2_map_f, #nhwc_fhwc2_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+#enc_nhwc_fhwc_out = #iree_encoding.encoding<operand_index = 2, op_type = conv,
+  element_types = [f32, f32, f32],
+  user_indexing_maps = [#nhwc_fhwc2_map_in, #nhwc_fhwc2_map_f, #nhwc_fhwc2_map_out],
+  iteration_sizes = [1, 14, 14, 8, 3, 3, 4]>
+
+func.func @conv_nhwc_fhwc_pack_canonicalization(
+    %input  : tensor<1x16x16x4xf32>,
+    %filter : tensor<8x3x3x4xf32>,
+    %output : tensor<1x14x14x8xf32>)
+    -> tensor<1x14x14x8xf32>
+    attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz",
+      {target_triple="aarch64-xyz-xyz", cpu_features="+neon",
+       iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %enc_in  = iree_encoding.set_encoding %input
+      : tensor<1x16x16x4xf32> -> tensor<1x16x16x4xf32, #enc_nhwc_fhwc_in>
+  %enc_f   = iree_encoding.set_encoding %filter
+      : tensor<8x3x3x4xf32> -> tensor<8x3x3x4xf32, #enc_nhwc_fhwc_f>
+  %enc_out = iree_encoding.set_encoding %output
+      : tensor<1x14x14x8xf32> -> tensor<1x14x14x8xf32, #enc_nhwc_fhwc_out>
+  %0 = linalg.conv_2d_nhwc_fhwc
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+         ins(%enc_in, %enc_f
+           : tensor<1x16x16x4xf32, #enc_nhwc_fhwc_in>,
+             tensor<8x3x3x4xf32, #enc_nhwc_fhwc_f>)
+         outs(%enc_out : tensor<1x14x14x8xf32, #enc_nhwc_fhwc_out>)
+         -> tensor<1x14x14x8xf32, #enc_nhwc_fhwc_out>
+  %1 = iree_encoding.unset_encoding %0
+      : tensor<1x14x14x8xf32, #enc_nhwc_fhwc_out> -> tensor<1x14x14x8xf32>
+  return %1 : tensor<1x14x14x8xf32>
+}
+// CHECK-LABEL: func.func @conv_nhwc_fhwc_pack_canonicalization
+// CHECK-SAME:    %[[IN:[a-zA-Z0-9]+]]: tensor<1x16x16x4xf32>
+// CHECK-SAME:    %[[F:[a-zA-Z0-9]+]]: tensor<8x3x3x4xf32>
+// CHECK-SAME:    %[[OUT:[a-zA-Z0-9]+]]: tensor<1x14x14x8xf32>
+//
+// Input pack: NHWC → [N, IC/c0, H, W, c0]  (NCHWc layout, same as HWCF variant)
+// CHECK:         %[[PACK_IN:.+]] = linalg.pack %[[IN]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x16x16x4xf32> -> tensor<1x1x16x16x4xf32>
+//
+// Filter pack: FHWC → [OC/k0, IC/c0, FH, FW, c0, k0]  (XNNPACK convention, tile dims 0 and 3)
+// CHECK:         %[[PACK_F:.+]] = linalg.pack %[[F]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [0, 3]
+// CHECK-SAME:      inner_tiles = [4, 4]
+// CHECK-SAME:      : tensor<8x3x3x4xf32> -> tensor<2x1x3x3x4x4xf32>
+//
+// Output pack: NHWC → [N, OC/k0, OH, OW, k0]  (NCHWc layout, same as HWCF variant)
+// CHECK:         %[[PACK_OUT:.+]] = linalg.pack %[[OUT]]
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x14x14x8xf32> -> tensor<1x2x14x14x4xf32>
+//
+// Output unpack: [N, OC/k0, OH, OW, k0] → NHWC
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %{{[^ ]+}}
+// CHECK-SAME:      outer_dims_perm = [0, 3, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [3]
+// CHECK-SAME:      inner_tiles = [4]
+// CHECK-SAME:      : tensor<1x2x14x14x4xf32> -> tensor<1x14x14x8xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -526,4 +526,176 @@ getEncodingInfoForMatmul(Encoding::EncodingAttr encoding,
   return encodingInfo;
 }
 
+/// Returns true if dim `d` appears as a bare AffineDimExpr in any result of
+/// `map`, i.e. getResultPosition succeeds.
+static bool isBareInMap(AffineMap map, unsigned d) {
+  auto dimExpr = getAffineDimExpr(d, map.getContext());
+  return map.getResultPosition(dimExpr).has_value();
+}
+
+/// Returns true if dim `d` participates in any result expression of `map`
+/// (bare or compound).
+static bool isUsedInMap(AffineMap map, unsigned d) {
+  return map.isFunctionOfDim(d);
+}
+
+FailureOr<ConvDimClassification>
+inferConvDimsFromMaps(ArrayRef<AffineMap> maps) {
+  if (maps.size() < 3) {
+    return failure();
+  }
+  AffineMap inputMap = maps[0];
+  AffineMap filterMap = maps[1];
+  AffineMap outputMap = maps[2];
+  unsigned numDims = inputMap.getNumDims();
+
+  ConvDimClassification result;
+
+  for (unsigned d = 0; d < numDims; ++d) {
+    bool bareInInput = isBareInMap(inputMap, d);
+    bool bareInFilter = isBareInMap(filterMap, d);
+    bool bareInOutput = isBareInMap(outputMap, d);
+    bool usedInInput = isUsedInMap(inputMap, d);
+    bool compoundInInput = usedInInput && !bareInInput;
+    bool absentFromInput = !usedInInput;
+    bool absentFromFilter = !isUsedInMap(filterMap, d);
+    bool absentFromOutput = !isUsedInMap(outputMap, d);
+
+    if (bareInInput && absentFromFilter && bareInOutput) {
+      result.batch.push_back(d);
+    } else if (compoundInInput && absentFromFilter && bareInOutput) {
+      result.outputImage.push_back(d);
+    } else if (absentFromInput && bareInFilter && bareInOutput) {
+      result.outputChannel.push_back(d);
+    } else if (compoundInInput && bareInFilter && absentFromOutput) {
+      result.filterLoop.push_back(d);
+    } else if (bareInInput && bareInFilter && absentFromOutput) {
+      result.inputChannel.push_back(d);
+    }
+    // Unclassified dims (e.g. depth/group) are silently ignored.
+    // Grouped convolutions are filtered upstream in isSupportedConvolutionOp.
+  }
+
+  if (result.outputImage.empty()) {
+    return failure();
+  }
+
+  return result;
+}
+
+FailureOr<MaterializeEncodingInfo>
+getEncodingInfoForConv(Encoding::EncodingAttr encoding, TileOCxIC tile) {
+  int64_t operandIdx = encoding.getOperandIndex().getInt();
+  SmallVector<AffineMap> maps = encoding.getRootMaps();
+
+  auto cDims = inferConvDimsFromMaps(maps);
+  if (failed(cDims)) {
+    return failure();
+  }
+
+  // Require at least one IC and one OC dimension for tiling.
+  // conv_2d (no channels) falls through to identity layout.
+  if (cDims->inputChannel.empty() || cDims->outputChannel.empty()) {
+    return failure();
+  }
+
+  // Map classified loop dims to tensor positions for this operand.
+  // mapDimToOperandIndex uses getResultPosition, which only works for dims
+  // that appear as bare AffineDimExpr in the operand's map. This covers
+  // batch, inputChannel, outputChannel, and filterLoop in their respective
+  // operand maps — but NOT outputImage/filterLoop in the input map (compound).
+  auto collectBarePositions =
+      [&](ArrayRef<unsigned> loopDims) -> SmallVector<int64_t> {
+    SmallVector<int64_t> positions;
+    for (unsigned d : loopDims) {
+      if (auto pos = encoding.mapDimToOperandIndex(d)) {
+        positions.push_back(static_cast<int64_t>(*pos));
+      }
+    }
+    return positions;
+  };
+
+  // For the input operand, outputImage dims (OH, OW) appear only as compound
+  // expressions (e.g. d_oh + d_fh). mapDimToOperandIndex returns nullopt for
+  // these. Instead, compute their positions as the tensor positions not
+  // occupied by batch or inputChannel dims (the only bare dims in the input).
+  auto collectRemainingPositions =
+      [](int64_t rank,
+         ArrayRef<int64_t> knownPositions) -> SmallVector<int64_t> {
+    llvm::SmallDenseSet<int64_t> known(knownPositions.begin(),
+                                       knownPositions.end());
+    SmallVector<int64_t> remaining;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (!known.contains(i)) {
+        remaining.push_back(i);
+      }
+    }
+    return remaining;
+  };
+
+  SmallVector<int64_t> batchPos = collectBarePositions(cDims->batch);
+  SmallVector<int64_t> ocPos = collectBarePositions(cDims->outputChannel);
+  SmallVector<int64_t> flPos = collectBarePositions(cDims->filterLoop);
+  SmallVector<int64_t> icPos = collectBarePositions(cDims->inputChannel);
+
+  MaterializeEncodingInfo info;
+
+  if (operandIdx == Encoding::CONV_IN) {
+    // NCHWc: [batch, inputChannel, spatial...]
+    // Channel before spatial for stride-c0 spatial window access.
+    if (icPos.empty()) {
+      return failure();
+    }
+    int64_t rank = maps[0].getNumResults();
+    SmallVector<int64_t> knownInputPos;
+    knownInputPos.append(batchPos);
+    knownInputPos.append(icPos);
+    SmallVector<int64_t> oiPosInput =
+        collectRemainingPositions(rank, knownInputPos);
+
+    SmallVector<int64_t> canonicalOrder;
+    canonicalOrder.append(batchPos);
+    canonicalOrder.append(icPos);      // channel BEFORE spatial
+    canonicalOrder.append(oiPosInput); // spatial AFTER channel
+
+    info.outerDimsPerm = canonicalOrder;
+    info.innerDimsPos = {icPos[0]};
+    info.innerTileSizes = {tile.IC};
+  } else if (operandIdx == Encoding::CONV_FILTER) {
+    // XNNPACK convention: [OC, IC, filterLoop...]
+    // OC before IC in inner tiles for mmt4d-compatible rhs shape.
+    if (ocPos.empty() || icPos.empty()) {
+      return failure();
+    }
+    SmallVector<int64_t> canonicalOrder;
+    canonicalOrder.append(ocPos);
+    canonicalOrder.append(icPos); // IC BEFORE filterLoop
+    canonicalOrder.append(flPos); // filterLoop AFTER IC
+
+    info.outerDimsPerm = canonicalOrder;
+    info.innerDimsPos = {ocPos[0], icPos[0]}; // OC before IC
+    info.innerTileSizes = {tile.OC, tile.IC};
+  } else if (operandIdx == Encoding::CONV_OUT) {
+    // NCHWc: [batch, outputChannel, spatial...]
+    // Channel before spatial, matching input layout.
+    if (ocPos.empty()) {
+      return failure();
+    }
+    SmallVector<int64_t> oiPosOutput = collectBarePositions(cDims->outputImage);
+
+    SmallVector<int64_t> canonicalOrder;
+    canonicalOrder.append(batchPos);
+    canonicalOrder.append(ocPos);       // channel BEFORE spatial
+    canonicalOrder.append(oiPosOutput); // spatial AFTER channel
+
+    info.outerDimsPerm = canonicalOrder;
+    info.innerDimsPos = {ocPos[0]};
+    info.innerTileSizes = {tile.OC};
+  } else {
+    return failure();
+  }
+
+  return info;
+}
+
 } // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
@@ -124,6 +124,35 @@ struct TileMxNxK {
 FailureOr<MaterializeEncodingInfo>
 getEncodingInfoForMatmul(Encoding::EncodingAttr encoding, TileMxNxK tileMxNxK);
 
+/// Convolution dimension classification for encoding purposes.
+/// Compatible with linalg::ConvolutionDimensions
+// TODO(jschuhmacher): remove after upstream
+// inferConvolutionDims(ArrayRef<AffineMap>) overload becomes available.
+struct ConvDimClassification {
+  SmallVector<unsigned> batch;         // e.g. N
+  SmallVector<unsigned> outputImage;   // e.g. OH, OW
+  SmallVector<unsigned> outputChannel; // e.g. OC
+  SmallVector<unsigned> filterLoop;    // e.g. FH, FW
+  SmallVector<unsigned> inputChannel;  // e.g. IC
+};
+
+/// Infers convolution dimension roles from indexing maps alone.
+/// Maps must be ordered [input, filter, output]. Returns failure if
+/// the maps don't describe a valid convolution (no spatial dims found,
+/// or maps have wrong count).
+FailureOr<ConvDimClassification>
+inferConvDimsFromMaps(ArrayRef<AffineMap> maps);
+
+/// Tile sizes for convolution encoding.
+struct TileOCxIC {
+  int64_t OC = 0; // k0: output channel tile
+  int64_t IC = 0; // c0: input channel tile
+};
+
+/// Returns MaterializeEncodingInfo for a convolution operand.
+FailureOr<MaterializeEncodingInfo>
+getEncodingInfoForConv(Encoding::EncodingAttr encoding, TileOCxIC tile);
+
 } // namespace mlir::iree_compiler::IREE::Codegen
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_UTILS_H_

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:ValueBoundsOpInterface",
     ],

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     MLIRIR
     MLIRLinalgDialect
     MLIRLinalgTransforms
+    MLIRSCFDialect
     MLIRTensorDialect
     MLIRValueBoundsOpInterface
     iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -1125,6 +1125,22 @@ struct CPUEncodingResolverMaterializerAttr final
       return lowerFillOpWithResolvedLayouts(b, fillOp, convertedResTypes,
                                             convertedOperands);
     }
+    if (linalg::isaConvolutionOpInterface(linalgOp)) {
+      auto cDims = linalg::inferConvolutionDims(linalgOp);
+      if (succeeded(cDims) && cDims->outputImage.size() == 2 &&
+          cDims->depth.empty()) {
+        return lowerConvolutionOpWithEncoding(
+            b, linalgOp, convertedOperands,
+            cast<IREE::Encoding::LayoutMaterializerAttr>(layoutAttr));
+      }
+
+      // Convolutions other than 2D are not yet supported, so we drop the
+      // encoding and clone the op as-is.
+      int64_t numInputs = linalgOp.getNumDpsInputs();
+      return dropEncodingAndCloneOp(b, linalgOp,
+                                    convertedOperands.take_front(numInputs),
+                                    convertedOperands.drop_front(numInputs));
+    }
     // Scaled contraction (MX matmul) is not yet supported on CPU, so we drop
     // the encoding and clone the op as-is.
     if (IREE::LinalgExt::isaScaledContractionOpInterface(linalgOp)) {
@@ -1132,11 +1148,6 @@ struct CPUEncodingResolverMaterializerAttr final
       return dropEncodingAndCloneOp(b, linalgOp,
                                     convertedOperands.take_front(numInputs),
                                     convertedOperands.drop_front(numInputs));
-    }
-    if (linalg::isaConvolutionOpInterface(linalgOp)) {
-      return lowerConvolutionOpWithEncoding(
-          b, linalgOp, convertedOperands,
-          cast<IREE::Encoding::LayoutMaterializerAttr>(layoutAttr));
     }
     if (linalg::isaContractionOpInterface(linalgOp)) {
       return lowerContractionOpWithEncoding(
@@ -1305,6 +1316,13 @@ struct VMVXEncodingResolverMaterializerAttr final
     if (auto fillOp = dyn_cast<linalg::FillOp>(op)) {
       return lowerFillOpWithResolvedLayouts(b, fillOp, convertedResTypes,
                                             convertedOperands);
+    }
+    if (linalg::isaConvolutionOpInterface(linalgOp)) {
+      // encoding and clone the op as-is.
+      int64_t numInputs = linalgOp.getNumDpsInputs();
+      return dropEncodingAndCloneOp(b, linalgOp,
+                                    convertedOperands.take_front(numInputs),
+                                    convertedOperands.drop_front(numInputs));
     }
     if (linalg::isaContractionOpInterface(linalgOp)) {
       return lowerContractionOpWithEncoding(

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -40,6 +40,7 @@
 //===---------------------------------------------------------------------===//
 
 #include "iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
@@ -60,6 +61,7 @@ namespace mlir::iree_compiler::IREE::CPU {
 
 using IREE::Codegen::MaterializeEncodingInfo;
 using IREE::Codegen::TileMxNxK;
+using IREE::Codegen::TileOCxIC;
 
 namespace {
 
@@ -363,6 +365,285 @@ Operation *lowerContractionOpWithEncoding(
                                              result->getResult(0), ri);
   }
   return result;
+}
+
+Operation *lowerConvolutionOpWithEncoding(
+    OpBuilder &builder, linalg::LinalgOp linalgOp, ValueRange operands,
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr) {
+  if (!linalgOp.hasPureTensorSemantics()) {
+    return nullptr;
+  }
+
+  auto inputs = linalgOp.getDpsInputOperands();
+  auto outputs = linalgOp.getDpsInits();
+
+  auto inType = cast<RankedTensorType>(inputs[0]->get().getType());
+  auto filterType = cast<RankedTensorType>(inputs[1]->get().getType());
+  auto outType = cast<RankedTensorType>(outputs[0].getType());
+  auto inEncoding = IREE::Encoding::getEncodingAttr(inType);
+  auto filterEncoding = IREE::Encoding::getEncodingAttr(filterType);
+  auto outEncoding = IREE::Encoding::getEncodingAttr(outType);
+  if (!inEncoding || !filterEncoding || !outEncoding) {
+    return nullptr;
+  }
+
+  if (inEncoding.getOperandIndex().getValue() != IREE::Encoding::CONV_IN ||
+      filterEncoding.getOperandIndex().getValue() !=
+          IREE::Encoding::CONV_FILTER ||
+      outEncoding.getOperandIndex().getValue() != IREE::Encoding::CONV_OUT) {
+    return nullptr;
+  }
+
+  MaterializeEncodingInfo encodingInfo = {};
+  if (auto packedLayoutAttr =
+          dyn_cast<IREE::Codegen::PackedLayoutMaterializerAttr>(layoutAttr)) {
+    encodingInfo = packedLayoutAttr.getEncodingInfo(
+        cast<RankedTensorType>(linalgOp->getResultTypes()[0]));
+  }
+
+  if (isIdentityLayout(encodingInfo)) {
+    return dropEncodingAndCloneOp(builder, linalgOp,
+                                  operands.take_front(inputs.size()),
+                                  operands.drop_front(inputs.size()));
+  }
+
+  // ---- Packed operands (already pack'd by MaterializeEncoding) ----
+  // operands[0] = packed input:  [N, IC/c0, H, W, c0]       (NCHWc)
+  // operands[1] = packed filter: [OC/k0, IC/c0, FH, FW, k0, c0] (XNNPACK)
+  // operands[2] = packed output: [N, OC/k0, OH, OW, k0]     (NCHWc)
+  Value packedInput = operands[0];
+  Value packedFilter = operands[1];
+  Value packedOutput = operands[2];
+
+  auto packedFilterType = cast<RankedTensorType>(packedFilter.getType());
+
+  Location loc = linalgOp.getLoc();
+  MLIRContext *ctx = builder.getContext();
+  Type elemType =
+      cast<RankedTensorType>(packedInput.getType()).getElementType();
+
+  // WORKAROUND: When N=1, the batch dim may be folded away (e.g., input is
+  // rank-4 [IC/c0, H, W, c0] instead of rank-5 [1, IC/c0, H, W, c0]).
+  // Restore the batch dim with expand_shape so the rest of the code always
+  // works with rank-5 input and rank-5 output.
+  // TODO: Fix root cause (prevent batch folding before materialization) and
+  // remove this workaround. Use --iree-global-opt-experimental-disable-conv-
+  // generalization to avoid folding in the first place.
+  bool batchDimFolded = false;
+  auto inputType = cast<RankedTensorType>(packedInput.getType());
+  auto outputType = cast<RankedTensorType>(packedOutput.getType());
+  if (inputType.getRank() == 4) {
+    batchDimFolded = true;
+    // WORKAROUND: expand_shape to restore folded N=1 batch dim.
+    // [IC/c0, H, W, c0] → [1, IC/c0, H, W, c0]
+    SmallVector<int64_t> expandedShape = {1};
+    expandedShape.append(inputType.getShape().begin(),
+                         inputType.getShape().end());
+    auto expandedType = RankedTensorType::get(expandedShape, elemType);
+    SmallVector<ReassociationIndices> ri = {{0, 1}, {2}, {3}, {4}};
+    packedInput = tensor::ExpandShapeOp::create(builder, loc, expandedType,
+                                                packedInput, ri);
+  }
+  if (outputType.getRank() == 4) {
+    // WORKAROUND: expand_shape to restore folded N=1 batch dim.
+    // [OC/k0, OH, OW, k0] → [1, OC/k0, OH, OW, k0]
+    SmallVector<int64_t> expandedShape = {1};
+    expandedShape.append(outputType.getShape().begin(),
+                         outputType.getShape().end());
+    auto expandedOutputType = RankedTensorType::get(expandedShape, elemType);
+    SmallVector<ReassociationIndices> ri = {{0, 1}, {2}, {3}, {4}};
+    packedOutput = tensor::ExpandShapeOp::create(
+        builder, loc, expandedOutputType, packedOutput, ri);
+  }
+
+  auto packedInputType = cast<RankedTensorType>(packedInput.getType());
+  auto packedOutputType = cast<RankedTensorType>(packedOutput.getType());
+
+  // From here on, input is always rank-5 [N, IC/c0, H, W, c0]
+  // and output is always rank-5 [N, OC/k0, OH, OW, k0].
+
+  // Extract tile sizes from packed shapes (NCHWc / XNNPACK).
+  // Input:  [N, IC/c0, H, W, c0]             — NCHWc
+  // Filter: [OC/k0, IC/c0, FH, FW, k0, c0]  — XNNPACK
+  // Output: [N, OC/k0, OH, OW, k0]           — NCHWc
+  // int64_t c0 = packedInputType.getDimSize(inputRank - 1);
+  // int64_t k0 = packedOutputType.getDimSize(packedOutputType.getRank() - 1);
+
+  // From packed filter: [OC/k0, IC/c0, FH, FW, k0, c0]
+  int64_t fh = packedFilterType.getDimSize(2);
+  int64_t fw = packedFilterType.getDimSize(3);
+  int64_t IC_tiles = packedFilterType.getDimSize(1); // IC/c0
+  (void)IC_tiles;
+  // From packed output: [N, OC/k0, OH, OW, k0]
+  int64_t OH = packedOutputType.getDimSize(2);
+  int64_t OW = packedOutputType.getDimSize(3);
+  // From packed input: [N, IC/c0, H, W, c0]
+  int64_t inputH = packedInputType.getDimSize(2);
+  int64_t inputW = packedInputType.getDimSize(3);
+
+  // Extract strides and dilations via inferConvolutionDims — the idiomatic
+  // approach used throughout MLIR (e.g., ConvertConv2DToImg2Col.cpp).
+  SmallVector<int64_t, 2> strides = {1, 1};
+  SmallVector<int64_t, 2> dilations = {1, 1};
+  auto cDims = linalg::inferConvolutionDims(linalgOp);
+  if (succeeded(cDims)) {
+    strides = cDims->strides;
+    dilations = cDims->dilations;
+  }
+
+  // ---- Direct-access compute generic ----
+  // Single linalg.generic with tensor.extract for windowed input access.
+  // No intermediate patches buffer, no 7D extraction.
+  // Implicit padding via bounds checking in the body.
+  //
+  // When batch dim is present (N > 1 or
+  // --iree-global-opt-experimental-disable-conv-generalization):
+  //   Loop dims: (n, oc_outer, oh, ow, ic_outer, fh, fw, oc_inner, ic_inner)
+  //               d0  d1        d2  d3  d4        d5  d6  d7        d8
+  //   filter: → (d1, d4, d5, d6, d7, d8)
+  //   output: → (d0, d1, d2, d3, d7)
+  //
+  // WORKAROUND: When batch dim is folded (N=1 without the flag), the packed
+  // input is rank-4 [IC/c0, H, W, c0] and output is rank-4 [OC/k0, OH, OW, k0].
+  // We use 8 loop dims instead of 9 (no batch dim d0).
+  //   Loop dims: (oc_outer, oh, ow, ic_outer, fh, fw, oc_inner, ic_inner)
+  //               d0        d1  d2  d3        d4  d5  d6        d7
+  //   filter: → (d0, d3, d4, d5, d6, d7)
+  //   output: → (d0, d1, d2, d6)
+  // TODO: Fix the root cause (prevent batch dim folding before materialization)
+  // so this workaround can be removed.
+
+  // Compute padding amounts from conv parameters.
+  int64_t requiredH = (OH - 1) * strides[0] + (fh - 1) * dilations[0] + 1;
+  int64_t requiredW = (OW - 1) * strides[1] + (fw - 1) * dilations[1] + 1;
+  int64_t padH = std::max<int64_t>(0, requiredH - inputH);
+  int64_t padW = std::max<int64_t>(0, requiredW - inputW);
+  int64_t padHLow = padH / 2;
+  int64_t padWLow = padW / 2;
+
+  AffineExpr e0, e1, e2, e3, e4, e5, e6, e7, e8;
+  bindDims(ctx, e0, e1, e2, e3, e4, e5, e6, e7, e8);
+
+  // Always 9D: (n, oc_outer, oh, ow, ic_outer, fh, fw, oc_inner, ic_inner)
+  AffineMap filterMap = AffineMap::get(9, 0, {e1, e4, e5, e6, e7, e8}, ctx);
+  AffineMap outputMap = AffineMap::get(9, 0, {e0, e1, e2, e3, e7}, ctx);
+
+  SmallVector<utils::IteratorType> iterTypes = {
+      utils::IteratorType::parallel,  // d0 = n
+      utils::IteratorType::parallel,  // d1 = oc_outer
+      utils::IteratorType::parallel,  // d2 = oh
+      utils::IteratorType::parallel,  // d3 = ow
+      utils::IteratorType::reduction, // d4 = ic_outer
+      utils::IteratorType::reduction, // d5 = fh
+      utils::IteratorType::reduction, // d6 = fw
+      utils::IteratorType::parallel,  // d7 = oc_inner (k0)
+      utils::IteratorType::reduction, // d8 = ic_inner (c0)
+  };
+
+  bool isFloat = isa<FloatType>(elemType);
+
+  // Capture stride/dilation/padding as constants for the body.
+  int64_t strideH = strides[0], strideW = strides[1];
+  int64_t dilationH = dilations[0], dilationW = dilations[1];
+
+  auto convOp = linalg::GenericOp::create(
+      builder, loc, packedOutputType,
+      /*inputs=*/ValueRange{packedFilter},
+      /*outputs=*/ValueRange{packedOutput},
+      ArrayRef<AffineMap>{filterMap, outputMap}, iterTypes,
+      [&](OpBuilder &b, Location l, ValueRange args) {
+        Value filterVal = args[0];
+        Value accVal = args[1];
+
+        // Get loop indices — always 9D after expand_shape workaround.
+        Value n_idx = linalg::IndexOp::create(b, l, 0);
+        Value oh_idx = linalg::IndexOp::create(b, l, 2);
+        Value ow_idx = linalg::IndexOp::create(b, l, 3);
+        Value ic_outer_idx = linalg::IndexOp::create(b, l, 4);
+        Value fh_idx = linalg::IndexOp::create(b, l, 5);
+        Value fw_idx = linalg::IndexOp::create(b, l, 6);
+        Value ic_inner_idx = linalg::IndexOp::create(b, l, 8);
+
+        // h = oh * stride_h + fh * dilation_h - pad_h_low
+        // w = ow * stride_w + fw * dilation_w - pad_w_low
+        auto cst = [&](int64_t v) {
+          return arith::ConstantIndexOp::create(b, l, v);
+        };
+        Value h = arith::AddIOp::create(
+            b, l, arith::MulIOp::create(b, l, oh_idx, cst(strideH)),
+            arith::MulIOp::create(b, l, fh_idx, cst(dilationH)));
+        h = arith::SubIOp::create(b, l, h, cst(padHLow));
+        Value w = arith::AddIOp::create(
+            b, l, arith::MulIOp::create(b, l, ow_idx, cst(strideW)),
+            arith::MulIOp::create(b, l, fw_idx, cst(dilationW)));
+        w = arith::SubIOp::create(b, l, w, cst(padWLow));
+
+        // Bounds check for implicit padding.
+        Value zero = cst(0);
+        Value hInBounds = arith::AndIOp::create(
+            b, l,
+            arith::CmpIOp::create(b, l, arith::CmpIPredicate::sge, h, zero),
+            arith::CmpIOp::create(b, l, arith::CmpIPredicate::slt, h,
+                                  cst(inputH)));
+        Value wInBounds = arith::AndIOp::create(
+            b, l,
+            arith::CmpIOp::create(b, l, arith::CmpIPredicate::sge, w, zero),
+            arith::CmpIOp::create(b, l, arith::CmpIPredicate::slt, w,
+                                  cst(inputW)));
+        Value inBounds = arith::AndIOp::create(b, l, hInBounds, wInBounds);
+
+        // Load input value (0 for out-of-bounds).
+        Value zeroPad =
+            arith::ConstantOp::create(b, l, b.getZeroAttr(elemType));
+        auto ifOp = scf::IfOp::create(b, l, TypeRange{elemType}, inBounds,
+                                      /*withElseRegion=*/true);
+        // Then block: extract from packed input [N, IC/c0, H, W, c0].
+        {
+          OpBuilder::InsertionGuard guard(b);
+          b.setInsertionPointToStart(ifOp.thenBlock());
+          Value v = tensor::ExtractOp::create(
+              b, l, packedInput,
+              ValueRange{n_idx, ic_outer_idx, h, w, ic_inner_idx});
+          scf::YieldOp::create(b, l, v);
+        }
+        // Else block: return zero (padding).
+        {
+          OpBuilder::InsertionGuard guard(b);
+          b.setInsertionPointToStart(ifOp.elseBlock());
+          scf::YieldOp::create(b, l, zeroPad);
+        }
+        Value inputVal = ifOp.getResult(0);
+
+        // Multiply-accumulate.
+        Value mul, add;
+        if (isFloat) {
+          // Extend input type if needed (e.g., f16 input, f32 accumulator).
+          if (inputVal.getType() != elemType) {
+            inputVal = arith::ExtFOp::create(b, l, elemType, inputVal);
+          }
+          mul = arith::MulFOp::create(b, l, inputVal, filterVal);
+          add = arith::AddFOp::create(b, l, mul, accVal);
+        } else {
+          Type outElemType = packedOutputType.getElementType();
+          if (inputVal.getType() != outElemType) {
+            inputVal = arith::ExtSIOp::create(b, l, outElemType, inputVal);
+          }
+          if (filterVal.getType() != outElemType) {
+            filterVal = arith::ExtSIOp::create(b, l, outElemType, filterVal);
+          }
+          mul = arith::MulIOp::create(b, l, inputVal, filterVal);
+          add = arith::AddIOp::create(b, l, mul, accVal);
+        }
+        linalg::YieldOp::create(b, l, add);
+      });
+
+  // WORKAROUND: collapse_shape to restore folded N=1 batch dim in output.
+  if (batchDimFolded) {
+    SmallVector<ReassociationIndices> ri = {{0, 1}, {2}, {3}, {4}};
+    return tensor::CollapseShapeOp::create(builder, loc, outputType,
+                                           convOp->getResult(0), ri);
+  }
+  return convOp;
 }
 
 //===----------------------------------------------------------------------===//
@@ -687,6 +968,73 @@ enumerateCPUMatmulTiles(IREE::Encoding::EncodingAttr encoding,
   return {};
 }
 
+static SmallVector<TileOCxIC> enumerateConvTileArm64(TypeRange elementTypes,
+                                                     DictionaryAttr config) {
+  assert(elementTypes.size() == 3);
+  Type inputElem = elementTypes[0];
+  Type outputElem = elementTypes[2];
+  if (isa<FloatType>(inputElem) && isa<FloatType>(outputElem)) {
+    // f32 → 4 lanes, f16/bf16 → 8 lanes per NEON 128-bit register.
+    int64_t lanes = 128 / inputElem.getIntOrFloatBitWidth();
+    return {TileOCxIC{lanes, lanes}};
+  }
+  if (inputElem.isSignlessInteger(8) && outputElem.isSignlessInteger(32)) {
+    return {TileOCxIC{4, 4}};
+  }
+  return {};
+}
+
+static SmallVector<TileOCxIC> enumerateConvTileX86_64(TypeRange elementTypes,
+                                                      DictionaryAttr config) {
+  assert(elementTypes.size() == 3);
+  Type inputElem = elementTypes[0];
+  Type outputElem = elementTypes[2];
+  if (isa<FloatType>(inputElem) && isa<FloatType>(outputElem)) {
+    if (hasFeature(config, "+avx512f")) {
+      int64_t lanes = 512 / inputElem.getIntOrFloatBitWidth();
+      return {TileOCxIC{lanes, lanes}};
+    }
+    if (hasFeature(config, "+avx")) {
+      int64_t lanes = 256 / inputElem.getIntOrFloatBitWidth();
+      return {TileOCxIC{lanes, lanes}};
+    }
+    int64_t lanes = 128 / inputElem.getIntOrFloatBitWidth();
+    return {TileOCxIC{lanes, lanes}};
+  }
+  return {};
+}
+
+static SmallVector<TileOCxIC> enumerateConvTileRiscv32(TypeRange elementTypes,
+                                                       DictionaryAttr config) {
+  // TODO(jschuhmacher)
+  return {};
+}
+
+static SmallVector<TileOCxIC> enumerateConvTileRiscv64(TypeRange elementTypes,
+                                                       DictionaryAttr config) {
+  // TODO(jschuhmacher)
+  return {};
+}
+
+static SmallVector<TileOCxIC>
+enumerateCPUConvTiles(IREE::Encoding::EncodingAttr encoding,
+                      DictionaryAttr config) {
+  SmallVector<Type> elementTypes = encoding.getElementTypesArray();
+  if (isAArch64(config)) {
+    return enumerateConvTileArm64(elementTypes, config);
+  }
+  if (isX86_64(config)) {
+    return enumerateConvTileX86_64(elementTypes, config);
+  }
+  if (isRISCV32(config)) {
+    return enumerateConvTileRiscv32(elementTypes, config);
+  }
+  if (isRISCV64(config)) {
+    return enumerateConvTileRiscv64(elementTypes, config);
+  }
+  return {};
+}
+
 struct CPUEncodingPackedLayoutMaterializerAttr
     : PackedLayoutMaterializerAttrExternalModelBase<
           CPUEncodingPackedLayoutMaterializerAttr, CPUEncodingResolverAttr> {
@@ -705,6 +1053,23 @@ struct CPUEncodingPackedLayoutMaterializerAttr
     MaterializeEncodingInfo info;
     if (!encoding) {
       return info;
+    }
+
+    // Handle convolution encodings.
+    if (encoding.getOpType().getValue() ==
+        IREE::Encoding::EncodingOpType::conv) {
+      SmallVector<TileOCxIC> tiles =
+          enumerateCPUConvTiles(encoding, layoutAttr.getConfiguration());
+      if (tiles.empty()) {
+        return info; // No tile → identity layout
+      }
+      TileOCxIC tile = tiles[0];
+      FailureOr<MaterializeEncodingInfo> maybeInfo =
+          IREE::Codegen::getEncodingInfoForConv(encoding, tile);
+      if (failed(maybeInfo)) {
+        return info;
+      }
+      return maybeInfo.value();
     }
 
     // We only know about contractions with {Batch, M, N, K} <= 1 at the moment.
@@ -767,6 +1132,11 @@ struct CPUEncodingResolverMaterializerAttr final
       return dropEncodingAndCloneOp(b, linalgOp,
                                     convertedOperands.take_front(numInputs),
                                     convertedOperands.drop_front(numInputs));
+    }
+    if (linalg::isaConvolutionOpInterface(linalgOp)) {
+      return lowerConvolutionOpWithEncoding(
+          b, linalgOp, convertedOperands,
+          cast<IREE::Encoding::LayoutMaterializerAttr>(layoutAttr));
     }
     if (linalg::isaContractionOpInterface(linalgOp)) {
       return lowerContractionOpWithEncoding(


### PR DESCRIPTION
Add encoding materialization for data tiling convolutions (https://github.com/iree-org/iree/pull/24061)
Parts 3 of introducing data tiling support for convolutions.

Encoding materialization (getEncodingInfoForConv) computes packing parameters (inner tile sizes, outerDimsPerm) for input, filter, and output tensors. Tiles along IC and OC dimensions using CPU-specific tile sizes (aarch64/x86_64).

All layouts are normalized into a canonical form (in line with https://hackmd.io/@phemashekar/conv-dt-layout):

 - Input [N, IC/16, H, W, ic=16]
 - Filter [IC/16, KH, KW, OC/16, ic=16, oc=16]
 - Output [N, OC/16, OH, OW, oc=16]

The inferConvDimsFromMaps helper should be replaced by a future upstream inferConvolutionDims(ArrayRef<AffineMap>) overload.

Split off from https://github.com/iree-org/iree/pull/23746, see there for full context.

Assisted by: Claude