### PR TITLE
[Codegen] Move DMA feasibility checks to ConfigUtils

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -173,47 +173,6 @@ static bool sourceIsFromFatRawBuffer(Value source) {
   return hasAMDGPUFatRawBufferAddressSpace(memrefType);
 }
 
-/// Returns the subgroup size if the available elements are aligned to DMA
-/// transfer sizes, std::nullopt otherwise.
-static std::optional<int64_t>
-getDMAAlignedSubgroupSize(FunctionOpInterface funcOp, Type elementType,
-                          int64_t availableElements) {
-  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
-  if (!subgroupSize) {
-    return std::nullopt;
-  }
-
-  int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
-  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-  if (!target || !targetSupportsGlobalLoadDMA(target)) {
-    return std::nullopt;
-  }
-
-  ArrayRef<int64_t> dmaSizes;
-  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
-    dmaSizes = dmaSizesAttr.asArrayRef();
-  }
-
-  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-  for (int64_t dmaSize : dmaSizes) {
-    if (dmaSize % elementBits != 0) {
-      continue;
-    }
-    int64_t elementsPerLane = dmaSize / elementBits;
-    int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-    minElementsPerTransfer =
-        std::min(minElementsPerTransfer, elementsPerTransfer);
-  }
-
-  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
-      availableElements % minElementsPerTransfer != 0) {
-    return std::nullopt;
-  }
-
-  return subgroupSize;
-}
-
 /// Helper to compute thread number of threads based on translation_info.
 /// Uses the subgroup_size from translation_info for thread-level tiling.
 static SmallVector<OpFoldResult>
@@ -230,26 +189,14 @@ computeThreadNumThreadsImpl(OpBuilder &builder, Operation *op,
     return {};
   }
 
-  int64_t rank = outputType.getRank();
-  int64_t innermostDim = outputType.getShape()[rank - 1];
-  if (ShapedType::isDynamic(innermostDim)) {
+  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+  if (!subgroupSize) {
     return {};
   }
-
-  // Determine how many elements are available for coalesced access.
-  // For CopyOp with output tracing to tensor.empty(), we can linearize.
-  ArrayRef<int64_t> shape = outputType.getShape();
-  int64_t availableElements = innermostDim;
-  if (auto copyOp = dyn_cast<linalg::CopyOp>(op)) {
-    Value output = copyOp.getOutputs()[0];
-    if (tracesToTensorEmpty(output) &&
-        llvm::none_of(shape, ShapedType::isDynamic)) {
-      availableElements = ShapedType::getNumElements(shape);
-    }
-  }
-
-  auto subgroupSize = getDMAAlignedSubgroupSize(
-      funcOp, outputType.getElementType(), availableElements);
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+  subgroupSize = getDMAAlignedSubgroupSize(target, *subgroupSize,
+                                           outputType.getElementType(),
+                                           outputType.getShape());
   if (!subgroupSize) {
     return {};
   }
@@ -273,55 +220,9 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
     return false;
   }
 
-  // Check if source tensor's innermost row size is DWORD (4-byte) aligned. On
-  // AMD CDNA, per-component range checking is performed for each DWORD. If a
-  // DWORD is partially out-of-bounds, the entire DWORD returns zero, causing
-  // incorrect results. Additionally, partial OOB triggers the slow path with
-  // multi-cycling and instruction issue penalties.
   auto sourceType = cast<RankedTensorType>(pad.getSource().getType());
-  int64_t innermostDim = sourceType.getShape().back();
-  if (ShapedType::isDynamic(innermostDim)) {
-    return false;
-  }
-  Type elemType = sourceType.getElementType();
-  int64_t rowBytes = innermostDim * (elemType.getIntOrFloatBitWidth() / 8);
-  return rowBytes % 4 == 0;
-}
-
-/// Check if a linalg.copy is viable for DMA conversion based on alignment,
-/// size and padding constraints. This does NOT modify the IR.
-static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
-  auto funcOp = copyOp->getParentOfType<FunctionOpInterface>();
-  if (!funcOp) {
-    return false;
-  }
-
-  auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
-  int64_t rank = outputType.getRank();
-  ArrayRef<int64_t> shape = outputType.getShape();
-  int64_t innermostDim = shape[rank - 1];
-  if (ShapedType::isDynamic(innermostDim)) {
-    return false;
-  }
-
-  // The pre-check runs before tiling but after promotion, so the output may
-  // have swizzle promotion ops (swizzle_hint, expand_shape) between it and
-  // tensor.empty. Use tracesToTensorEmpty to handle both cases.
-  int64_t availableElements = innermostDim;
-  Value output = copyOp.getOutputs()[0];
-  if (tracesToTensorEmpty(output) &&
-      llvm::none_of(shape, ShapedType::isDynamic)) {
-    availableElements = ShapedType::getNumElements(shape);
-  }
-
-  tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0]);
-  if (pad && !isValidPadForDMA(pad)) {
-    return false;
-  }
-
-  return getDMAAlignedSubgroupSize(funcOp, outputType.getElementType(),
-                                   availableElements)
-      .has_value();
+  return isDWORDAligned(sourceType.getShape().back(),
+                        sourceType.getElementType());
 }
 
 /// Check if the given forall op has warp mapping.
@@ -457,7 +358,10 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
     //   tensor.extract_slice %padded[...] [...] [1, 1]
     // We need to trace through extract_slice to find if source is tensor.pad.
     tensor::PadOp pad = traceToTensorPad(input);
