### PR TITLE
[Codegen] Use local binders for optimization flags in codegen.

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/Internal/BUILD.bazel
@@ -83,7 +83,6 @@ iree_compiler_cc_library(
         "//compiler/bindings/c:headers",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",
         "//compiler/src/iree/compiler/Dialect/VM/Target:init_targets",
-        "//compiler/src/iree/compiler/Pipelines:Options",
         "//compiler/src/iree/compiler/PluginAPI:PluginManager",
         "//compiler/src/iree/compiler/Tools:init_llvmir_translations",
         "//compiler/src/iree/compiler/Tools:init_passes_and_dialects",

--- a/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
@@ -85,7 +85,6 @@ iree_cc_library(
     MLIRSupport
     iree::compiler::Dialect::HAL::Target
     iree::compiler::Dialect::VM::Target::init_targets
-    iree::compiler::Pipelines::Options
     iree::compiler::PluginAPI::PluginManager
     iree::compiler::Tools::init_llvmir_translations
     iree::compiler::Tools::init_passes_and_dialects

--- a/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
@@ -10,7 +10,6 @@
 
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/VM/Target/init_targets.h"
-#include "iree/compiler/Pipelines/Options.h"
 #include "iree/compiler/PluginAPI/PluginManager.h"
 #include "iree/compiler/Tools/init_dialects.h"
 #include "iree/compiler/Tools/init_llvmir_translations.h"
@@ -76,9 +75,6 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
   tracing::DebugCounter::registerCLOptions();
   auto &pluginManagerOptions =
       mlir::iree_compiler::PluginManagerOptions::FromFlags::get();
-  // Register the top-level optimization level flag (--iree-opt-level) and
-  // pipeline options so that optimization-level cascading works in iree-opt.
-  mlir::iree_compiler::GlobalPipelineOptions::FromFlags::get();
 
   // Build the list of dialects as a header for the --help message.
   std::string helpHeader = (toolName + "\nAvailable Dialects: ").str();
@@ -90,13 +86,6 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
 
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, helpHeader);
-
-  // Apply optimization-level-dependent defaults to global options.
-  {
-    auto globalBinder = mlir::iree_compiler::OptionsBinder::global();
-    globalBinder.applyOptimizationDefaults();
-  }
-
   MlirOptMainConfig config = MlirOptMainConfig::createFromCLOptions();
 
   // The local binder is meant for overriding session-level options, but for

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -703,6 +703,16 @@ void buildLLVMCPULinkingPassPipeline(OpPassManager &modulePassManager,
 // Register LLVMCPU Passes
 //===---------------------------------------------------------------------===//
 
+template <typename PipelineOptionsT>
+static CPUCodegenOptions
+getCPUCodegenOptionsForTextualPipeline(const PipelineOptionsT &options) {
+  CPUCodegenOptions cpuOpts = CPUCodegenOptions::FromFlags::get();
+  if (options.optLevel.hasValue()) {
+    cpuOpts.setWithOptLevel(mapCodegenPipelineOptLevel(options.optLevel));
+  }
+  return cpuOpts;
+}
+
 /// CPU pipeline builder callback. Dispatches CPU::PipelineAttr to the
 /// appropriate pass pipeline construction function.
 static LogicalResult buildCPUPipeline(Attribute attr, OpPassManager &pm,
@@ -757,14 +767,32 @@ void registerCodegenLLVMCPUPasses() {
   // Generated.
   registerPasses();
 
-  static PassPipelineRegistration<> LLVMCPUConfigPipeline(
-      "iree-codegen-llvmcpu-configuration-pipeline",
-      "Runs the translation strategy configuration pipeline on Linalg for CPU",
-      [](OpPassManager &modulePassManager) {
-        const CPUCodegenOptions &cpuOpts = CPUCodegenOptions::FromFlags::get();
-        buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager,
-                                                         cpuOpts);
-      });
+  struct LLVMCPUConfigurationPipelineOptions final
+      : PassPipelineOptions<LLVMCPUConfigurationPipelineOptions> {
+    Option<CodegenPipelineOptLevel> optLevel{
+        *this, "opt-level",
+        llvm::cl::desc(
+            "Optimization level used to derive CPU codegen defaults."),
+        llvm::cl::values(
+            clEnumValN(CodegenPipelineOptLevel::O0, "O0", "Use O0 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O1, "O1", "Use O1 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O2, "O2", "Use O2 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O3, "O3", "Use O3 defaults.")),
+        llvm::cl::init(CodegenPipelineOptLevel::O0)};
+  };
+
+  static PassPipelineRegistration<LLVMCPUConfigurationPipelineOptions>
+      LLVMCPUConfigPipeline(
+          "iree-codegen-llvmcpu-configuration-pipeline",
+          "Runs the translation strategy configuration pipeline on Linalg for "
+          "CPU",
+          [](OpPassManager &modulePassManager,
+             const LLVMCPUConfigurationPipelineOptions &options) {
+            CPUCodegenOptions cpuOpts =
+                getCPUCodegenOptionsForTextualPipeline(options);
+            buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager,
+                                                             cpuOpts);
+          });
 
   static PassPipelineRegistration<> LLVMCPUBufferizationPipeline(
       "iree-codegen-llvmcpu-bufferization-pipeline",
@@ -784,6 +812,16 @@ void registerCodegenLLVMCPUPasses() {
 
   struct LLVMCPULoweringPipelineOptions
       : PassPipelineOptions<LLVMCPULoweringPipelineOptions> {
+    Option<CodegenPipelineOptLevel> optLevel{
+        *this, "opt-level",
+        llvm::cl::desc(
+            "Optimization level used to derive CPU codegen defaults."),
+        llvm::cl::values(
+            clEnumValN(CodegenPipelineOptLevel::O0, "O0", "Use O0 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O1, "O1", "Use O1 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O2, "O2", "Use O2 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O3, "O3", "Use O3 defaults.")),
+        llvm::cl::init(CodegenPipelineOptLevel::O0)};
     Option<bool> enableArmSME{
         *this, "enable-arm-sme",
         llvm::cl::desc("Enable the ArmSME lowering pipeline.")};
@@ -799,9 +837,8 @@ void registerCodegenLLVMCPUPasses() {
           "Runs the LLVMCPU lowering pipeline",
           [](OpPassManager &modulePassManager,
              LLVMCPULoweringPipelineOptions const &options) {
-            // Use global codegen options for pipeline registration.
-            const CPUCodegenOptions &cpuOpts =
-                CPUCodegenOptions::FromFlags::get();
+            CPUCodegenOptions cpuOpts =
+                getCPUCodegenOptionsForTextualPipeline(options);
             buildLLVMCPUCodegenPassPipeline(modulePassManager, cpuOpts,
                                             options.enableArmSME,
                                             options.includeLLVMLowering);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -89,7 +89,7 @@ def LLVMCPULowerExecutableTargetPass :
   }];
   let options = [
     Option<"cpuOptions", "cpu-options", "CPUCodegenOptions",
-      /*default=*/"CPUCodegenOptions::FromFlags::get()",
+      /*default=*/"CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel::O0)",
       "Session-scoped CPU codegen options controlling optimization level, "
       "distribution, etc.">,
   ];

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
@@ -1,10 +1,12 @@
-// CPU backend disable fp reassociation for O0 and O1, so the checks should be the same.
+// CPU backend disables fp reassociation for O0 and O1, so the checks should be
+// the same.
 // RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O0 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='opt-level=O0' --iree-codegen-llvmcpu-lowering-pipeline='opt-level=O0 include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
-// CPU backend enables fp reassociation starting from O2, so the checks should be the same.
+// CPU backend enables fp reassociation starting from O2, so the checks should
+// be the same.
 // RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='opt-level=O2' --iree-codegen-llvmcpu-lowering-pipeline='opt-level=O2 include-llvm-lowering=false' --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='opt-level=O2' --iree-codegen-llvmcpu-lowering-pipeline='opt-level=O2 include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 // Check that this dispatch compiles to vectors and that there are no allocas.
 // By proxy checks that destination passing style kicked in correctly

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -113,7 +113,7 @@ def LLVMGPUSelectLoweringStrategyPass :
   let summary = "Select a IREE::HAL::DispatchLoweringPassPipeline for lowering the target variant";
   let options = [
     Option<"gpuOptions", "gpu-options", "GPUCodegenOptions",
-      /*default=*/"GPUCodegenOptions::FromFlags::get()",
+      /*default=*/"GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel::O0)",
       "Session-scoped GPU codegen options (tuning spec, etc.).">,
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -11,9 +11,40 @@ IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
 namespace mlir::iree_compiler {
 
+namespace {
+
+// Applies the opt-level default cascade using a local binder.
+template <typename CodegenOptionsT>
+void applyOptLevelDefaults(CodegenOptionsT &opts,
+                           llvm::OptimizationLevel level) {
+  auto binder = OptionsBinder::local();
+  // Anchor the opt-level hierarchy so applyOptimizationDefaults can walk it.
+  binder.topLevelOpt("opt-level", level);
+  opts.bindOptions(binder);
+  binder.applyOptimizationDefaults();
+}
+
+} // namespace
+
 std::string CodegenOptions::tuningSpecPath = "";
 bool CodegenOptions::setTunerAttributes = false;
 bool CodegenOptions::emitPipelineConstraints = false;
+
+llvm::OptimizationLevel
+mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel) {
+  switch (optLevel) {
+  case CodegenPipelineOptLevel::O0:
+    return llvm::OptimizationLevel::O0;
+  case CodegenPipelineOptLevel::O1:
+    return llvm::OptimizationLevel::O1;
+  case CodegenPipelineOptLevel::O2:
+    return llvm::OptimizationLevel::O2;
+  case CodegenPipelineOptLevel::O3:
+    return llvm::OptimizationLevel::O3;
+  }
+  assert(false && "unhandled codegen pipeline optimization level");
+  return llvm::OptimizationLevel::O0;
+}
 
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category("IREE Codegen Options");
@@ -40,6 +71,17 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
       emitPipelineConstraints, llvm::cl::cat(category),
       llvm::cl::desc("Emit and verify SMT pipeline constraints for root ops. "
                      "Implies --iree-codegen-add-tuner-attributes."));
+}
+
+void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
+  applyOptLevelDefaults(*this, level);
+}
+
+CPUCodegenOptions
+CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
+  CPUCodegenOptions opts;
+  opts.setWithOptLevel(level);
+  return opts;
 }
 
 void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
@@ -98,6 +140,17 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
           "tracking. Use with --iree-hal-instrument-dispatches=<buffer-size> "
           "and analyze results with iree-dump-instruments."),
       llvm::cl::cat(category));
+}
+
+void GPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
+  applyOptLevelDefaults(*this, level);
+}
+
+GPUCodegenOptions
+GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
+  GPUCodegenOptions opts;
+  opts.setWithOptLevel(level);
+  return opts;
 }
 
 void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -11,6 +11,19 @@
 
 namespace mlir::iree_compiler {
 
+// Bridge type for MLIR pass/pipeline options, which cannot store
+// llvm::OptimizationLevel directly because it is a final class.
+enum class CodegenPipelineOptLevel {
+  O0 = 0,
+  O1 = 1,
+  O2 = 2,
+  O3 = 3,
+};
+
+// Maps the pass/pipeline bridge enum to llvm::OptimizationLevel.
+llvm::OptimizationLevel
+mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel);
+
 // A base class that defines common codegen options that are shared across
 // different backends (e.g., CPU and GPU). Derived classes can add
 // backend-specific options as needed.
@@ -58,11 +71,27 @@ struct CPUCodegenOptions : CodegenOptions {
 
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
+
+  // Applies opt-level-dependent defaults to the current option set.
+  void setWithOptLevel(llvm::OptimizationLevel level);
+
+  // Returns a CPUCodegenOptions with all opt-level-dependent defaults derived
+  // from `level`. Uses a local OptionsBinder so the global flags are not
+  // touched.
+  static CPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
 struct GPUCodegenOptions : CodegenOptions {
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GPUCodegenOptions>;
+
+  // Applies opt-level-dependent defaults to the current option set.
+  void setWithOptLevel(llvm::OptimizationLevel level);
+
+  // Returns a GPUCodegenOptions with all opt-level-dependent defaults derived
+  // from `level`. Uses a local OptionsBinder so the global flags are not
+  // touched.
+  static GPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
 } // namespace mlir::iree_compiler


### PR DESCRIPTION
Previously, I made a workaround in https://github.com/iree-org/iree/commit/1b75890ac8093dd9b74b8110833bd2a46b3da7f0. The main reason is that all the codegen pipeline tests were anchor on a single pass (e.g., `XXXLowerExecutableTargetPass`), which makes plumbing through options infeasible.

After migrating to the real pipeline transformations, we are able to use the option in whole pipeline tests; we can drop the old workaround from iree-opt changes.

The revision introduces the option for each backend (default `O0`) and use local binders to apply the optimization flags. It drops the `XXX::FromFlags::get()` uses from Codegen.