### PR TITLE
[Codegen] Add unswizzled_operands attribute to DataTiledScaledMMAAttr

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -262,8 +262,8 @@ TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
 
 TileSwizzle getDistributionSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
                                    unsigned operandIdx) {
-  assert(scaledMma.isUnshuffledOperand(operandIdx) &&
-         "getDistributionSwizzle is only meaningful for unshuffled operands");
+  assert(scaledMma.isUnswizzledOperand(operandIdx) &&
+         "getDistributionSwizzle is only meaningful for unswizzled operands");
   return getSwizzleImpl(scaledMma, operandIdx);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -250,6 +250,20 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
 
 TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
                        unsigned operandIdx) {
+  TileSwizzle swizzle = getSwizzleImpl(scaledMma, operandIdx);
+  if (scaledMma.isUnswizzledOperand(operandIdx)) {
+    // Reset permutation to identity, the expand dims are preserved so the
+    // tile shape matches the MMA layout, but no transpose is applied.
+    auto &perm = swizzle.permutation();
+    std::iota(perm.begin(), perm.end(), 0);
+  }
+  return swizzle;
+}
+
+TileSwizzle getDistributionSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
+                                   unsigned operandIdx) {
+  assert(scaledMma.isUnshuffledOperand(operandIdx) &&
+         "getDistributionSwizzle is only meaningful for unshuffled operands");
   return getSwizzleImpl(scaledMma, operandIdx);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -250,6 +250,16 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
 
 TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
                        unsigned operandIdx) {
+  TileSwizzle swizzle = getSwizzleImpl(scaledMma, operandIdx);
+  if (scaledMma.isUnshuffledOperand(operandIdx)) {
+    auto &perm = swizzle.permutation();
+    std::iota(perm.begin(), perm.end(), 0);
+  }
+  return swizzle;
+}
+
+TileSwizzle getDistributionSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
+                                   unsigned operandIdx) {
   return getSwizzleImpl(scaledMma, operandIdx);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
@@ -19,9 +19,18 @@ Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
                                 int operandIndex);
 
 /// Returns the swizzle for the full data-tiled-scaled-mma tile, including all
-/// the relevant unrolling and expansion factors.
+/// the relevant unrolling and expansion factors. For operands listed in
+/// `unshuffled_operands`, the permutation is reset to identity.
 Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
                                 unsigned operandIdx);
+
+/// Returns the swizzle with the non-identity permutation that encodes thread
+/// stride (tstride) ordering. Used for thread ID delinearization in
+/// populateOperandOffsetsSizesStrides, where the permutation must reflect the
+/// MMA layout's tstrides rather than the physical data layout.
+Codegen::TileSwizzle
+getDistributionSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
+                       unsigned operandIdx);
 
 /// Returns the swizzle for the data-tiled-mma tile, based on the `fragment`
 /// and contraction dimensions required from the `encoding`.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
@@ -20,7 +20,7 @@ Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
 
 /// Returns the swizzle for the full data-tiled-scaled-mma tile, including all
 /// the relevant unrolling and expansion factors. For operands listed in
-/// `unshuffled_operands`, the permutation is reset to identity.
+/// `unswizzled_operands`, the permutation is reset to identity.
 Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
                                 unsigned operandIdx);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2810,7 +2810,7 @@ LogicalResult DataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
   if (!isUnswizzledOperand(operandIndex)) {
-    return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+    return cast<DataTiledMMAInterfaceAttr>(*this)
         .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
                                             permutation, offsets, sizes,
                                             strides);
