### PR TITLE
[Codegen] inner_tiled op: finish CPU support including scalable tiles.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
 
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.cpp.inc"
@@ -349,9 +350,42 @@ getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
   }
 }
 
+/// Helper for `getIntrinsicSwizzle`:
+/// Ensures every `expandShape` row has at least one piece (unit
+/// dims that received no explicit `expand` get a non-scalable size-1 Internal
+/// piece), and sets `permutation` to the identity over the total number of
+/// expanded dims.
+static Codegen::TileSwizzle fixupSwizzle(Codegen::TileSwizzle swizzle) {
+  for (auto &group : swizzle.expandShape()) {
+    if (group.empty()) {
+      group.push_back(Codegen::TileSwizzle::Dim::internal(1));
+    }
+  }
+  auto &permutation = swizzle.permutation();
+  permutation.resize(swizzle.getExpandedSize());
+  for (size_t i = 0; i < permutation.size(); ++i) {
+    permutation[i] = i;
+  }
+  return swizzle;
+}
+
 Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
                                          int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
+  using Dim = TileSwizzle::Dim;
+
+  // Just one scalable intrinsic for now, to allow writing some tests.
+  if (mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32) {
+    TileSwizzle swizzle;
+    swizzle.expandShape().resize(2);
+    if (operandIdx != 0) {
+      Codegen::expand(
+          swizzle, /*srcDim=*/0,
+          Dim::internal(4, Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits));
+    }
+    return fixupSwizzle(std::move(swizzle));
+  }
+
   auto maybeMnkTuple = getRowMajorTilesMNKShape(mma);
   if (!maybeMnkTuple) {
     // Whenever one adds support for a new intrinsic that doesn't have a
@@ -377,11 +411,11 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
     expandIfNonUnit(swizzle, K, kSize);
     expandIfNonUnit(swizzle, N, nSize);
   } else {
-    constexpr int N = 0, M = 1;
+    constexpr int M = 0, N = 1;
     expandIfNonUnit(swizzle, N, nSize);
     expandIfNonUnit(swizzle, M, mSize);
   }
-  return swizzle;
+  return fixupSwizzle(std::move(swizzle));
 }
 
 Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
@@ -394,7 +428,10 @@ Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
       TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsN());
   TileSwizzle::Dim intrinsicsK =
       TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsK());
-  // LHS: (M, K); RHS: (K, N); Acc: (M, N).
+  // Each swizzle is built as (outer physical dim, inner physical dim) in
+  // expandShape[0], expandShape[1]. LHS is (M, K), RHS is (N, K), ACC is
+  // (M, N). The expansion below injects the intrinsics_* cross-intrinsic
+  // factors into whichever group represents each logical dim.
   if (operandIdx == 0) {
     constexpr int M = 0, K = 1;
     if (intrinsicsK.size() > 1) {
@@ -451,6 +488,8 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
     return {i8, i8, i32};
+  case MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32:
+    return {f32, f32, f32};
   default:
     return {Type(), Type(), Type()};
   }
@@ -469,6 +508,21 @@ DataTiledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
   return linalg::inferContractionDims(maps);
 }
 
