### PR TITLE
[hal/local_task] Fix hang when command buffer ends with trailing barrier

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -275,6 +275,16 @@ static iree_status_t iree_hal_task_command_buffer_flush_tasks(
 // to build out the proper task graph.
 static iree_status_t iree_hal_task_command_buffer_emit_global_barrier(
     iree_hal_task_command_buffer_t* command_buffer) {
+  // If no tasks were recorded since the last barrier, skip creating a new one.
+  // Creating it would wire the existing leaf barrier to the new one via
+  // iree_task_set_completion_task, setting its completion_task. Later,
+  // iree_hal_task_command_buffer_issue would attempt to set completion_task
+  // again to retire_task, which violates the single-completion invariant and
+  // causes retire_task to never be signaled. (#20166)
+  if (command_buffer->state.open_barrier != NULL &&
+      command_buffer->state.open_task_count == 0) {
+    return iree_ok_status();
+  }
   // Flush open tasks to the previous barrier. This resets our state such that
   // we can assign the new open barrier and start recording tasks for it.
   // Previous tasks will be moved into the leaf_tasks list.

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -71,6 +71,7 @@ iree_check_single_backend_test_suite(
         "layernorm.mlir",
         "pack_pad_transpose_1x9_into_2x1x8x4_issue_12546.mlir",
         "split_reduction_using_tiling.mlir",
+        "trailing_barrier_hang_issue_20166.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
     driver = "local-task",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -60,6 +60,7 @@ iree_check_single_backend_test_suite(
     "softmax.mlir"
     "split_reduction_using_tiling.mlir"
     "strided_slice.mlir"
+    "trailing_barrier_hang_issue_20166.mlir"
     "transpose.mlir"
   TARGET_BACKEND
     "llvm-cpu"

--- a/tests/e2e/regression/trailing_barrier_hang_issue_20166.mlir
+++ b/tests/e2e/regression/trailing_barrier_hang_issue_20166.mlir
@@ -1,0 +1,47 @@
+func.func @trailing_barrier_hang_1_iters_issue_20166(){
+  %iters = util.unfoldable_constant 1 : i64
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %init = flow.tensor.dynamic_constant dense<> : tensor<0xi64> -> tensor<?xi64>
+  %result = scf.for %i = %c0 to %iters step %c1 iter_args(%iter_arg = %init) -> (tensor<?xi64>) : i64 {
+    %empty = tensor.empty() : tensor<1xi64>
+    %fill = linalg.fill ins(%i : i64) outs(%empty : tensor<1xi64>) -> tensor<1xi64>
+    %concat = tensor.concat dim(0) %iter_arg, %fill : (tensor<?xi64>, tensor<1xi64>) -> tensor<?xi64>
+    scf.yield %concat : tensor<?xi64>
+  }
+  %static = tensor.cast %result : tensor<?xi64> to tensor<1xi64>
+  check.expect_eq_const(%static, dense<[0]> : tensor<1xi64>) : tensor<1xi64>
+  return
+}
+
+func.func @trailing_barrier_hang_10_iters_issue_20166(){
+  %iters = util.unfoldable_constant 10 : i64
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %init = flow.tensor.dynamic_constant dense<> : tensor<0xi64> -> tensor<?xi64>
+  %result = scf.for %i = %c0 to %iters step %c1 iter_args(%iter_arg = %init) -> (tensor<?xi64>) : i64 {
+    %empty = tensor.empty() : tensor<1xi64>
+    %fill = linalg.fill ins(%i : i64) outs(%empty : tensor<1xi64>) -> tensor<1xi64>
+    %concat = tensor.concat dim(0) %iter_arg, %fill : (tensor<?xi64>, tensor<1xi64>) -> tensor<?xi64>
+    scf.yield %concat : tensor<?xi64>
+  }
+  %static = tensor.cast %result : tensor<?xi64> to tensor<10xi64>
+  check.expect_eq_const(%static, dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]> : tensor<10xi64>) : tensor<10xi64>
+  return
+}
+
+func.func @trailing_barrier_hang_0_iters_issue_20166(){
+  %iters = util.unfoldable_constant 0 : i64
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %init = flow.tensor.dynamic_constant dense<> : tensor<0xi64> -> tensor<?xi64>
+  %result = scf.for %i = %c0 to %iters step %c1 iter_args(%iter_arg = %init) -> (tensor<?xi64>) : i64 {
+    %empty = tensor.empty() : tensor<1xi64>
+    %fill = linalg.fill ins(%i : i64) outs(%empty : tensor<1xi64>) -> tensor<1xi64>
+    %concat = tensor.concat dim(0) %iter_arg, %fill : (tensor<?xi64>, tensor<1xi64>) -> tensor<?xi64>
+    scf.yield %concat : tensor<?xi64>
+  }
+  %static = tensor.cast %result : tensor<?xi64> to tensor<0xi64>
+  check.expect_eq_const(%static, dense<> : tensor<0xi64>) : tensor<0xi64>
+  return
+}


### PR DESCRIPTION
The compiler's `insertSerializationBarriers` pass emits an `execution_barrier` after every op, so command buffers always end with a trailing barrier that has no commands recorded after it. The local-task driver's `emit_global_barrier` unconditionally creates a task node for this trailing barrier, which can cause the submitting VM to hang waiting on the fence.

When `open_task_count == 0` and `open_barrier` is non-null, wiring `leaf_tasks` -> `new_barrier` overwrites the existing leaf barrier's `completion_task`. Later, `iree_hal_task_command_buffer_issue` wires `leaf_tasks` -> `retire_task`, assigning completion_task again. This violates the single-completion invariant: `retire_task`'s `pending_dependency_count` is incremented twice but only decremented once, so `retire_task` never fires and the fence is never signaled.

Fix: in `emit_global_barrier`, skip barrier emission when no tasks were recorded since the previous barrier. The previous barrier remains the leaf, issue() wires it to retire_task, and completion proceeds normally.

Regression test (tests/e2e/regression/trailing_barrier_hang_issue_20166.mlir) covers 0/1/10 scf.for iterations on local-task/llvm-cpu, including the tensor<0xi64> case from the bug report.

Fixes #20166