@@ -2852,15 +2852,15 @@ DataTiledScaledMMAAttr::getOperandIteratorTypes() const {
           {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
-bool DataTiledScaledMMAAttr::isUnshuffledOperand(unsigned idx) const {
+bool DataTiledScaledMMAAttr::isUnswizzledOperand(unsigned idx) const {
   assert(idx < (unsigned)(getExpectedNumInputs() + getExpectedNumOutputs()) &&
          "operand index out of range for scaled MMA");
-  auto attr = getUnshuffledOperands();
+  auto attr = getUnswizzledOperands();
   return attr && llvm::is_contained(attr.asArrayRef(), idx);
 }
 
-bool DataTiledScaledMMAAttr::hasUnshuffledOperands() const {
-  auto attr = getUnshuffledOperands();
+bool DataTiledScaledMMAAttr::hasUnswizzledOperands() const {
+  auto attr = getUnswizzledOperands();
   return attr && !attr.empty();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2809,9 +2809,22 @@ LogicalResult DataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
     ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
-  return cast<DataTiledMMAInterfaceAttr>(*this)
-      .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
-                                          permutation, offsets, sizes, strides);
+  if (!isUnswizzledOperand(operandIndex)) {
+    return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+        .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
+                                            permutation, offsets, sizes,
+                                            strides);
+  }
+  // For unswizzled operands, getTileSwizzle returns an identity permutation,
+  // but populateSwizzleBasedOffsetsSizesStrides uses the swizzle's permutation
+  // to order the delinearization basis, it must reflect the MMA tstrides. Use
+  // the non-identity-reset swizzle for both the delinearization and the output
+  // reordering so the two cancel out, yielding source-order offsets that match
+  // the identity layout.
+  TileSwizzle dtSwizzle = getDistributionSwizzle(*this, operandIndex);
+  return populateSwizzleBasedOffsetsSizesStrides(
+      builder, loc, dtSwizzle, laneId, dtSwizzle.permutation(), offsets, sizes,
+      strides);
 }
 
 int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
@@ -2837,6 +2850,18 @@ DataTiledScaledMMAAttr::getOperandIteratorTypes() const {
           {utils::IteratorType::parallel, utils::IteratorType::reduction},
           {utils::IteratorType::reduction, utils::IteratorType::parallel},
           {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+}
+
+bool DataTiledScaledMMAAttr::isUnshuffledOperand(unsigned idx) const {
+  assert(idx < (unsigned)(getExpectedNumInputs() + getExpectedNumOutputs()) &&
+         "operand index out of range for scaled MMA");
+  auto attr = getUnshuffledOperands();
+  return attr && llvm::is_contained(attr.asArrayRef(), idx);
+}
+
+bool DataTiledScaledMMAAttr::hasUnshuffledOperands() const {
+  auto attr = getUnshuffledOperands();
+  return attr && !attr.empty();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2809,9 +2809,22 @@ LogicalResult DataTiledScaledMMAAttr::populateOperandOffsetsSizesStrides(
     ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
-  return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
-      .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
-                                          permutation, offsets, sizes, strides);
+  if (!isUnshuffledOperand(operandIndex)) {
+    return cast<DataTiledMMAInterfaceAttr>(Attribute(*this))
+        .populateOperandOffsetsSizesStrides(builder, loc, operandIndex, laneId,
+                                            permutation, offsets, sizes,
+                                            strides);
+  }
+  // For unshuffled operands, getTileSwizzle returns an identity permutation,
+  // but populateSwizzleBasedOffsetsSizesStrides uses the swizzle's permutation
+  // to order the delinearization basis — it must reflect the MMA tstrides. Use
+  // the non-identity-reset swizzle for both the delinearization and the output
+  // reordering so the two cancel out, yielding source-order offsets that match
+  // the identity layout.
+  TileSwizzle dtSwizzle = getDistributionSwizzle(*this, operandIndex);
+  return populateSwizzleBasedOffsetsSizesStrides(
+      builder, loc, dtSwizzle, laneId, dtSwizzle.permutation(), offsets, sizes,
+      strides);
 }
 
 int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
@@ -2837,6 +2850,16 @@ DataTiledScaledMMAAttr::getOperandIteratorTypes() const {
           {utils::IteratorType::parallel, utils::IteratorType::reduction},
           {utils::IteratorType::reduction, utils::IteratorType::parallel},
           {utils::IteratorType::parallel, utils::IteratorType::parallel}};
+}
+
+bool DataTiledScaledMMAAttr::isUnshuffledOperand(unsigned idx) const {
+  auto attr = getUnshuffledOperands();
+  return attr && llvm::is_contained(attr.asArrayRef(), idx);
+}
+
+bool DataTiledScaledMMAAttr::hasUnshuffledOperands() const {
+  auto attr = getUnshuffledOperands();
+  return attr && !attr.empty();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -472,6 +472,12 @@ def IREEGPU_DataTiledScaledMMAAttr :
     types for the scales operands are always Float8E8M0FNUType, so they are not
     specified on the attribute.
 
+    The optional |unswizzled_operands| field lists operand indices whose data
+    layout is unswizzled (pack and expand only, no transpose). When set, those
+    operands get an identity permutation in the swizzle and use a distribution
+    swizzle for thread ID delinearization. Other operands are fully swizzled as
+    usual. When empty (default), all operands are fully data-tiled.
+
     The other fields are similar to DataTiledMMAAttr, refer to its documentation.
   }];
 
@@ -503,7 +509,15 @@ def IREEGPU_DataTiledScaledMMAAttr :
           OptionalParameter<
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_n,
           OptionalParameter<
-              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k);
+              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k,
+          OptionalParameter<
+              "DenseI64ArrayAttr",
+              "Operand indices with row-major (unshuffled) layout.">:$unshuffled_operands);
+
+  let extraClassDeclaration = [{
+    bool isUnshuffledOperand(unsigned idx) const;
+    bool hasUnshuffledOperands() const;
+  }];
 }
 
 def IREEGPU_VirtualMMAIntrinsicAttr

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -512,11 +512,11 @@ def IREEGPU_DataTiledScaledMMAAttr :
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k,
           OptionalParameter<
               "DenseI64ArrayAttr",
