### PR TITLE
[Codegen] Enable software pipelining and XOR swizzling in DataTiledScaledMMAAttr path

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -835,6 +835,12 @@ getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
         smmaAttr.getIntrinsic(), operandIndex,
         operandIndex == kScaledMMAOperandAcc && smmaAttr.getColMajor());
   }
+  if (auto dtsmma = dyn_cast<DataTiledScaledMMAAttr>(mmaKind)) {
+    // DataTiledScaledMMAAttr does not carry a col_major field; column-major
+    // accumulator layouts are not used with data-tiled scaled MMA today.
+    return IREE::GPU::getSingleSubgroupLayout(dtsmma.getIntrinsic(),
+                                              operandIndex);
+  }
   assert(false && "unhandled MMA Interface type.");
   return {};
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -116,7 +116,7 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
     // operand that will be created together with the ukernel op.
     if (auto dtScaledMma =
             dyn_cast<GPU::DataTiledScaledMMAAttr>(dataTiledMmaAttr);
-        dtScaledMma && dtScaledMma.hasUnshuffledOperands()) {
+        dtScaledMma && dtScaledMma.hasUnswizzledOperands()) {
       defaultPrefetch = 2;
       operandList.append({2, 3});
       auto defaultCfg = GPU::DerivedThreadConfigAttr::get(context);
@@ -143,7 +143,7 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   // By default, don't add any special padding or prefetching, since the
-  // data-tiled layout is already what we want. For unshuffled operands default
+  // data-tiled layout is already what we want. For unswizzled operands default
   // to 2 prefetch stages to enable software pipelining.
   SmallVector<NamedAttribute, 1> pipelineAttrs;
   int64_t prefetchStages = prefetchNumStages.value_or(defaultPrefetch);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -103,6 +103,9 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
       {"workgroup", b.getI64ArrayAttr(workgroupTileSizes)},
       {"reduction", b.getI64ArrayAttr(reductionTileSizes)},
   };
+  SmallVector<int64_t> operandList = {0, 1};
+  SmallVector<Attribute> promotionArray = {};
+  int64_t defaultPrefetch = 0;
   if (ukernelConfig) {
     op->setAttr(kUkernelAttrName, ukernelConfig);
   } else {
@@ -111,15 +114,39 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
     // large to fit in shared memory, so they just want global memory and they
     // will take care of moving small chunks at a time into a shared memory
     // operand that will be created together with the ukernel op.
-    GPU::appendPromotedOperandsList(context, attrs, {0, 1});
+    if (auto dtScaledMma =
+            dyn_cast<GPU::DataTiledScaledMMAAttr>(dataTiledMmaAttr);
+        dtScaledMma && dtScaledMma.hasUnshuffledOperands()) {
+      defaultPrefetch = 2;
+      operandList.append({2, 3});
+      auto defaultCfg = GPU::DerivedThreadConfigAttr::get(context);
+      // reductionTileSizes is empty because data-tiled inner layouts already
+      // encode the reduction tiling; the XOR swizzle only needs the intrinsic
+      // tile shape, which is derived from the attr itself.
+      FailureOr<Attribute> lhsSwizzle =
+          getXorShuffleAttr(context, defaultCfg, target, dtScaledMma,
+                            /*reductionTileSizes=*/{}, kScaledMMAOperandLhs);
+      FailureOr<Attribute> rhsSwizzle =
+          getXorShuffleAttr(context, defaultCfg, target, dtScaledMma,
+                            /*reductionTileSizes=*/{}, kScaledMMAOperandRhs);
+      if (succeeded(lhsSwizzle) && succeeded(rhsSwizzle)) {
+        promotionArray = {*lhsSwizzle, *rhsSwizzle, defaultCfg, defaultCfg};
+      } else {
+        op->emitRemark("XOR swizzle unavailable for intrinsic; promoting "
+                       "without bank-conflict avoidance");
+      }
+    }
+    GPU::appendPromotedOperandsList(context, attrs, operandList,
+                                    promotionArray);
   }
   DictionaryAttr configDict = b.getDictionaryAttr(attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   // By default, don't add any special padding or prefetching, since the
-  // data-tiled layout is already what we want.
+  // data-tiled layout is already what we want. For unshuffled operands default
+  // to 2 prefetch stages to enable software pipelining.
   SmallVector<NamedAttribute, 1> pipelineAttrs;
-  int64_t prefetchStages = prefetchNumStages.value_or(0);
+  int64_t prefetchStages = prefetchNumStages.value_or(defaultPrefetch);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       context, /*prefetchNumStages=*/prefetchStages,
       /*no_reduce_shared_memory_bank_conflicts=*/true,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -103,6 +103,9 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
       {"workgroup", b.getI64ArrayAttr(workgroupTileSizes)},
       {"reduction", b.getI64ArrayAttr(reductionTileSizes)},
   };
