### PR TITLE
[VectorDistribute] Support `linalg_ext.scan` in `ConfigureTensorLayouts`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -191,6 +191,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:GPUTransformOps",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:IndexingMapOpInterface",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -131,6 +131,7 @@ iree_cc_library(
     MLIRGPUTransformOps
     MLIRGPUTransforms
     MLIRIR
+    MLIRIndexingMapOpInterface
     MLIRLLVMCommonConversion
     MLIRLLVMDialect
     MLIRLinalgDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -10,10 +10,12 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/IndexingMapOpInterface.h"
 
 #include "iree/compiler/Codegen/Utils/Utils.h"
 
@@ -284,14 +286,14 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
   return ContractionLayout{lhs, rhs, acc};
 }
 
-SmallVector<int64_t> getIterationSpaceBounds(linalg::LinalgOp linalgOp) {
-  SmallVector<int64_t> bounds = linalgOp.getStaticLoopRanges();
-  std::optional<VectorizationTileSizes> sizes =
-      inferSizesFromIR(linalgOp, std::nullopt);
-  // Even though the opShape could be dynamic, we could potentially
-  // infer the vector shape
-  if (sizes.has_value()) {
-    bounds = sizes.value().vectorSizes;
+SmallVector<int64_t> getIterationSpaceBounds(IndexingMapOpInterface candidate) {
+  SmallVector<int64_t> bounds = candidate.getStaticLoopRanges();
+  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(candidate.getOperation())) {
+    std::optional<VectorizationTileSizes> sizes =
+        inferSizesFromIR(linalgOp, std::nullopt);
+    if (sizes.has_value()) {
+      bounds = sizes.value().vectorSizes;
+    }
   }
   return bounds;
 }
@@ -354,31 +356,24 @@ setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
 }
 
 static LogicalResult setDerivedThreadConfigLayout(
-    IREE::GPU::DerivedThreadConfigAttr config, linalg::LinalgOp linalgOp,
+    IREE::GPU::DerivedThreadConfigAttr config, IndexingMapOpInterface candidate,
     ArrayRef<int64_t> workgroupSize, RewriterBase &rewriter) {
 
-  int64_t opRank = linalgOp.getNumLoops();
+  SmallVector<int64_t> opShape = getIterationSpaceBounds(candidate);
+  int64_t opRank = opShape.size();
 
   SmallVector<int64_t> elementTile = config.getStaticTilingLevelSizes(
-      static_cast<unsigned>(IREE::GPU::TilingLevel::Thread), linalgOp);
-
-  SmallVector<int64_t> opShape = linalgOp.getStaticLoopRanges();
-  std::optional<VectorizationTileSizes> sizes =
-      inferSizesFromIR(linalgOp, std::nullopt);
-  // Even though the opShape could be dynamic, we could potentially
-  // infer the vector shape
-  if (sizes.has_value()) {
-    opShape = sizes.value().vectorSizes;
-  }
+      static_cast<unsigned>(IREE::GPU::TilingLevel::Thread),
+      candidate.getOperation());
 
   for (auto [index, size, element] : llvm::enumerate(opShape, elementTile)) {
     if (ShapedType::isDynamic(size)) {
-      linalgOp->emitError() << "opShape could not be inferred";
+      candidate->emitError() << "opShape could not be inferred";
       return failure();
     }
 
     if (size % element != 0) {
-      linalgOp->emitError()
+      candidate->emitError()
           << "Operation with unsupported number of elements. "
              "Chosen vector tile sizes for operation are not "
              "divisible by operation loop ranges at dim: "
@@ -403,7 +398,8 @@ static LogicalResult setDerivedThreadConfigLayout(
     } else if (size % residualThreads == 0) {
       threadBlock = residualThreads;
     } else {
-      linalgOp->emitError() << "Operation with unsupported number of elements.";
+      candidate->emitError()
+          << "Operation with unsupported number of elements.";
       return failure();
     }
 
@@ -424,13 +420,15 @@ static LogicalResult setDerivedThreadConfigLayout(
       context, subgroupTile, opShape, outerTile, threadTile, elementTile,
       subgroupStrides, threadStrides);
 
-  Location loc = linalgOp.getLoc();
+  Location loc = candidate->getLoc();
+  auto dpsOp = cast<DestinationStyleOpInterface>(candidate.getOperation());
 
-  rewriter.setInsertionPointAfter(linalgOp);
-  for (OpResult result : linalgOp->getResults()) {
-    VectorLayoutInterface resultLayout =
-        layout.apply(linalgOp.getIndexingMapMatchingResult(result));
-    auto toLayout = ToLayoutOp::create(rewriter, loc, result, resultLayout);
+  rewriter.setInsertionPointAfter(candidate.getOperation());
+  for (OpResult result : candidate->getResults()) {
+    AffineMap resultMap = candidate.getMatchingIndexingMap(
+        dpsOp.getDpsInitOperand(result.getResultNumber()));
+    auto toLayout =
+        ToLayoutOp::create(rewriter, loc, result, layout.apply(resultMap));
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 
@@ -458,16 +456,16 @@ static LogicalResult setIntrinsicLoweringConfigLayout(
 }
 
 static LogicalResult setGPULoweringConfigLayout(
-    IREE::GPU::LoweringConfigAttr config, linalg::LinalgOp candidate,
+    IREE::GPU::LoweringConfigAttr config, IndexingMapOpInterface candidate,
     ArrayRef<int64_t> workgroupSize, RewriterBase &rewriter) {
   MLIRContext *context = config.getContext();
-  Location loc = candidate.getLoc();
+  Location loc = candidate->getLoc();
 
   SmallVector<int64_t> bounds = getIterationSpaceBounds(candidate);
 
   // Subgroup distribution layouts.
   SmallVector<int64_t> subgroupSizes, subgroupStrides;
-  if (failed(distributeTilingSizes(candidate, config,
+  if (failed(distributeTilingSizes(candidate.getOperation(), config,
                                    IREE::GPU::TilingLevel::Subgroup, bounds,
                                    subgroupSizes, subgroupStrides))) {
     return failure();
@@ -475,7 +473,7 @@ static LogicalResult setGPULoweringConfigLayout(
 
   // Thread distribution layouts.
   SmallVector<int64_t> threadSizes, threadStrides;
-  if (failed(distributeTilingSizes(candidate, config,
+  if (failed(distributeTilingSizes(candidate.getOperation(), config,
                                    IREE::GPU::TilingLevel::Thread, bounds,
                                    threadSizes, threadStrides))) {
     return failure();
@@ -483,7 +481,8 @@ static LogicalResult setGPULoweringConfigLayout(
 
   // Use thread tile sizes as the vector width for each thread.
   SmallVector<int64_t> threadTileSizes = config.getStaticTilingLevelSizes(
-      llvm::to_underlying(IREE::GPU::TilingLevel::Thread), candidate);
+      llvm::to_underlying(IREE::GPU::TilingLevel::Thread),
+      candidate.getOperation());
   FailureOr<SmallVector<int64_t>> elementTile =
       divideTile(bounds, threadTileSizes);
   if (failed(elementTile)) {
@@ -499,9 +498,10 @@ static LogicalResult setGPULoweringConfigLayout(
       context, subgroupSizes, batchTile, outerTile, threadSizes,
       elementTile.value(), subgroupStrides, threadStrides);
 
-  SmallVector<bool> promotedOperands = getPromotedOperands(candidate);
+  SmallVector<bool> promotedOperands =
+      getPromotedOperands(candidate.getOperation());
 
-  rewriter.setInsertionPoint(candidate);
+  rewriter.setInsertionPoint(candidate.getOperation());
   for (OpOperand &operand : candidate->getOpOperands()) {
     VectorLayoutInterface operandLayout =
         layout.apply(candidate.getMatchingIndexingMap(&operand));
@@ -513,11 +513,13 @@ static LogicalResult setGPULoweringConfigLayout(
     operand.set(toLayout);
   }
 
-  rewriter.setInsertionPointAfter(candidate);
+  auto dpsOp = cast<DestinationStyleOpInterface>(candidate.getOperation());
+  rewriter.setInsertionPointAfter(candidate.getOperation());
   for (OpResult result : candidate->getResults()) {
-    VectorLayoutInterface resultLayout =
-        layout.apply(candidate.getIndexingMapMatchingResult(result));
-    auto toLayout = ToLayoutOp::create(rewriter, loc, result, resultLayout);
+    AffineMap resultMap = candidate.getMatchingIndexingMap(
+        dpsOp.getDpsInitOperand(result.getResultNumber()));
+    auto toLayout =
+        ToLayoutOp::create(rewriter, loc, result, layout.apply(resultMap));
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 
@@ -554,27 +556,31 @@ struct LLVMGPUConfigureTensorLayoutsPass final
   LogicalResult setLayoutsFromLoweringConfig(FunctionOpInterface funcOp,
                                              ArrayRef<int64_t> workgroupSize,
                                              RewriterBase &rewriter) {
-    SmallVector<linalg::LinalgOp> candidates;
-    funcOp->walk([&](linalg::LinalgOp op) {
-      if (getLoweringConfig(op)) {
-        candidates.push_back(op);
+    SmallVector<Operation *> candidates;
+    funcOp.walk([&](Operation *op) {
+      if (!isa<linalg::LinalgOp, IREE::LinalgExt::ScanOp>(op) ||
+          !getLoweringConfig(op)) {
+        return;
       }
+      candidates.push_back(op);
     });
 
-    for (linalg::LinalgOp candidate : candidates) {
-      auto result =
+    for (Operation *candidate : candidates) {
+      auto indexingMapOp = cast<IndexingMapOpInterface>(candidate);
+      LogicalResult result =
           TypeSwitch<IREE::Codegen::LoweringConfigAttrInterface, LogicalResult>(
               getLoweringConfig(candidate))
               .Case([&](IREE::GPU::DerivedThreadConfigAttr config) {
-                return setDerivedThreadConfigLayout(config, candidate,
+                return setDerivedThreadConfigLayout(config, indexingMapOp,
                                                     workgroupSize, rewriter);
               })
               .Case([&](IREE::GPU::LoweringConfigAttr config) {
                 if (getMmaKind(config)) {
                   return setIntrinsicLoweringConfigLayout(
-                      config, candidate, workgroupSize, rewriter);
+                      config, cast<linalg::LinalgOp>(candidate), workgroupSize,
+                      rewriter);
                 }
-                return setGPULoweringConfigLayout(config, candidate,
+                return setGPULoweringConfigLayout(config, indexingMapOp,
                                                   workgroupSize, rewriter);
               })
               .Default(failure());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -54,6 +54,46 @@ func.func @matmul_96x64x16_mfma(%lhs: tensor<96x16xf16>,
                                               workgroup_size = [64, 1, 1]
                                               subgroup_size = 64>
 
+#scan_config = #iree_gpu.lowering_config<{
+  subgroup_basis = [[1, 1], [0, 1]],
+  lane_basis = [[1, 8], [0, 1]],
+  thread = [1, 8]
+}>
+
+func.func @scan_dim1(%input: tensor<4x16xf32>,
+                     %output: tensor<4x16xf32>,
+                     %accum: tensor<4xf32>)
+                     -> (tensor<4x16xf32>, tensor<4xf32>)
+                     attributes {translation_info = #translation} {
+  %result:2 = iree_linalg_ext.scan {lowering_config = #scan_config}
+      dimension(1) inclusive(true)
+      ins(%input : tensor<4x16xf32>)
+      outs(%output, %accum : tensor<4x16xf32>, tensor<4xf32>) {
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      iree_linalg_ext.yield %sum : f32
+  } -> tensor<4x16xf32>, tensor<4xf32>
+  return %result#0, %result#1 : tensor<4x16xf32>, tensor<4xf32>
+}
+
+// CHECK-DAG: #[[$SCAN_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [4, 1], outer_tile = [1, 1], thread_tile = [1, 8], element_tile = [1, 8], subgroup_strides = [0, 0], thread_strides = [0, 1]>
+// CHECK-DAG: #[[$SCAN_ACC_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1], batch_tile = [4], outer_tile = [1], thread_tile = [1], element_tile = [1], subgroup_strides = [0], thread_strides = [0]>
+// CHECK-LABEL: func.func @scan_dim1
+// CHECK-DAG: %[[INPUT_LAYOUT:.+]] = iree_vector_ext.to_layout %arg0 to layout(#[[$SCAN_LAYOUT]]) : tensor<4x16xf32>
+// CHECK-DAG: %[[OUTPUT_LAYOUT:.+]] = iree_vector_ext.to_layout %arg1 to layout(#[[$SCAN_LAYOUT]]) : tensor<4x16xf32>
+// CHECK-DAG: %[[ACC_LAYOUT:.+]] = iree_vector_ext.to_layout %arg2 to layout(#[[$SCAN_ACC_LAYOUT]]) : tensor<4xf32>
+// CHECK: %[[SCAN0:.+]]:2 = iree_linalg_ext.scan
+// CHECK-SAME: ins(%[[INPUT_LAYOUT]] : tensor<4x16xf32>)
+// CHECK-SAME: outs(%[[OUTPUT_LAYOUT]], %[[ACC_LAYOUT]] : tensor<4x16xf32>, tensor<4xf32>)
+// CHECK-DAG: iree_vector_ext.to_layout %[[SCAN0]]#0 to layout(#[[$SCAN_LAYOUT]]) : tensor<4x16xf32>
+// CHECK-DAG: iree_vector_ext.to_layout %[[SCAN0]]#1 to layout(#[[$SCAN_ACC_LAYOUT]]) : tensor<4xf32>
+
+// -----
+
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+                                              workgroup_size = [64, 1, 1]
+                                              subgroup_size = 64>
+
 #maps = [
   affine_map<(m, n, k) -> (m, k)>,
   affine_map<(m, n, k) -> (n, k)>,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1242,6 +1242,30 @@ ScanOp::reifyResultShapes(OpBuilder &b,
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
+ArrayAttr ScanOp::getIndexingMaps() {
+  Builder b(getContext());
+  return b.getAffineMapArrayAttr(getIndexingMapsArray());
+}
+
+SmallVector<AffineMap> ScanOp::getIndexingMapsArray() {
+  MLIRContext *ctx = getContext();
+  int64_t rank = getOperandRank();
+
+  AffineMap inputOutputMap = AffineMap::getMultiDimIdentityMap(rank, ctx);
+
+  SmallVector<AffineExpr> accumulatorResults;
+  accumulatorResults.reserve(rank - 1);
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (dim == getDimension()) {
+      continue;
+    }
+    accumulatorResults.push_back(getAffineDimExpr(dim, ctx));
+  }
+  AffineMap accumulatorMap = AffineMap::get(rank, 0, accumulatorResults, ctx);
+
+  return {inputOutputMap, inputOutputMap, accumulatorMap};
+}
+
 MutableOperandRange ScanOp::getDpsInitsMutable() {
   return MutableOperandRange(*this, /*numInputs=*/1, /*numInits=*/2);
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1243,11 +1243,6 @@ ScanOp::reifyResultShapes(OpBuilder &b,
 }
 
 ArrayAttr ScanOp::getIndexingMaps() {
-  Builder b(getContext());
-  return b.getAffineMapArrayAttr(getIndexingMapsArray());
-}
-
-SmallVector<AffineMap> ScanOp::getIndexingMapsArray() {
   MLIRContext *ctx = getContext();
   int64_t rank = getOperandRank();
 
@@ -1263,7 +1258,9 @@ SmallVector<AffineMap> ScanOp::getIndexingMapsArray() {
   }
   AffineMap accumulatorMap = AffineMap::get(rank, 0, accumulatorResults, ctx);
 
-  return {inputOutputMap, inputOutputMap, accumulatorMap};
+  Builder b(ctx);
+  return b.getAffineMapArrayAttr(
+      {inputOutputMap, inputOutputMap, accumulatorMap});
 }
 
 MutableOperandRange ScanOp::getDpsInitsMutable() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -602,7 +602,8 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
 }
 
 def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
-    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+    [IndexingMapOpInterface,
+     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["generateScalarImplementation",
        "getIterationDomain",
@@ -640,6 +641,9 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
     int64_t getOperandRank() {
       return getOperandType().getRank();
     }
+
+    ArrayAttr getIndexingMaps();
+    SmallVector<AffineMap> getIndexingMapsArray();
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -602,7 +602,7 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
 }
 
 def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
-    [IndexingMapOpInterface,
+    [DeclareOpInterfaceMethods<IndexingMapOpInterface>,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["generateScalarImplementation",
@@ -641,9 +641,6 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
     int64_t getOperandRank() {
       return getOperandType().getRank();
     }
-
-    ArrayAttr getIndexingMaps();
-    SmallVector<AffineMap> getIndexingMapsArray();
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface


### PR DESCRIPTION
Implements the `IndexingMapOpInterface` for `linalg_ext.scan` and then uses that interface in the `LLVMGPUConfigureTensorLayouts` pass to to make the pass more generic and allow inserting `to_layout` operations based on the lowering configuration attached to a `linalg_ext.scan`. 

This is part of https://github.com/iree-org/iree/issues/24186.

Assisted-by: Claude Code and Codex