-              "Operand indices with row-major (unshuffled) layout.">:$unshuffled_operands);
+              "Operand indices with row-major (unswizzled) layout.">:$unswizzled_operands);
 
   let extraClassDeclaration = [{
-    bool isUnshuffledOperand(unsigned idx) const;
-    bool hasUnshuffledOperands() const;
+    bool isUnswizzledOperand(unsigned idx) const;
+    bool hasUnswizzledOperands() const;
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -472,6 +472,12 @@ def IREEGPU_DataTiledScaledMMAAttr :
     types for the scales operands are always Float8E8M0FNUType, so they are not
     specified on the attribute.
 
+    The optional |unshuffled_operands| field lists operand indices whose data
+    layout is row-major (pack-only, no expand_shape/transpose). When set, those
+    operands get an identity permutation in the swizzle and use a distribution
+    swizzle for thread ID delinearization. Other operands are fully shuffled as
+    usual. When empty (default), all operands are fully data-tiled.
+
     The other fields are similar to DataTiledMMAAttr, refer to its documentation.
   }];
 
@@ -503,7 +509,15 @@ def IREEGPU_DataTiledScaledMMAAttr :
           OptionalParameter<
               "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_n,
           OptionalParameter<
-              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k);
+              "DenseI64ArrayAttr">:$operands_interleaving_intrinsics_k,
+          OptionalParameter<
+              "DenseI64ArrayAttr",
+              "Operand indices with row-major (unshuffled) layout.">:$unshuffled_operands);
+
+  let extraClassDeclaration = [{
+    bool isUnshuffledOperand(unsigned idx) const;
+    bool hasUnshuffledOperands() const;
+  }];
 }
 
 def IREEGPU_VirtualMMAIntrinsicAttr

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -441,3 +441,12 @@ module {
 //  CHECK-SAME:   matmul = #iree_gpu.spirv_pipeline<MatmulPromoteVectorize>
 //  CHECK-SAME:   subgroup = #iree_gpu.spirv_pipeline<SubgroupReduce>
 //  CHECK-SAME:   winograd = #iree_gpu.spirv_pipeline<WinogradVectorize>
+
+module {
+  func.func @test_data_tiled_scaled_mfma_F32_16x16x128_B32_unshuffled() attributes {
+      mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, unshuffled_operands = [0, 1]>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_data_tiled_scaled_mfma_F32_16x16x128_B32_unshuffled
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, unshuffled_operands = [0, 1]>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -443,10 +443,10 @@ module {
 //  CHECK-SAME:   winograd = #iree_gpu.spirv_pipeline<WinogradVectorize>
 
 module {
-  func.func @test_data_tiled_scaled_mfma_F32_16x16x128_B32_unshuffled() attributes {
-      mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, unshuffled_operands = [0, 1]>} {
+  func.func @test_data_tiled_scaled_mfma_F32_16x16x128_B32_unswizzled() attributes {
+      mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, unswizzled_operands = [0, 1]>} {
     return
   }
 }
-// CHECK-LABEL: func @test_data_tiled_scaled_mfma_F32_16x16x128_B32_unshuffled
-//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, unshuffled_operands = [0, 1]>
+// CHECK-LABEL: func @test_data_tiled_scaled_mfma_F32_16x16x128_B32_unswizzled
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, unswizzled_operands = [0, 1]>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
@@ -581,14 +581,14 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: te
   affine_map<(m, n, k, kb) -> (n, k)>,
   affine_map<(m, n, k, kb) -> (m, n)>
 ]
-func.func @unshuffled_data_tiled_scaled_1x1x1_tensor_multi_mma(
+func.func @unswizzled_data_tiled_scaled_1x1x1_tensor_multi_mma(
     %lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %rhs: tensor<?x?x1x16x4x32xf4E2M1FN>,
     %lhs_scales: tensor<?x?x4x16xf8E8M0FNU>, %rhs_scales: tensor<?x?x4x16xf8E8M0FNU>,
     %acc: tensor<?x?x4x16x4xf32>) -> tensor<?x?x4x16x4xf32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
-    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unswizzled_operands = [0, 1]>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
   } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>
   return %0 : tensor<?x?x4x16x4xf32>
@@ -600,9 +600,9 @@ func.func @unshuffled_data_tiled_scaled_1x1x1_tensor_multi_mma(
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
-// CHECK-LABEL: func @unshuffled_data_tiled_scaled_1x1x1_tensor_multi_mma
+// CHECK-LABEL: func @unswizzled_data_tiled_scaled_1x1x1_tensor_multi_mma
 //       CHECK:   iree_codegen.inner_tiled ins(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) outs(%{{.*}})
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
 //  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unswizzled_operands = [0, 1]>
 //  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
@@ -571,3 +571,38 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: te
 //  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
 //  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
 //  CHECK-SAME:     : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>
+
+// -----
+
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @unshuffled_data_tiled_scaled_1x1x1_tensor_multi_mma(
+    %lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %rhs: tensor<?x?x1x16x4x32xf4E2M1FN>,
+    %lhs_scales: tensor<?x?x4x16xf8E8M0FNU>, %rhs_scales: tensor<?x?x4x16xf8E8M0FNU>,
+    %acc: tensor<?x?x4x16x4xf32>) -> tensor<?x?x4x16x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+  } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>
+  return %0 : tensor<?x?x4x16x4xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @unshuffled_data_tiled_scaled_1x1x1_tensor_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) outs(%{{.*}})
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
+//  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>
+//  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
@@ -571,3 +571,38 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: te
 //  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
 //  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
 //  CHECK-SAME:     : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>
+
+// -----
+
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @partial_data_tiled_scaled_1x1x1_tensor_multi_mma(
+    %lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %rhs: tensor<?x?x1x16x4x32xf4E2M1FN>,
+    %lhs_scales: tensor<?x?x4x16xf8E8M0FNU>, %rhs_scales: tensor<?x?x4x16xf8E8M0FNU>,
+    %acc: tensor<?x?x4x16x4xf32>) -> tensor<?x?x4x16x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+  } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>
+  return %0 : tensor<?x?x4x16x4xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @partial_data_tiled_scaled_1x1x1_tensor_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) outs(%{{.*}})
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
+//  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>
+//  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x4x16xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x4x16x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -1271,3 +1271,51 @@ func.func @fuse_producer_slice(%arg1 : tensor<4x2x16x16xbf16>, %arg2 : tensor<1x
 //       CHECK:     iree_codegen.inner_tiled
 //  CHECK-SAME:     outs(%[[FILL]])
 //       CHECK:     mapping = [#iree_gpu.lane_id<0>]
+
+// -----
+
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @unshuffled_data_tiled_scaled_1x1x1_distribute(
+    %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
+    %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+    %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+  } : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+  return %0 : tensor<1x1x4x16x4xf32>
+}
+
+// CHECK-LABEL: func @unshuffled_data_tiled_scaled_1x1x1_distribute
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]
+//       CHECK:   scf.forall (%[[THREAD_ID:.+]]) in (64) shared_outs(%[[ACC_ARG:.+]] = %[[ACC]]) -> (tensor<1x1x4x16x4xf32>)
+//   CHECK-DAG:     %[[IDS:.+]]:3 = affine.delinearize_index {{.*}} into (4, 16)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#2, %[[IDS]]#1, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#2, %[[IDS]]#1, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>
+//  CHECK-SAME:       : tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1xf8E8M0FNU>, tensor<1x1x1x1xf8E8M0FNU> into tensor<1x1x1x1x4xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -1271,3 +1271,51 @@ func.func @fuse_producer_slice(%arg1 : tensor<4x2x16x16xbf16>, %arg2 : tensor<1x
 //       CHECK:     iree_codegen.inner_tiled
 //  CHECK-SAME:     outs(%[[FILL]])
 //       CHECK:     mapping = [#iree_gpu.lane_id<0>]
