### PR TITLE
[Codegen][NFC] Make getMmaScheduleFromProblemAndTarget and padding utilities public

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -189,6 +189,53 @@ struct GPUMMASchedule {
   }
 };
 
+/// Pads a dimension bound to a favorable alignment for the MMA heuristic.
+/// The heuristic uses power-of-2 split factors, so odd tile counts (e.g.,
+/// ceil(1000/16) = 63) cannot distribute evenly. Padding to a multiple of
+/// |alignment| avoids this. Returns the original bound if already aligned
+/// or dynamic.
+inline int64_t padBoundForHeuristic(int64_t bound, int64_t alignment) {
+  if (ShapedType::isDynamic(bound)) {
+    return bound;
+  }
+  int64_t remainder = bound % alignment;
+  if (remainder == 0) {
+    return bound;
+  }
+  return bound + alignment - remainder;
+}
+
+/// Pads M and N sizes in a GPUMatmulShapeType so that the MMA heuristic sees
+/// power-of-2-friendly tile counts. This matches the padding applied by the
+/// TileAndFuse config path in ConfigUtils.cpp.
+///
+/// Thresholds: <=32 left as-is (single or few tiles, padding unnecessary);
+/// (32,128] padded to 32; >128 padded to 128. These correspond to the
+/// workgroup tile sizes the TileAndFuse config path typically selects.
+///
+/// K dimensions are not padded because the heuristic's K split factors are
+/// less alignment-sensitive than M/N workgroup distribution.
+inline void padProblemForHeuristic(GPUMatmulShapeType &problem) {
+  auto padDim = [](int64_t bound) -> int64_t {
+    if (ShapedType::isDynamic(bound)) {
+      return bound;
+    }
+    if (bound > 128) {
+      return padBoundForHeuristic(bound, 128);
+    }
+    if (bound > 32) {
+      return padBoundForHeuristic(bound, 32);
+    }
+    return bound;
+  };
+  for (int64_t &m : problem.mSizes) {
+    m = padDim(m);
+  }
+  for (int64_t &n : problem.nSizes) {
+    n = padDim(n);
+  }
+}
+
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
 /// When |target| is provided, architecture-specific seed adjustments (e.g.,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -189,6 +189,48 @@ struct GPUMMASchedule {
   }
 };
 
+/// Pads a dimension bound to a favorable alignment for the MMA heuristic.
+/// The heuristic uses power-of-2 split factors, so odd tile counts (e.g.,
+/// ceil(1000/16) = 63) cannot distribute evenly. Padding to a multiple of
+/// |alignment| avoids this. Returns the original bound if already aligned
+/// or dynamic.
+inline int64_t padBoundForHeuristic(int64_t bound, int64_t alignment) {
+  if (ShapedType::isDynamic(bound)) {
+    return bound;
+  }
+  int64_t remainder = bound % alignment;
+  if (remainder == 0) {
+    return bound;
+  }
+  return bound + alignment - remainder;
+}
+
+/// Pads M and N sizes in a GPUMatmulShapeType so that the MMA heuristic sees
+/// power-of-2-friendly tile counts. This matches the padding applied by the
+/// TileAndFuse config path in ConfigUtils.cpp. Dimensions <= 32 are left
+/// unpadded; dimensions > 128 are padded to 128; dimensions in (32, 128] are
+/// padded to 32.
+inline void padProblemForHeuristic(GPUMatmulShapeType &problem) {
+  auto padDim = [](int64_t bound) -> int64_t {
+    if (ShapedType::isDynamic(bound)) {
+      return bound;
+    }
+    if (bound > 128) {
+      return padBoundForHeuristic(bound, 128);
+    }
+    if (bound > 32) {
+      return padBoundForHeuristic(bound, 32);
+    }
+    return bound;
+  };
+  for (int64_t &m : problem.mSizes) {
+    m = padDim(m);
+  }
+  for (int64_t &n : problem.nSizes) {
+    n = padDim(n);
+  }
+}
+
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
 /// When |target| is provided, architecture-specific seed adjustments (e.g.,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -293,11 +293,11 @@ getContractionHeuristicSeeds(IREE::GPU::TargetAttr target,
 /// When `doCPromotion` is true, the accumulator uses shared memory. This can be
 /// due to padding requirements or because the operation has an existing
 /// accumulator that needs to be loaded from global memory (matmul_accumulate).
-static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
+std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
     IREE::GPU::TargetAttr target, GPUMatmulShapeType problem, Location loc,
     bool transposedLhs, bool transposedRhs, bool isGemm, bool scaled,
-    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned = true,
-    bool doCPromotion = false, int64_t splitReductionTripCnt = 0) {
+    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned,
+    bool doCPromotion, int64_t splitReductionTripCnt) {
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
   SmallVector<GPUIntrinsicType> intrinsics;
   if (scaled) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 
+#include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "mlir/IR/Operation.h"
@@ -44,6 +45,14 @@ setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
                         mlir::FunctionOpInterface entryPoint, Operation *op,
                         bool useDirectLoad,
                         std::optional<uint64_t> prefetchNumStages);
+
+/// Computes an MMA schedule from a problem description and target, using
+/// architecture-specific seed-based heuristics (deduceMMASchedule).
+std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
+    IREE::GPU::TargetAttr target, GPUMatmulShapeType problem, Location loc,
+    bool transposedLhs, bool transposedRhs, bool isGemm, bool scaled,
+    bool useDirectLoad, int64_t prefetchNumStages, bool mustBeAligned = true,
+    bool doCPromotion = false, int64_t splitReductionTripCnt = 0);
 
 /// Helper for setting up a default tile and fuse config for targeting
 /// simple thread distribution. Currently restricted to linalg ops.


### PR DESCRIPTION
This PR is part of a series of PRs aiming to enable scale operand preshuffling for mxfp4 gemms on cdna4.

Make getMmaScheduleFromProblemAndTarget a public function (was static) so that GPUEncodingExternalModels can call it to compute MMA schedules when choosing data-tiled layouts. Add padBoundForHeuristic and padProblemForHeuristic inline helpers to GPUHeuristics.h for reuse outside ConfigUtils.

Specifically, this change enables this future PR: https://github.com/iree-org/iree/pull/24198.

Made-with: Cursor