+/// Returns a pair where the first element is the element count of the group and
+/// the second element is whether the group contains a scalable dimension.
+static std::pair<int64_t, bool>
+getVectorAxisSizeAndScalability(ArrayRef<Codegen::TileSwizzle::Dim> group) {
+  using Dim = Codegen::TileSwizzle::Dim;
+  int64_t size = 1;
+  bool scalable = false;
+  for (const Dim &d : group) {
+    size *= d.size();
+    scalable |= d.kind() == Dim::Kind::Internal &&
+                d.symbolicMultiplier() != Dim::SymbolicMultiplier::One;
+  }
+  return {size, scalable};
+}
+
 void DataTiledMMAAttr::getUndistributedTileTypes(
     SmallVectorImpl<VectorType> &result) const {
   MLIRContext *ctx = getContext();
@@ -477,22 +531,23 @@ void DataTiledMMAAttr::getUndistributedTileTypes(
     result.clear();
     return;
   }
-  auto lhsSwizzle = getSwizzle(*this, 0);
-  auto rhsSwizzle = getSwizzle(*this, 1);
-  auto getTileSize = [](const Codegen::TileSwizzle &swizzle, int srcDimIdx) {
-    int64_t size = 1;
-    auto e = swizzle.expandShape()[srcDimIdx];
-    for (auto d : e) {
-      size *= d.size();
-    }
-    return size;
-  };
-  int64_t m = getTileSize(lhsSwizzle, 0);
-  int64_t n = getTileSize(rhsSwizzle, 0);
-  int64_t k = getTileSize(rhsSwizzle, 1);
   auto [aType, bType, cType] = getABCElementTypes(ctx, intrinsic);
-  result.assign({VectorType::get({m, k}, aType), VectorType::get({k, n}, bType),
-                 VectorType::get({m, n}, cType)});
+  // Each operand's swizzle encodes its tile shape as (outer physical dim,
+  // inner physical dim) in expandShape[0], expandShape[1]. This mirrors GPU's
+  // DataTiledMMA, where the tile types encode the layout directly and no
+  // separate `permutations` attribute is needed on `inner_tiled`. LHS is
+  // (M, K), RHS is (N, K), ACC is (M, N).
+  auto tileType = [&](Codegen::TileSwizzle swizzle, Type elemType) {
+    auto [outer, outerScalable] =
+        getVectorAxisSizeAndScalability(swizzle.expandShape()[0]);
+    auto [inner, innerScalable] =
+        getVectorAxisSizeAndScalability(swizzle.expandShape()[1]);
+    bool scalable[] = {outerScalable, innerScalable};
+    return VectorType::get({outer, inner}, elemType, scalable);
+  };
+  result.assign({tileType(getSwizzle(*this, 0), aType),
+                 tileType(getSwizzle(*this, 1), bType),
+                 tileType(getSwizzle(*this, 2), cType)});
 }
 
 void DataTiledMMAAttr::getDistributedTileTypes(

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -115,6 +115,11 @@ def MMA_X86_AVX512_1x16x2_I32_I8_CASTI16
 def MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16", 0x13C1>;
 
+// AArch64 SVE `fmla` (f32, f32): 1×N×1 matmul tile; N is a scalable vector of
+// 4 f32 lanes per 128-bit chunk (see `ArmSveVLIn128bitUnits`).
+def MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32
+    : I32EnumAttrCase<"MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32", 0x2210>;
+
 def IREECPU_MMAIntrinsic
     : IREECPU_I32EnumAttr<
           "MMAIntrinsic", "Descriptor for different MMA intrinsics",
@@ -127,7 +132,10 @@ def IREECPU_MMAIntrinsic
            MMA_X86_AVX512BF16_1x16x2_F32_BF16, MMA_X86_AVX512_1x16x2_I32_I16,
            MMA_X86_AVX512VNNI_1x16x2_I32_I16,
            MMA_X86_AVX512_1x16x2_I32_I8_CASTI16,
-           MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16]>;
+           MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
+
+           // Arm SVE
+           MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32]>;
 
 //===----------------------------------------------------------------------===//
 // CPU Lowering Pipelines

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
@@ -36,3 +36,89 @@
 
 // expected-error@+1 {{}}
 #invalid_vector_inner_parallel_config = #iree_cpu.lowering_config<vector_inner_parallel = 128 : i64>
+
+// -----
+
+// `inner_tiled` rejects kind and semantics attributes from different dialects.
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+func.func @cpu_inner_tiled_requires_cpu_semantics(
+    %lhs: tensor<1x1x16x1xf32>, %rhs: tensor<1x1x16x1xf32>, %acc: tensor<1x1x16x16xf32>) -> tensor<1x1x16x16xf32> {
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op kind attribute (dialect 'iree_cpu') and semantics attribute (dialect 'iree_gpu') must use the same dialect namespace}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>,
+    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>
+  } : tensor<1x1x16x1xf32>, tensor<1x1x16x1xf32> into tensor<1x1x16x16xf32>
+  return %0 : tensor<1x1x16x16xf32>
+}
+
+// -----
+
+// Inner tiles do not match the MMA tiles of the (default) 1×1×1 intrinsic:
+// `intrinsics_m = 16` is needed to match the 16×1 / 16×1 / 16×16 inner shapes.
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+func.func @cpu_inner_tiled_f32_avx512_missing_intrinsics_m(
+    %lhs: tensor<1x1x16x1xf32>, %rhs: tensor<1x1x16x1xf32>, %acc: tensor<1x1x16x16xf32>) -> tensor<1x1x16x16xf32> {
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<16x1xf32>' is incompatible with expected MMA tile type 'vector<1x1xf32>'}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<1x1x16x1xf32>, tensor<1x1x16x1xf32> into tensor<1x1x16x16xf32>
+  return %0 : tensor<1x1x16x16xf32>
+}
+
+// -----
+
+// Operand element type must match the MMA tile element type.
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+func.func @cpu_inner_tiled_element_type_mismatch(
+    %lhs: tensor<1x1x16x1xf16>, %rhs: tensor<1x1x16x1xf16>, %acc: tensor<1x1x16x16xf32>) -> tensor<1x1x16x16xf32> {
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<16x1xf16>' is incompatible with expected MMA tile type 'vector<16x1xf32>'}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<1x1x16x1xf16>, tensor<1x1x16x1xf16> into tensor<1x1x16x16xf32>
+  return %0 : tensor<1x1x16x16xf32>
+}
+
+// -----
+
+// Scalable MMA tile axes (here N in `vector<1x[4]xf32>`) require a dynamic
+// tensor extent; a fixed extent like 4 does not match.
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+func.func @cpu_inner_tiled_sve_rhs_n_must_be_dynamic(
+    %lhs: tensor<1x1x1x1xf32>, %rhs: tensor<1x1x4x1xf32>, %acc: tensor<1x1x1x?xf32>) -> tensor<1x1x1x?xf32> {
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #1 inner tile 'tensor<4x1xf32>' is incompatible with expected MMA tile type 'vector<[4]x1xf32>'}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<1x1x1x1xf32>, tensor<1x1x4x1xf32> into tensor<1x1x1x?xf32>
+  return %0 : tensor<1x1x1x?xf32>
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -1,8 +1,4 @@
 // RUN: iree-opt %s -split-input-file | FileCheck %s
-//
-// Test that iree_codegen.inner_tiled accepts kind = #iree_cpu.data_tiled_mma_layout<...>
-// with semantics = #iree_cpu.mma_semantics<...>, exercising different
-// IREECPU_MMAIntrinsic enum values and power-of-two intrinsics_{m,n,k} in 1..8.
 
 #contraction_accesses = [
   affine_map<(i, j, k) -> (i, k)>,
@@ -82,14 +78,14 @@ func.func @cpu_avx512_1x16x1_f16_castf32(
 ]
 // MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics 1x1x2
 func.func @cpu_avx512fp16_1x32x1_f16(
-    %lhs: vector<1x2x1x2xf16>, %rhs: vector<2x1x2x32xf16>, %acc: vector<1x1x1x32xf16>)
+    %lhs: vector<1x2x1x2xf16>, %rhs: vector<2x1x32x2xf16>, %acc: vector<1x1x1x32xf16>)
     -> vector<1x1x1x32xf16> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics_k = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x2x1x2xf16>, vector<2x1x2x32xf16> into vector<1x1x1x32xf16>
