### PR TITLE
[Bazel] Move HAL materializeConstant to break IR/HALDialect circular dependency

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
@@ -112,7 +112,6 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/VM/Conversion",
         "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -71,7 +71,6 @@ iree_cc_library(
   DEPS
     ::IR
     LLVMSupport
-    MLIRArithDialect
     MLIRControlFlowDialect
     MLIRFuncDialect
     MLIRFunctionInterfaces

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Parser/Parser.h"
 
@@ -1342,6 +1343,19 @@ void HALDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
       assert(false && "unhandled HAL attribute kind");
     }
   });
+}
+
+//===----------------------------------------------------------------------===//
+// Dialect hooks
+//===----------------------------------------------------------------------===//
+
+Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
+                                           Type type, Location loc) {
+  if (!isa<IndexType>(type)) {
+    return nullptr;
+  }
+  return mlir::arith::ConstantIndexOp::create(
+      builder, loc, cast<IntegerAttr>(value).getValue().getSExtValue());
 }
 
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -1352,7 +1352,7 @@ void HALDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
 Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
   if (isa<IndexType>(type)) {
-    // Some folders materialize raw index types, which just become std
+    // Some folders materialize raw index types, which just become arith
     // constants.
     return mlir::arith::ConstantIndexOp::create(
         builder, loc, cast<IntegerAttr>(value).getValue().getSExtValue());

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -1351,11 +1351,13 @@ void HALDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
 
 Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
-  if (!isa<IndexType>(type)) {
-    return nullptr;
+  if (isa<IndexType>(type)) {
+    // Some folders materialize raw index types, which just become std
+    // constants.
+    return mlir::arith::ConstantIndexOp::create(
+        builder, loc, cast<IntegerAttr>(value).getValue().getSExtValue());
   }
-  return mlir::arith::ConstantIndexOp::create(
-      builder, loc, cast<IntegerAttr>(value).getValue().getSExtValue());
+  return nullptr;
 }
 
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -15,7 +15,6 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/VM/Conversion/ConversionDialectInterface.h"
 #include "llvm/Support/SourceMgr.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -192,21 +191,6 @@ HALDialect::HALDialect(MLIRContext *context)
   addInterfaces<HALInlinerInterface, HALOpAsmInterface,
                 HALAffinityAnalysisDialectInterface,
                 HALToVMConversionInterface>();
-}
-
-//===----------------------------------------------------------------------===//
-// Dialect hooks
-//===----------------------------------------------------------------------===//
-
-Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
-                                           Type type, Location loc) {
-  if (isa<IndexType>(type)) {
-    // Some folders materialize raw index types, which just become std
-    // constants.
-    return mlir::arith::ConstantIndexOp::create(
-        builder, loc, cast<IntegerAttr>(value).getValue().getSExtValue());
-  }
-  return nullptr;
 }
 
 } // namespace mlir::iree_compiler::IREE::HAL


### PR DESCRIPTION
The previous IREE has a hidden circular reference at link time:
```
:HALDialect --depends on--> :IR
:IR (vtable in HALAttrs.o) --references--> :HALDialect (materializeConstant in HALDialect.o)
```
This becomes a problem for build targets that intend to depend only on `:IR`:
1. They must add `:HALDialect` to Bazel deps to resolve:
```
cmake linker error: undefined symbol: mlir::iree_compiler::IREE::HAL::HALDialect::materializeConstant(mlir::OpBuilder&, mlir::Attribute, mlir::Type, mlir::Location)
>>> referenced by HALAttrs.cpp
>>>               lib/libiree_compiler_Dialect_HAL_IR_IR.a(lib/../compiler/src/iree/compiler/Dialect/HAL/IR/CMakeFiles/iree_compiler_Dialect_HAL_IR_IR.objects.dir/HALAttrs.cpp.o)
```
2. Bazel then sorted `:HALDialect` before `:IR` and result in:
```
ld.lld: error: backward reference detected: _ZN4mlir13iree_compiler4IREE3HAL10HALDialect19materializeConstantERNS_9OpBuilderENS_9AttributeENS_4TypeENS_8LocationE in bazel-out/k8-opt/bin/compiler/src/iree/compiler/Dialect/HAL/IR/_objs/IR/HALAttrs.pic.o refers to bazel-out/k8-opt/bin/compiler/src/iree/compiler/Dialect/HAL/IR/_objs/HALDialect/HALDialect.pic.o
```

This PR moves `materializeConstant` to `HALAttrs.cpp`, which is included in `:IR` srcs, breaking the reference cycle.