### PR TITLE
[Codegen][GPU] Support pipelining gather_to_lds inside nested regions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -97,22 +97,6 @@ static bool hasDirectGatherToLDS(scf::ForOp forOp) {
   return false;
 }
 
-/// Checks if a loop contains gather_to_lds operations nested inside regions
-/// (e.g., inside scf.if). Such conditional async copies can't be reliably
-/// pipelined.
-static bool hasNestedGatherToLDS(scf::ForOp forOp) {
-  for (Operation &op : forOp.getBody()->getOperations()) {
-    if (op.getNumRegions() > 0) {
-      bool hasNested = false;
-      op.walk([&](amdgpu::GatherToLDSOp) { hasNested = true; });
-      if (hasNested) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 /// Checks if a loop contains stream copy operations (global read + shared
 /// write). This is mutually exclusive with async copy mode.
 static bool hasStreamCopyOps(scf::ForOp forOp) {
@@ -386,10 +370,10 @@ static LogicalResult checkLoopIterations(scf::ForOp forOp) {
 
 // Step 1: Identify root operations for each stage.
 // Root operations are the anchors from which we compute backward slices.
-// This function looks inside scf.if blocks to find roots, so that backward
-// slice computation works naturally without special handling.
+// In async copy mode, any region-bearing op containing gather_to_lds is
+// treated as a load root. In stream copy mode, only scf.if is handled.
 // Returns failure if any scf.if has conflicting operations (both global reads
-// and shared writes).
+// and shared writes) in stream copy mode.
 static LogicalResult identifyRootOperations(
     scf::ForOp forOp, PipelineMode mode, SmallVector<Operation *> &loadRoots,
     SmallVector<Operation *> &readRoots, SmallVector<Operation *> &writeRoots,
@@ -399,13 +383,22 @@ static LogicalResult identifyRootOperations(
 
   for (Operation &op : forOp.getBody()->getOperations()) {
     if (mode == PipelineMode::AsyncCopy) {
-      // Async copy mode: gather_to_lds and scf.yield
       if (isa<amdgpu::GatherToLDSOp>(op)) {
         loadRoots.push_back(&op);
         LDBG() << "  Load root: " << op;
       } else if (isa<scf::YieldOp>(op)) {
         computeRoots.push_back(&op);
         LDBG() << "  Compute root: " << op;
+      } else if (op.getNumRegions() > 0) {
+        // Region-bearing ops (e.g., scf.if, scf.for) may wrap gather_to_lds.
+        // Treat the enclosing op as a load root so it gets scheduled in the
+        // load stage as a single unit.
+        bool hasNestedGather = false;
+        op.walk([&](amdgpu::GatherToLDSOp) { hasNestedGather = true; });
+        if (hasNestedGather) {
+          loadRoots.push_back(&op);
+          LDBG() << "  Load root (nested gather_to_lds): " << op;
+        }
       }
     } else {
       // Stream copy mode: transfer_read, transfer_write, scf.yield
@@ -473,37 +466,40 @@ static LogicalResult computeBackwardSlice(ArrayRef<Operation *> roots,
     slice.insert(root);
     slice.insert_range(rootSlice);
 
+    // If the root is a region-bearing op (e.g., scf.if wrapping gather_to_lds),
+    // capture backward slices of all nested operations to get their
+    // dependencies.
+    if (root->getNumRegions() > 0) {
+      root->walk([&](Operation *nestedOp) {
+        if (nestedOp != root) {
+          SetVector<Operation *> nestedSlice;
+          (void)getBackwardSlice(nestedOp, &nestedSlice, options);
+          slice.insert_range(nestedSlice);
+        }
+      });
+    }
+
     // Also add any parent scf.if operations that contain this root
     // This is necessary because roots inside scf.if need the if to be scheduled
     // We also need to compute backward slices of ALL operations inside the
     // scf.if to capture dependencies like memref.alloca that nested ops use
     Operation *parent = root->getParentOp();
     while (parent != forOp.getOperation()) {
-      if (auto ifOp = dyn_cast<scf::IfOp>(parent)) {
-        slice.insert(ifOp.getOperation());
+      if (parent->getNumRegions() > 0) {
+        slice.insert(parent);
 
-        // Compute backward slice OF the scf.if itself to capture its condition
-        SetVector<Operation *> ifSlice;
-        (void)getBackwardSlice(ifOp.getOperation(), &ifSlice, options);
-        slice.insert_range(ifSlice);
+        SetVector<Operation *> parentSlice;
+        (void)getBackwardSlice(parent, &parentSlice, options);
+        slice.insert_range(parentSlice);
 
-        // Compute backward slices of all nested operations to get dependencies
-        // This approach ensures correctness by capturing all transitive
-        // dependencies like memref.alloca that nested operations may use.
-        ifOp.getOperation()->walk([&](Operation *nestedOp) {
-          if (nestedOp != ifOp.getOperation()) {
+        parent->walk([&](Operation *nestedOp) {
+          if (nestedOp != parent) {
             SetVector<Operation *> nestedSlice;
             (void)getBackwardSlice(nestedOp, &nestedSlice, options);
             slice.insert_range(nestedSlice);
           }
         });
-      } else if (parent->getNumRegions() > 0) {
-        // If we encounter a region-bearing op that's not scf.if, fail
-        LDBG() << "  ERROR: Unsupported nested region-bearing operation: "
-               << parent->getName();
-        return failure();
       }
-      // else: Non-region-bearing intermediate operation, continue walking up
       parent = parent->getParentOp();
     }
   }
@@ -1067,6 +1063,13 @@ static Operation *findLastGatherToLDS(Block::iterator begin,
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
       return &*it;
     }
+    if (it->getNumRegions() > 0) {
+      bool hasNested = false;
+      it->walk([&](amdgpu::GatherToLDSOp) { hasNested = true; });
+      if (hasNested) {
+        return &*it;
+      }
+    }
   }
   return nullptr;
 }
@@ -1091,6 +1094,12 @@ static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
   for (auto it = parentBlock->begin(); it != loopStart; ++it) {
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
       prologueGathers.push_back(&*it);
+    } else if (it->getNumRegions() > 0) {
+      bool hasNested = false;
+      it->walk([&](amdgpu::GatherToLDSOp) { hasNested = true; });
+      if (hasNested) {
+        prologueGathers.push_back(&*it);
+      }
     }
   }
 
@@ -1225,14 +1234,6 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
                                                unsigned numStages) {
   PipelineMode mode = hasGatherToLDS(forOp) ? PipelineMode::AsyncCopy
                                             : PipelineMode::StreamCopy;
-
-  // Check for nested gather_to_lds (e.g., inside scf.if) - this is unsupported
-  // because conditional async copies can't be reliably pipelined.
-  if (hasNestedGatherToLDS(forOp)) {
-    LDBG() << "Loop has gather_to_lds inside nested region (e.g., scf.if) - "
-           << "cannot pipeline";
-    return failure();
-  }
 
   // Check for mixed mode: both gather_to_lds and stream copy ops.
   // This is unsupported - bail out entirely without any pipelining.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -86,6 +86,15 @@ struct StageClassification {
 };
 } // namespace
 
+/// Returns true if the given operation contains gather_to_lds ops nested
+/// inside its regions. This is used to detect region-bearing ops (e.g.,
+/// scf.if) that wrap async DMA loads for warp predication.
+static bool containsNestedGatherToLDS(Operation *op) {
+  bool found = false;
+  op->walk([&](amdgpu::GatherToLDSOp) { found = true; });
+  return found;
+}
+
 /// Checks if a loop contains gather_to_lds operations directly in the loop
 /// body (immediate children of the for loop's body block).
 static bool hasDirectGatherToLDS(scf::ForOp forOp) {
@@ -389,16 +398,12 @@ static LogicalResult identifyRootOperations(
       } else if (isa<scf::YieldOp>(op)) {
         computeRoots.push_back(&op);
         LDBG() << "  Compute root: " << op;
-      } else if (op.getNumRegions() > 0) {
+      } else if (op.getNumRegions() > 0 && containsNestedGatherToLDS(&op)) {
         // Region-bearing ops (e.g., scf.if, scf.for) may wrap gather_to_lds.
         // Treat the enclosing op as a load root so it gets scheduled in the
         // load stage as a single unit.
-        bool hasNestedGather = false;
-        op.walk([&](amdgpu::GatherToLDSOp) { hasNestedGather = true; });
-        if (hasNestedGather) {
-          loadRoots.push_back(&op);
-          LDBG() << "  Load root (nested gather_to_lds): " << op;
-        }
+        loadRoots.push_back(&op);
+        LDBG() << "  Load root (nested gather_to_lds): " << op;
       }
     } else {
       // Stream copy mode: transfer_read, transfer_write, scf.yield
@@ -1063,12 +1068,8 @@ static Operation *findLastGatherToLDS(Block::iterator begin,
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
       return &*it;
     }
-    if (it->getNumRegions() > 0) {
-      bool hasNested = false;
-      it->walk([&](amdgpu::GatherToLDSOp) { hasNested = true; });
-      if (hasNested) {
-        return &*it;
-      }
+    if (it->getNumRegions() > 0 && containsNestedGatherToLDS(&*it)) {
+      return &*it;
     }
   }
   return nullptr;
@@ -1094,12 +1095,8 @@ static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
   for (auto it = parentBlock->begin(); it != loopStart; ++it) {
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
       prologueGathers.push_back(&*it);
-    } else if (it->getNumRegions() > 0) {
-      bool hasNested = false;
-      it->walk([&](amdgpu::GatherToLDSOp) { hasNested = true; });
-      if (hasNested) {
-        prologueGathers.push_back(&*it);
-      }
+    } else if (it->getNumRegions() > 0 && containsNestedGatherToLDS(&*it)) {
+      prologueGathers.push_back(&*it);
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -481,8 +481,11 @@ func.func @prefetch_gather_to_lds_two_operands(
 
 // -----
 
-// CHECK-LABEL: @gather_to_lds_inside_if_not_multibuffered
-func.func @gather_to_lds_inside_if_not_multibuffered(
+// Verify that gather_to_lds inside scf.if IS pipelined with async copy mode.
+// The scf.if is treated as a load root unit, enabling multi-buffering and
+// async mark insertion.
+// CHECK-LABEL: @gather_to_lds_inside_if_pipelined
+func.func @gather_to_lds_inside_if_pipelined(
     %global: memref<128x128xf32>,
     %output: memref<128xf32>,
     %bound: index) {
@@ -492,26 +495,37 @@ func.func @gather_to_lds_inside_if_not_multibuffered(
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
 
-  // CHECK: memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
-  // CHECK-NOT: memref<2x1xf32
+  // Multi-buffered to double-buffer.
+  // CHECK: memref.alloc() : memref<2x1xf32, #gpu.address_space<workgroup>>
   %lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
 
+  // Prologue: scf.if wrapping async gather + asyncmark.
+  // CHECK: scf.if
+  // CHECK:   amdgpu.gather_to_lds async
+  // CHECK: rocdl.asyncmark
+  // CHECK: scf.for
   %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
-    // CHECK: scf.if
     %in_bounds = arith.cmpi slt, %k, %bound : index
-    // CHECK: amdgpu.gather_to_lds
-    // CHECK-NOT: rocdl.asyncmark
-    // CHECK-NOT: rocdl.wait.asyncmark
     scf.if %in_bounds {
       amdgpu.gather_to_lds %global[%c0, %k], %lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
     }
-    // CHECK: vector.transfer_read
+    // Loop body: barrier, next-iteration load (in if), asyncmark, wait, barrier, compute.
+    // CHECK: gpu.barrier
+    // CHECK: scf.if
+    // CHECK:   amdgpu.gather_to_lds async
+    // CHECK: rocdl.asyncmark
+    // CHECK: rocdl.wait.asyncmark 1
+    // CHECK: gpu.barrier
     %val = vector.transfer_read %lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    // CHECK: vector.transfer_read
     // CHECK: arith.addf
     %sum = arith.addf %val, %acc : vector<1xf32>
     // CHECK: scf.yield
     scf.yield %sum : vector<1xf32>
   }
+  // Epilogue: wait for all, barrier, compute.
+  // CHECK: rocdl.wait.asyncmark 0
+  // CHECK: gpu.barrier
 
   vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
   return
@@ -520,8 +534,8 @@ func.func @gather_to_lds_inside_if_not_multibuffered(
 // -----
 
 // Test: gather_to_lds with two operands where one is inside scf.if.
-// The scf.if blocks pipelining in async copy mode. The pre-flight guard
-// should skip both multi-buffering and pipelining, leaving the IR untouched.
+// Both the unconditional and predicated DMAs are pipelined together. The
+// scf.if wrapping the predicated DMA is treated as a load root unit.
 // CHECK-LABEL: @gather_to_lds_two_operands_one_predicated
 func.func @gather_to_lds_two_operands_one_predicated(
     %A_global: memref<128x128xf32>,
@@ -534,29 +548,34 @@ func.func @gather_to_lds_two_operands_one_predicated(
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
 
-  // No multi-buffering: both allocs stay as memref<1xf32, ...>.
-  // CHECK: memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
-  // CHECK: memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
-  // CHECK-NOT: memref<2x1xf32
+  // Both allocs are multi-buffered (double-buffered for 2-stage).
+  // CHECK-DAG: memref.alloc() : memref<2x1xf32, #gpu.address_space<workgroup>>
+  // CHECK-DAG: memref.alloc() : memref<2x1xf32, #gpu.address_space<workgroup>>
   %A_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
   %B_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
 
+  // Prologue: unconditional DMA + predicated DMA in scf.if + asyncmark.
+  // CHECK: amdgpu.gather_to_lds async
+  // CHECK: scf.if
+  // CHECK:   amdgpu.gather_to_lds async
+  // CHECK: rocdl.asyncmark
   // CHECK: scf.for
   %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %cst) -> (vector<1xf32>) {
-    // First DMA is unconditional.
-    // CHECK: amdgpu.gather_to_lds
     amdgpu.gather_to_lds %A_global[%c0, %k], %A_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
 
-    // Second DMA is predicated — blocks pipelining.
     %in_bounds = arith.cmpi slt, %k, %bound : index
-    // CHECK: scf.if
-    // CHECK: amdgpu.gather_to_lds
     scf.if %in_bounds {
       amdgpu.gather_to_lds %B_global[%k, %c0], %B_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
     }
 
-    // CHECK-NOT: rocdl.asyncmark
-    // CHECK-NOT: rocdl.wait.asyncmark
+    // Loop body: barrier, next-iteration loads, asyncmark, wait, barrier, compute.
+    // CHECK: gpu.barrier
+    // CHECK: amdgpu.gather_to_lds async
+    // CHECK: scf.if
+    // CHECK:   amdgpu.gather_to_lds async
+    // CHECK: rocdl.asyncmark
+    // CHECK: rocdl.wait.asyncmark 1
+    // CHECK: gpu.barrier
     %a_val = vector.transfer_read %A_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
     %b_val = vector.transfer_read %B_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
     %prod = arith.mulf %a_val, %b_val : vector<1xf32>
@@ -564,6 +583,9 @@ func.func @gather_to_lds_two_operands_one_predicated(
     // CHECK: scf.yield
     scf.yield %sum : vector<1xf32>
   }
+  // Epilogue: wait for all, barrier, compute.
+  // CHECK: rocdl.wait.asyncmark 0
+  // CHECK: gpu.barrier
 
   vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
   return


### PR DESCRIPTION
This PR fixed most (if not all) of the TN shape regressions in my local perf regression test.

Enable the prefetch pass to pipeline async gather_to_lds operations that are wrapped inside region-bearing ops (e.g., scf.if guards from warp predication). Previously, any gather_to_lds nested inside a region was rejected, causing fallback to stream copy mode and significant performance regressions for shapes where not all warps participate in DMA (e.g., 1134x2048x150000 f32 LHS-transposed GEMM). - This config is still skipped by current branch because innermost pad created a dynamic dim, but that's a separate issue.

If a warp skips its conditional async load, its vmcnt is already lower, so the wait is trivially satisfied. This makes pipelining scf.if-guarded async loads both safe.

Changes:
- Remove the hasNestedGatherToLDS pre-flight rejection.
- In async copy mode, treat any region-bearing op containing gather_to_lds as a load root, scheduling it as a single unit.
- Extend backward slice computation to capture dependencies of ops nested inside region-bearing roots and parents.
- Update tests to verify pipelining of predicated gather_to_lds.