+  } : vector<1x2x1x2xf16>, vector<2x1x32x2xf16> into vector<1x1x1x32xf16>
   return %0 : vector<1x1x1x32xf16>
 }
 // CHECK-LABEL: func @cpu_avx512fp16_1x32x1_f16
@@ -105,14 +101,14 @@ func.func @cpu_avx512fp16_1x32x1_f16(
 ]
 // MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics 2x2x1
 func.func @cpu_avx512bf16_1x16x2_bf16(
-    %lhs: vector<2x1x2x2xbf16>, %rhs: vector<1x2x2x32xbf16>, %acc: vector<2x2x2x32xf32>)
+    %lhs: vector<2x1x2x2xbf16>, %rhs: vector<1x2x32x2xbf16>, %acc: vector<2x2x2x32xf32>)
     -> vector<2x2x2x32xf32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 2, intrinsics_n = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<2x1x2x2xbf16>, vector<1x2x2x32xbf16> into vector<2x2x2x32xf32>
+  } : vector<2x1x2x2xbf16>, vector<1x2x32x2xbf16> into vector<2x2x2x32xf32>
   return %0 : vector<2x2x2x32xf32>
 }
 // CHECK-LABEL: func @cpu_avx512bf16_1x16x2_bf16
@@ -128,14 +124,14 @@ func.func @cpu_avx512bf16_1x16x2_bf16(
 ]
 // MMA_X86_AVX512_1x16x2_I32_I16, intrinsics 1x4x1
 func.func @cpu_avx512_1x16x2_i32_i16(
-    %lhs: vector<1x1x1x2xi16>, %rhs: vector<1x4x2x64xi16>, %acc: vector<1x4x1x64xi32>)
+    %lhs: vector<1x1x1x2xi16>, %rhs: vector<1x4x64x2xi16>, %acc: vector<1x4x1x64xi32>)
     -> vector<1x4x1x64xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I16, intrinsics_n = 4>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x1x1x2xi16>, vector<1x4x2x64xi16> into vector<1x4x1x64xi32>
+  } : vector<1x1x1x2xi16>, vector<1x4x64x2xi16> into vector<1x4x1x64xi32>
   return %0 : vector<1x4x1x64xi32>
 }
 // CHECK-LABEL: func @cpu_avx512_1x16x2_i32_i16
@@ -151,14 +147,14 @@ func.func @cpu_avx512_1x16x2_i32_i16(
 ]
 // MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics 2x1x2
 func.func @cpu_avx512vnni_1x16x2_i32_i16(
-    %lhs: vector<2x2x2x4xi16>, %rhs: vector<2x1x4x16xi16>, %acc: vector<2x1x2x16xi32>)
+    %lhs: vector<2x2x2x4xi16>, %rhs: vector<2x1x16x4xi16>, %acc: vector<2x1x2x16xi32>)
     -> vector<2x1x2x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics_m = 2, intrinsics_k = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<2x2x2x4xi16>, vector<2x1x4x16xi16> into vector<2x1x2x16xi32>
+  } : vector<2x2x2x4xi16>, vector<2x1x16x4xi16> into vector<2x1x2x16xi32>
   return %0 : vector<2x1x2x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512vnni_1x16x2_i32_i16
@@ -174,14 +170,14 @@ func.func @cpu_avx512vnni_1x16x2_i32_i16(
 ]
 // MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics 1x1x4
 func.func @cpu_avx512_1x16x2_i32_i8(
-    %lhs: vector<1x4x1x8xi8>, %rhs: vector<4x1x8x16xi8>, %acc: vector<1x1x1x16xi32>)
+    %lhs: vector<1x4x1x8xi8>, %rhs: vector<4x1x16x8xi8>, %acc: vector<1x1x1x16xi32>)
     -> vector<1x1x1x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics_k = 4>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x4x1x8xi8>, vector<4x1x8x16xi8> into vector<1x1x1x16xi32>
+  } : vector<1x4x1x8xi8>, vector<4x1x16x8xi8> into vector<1x1x1x16xi32>
   return %0 : vector<1x1x1x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512_1x16x2_i32_i8
