### PR TITLE
[CPU] Drop benchmarking requirement from cpu torch op tests.

### DIFF
--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -39,7 +39,6 @@ jobs:
               - persistent-cache
               - Linux
               - X64
-              - threadripper
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
@@ -15,14 +15,5 @@
     "AB/2048x2048xf32_bench"
   ],
   "expected_compile_failures": [],
-  "expected_run_failures": [],
-  "golden_times_ms": {
-    "AB/8192x8192xf32_bench": 5587.488262355328,
-    "AB/1024x1024xf32_bench": 1.1874544098876767,
-    "AB/256x256xf32_bench": 0.044473891122477315,
-    "AB/128x128xf32_bench": 0.03577919309132721,
-    "AB/2048x2048xf32_bench": 10.41092509722771,
-    "AB/4096x4096xf32_bench": 131.7884701769799,
-    "AB/512x512xf32_bench": 0.12528392536236224
-  }
+  "expected_run_failures": []
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
@@ -10,9 +10,13 @@
     "InterestingShapesBiasAdd/997x997xi8_NN_bias"
   ],
   "skip_run_tests": [
-    "AB/8192x8192xf32_bench",
+    "AB/128x128xf32_bench",
+    "AB/256x256xf32_bench",
+    "AB/512x512xf32_bench",
+    "AB/1024x1024xf32_bench",
+    "AB/2048x2048xf32_bench",
     "AB/4096x4096xf32_bench",
-    "AB/2048x2048xf32_bench"
+    "AB/8192x8192xf32_bench"
   ],
   "expected_compile_failures": [],
   "expected_run_failures": []

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_cpu_llvm_sync.json
@@ -7,6 +7,13 @@
   ],
   "iree_run_module_flags": [],
   "skip_compile_tests": [
+    "AB/128x128xf32_bench",
+    "AB/256x256xf32_bench",
+    "AB/512x512xf32_bench",
+    "AB/1024x1024xf32_bench",
+    "AB/2048x2048xf32_bench",
+    "AB/4096x4096xf32_bench",
+    "AB/8192x8192xf32_bench",
     "InterestingShapesBiasAdd/997x997xi8_NN_bias"
   ],
   "skip_run_tests": [


### PR DESCRIPTION
We do not track matmul perf actively on threadripper, so we can drop the config. It relaxes the resource requirement, so the future cpu torch op tests can be run on more runners -- which reduces the waiting time.