### PR TITLE
[Codegen][NFC] Move populateSwizzleBasedOffsetsSizesStrides to standalone function

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1349,6 +1349,16 @@ int64_t DataTiledMMAAttr::getExpectedNumInputs() const { return 2; }
 
 int64_t DataTiledMMAAttr::getExpectedNumOutputs() const { return 1; }
 
+LogicalResult DataTiledMMAAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) const {
+  return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+      .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
+                                          permutation, offsets, sizes, strides);
+}
+
 LogicalResult
 DataTiledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
   return verifyMmaIndexingMaps(maps);
@@ -2793,6 +2803,16 @@ LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
 int64_t DataTiledScaledMMAAttr::getExpectedNumInputs() const { return 4; }
 
 int64_t DataTiledScaledMMAAttr::getExpectedNumOutputs() const { return 1; }
+
+LogicalResult DataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) const {
+  return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+      .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
+                                          permutation, offsets, sizes, strides);
+}
 
 int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic());

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1354,7 +1354,7 @@ LogicalResult DataTiledMMAAttr::populateOperandOffsetsSizesStrides(
     ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
-  return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+  return cast<DataTiledMMAInterfaceAttr>(*this)
       .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
                                           permutation, offsets, sizes, strides);
 }
@@ -2809,7 +2809,7 @@ LogicalResult DataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
     ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
-  return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+  return cast<DataTiledMMAInterfaceAttr>(*this)
       .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
                                           permutation, offsets, sizes, strides);
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -320,7 +320,6 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
         "getUndistributedTileTypes",
         "getDistributedTileTypes",
         "getUndistributedTileDimExpansion",
-        "populateOperandOffsetsSizesStrides",
         "getDistributionMappingKind",
         "getDistributionWorkerCount",
         "getOperandIteratorTypes",
@@ -360,17 +359,6 @@ class IREEGPU_DataTiledMMAInnerTileDescAttr<string mnemonic, list<Trait> traits 
           .getUndistributedTileDimExpansion(operandIndex, logicalDim);
     }
 
-    LogicalResult $cppClass::populateOperandOffsetsSizesStrides(
-        OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
-        ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
-        SmallVectorImpl<OpFoldResult> &sizes,
-        SmallVectorImpl<OpFoldResult> &strides) const {
-      return cast<DataTiledMMAInterfaceAttr>(*this)
-          .populateOperandOffsetsSizesStrides(builder, loc, operandIndex,
-                                              laneId, permutation, offsets,
-                                              sizes, strides);
-    }
-
     Attribute $cppClass::getDistributionMappingKind() const {
       return cast<DataTiledMMAInterfaceAttr>(*this)
           .getDistributionMappingKind();
@@ -393,6 +381,7 @@ def IREEGPU_DataTiledMMAAttr :
     "getExpectedNumInputs",
     "getExpectedNumOutputs",
     "verifyIndexingMaps",
+    "populateOperandOffsetsSizesStrides",
     "getOperandIteratorTypes",
     "buildUnderlyingOperations",
   ]>
@@ -466,6 +455,7 @@ def IREEGPU_DataTiledScaledMMAAttr :
     "getExpectedNumInputs",
     "getExpectedNumOutputs",
     "verifyIndexingMaps",