@@ -197,16 +193,90 @@ func.func @cpu_avx512_1x16x2_i32_i8(
 ]
 // MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics 4x1x2
 func.func @cpu_avx512vnni_1x16x2_i32_i8(
-    %lhs: vector<4x2x4x4xi8>, %rhs: vector<2x1x4x16xi8>, %acc: vector<4x1x4x16xi32>)
+    %lhs: vector<4x2x4x4xi8>, %rhs: vector<2x1x16x4xi8>, %acc: vector<4x1x4x16xi32>)
     -> vector<4x1x4x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics_m = 4, intrinsics_k = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<4x2x4x4xi8>, vector<2x1x4x16xi8> into vector<4x1x4x16xi32>
+  } : vector<4x2x4x4xi8>, vector<2x1x16x4xi8> into vector<4x1x4x16xi32>
   return %0 : vector<4x1x4x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512vnni_1x16x2_i32_i8
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics_m = 4, intrinsics_k = 2>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+func.func @cpu_inner_tiled_tensor_avx512_f32_packed_m16(
+    %lhs: tensor<2x4x16x1xf32>, %rhs: tensor<4x3x16x1xf32>, %acc: tensor<2x3x16x16xf32>)
+    -> tensor<2x3x16x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<2x4x16x1xf32>, tensor<4x3x16x1xf32> into tensor<2x3x16x16xf32>
+  return %0 : tensor<2x3x16x16xf32>
+}
+// CHECK-LABEL: func @cpu_inner_tiled_tensor_avx512_f32_packed_m16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// Same as the f32 testcase above, but using bf16 so the undistributed LHS/RHS
+// tiles are 16×2 instead of 16×1. This exercises the non-unit RHS N/K shape
+// mismatch that would occur without using the physical N×K MMA tile layout.
+func.func @cpu_inner_tiled_tensor_avx512bf16_packed_m16(
+    %lhs: tensor<2x4x16x2xbf16>, %rhs: tensor<4x3x16x2xbf16>, %acc: tensor<2x3x16x16xf32>)
+    -> tensor<2x3x16x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 16>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<2x4x16x2xbf16>, tensor<4x3x16x2xbf16> into tensor<2x3x16x16xf32>
+  return %0 : tensor<2x3x16x16xf32>
+}
+// CHECK-LABEL: func @cpu_inner_tiled_tensor_avx512bf16_packed_m16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 16>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// AArch64 SVE `fmla`: scalable N in the RHS/acc MMA tiles (`vector<1x[4]xf32>`)
+// pairs with dynamic (`?`) tensor inner extents on N.
+func.func @cpu_inner_tiled_tensor_arm_sve_fmla_f32(
+    %lhs: tensor<2x2x1x1xf32>, %rhs: tensor<2x2x1x?xf32>, %acc: tensor<2x2x1x?xf32>)
+    -> tensor<2x2x1x?xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<2x2x1x1xf32>, tensor<2x2x1x?xf32> into tensor<2x2x1x?xf32>
+  return %0 : tensor<2x2x1x?xf32>
+}
+// CHECK-LABEL: func @cpu_inner_tiled_tensor_arm_sve_fmla_f32
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -21,6 +22,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -221,21 +223,56 @@ InnerTiledOp::inferReturnTypes(MLIRContext *, std::optional<Location>,
   return success();
 }
 