+  SmallVector<int64_t> operandList = {0, 1};
+  SmallVector<Attribute> promotionArray = {};
+  int64_t defaultPrefetch = 0;
   if (ukernelConfig) {
     op->setAttr(kUkernelAttrName, ukernelConfig);
   } else {
@@ -111,15 +114,33 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
     // large to fit in shared memory, so they just want global memory and they
     // will take care of moving small chunks at a time into a shared memory
     // operand that will be created together with the ukernel op.
-    GPU::appendPromotedOperandsList(context, attrs, {0, 1});
+    if (auto dtScaledMma =
+            dyn_cast<GPU::DataTiledScaledMMAAttr>(dataTiledMmaAttr);
+        dtScaledMma && dtScaledMma.hasUnshuffledOperands()) {
+      defaultPrefetch = 2;
+      operandList.append({2, 3});
+      auto defaultCfg = GPU::DerivedThreadConfigAttr::get(context);
+      FailureOr<Attribute> lhsSwizzle =
+          getXorShuffleAttr(context, defaultCfg, target, dtScaledMma,
+                            /*reductionTileSizes=*/{}, kScaledMMAOperandLhs);
+      FailureOr<Attribute> rhsSwizzle =
+          getXorShuffleAttr(context, defaultCfg, target, dtScaledMma,
+                            /*reductionTileSizes=*/{}, kScaledMMAOperandRhs);
+      if (succeeded(lhsSwizzle) && succeeded(rhsSwizzle)) {
+        promotionArray = {*lhsSwizzle, *rhsSwizzle, defaultCfg, defaultCfg};
+      }
+    }
+    GPU::appendPromotedOperandsList(context, attrs, operandList,
+                                    promotionArray);
   }
   DictionaryAttr configDict = b.getDictionaryAttr(attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   // By default, don't add any special padding or prefetching, since the
-  // data-tiled layout is already what we want.
+  // data-tiled layout is already what we want. For unshuffled operands default
+  // to 2 prefetch stages to enable software pipelining.
   SmallVector<NamedAttribute, 1> pipelineAttrs;
-  int64_t prefetchStages = prefetchNumStages.value_or(0);
+  int64_t prefetchStages = prefetchNumStages.value_or(defaultPrefetch);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       context, /*prefetchNumStages=*/prefetchStages,
       /*no_reduce_shared_memory_bank_conflicts=*/true,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -305,6 +305,36 @@ func.func @data_tiled_scaled_mma_inner_tiled_with_copy(
 
 // -----
 
+module {
+  func.func @unshuffled_data_tiled_scaled_mma_inner_tiled(
+      %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
+      %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+      %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32> {
+    %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+      indexing_maps = [affine_map<(m, n, k, kb) -> (m, k, kb)>,
+                       affine_map<(m, n, k, kb) -> (n, k, kb)>,
+                       affine_map<(m, n, k, kb) -> (m, k)>,
+                       affine_map<(m, n, k, kb) -> (n, k)>,
+                       affine_map<(m, n, k, kb) -> (m, n)>],
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+      semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
+      : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+      return %0 : tensor<1x1x4x16x4xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @unshuffled_data_tiled_scaled_mma_inner_tiled
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
+//       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+//  CHECK-SAME:     reduction = [0, 0, 1, 1]
+//  CHECK-SAME:     workgroup = [1, 1, 0, 0]
+
+// -----
+
 // Test that scaled matmul with an existing accumulator (matmul_accumulate)
 // gets smaller tiles than a zero-initialized matmul to account for accumulator
 // memory in workgroup memory (LDS). Without this, 256x256 tiles would be

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -318,7 +318,7 @@ func.func @data_tiled_scaled_mma_inner_tiled_with_copy(
 // -----
 
 module {
-  func.func @unshuffled_data_tiled_scaled_mma_inner_tiled(
+  func.func @unswizzled_data_tiled_scaled_mma_inner_tiled(
       %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
       %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
       %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32> {
@@ -329,14 +329,14 @@ module {
                        affine_map<(m, n, k, kb) -> (n, k)>,
                        affine_map<(m, n, k, kb) -> (m, n)>],
       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
-      kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+      kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unswizzled_operands = [0, 1]>,
       semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
       : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
       return %0 : tensor<1x1x4x16x4xf32>
   }
 }
 
-// CHECK-LABEL: func.func @unshuffled_data_tiled_scaled_mma_inner_tiled
+// CHECK-LABEL: func.func @unswizzled_data_tiled_scaled_mma_inner_tiled
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -317,6 +317,36 @@ func.func @data_tiled_scaled_mma_inner_tiled_with_copy(
 
 // -----
 
+module {
+  func.func @unshuffled_data_tiled_scaled_mma_inner_tiled(
+      %lhs: tensor<1x1x1x16x4x32xf4E2M1FN>, %rhs: tensor<1x1x1x16x4x32xf4E2M1FN>,
+      %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+      %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32> {
+    %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+      indexing_maps = [affine_map<(m, n, k, kb) -> (m, k, kb)>,
+                       affine_map<(m, n, k, kb) -> (n, k, kb)>,
+                       affine_map<(m, n, k, kb) -> (m, k)>,
+                       affine_map<(m, n, k, kb) -> (n, k)>,
+                       affine_map<(m, n, k, kb) -> (m, n)>],
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3], unshuffled_operands = [0, 1]>,
+      semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
+      : tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x1x16x4x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+      return %0 : tensor<1x1x4x16x4xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @unshuffled_data_tiled_scaled_mma_inner_tiled
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
+//       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//  CHECK-SAME:     promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config, swizzle = #iree_codegen.xor_shuffle<256, 32>>, #iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config]
+//  CHECK-SAME:     reduction = [0, 0, 1, 1]
+//  CHECK-SAME:     workgroup = [1, 1, 0, 0]
+
+// -----
+
 // Test that scaled matmul with an existing accumulator (matmul_accumulate)
 // gets smaller tiles than a zero-initialized matmul to account for accumulator
 // memory in workgroup memory (LDS). Without this, 256x256 tiles would be

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -375,7 +375,7 @@ func.func @matmul_i8()
 
 // -----
 
-// DataTiledScaledMMAAttr with unshuffled_operands pipeline test: verifies XOR
+// DataTiledScaledMMAAttr with unswizzled_operands pipeline test: verifies XOR
 // swizzle hints on data operands, software pipelining, and amdgpu.scaled_mfma
 // generation.
 
@@ -410,7 +410,7 @@ func.func @matmul_i8()
     #iree_gpu.derived_thread_config,
     #iree_gpu.derived_thread_config]
 }>
-func.func @unshuffled_dt_scaled_mma()
+func.func @unswizzled_dt_scaled_mma()
   attributes {hal.executable.target = #executable_target_rocm_pdt, translation_info = #translation_info_pdt} {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
@@ -442,14 +442,14 @@ func.func @unshuffled_dt_scaled_mma()
       operands_interleaving_intrinsics_m = [2],
       operands_interleaving_intrinsics_n = [3],
       operands_interleaving_intrinsics_k = [2, 3],
-      unshuffled_operands = [0, 1]>,
+      unswizzled_operands = [0, 1]>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
     : tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x4x16xf8E8M0FNU>, tensor<9x9x4x16xf8E8M0FNU> into tensor<9x9x4x16x4xf32>
   iree_tensor_ext.dispatch.tensor.store %10, %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : tensor<9x9x4x16x4xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
   return
 }
 
-// CHECK-LABEL: func.func @unshuffled_dt_scaled_mma()
+// CHECK-LABEL: func.func @unswizzled_dt_scaled_mma()
 // CHECK-DAG:  %[[PDT_C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:  %[[PDT_C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:  %[[PDT_C8:.+]] = arith.constant 8 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -372,3 +372,97 @@ func.func @matmul_i8()
 //          CHECK:   }
 //          CHECK:   vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xi32>, memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
 //          CHECK:   iree_codegen.dispatch_config @matmul_i8 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+// -----
+
+// DataTiledScaledMMAAttr with unshuffled_operands pipeline test: verifies XOR
+// swizzle hints on data operands, software pipelining, and amdgpu.scaled_mfma
+// generation.
+
+#executable_target_rocm_pdt = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout_pdt = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, Indirect>],
+  flags = Indirect
+>
+#translation_info_pdt = #iree_codegen.translation_info<pipeline =
+  #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64,
+  {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      prefetch_num_stages = 2,
+      no_reduce_shared_memory_bank_conflicts = true>
+  }
+>
+#config_pdt = #iree_gpu.lowering_config<{
+  workgroup = [1, 1, 0, 0],
+  reduction = [0, 0, 1, 1],
+  promote_operands = [0, 1, 2, 3],
+  promotion_types = [
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config,
+      swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config,
+      swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.derived_thread_config,
+    #iree_gpu.derived_thread_config]
+}>
+func.func @unshuffled_dt_scaled_mma()
+  attributes {hal.executable.target = #executable_target_rocm_pdt, translation_info = #translation_info_pdt} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>>
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(4) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 16, 4, 32], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>> -> tensor<9x9x1x16x4x32xf4E2M1FN>
+  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 16, 4, 32], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>> -> tensor<9x9x1x16x4x32xf4E2M1FN>
+  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [9, 9, 4, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>> -> tensor<9x9x4x16xf8E8M0FNU>
+  %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [9, 9, 4, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>> -> tensor<9x9x4x16xf8E8M0FNU>
+  %9 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>> -> tensor<9x9x4x16x4xf32>
+  %10 = iree_codegen.inner_tiled ins(%5, %6, %7, %8) outs(%9) {
+    lowering_config = #config_pdt,
+    indexing_maps = [
+      affine_map<(m, n, k, kb) -> (m, k, kb)>,
+      affine_map<(m, n, k, kb) -> (n, k, kb)>,
+      affine_map<(m, n, k, kb) -> (m, k)>,
+      affine_map<(m, n, k, kb) -> (n, k)>,
+      affine_map<(m, n, k, kb) -> (m, n)>],
+    iterator_types = [
+      #linalg.iterator_type<parallel>,
+      #linalg.iterator_type<parallel>,
+      #linalg.iterator_type<reduction>,
+      #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32,
+      operands_interleaving_intrinsics_m = [2],
+      operands_interleaving_intrinsics_n = [3],
+      operands_interleaving_intrinsics_k = [2, 3],
+      unshuffled_operands = [0, 1]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
+    : tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x4x16xf8E8M0FNU>, tensor<9x9x4x16xf8E8M0FNU> into tensor<9x9x4x16x4xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : tensor<9x9x4x16x4xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
+  return
+}
+
+// CHECK-LABEL: func.func @unshuffled_dt_scaled_mma()
+// CHECK-DAG:  %[[PDT_C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:  %[[PDT_C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:  %[[PDT_C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:  %[[PDT_BUFFER_A:.+]] = amdgpu.fat_raw_buffer_cast %{{.*}} : memref<9x9x1x16x4x32xf4E2M1FN{{.*}}> to memref<9x9x1x16x4x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-DAG:  %[[PDT_BUFFER_B:.+]] = amdgpu.fat_raw_buffer_cast %{{.*}} : memref<9x9x1x16x4x32xf4E2M1FN{{.*}}> to memref<9x9x1x16x4x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-DAG:  %[[PDT_A_ALLOC:.+]] = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 32>} : memref<2048xf4E2M1FN, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[PDT_B_ALLOC:.+]] = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 32>} : memref<2048xf4E2M1FN, #gpu.address_space<workgroup>>
+//     CHECK:  gpu.barrier memfence [#gpu.address_space<workgroup>]
+//     CHECK:  scf.for {{.*}} %[[PDT_C0]] to %[[PDT_C8]] step %[[PDT_C1]] iter_args({{.*}}) -> (vector<4xf32>)
+// CHECK-DAG:    vector.transfer_read %[[PDT_BUFFER_A]]{{.*}} vector<32xf4E2M1FN>
+// CHECK-DAG:    vector.transfer_read %[[PDT_BUFFER_B]]{{.*}} vector<32xf4E2M1FN>
+//     CHECK:    gpu.barrier
+//     CHECK:    amdgpu.scaled_mfma 16x16x128
+//     CHECK:    scf.yield
+//     CHECK:  }
+//     CHECK:  amdgpu.scaled_mfma 16x16x128

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -372,3 +372,97 @@ func.func @matmul_i8()
 //          CHECK:   }
 //          CHECK:   vector.transfer_write {{.*}} %[[GLOBAL_C]]{{.*}} : vector<{{.*}}xi32>, memref<{{.*}}xi32, #amdgpu.address_space<fat_raw_buffer>>
 //          CHECK:   iree_codegen.dispatch_config @matmul_i8 workgroup_size = [256, 1, 1] subgroup_size = 64
+
+// -----
+
+// DataTiledScaledMMAAttr with unshuffled_operands pipeline test: verifies XOR
+// swizzle hints on data operands, software pipelining, and amdgpu.scaled_mfma
+// generation.
+
+#executable_target_rocm_pdt = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout_pdt = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, Indirect>],
+  flags = Indirect
+>
+#translation_info_pdt = #iree_codegen.translation_info<pipeline =
+  #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64,
+  {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      prefetch_num_stages = 2,
+      no_reduce_shared_memory_bank_conflicts = true>
+  }
+>
+#config_pdt = #iree_gpu.lowering_config<{
+  workgroup = [1, 1, 0, 0],
+  reduction = [0, 0, 1, 1],
+  promote_operands = [0, 1, 2, 3],
+  promotion_types = [
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config,
+      swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.swizzle_operand<copy_config = #iree_gpu.derived_thread_config,
+      swizzle = #iree_codegen.xor_shuffle<256, 32>>,
+    #iree_gpu.derived_thread_config,
+    #iree_gpu.derived_thread_config]
+}>
+func.func @partial_dt_scaled_mma()
+  attributes {hal.executable.target = #executable_target_rocm_pdt, translation_info = #translation_info_pdt} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>>
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout_pdt) binding(4) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 16, 4, 32], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>> -> tensor<9x9x1x16x4x32xf4E2M1FN>
+  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 16, 4, 32], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x16x4x32xf4E2M1FN>> -> tensor<9x9x1x16x4x32xf4E2M1FN>
+  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [9, 9, 4, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>> -> tensor<9x9x4x16xf8E8M0FNU>
+  %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [9, 9, 4, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x16xf8E8M0FNU>> -> tensor<9x9x4x16xf8E8M0FNU>
+  %9 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>> -> tensor<9x9x4x16x4xf32>
+  %10 = iree_codegen.inner_tiled ins(%5, %6, %7, %8) outs(%9) {
+    lowering_config = #config_pdt,
+    indexing_maps = [
+      affine_map<(m, n, k, kb) -> (m, k, kb)>,
+      affine_map<(m, n, k, kb) -> (n, k, kb)>,
+      affine_map<(m, n, k, kb) -> (m, k)>,
+      affine_map<(m, n, k, kb) -> (n, k)>,
+      affine_map<(m, n, k, kb) -> (m, n)>],
+    iterator_types = [
+      #linalg.iterator_type<parallel>,
+      #linalg.iterator_type<parallel>,
+      #linalg.iterator_type<reduction>,
+      #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32,
+      operands_interleaving_intrinsics_m = [2],
+      operands_interleaving_intrinsics_n = [3],
+      operands_interleaving_intrinsics_k = [2, 3],
+      unshuffled_operands = [0, 1]>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>}
+    : tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x1x16x4x32xf4E2M1FN>, tensor<9x9x4x16xf8E8M0FNU>, tensor<9x9x4x16xf8E8M0FNU> into tensor<9x9x4x16x4xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %4, offsets = [0, 0, 0, 0, 0], sizes = [9, 9, 4, 16, 4], strides = [1, 1, 1, 1, 1] : tensor<9x9x4x16x4xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x16x4xf32>>
+  return
+}
+
+// CHECK-LABEL: func.func @partial_dt_scaled_mma()
+// CHECK-DAG:  %[[PDT_C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:  %[[PDT_C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:  %[[PDT_C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:  %[[PDT_BUFFER_A:.+]] = amdgpu.fat_raw_buffer_cast %{{.*}} : memref<9x9x1x16x4x32xf4E2M1FN{{.*}}> to memref<9x9x1x16x4x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-DAG:  %[[PDT_BUFFER_B:.+]] = amdgpu.fat_raw_buffer_cast %{{.*}} : memref<9x9x1x16x4x32xf4E2M1FN{{.*}}> to memref<9x9x1x16x4x32xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-DAG:  %[[PDT_A_ALLOC:.+]] = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 32>} : memref<2048xf4E2M1FN, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[PDT_B_ALLOC:.+]] = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<256, 32>} : memref<2048xf4E2M1FN, #gpu.address_space<workgroup>>
+//     CHECK:  gpu.barrier memfence [#gpu.address_space<workgroup>]
+//     CHECK:  scf.for {{.*}} %[[PDT_C0]] to %[[PDT_C8]] step %[[PDT_C1]] iter_args({{.*}}) -> (vector<4xf32>)
+// CHECK-DAG:    vector.transfer_read %[[PDT_BUFFER_A]]{{.*}} vector<32xf4E2M1FN>
+// CHECK-DAG:    vector.transfer_read %[[PDT_BUFFER_B]]{{.*}} vector<32xf4E2M1FN>
+//     CHECK:    gpu.barrier
+//     CHECK:    amdgpu.scaled_mfma 16x16x128
+//     CHECK:    scf.yield
+//     CHECK:  }
+//     CHECK:  amdgpu.scaled_mfma 16x16x128

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -824,6 +824,16 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
       return failure();
     }
   }
+  if (auto dtsmma = dyn_cast<IREE::GPU::DataTiledScaledMMAAttr>(intrinsic)) {
+    switch (dtsmma.getIntrinsic()) {
+    case IREE::GPU::ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+      return XorShuffleParams({/*rowElems=*/256,
+                               /*accessElems=*/32});
+    // TODO(muzasyed): Derive XOR params for MFMA_SCALE_F32_32x32x64_B32.
+    default:
+      return failure();
+    }
+  }
   return failure();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -826,6 +826,15 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
       return failure();
     }
   }
+  if (auto dtsmma = dyn_cast<IREE::GPU::DataTiledScaledMMAAttr>(intrinsic)) {
+    switch (dtsmma.getIntrinsic()) {
+    case IREE::GPU::ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+      return XorShuffleParams({/*rowElems=*/256,
+                               /*accessElems=*/32});
+    default:
+      return failure();
+    }
+  }
   return failure();
 }
 


### PR DESCRIPTION
This PR is part of series of PRs aiming to enable scale operand preshuffling for mxfp4 gemms on cdna4.

When DataTiledScaledMMAAttr has unshuffled operands, the inner-tiled lowering config now:
  - Promotes all 4 operands (data + scales) to shared memory
  - Computes XOR shuffle swizzle attrs for LHS/RHS bank conflict avoidance
  - Defaults to 2 prefetch stages for software pipelining

Also adds getSingleSubgroupLayout support for DataTiledScaledMMAAttr and XorShuffleParams for the MFMA_SCALE_F32_16x16x128_B32 intrinsic.

Made-with: Cursor