+    "populateOperandOffsetsSizesStrides",
     "buildUnderlyingOperations"
   ]>
 ]> {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -87,17 +87,12 @@ DataTiledMMAInterfaceAttr::getUndistributedTileDimExpansion(
   return std::nullopt;
 }
 
-LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
-    OpBuilder &builder, Location loc, uint32_t operandIndex, Value threadId,
-    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+LogicalResult populateSwizzleBasedOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, const TileSwizzle &swizzle,
+    Value threadId, ArrayRef<int64_t> permutation,
+    SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) {
-  TileSwizzle swizzle = getTileSwizzle(operandIndex);
-
-  LDBG() << "DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides\n"
-         << "    operand: " << operandIndex << "\n"
-         << "    swizzle: " << swizzle << "\n";
-
   SmallVector<int64_t> distributionThreadSizes =
       getSwizzledDistributionShape(swizzle);
 
@@ -151,6 +146,21 @@ LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
   strides.append(tileStrides);
 
   return success();
+}
+
+LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value threadId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) {
+  TileSwizzle swizzle = getTileSwizzle(operandIndex);
+
+  LDBG() << "DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides\n"
+         << "    operand: " << operandIndex << "\n"
+         << "    swizzle: " << swizzle << "\n";
+
+  return populateSwizzleBasedOffsetsSizesStrides(
+      builder, loc, swizzle, threadId, permutation, offsets, sizes, strides);
 }
 
 Attribute DataTiledMMAInterfaceAttr::getDistributionMappingKind() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -88,9 +88,8 @@ DataTiledMMAInterfaceAttr::getUndistributedTileDimExpansion(
 }
 
 LogicalResult populateSwizzleBasedOffsetsSizesStrides(
-    OpBuilder &builder, Location loc, const TileSwizzle &swizzle,
-    Value threadId, ArrayRef<int64_t> permutation,
-    SmallVectorImpl<OpFoldResult> &offsets,
+    OpBuilder &builder, Location loc, const TileSwizzle &swizzle, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) {
   SmallVector<int64_t> distributionThreadSizes =
@@ -101,7 +100,7 @@ LogicalResult populateSwizzleBasedOffsetsSizesStrides(
   // to get clamping behavior.
   SmallVector<OpFoldResult> tileOffsets =
       affine::AffineDelinearizeIndexOp::create(
-          builder, loc, getValueOrCreateConstantIndexOp(builder, loc, threadId),
+          builder, loc, getValueOrCreateConstantIndexOp(builder, loc, laneId),
           distributionThreadSizes, /*hasOuterBound=*/false)
           ->getResults()
           .drop_front();
@@ -149,7 +148,7 @@ LogicalResult populateSwizzleBasedOffsetsSizesStrides(
 }
 
 LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
-    OpBuilder &builder, Location loc, uint32_t operandIndex, Value threadId,
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
     ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) {
@@ -160,7 +159,7 @@ LogicalResult DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides(
          << "    swizzle: " << swizzle << "\n";
 
   return populateSwizzleBasedOffsetsSizesStrides(
-      builder, loc, swizzle, threadId, permutation, offsets, sizes, strides);
+      builder, loc, swizzle, laneId, permutation, offsets, sizes, strides);
 }
 
 Attribute DataTiledMMAInterfaceAttr::getDistributionMappingKind() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
@@ -26,7 +26,7 @@ Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
 /// called directly when a custom swizzle is needed.
 LogicalResult populateSwizzleBasedOffsetsSizesStrides(
     OpBuilder &builder, Location loc, const Codegen::TileSwizzle &swizzle,
-    Value threadId, ArrayRef<int64_t> permutation,
+    Value laneId, ArrayRef<int64_t> permutation,
     SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
@@ -19,6 +19,18 @@
 namespace mlir::iree_compiler::IREE::GPU {
 Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
                            Attribute attr);
+
+/// Computes offsets/sizes/strides for a single operand tile from a swizzle
+/// description and a thread ID. This is the shared implementation behind
+/// DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides and can be
+/// called directly when a custom swizzle is needed (e.g., PDT data operands).
+LogicalResult populateSwizzleBasedOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, const Codegen::TileSwizzle &swizzle,
+    Value threadId, ArrayRef<int64_t> permutation,
+    SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides);
+
 } // namespace mlir::iree_compiler::IREE::GPU
 
 // clang-format off

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
@@ -19,6 +19,18 @@
 namespace mlir::iree_compiler::IREE::GPU {
 Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
                            Attribute attr);
+
+/// Computes offsets/sizes/strides for a single operand tile from a swizzle
+/// description and a thread ID. This is the shared implementation behind
+/// DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides and can be
+/// called directly when a custom swizzle is needed.
+LogicalResult populateSwizzleBasedOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, const Codegen::TileSwizzle &swizzle,
+    Value threadId, ArrayRef<int64_t> permutation,
+    SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides);
+
 } // namespace mlir::iree_compiler::IREE::GPU
 
 // clang-format off


### PR DESCRIPTION
Part of a series of PRs aimed at enabling preshuffling scales in mxfp4 gemms.

Move the body of `DataTiledMMAInterfaceAttr::populateOperandOffsetsSizesStrides` into a free function `populateSwizzleBasedOffsetsSizesStrides` so that callers with a custom `TileSwizzle` can reuse the same delinearization logic. Move the concrete `populateOperandOffsetsSizesStrides` overrides from the TableGen base class template into each concrete attr (DataTiledMMAAttr and DataTiledScaledMMAAttr) so they can be individually customized in a future PR. Specifically, `DataTiledScaledMMAAttr` is updated to handle special handling of `unswizzled_operands` when computing offsets, which are only a concern for scaled gemms.

Made-with: Cursor