### PR TITLE
[samples] Install iree-turbine nightly wheels in Colab notebooks

### DIFF
--- a/samples/colab/pytorch_aot_advanced.ipynb
+++ b/samples/colab/pytorch_aot_advanced.ipynb
@@ -150,7 +150,7 @@
    ],
    "source": [
     "#@title Install iree-turbine\n",
-    "!python -m pip install iree-turbine"
+    "!python -m pip install --pre iree-turbine -f https://iree.dev/pip-release-links.html"
    ]
   },
   {

--- a/samples/colab/pytorch_aot_simple.ipynb
+++ b/samples/colab/pytorch_aot_simple.ipynb
@@ -151,7 +151,7 @@
    "source": [
     "#@title Install iree-turbine\n",
     "\n",
-    "!python -m pip install iree-turbine"
+    "!python -m pip install --pre iree-turbine -f https://iree.dev/pip-release-links.html"
    ]
   },
   {

--- a/samples/colab/pytorch_huggingface_whisper.ipynb
+++ b/samples/colab/pytorch_huggingface_whisper.ipynb
@@ -173,7 +173,7 @@
         }
       ],
       "source": [
-        "!python -m pip install iree-turbine"
+        "!python -m pip install --pre iree-turbine -f https://iree.dev/pip-release-links.html"
       ]
     },
     {

--- a/samples/colab/pytorch_jit.ipynb
+++ b/samples/colab/pytorch_jit.ipynb
@@ -148,7 +148,7 @@
       ],
       "source": [
         "#@title Install iree-turbine\n",
-        "!python -m pip install iree-turbine"
+        "!python -m pip install --pre iree-turbine -f https://iree.dev/pip-release-links.html"
       ]
     },
     {


### PR DESCRIPTION
The latest published iree-turbine wheel on `PyPI` (`v3.9.0, 2025-11-25`) calls the removed static method `RankedTensorType.isinstance(x)`, which was dropped from the MLIR Python bindings in `iree-base-compiler 3.11.0` (released `2026-03-20`). This has broken the nightly samples workflow since `2026-03-20`. The fix already landed on iree-turbine main in commit [/dc5ce4aa](https://github.com/iree-org/iree-turbine/commit/dc5ce4aab550f89afbb3f0fc8f6957d44fa9bb55) but no PyPI release has been cut since.

The revision just uses the nightly wheels which as the same as the IREE setup in colab notebooks.