### PR TITLE
[LLVMCPU] Add --iree-llvmcpu-enable-inner-tiled target flag.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
@@ -116,6 +116,7 @@ void LLVMTarget::print(llvm::raw_ostream &os) const {
      << "  }\n"
      << "  ukernels=" << ukernels << "\n"
      << "  linkUkernelBitcode=" << linkUkernelBitcode << "\n"
+     << "  enableInnerTiled=" << enableInnerTiled << "\n"
      << "}\n";
 }
 
@@ -197,6 +198,9 @@ void LLVMTarget::storeToConfigAttrs(MLIRContext *context,
   }
   if (linkUkernelBitcode != DEFAULT_LINK_UKERNEL_BITCODE) {
     addBool("link_ukernel_bitcode", linkUkernelBitcode);
+  }
+  if (enableInnerTiled) {
+    addBool("enable_inner_tiled", true);
   }
 }
 
@@ -325,6 +329,8 @@ LLVMTarget::loadFromConfigAttr(Location loc, DictionaryAttr config,
   target.ukernels = getString("ukernels", target.ukernels, false);
   target.linkUkernelBitcode =
       getBool("link_ukernel_bitcode", target.linkUkernelBitcode);
+  target.enableInnerTiled =
+      getBool("enable_inner_tiled", LLVMTarget::DEFAULT_ENABLE_INNER_TILED);
 
   if (hasFailures) {
     return {};
@@ -601,6 +607,11 @@ void LLVMCPUTargetCLOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::cat(category),
       llvm::cl::desc(
           "Link ukernel bitcode libraries into generated executables"));
+  binder.opt<bool>(
+      "iree-llvmcpu-enable-inner-tiled", enableInnerTiled,
+      llvm::cl::cat(category),
+      llvm::cl::desc("Lower encoded matmuls to iree_codegen.inner_tiled on "
+                     "LLVM CPU instead of linalg.mmt4d."));
 }
 
 LLVMTargetOptions LLVMCPUTargetCLOptions::getTargetOptions() {
@@ -647,6 +658,7 @@ LLVMTargetOptions LLVMCPUTargetCLOptions::getTargetOptions() {
   target.maxStackAllocSizeInBytes = targetMaxStackAllocSizeInBytes.value;
   target.ukernels = enableUkernels;
   target.linkUkernelBitcode = linkUKernelBitcode;
+  target.enableInnerTiled = enableInnerTiled;
 
   target.populateDefaultsFromTargetMachine();
   return targetOptions;

--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
@@ -46,6 +46,7 @@ struct LLVMTarget {
       llvm::FloatABI::ABIType::Hard;
   static constexpr const char *DEFAULT_ENABLE_UKERNELS = "default";
   static constexpr bool DEFAULT_LINK_UKERNEL_BITCODE = true;
+  static constexpr bool DEFAULT_ENABLE_INNER_TILED = false;
 
   // Default initialize all fields.
   LLVMTarget();
@@ -59,6 +60,7 @@ struct LLVMTarget {
     linkEmbedded = other.linkEmbedded;
     ukernels = other.ukernels;
     linkUkernelBitcode = other.linkUkernelBitcode;
+    enableInnerTiled = other.enableInnerTiled;
   }
 
   void print(llvm::raw_ostream &os) const;
@@ -130,6 +132,10 @@ struct LLVMTarget {
   // Link built-in ukernel bitcode libraries into generated executables.
   bool linkUkernelBitcode = DEFAULT_LINK_UKERNEL_BITCODE;
 
+  // When true, matmuls with encodings lower to iree_codegen.inner_tiled instead
+  // of linalg.mmt4d on LLVM CPU.
+  bool enableInnerTiled = DEFAULT_ENABLE_INNER_TILED;
+
 private:
   void populateDefaultsFromTargetMachine();
 
@@ -200,6 +206,7 @@ struct LLVMCPUTargetCLOptions {
       LLVMTarget::DEFAULT_MAX_STACK_ALLOC_SIZE_IN_BYTES;
   std::string enableUkernels = LLVMTarget::DEFAULT_ENABLE_UKERNELS;
   bool linkUKernelBitcode = LLVMTarget::DEFAULT_LINK_UKERNEL_BITCODE;
+  bool enableInnerTiled = LLVMTarget::DEFAULT_ENABLE_INNER_TILED;
   bool listTargets; // Ignored - used with llvm::cl::ValueDisallowed.
 
   void bindOptions(OptionsBinder &binder);

--- a/compiler/plugins/target/LLVMCPU/test/hal_target_device_attributes.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/hal_target_device_attributes.mlir
@@ -32,6 +32,14 @@
 //
 // CHECK-INCORRECT-OPT-STACK-VALUE: for the --iree-llvmcpu-stack-allocation-limit option: '64266' value not a power-of-two
 
+// RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=local --iree-hal-local-target-device-backends=llvm-cpu --iree-llvmcpu-target-triple=x86_64-linux-gnu --iree-llvmcpu-enable-inner-tiled %s \
+// RUN: | FileCheck %s --check-prefix=CHECK-INNER-TILED-FLAG
+//
+// CHECK-INNER-TILED-FLAG: module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
+// CHECK-INNER-TILED-FLAG-NEXT: util.global private @__device_0 = #hal.device.target<"local",
+// CHECK-INNER-TILED-FLAG-SAME: [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+// CHECK-INNER-TILED-FLAG-SAME: enable_inner_tiled = true
+
 module {
   util.func public @foo(%arg0: tensor<?xf32>) -> tensor<?xf32> {
     util.return %arg0 : tensor<?xf32>


### PR DESCRIPTION
Plumb a new LLVMTarget option and matching CLI flag through the LLVMCPU target backend so it is serialized into
hal.executable.target's config dict as `enable_inner_tiled`.

Downstream materialize-encoding logic will, in a follow-up commit, use this attribute to select `iree_codegen.inner_tiled` lowering over `linalg.mmt4d` for encoded matmuls. The flag defaults to false, so no behavior changes yet.

AI: Claude Opus 4.7 in Cursor.