+
+// -----
+
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @partial_data_tiled_scaled_1x1x1_distribute(
+    %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
+    %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+    %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
+  } : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+  return %0 : tensor<1x1x4x16x4xf32>
+}
+
+// CHECK-LABEL: func @partial_data_tiled_scaled_1x1x1_distribute
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]
+//       CHECK:   scf.forall (%[[THREAD_ID:.+]]) in (64) shared_outs(%[[ACC_ARG:.+]] = %[[ACC]]) -> (tensor<1x1x4x16x4xf32>)
+//   CHECK-DAG:     %[[IDS:.+]]:3 = affine.delinearize_index {{.*}} into (4, 16)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#2, %[[IDS]]#1, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#2, %[[IDS]]#1, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>
+//  CHECK-SAME:       : tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1xf8E8M0FNU>, tensor<1x1x1x1xf8E8M0FNU> into tensor<1x1x1x1x4xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -1281,7 +1281,7 @@ func.func @fuse_producer_slice(%arg1 : tensor<4x2x16x16xbf16>, %arg2 : tensor<1x
   affine_map<(m, n, k, kb) -> (n, k)>,
   affine_map<(m, n, k, kb) -> (m, n)>
 ]
-func.func @unshuffled_data_tiled_scaled_1x1x1_distribute(
+func.func @unswizzled_data_tiled_scaled_1x1x1_distribute(
     %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
     %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
     %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
@@ -1289,13 +1289,13 @@ func.func @unshuffled_data_tiled_scaled_1x1x1_distribute(
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
     indexing_maps = #scaled_contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
-    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unswizzled_operands = [0, 1]>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
   } : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
   return %0 : tensor<1x1x4x16x4xf32>
 }
 
-// CHECK-LABEL: func @unshuffled_data_tiled_scaled_1x1x1_distribute
+// CHECK-LABEL: func @unswizzled_data_tiled_scaled_1x1x1_distribute
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]
 //  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9]+]]