-static bool tileShapesMatch(ArrayRef<int64_t> operandTile,
-                            ArrayRef<int64_t> mmaTile, bool opaque) {
-  if (opaque) {
-    // Opaque tiles: only compare element counts.
-    return llvm::product_of(operandTile) == llvm::product_of(mmaTile);
+// Returns true when the operand's inner tile (`tensorTileType`) matches
+// the MMA vector tile `vectorType`:
+//   - element types must match;
+//   - If `opaqueSemantics` and the tiles are static/non-scalable, the
+//     element counts must match.
+//   - Otherwise, the shapes must match after dropping non-scalable unit extents
+//     from each side.
+static bool matchTileTypes(RankedTensorType tensorTileType,
+                           VectorType vectorType, bool opaqueSemantics) {
+  if (tensorTileType.getElementType() != vectorType.getElementType()) {
+    return false;
   }
-  // Compare tile shapes for equality modulo unit dims.
-  auto nonUnitDim = [](int64_t n) { return n != 1; };
-  return llvm::filter_to_vector(operandTile, nonUnitDim) ==
-         llvm::filter_to_vector(mmaTile, nonUnitDim);
+
+  if (opaqueSemantics) {
+    // Opaque semantics are only used on GPU. No scalable vectors.
+    return tensorTileType.hasStaticShape() && !vectorType.isScalable() &&
+           llvm::product_of(tensorTileType.getShape()) ==
+               llvm::product_of(vectorType.getShape());
+  }
+
+  // Keep only non-unit extents on the tensor side, and non-unit-or-scalable
+  // extents (paired with their scalable flag) on the MMA side.
+  auto tensorDims = llvm::filter_to_vector(tensorTileType.getShape(),
+                                           [](int64_t d) { return d != 1; });
+  auto vectorDims = llvm::filter_to_vector(
+      llvm::zip_equal(vectorType.getShape(), vectorType.getScalableDims()),
+      [](auto dim) {
+        auto [size, scalable] = dim;
+        return scalable || size != 1;
+      });
+
+  if (tensorDims.size() != vectorDims.size()) {
+    return false;
+  }
+  for (auto [tensorSize, vecDim] : llvm::zip_equal(tensorDims, vectorDims)) {
+    auto [vecSize, scalable] = vecDim;
+    if (scalable && ShapedType::isStatic(tensorSize)) {
+      return false;
+    }
+    if (!scalable && tensorSize != vecSize) {
+      return false;
+    }
+  }
+  return true;
 }
 
 static LogicalResult verifyOperandTypes(InnerTiledOp tiledOp) {
   SmallVector<VectorType> mmaVectorTypes;
   tiledOp.getSemantics().getTileTypes(tiledOp.getKind(), mmaVectorTypes);
+  const bool opaque = tiledOp.getSemantics().getOpaque();
 
   for (auto [index, tuple] : llvm::enumerate(llvm::zip_equal(
            tiledOp.getOperandTypes(),
@@ -244,44 +281,28 @@ static LogicalResult verifyOperandTypes(InnerTiledOp tiledOp) {
     auto [opType, map, mmaVectorType] = tuple;
     ShapedType operandShapedType = cast<ShapedType>(opType);
     Type operandElemType = operandShapedType.getElementType();
-    Type mmaElemType = mmaVectorType.getElementType();
-    if (operandElemType != mmaElemType) {
-      return tiledOp.emitOpError(
-          llvm::formatv("operand element type {} does not match expected MMA "
-                        "tile element type {}",
-                        operandElemType, mmaElemType));
-    }
-    ArrayRef<int64_t> operandShape = cast<ShapedType>(opType).getShape();
+
+    ArrayRef<int64_t> operandShape = operandShapedType.getShape();
     ArrayRef<int64_t> operandTileShape(
         operandShape.drop_front(map.getNumResults()));
-    ArrayRef<int64_t> mmaTileShape = mmaVectorType.getShape();
-    SmallVector<int64_t> permutedMmaTileShape(mmaTileShape);
+    auto tensorTileType =
+        RankedTensorType::get(operandTileShape, operandElemType);
+    SmallVector<int64_t> mmaShape(mmaVectorType.getShape());
+    SmallVector<bool> mmaScalable(mmaVectorType.getScalableDims());
     std::optional<ArrayAttr> permutations = tiledOp.getPermutations();
-    bool opaque = tiledOp.getSemantics().getOpaque();
     if (permutations && !opaque) {
       ArrayRef<int64_t> perm =
-          cast<DenseI64ArrayAttr>(permutations.value()[index]).asArrayRef();
-      applyPermutationToVector(permutedMmaTileShape, perm);
+          cast<DenseI64ArrayAttr>((*permutations)[index]).asArrayRef();
+      applyPermutationToVector(mmaShape, perm);
+      applyPermutationToVector(mmaScalable, perm);
     }
-    if (!tileShapesMatch(operandTileShape, permutedMmaTileShape, opaque)) {
-      VectorType operandTileType =
-          VectorType::get(operandTileShape, operandElemType);
-      VectorType permutedMmaTileType =
-          VectorType::get(permutedMmaTileShape, operandElemType);
+    auto vectorType =
+        VectorType::get(mmaShape, mmaVectorType.getElementType(), mmaScalable);
 
-      std::string permutationNote;
-      if (permutations) {
-        permutationNote = llvm::formatv(
-            " Note: the permuted InnerTiledDescAttr tile type {} comes from "
-            "applying the permutation {} to the original InnerTiledDescAttr "
-            "tile type {}.",
-            permutedMmaTileType, permutations.value()[index], mmaVectorType);
-      }
-      return tiledOp->emitOpError(llvm::formatv(
-          "operand type {}, implying tile type {}, is incompatible with "
-          "permuted InnerTiledDescAttr tile type {} under semantics {}.{}",
-          opType, operandTileType, permutedMmaTileType, tiledOp.getSemantics(),
-          permutationNote));
+    if (!matchTileTypes(tensorTileType, vectorType, opaque)) {
+      return tiledOp.emitOpError()
+             << "operand #" << index << " inner tile " << tensorTileType
+             << " is incompatible with expected MMA tile type " << vectorType;
     }
   }
   return success();
@@ -299,6 +320,15 @@ LogicalResult InnerTiledOp::verify() {
     return emitOpError("number of outputs (" + Twine(getNumOutputs()) +
                        ") doesn't match expected number from kind (" +
                        Twine(expectedNumOuts) + ")");
+  }
+
+  StringRef kindNs = cast<Attribute>(getKind()).getDialect().getNamespace();
+  StringRef semNs = cast<Attribute>(getSemantics()).getDialect().getNamespace();
+  if (kindNs != semNs) {
+    return emitOpError(
+        llvm::formatv("kind attribute (dialect '{0}') and semantics attribute "
+                      "(dialect '{1}') must use the same dialect namespace",
+                      kindNs, semNs));
   }
 
   SmallVector<ShapedType> opTypes =
@@ -336,14 +366,6 @@ LogicalResult InnerTiledOp::verify() {
     if (!map.isProjectedPermutation()) {
       return emitOpError("expected indexing map ")
              << index << " to be a projected permutation";
-    }
-
-    for (int64_t size :
-         shapedType.getShape().take_back(rank - map.getNumResults())) {
-      if (ShapedType::isDynamic(size)) {
-        return emitOpError("Unexpected dynamic inner dim for operand ")
-               << index << " of type " << shapedType;
-      }
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -267,158 +267,101 @@ def IREECodegen_InnerTiledOp : Op<IREECodegen_Dialect, "inner_tiled", [
         "getTiledImplementation",
         "getResultTilePosition"]>
     ]> {
-  let summary = [{Models an inner-tiled operation that may perform contractions.}];
+  let summary = [{Generic operation on tiled operands based on an intrinsic.}];
   let description = [{
-    Represents an operation that updates "inner tiles" (vector slices) of its accumulator
-    outputs using inner tiles of its input operands. The way the inner tiles are
-    used is determined by the semantics of the `kind` attribute. These inner tiles
-    are the trailing dimensions of the tensor/vector operands that are not present
-    in the indexing maps.
+    Each operand's shape is viewed as `outer_dims x inner_tile`:
+    - The outer dims are those described by the operand's indexing map; they
+      are iterated by an outer loop nest specified by `iterator_types` and
+      `indexing_maps`, with the same conventions as `vector.contract`.
+    - The remaining trailing dims form the operand's inner tile. At each
+      outer iteration point, the output inner tiles are updated from the
+      input inner tiles by the intrinsic named by `kind`.
 
-    In the case of a matrix-multiply-accumulate (MMA) inner tiled operation,
-    the semantics logically match `vector.contraction`. However, instead of a
-    combiner type, it has a intrinsic description that specifies how the inner tiles
-    are combined.
+    Operands may be tensors, memrefs or vectors. Inner-tile dims are generally
+    static, the only exception being scalable vectors dimensions which
+    correspond to dynamic tensor dimensions.
 
-    Similar to `vector.contract`, an iterator type attribute list must be
-    specified, where each element of the list represents an iterator over one
-    of the outer dimensions. Iteration of inner dimensions is defined solely by
-    the intrinsic and may be opaque.
+    ### Attributes
 
-    An indexing map attribute list must be specified with an entry for input and
-    output arguments. An indexing map attribute specifies a mapping from each
-    outer loop iterator in the iterator type list, to each dimension of each
-    operand.
+    - `kind` (`InnerTileDescAttrInterface`): names the intrinsic. It fixes
+      the number of inputs/outputs and, together with `semantics`, the
+      canonical inner-tile vector type of each operand.
+    - `semantics` (`InnerTiledSemanticsAttrInterface`): controls how strictly
+      operand inner tiles are checked against `kind`. Different `semantics`
+      attributes from different dialects may adopt different conventions, but
+      there are generally two main modes:
+      * `opaque = true`: only the element type and total element count of
+        each inner tile must match the canonical vector type. Shape and
+        rank are otherwise free. Scalable vectors and dynamic tensor dims
+        are not allowed in this mode.
+      * Default / `opaque = false`: after dropping non-scalable unit dims, the
+        operand inner-tile shape must match the (permuted) canonical shape
+        one-to-one. Scalable vector dimensions are supported and must correspond
+        to dynamic tensor dimensions. Every other tensor dimension must be static.
+    - `indexing_maps`: one projected-permutation `AffineMap` per operand
+      (inputs first, then outputs), all sharing the same number of dims
+      (equal to `iterator_types.size()`) and no symbols.
+    - `iterator_types`: one of `parallel` / `reduction` for each outer
+      iterator dim.
+    - `permutations` (optional): If present, there is one entry per operand,
+      each a permutation vector
+      `p` of length equal to that operand's inner rank, giving the
+      relationship between the canonical inner-tile shape `C` (from
+      `kind`/`semantics`) and the operand's actual inner-tile shape `S`:
+      `S[i] == C[p[i]]`.
 
-    Example:
+    ### Examples
 
-    ```mlir
-    #contraction_accesses = [
-     affine_map<(i, j, k) -> (i, k)>,
-     affine_map<(i, j, k) -> (k, j)>,
-     affine_map<(i, j, k) -> (i, j)>
-    ]
-    #contraction_trait = {
-      indexing_maps = #contraction_accesses,
-      iterator_types = ["parallel", "parallel", "reduction"],
-      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-      distributed = true,
-      opaque = false
-    }
-    %3 = iree_codegen.inner_tiled ins(%0, %1) outs(%2) #contraction_trait
-      : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
-
-    // Takes tensors as well, however the inner dimensions must always be
-    // static.
-    %7 = iree_codegen.inner_tiled ins(%4, %5) outs(%6) #contraction_trait
-      : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
-    ```
-
-    The example above can be logically lowered directly to loops like this
-    (ignoring type conversions from tensor to vector needed for the mfma).
-    ```
-    %outer_m = tensor.dim %6, %c0 : index
-    %outer_n = tensor.dim %6, %c1 : index
-    %outer_k = tensor.dim %4, %c1 : index
-    %7 = scf.for %i = %c0 to %outer_m iter_args(%arg0 = %6) {
-      %8 = scf.for %j = %c0 to %outer_n iter_args(%arg1 = %arg0) {
-        %9 = scf.for %k = %c0 to %outer_k iter_args(%arg2 = %arg1) {
-          %lhs = tensor.extract_slice %4 [%i, %k, 0] [1, 1, 4] [1, 1, 1] : tensor<4xf16>
-          %rhs = tensor.extract_slice %5 [%k, %j, 0] [1, 1, 4] [1, 1, 1] : tensor<4xf16>
-          %acc = tensor.extract_slice %arg2 [%i, %j, 0] [1, 1, 4] [1, 1, 1] : tensor<4xf32>
-          %res = amdgpu.mfma %lhs, %rhs, %acc : tensor<4xf32>
-          %ret = tensor.insert_slice %acc into %arg2 [%i, %j, 0] [1, 1, 4] [1, 1, 1] : tensor<?x?x4xf32>
-          scf.yield %ret : tensor<?x?x4xf32>
-        }
-        scf.yield %9 : tensor<?x?x4xf32>
-      }
-      scf.yield %8 : tensor<?x?x4xf32>
-    }
-    ```
-
-    Or alternatively unrolled to a single intrinsic when operating on vectors.
-    ```mlir
-    #contraction_accesses = [
-     affine_map<() -> ()>,
-     affine_map<() -> ()>,
-     affine_map<() -> ()>
-    ]
-    #contraction_trait = {
-      indexing_maps = #contraction_accesses,
-      iterator_types = [],
-      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-      distributed = true,
-      opaque = false
-    }
-    %3 = iree_codegen.inner_tiled ins(%0, %1) outs(%2) #contraction_trait
-      : vector<4xf16>, vector<4xf16> into vector<4xf32>
-    ```
-
-    This operation can represent an intrinsic both in undistributed
-    (workgroup/subgroup/warp) and distributed (thread) level. This is indicated
-    by the `distributed` boolean attribute. The same `kind` attribute may be
-    used in both cases.
-
-    The inner-tile shapes of tensor operands (defined as above as the trailing
-    dimensions not present in the indexing maps) must agree with the shapes of
-    the vector tiles implied by the intrinsic specified in `kind`. The exact
-    criterion depends on the `opaque` boolean attribute:
-    * When `opaque = true`, the only requirement is that they have the same
-      number of elements.
-    * When `opaque = false`, the shapes must match exactly after omitting any
-      unit-dimensions.
-
-    Note that different `kind` attributes may adopt different conventions as to
-    the intrinsic vector tile formats. Some may use only flattened 1-D vectors,
-    and it may be necessary to use `opaque = true` to accommodate them. Others
-    may use higher-rank vectors with shapes reflecting semantics, allowing to
-    use `opaque = false`, which is preferable when possible at all thanks to the
-    stricter semantics. However, that is not only a function of the `kind`
-    attribute: using `opaque = false` also requires the tensor operands to have
-    appropriate shapes.
-
-    In some cases, variations on the inner tiled operations can be expressed
-    with the permutations attribute. This attribute represents the permutation
-    from that intrinsic's "canonical" layout (in the case of matrix multiplication,
-    this is row-major storage of the inner tile) to the format of the inner tile
-    in the arguments, with a permutation specified for each argument.
-
-    For example, an MMT product of inner dimensions with warp semantics can be
-    represented with the following.
+    Subgroup-level (undistributed) MMA on tensors using the AMD MFMA
+    intrinsic `MFMA_F32_32x32x8_F16`, whose canonical per-operand inner
+    tiles are LHS = `32x8` (M, K), RHS = `8x32` (K, N) and ACC = `32x32`
+    (M, N). In practice the RHS is typically stored with its inner dims
+    swapped (the matmul is really an MMT at the tile level); this is
+    expressed by the `[1, 0]` entry in `permutations` on the RHS operand,
+    which makes its inner-tile shape `canonical[1] x canonical[0]` =
+    `N x K` = `32 x 8`.
 
     ```mlir
-    #contraction_accesses = [
-     affine_map<(i, j, k) -> (i, k)>,
-     affine_map<(i, j, k) -> (k, j)>,
-     affine_map<(i, j, k) -> (i, j)>
-    ]
-    #contraction_trait = {
-      indexing_maps = #contraction_accesses,
-      iterator_types = ["parallel", "parallel", "reduction"],
-      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-      permutations = [[0, 1], [1, 0], [0, 1]]
-    }
-    %7 = iree_codegen.inner_tiled ins(%4, %5) outs(%6) #contraction_trait
-      : tensor<?x?x16x16xf16>, tensor<?x?x16x16xf16> into tensor<?x?x16x16xf32>
+    %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+        indexing_maps = [
+          affine_map<(m, n, k) -> (m, k)>,
+          affine_map<(m, n, k) -> (n, k)>,
+          affine_map<(m, n, k) -> (m, n)>
+        ],
+        iterator_types = [
+          #linalg.iterator_type<parallel>,
+          #linalg.iterator_type<parallel>,
+          #linalg.iterator_type<reduction>
+        ],
+        kind         = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+        semantics    = #iree_gpu.mma_semantics<distributed = false, opaque = false>,
+        permutations = [array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+      } : tensor<?x?x32x8xf16>, tensor<?x?x32x8xf16>
+          into tensor<?x?x32x32xf32>
     ```
 
-    #### Motivation, Design Choices, and Pitfalls
+    After distribution across the 64 lanes of a wave, the per-operand
+    inner tiles become the canonical *per-lane* shares of the intrinsic:
+    `256 / 64 = 4` f16 elements per lane for LHS and RHS, `1024 / 64 = 16`
+    f32 elements per lane for ACC.
 
-    This operation grew out of a general representation for matrix multiplication
-    intrinsics on GPUs, where the inner tiles would be the tiles of the A, B,
-    and C matrices that were computed by an entire GPU workgroup or subgroup. It
-    is now used for generalizations of such multiplications. Currently,
-    the only usage is for scaled matrix-multiply-accumulate, where block scales
-    must be passed in as additional inputs, but it's possible more uses
-    will be possible in the future.
-
-    The idea behind this operation is to decouple the layout setting/tiling
-    required to target certain intrinsics from the lowering to them. Because
-    typically tiling of this sort happens on tensor operands, however the target
-    intrinsics operate on vectors, we use this operation to bridge the gap. The
-    choice for a shared operation is intended to ease the lowering process and
-    allow for different transformations at different stages of the pipeline
-    without needing to essentially clone this op.
+    ```mlir
+    %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+        indexing_maps = [
+          affine_map<(m, n, k) -> (m, k)>,
+          affine_map<(m, n, k) -> (n, k)>,
+          affine_map<(m, n, k) -> (m, n)>
+        ],
+        iterator_types = [
+          #linalg.iterator_type<parallel>,
+          #linalg.iterator_type<parallel>,
+          #linalg.iterator_type<reduction>
+        ],
+        kind      = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+        semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
+      } : tensor<?x?x4xf16>, tensor<?x?x4xf16>
+          into tensor<?x?x16xf32>
+    ```
   }];
 
   let arguments = (ins Variadic<AnyRankedTensorOrVector>:$inputs,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -92,7 +92,7 @@ func.func @mma_inner_tiled_invalid_outer_shape(%lhs: tensor<2x2x4xf16>, %rhs: te
 // -----
 
 func.func @mma_inner_tiled_invalid_dynamic_inner_dim(%lhs: tensor<?x?x?xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
-  // expected-error @+1 {{Unexpected dynamic inner dim for operand 0 of type 'tensor<?x?x?xf16>'}}
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<?xf16>' is incompatible with expected MMA tile type 'vector<16x16xf16>'}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -105,7 +105,7 @@ func.func @mma_inner_tiled_invalid_dynamic_inner_dim(%lhs: tensor<?x?x?xf16>, %r
 // -----
 
 func.func @mma_inner_tiled_invalid_element_type(%lhs: tensor<?x?x4xf32>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
-  // expected-error @+1 {{op operand element type f32 does not match expected MMA tile element type f16}}
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<4xf32>' is incompatible with expected MMA tile type 'vector<16x16xf16>'}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -118,7 +118,7 @@ func.func @mma_inner_tiled_invalid_element_type(%lhs: tensor<?x?x4xf32>, %rhs: t
 // -----
 
 func.func @mma_inner_tiled_invalid_inner_types_distributed_opaque(%lhs: tensor<?x?x3xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
-  // expected-error @+1 {{op operand type tensor<?x?x3xf16>, implying tile type vector<3xf16>, is incompatible with permuted InnerTiledDescAttr tile type vector<4xf16> under semantics #iree_gpu.mma_semantics<distributed = true, opaque = true>}}
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<3xf16>' is incompatible with expected MMA tile type 'vector<4xf16>'}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -131,7 +131,7 @@ func.func @mma_inner_tiled_invalid_inner_types_distributed_opaque(%lhs: tensor<?
 // -----
 
 func.func @mma_inner_tiled_invalid_inner_types_undistributed_nonopaque(%lhs: tensor<?x?x4x16x4xf16>, %rhs: tensor<?x?x4x16x4xf16>, %acc: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
-  // expected-error @+1 {{op operand type tensor<?x?x16x16xf32>, implying tile type vector<16x16xf32>, is incompatible with permuted InnerTiledDescAttr tile type vector<4x16x4xf32> under semantics #iree_gpu.mma_semantics<distributed = false, opaque = false>}}
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #2 inner tile 'tensor<16x16xf32>' is incompatible with expected MMA tile type 'vector<4x16x4xf32>'}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
@@ -144,7 +144,7 @@ func.func @mma_inner_tiled_invalid_inner_types_undistributed_nonopaque(%lhs: ten
 // -----
 
 func.func @mma_inner_tiled_invalid_inner_types_distributed_nonopaque(%lhs: tensor<?x?x1x1x4xf16>, %rhs: tensor<?x?x1x1x4xf16>, %acc: tensor<?x?x1x2x2xf32>) -> tensor<?x?x1x2x2xf32> {
-  // expected-error @+1 {{op operand type tensor<?x?x1x2x2xf32>, implying tile type vector<1x2x2xf32>, is incompatible with permuted InnerTiledDescAttr tile type vector<1x1x4xf32> under semantics #iree_gpu.mma_semantics<distributed = true, opaque = false>}}
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #2 inner tile 'tensor<1x2x2xf32>' is incompatible with expected MMA tile type 'vector<1x1x4xf32>'}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],


### PR DESCRIPTION
This finishes generalizing the inner_tiled op to support CPU usage, including scalable dimensions.

AI: Claude Opus 4.7 in Cursor.
