### PR TITLE
Bump LLVM to llvm/llvm-project@5ea5b9eb8eec

### DIFF
--- a/compiler/plugins/target/LLVMCPU/internal/WindowsLinkerTool.cpp
+++ b/compiler/plugins/target/LLVMCPU/internal/WindowsLinkerTool.cpp
@@ -179,8 +179,7 @@ public:
         "/out:" + artifacts.libraryFile.path,
     };
 
-    if (targetOptions.target.optimizerOptLevel.getSpeedupLevel() >= 2 ||
-        targetOptions.target.optimizerOptLevel.getSizeLevel() >= 2) {
+    if (targetOptions.target.optimizerOptLevel.getSpeedupLevel() >= 2) {
       // https://docs.microsoft.com/en-us/cpp/build/reference/opt-optimizations?view=vs-2019
       // Enable all the fancy optimizations.
       flags.push_back("/opt:ref,icf,lbr");

--- a/compiler/src/iree/compiler/Utils/OptionUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.cpp
@@ -214,8 +214,6 @@ bool llvm::cl::parser<llvm::OptimizationLevel>::parse(
                  .Case("O1", OptimizationLevel::O1)
                  .Case("O2", OptimizationLevel::O2)
                  .Case("O3", OptimizationLevel::O3)
-                 // .Case("Os", OptimizationLevel::Os)
-                 // .Case("Oz", OptimizationLevel::Oz)
                  .Default(std::nullopt);
   if (!val) {
     return O.error("'" + Arg +
@@ -233,13 +231,13 @@ void llvm::cl::parser<llvm::OptimizationLevel>::printOptionDiff(
   std::string Str;
   {
     llvm::raw_string_ostream SS(Str);
-    SS << V.getSpeedupLevel() << "/" << V.getSizeLevel();
+    SS << V.getSpeedupLevel();
   }
   outs() << "= " << Str;
   outs().indent(2) << " (default: ";
   if (Default.hasValue()) {
     auto defaultVal = Default.getValue();
-    outs() << defaultVal.getSpeedupLevel() << "/" << defaultVal.getSizeLevel();
+    outs() << defaultVal.getSpeedupLevel();
   } else {
     outs() << "*no default*";
   }

--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -35,7 +35,6 @@ struct opt_initializer {
                   const Ty &val)
       : parentName(parentName), init(val), optLevel(opt) {}
   void apply(const llvm::OptimizationLevel inLevel, Ty &val) const {
-    assert(inLevel.getSizeLevel() == 0 && "size level not implemented");
     if (inLevel.getSpeedupLevel() >= optLevel.getSpeedupLevel()) {
       val = init;
     }


### PR DESCRIPTION
Applied fixes for https://github.com/llvm/llvm-project/commit/86b9775612f8
- Drop `getSizeLevel()`, `isOptimizingForSize()`, `OptimizationLevel::Os`, and `OptimizationLevel::Oz`, on the rationale that size optimization should come from` O2 + optsize/minsize` function attributes instead of pipeline-level `Os/Oz`.