@@ -1314,7 +1314,7 @@ func.func @unshuffled_data_tiled_scaled_1x1x1_distribute(
 //   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
 //  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
 //       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
-//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unswizzled_operands = [0, 1]>
 //  CHECK-SAME:       : tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1xf8E8M0FNU>, tensor<1x1x1x1xf8E8M0FNU> into tensor<1x1x1x1x4xf32>
 //       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC_ARG]]
 //  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -374,7 +374,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       subgroupsN, intrinsicsK, subgroupsK,
       /*operands_interleaving_intrinsics_m=*/{},
       /*operands_interleaving_intrinsics_n=*/{},
-      /*operands_interleaving_intrinsics_k=*/scaledMmaInterleaveK);
+      /*operands_interleaving_intrinsics_k=*/scaledMmaInterleaveK,
+      /*unshuffled_operands=*/{});
 }
 
 static Operation *lowerContractionOrScaledContractionOpToInnerTiledOp(

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -375,7 +375,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       /*operands_interleaving_intrinsics_m=*/{},
       /*operands_interleaving_intrinsics_n=*/{},
       /*operands_interleaving_intrinsics_k=*/scaledMmaInterleaveK,
-      /*unshuffled_operands=*/{});
+      /*unswizzled_operands=*/{});
 }
 
 static Operation *lowerContractionOrScaledContractionOpToInnerTiledOp(


### PR DESCRIPTION
This PR is part of series of PRs aiming to enable scale operand preshuffling for mxfp4 gemms on cdna4.

Add an optional `unswizzled_operands` field to `DataTiledScaledMMAAttr` that lists operand indices whose data layout should not be shuffled (pack-only, no expand_shape/transpose). For these operands, `getSwizzle` returns an identity permutation and `populateOperandOffsetsSizesStrides` uses the distribution swizzle for thread delinearization.

This enables a codegen path where data operands (LHS/RHS) skip the expensive global-to-LDS transpose by keeping their packed layout identity-ordered, while scale operands remain fully shuffled for MMA consumption.

Made-with: Cursor