-    if (pad && isValidPadForDMA(pad)) {
+    if (pad) {
+      assert(isValidPadForDMA(pad) &&
+             "DMA-marked copy has invalid pad; ConfigUtils should have "
+             "rejected DMA for this operation");
       source = pad.getSource();
       // Compute in_bounds based on whether padding was added per dimension.
       for (auto [low, high] :
@@ -466,11 +370,9 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
             isConstantIntValue(low, 0) && isConstantIntValue(high, 0);
         inBoundsVec.push_back(isInBounds);
       }
-    }
-
-    // Fallback: no tensor.pad fusion. The input is an extract_slice from
-    // tiling; trace through it to get the actual source.
-    if (!source) {
+    } else {
+      // No tensor.pad fusion. The input is an extract_slice from tiling;
+      // trace through it to get the actual source.
       if (auto extractSlice = input.getDefiningOp<tensor::ExtractSliceOp>()) {
         source = extractSlice.getSource();
       } else {
@@ -577,8 +479,6 @@ struct ConvertToCoalescedDMABase : OpRewritePattern<OpTy> {
     // createDMAInForall must not fail after tileToThreadLevel, because
     // tileToThreadLevel already erased the original op via replaceOp.
     // Failing here would leave a dangling reference (use-after-free).
-    // All eligibility checks must happen before this point (e.g., in
-    // isCopyDMAConvertible / computeThreadNumThreads).
     [[maybe_unused]] LogicalResult result =
         createDMAInForall<OpTy>(threadForallOp, rewriter);
     assert(succeeded(result) &&
@@ -600,9 +500,9 @@ protected:
   SmallVector<OpFoldResult>
   computeThreadNumThreads(OpBuilder &builder,
                           linalg::CopyOp copyOp) const override {
-    if (!sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
-      return {};
-    }
+    assert(sourceIsFromFatRawBuffer(copyOp.getInputs()[0]) &&
+           "DMA-marked copy source lacks fat_raw_buffer address space; "
+           "ConfigUtils canUseFatRawBuffer check may be out of sync");
     auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
     return computeThreadNumThreadsImpl(builder, copyOp, outputType);
   }
@@ -621,10 +521,9 @@ struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
       return failure();
     }
 
-    // Skip if source is not from fat_raw_buffer.
-    if (!sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
-      return failure();
-    }
+    assert(sourceIsFromFatRawBuffer(copyOp.getInputs()[0]) &&
+           "DMA-marked copy source lacks fat_raw_buffer address space; "
+           "ConfigUtils canUseFatRawBuffer check may be out of sync");
 
     // Check if this is a tensor.pad fusion case.
     tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0]);
@@ -850,48 +749,6 @@ struct GPUConvertToCoalescedDMAPass final
     FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
 
-    // Pre-check: decide whether all linalg.copy ops should be DMA-converted.
-    // Only activate when at least one copy already has use_global_load_dma
-    // (indicating DMA intent from upstream config, e.g. --iree-llvmgpu-use-
-    // direct-load). Collect all promoted copies (use_global_load_dma or
-    // derived_thread_config). If ALL are DMA-convertible, upgrade them all to
-    // use_global_load_dma. If ANY fails, downgrade them all to
-    // derived_thread_config.
-    // Note: GatherOps are excluded — they come from input IR (not from
-    // GPUPromoteMatmulOperands) and are handled independently by
-    // ConvertGatherToCoalescedDMA.
-    SmallVector<linalg::CopyOp> promotedCopies;
-    bool hasDMAIntent = false;
-    funcOp->walk([&](linalg::CopyOp copyOp) {
-      if (getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp)) {
-        hasDMAIntent = true;
-        promotedCopies.push_back(copyOp);
-      } else if (getLoweringConfig<IREE::GPU::DerivedThreadConfigAttr>(
-                     copyOp)) {
-        promotedCopies.push_back(copyOp);
-      }
-    });
-
-    if (hasDMAIntent) {
-      bool allConvertible = llvm::all_of(promotedCopies, isCopyDMAConvertible);
-      LLVM_DEBUG({
-        if (!allConvertible) {
-          llvm::dbgs() << "DMA pre-check: not all copies convertible, "
-                       << "downgrading " << promotedCopies.size()
-                       << " copies to derived_thread_config\n";
-        }
-      });
-      for (linalg::CopyOp copyOp : promotedCopies) {
-        if (allConvertible) {
-          setLoweringConfig(copyOp,
-                            IREE::GPU::UseGlobalLoadDMAAttr::get(context));
-        } else {
-          setLoweringConfig(copyOp,
-                            IREE::GPU::DerivedThreadConfigAttr::get(context));
-        }
-      }
-    }
-
     // Preprocessing: apply subgroup-level tiling.
     if (failed(applySubgroupTiling(funcOp))) {
       return signalPassFailure();
@@ -905,6 +762,20 @@ struct GPUConvertToCoalescedDMAPass final
     patterns.add<ConvertPadFusionCopyToCoalescedDMA>(context);
 
     walkAndApplyPatterns(funcOp, std::move(patterns));
+
+    // Verify all DMA-marked copies were converted.
+    WalkResult result = funcOp->walk([&](linalg::CopyOp copyOp) {
+      if (getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp)) {
+        copyOp.emitOpError(
+            "copy marked with use_global_load_dma was not converted to DMA; "
+            "DMA feasibility prediction in ConfigUtils may need updating");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted()) {
+      return signalPassFailure();
+    }
   }
 
 private:
@@ -1122,9 +993,12 @@ private:
     funcOp->walk([&](Operation *op) {
       if (auto copyOp = dyn_cast<linalg::CopyOp>(op)) {
         auto config = getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(op);
-        if (!config || !sourceIsFromFatRawBuffer(copyOp.getInputs()[0])) {
+        if (!config) {
           return;
         }
+        assert(sourceIsFromFatRawBuffer(copyOp.getInputs()[0]) &&
+               "DMA-marked copy source lacks fat_raw_buffer address space; "
+               "ConfigUtils canUseFatRawBuffer check may be out of sync");
         auto parentForall = op->getParentOfType<scf::ForallOp>();
         if (!hasWarpMapping(parentForall)) {
           opsToTile.push_back(op);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -173,47 +173,6 @@ static bool sourceIsFromFatRawBuffer(Value source) {
   return hasAMDGPUFatRawBufferAddressSpace(memrefType);
 }
 
-/// Returns the subgroup size if the available elements are aligned to DMA
-/// transfer sizes, std::nullopt otherwise.
-static std::optional<int64_t>
-getDMAAlignedSubgroupSize(FunctionOpInterface funcOp, Type elementType,
-                          int64_t availableElements) {
-  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
-  if (!subgroupSize) {
-    return std::nullopt;
-  }
-
-  int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
-  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-  if (!target || !targetSupportsGlobalLoadDMA(target)) {
-    return std::nullopt;
-  }
-
-  ArrayRef<int64_t> dmaSizes;
-  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
-    dmaSizes = dmaSizesAttr.asArrayRef();
-  }
-
-  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-  for (int64_t dmaSize : dmaSizes) {
-    if (dmaSize % elementBits != 0) {
-      continue;
-    }
-    int64_t elementsPerLane = dmaSize / elementBits;
-    int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-    minElementsPerTransfer =
-        std::min(minElementsPerTransfer, elementsPerTransfer);
-  }
-
-  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
-      availableElements % minElementsPerTransfer != 0) {
-    return std::nullopt;
-  }
-
-  return subgroupSize;
-}
-
 /// Largest numWarps in [1, totalWarps] (by repeated halving) such that
 /// `product(shape) / numWarps` satisfies the minimum DMA transfer alignment.
 /// Conservative for shapes that don't divide evenly (the real greedy in
@@ -250,27 +209,13 @@ computeThreadNumThreadsImpl(OpBuilder &builder, Operation *op,
     return {};
   }
 
-  int64_t rank = outputType.getRank();
-  int64_t innermostDim = outputType.getShape()[rank - 1];
-  if (ShapedType::isDynamic(innermostDim)) {
+  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+  if (!subgroupSize) {
     return {};
   }
-
-  // Determine how many elements are available for coalesced access.
-  // For CopyOp with output tracing to tensor.empty(), we can linearize.
-  ArrayRef<int64_t> shape = outputType.getShape();
-  int64_t availableElements = innermostDim;
-  if (auto copyOp = dyn_cast<linalg::CopyOp>(op)) {
-    Value output = copyOp.getOutputs()[0];
-    if (tracesToTensorEmpty(output) &&
-        llvm::none_of(shape, ShapedType::isDynamic)) {
-      availableElements = ShapedType::getNumElements(shape);
-    }
-  }
-
-  auto subgroupSize = getDMAAlignedSubgroupSize(
-      funcOp, outputType.getElementType(), availableElements);
-  if (!subgroupSize) {
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+  if (!isDMATransferAligned(target, *subgroupSize, outputType.getElementType(),
+                            outputType.getShape())) {
     return {};
   }
 
@@ -293,55 +238,8 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
     return false;
   }
 
-  // Check if source tensor's innermost row size is DWORD (4-byte) aligned. On
-  // AMD CDNA, per-component range checking is performed for each DWORD. If a
-  // DWORD is partially out-of-bounds, the entire DWORD returns zero, causing
-  // incorrect results. Additionally, partial OOB triggers the slow path with
-  // multi-cycling and instruction issue penalties.
   auto sourceType = cast<RankedTensorType>(pad.getSource().getType());
-  int64_t innermostDim = sourceType.getShape().back();
-  if (ShapedType::isDynamic(innermostDim)) {
-    return false;
-  }
-  Type elemType = sourceType.getElementType();
-  int64_t rowBytes = innermostDim * (elemType.getIntOrFloatBitWidth() / 8);
-  return rowBytes % 4 == 0;
-}
-
-/// Check if a linalg.copy is viable for DMA conversion based on alignment,
-/// size and padding constraints. This does NOT modify the IR.
-static bool isCopyDMAConvertible(linalg::CopyOp copyOp) {
-  auto funcOp = copyOp->getParentOfType<FunctionOpInterface>();
-  if (!funcOp) {
-    return false;
-  }
-
-  auto outputType = cast<RankedTensorType>(copyOp.getOutputs()[0].getType());
-  int64_t rank = outputType.getRank();
-  ArrayRef<int64_t> shape = outputType.getShape();
-  int64_t innermostDim = shape[rank - 1];
-  if (ShapedType::isDynamic(innermostDim)) {
-    return false;
-  }
-
-  // The pre-check runs before tiling but after promotion, so the output may
-  // have swizzle promotion ops (swizzle_hint, expand_shape) between it and
-  // tensor.empty. Use tracesToTensorEmpty to handle both cases.
-  int64_t availableElements = innermostDim;
-  Value output = copyOp.getOutputs()[0];
-  if (tracesToTensorEmpty(output) &&
-      llvm::none_of(shape, ShapedType::isDynamic)) {
-    availableElements = ShapedType::getNumElements(shape);
-  }
-
-  tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0]);
-  if (pad && !isValidPadForDMA(pad)) {
-    return false;
-  }
-
-  return getDMAAlignedSubgroupSize(funcOp, outputType.getElementType(),
-                                   availableElements)
-      .has_value();
+  return isTypeDWORDAligned(sourceType);
 }
 
 /// Check if the given forall op has warp mapping.
@@ -515,7 +413,8 @@ static Value createClampedSourceSliceFromPad(PatternRewriter &rewriter,
 /// Handles both copy and gather operations.
 template <typename OpTy>
 static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
-                                       PatternRewriter &rewriter) {
+                                       PatternRewriter &rewriter,
+                                       tensor::PadOp pad = nullptr) {
   // Find the inner operation.
   OpTy innerOp = nullptr;
   threadForallOp->walk([&](OpTy foundOp) {
@@ -551,14 +450,9 @@ static LogicalResult createDMAInForall(scf::ForallOp threadForallOp,
   if constexpr (std::is_same_v<OpTy, linalg::CopyOp>) {
     Value input = innerOp.getInputs()[0];
 
-    // After tiling, the input is typically:
-    //   tensor.extract_slice %padded[...] [...] [1, 1]
-    // We need to trace through extract_slice to find if source is tensor.pad.
-    tensor::PadOp pad = traceToTensorPad(input);
-    if (pad && isValidPadForDMA(pad)) {
+    if (pad) {
       source =
           createClampedSourceSliceFromPad(rewriter, loc, pad, inParallelOp);
-
       // Compute in_bounds based on whether padding was added per dimension.
       for (auto [low, high] :
            llvm::zip(pad.getMixedLowPad(), pad.getMixedHighPad())) {
@@ -662,6 +556,14 @@ struct ConvertToCoalescedDMABase : OpRewritePattern<OpTy> {
       return failure();
     }
 
+    tensor::PadOp pad = nullptr;
+    if constexpr (std::is_same_v<OpTy, linalg::CopyOp>) {
+      pad = traceToTensorPad(op.getInputs()[0]);
+      if (pad && !isValidPadForDMA(pad)) {
+        return failure();
+      }
+    }
+
     SmallVector<OpFoldResult> threadNumThreads =
         computeThreadNumThreads(rewriter, op);
     if (threadNumThreads.empty()) {
@@ -677,10 +579,8 @@ struct ConvertToCoalescedDMABase : OpRewritePattern<OpTy> {
     // createDMAInForall must not fail after tileToThreadLevel, because
     // tileToThreadLevel already erased the original op via replaceOp.
     // Failing here would leave a dangling reference (use-after-free).
-    // All eligibility checks must happen before this point (e.g., in
-    // isCopyDMAConvertible / computeThreadNumThreads).
     [[maybe_unused]] LogicalResult result =
-        createDMAInForall<OpTy>(threadForallOp, rewriter);
+        createDMAInForall<OpTy>(threadForallOp, rewriter, pad);
     assert(succeeded(result) &&
            "createDMAInForall must not fail after tileToThreadLevel erased "
            "the original op");
@@ -737,10 +637,10 @@ struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
       return failure();
     }
 
-    // Check if this is a tensor.pad fusion case.
+    // Check if this is a valid tensor.pad fusion case.
     tensor::PadOp pad = traceToTensorPad(copyOp.getInputs()[0]);
-    if (!pad) {
-      return failure(); // Not a pad fusion case
+    if (!pad || !isValidPadForDMA(pad)) {
+      return failure();
     }
 
     // Check if padding exists (non-zero low/high pad).
@@ -772,7 +672,7 @@ struct ConvertPadFusionCopyToCoalescedDMA : OpRewritePattern<linalg::CopyOp> {
     }
 
     [[maybe_unused]] LogicalResult result =
-        createDMAInForall<linalg::CopyOp>(threadForallOp, rewriter);
+        createDMAInForall<linalg::CopyOp>(threadForallOp, rewriter, pad);
     assert(succeeded(result) &&
            "createDMAInForall must not fail after tileToThreadLevel erased "
            "the original op");
@@ -817,38 +717,13 @@ struct ConvertGatherToCoalescedDMA
 
     // Validate that innermost dimension is large enough for coalesced DMA.
     auto outputType = cast<RankedTensorType>(gatherOp.getOutput().getType());
-    int64_t rank = outputType.getRank();
-    int64_t innermostDim = outputType.getShape()[rank - 1];
-    if (ShapedType::isDynamic(innermostDim)) {
-      return failure();
-    }
-
-    Type elementType = outputType.getElementType();
-    int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
     IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
     if (!target || !targetSupportsGlobalLoadDMA(target)) {
       return failure();
     }
-
-    ArrayRef<int64_t> dmaSizes;
-    if (DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes()) {
-      dmaSizes = dmaSizesAttr.asArrayRef();
-    }
-
-    int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-    for (int64_t dmaSize : dmaSizes) {
-      if (dmaSize % elementBits != 0) {
-        continue;
-      }
-      int64_t elementsPerLane = dmaSize / elementBits;
-      int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-      minElementsPerTransfer =
-          std::min(minElementsPerTransfer, elementsPerTransfer);
-    }
-
-    if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
-        innermostDim % minElementsPerTransfer != 0) {
+    if (!isDMATransferAligned(target, *subgroupSize,
+                              outputType.getElementType(),
+                              {outputType.getShape().back()})) {
       return failure();
     }
 
@@ -961,48 +836,6 @@ struct GPUConvertToCoalescedDMAPass final
     FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
 
-    // Pre-check: decide whether all linalg.copy ops should be DMA-converted.
-    // Only activate when at least one copy already has use_global_load_dma
-    // (indicating DMA intent from upstream config, e.g. --iree-llvmgpu-use-
-    // direct-load). Collect all promoted copies (use_global_load_dma or
-    // derived_thread_config). If ALL are DMA-convertible, upgrade them all to
-    // use_global_load_dma. If ANY fails, downgrade them all to
-    // derived_thread_config.
-    // Note: GatherOps are excluded — they come from input IR (not from
-    // GPUPromoteMatmulOperands) and are handled independently by
-    // ConvertGatherToCoalescedDMA.
-    SmallVector<linalg::CopyOp> promotedCopies;
-    bool hasDMAIntent = false;
-    funcOp->walk([&](linalg::CopyOp copyOp) {
-      if (getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp)) {
-        hasDMAIntent = true;
-        promotedCopies.push_back(copyOp);
-      } else if (getLoweringConfig<IREE::GPU::DerivedThreadConfigAttr>(
-                     copyOp)) {
-        promotedCopies.push_back(copyOp);
-      }
-    });
-
-    if (hasDMAIntent) {
-      bool allConvertible = llvm::all_of(promotedCopies, isCopyDMAConvertible);
-      LLVM_DEBUG({
-        if (!allConvertible) {
-          llvm::dbgs() << "DMA pre-check: not all copies convertible, "
-                       << "downgrading " << promotedCopies.size()
-                       << " copies to derived_thread_config\n";
-        }
-      });
-      for (linalg::CopyOp copyOp : promotedCopies) {
-        if (allConvertible) {
-          setLoweringConfig(copyOp,
-                            IREE::GPU::UseGlobalLoadDMAAttr::get(context));
-        } else {
-          setLoweringConfig(copyOp,
-                            IREE::GPU::DerivedThreadConfigAttr::get(context));
-        }
-      }
-    }
-
     // Preprocessing: apply subgroup-level tiling.
     if (failed(applySubgroupTiling(funcOp))) {
       return signalPassFailure();
@@ -1016,6 +849,20 @@ struct GPUConvertToCoalescedDMAPass final
     patterns.add<ConvertPadFusionCopyToCoalescedDMA>(context);
 
     walkAndApplyPatterns(funcOp, std::move(patterns));
+
+    // Verify all DMA-marked copies were converted.
+    WalkResult result = funcOp->walk([&](linalg::CopyOp copyOp) {
+      if (getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copyOp)) {
+        copyOp.emitOpError(
+            "copy marked with use_global_load_dma was not converted to DMA; "
+            "DMA feasibility prediction in ConfigUtils may need updating");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted()) {
+      return signalPassFailure();
+    }
   }
 
 private:

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -598,14 +598,13 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
     tensor.yield %cst : f16
   } : tensor<?x121xf16> to tensor<4x124xf16>
 
-  // Copy from padded tensor.
-  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+  // Copy from padded tensor. ConfigUtils rejects DMA because source row size
+  // (121 * 2 = 242 bytes) is not DWORD-aligned, so derived_thread_config is
+  // used instead.
+  %result = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
     ins(%padded : tensor<4x124xf16>)
     outs(%init : tensor<4x124xf16>) -> tensor<4x124xf16>
 
-  // Source row size (121 * 2 = 242 bytes) is not DWORD-aligned.
-  // Coalesced DMA bails out to avoid partial OOB in per-DWORD range checking.
-  // The copy is downgraded from use_global_load_dma to derived_thread_config.
   // CHECK: tensor.pad
   // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
   // CHECK-NOT: iree_gpu.coalesced_gather_dma
@@ -644,12 +643,12 @@ func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %
     tensor.yield %cst : i8
   } : tensor<?x?xi8> to tensor<4x256xi8>
 
-  // Copy from padded tensor.
-  %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
+  // Copy from padded tensor. ConfigUtils rejects DMA because source innermost
+  // dimension is dynamic, so derived_thread_config is used instead.
+  %result = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
     ins(%padded : tensor<4x256xi8>)
     outs(%init : tensor<4x256xi8>) -> tensor<4x256xi8>
 
-  // The copy is downgraded from use_global_load_dma to derived_thread_config.
   // CHECK: tensor.pad
   // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
   // CHECK-NOT: iree_gpu.coalesced_gather_dma

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-convert-to-coalesced-dma,canonicalize))" %s --split-input-file | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-convert-to-coalesced-dma,canonicalize))" %s --split-input-file --verify-diagnostics 2>&1 | FileCheck %s
 
 #gpu_target_copy = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
@@ -114,20 +114,12 @@ func.func @gather(%source: tensor<64x512xf32>, %indices: tensor<64xi32>, %init: 
 #exec_target_small_inner = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_small_inner}>
 #translation_small_inner = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_small_innermost_dim
-// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<64x32xf32>
-// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x32xf32>
 func.func @copy_small_innermost_dim(%source: tensor<64x32xf32>, %init: tensor<64x32xf32>) -> tensor<64x32xf32>
   attributes {hal.executable.target = #exec_target_small_inner, translation_info = #translation_small_inner} {
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%source : tensor<64x32xf32>)
     outs(%init : tensor<64x32xf32>) -> tensor<64x32xf32>
-
-  // Innermost dimension (32) < subgroup size (64), so coalesced DMA should NOT be applied.
-  // The linalg.copy should remain unchanged.
-  // CHECK: linalg.copy
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-
   return %result : tensor<64x32xf32>
 }
 
@@ -151,19 +143,13 @@ func.func @copy_small_innermost_dim(%source: tensor<64x32xf32>, %init: tensor<64
 #exec_target_not_aligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_not_aligned}>
 #translation_not_aligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_not_aligned_to_dma
-// CHECK-SAME:    %[[SRC_BUF:[a-zA-Z0-9]+]]: memref<320xbf16, #amdgpu.address_space<fat_raw_buffer>>
-// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<320xbf16>
 func.func @copy_not_aligned_to_dma(%source_buffer: memref<320xbf16, #amdgpu.address_space<fat_raw_buffer>>, %init: tensor<320xbf16>) -> tensor<320xbf16>
   attributes {hal.executable.target = #exec_target_not_aligned, translation_info = #translation_not_aligned} {
   %source = iree_codegen.load_from_buffer %source_buffer : memref<320xbf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<320xbf16>
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%source : tensor<320xbf16>)
     outs(%init : tensor<320xbf16>) -> tensor<320xbf16>
-
-  // CHECK: linalg.copy
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-
   return %result : tensor<320xbf16>
 }
 
@@ -369,23 +355,12 @@ func.func @copy_1d_tensor(%source: tensor<2048xf32>) -> tensor<2048xf32>
 #exec_target_no_linearize = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_no_linearize}>
 #translation_no_linearize = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64>
 
-// CHECK-LABEL: func.func @copy_small_innermost_no_linearize
-// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<128x16xf32>
-// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: tensor<128x16xf32>
 func.func @copy_small_innermost_no_linearize(%source: tensor<128x16xf32>, %dest: tensor<128x16xf32>) -> tensor<128x16xf32>
   attributes {hal.executable.target = #exec_target_no_linearize, translation_info = #translation_no_linearize} {
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%source : tensor<128x16xf32>)
     outs(%dest : tensor<128x16xf32>) -> tensor<128x16xf32>
-
-  // Innermost dimension (16) < minElementsPerTransfer (64), and output is not
-  // tensor.empty(), so linearization is not possible. The copy should remain.
-
-  // CHECK: %[[RESULT:.+]] = linalg.copy
-  // CHECK-SAME: ins(%[[SRC]] : tensor<128x16xf32>)
-  // CHECK-SAME: outs(%[[DST]] : tensor<128x16xf32>)
-  // CHECK: return %[[RESULT]]
-
   return %result : tensor<128x16xf32>
 }
 
@@ -611,7 +586,7 @@ func.func @copy_with_tensor_pad_both_dims(%source: tensor<500x96xf32>, %init: te
 
 // -----
 
-// Test: tensor.pad fusion bails out when source row size is not DWORD-aligned.
+// Negative test: tensor.pad fusion bails out when source row size is not DWORD-aligned.
 // On AMD CDNA, per-component range checking is performed for each DWORD.
 // If a DWORD is partially out-of-bounds, the entire DWORD returns zero,
 // causing incorrect results. We bail out to avoid the slow path.
@@ -627,9 +602,6 @@ func.func @copy_with_tensor_pad_both_dims(%source: tensor<500x96xf32>, %init: te
 #exec_target_pad_unaligned = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_unaligned}>
 #translation_pad_unaligned = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_with_tensor_pad_unaligned_row
-// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<65x121xf16>
-// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x124xf16>
 func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init: tensor<4x124xf16>, %off: index, %sz: index, %high_m: index) -> tensor<4x124xf16>
   attributes {hal.executable.target = #exec_target_pad_unaligned, translation_info = #translation_pad_unaligned} {
   // Extract a dynamic slice: tensor<?x121xf16>.
@@ -645,17 +617,13 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
   } : tensor<?x121xf16> to tensor<4x124xf16>
 
   // Copy from padded tensor.
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%padded : tensor<4x124xf16>)
     outs(%init : tensor<4x124xf16>) -> tensor<4x124xf16>
 
   // Source row size (121 * 2 = 242 bytes) is not DWORD-aligned.
   // Coalesced DMA bails out to avoid partial OOB in per-DWORD range checking.
-  // The copy is downgraded from use_global_load_dma to derived_thread_config.
-  // CHECK: tensor.pad
-  // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-
   return %result : tensor<4x124xf16>
 }
 
@@ -674,9 +642,6 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
 #exec_target_pad_dynamic_inner = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_pad_dynamic_inner}>
 #translation_pad_dynamic_inner = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_with_tensor_pad_dynamic_inner_dim
-// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: tensor<457x330xi8>
-// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<4x256xi8>
 func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %init: tensor<4x256xi8>, %off: index, %sz_m: index, %sz_k: index, %high_m: index, %high_k: index) -> tensor<4x256xi8>
   attributes {hal.executable.target = #exec_target_pad_dynamic_inner, translation_info = #translation_pad_dynamic_inner} {
   // Extract a dynamic slice where both dimensions are dynamic.
@@ -691,15 +656,10 @@ func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %
   } : tensor<?x?xi8> to tensor<4x256xi8>
 
   // Copy from padded tensor.
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%padded : tensor<4x256xi8>)
     outs(%init : tensor<4x256xi8>) -> tensor<4x256xi8>
-
-  // The copy is downgraded from use_global_load_dma to derived_thread_config.
-  // CHECK: tensor.pad
-  // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-
   return %result : tensor<4x256xi8>
 }
 
@@ -789,7 +749,7 @@ func.func @copy_from_fat_raw_buffer_small(
 
 // -----
 
-// Test: Copy from load_from_buffer with storage_buffer (non-fat_raw_buffer).
+// Negative test: Copy from load_from_buffer with storage_buffer (non-fat_raw_buffer).
 // DMA should NOT be applied because the source binding was not converted to
 // fat_raw_buffer, indicating it exceeds the 2GB limit.
 
@@ -804,30 +764,22 @@ func.func @copy_from_fat_raw_buffer_small(
 #exec_target_storage_buf = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_storage_buf}>
 #translation_storage_buf = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_from_non_fat_raw_buffer
-// CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]: memref<64x512xbf16, #hal.descriptor_type<storage_buffer>>
-// CHECK-SAME:    %[[INIT:[a-zA-Z0-9]+]]: tensor<64x512xbf16>
 func.func @copy_from_non_fat_raw_buffer(
     %buf: memref<64x512xbf16, #hal.descriptor_type<storage_buffer>>,
     %init: tensor<64x512xbf16>) -> tensor<64x512xbf16>
   attributes {hal.executable.target = #exec_target_storage_buf, translation_info = #translation_storage_buf} {
   %source = iree_codegen.load_from_buffer %buf
       : memref<64x512xbf16, #hal.descriptor_type<storage_buffer>> -> tensor<64x512xbf16>
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%source : tensor<64x512xbf16>)
     outs(%init : tensor<64x512xbf16>) -> tensor<64x512xbf16>
-
-  // storage_buffer source: sourceIsNotFromFatRawBuffer returns true, DMA skipped.
-  // The linalg.copy should remain unchanged.
-  // CHECK: linalg.copy
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-
   return %result : tensor<64x512xbf16>
 }
 
 // -----
 
-// Test: Copy from dispatch.tensor.load source.
+// Negative test: Copy from dispatch.tensor.load source.
 // DMA should NOT be applied because dispatch.tensor.load indicates the binding
 // was not bufferized to a memref (e.g., >2GB binding loaded via dispatch tensor
 // path), so fat_raw_buffer is not available.
@@ -848,7 +800,6 @@ func.func @copy_from_non_fat_raw_buffer(
 #exec_target_dtl = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_dtl}>
 #translation_dtl = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
-// CHECK-LABEL: func.func @copy_from_dispatch_tensor_load
 func.func @copy_from_dispatch_tensor_load(%init: tensor<64x512xbf16>) -> tensor<64x512xbf16>
   attributes {hal.executable.target = #exec_target_dtl, translation_info = #translation_dtl} {
   %c0 = arith.constant 0 : index
@@ -856,15 +807,10 @@ func.func @copy_from_dispatch_tensor_load(%init: tensor<64x512xbf16>) -> tensor<
       : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x512xbf16>>
   %source = iree_tensor_ext.dispatch.tensor.load %binding, offsets = [0, 0], sizes = [64, 512], strides = [1, 1]
       : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x512xbf16>> -> tensor<64x512xbf16>
+  // expected-error @+1 {{copy marked with use_global_load_dma was not converted to DMA}}
   %result = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%source : tensor<64x512xbf16>)
     outs(%init : tensor<64x512xbf16>) -> tensor<64x512xbf16>
-
-  // dispatch.tensor.load source: sourceIsNotFromFatRawBuffer returns true,
-  // DMA skipped. The linalg.copy should remain unchanged.
-  // CHECK: linalg.copy
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
-
   return %result : tensor<64x512xbf16>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
@@ -33,6 +33,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
+        "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AMDGPUUtils",
         "@llvm-project//mlir:Analysis",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
+    iree::compiler::Dialect::Util::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -557,17 +558,22 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
-/// Returns true if direct load DMA should be rejected, and fall back to stream
-/// copies.
+/// Pre-schedule rejection: returns true if direct load DMA should be rejected
+/// based on checks that do not require tile sizes (run before MMA schedule
+/// selection).
 ///
 /// Rejection cases:
 ///   1. Target does not support DMA (requires gfx950+ / CDNA4+).
 ///   2. Not a GEMM. TODO(#23907): support convolution.
 ///   3. Data types are not f16 or bf16. TODO(#22119): support MXFP4.
 ///   4. LHS transposed, RHS not transposed shows regressions. TODO (#24117).
-static bool shouldRejectDirectLoadDMA(IREE::GPU::TargetAttr target, bool isGemm,
-                                      Type lhsElemType, Type rhsElemType,
-                                      bool transposedLhs, bool transposedRhs) {
+///   5. Operand buffer exceeds INT32_MAX bytes (no fat_raw_buffer support).
+///      When split-reduction is active, operand shapes are post-split; the
+///      original buffer is splitReductionTripCnt times larger.
+static bool shouldRejectDirectLoadDMAPreSchedule(
+    IREE::GPU::TargetAttr target, bool isGemm, ArrayRef<Value> operands,
+    Type lhsElemType, Type rhsElemType, bool transposedLhs, bool transposedRhs,
+    int64_t splitReductionTripCnt = 0) {
   auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
 
   // Case 1: DMA requires hardware support (gfx950+ / CDNA4+).
@@ -590,6 +596,98 @@ static bool shouldRejectDirectLoadDMA(IREE::GPU::TargetAttr target, bool isGemm,
     return true;
   }
 
+  // Case 5: Operand buffers must fit in fat_raw_buffer (INT32_MAX bytes).
+  // When split-reduction is active, operand shapes are post-split but the
+  // underlying HAL bindings reference the original (pre-split) buffers.
+  // Scale the effective size by splitReductionTripCnt to check the original.
+  auto lhsShape = dyn_cast<ShapedType>(operands[0].getType());
+  auto rhsShape = dyn_cast<ShapedType>(operands[1].getType());
+  std::optional<ValueRange> lhsDynDims =
+      IREE::Util::findDynamicDims(operands[0]);
+  std::optional<ValueRange> rhsDynDims =
+      IREE::Util::findDynamicDims(operands[1]);
+  if (!canUseFatRawBuffer(lhsShape, lhsDynDims, /*solver=*/nullptr,
+                          splitReductionTripCnt) ||
+      !canUseFatRawBuffer(rhsShape, rhsDynDims, /*solver=*/nullptr,
+                          splitReductionTripCnt)) {
+    return true;
+  }
+
+  return false;
+}
+
+/// Build the promoted tile shape for an operand by projecting
+/// |paddingTileSizes| through the operand's affine map.
+static SmallVector<int64_t>
+getPromotedTileShape(AffineMap map, ArrayRef<int64_t> paddingTileSizes) {
+  SmallVector<int64_t> tileShape;
+  for (AffineExpr result : map.getResults()) {
+    unsigned pos = cast<AffineDimExpr>(result).getPosition();
+    tileShape.push_back(paddingTileSizes[pos]);
+  }
+  return tileShape;
+}
+
+/// Post-schedule rejection: returns true if direct load DMA should be rejected
+/// based on checks that require computed tile sizes (run after MMA schedule
+/// selection).
+///
+/// Rejection cases:
+///   1. Promoted tile elements are not aligned to DMA transfer sizes.
+///   2. Source innermost row is not DWORD-aligned when padding may occur.
+static bool shouldRejectDirectLoadDMAPostSchedule(
+    IREE::GPU::TargetAttr target, int64_t targetSubgroupSize,
+    ArrayRef<int64_t> paddingTileSizes, Type lhsElemType, Type rhsElemType,
+    ArrayRef<AffineMap> maps, ArrayRef<int64_t> bounds, bool couldNeedPadding,
+    bool mustBeAligned) {
+  SmallVector<int64_t> lhsTileShape =
+      getPromotedTileShape(maps[0], paddingTileSizes);
+  SmallVector<int64_t> rhsTileShape =
+      getPromotedTileShape(maps[1], paddingTileSizes);
+
+  // Case 1: Check alignment against DMA transfer sizes.
+  if (!getDMAAlignedSubgroupSize(target, targetSubgroupSize, lhsElemType,
+                                 lhsTileShape) ||
+      !getDMAAlignedSubgroupSize(target, targetSubgroupSize, rhsElemType,
+                                 rhsTileShape)) {
+    LDBG() << "DMA alignment check failed, falling back to stream copies";
+    return true;
+  }
+
+  // Case 2: If padding may occur, check DWORD alignment of source innermost
+  // rows. Also reject when the innermost dim doesn't divide evenly by its
+  // tile size, because the last tile would have a dynamic innermost dim that
+  // cannot be statically verified for DWORD alignment at conversion time.
+  if (couldNeedPadding || !mustBeAligned) {
+    unsigned lhsInnermostIterDim =
+        cast<AffineDimExpr>(maps[0].getResults().back()).getPosition();
+    unsigned rhsInnermostIterDim =
+        cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
+    if (!isDWORDAligned(bounds[lhsInnermostIterDim], lhsElemType)) {
+      LDBG() << "LHS DWORD alignment check failed, falling back to "
+                "stream copies";
+      return true;
+    }
+    if (!isDWORDAligned(bounds[rhsInnermostIterDim], rhsElemType)) {
+      LDBG() << "RHS DWORD alignment check failed, falling back to "
+                "stream copies";
+      return true;
+    }
+    if (bounds[lhsInnermostIterDim] >= paddingTileSizes[lhsInnermostIterDim] &&
+        bounds[lhsInnermostIterDim] % paddingTileSizes[lhsInnermostIterDim] !=
+            0) {
+      LDBG() << "LHS innermost dim not divisible by tile size, falling "
+                "back to stream copies";
+      return true;
+    }
+    if (bounds[rhsInnermostIterDim] >= paddingTileSizes[rhsInnermostIterDim] &&
+        bounds[rhsInnermostIterDim] % paddingTileSizes[rhsInnermostIterDim] !=
+            0) {
+      LDBG() << "RHS innermost dim not divisible by tile size, falling "
+                "back to stream copies";
+      return true;
+    }
+  }
   return false;
 }
 
@@ -788,8 +886,9 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
 
   Location loc = operands[0].getLoc();
   if (useDirectLoad &&
-      shouldRejectDirectLoadDMA(target, isGemm, lhsElemType, rhsElemType,
-                                transposedLhs, transposedRhs)) {
+      shouldRejectDirectLoadDMAPreSchedule(
+          target, isGemm, operands, lhsElemType, rhsElemType, transposedLhs,
+          transposedRhs, splitReductionTripCnt)) {
     LDBG() << "overriding direct load DMA, falling back to stream copies";
     useDirectLoad = false;
   }
@@ -907,9 +1006,34 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     }
   }
 
+  // Compute the promoted tile sizes in the iteration domain. This merges
+  // workgroup, reduction, and intrinsic K-packing into one array that
+  // both the DMA alignment check and the "padding" attribute can share.
+  SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
+  for (int64_t kDim : kDims) {
+    paddingTileSizes[kDim] = reductionTileSizes[kDim];
+  }
+  int64_t kPackFactor;
+  int64_t innerKDim = contractionK.back();
+  if (scaled) {
+    auto smmaKind = cast<IREE::GPU::ScaledMMAAttr>(kind);
+    kPackFactor = std::get<2>(smmaKind.getScaledMNKShape());
+  } else {
+    auto mmaKind = cast<IREE::GPU::MmaInterfaceAttr>(kind);
+    kPackFactor = std::get<2>(mmaKind.getMNKShape());
+  }
+  paddingTileSizes[innerKDim] *= kPackFactor;
+
   // Use global load DMA attribute (subgroup sizes will be derived from
   // translation_info).
   SmallVector<Attribute> promotionArray;
+  if (useDirectLoad &&
+      shouldRejectDirectLoadDMAPostSchedule(
+          target, targetSubgroupSize, paddingTileSizes, lhsElemType,
+          rhsElemType, maps, bounds, couldNeedPadding, mustBeAligned)) {
+    useDirectLoad = false;
+  }
+
   if (useDirectLoad) {
     Attribute lhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
@@ -953,22 +1077,6 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   GPU::appendPromotedOperandsList(context, attrs, promotionList,
                                   promotionArray);
   if (!mustBeAligned || couldNeedPadding) {
-    SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
-
-    // Initialize inner and outer padding sizes from reductionTileSizes.
-    for (int64_t kDim : kDims) {
-      paddingTileSizes[kDim] = reductionTileSizes[kDim];
-    }
-
-    int64_t kPackFactor, innerKDim = contractionK.back();
-    if (scaled) {
-      auto smmaKind = cast<IREE::GPU::ScaledMMAAttr>(kind);
-      kPackFactor = std::get<2>(smmaKind.getScaledMNKShape());
-    } else {
-      auto mmaKind = cast<IREE::GPU::MmaInterfaceAttr>(kind);
-      kPackFactor = std::get<2>(mmaKind.getMNKShape());
-    }
-    paddingTileSizes[innerKDim] *= kPackFactor;
     attrs.emplace_back("padding", b.getI64ArrayAttr(paddingTileSizes));
 
     // Create `padding_conv` attribute when padding convolutions before IGEMM

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -585,13 +586,112 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
+/// Pre-schedule rejection: returns true if direct load DMA should be rejected
+/// based on checks that do not require tile sizes (run before MMA schedule
+/// selection).
+///
+/// Rejection cases:
+///   1. Target does not support DMA (requires gfx950+ / CDNA4+).
+///   2. Not a GEMM. TODO(#23907): support convolution.
+///   3. Data types are not f16 or bf16. TODO(#22119): support MXFP4.
+///   4. LHS transposed, RHS not transposed shows regressions. TODO(#24117).
+///   5. Operand cannot fit in AMDGPU fat_raw_buffer (> INT32_MAX bytes).
+static bool shouldRejectDMAPreSchedule(IREE::GPU::TargetAttr target,
+                                       bool isGemm, ArrayRef<Value> operands,
+                                       Type lhsElemType, Type rhsElemType,
+                                       bool transposedLhs, bool transposedRhs,
+                                       int64_t splitReductionTripCnt = 0) {
+  auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
+
+  // Case 1: DMA requires hardware support (gfx950+ / CDNA4+).
+  if (!targetSupportsGlobalLoadDMA(target)) {
+    LDBG() << "Target does not support global load DMA";
+    return true;
+  }
+
+  // Case 2: Only GEMM are supported currently.
+  if (!isGemm) {
+    LDBG() << "Only GEMM are supported currently";
+    return true;
+  }
+
+  // Case 3: Only f16/bf16 are supported currently.
+  if (!isF16OrBF16(lhsElemType) || !isF16OrBF16(rhsElemType)) {
+    LDBG() << "Only f16/bf16 are supported currently";
+    return true;
+  }
+
+  // Case 4: LHS transposed, RHS not transposed show regressions with DMA.
+  if (transposedLhs && !transposedRhs) {
+    LDBG() << "LHS transposed, RHS not transposed show regressions";
+    return true;
+  }
+
+  // Case 5: Operand buffers must fit in fat_raw_buffer (INT32_MAX bytes).
+  // When split-reduction is active, operand shapes are post-split but the
+  // underlying HAL bindings reference the original (pre-split) buffers.
+  // Scale the effective size by splitReductionTripCnt to check the original.
+  auto lhsShape = dyn_cast<ShapedType>(operands[0].getType());
+  auto rhsShape = dyn_cast<ShapedType>(operands[1].getType());
+  std::optional<ValueRange> lhsDynDims =
+      IREE::Util::findDynamicDims(operands[0]);
+  std::optional<ValueRange> rhsDynDims =
+      IREE::Util::findDynamicDims(operands[1]);
+  if (!canFitAMDGPUFatRawBuffer(lhsShape, lhsDynDims, /*solver=*/nullptr,
+                                splitReductionTripCnt) ||
+      !canFitAMDGPUFatRawBuffer(rhsShape, rhsDynDims, /*solver=*/nullptr,
+                                splitReductionTripCnt)) {
+    LDBG() << "Operands do not fit in fat_raw_buffer";
+    return true;
+  }
+
+  return false;
+}
+
+/// Build the promoted (post-pad) tile shape for an operand by projecting
+/// |paddingTileSizes| through the operand's affine map.
+static SmallVector<int64_t>
+getPromotedTileShape(AffineMap map, ArrayRef<int64_t> paddingTileSizes) {
+  SmallVector<int64_t> tileShape;
+  for (AffineExpr result : map.getResults()) {
+    unsigned pos = cast<AffineDimExpr>(result).getPosition();
+    tileShape.push_back(paddingTileSizes[pos]);
+  }
+  return tileShape;
+}
+
+/// Build the pre-pad tile shape for an operand by projecting |bounds| and
+/// |paddingTileSizes| through the operand's affine map. For each dimension,
+/// the pre-pad size is:
+///   - bounds[dim]              if bounds < tileSize (single tile, padded up)
+///   - tileSize                 if bounds evenly divides by tileSize
+///   - ShapedType::kDynamic     otherwise (last tile has dynamic size)
+static SmallVector<int64_t>
+getPrePadTileShape(AffineMap map, ArrayRef<int64_t> bounds,
+                   ArrayRef<int64_t> paddingTileSizes) {
+  SmallVector<int64_t> tileShape;
+  for (AffineExpr result : map.getResults()) {
+    unsigned pos = cast<AffineDimExpr>(result).getPosition();
+    int64_t bound = bounds[pos];
+    int64_t tileSize = paddingTileSizes[pos];
+    if (bound < tileSize) {
+      tileShape.push_back(bound);
+    } else if (bound % tileSize == 0) {
+      tileShape.push_back(tileSize);
+    } else {
+      tileShape.push_back(ShapedType::kDynamic);
+    }
+  }
+  return tileShape;
+}
+
 constexpr int64_t kMinWorkgroupsPerCU = 2;
 
-/// Rejects DMA when its extra LDS usage would drop occupancy (WGs/CU) below
-/// `kMinWorkgroupsPerCU` while non-DMA would still meet it. When chip info
-/// is available, the LDS-limited occupancy is capped by actual work
-/// (totalWorkgroups / numCUs) so that under-subscribed shapes are not
-/// penalized.
+/// Returns true if direct load DMA should be rejected because its extra LDS
+/// usage would drop occupancy (WGs/CU) below `kMinWorkgroupsPerCU` while
+/// non-DMA would still meet it. When chip info is available, the LDS-limited
+/// occupancy is capped by actual work (totalWorkgroups / numCUs) so that
+/// under-subscribed shapes are not penalized.
 /// TODO(#24375): Remove this guard once the tile-size heuristic stops
 /// over-allocating LDS or 1-warp/SIMD codegen can recover the perf without
 /// requiring inter-SIMD latency hiding via WGs/CU >= 2.
@@ -600,24 +700,19 @@ static bool shouldRejectDMAForOccupancy(
     IREE::GPU::TargetAttr target, int64_t prefetchNumStages, bool doCPromotion,
     ArrayRef<int64_t> bounds, ArrayRef<int64_t> workgroupTileSizes) {
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
-
   int64_t dmaLdsBytes = calculateTotalSharedMemoryUsedInBytes(
       schedule, problem, /*useDirectLoad=*/true, prefetchNumStages,
       doCPromotion);
   int64_t nonDmaLdsBytes = calculateTotalSharedMemoryUsedInBytes(
       schedule, problem, /*useDirectLoad=*/false, /*prefetchNumStages=*/0,
       doCPromotion);
-
   assert(dmaLdsBytes > 0 && nonDmaLdsBytes > 0 && "LDS usage must be positive");
-
   int64_t dmaMaxWgsPerCU = maxSharedMemoryBytes / dmaLdsBytes;
   int64_t nonDmaMaxWgsPerCU = maxSharedMemoryBytes / nonDmaLdsBytes;
-
   // When chip info is available, cap effective WGs/CU by how many workgroups
   // actually exist per CU. This avoids over-rejecting DMA for small shapes
   // where the GPU is under-subscribed.
-  IREE::GPU::TargetChipAttr chip = target.getChip();
-  if (chip) {
+  if (IREE::GPU::TargetChipAttr chip = target.getChip()) {
     int64_t numCUs = chip.getWgpCount();
     int64_t totalWorkgroups = 1;
     for (auto [dim, tileSize] : llvm::zip_equal(bounds, workgroupTileSizes)) {
@@ -629,44 +724,62 @@ static bool shouldRejectDMAForOccupancy(
     dmaMaxWgsPerCU = std::min(maxWgsPerCU, dmaMaxWgsPerCU);
     nonDmaMaxWgsPerCU = std::min(maxWgsPerCU, nonDmaMaxWgsPerCU);
   }
-
   return dmaMaxWgsPerCU < kMinWorkgroupsPerCU &&
          nonDmaMaxWgsPerCU >= kMinWorkgroupsPerCU;
 }
 
-/// Returns true if direct load DMA should be rejected, and fall back to stream
-/// copies.
+/// Post-schedule rejection: returns true if direct load DMA should be rejected
+/// based on checks that require computed tile sizes (run after MMA schedule
+/// selection).
 ///
 /// Rejection cases:
-///   1. Target does not support DMA (requires gfx950+ / CDNA4+).
-///   2. Not a GEMM. TODO(#23907): support convolution.
-///   3. Data types are not f16 or bf16. TODO(#22119): support MXFP4.
-///   4. LHS transposed, RHS not transposed shows regressions. TODO (#24117).
-static bool shouldRejectDirectLoadDMA(IREE::GPU::TargetAttr target, bool isGemm,
-                                      Type lhsElemType, Type rhsElemType,
-                                      bool transposedLhs, bool transposedRhs) {
-  auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
+///   1. Promoted (post-pad) tile elements are not aligned to DMA transfer
+///   sizes.
+///   2. Pre-pad tile source is not DWORD-aligned.
+///   3. LDS-limited occupancy drop (see `shouldRejectDMAForOccupancy`).
+static bool shouldRejectDMAPostSchedule(
+    IREE::GPU::TargetAttr target, int64_t targetSubgroupSize,
+    ArrayRef<Value> operands, ArrayRef<AffineMap> maps,
+    ArrayRef<int64_t> bounds, const GPUMatmulShapeType &problem,
+    const GPUMMASchedule &schedule, int64_t prefetchNumStages,
+    bool doCPromotion, ArrayRef<int64_t> workgroupTileSizes,
+    ArrayRef<int64_t> paddingTileSizes) {
+  auto lhsType = cast<RankedTensorType>(operands[0].getType());
+  auto rhsType = cast<RankedTensorType>(operands[1].getType());
 
-  // Case 1: DMA requires hardware support (gfx950+ / CDNA4+).
-  if (!targetSupportsGlobalLoadDMA(target)) {
+  SmallVector<int64_t> lhsTileShape =
+      getPromotedTileShape(maps[0], paddingTileSizes);
+  SmallVector<int64_t> rhsTileShape =
+      getPromotedTileShape(maps[1], paddingTileSizes);
+
+  // Case 1: Check alignment against DMA transfer sizes.
+  if (!isDMATransferAligned(target, targetSubgroupSize,
+                            lhsType.getElementType(), lhsTileShape) ||
+      !isDMATransferAligned(target, targetSubgroupSize,
+                            rhsType.getElementType(), rhsTileShape)) {
+    LDBG() << "DMA alignment check failed";
     return true;
   }
 
-  // Case 2: Only GEMM are supported currently.
-  if (!isGemm) {
+  // Case 2: Check DWORD alignment of pre-pad tile source.
+  auto lhsPrePadType = RankedTensorType::get(
+      getPrePadTileShape(maps[0], bounds, paddingTileSizes),
+      lhsType.getElementType());
+  auto rhsPrePadType = RankedTensorType::get(
+      getPrePadTileShape(maps[1], bounds, paddingTileSizes),
+      rhsType.getElementType());
+  if (!isTypeDWORDAligned(lhsPrePadType) ||
+      !isTypeDWORDAligned(rhsPrePadType)) {
+    LDBG() << "Pre-pad source not DWORD-aligned";
     return true;
   }
 
-  // Case 3: Only f16/bf16 are supported currently.
-  if (!isF16OrBF16(lhsElemType) || !isF16OrBF16(rhsElemType)) {
+  // Case 3: LDS-limited occupancy drop.
+  if (shouldRejectDMAForOccupancy(schedule, problem, target, prefetchNumStages,
+                                  doCPromotion, bounds, workgroupTileSizes)) {
+    LDBG() << "LDS limits occupancy (WGs/CU)";
     return true;
   }
-
-  // Case 4: LHS transposed, RHS not transposed show regressions with DMA.
-  if (transposedLhs && !transposedRhs) {
-    return true;
-  }
-
   return false;
 }
 
@@ -865,12 +978,13 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
 
   Location loc = operands[0].getLoc();
   // Stage 1 (problem-size + target-arch) DMA rejection. Stage 2 (tile-size)
-  // happens below via shouldRejectDMAForOccupancy after the schedule and
+  // happens below via shouldRejectDMAPostSchedule after the schedule and
   // workgroup tiles are computed.
   if (useDirectLoad &&
-      shouldRejectDirectLoadDMA(target, isGemm, lhsElemType, rhsElemType,
-                                transposedLhs, transposedRhs)) {
-    LDBG() << "overriding direct load DMA, falling back to stream copies";
+      shouldRejectDMAPreSchedule(target, isGemm, operands, lhsElemType,
+                                 rhsElemType, transposedLhs, transposedRhs,
+                                 splitReductionTripCnt)) {
+    LDBG() << "Overriding direct load DMA, falling back to stream copies";
     useDirectLoad = false;
   }
 
@@ -999,15 +1113,34 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     }
   }
 
-  // Stage 2 (tile-size) DMA rejection: now that workgroup tiles are known,
-  // check whether DMA would cause an unacceptable occupancy drop. Stage 1
-  // (problem-size + target-arch) ran above via shouldRejectDirectLoadDMA.
+  // Compute the promoted tile sizes in the iteration domain. This merges
+  // workgroup, reduction, and intrinsic K-packing into one array that
+  // both the DMA alignment check and the "padding" attribute can share.
+  SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
+  for (int64_t kDim : kDims) {
+    paddingTileSizes[kDim] = reductionTileSizes[kDim];
+  }
+  int64_t kPackFactor;
+  int64_t innerKDim = contractionK.back();
+  if (scaled) {
+    auto smmaKind = cast<IREE::GPU::ScaledMMAAttr>(kind);
+    kPackFactor = std::get<2>(smmaKind.getScaledMNKShape());
+  } else {
+    auto mmaKind = cast<IREE::GPU::MmaInterfaceAttr>(kind);
+    kPackFactor = std::get<2>(mmaKind.getMNKShape());
+  }
+  paddingTileSizes[innerKDim] *= kPackFactor;
+
+  // Stage 2 (post-schedule) DMA rejection: now that workgroup tiles are known,
+  // run alignment, DWORD, and occupancy checks. Stage 1 (problem-size +
+  // target-arch) ran above via shouldRejectDMAPreSchedule.
   if (useDirectLoad &&
-      shouldRejectDMAForOccupancy(*schedule, problem, target, prefetchNumStages,
-                                  hasExistingAccumulator, bounds,
-                                  workgroupTileSizes)) {
-    LDBG() << "rejecting direct load DMA: LDS limits occupancy (WGs/CU)";
+      shouldRejectDMAPostSchedule(target, targetSubgroupSize, operands, maps,
+                                  bounds, problem, *schedule, prefetchNumStages,
+                                  hasExistingAccumulator, workgroupTileSizes,
+                                  paddingTileSizes)) {
     useDirectLoad = false;
+    LDBG() << "Overriding direct load DMA, falling back to stream copies";
   }
 
   // Use global load DMA attribute (subgroup sizes will be derived from
@@ -1059,22 +1192,6 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   GPU::appendPromotedOperandsList(context, attrs, promotionList,
                                   promotionArray);
   if (!mustBeAligned || couldNeedPadding) {
-    SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
-
-    // Initialize inner and outer padding sizes from reductionTileSizes.
-    for (int64_t kDim : kDims) {
-      paddingTileSizes[kDim] = reductionTileSizes[kDim];
-    }
-
-    int64_t kPackFactor, innerKDim = contractionK.back();
-    if (scaled) {
-      auto smmaKind = cast<IREE::GPU::ScaledMMAAttr>(kind);
-      kPackFactor = std::get<2>(smmaKind.getScaledMNKShape());
-    } else {
-      auto mmaKind = cast<IREE::GPU::MmaInterfaceAttr>(kind);
-      kPackFactor = std::get<2>(mmaKind.getMNKShape());
-    }
-    paddingTileSizes[innerKDim] *= kPackFactor;
     attrs.emplace_back("padding", b.getI64ArrayAttr(paddingTileSizes));
 
     // Create `padding_conv` attribute when padding convolutions before IGEMM

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -74,44 +74,6 @@ static bool isDefinitelyWorkgroupUniform(Value arg) {
   });
 }
 
-/// Return the maximum number of bytes spanned by the binding, or nullopt if
-/// unable to determine or if the calculation would overflow.
-static std::optional<int64_t>
-getSpannedBytes(IREE::HAL::InterfaceBindingSubspanOp binding,
-                const DataFlowSolver &solver) {
-  int64_t maxNumElems = 1;
-  ShapedType resultTy = dyn_cast<ShapedType>(binding.getType());
-  if (auto tensorType =
-          dyn_cast<IREE::TensorExt::DispatchTensorType>(binding.getType())) {
-    resultTy = tensorType.asRankedTensorType();
-  }
-  if (!resultTy || !resultTy.hasRank()) {
-    return std::nullopt;
-  }
-  // Handle dynamic dimensions.
-  for (Value dynArg : binding.getResultDynamicDims(0)) {
-    FailureOr<int64_t> dimMax = getDynamicUpperBound(dynArg, solver);
-    if (failed(dimMax)) {
-      return std::nullopt;
-    }
-    if (llvm::MulOverflow(maxNumElems, *dimMax, maxNumElems)) {
-      return std::nullopt;
-    }
-  }
-  // Handle static dimensions.
-  for (int64_t dim :
-       llvm::make_filter_range(resultTy.getShape(), ShapedType::isStatic)) {
-    if (llvm::MulOverflow(maxNumElems, dim, maxNumElems)) {
-      return std::nullopt;
-    }
-  }
-  int64_t elementBits = IREE::Util::getTypeBitWidth(resultTy.getElementType());
-  if (llvm::MulOverflow(maxNumElems, elementBits, maxNumElems)) {
-    return std::nullopt;
-  }
-  return maxNumElems / 8;
-}
-
 namespace {
 
 struct ROCDLConfigureBufferInstructionsPass final
@@ -150,15 +112,14 @@ struct ROCDLConfigureBufferInstructionsPass final
                << " not known workgroup-uniform\n";
         return;
       }
-      std::optional<int64_t> maxBytes = getSpannedBytes(binding, solver);
-      if (!maxBytes) {
-        LDBG() << "Couldn't bound binding size for " << binding;
-        return;
+      ShapedType resultTy = dyn_cast<ShapedType>(binding.getType());
+      if (auto tensorType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
+              binding.getType())) {
+        resultTy = tensorType.asRankedTensorType();
       }
-      if (*maxBytes >=
-          static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
-        LDBG() << "Size of " << binding << " too large (" << *maxBytes
-               << " bytes)";
+      if (!canUseFatRawBuffer(resultTy, binding.getResultDynamicDims(0),
+                              &solver)) {
+        LDBG() << "Size of " << binding << " too large or unbounded";
         return;
       }
       annotationHelper.setAttr(binding, unitAttr);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -74,44 +74,6 @@ static bool isDefinitelyWorkgroupUniform(Value arg) {
   });
 }
 
-/// Return the maximum number of bytes spanned by the binding, or nullopt if
-/// unable to determine or if the calculation would overflow.
-static std::optional<int64_t>
-getSpannedBytes(IREE::HAL::InterfaceBindingSubspanOp binding,
-                const DataFlowSolver &solver) {
-  int64_t maxNumElems = 1;
-  ShapedType resultTy = dyn_cast<ShapedType>(binding.getType());
-  if (auto tensorType =
-          dyn_cast<IREE::TensorExt::DispatchTensorType>(binding.getType())) {
-    resultTy = tensorType.asRankedTensorType();
-  }
-  if (!resultTy || !resultTy.hasRank()) {
-    return std::nullopt;
-  }
-  // Handle dynamic dimensions.
-  for (Value dynArg : binding.getResultDynamicDims(0)) {
-    FailureOr<int64_t> dimMax = getDynamicUpperBound(dynArg, solver);
-    if (failed(dimMax)) {
-      return std::nullopt;
-    }
-    if (llvm::MulOverflow(maxNumElems, *dimMax, maxNumElems)) {
-      return std::nullopt;
-    }
-  }
-  // Handle static dimensions.
-  for (int64_t dim :
-       llvm::make_filter_range(resultTy.getShape(), ShapedType::isStatic)) {
-    if (llvm::MulOverflow(maxNumElems, dim, maxNumElems)) {
-      return std::nullopt;
-    }
-  }
-  int64_t elementBits = IREE::Util::getTypeBitWidth(resultTy.getElementType());
-  if (llvm::MulOverflow(maxNumElems, elementBits, maxNumElems)) {
-    return std::nullopt;
-  }
-  return maxNumElems / 8;
-}
-
 namespace {
 
 struct ROCDLConfigureBufferInstructionsPass final
@@ -150,15 +112,14 @@ struct ROCDLConfigureBufferInstructionsPass final
                << " not known workgroup-uniform\n";
         return;
       }
-      std::optional<int64_t> maxBytes = getSpannedBytes(binding, solver);
-      if (!maxBytes) {
-        LDBG() << "Couldn't bound binding size for " << binding;
-        return;
+      ShapedType resultTy = dyn_cast<ShapedType>(binding.getType());
+      if (auto tensorType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
+              binding.getType())) {
+        resultTy = tensorType.asRankedTensorType();
       }
-      if (*maxBytes >=
-          static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
-        LDBG() << "Size of " << binding << " too large (" << *maxBytes
-               << " bytes)";
+      if (!canFitAMDGPUFatRawBuffer(resultTy, binding.getResultDynamicDims(0),
+                                    &solver)) {
+        LDBG() << "Size of " << binding << " too large or unbounded";
         return;
       }
       annotationHelper.setAttr(binding, unitAttr);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -19,6 +19,12 @@
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
 // RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
+// RUN: %s | FileCheck %s --check-prefix=CHECK-DIRECT-LOAD
+//
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-2
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
@@ -660,3 +666,38 @@ func.func @conv_1x1_mi355x_dma_rejected_occ(
 // MI355X-DIRECT-LOAD:       linalg.generic
 // MI355X-DIRECT-LOAD-SAME:   promote_operands = [0, 1]
 // MI355X-DIRECT-LOAD-NOT:   use_global_load_dma
+
+// -----
+
+// DMA rejected: operand exceeds AMDGPU fat_raw_buffer INT32_MAX byte limit.
+// LHS = 16384 x 150000 x bf16 = ~4.9GB > INT32_MAX (2GB).
+func.func @matmul_bf16_fat_raw_overflow_no_dma(
+    %arg0: tensor<16384x150000xbf16>,
+    %arg1: tensor<150000x4096xbf16>,
+    %arg2: tensor<16384x4096xf32>) -> tensor<16384x4096xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<16384x150000xbf16>, tensor<150000x4096xbf16>)
+                      outs(%arg2 : tensor<16384x4096xf32>) -> tensor<16384x4096xf32>
+  return %0 : tensor<16384x4096xf32>
+}
+
+// CHECK-DIRECT-LOAD-LABEL: func.func @matmul_bf16_fat_raw_overflow_no_dma
+// CHECK-DIRECT-LOAD:       linalg.matmul {lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-NOT:     use_global_load_dma
+
+// -----
+
+// DMA rejected: K=65 with bf16 causes a non-evenly-divisible pre-pad tile
+// (65 > tileK=32, 65 % 32 != 0), producing a dynamic innermost dimension that
+// fails the DWORD alignment check.
+func.func @matmul_bf16_non_dword_aligned_no_dma(
+    %arg0: tensor<4096x65xbf16>,
+    %arg1: tensor<65x4096xbf16>,
+    %arg2: tensor<4096x4096xf32>) -> tensor<4096x4096xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<4096x65xbf16>, tensor<65x4096xbf16>)
+                      outs(%arg2 : tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
+  return %0 : tensor<4096x4096xf32>
+}
+
+// CHECK-DIRECT-LOAD-LABEL: func.func @matmul_bf16_non_dword_aligned_no_dma
+// CHECK-DIRECT-LOAD:       linalg.matmul {lowering_config = #iree_gpu.lowering_config
+// CHECK-DIRECT-LOAD-NOT:     use_global_load_dma

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
+        "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TargetParser",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -80,6 +80,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::TensorExt::IR
+    iree::compiler::Dialect::Util::IR
     iree::compiler::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -12,11 +12,13 @@
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InterleavedRange.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -29,6 +31,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
@@ -1316,6 +1319,103 @@ bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
     return false;
   }
   return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
+}
+
+std::optional<int64_t> getDMAAlignedSubgroupSize(IREE::GPU::TargetAttr target,
+                                                 int64_t subgroupSize,
+                                                 Type elementType,
+                                                 ArrayRef<int64_t> shape) {
+  if (!target || shape.empty()) {
+    return std::nullopt;
+  }
+
+  // If any dimension is dynamic, fall back to just the innermost dimension.
+  int64_t availableElements;
+  if (llvm::any_of(shape, ShapedType::isDynamic)) {
+    int64_t innermostDim = shape.back();
+    if (ShapedType::isDynamic(innermostDim)) {
+      return std::nullopt;
+    }
+    availableElements = innermostDim;
+  } else {
+    availableElements = ShapedType::getNumElements(shape);
+  }
+  int64_t elementBits = elementType.getIntOrFloatBitWidth();
+
+  ArrayRef<int64_t> dmaSizes;
+  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+    dmaSizes = dmaSizesAttr.asArrayRef();
+  }
+
+  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
+  for (int64_t dmaSize : dmaSizes) {
+    if (dmaSize % elementBits != 0) {
+      continue;
+    }
+    int64_t elementsPerLane = dmaSize / elementBits;
+    int64_t elementsPerTransfer = subgroupSize * elementsPerLane;
+    minElementsPerTransfer =
+        std::min(minElementsPerTransfer, elementsPerTransfer);
+  }
+
+  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max() ||
+      availableElements % minElementsPerTransfer != 0) {
+    return std::nullopt;
+  }
+
+  return subgroupSize;
+}
+
+bool isDWORDAligned(int64_t dimSize, Type elementType) {
+  if (ShapedType::isDynamic(dimSize)) {
+    return false;
+  }
+  int64_t rowBytes = dimSize * (elementType.getIntOrFloatBitWidth() / 8);
+  return rowBytes % 4 == 0;
+}
+
+bool canUseFatRawBuffer(ShapedType type, std::optional<ValueRange> dynamicDims,
+                        const DataFlowSolver *solver, int64_t scaleFactor) {
+  if (!type || !type.hasRank()) {
+    return false;
+  }
+  int64_t maxNumElems = 1;
+  // Handle dynamic dimensions.
+  for (Value dynArg : dynamicDims.value_or(ValueRange{})) {
+    if (!solver) {
+      return false;
+    }
+    FailureOr<int64_t> dimMax = getDynamicUpperBound(dynArg, *solver);
+    if (failed(dimMax)) {
+      return false;
+    }
+    if (llvm::MulOverflow(maxNumElems, *dimMax, maxNumElems)) {
+      return false;
+    }
+  }
+  // Handle static dimensions.
+  for (int64_t dim : type.getShape()) {
+    if (ShapedType::isDynamic(dim)) {
+      if (!dynamicDims) {
+        return false;
+      }
+      continue;
+    }
+    if (llvm::MulOverflow(maxNumElems, dim, maxNumElems)) {
+      return false;
+    }
+  }
+  int64_t elementBits = IREE::Util::getTypeBitWidth(type.getElementType());
+  if (llvm::MulOverflow(maxNumElems, elementBits, maxNumElems)) {
+    return false;
+  }
+  int64_t totalBytes = maxNumElems / 8;
+  if (scaleFactor > 1) {
+    if (llvm::MulOverflow(totalBytes, scaleFactor, totalBytes)) {
+      return false;
+    }
+  }
+  return totalBytes < static_cast<int64_t>(std::numeric_limits<int32_t>::max());
 }
 
 void addConfigGPUTarget(MLIRContext *context,

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -12,11 +12,13 @@
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InterleavedRange.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -32,6 +34,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
@@ -1321,6 +1324,100 @@ bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
     return false;
   }
   return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
+}
+
+bool isDMATransferAligned(IREE::GPU::TargetAttr target, int64_t subgroupSize,
+                          Type elementType, ArrayRef<int64_t> shape) {
+  if (!target || shape.empty()) {
+    return false;
+  }
+
+  // If any dimension is dynamic, fall back to just the innermost dimension.
+  int64_t availableElements;
+  if (llvm::any_of(shape, ShapedType::isDynamic)) {
+    int64_t innermostDim = shape.back();
+    if (ShapedType::isDynamic(innermostDim)) {
+      return false;
+    }
+    availableElements = innermostDim;
+  } else {
+    availableElements = ShapedType::getNumElements(shape);
+  }
+  int64_t elementBits = elementType.getIntOrFloatBitWidth();
+
+  ArrayRef<int64_t> dmaSizes;
+  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+    dmaSizes = dmaSizesAttr.asArrayRef();
+  }
+
+  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
+  for (int64_t dmaSize : dmaSizes) {
+    if (dmaSize % elementBits != 0) {
+      continue;
+    }
+    int64_t elementsPerLane = dmaSize / elementBits;
+    int64_t elementsPerTransfer = subgroupSize * elementsPerLane;
+    minElementsPerTransfer =
+        std::min(minElementsPerTransfer, elementsPerTransfer);
+  }
+
+  return minElementsPerTransfer != std::numeric_limits<int64_t>::max() &&
+         availableElements % minElementsPerTransfer == 0;
+}
+
+bool isTypeDWORDAligned(RankedTensorType type) {
+  int64_t dimSize = type.getShape().back();
+  if (ShapedType::isDynamic(dimSize)) {
+    return false;
+  }
+  int64_t rowBytes = dimSize * (type.getElementTypeBitWidth() / 8);
+  return rowBytes % 4 == 0;
+}
+
+bool canFitAMDGPUFatRawBuffer(ShapedType type,
+                              std::optional<ValueRange> dynamicDims,
+                              const DataFlowSolver *solver,
+                              int64_t scaleFactor) {
+  if (!type || !type.hasRank()) {
+    return false;
+  }
+  int64_t maxNumElems = 1;
+  // Handle dynamic dimensions.
+  for (Value dynArg : dynamicDims.value_or(ValueRange{})) {
+    if (!solver) {
+      return false;
+    }
+    FailureOr<int64_t> dimMax = getDynamicUpperBound(dynArg, *solver);
+    if (failed(dimMax)) {
+      return false;
+    }
+    if (llvm::MulOverflow(maxNumElems, *dimMax, maxNumElems)) {
+      return false;
+    }
+  }
+  // Handle static dimensions.
+  for (int64_t dim : type.getShape()) {
+    if (ShapedType::isDynamic(dim)) {
+      if (!dynamicDims) {
+        return false;
+      }
+      continue;
+    }
+    if (llvm::MulOverflow(maxNumElems, dim, maxNumElems)) {
+      return false;
+    }
+  }
+  int64_t elementBits = IREE::Util::getTypeBitWidth(type.getElementType());
+  if (llvm::MulOverflow(maxNumElems, elementBits, maxNumElems)) {
+    return false;
+  }
+  int64_t totalBytes = maxNumElems / 8;
+  if (scaleFactor > 1) {
+    if (llvm::MulOverflow(totalBytes, scaleFactor, totalBytes)) {
+      return false;
+    }
+  }
+  return totalBytes < static_cast<int64_t>(std::numeric_limits<int32_t>::max());
 }
 
 void addConfigGPUTarget(MLIRContext *context,

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -19,6 +19,10 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
+namespace mlir {
+class DataFlowSolver;
+} // namespace mlir
+
 namespace mlir::iree_compiler {
 
 static constexpr int32_t kNumGPUDims = 3;
@@ -310,6 +314,32 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 /// Check if the target architecture supports global load DMA.
 /// Returns true only for CDNA4+ (gfx950+) architectures.
 bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target);
+
+/// Returns the subgroup size if the total elements of |shape| are aligned to
+/// DMA transfer sizes, std::nullopt otherwise. When |shape| contains dynamic
+/// dimensions, falls back to checking only the innermost (last) dimension.
+std::optional<int64_t> getDMAAlignedSubgroupSize(IREE::GPU::TargetAttr target,
+                                                 int64_t subgroupSize,
+                                                 Type elementType,
+                                                 ArrayRef<int64_t> shape);
+
+/// Returns true if a row of |dimSize| elements of |elementType| is DWORD
+/// (4-byte) aligned. On AMD CDNA, partial out-of-bounds DWORDs return zero,
+/// so DMA copies require DWORD-aligned source rows. Returns false for dynamic
+/// dimensions.
+bool isDWORDAligned(int64_t dimSize, Type elementType);
+
+/// Check if the total buffer size for the given shaped type fits within
+/// INT32_MAX bytes, which is required for fat_raw_buffer addressing on AMDGPU.
+/// For types with dynamic dimensions, |dynamicDims| and a DataFlowSolver are
+/// needed to compute upper bounds. Returns false conservatively when bounds
+/// cannot be determined. |scaleFactor| multiplies the computed size to account
+/// for split-reduction where the dispatch operand is a fraction of the full
+/// buffer.
+bool canUseFatRawBuffer(ShapedType type,
+                        std::optional<ValueRange> dynamicDims = std::nullopt,
+                        const DataFlowSolver *solver = nullptr,
+                        int64_t scaleFactor = 0);
 
 // Methods to retrieve information association with `configuration` field
 // of `hal.executable.target` attribute used commonly in GPU codegen pipelines.

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -19,6 +19,10 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
+namespace mlir {
+class DataFlowSolver;
+} // namespace mlir
+
 namespace mlir::iree_compiler {
 
 static constexpr int32_t kNumGPUDims = 3;
@@ -333,6 +337,29 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 /// Check if the target architecture supports global load DMA.
 /// Returns true only for CDNA4+ (gfx950+) architectures.
 bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target);
+
+/// Returns true if the total elements of |shape| are aligned to DMA transfer
+/// sizes. When |shape| contains dynamic dimensions, falls back to checking
+/// only the innermost (last) dimension.
+bool isDMATransferAligned(IREE::GPU::TargetAttr target, int64_t subgroupSize,
+                          Type elementType, ArrayRef<int64_t> shape);
+
+/// Returns true if the innermost dimension of |type| is DWORD (4-byte)
+/// aligned. On AMD CDNA, partial out-of-bounds DWORDs return zero, so DMA
+/// copies require DWORD-aligned source rows. Returns false for dynamic
+/// innermost dimensions.
+bool isTypeDWORDAligned(RankedTensorType type);
+
+/// Check if the total buffer size for the given shaped type fits within
+/// INT32_MAX bytes, which is required for fat_raw_buffer addressing on AMDGPU.
+/// For types with dynamic dimensions, |dynamicDims| and a DataFlowSolver are
+/// needed to compute upper bounds. Returns false conservatively when bounds
+/// cannot be determined. |scaleFactor| multiplies the computed size to account
+/// for split-reduction where the dispatch operand is a fraction of the full
+/// buffer.
+bool canFitAMDGPUFatRawBuffer(
+    ShapedType type, std::optional<ValueRange> dynamicDims = std::nullopt,
+    const DataFlowSolver *solver = nullptr, int64_t scaleFactor = 0);
 
 // Methods to retrieve information association with `configuration` field
 // of `hal.executable.target` attribute used commonly in GPU codegen pipelines.


### PR DESCRIPTION
Previously, GPUConvertToCoalescedDMA performed its own DMA feasibility checks (alignment, buffer size, pad validity) at conversion time and silently fell back to stream copies when checks failed. This made it hard to reason about which ops would use DMA vs stream copies, since the decision happened late in the pipeline and was spread across two files.

This PR moves all DMA convertibility checks from GPUConvertToCoalescedDMA (late pipeline) to ConfigUtils (early strategy selection). The conversion pass now trusts that ConfigUtils made the right decisio, checks that previously triggered silent fallback are now assertions, and the pass returns failure if any DMA-marked copy is not lowered.

Verified against 320 gemm shapes: all identical DMA decisions. 8 large-K shapes (K=150000) previously had DMA marked in ConfigUtils but GPUConvertToCoalescedDMA silently failed to convert (buffer exceeded fat_raw_buffer INT32_MAX limit) without downgrading the flag, leaving stale use_global_load_dma attributes. These are now correctly rejected upfront in ConfigUtils.

Assisted-by: Cursor (Claude)