### PR TITLE
[DispatchCreation] Check all operands of a consumer before fusing

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -658,11 +658,7 @@ fuseRootsWithConsumers(MLIRContext *context, ArrayRef<Operation *> roots,
       }
 
       // Group operands by owning consumer so the per-operand checks inside
-      // `isFusableWithConsumer` (e.g. pack-identity, insert_slice source
-      // single-use) are evaluated for every operand of a consumer, not just
-      // the first. Without the grouping, the first operand's verdict would
-      // mark the consumer fused and subsequent operands would be skipped via
-      // `isFusedOp`.
+      // `isFusableWithConsumer` are evaluated for every operand of a consumer.
       llvm::MapVector<Operation *, SmallVector<OpOperand *>> usesByConsumer;
       for (OpOperand *use : fusableUses) {
         usesByConsumer[use->getOwner()].push_back(use);
@@ -680,8 +676,6 @@ fuseRootsWithConsumers(MLIRContext *context, ArrayRef<Operation *> roots,
           continue;
         }
 
-        // All operands of this consumer that come from the current producer
-        // must pass the per-operand fusibility check.
         if (!llvm::all_of(operands, [&](OpOperand *use) {
               return isFusableWithConsumer(*use, tracker, options);
             })) {

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -657,24 +657,38 @@ fuseRootsWithConsumers(MLIRContext *context, ArrayRef<Operation *> roots,
         continue;
       }
 
-      // Analyse the use to see if it is fusable.
-      for (OpOperand *fusableUse : fusableUses) {
-        Operation *consumerOp = fusableUse->getOwner();
+      // Group operands by owning consumer so the per-operand checks inside
+      // `isFusableWithConsumer` (e.g. pack-identity, insert_slice source
+      // single-use) are evaluated for every operand of a consumer, not just
+      // the first. Without the grouping, the first operand's verdict would
+      // mark the consumer fused and subsequent operands would be skipped via
+      // `isFusedOp`.
+      llvm::MapVector<Operation *, SmallVector<OpOperand *>> usesByConsumer;
+      for (OpOperand *use : fusableUses) {
+        usesByConsumer[use->getOwner()].push_back(use);
+      }
+
+      for (auto &[consumerOp, operands] : usesByConsumer) {
         if (tracker.isRootOp(consumerOp) || tracker.isFusedOp(consumerOp)) {
           continue;
         }
 
         // Ensure that fusing the consumer would not cause use-def violations.
         if (tracker.getFusionGroup(currRoot)
-                .hasTransitiveDependencyOnFusionGroup(fusableUse->getOwner(),
+                .hasTransitiveDependencyOnFusionGroup(consumerOp,
                                                       dominanceInfo)) {
           continue;
         }
 
-        if (isFusableWithConsumer(*fusableUse, tracker, options)) {
-          tracker.appendToFusionGroup(consumerOp, fusionGroup);
-          workList.push_back(consumerOp);
+        // All operands of this consumer that come from the current producer
+        // must pass the per-operand fusibility check.
+        if (!llvm::all_of(operands, [&](OpOperand *use) {
+              return isFusableWithConsumer(*use, tracker, options);
+            })) {
+          continue;
         }
+        tracker.appendToFusionGroup(consumerOp, fusionGroup);
+        workList.push_back(consumerOp);
       }
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -2763,10 +2763,6 @@ util.func public @scatter_chain_dispatch_ordering(
 // result 0 has a non-identity indexing map while result 1 has an identity
 // map, so the pack-identity per-operand check fails on the source operand
 // but passes on the dest operand. Fusion must be rejected.
-//
-// Without the group-by-consumer fix in fuseRootsWithConsumers, the first
-// operand's failure is silently dropped: the loop moves on, the dest
-// operand passes, and pack is incorrectly appended to the fusion group.
 
 util.func public @pack_per_operand_rejection(
     %a: tensor<1x1xf32>, %b: tensor<1x1xf32>) -> tensor<1x1x1x1xf32> {

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -2756,3 +2756,48 @@ util.func public @scatter_chain_dispatch_ordering(
 //      CHECK:     iree_linalg_ext.scatter
 // CHECK-SAME:       outs(%[[S2]]
 //      CHECK:   util.return %[[S3]]
+
+// -----
+
+// Multi-result producer feeds a pack consumer via two operands. Producer
+// result 0 has a non-identity indexing map while result 1 has an identity
+// map, so the pack-identity per-operand check fails on the source operand
+// but passes on the dest operand. Fusion must be rejected.
+//
+// Without the group-by-consumer fix in fuseRootsWithConsumers, the first
+// operand's failure is silently dropped: the loop moves on, the dest
+// operand passes, and pack is incorrectly appended to the fusion group.
+
+util.func public @pack_per_operand_rejection(
+    %a: tensor<1x1xf32>, %b: tensor<1x1xf32>) -> tensor<1x1x1x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %eR = tensor.empty() : tensor<1x1xf32>
+  %fR = linalg.fill ins(%cst : f32) outs(%eR : tensor<1x1xf32>) -> tensor<1x1xf32>
+  %R = linalg.matmul ins(%a, %b : tensor<1x1xf32>, tensor<1x1xf32>)
+                    outs(%fR : tensor<1x1xf32>) -> tensor<1x1xf32>
+  %eA = tensor.empty() : tensor<1x1xf32>
+  %eB = tensor.empty() : tensor<1x1x1x1xf32>
+  %X:2 = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+      affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  } ins(%R : tensor<1x1xf32>) outs(%eA, %eB : tensor<1x1xf32>, tensor<1x1x1x1xf32>) {
+  ^bb0(%in: f32, %oA: f32, %oB: f32):
+    linalg.yield %in, %in : f32, f32
+  } -> (tensor<1x1xf32>, tensor<1x1x1x1xf32>)
+  %packed = linalg.pack %X#0 inner_dims_pos = [0, 1] inner_tiles = [1, 1] into %X#1 : tensor<1x1xf32> -> tensor<1x1x1x1xf32>
+  util.return %packed : tensor<1x1x1x1xf32>
+}
+
+//      CHECK-LABEL: @pack_per_operand_rejection
+//            CHECK:   %[[RX:.+]]:2 = flow.dispatch.region
+//            CHECK:     linalg.matmul
+//            CHECK:     linalg.generic
+//            CHECK:     flow.return
+//            CHECK:   flow.dispatch.region
+//            CHECK:     linalg.pack %[[RX]]#0
+//       CHECK-SAME:       into %[[RX]]#1
+//            CHECK:     flow.return


### PR DESCRIPTION
`fuseRootsWithConsumers` iterates `getFusableUses`'s result one `OpOperand` at a time. When > 1 operands share a consumer, the first operand's verdict marks the consumer fused and the second operand is skipped via `isFusedOp`. That silently drops per-operand rejections that `isFusableWithConsumer` could raise.


Fixes https://github.com/iree-org/iree/issues/24206