### PR TITLE
[IREEGPU] Introduce `async_dma` operation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -11,10 +11,12 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
@@ -407,29 +409,210 @@ void AsyncDMAOp::getEffects(
   }
 }
 
+void AsyncDMAOp::print(OpAsmPrinter &p) {
+  p << ' ' << getSource() << '[';
+  llvm::interleaveComma(getSourceIndices(), p, [&](Value v) { p << v; });
+  p << "] to " << getDest() << '[';
+  llvm::interleaveComma(getDestIndices(), p, [&](Value v) { p << v; });
+  p << "], " << getLayoutAttr();
+
+  if (getPermutationMapAttr()) {
+    p << " permutation_map ";
+    p.printAttribute(getPermutationMapAttr());
+  }
+
+  if (std::optional<ArrayAttr> inBounds = getInBounds()) {
+    p << " in_bounds [";
+    llvm::interleaveComma(*inBounds, p, [&](Attribute a) {
+      p << (cast<BoolAttr>(a).getValue() ? "true" : "false");
+    });
+    p << ']';
+  }
+
+  p.printOptionalAttrDict(
+      (*this)->getAttrs(),
+      {"layout", "permutation_map", "in_bounds", "operandSegmentSizes"});
+
+  p << " : " << getSource().getType();
+  if (hasGatherIndices()) {
+    p << " [";
+    llvm::interleaveComma(getSourceIndices().getTypes(), p);
+    p << ']';
+  }
+  p << ", " << getDest().getType();
+  if (getResult()) {
+    p << " -> " << getResult().getType();
+  }
+}
+
+ParseResult AsyncDMAOp::parse(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::UnresolvedOperand source;
+  if (parser.parseOperand(source)) {
+    return failure();
+  }
+
+  SmallVector<OpAsmParser::UnresolvedOperand> sourceIndices;
+  if (parser.parseLSquare() || parser.parseOperandList(sourceIndices) ||
+      parser.parseRSquare()) {
+    return failure();
+  }
+
+  if (parser.parseKeyword("to")) {
+    return failure();
+  }
+
+  OpAsmParser::UnresolvedOperand dest;
+  if (parser.parseOperand(dest)) {
+    return failure();
+  }
+
+  SmallVector<OpAsmParser::UnresolvedOperand> destIndices;
+  if (parser.parseLSquare() || parser.parseOperandList(destIndices) ||
+      parser.parseRSquare()) {
+    return failure();
+  }
+
+  if (parser.parseComma()) {
+    return failure();
+  }
+
+  // Parse the layout attribute (VectorLayoutInterface).
+  Attribute layoutAttr;
+  if (parser.parseAttribute(layoutAttr)) {
+    return failure();
+  }
+  result.addAttribute("layout", layoutAttr);
+
+  // Optionally parse permutation_map.
+  if (succeeded(parser.parseOptionalKeyword("permutation_map"))) {
+    AffineMapAttr mapAttr;
+    if (parser.parseAttribute(mapAttr)) {
+      return failure();
+    }
+    result.addAttribute("permutation_map", mapAttr);
+  }
+
+  // Optionally parse in_bounds.
+  if (succeeded(parser.parseOptionalKeyword("in_bounds"))) {
+    SmallVector<bool> inBoundsVals;
+    if (parser.parseLSquare()) {
+      return failure();
+    }
+    auto parseOne = [&]() -> ParseResult {
+      bool val;
+      if (succeeded(parser.parseOptionalKeyword("true"))) {
+        val = true;
+      } else if (succeeded(parser.parseOptionalKeyword("false"))) {
+        val = false;
+      } else {
+        return parser.emitError(parser.getCurrentLocation(),
+                                "expected 'true' or 'false'");
+      }
+      inBoundsVals.push_back(val);
+      return success();
+    };
+    if (parser.parseCommaSeparatedList(parseOne) || parser.parseRSquare()) {
+      return failure();
+    }
+    SmallVector<Attribute> attrs;
+    for (bool b : inBoundsVals) {
+      attrs.push_back(parser.getBuilder().getBoolAttr(b));
+    }
+    result.addAttribute("in_bounds", parser.getBuilder().getArrayAttr(attrs));
+  }
+
+  if (parser.parseOptionalAttrDict(result.attributes)) {
+    return failure();
+  }
+
+  if (parser.parseColon()) {
+    return failure();
+  }
+
+  // Parse source_type, optionally followed by [index_types].
+  Type sourceType;
+  if (parser.parseType(sourceType)) {
+    return failure();
+  }
+
+  SmallVector<Type> sourceIndexTypes;
+  if (succeeded(parser.parseOptionalLSquare())) {
+    if (parser.parseTypeList(sourceIndexTypes) || parser.parseRSquare()) {
+      return failure();
+    }
+  } else {
+    sourceIndexTypes.assign(sourceIndices.size(),
+                            parser.getBuilder().getIndexType());
+  }
+
+  // Parse , dest_type.
+  Type destType;
+  if (parser.parseComma() || parser.parseType(destType)) {
+    return failure();
+  }
+
+  // Optionally parse -> result_type.
+  if (succeeded(parser.parseOptionalArrow())) {
+    Type resultType;
+    if (parser.parseType(resultType)) {
+      return failure();
+    }
+    result.addTypes(resultType);
+  }
+
+  // Resolve operands.
+  SmallVector<Type> destIndexTypes(destIndices.size(),
+                                   parser.getBuilder().getIndexType());
+  if (parser.resolveOperand(source, sourceType, result.operands) ||
+      parser.resolveOperands(sourceIndices, sourceIndexTypes,
+                             parser.getCurrentLocation(), result.operands) ||
+      parser.resolveOperand(dest, destType, result.operands) ||
+      parser.resolveOperands(destIndices, destIndexTypes,
+                             parser.getCurrentLocation(), result.operands)) {
+    return failure();
+  }
+
+  result.addAttribute("operandSegmentSizes",
+                      parser.getBuilder().getDenseI32ArrayAttr(
+                          {1, static_cast<int32_t>(sourceIndices.size()), 1,
+                           static_cast<int32_t>(destIndices.size())}));
+
+  return success();
+}
+
 LogicalResult AsyncDMAOp::verify() {
   auto sourceType = cast<ShapedType>(getSource().getType());
   auto destType = cast<ShapedType>(getDest().getType());
 
-  unsigned sourceRank = sourceType.getRank();
-  unsigned destRank = destType.getRank();
+  int64_t sourceRank = sourceType.getRank();
+  int64_t destRank = destType.getRank();
 
-  // source_indices count must match source rank.
   if (getSourceIndices().size() != sourceRank) {
     return emitOpError("expected ")
            << sourceRank << " source indices (source rank), got "
            << getSourceIndices().size();
   }
 
-  // SameVariadicOperandSize enforces source_indices and dest_indices have the
-  // same count, so dest_indices count == source rank too. Verify rank match.
-  if (sourceRank != destRank) {
-    return emitOpError("expected source and dest to have the same rank, got ")
-           << sourceRank << " and " << destRank;
+  if (getDestIndices().size() != destRank) {
+    return emitOpError("expected ")
+           << destRank << " dest indices (dest rank), got "
+           << getDestIndices().size();
   }
 
-  // If the op has tensor semantics, it must have a result of the right type. If
-  // it doesn't have tensor semantics, it shouldn't have a result.
+  // Each source index must be index or 1-D vector<Nxindex>.
+  for (auto [i, idx] : llvm::enumerate(getSourceIndices())) {
+    Type idxType = idx.getType();
+    if (isa<IndexType>(idxType)) {
+      continue;
+    }
+    auto vecType = dyn_cast<VectorType>(idxType);
+    if (!vecType || vecType.getRank() != 1 ||
+        !vecType.getElementType().isIndex()) {
+      return emitOpError("source index #")
+             << i << " must be index or vector<Nxindex>, got " << idxType;
+    }
+  }
+
   if (hasTensorSemantics()) {
     if (!getResult()) {
       return emitOpError("expected result for tensor operand");
@@ -443,26 +626,70 @@ LogicalResult AsyncDMAOp::verify() {
     }
   }
 
-  // Element types must match.
   if (sourceType.getElementType() != destType.getElementType()) {
     return emitOpError(
         "expected source and dest to have the same element type");
   }
 
-  // in_bounds size must match rank if present.
+  // Layout rank must match dest rank.
+  if (getLayout().getRank() != destRank) {
+    return emitOpError("layout rank (")
+           << getLayout().getRank() << ") must match dest rank (" << destRank
+           << ")";
+  }
+
+  // in_bounds size must match dest rank if present.
   if (std::optional<ArrayAttr> inBoundsAttr = getInBounds()) {
-    if (static_cast<unsigned>(inBoundsAttr->size()) != sourceRank) {
+    if (static_cast<int64_t>(inBoundsAttr->size()) != destRank) {
       return emitOpError("in_bounds array size (")
-             << inBoundsAttr->size() << ") must match operand rank ("
-             << sourceRank << ")";
+             << inBoundsAttr->size() << ") must match dest rank (" << destRank
+             << ")";
     }
   }
 
-  // Layout rank must match operand rank.
-  if (static_cast<unsigned>(getLayout().getRank()) != sourceRank) {
-    return emitOpError("layout rank (")
-           << getLayout().getRank() << ") must match operand rank ("
-           << sourceRank << ")";
+  // Permutation map validation.
+  if (std::optional<AffineMap> map = getPermutationMap()) {
+    if (map->getNumDims() != sourceRank) {
+      return emitOpError("permutation_map num dims (")
+             << map->getNumDims() << ") must match source rank (" << sourceRank
+             << ")";
+    }
+    if (map->getNumResults() != destRank) {
+      return emitOpError("permutation_map num results (")
+             << map->getNumResults() << ") must match dest rank (" << destRank
+             << ")";
+    }
+    if (!map->isProjectedPermutation()) {
+      return emitOpError("permutation_map must be a projected permutation");
+    }
+  } else if (sourceRank != destRank) {
+    return emitOpError("permutation_map is required when source rank (")
+           << sourceRank << ") differs from dest rank (" << destRank << ")";
+  }
+
+  // Validate vector gather index sizes against layout dimensions.
+  AffineMap map = getPermutationMap().value_or(
+      AffineMap::getMultiDimIdentityMap(sourceRank, getContext()));
+  SmallVector<int64_t> layoutShape = getLayout().getUndistributedShape();
+  for (auto [i, idx] : llvm::enumerate(getSourceIndices())) {
+    auto vecType = dyn_cast<VectorType>(idx.getType());
+    if (!vecType) {
+      continue;
+    }
+    std::optional<unsigned> destDim =
+        map.getResultPosition(getAffineDimExpr(i, getContext()));
+    if (!destDim) {
+      return emitOpError("source dimension ")
+             << i << " has a gather index but is not mapped by permutation_map";
+    }
+    int64_t expectedSize = layoutShape[*destDim];
+    int64_t actualSize = vecType.getDimSize(0);
+    if (actualSize != expectedSize) {
+      return emitOpError("gather index size (")
+             << actualSize << ") for source dimension " << i
+             << " must match layout size (" << expectedSize
+             << ") in dest dimension " << *destDim;
+    }
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -26,12 +26,11 @@ static void printAsyncDMASourceIndexTypes(OpAsmPrinter &p, Operation *op,
                                           OperandRange sourceIndices,
                                           TypeRange sourceIndexTypes) {
   if (llvm::all_of(sourceIndexTypes, llvm::IsaPred<IndexType>)) {
-    p << ", ";
     return;
   }
   p << " [";
   llvm::interleaveComma(sourceIndexTypes, p);
-  p << "], ";
+  p << "]";
 }
 
 static ParseResult parseAsyncDMASourceIndexTypes(
@@ -40,10 +39,9 @@ static ParseResult parseAsyncDMASourceIndexTypes(
   if (failed(parser.parseOptionalLSquare())) {
     sourceIndexTypes.assign(sourceIndices.size(),
                             parser.getBuilder().getIndexType());
-    return parser.parseComma();
+    return success();
   }
-  if (parser.parseTypeList(sourceIndexTypes) || parser.parseRSquare() ||
-      parser.parseComma()) {
+  if (parser.parseTypeList(sourceIndexTypes) || parser.parseRSquare()) {
     return failure();
   }
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.h"
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -380,6 +381,88 @@ LogicalResult CoalescedGatherDMAOp::verify() {
              << inBoundsAttr->size() << ") must match init rank (" << initRank
              << ")";
     }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// AsyncDMAOp
+//===----------------------------------------------------------------------===//
+
+void AsyncDMAOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  Value source = getSource();
+  Value dest = getDest();
+
+  if (isa<MemRefType>(source.getType())) {
+    effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
+                         SideEffects::DefaultResource::get());
+  }
+
+  if (isa<MemRefType>(dest.getType())) {
+    effects.emplace_back(MemoryEffects::Write::get(), &getDestMutable(),
+                         SideEffects::DefaultResource::get());
+  }
+}
+
+LogicalResult AsyncDMAOp::verify() {
+  auto sourceType = cast<ShapedType>(getSource().getType());
+  auto destType = cast<ShapedType>(getDest().getType());
+
+  unsigned sourceRank = sourceType.getRank();
+  unsigned destRank = destType.getRank();
+
+  // source_indices count must match source rank.
+  if (getSourceIndices().size() != sourceRank) {
+    return emitOpError("expected ")
+           << sourceRank << " source indices (source rank), got "
+           << getSourceIndices().size();
+  }
+
+  // SameVariadicOperandSize enforces source_indices and dest_indices have the
+  // same count, so dest_indices count == source rank too. Verify rank match.
+  if (sourceRank != destRank) {
+    return emitOpError("expected source and dest to have the same rank, got ")
+           << sourceRank << " and " << destRank;
+  }
+
+  // If the op has tensor semantics, it must have a result of the right type. If
+  // it doesn't have tensor semantics, it shouldn't have a result.
+  if (hasTensorSemantics()) {
+    if (!getResult()) {
+      return emitOpError("expected result for tensor operand");
+    }
+    if (getResult().getType() != getDest().getType()) {
+      return emitOpError("result type must match dest type");
+    }
+  } else {
+    if (getResult()) {
+      return emitOpError("unexpected result for memref operand");
+    }
+  }
+
+  // Element types must match.
+  if (sourceType.getElementType() != destType.getElementType()) {
+    return emitOpError(
+        "expected source and dest to have the same element type");
+  }
+
+  // in_bounds size must match rank if present.
+  if (std::optional<ArrayAttr> inBoundsAttr = getInBounds()) {
+    if (static_cast<unsigned>(inBoundsAttr->size()) != sourceRank) {
+      return emitOpError("in_bounds array size (")
+             << inBoundsAttr->size() << ") must match operand rank ("
+             << sourceRank << ")";
+    }
+  }
+
+  // Layout rank must match operand rank.
+  if (static_cast<unsigned>(getLayout().getRank()) != sourceRank) {
+    return emitOpError("layout rank (")
+           << getLayout().getRank() << ") must match operand rank ("
+           << sourceRank << ")";
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -6,7 +6,6 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 
-#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.h"
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -414,7 +413,7 @@ void AsyncDMAOp::print(OpAsmPrinter &p) {
   llvm::interleaveComma(getSourceIndices(), p, [&](Value v) { p << v; });
   p << "] to " << getDest() << '[';
   llvm::interleaveComma(getDestIndices(), p, [&](Value v) { p << v; });
-  p << "], " << getLayoutAttr();
+  p << "], " << getTransferType();
 
   if (getPermutationMapAttr()) {
     p << " permutation_map ";
@@ -431,7 +430,7 @@ void AsyncDMAOp::print(OpAsmPrinter &p) {
 
   p.printOptionalAttrDict(
       (*this)->getAttrs(),
-      {"layout", "permutation_map", "in_bounds", "operandSegmentSizes"});
+      {"transfer_type", "permutation_map", "in_bounds", "operandSegmentSizes"});
 
   p << " : " << getSource().getType();
   if (hasGatherIndices()) {
@@ -476,12 +475,12 @@ ParseResult AsyncDMAOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   }
 
-  // Parse the layout attribute (VectorLayoutInterface).
-  Attribute layoutAttr;
-  if (parser.parseAttribute(layoutAttr)) {
+  // Parse the transfer type (VectorType).
+  Type transferType;
+  if (parser.parseType(transferType)) {
     return failure();
   }
-  result.addAttribute("layout", layoutAttr);
+  result.addAttribute("transfer_type", TypeAttr::get(transferType));
 
   // Optionally parse permutation_map.
   if (succeeded(parser.parseOptionalKeyword("permutation_map"))) {
@@ -631,14 +630,24 @@ LogicalResult AsyncDMAOp::verify() {
         "expected source and dest to have the same element type");
   }
 
-  // Layout rank must match dest rank.
-  if (getLayout().getRank() != destRank) {
-    return emitOpError("layout rank (")
-           << getLayout().getRank() << ") must match dest rank (" << destRank
-           << ")";
+  auto transferVectorType = dyn_cast<VectorType>(getTransferType());
+  if (!transferVectorType) {
+    return emitOpError("transfer_type must be a VectorType");
   }
 
-  // in_bounds size must match dest rank if present.
+  if (transferVectorType.getElementType() != sourceType.getElementType()) {
+    return emitOpError("transfer_type element type (")
+           << transferVectorType.getElementType()
+           << ") must match source/dest element type ("
+           << sourceType.getElementType() << ")";
+  }
+
+  if (transferVectorType.getRank() != destRank) {
+    return emitOpError("transfer_type rank (")
+           << transferVectorType.getRank() << ") must match dest rank ("
+           << destRank << ")";
+  }
+
   if (std::optional<ArrayAttr> inBoundsAttr = getInBounds()) {
     if (static_cast<int64_t>(inBoundsAttr->size()) != destRank) {
       return emitOpError("in_bounds array size (")
@@ -667,10 +676,10 @@ LogicalResult AsyncDMAOp::verify() {
            << sourceRank << ") differs from dest rank (" << destRank << ")";
   }
 
-  // Validate vector gather index sizes against layout dimensions.
+  // Validate vector gather index sizes against transfer_type dimensions.
   AffineMap map = getPermutationMap().value_or(
       AffineMap::getMultiDimIdentityMap(sourceRank, getContext()));
-  SmallVector<int64_t> layoutShape = getLayout().getUndistributedShape();
+  ArrayRef<int64_t> transferShape = transferVectorType.getShape();
   for (auto [i, idx] : llvm::enumerate(getSourceIndices())) {
     auto vecType = dyn_cast<VectorType>(idx.getType());
     if (!vecType) {
@@ -682,12 +691,12 @@ LogicalResult AsyncDMAOp::verify() {
       return emitOpError("source dimension ")
              << i << " has a gather index but is not mapped by permutation_map";
     }
-    int64_t expectedSize = layoutShape[*destDim];
+    int64_t expectedSize = transferShape[*destDim];
     int64_t actualSize = vecType.getDimSize(0);
     if (actualSize != expectedSize) {
       return emitOpError("gather index size (")
              << actualSize << ") for source dimension " << i
-             << " must match layout size (" << expectedSize
+             << " must match transfer_type size (" << expectedSize
              << ") in dest dimension " << *destDim;
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -20,6 +20,37 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 
+namespace mlir::iree_compiler::IREE::GPU {
+
+static void printAsyncDMASourceIndexTypes(OpAsmPrinter &p, Operation *op,
+                                          OperandRange sourceIndices,
+                                          TypeRange sourceIndexTypes) {
+  if (llvm::all_of(sourceIndexTypes, llvm::IsaPred<IndexType>)) {
+    p << ", ";
+    return;
+  }
+  p << " [";
+  llvm::interleaveComma(sourceIndexTypes, p);
+  p << "], ";
+}
+
+static ParseResult parseAsyncDMASourceIndexTypes(
+    OpAsmParser &parser, ArrayRef<OpAsmParser::UnresolvedOperand> sourceIndices,
+    SmallVectorImpl<Type> &sourceIndexTypes) {
+  if (failed(parser.parseOptionalLSquare())) {
+    sourceIndexTypes.assign(sourceIndices.size(),
+                            parser.getBuilder().getIndexType());
+    return parser.parseComma();
+  }
+  if (parser.parseTypeList(sourceIndexTypes) || parser.parseRSquare() ||
+      parser.parseComma()) {
+    return failure();
+  }
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU
+
 // clang-format off
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp.inc" // IWYU pragma: keep
@@ -406,177 +437,6 @@ void AsyncDMAOp::getEffects(
     effects.emplace_back(MemoryEffects::Write::get(), &getDestMutable(),
                          SideEffects::DefaultResource::get());
   }
-}
-
-void AsyncDMAOp::print(OpAsmPrinter &p) {
-  p << ' ' << getSource() << '[';
-  llvm::interleaveComma(getSourceIndices(), p, [&](Value v) { p << v; });
-  p << "] to " << getDest() << '[';
-  llvm::interleaveComma(getDestIndices(), p, [&](Value v) { p << v; });
-  p << "], " << getTransferType();
-
-  if (getPermutationMapAttr()) {
-    p << " permutation_map ";
-    p.printAttribute(getPermutationMapAttr());
-  }
-
-  if (std::optional<ArrayAttr> inBounds = getInBounds()) {
-    p << " in_bounds [";
-    llvm::interleaveComma(*inBounds, p, [&](Attribute a) {
-      p << (cast<BoolAttr>(a).getValue() ? "true" : "false");
-    });
-    p << ']';
-  }
-
-  p.printOptionalAttrDict(
-      (*this)->getAttrs(),
-      {"transfer_type", "permutation_map", "in_bounds", "operandSegmentSizes"});
-
-  p << " : " << getSource().getType();
-  if (hasGatherIndices()) {
-    p << " [";
-    llvm::interleaveComma(getSourceIndices().getTypes(), p);
-    p << ']';
-  }
-  p << ", " << getDest().getType();
-  if (getResult()) {
-    p << " -> " << getResult().getType();
-  }
-}
-
-ParseResult AsyncDMAOp::parse(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::UnresolvedOperand source;
-  if (parser.parseOperand(source)) {
-    return failure();
-  }
-
-  SmallVector<OpAsmParser::UnresolvedOperand> sourceIndices;
-  if (parser.parseLSquare() || parser.parseOperandList(sourceIndices) ||
-      parser.parseRSquare()) {
-    return failure();
-  }
-
-  if (parser.parseKeyword("to")) {
-    return failure();
-  }
-
-  OpAsmParser::UnresolvedOperand dest;
-  if (parser.parseOperand(dest)) {
-    return failure();
-  }
-
-  SmallVector<OpAsmParser::UnresolvedOperand> destIndices;
-  if (parser.parseLSquare() || parser.parseOperandList(destIndices) ||
-      parser.parseRSquare()) {
-    return failure();
-  }
-
-  if (parser.parseComma()) {
-    return failure();
-  }
-
-  // Parse the transfer type (VectorType).
-  Type transferType;
-  if (parser.parseType(transferType)) {
-    return failure();
-  }
-  result.addAttribute("transfer_type", TypeAttr::get(transferType));
-
-  // Optionally parse permutation_map.
-  if (succeeded(parser.parseOptionalKeyword("permutation_map"))) {
-    AffineMapAttr mapAttr;
-    if (parser.parseAttribute(mapAttr)) {
-      return failure();
-    }
-    result.addAttribute("permutation_map", mapAttr);
-  }
-
-  // Optionally parse in_bounds.
-  if (succeeded(parser.parseOptionalKeyword("in_bounds"))) {
-    SmallVector<bool> inBoundsVals;
-    if (parser.parseLSquare()) {
-      return failure();
-    }
-    auto parseOne = [&]() -> ParseResult {
-      bool val;
-      if (succeeded(parser.parseOptionalKeyword("true"))) {
-        val = true;
-      } else if (succeeded(parser.parseOptionalKeyword("false"))) {
-        val = false;
-      } else {
-        return parser.emitError(parser.getCurrentLocation(),
-                                "expected 'true' or 'false'");
-      }
-      inBoundsVals.push_back(val);
-      return success();
-    };
-    if (parser.parseCommaSeparatedList(parseOne) || parser.parseRSquare()) {
-      return failure();
-    }
-    SmallVector<Attribute> attrs;
-    for (bool b : inBoundsVals) {
-      attrs.push_back(parser.getBuilder().getBoolAttr(b));
-    }
-    result.addAttribute("in_bounds", parser.getBuilder().getArrayAttr(attrs));
-  }
-
-  if (parser.parseOptionalAttrDict(result.attributes)) {
-    return failure();
-  }
-
-  if (parser.parseColon()) {
-    return failure();
-  }
-
-  // Parse source_type, optionally followed by [index_types].
-  Type sourceType;
-  if (parser.parseType(sourceType)) {
-    return failure();
-  }
-
-  SmallVector<Type> sourceIndexTypes;
-  if (succeeded(parser.parseOptionalLSquare())) {
-    if (parser.parseTypeList(sourceIndexTypes) || parser.parseRSquare()) {
-      return failure();
-    }
-  } else {
-    sourceIndexTypes.assign(sourceIndices.size(),
-                            parser.getBuilder().getIndexType());
-  }
-
-  // Parse , dest_type.
-  Type destType;
-  if (parser.parseComma() || parser.parseType(destType)) {
-    return failure();
-  }
-
-  // Optionally parse -> result_type.
-  if (succeeded(parser.parseOptionalArrow())) {
-    Type resultType;
-    if (parser.parseType(resultType)) {
-      return failure();
-    }
-    result.addTypes(resultType);
-  }
-
-  // Resolve operands.
-  SmallVector<Type> destIndexTypes(destIndices.size(),
-                                   parser.getBuilder().getIndexType());
-  if (parser.resolveOperand(source, sourceType, result.operands) ||
-      parser.resolveOperands(sourceIndices, sourceIndexTypes,
-                             parser.getCurrentLocation(), result.operands) ||
-      parser.resolveOperand(dest, destType, result.operands) ||
-      parser.resolveOperands(destIndices, destIndexTypes,
-                             parser.getCurrentLocation(), result.operands)) {
-    return failure();
-  }
-
-  result.addAttribute("operandSegmentSizes",
-                      parser.getBuilder().getDenseI32ArrayAttr(
-                          {1, static_cast<int32_t>(sourceIndices.size()), 1,
-                           static_cast<int32_t>(destIndices.size())}));
-
-  return success();
 }
 
 LogicalResult AsyncDMAOp::verify() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -369,7 +369,7 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
 def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
     DestinationStyleOpInterface,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-    SameVariadicOperandSize]> {
+    AttrSizedOperandSegments]> {
   let summary = "Asynchronous data movement";
   let description = [{
     Represents an asynchronous data movement from one memory to another without
@@ -378,6 +378,15 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
     The `layout` attribute describes the transfer shape and the layout that will
     be used to read the data from destination memory after the transfer has
     completed.
+
+    Each source index can be either a scalar `index` (contiguous read starting
+    at that offset) or a `vector<Nxindex>` (gather: read N elements at the
+    positions specified by the vector). When a source index is a vector, its
+    size must match the layout size in the corresponding destination dimension.
+
+    Source and destination ranks may differ. When they do, a `permutation_map`
+    must be provided to map source dimensions to destination/layout dimensions.
+    When omitted, identity mapping is assumed (requires equal ranks).
 
     This operation exists in two forms: tensor-based (value-semantic) and
     buffer-based (memref-semantic). In tensor form, the operation returns a
@@ -388,21 +397,17 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
 
   let arguments = (ins
     AnyRankedTensorOrMemRef:$source,
-    Variadic<Index>:$source_indices,
+    Variadic<AnyTypeOf<[Index, VectorOfAnyRankOf<[Index]>]>>:$source_indices,
     AnyRankedTensorOrMemRef:$dest,
     Variadic<Index>:$dest_indices,
     VectorLayoutInterface:$layout,
+    OptionalAttr<AffineMapAttr>:$permutation_map,
     OptionalAttr<BoolArrayAttr>:$in_bounds
   );
 
   let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
 
-  let assemblyFormat = [{
-    $source `[` $source_indices `]` `to` $dest `[` $dest_indices `]` `,`
-    $layout (`in_bounds` $in_bounds^)?
-    attr-dict `:` `(` type($source) `,` type($dest) `)` (`->` type($result)^)?
-  }];
-
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
@@ -416,6 +421,18 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
 
     unsigned getDestRank() {
       return ::llvm::cast<ShapedType>(getDest().getType()).getRank();
+    }
+
+    bool hasGatherIndices() {
+      return ::llvm::any_of(getSourceIndices(), [](Value v) {
+        return ::llvm::isa<VectorType>(v.getType());
+      });
+    }
+
+    unsigned getNumGatherDims() {
+      return ::llvm::count_if(getSourceIndices(), [](Value v) {
+        return ::llvm::isa<VectorType>(v.getType());
+      });
     }
 
     // DestinationStyleOpInterface

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -10,6 +10,7 @@
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td"
+include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td"
 include "iree/compiler/Codegen/Interfaces/HoistableRegionOpInterface.td"
 include "iree/compiler/Utils/CommonTypeConstraints.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
@@ -357,6 +358,69 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
 
     bool hasTensorSemantics() {
       return ::llvm::isa<RankedTensorType>(getInit().getType());
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// AsyncDMAOp
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
+    DestinationStyleOpInterface,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+    SameVariadicOperandSize]> {
+  let summary = "Asynchronous data movement";
+  let description = [{
+    Represents an asynchronous data movement from one memory to another without
+    intermediate materialization of the values in registers.
+
+    The `layout` attribute describes the transfer shape and the layout that will
+    be used to read the data from destination memory after the transfer has
+    completed.
+
+    This operation exists in two forms: tensor-based (value-semantic) and
+    buffer-based (memref-semantic). In tensor form, the operation returns a
+    result that aliases the `dest` operand and can be used in combination with
+    `iree_gpu.value_barrier` to synchronize with the data movement. In memref
+    form, the operation has no result and writes directly to the `dest` memref.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensorOrMemRef:$source,
+    Variadic<Index>:$source_indices,
+    AnyRankedTensorOrMemRef:$dest,
+    Variadic<Index>:$dest_indices,
+    VectorLayoutInterface:$layout,
+    OptionalAttr<BoolArrayAttr>:$in_bounds
+  );
+
+  let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
+
+  let assemblyFormat = [{
+    $source `[` $source_indices `]` `to` $dest `[` $dest_indices `]` `,`
+    $layout (`in_bounds` $in_bounds^)?
+    attr-dict `:` `(` type($source) `,` type($dest) `)` (`->` type($result)^)?
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    bool hasTensorSemantics() {
+      return ::llvm::isa<RankedTensorType>(getDest().getType());
+    }
+
+    unsigned getSourceRank() {
+      return ::llvm::cast<ShapedType>(getSource().getType()).getRank();
+    }
+
+    unsigned getDestRank() {
+      return ::llvm::cast<ShapedType>(getDest().getType()).getRank();
+    }
+
+    // DestinationStyleOpInterface
+    MutableOperandRange getDpsInitsMutable() {
+      return getDestMutable();
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -10,7 +10,6 @@
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td"
-include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td"
 include "iree/compiler/Codegen/Interfaces/HoistableRegionOpInterface.td"
 include "iree/compiler/Utils/CommonTypeConstraints.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
@@ -375,14 +374,15 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
     Represents an asynchronous data movement from one memory to another without
     intermediate materialization of the values in registers.
 
-    The `layout` attribute describes the transfer shape and the layout that will
-    be used to read the data from destination memory after the transfer has
-    completed.
+    The `transfer_type` attribute is a `VectorType` describing the shape and
+    element type of the transfer. The shape is used to determine the transfer
+    tile and to validate gather indices.
 
     Each source index can be either a scalar `index` (contiguous read starting
     at that offset) or a `vector<Nxindex>` (gather: read N elements at the
     positions specified by the vector). When a source index is a vector, its
-    size must match the layout size in the corresponding destination dimension.
+    size must match the transfer_type size in the corresponding destination
+    dimension.
 
     Source and destination ranks may differ. When they do, a `permutation_map`
     must be provided to map source dimensions to destination/layout dimensions.
@@ -400,7 +400,7 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
     Variadic<AnyTypeOf<[Index, VectorOfAnyRankOf<[Index]>]>>:$source_indices,
     AnyRankedTensorOrMemRef:$dest,
     Variadic<Index>:$dest_indices,
-    VectorLayoutInterface:$layout,
+    TypeAttr:$transfer_type,
     OptionalAttr<AffineMapAttr>:$permutation_map,
     OptionalAttr<BoolArrayAttr>:$in_bounds
   );

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -410,13 +410,14 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
   let assemblyFormat = [{
     $source `[` $source_indices `]` `to` $dest `[` $dest_indices `]` `,`
     $transfer_type
-    (`permutation_map` $permutation_map^)?
-    (`in_bounds` $in_bounds^)?
+    oilist(
+      `permutation_map` $permutation_map |
+      `in_bounds` $in_bounds
+    )
     attr-dict `:` type($source)
     ``
     custom<AsyncDMASourceIndexTypes>(ref($source_indices), type($source_indices))
-    ``
-    type($dest) ( `->` type($result)^ )?
+    `` `,` type($dest) ( `->` type($result)^ )?
   }];
   let hasVerifier = 1;
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -407,7 +407,17 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
 
   let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{
+    $source `[` $source_indices `]` `to` $dest `[` $dest_indices `]` `,`
+    $transfer_type
+    (`permutation_map` $permutation_map^)?
+    (`in_bounds` $in_bounds^)?
+    attr-dict `:` type($source)
+    ``
+    custom<AsyncDMASourceIndexTypes>(ref($source_indices), type($source_indices))
+    ``
+    type($dest) ( `->` type($result)^ )?
+  }];
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -393,6 +393,15 @@ def IREEGPU_AsyncDMAOp : Op<IREEGPU_Dialect, "async_dma", [
     result that aliases the `dest` operand and can be used in combination with
     `iree_gpu.value_barrier` to synchronize with the data movement. In memref
     form, the operation has no result and writes directly to the `dest` memref.
+
+    Example:
+    ```mlir
+    %result = iree_gpu.async_dma %src[%i, %j] to %dst[%c0], vector<64xf16>
+        permutation_map affine_map<(d0, d1) -> (d1)>
+        in_bounds [true]
+        : tensor<20x256xf16>, tensor<128xf16, #gpu.address_space<workgroup>>
+        -> tensor<128xf16, #gpu.address_space<workgroup>>
+    ```
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -208,58 +208,35 @@ func.func @async_dma_wrong_index_count(%src: tensor<20x64xf16>,
                                         %i: index, %c0: index) {
   // expected-error @+1 {{expected 2 source indices (source rank), got 1}}
   %0 = iree_gpu.async_dma %src[%i] to %dest[%c0], #layout_err_idx
-      : (tensor<20x64xf16>, tensor<1x64xf16>) -> tensor<1x64xf16>
+      : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
   return
 }
 
 // -----
 
-// async_dma: mismatched ranks (same index count to pass SameVariadicOperandSize).
-#layout_err_rank = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
+// async_dma: permutation_map required when ranks differ.
+#layout_err_perm = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+  subgroup_strides = [0],
+  thread_strides = [1]
 >
 
-func.func @async_dma_rank_mismatch(%src: tensor<20x64xf16>,
-                                    %dest: tensor<64xf16>,
-                                    %i: index, %j: index, %c0: index) {
-  // expected-error @+1 {{expected source and dest to have the same rank, got 2 and 1}}
-  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_rank
-      : (tensor<20x64xf16>, tensor<64xf16>)
+func.func @async_dma_missing_permutation_map(%src: memref<20x64xf16>,
+                                              %dest: memref<64xf16>,
+                                              %i: index, %j: index, %c0: index) {
+  // expected-error @+1 {{permutation_map is required when source rank (2) differs from dest rank (1)}}
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0], #layout_err_perm
+      : memref<20x64xf16>, memref<64xf16>
   return
 }
 
 // -----
 
-// async_dma: mismatched element types.
-#layout_err_elt = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
-func.func @async_dma_element_type_mismatch(%src: tensor<20x64xf16>,
-                                            %dest: tensor<1x64xf32>,
-                                            %i: index, %j: index,
-                                            %c0: index) {
-  // expected-error @+1 {{expected source and dest to have the same element type}}
-  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_elt
-      : (tensor<20x64xf16>, tensor<1x64xf32>) -> tensor<1x64xf32>
-  return
-}
-
-// -----
-
-// async_dma: wrong in_bounds array size.
+// async_dma: wrong in_bounds array size (checked against dest rank).
 #layout_err_ib = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile = [1, 1],
@@ -274,10 +251,10 @@ func.func @async_dma_in_bounds_wrong_size(%src: tensor<20x64xf16>,
                                            %dest: tensor<1x64xf16>,
                                            %i: index, %j: index,
                                            %c0: index) {
-  // expected-error @+1 {{in_bounds array size (1) must match operand rank (2)}}
+  // expected-error @+1 {{in_bounds array size (1) must match dest rank (2)}}
   %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_ib
       in_bounds [true]
-      : (tensor<20x64xf16>, tensor<1x64xf16>) -> tensor<1x64xf16>
+      : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
   return
 }
 
@@ -298,8 +275,79 @@ func.func @async_dma_layout_rank_mismatch(%src: tensor<20x64xf16>,
                                             %dest: tensor<1x64xf16>,
                                             %i: index, %j: index,
                                             %c0: index) {
-  // expected-error @+1 {{layout rank (1) must match operand rank (2)}}
+  // expected-error @+1 {{layout rank (1) must match dest rank (2)}}
   %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_layout_rank
-      : (tensor<20x64xf16>, tensor<1x64xf16>) -> tensor<1x64xf16>
+      : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
+  return
+}
+
+// -----
+
+// async_dma: permutation_map has wrong number of dims.
+#layout_err_perm_dims = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+  subgroup_strides = [0],
+  thread_strides = [1]
+>
+
+func.func @async_dma_permutation_map_wrong_dims(%src: memref<20x64xf16>,
+                                                  %dest: memref<64xf16>,
+                                                  %i: index, %j: index, %c0: index) {
+  // expected-error @+1 {{permutation_map num dims (1) must match source rank (2)}}
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0], #layout_err_perm_dims
+      permutation_map affine_map<(d0) -> (d0)>
+      : memref<20x64xf16>, memref<64xf16>
+  return
+}
+
+// -----
+
+// async_dma: permutation_map has wrong number of results.
+#layout_err_perm_results = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_permutation_map_wrong_results(%src: memref<20x64xf16>,
+                                                     %dest: memref<1x64xf16>,
+                                                     %i: index, %j: index,
+                                                     %c0: index) {
+  // expected-error @+1 {{permutation_map num results (1) must match dest rank (2)}}
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_perm_results
+      permutation_map affine_map<(d0, d1) -> (d0)>
+      : memref<20x64xf16>, memref<1x64xf16>
+  return
+}
+
+// -----
+
+// async_dma: gather index size doesn't match layout dimension size.
+#layout_err_gather_size = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_gather_size_mismatch(%src: tensor<1024x64xf16>,
+                                           %dest: tensor<1x64xf16>,
+                                           %indices: vector<4xindex>,
+                                           %j: index, %c0: index) {
+  // expected-error @+1 {{gather index size (4) for source dimension 0 must match layout size (1) in dest dimension 0}}
+  %0 = iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], #layout_err_gather_size
+      : tensor<1024x64xf16> [vector<4xindex>, index],
+        tensor<1x64xf16> -> tensor<1x64xf16>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -189,3 +189,117 @@ func.func @vector_multi_mma_with_permutation_of_wrong_size(%lhs: vector<2x3x4xf1
   } : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
   return %0 : vector<2x5x4xf32>
 }
+
+// -----
+
+// async_dma: wrong number of source indices.
+#layout_err_idx = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_wrong_index_count(%src: tensor<20x64xf16>,
+                                        %dest: tensor<1x64xf16>,
+                                        %i: index, %c0: index) {
+  // expected-error @+1 {{expected 2 source indices (source rank), got 1}}
+  %0 = iree_gpu.async_dma %src[%i] to %dest[%c0], #layout_err_idx
+      : (tensor<20x64xf16>, tensor<1x64xf16>) -> tensor<1x64xf16>
+  return
+}
+
+// -----
+
+// async_dma: mismatched ranks (same index count to pass SameVariadicOperandSize).
+#layout_err_rank = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_rank_mismatch(%src: tensor<20x64xf16>,
+                                    %dest: tensor<64xf16>,
+                                    %i: index, %j: index, %c0: index) {
+  // expected-error @+1 {{expected source and dest to have the same rank, got 2 and 1}}
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_rank
+      : (tensor<20x64xf16>, tensor<64xf16>)
+  return
+}
+
+// -----
+
+// async_dma: mismatched element types.
+#layout_err_elt = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_element_type_mismatch(%src: tensor<20x64xf16>,
+                                            %dest: tensor<1x64xf32>,
+                                            %i: index, %j: index,
+                                            %c0: index) {
+  // expected-error @+1 {{expected source and dest to have the same element type}}
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_elt
+      : (tensor<20x64xf16>, tensor<1x64xf32>) -> tensor<1x64xf32>
+  return
+}
+
+// -----
+
+// async_dma: wrong in_bounds array size.
+#layout_err_ib = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_in_bounds_wrong_size(%src: tensor<20x64xf16>,
+                                           %dest: tensor<1x64xf16>,
+                                           %i: index, %j: index,
+                                           %c0: index) {
+  // expected-error @+1 {{in_bounds array size (1) must match operand rank (2)}}
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_ib
+      in_bounds [true]
+      : (tensor<20x64xf16>, tensor<1x64xf16>) -> tensor<1x64xf16>
+  return
+}
+
+// -----
+
+// async_dma: layout rank mismatch.
+#layout_err_layout_rank = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+  subgroup_strides = [0],
+  thread_strides = [1]
+>
+
+func.func @async_dma_layout_rank_mismatch(%src: tensor<20x64xf16>,
+                                            %dest: tensor<1x64xf16>,
+                                            %i: index, %j: index,
+                                            %c0: index) {
+  // expected-error @+1 {{layout rank (1) must match operand rank (2)}}
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_layout_rank
+      : (tensor<20x64xf16>, tensor<1x64xf16>) -> tensor<1x64xf16>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -193,21 +193,11 @@ func.func @vector_multi_mma_with_permutation_of_wrong_size(%lhs: vector<2x3x4xf1
 // -----
 
 // async_dma: wrong number of source indices.
-#layout_err_idx = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_wrong_index_count(%src: tensor<20x64xf16>,
                                         %dest: tensor<1x64xf16>,
                                         %i: index, %c0: index) {
   // expected-error @+1 {{expected 2 source indices (source rank), got 1}}
-  %0 = iree_gpu.async_dma %src[%i] to %dest[%c0], #layout_err_idx
+  %0 = iree_gpu.async_dma %src[%i] to %dest[%c0], vector<1x64xf16>
       : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
   return
 }
@@ -215,21 +205,11 @@ func.func @async_dma_wrong_index_count(%src: tensor<20x64xf16>,
 // -----
 
 // async_dma: permutation_map required when ranks differ.
-#layout_err_perm = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1],
-  batch_tile = [1],
-  outer_tile = [1],
-  thread_tile = [64],
-  element_tile = [1],
-  subgroup_strides = [0],
-  thread_strides = [1]
->
-
 func.func @async_dma_missing_permutation_map(%src: memref<20x64xf16>,
                                               %dest: memref<64xf16>,
                                               %i: index, %j: index, %c0: index) {
   // expected-error @+1 {{permutation_map is required when source rank (2) differs from dest rank (1)}}
-  iree_gpu.async_dma %src[%i, %j] to %dest[%c0], #layout_err_perm
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0], vector<64xf16>
       : memref<20x64xf16>, memref<64xf16>
   return
 }
@@ -237,22 +217,12 @@ func.func @async_dma_missing_permutation_map(%src: memref<20x64xf16>,
 // -----
 
 // async_dma: wrong in_bounds array size (checked against dest rank).
-#layout_err_ib = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_in_bounds_wrong_size(%src: tensor<20x64xf16>,
                                            %dest: tensor<1x64xf16>,
                                            %i: index, %j: index,
                                            %c0: index) {
   // expected-error @+1 {{in_bounds array size (1) must match dest rank (2)}}
-  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_ib
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
       in_bounds [true]
       : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
   return
@@ -260,23 +230,13 @@ func.func @async_dma_in_bounds_wrong_size(%src: tensor<20x64xf16>,
 
 // -----
 
-// async_dma: layout rank mismatch.
-#layout_err_layout_rank = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1],
-  batch_tile = [1],
-  outer_tile = [1],
-  thread_tile = [64],
-  element_tile = [1],
-  subgroup_strides = [0],
-  thread_strides = [1]
->
-
-func.func @async_dma_layout_rank_mismatch(%src: tensor<20x64xf16>,
-                                            %dest: tensor<1x64xf16>,
-                                            %i: index, %j: index,
-                                            %c0: index) {
-  // expected-error @+1 {{layout rank (1) must match dest rank (2)}}
-  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_layout_rank
+// async_dma: transfer_type rank mismatch (checked against dest rank).
+func.func @async_dma_transfer_type_rank_mismatch(%src: tensor<20x64xf16>,
+                                                   %dest: tensor<1x64xf16>,
+                                                   %i: index, %j: index,
+                                                   %c0: index) {
+  // expected-error @+1 {{transfer_type rank (1) must match dest rank (2)}}
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], vector<64xf16>
       : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
   return
 }
@@ -284,21 +244,11 @@ func.func @async_dma_layout_rank_mismatch(%src: tensor<20x64xf16>,
 // -----
 
 // async_dma: permutation_map has wrong number of dims.
-#layout_err_perm_dims = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1],
-  batch_tile = [1],
-  outer_tile = [1],
-  thread_tile = [64],
-  element_tile = [1],
-  subgroup_strides = [0],
-  thread_strides = [1]
->
-
 func.func @async_dma_permutation_map_wrong_dims(%src: memref<20x64xf16>,
                                                   %dest: memref<64xf16>,
                                                   %i: index, %j: index, %c0: index) {
   // expected-error @+1 {{permutation_map num dims (1) must match source rank (2)}}
-  iree_gpu.async_dma %src[%i, %j] to %dest[%c0], #layout_err_perm_dims
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0], vector<64xf16>
       permutation_map affine_map<(d0) -> (d0)>
       : memref<20x64xf16>, memref<64xf16>
   return
@@ -307,22 +257,12 @@ func.func @async_dma_permutation_map_wrong_dims(%src: memref<20x64xf16>,
 // -----
 
 // async_dma: permutation_map has wrong number of results.
-#layout_err_perm_results = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_permutation_map_wrong_results(%src: memref<20x64xf16>,
                                                      %dest: memref<1x64xf16>,
                                                      %i: index, %j: index,
                                                      %c0: index) {
   // expected-error @+1 {{permutation_map num results (1) must match dest rank (2)}}
-  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_err_perm_results
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
       permutation_map affine_map<(d0, d1) -> (d0)>
       : memref<20x64xf16>, memref<1x64xf16>
   return
@@ -330,23 +270,13 @@ func.func @async_dma_permutation_map_wrong_results(%src: memref<20x64xf16>,
 
 // -----
 
-// async_dma: gather index size doesn't match layout dimension size.
-#layout_err_gather_size = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
+// async_dma: gather index size doesn't match transfer_type dimension size.
 func.func @async_dma_gather_size_mismatch(%src: tensor<1024x64xf16>,
                                            %dest: tensor<1x64xf16>,
                                            %indices: vector<4xindex>,
                                            %j: index, %c0: index) {
-  // expected-error @+1 {{gather index size (4) for source dimension 0 must match layout size (1) in dest dimension 0}}
-  %0 = iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], #layout_err_gather_size
+  // expected-error @+1 {{gather index size (4) for source dimension 0 must match transfer_type size (1) in dest dimension 0}}
+  %0 = iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], vector<1x64xf16>
       : tensor<1024x64xf16> [vector<4xindex>, index],
         tensor<1x64xf16> -> tensor<1x64xf16>
   return

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -252,6 +252,28 @@ func.func @async_dma_in_bounds(%src: tensor<20x64xf16>,
 
 // -----
 
+func.func @async_dma_clause_reordering(%src: tensor<20x64xf16>,
+                                        %dest: tensor<64xf16, #gpu.address_space<workgroup>>,
+                                        %i: index, %j: index, %c0: index)
+    -> tensor<64xf16, #gpu.address_space<workgroup>> {
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0], vector<64xf16>
+      in_bounds [true]
+      permutation_map affine_map<(d0, d1) -> (d1)>
+      : tensor<20x64xf16>, tensor<64xf16, #gpu.address_space<workgroup>>
+      -> tensor<64xf16, #gpu.address_space<workgroup>>
+  return %0 : tensor<64xf16, #gpu.address_space<workgroup>>
+}
+
+// CHECK-DAG: #[[$MAP_REORDER:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-LABEL: func @async_dma_clause_reordering
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}], vector<64xf16>
+//  CHECK-SAME:     permutation_map #[[$MAP_REORDER]]
+//  CHECK-SAME:     in_bounds [true]
+//  CHECK-SAME:     : tensor<20x64xf16>, tensor<64xf16, #gpu.address_space<workgroup>>
+//  CHECK-SAME:     -> tensor<64xf16, #gpu.address_space<workgroup>>
+
+// -----
+
 // Test async_dma with gather (vector) source indices.
 func.func @async_dma_gather(%src: tensor<1024x64xf16>,
                              %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -197,3 +197,88 @@ func.func @coalesced_gather_dma_tensor_indices(%idx0: tensor<64xi32>, %source: t
 //       CHECK:   scf.forall
 //       CHECK:     scf.forall.in_parallel
 //       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : tensor<4096xf32>, tensor<64xi32>, tensor<64xf32>, index -> tensor<64xf32>
+
+// -----
+
+#layout_2d = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_tensor(%src: tensor<20x64xf16>,
+                             %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,
+                             %i: index, %j: index, %c0: index)
+    -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d
+      : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+      -> tensor<1x64xf16, #gpu.address_space<workgroup>>
+  return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
+}
+
+// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-LABEL: func @async_dma_tensor
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: tensor<20x64xf16>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<1x64xf16, #gpu.address_space<workgroup>>
+//       CHECK:   iree_gpu.async_dma %[[SRC]][%{{.+}}, %{{.+}}] to %[[DEST]][%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//  CHECK-SAME:     : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+//  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
+
+// -----
+
+#layout_2d_memref = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_memref(%src: memref<20x64xf16>,
+                             %dest: memref<1x64xf16, #gpu.address_space<workgroup>>,
+                             %i: index, %j: index, %c0: index) {
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d_memref
+      : (memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>)
+  return
+}
+
+// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-LABEL: func @async_dma_memref
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//  CHECK-SAME:     : (memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>)
+
+// -----
+
+#layout_2d_ib = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_in_bounds(%src: tensor<20x64xf16>,
+                                %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,
+                                %i: index, %j: index, %c0: index)
+    -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d_ib
+      in_bounds [true, false]
+      : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+      -> tensor<1x64xf16, #gpu.address_space<workgroup>>
+  return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
+}
+
+// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-LABEL: func @async_dma_in_bounds
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//  CHECK-SAME:     in_bounds [true, false]
+//  CHECK-SAME:     : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+//  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -215,7 +215,7 @@ func.func @async_dma_tensor(%src: tensor<20x64xf16>,
                              %i: index, %j: index, %c0: index)
     -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
   %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d
-      : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+      : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
       -> tensor<1x64xf16, #gpu.address_space<workgroup>>
   return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
 }
@@ -225,7 +225,7 @@ func.func @async_dma_tensor(%src: tensor<20x64xf16>,
 //  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: tensor<20x64xf16>
 //  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<1x64xf16, #gpu.address_space<workgroup>>
 //       CHECK:   iree_gpu.async_dma %[[SRC]][%{{.+}}, %{{.+}}] to %[[DEST]][%{{.+}}, %{{.+}}], #[[$LAYOUT]]
-//  CHECK-SAME:     : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+//  CHECK-SAME:     : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
 
 // -----
@@ -244,14 +244,14 @@ func.func @async_dma_memref(%src: memref<20x64xf16>,
                              %dest: memref<1x64xf16, #gpu.address_space<workgroup>>,
                              %i: index, %j: index, %c0: index) {
   iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d_memref
-      : (memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>)
+      : memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
   return
 }
 
 // CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-LABEL: func @async_dma_memref
 //       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
-//  CHECK-SAME:     : (memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>)
+//  CHECK-SAME:     : memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
 
 // -----
 
@@ -271,7 +271,7 @@ func.func @async_dma_in_bounds(%src: tensor<20x64xf16>,
     -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
   %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d_ib
       in_bounds [true, false]
-      : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+      : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
       -> tensor<1x64xf16, #gpu.address_space<workgroup>>
   return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
 }
@@ -280,5 +280,96 @@ func.func @async_dma_in_bounds(%src: tensor<20x64xf16>,
 // CHECK-LABEL: func @async_dma_in_bounds
 //       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
 //  CHECK-SAME:     in_bounds [true, false]
-//  CHECK-SAME:     : (tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>)
+//  CHECK-SAME:     : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
+
+// -----
+
+// Test async_dma with gather (vector) source indices.
+#layout_gather = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_gather(%src: tensor<1024x64xf16>,
+                             %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,
+                             %indices: vector<1xindex>, %j: index, %c0: index)
+    -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
+  %0 = iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], #layout_gather
+      : tensor<1024x64xf16> [vector<1xindex>, index],
+        tensor<1x64xf16, #gpu.address_space<workgroup>>
+      -> tensor<1x64xf16, #gpu.address_space<workgroup>>
+  return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
+}
+
+// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-LABEL: func @async_dma_gather
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//  CHECK-SAME:     : tensor<1024x64xf16> [vector<1xindex>, index],
+//  CHECK-SAME:     tensor<1x64xf16, #gpu.address_space<workgroup>>
+//  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
+
+// -----
+
+// Test async_dma gather with memref form.
+#layout_gather_memref = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 1]
+>
+
+func.func @async_dma_gather_memref(%src: memref<1024x64xf16>,
+                                    %dest: memref<1x64xf16, #gpu.address_space<workgroup>>,
+                                    %indices: vector<1xindex>, %j: index, %c0: index) {
+  iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], #layout_gather_memref
+      : memref<1024x64xf16> [vector<1xindex>, index],
+        memref<1x64xf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-LABEL: func @async_dma_gather_memref
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//  CHECK-SAME:     : memref<1024x64xf16> [vector<1xindex>, index],
+//  CHECK-SAME:     memref<1x64xf16, #gpu.address_space<workgroup>>
+
+// -----
+
+// Test async_dma with decoupled ranks and permutation_map.
+#layout_1d = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+  subgroup_strides = [0],
+  thread_strides = [1]
+>
+
+func.func @async_dma_permutation_map(%src: tensor<20x64xf16>,
+                                      %dest: tensor<64xf16, #gpu.address_space<workgroup>>,
+                                      %i: index, %j: index, %c0: index)
+    -> tensor<64xf16, #gpu.address_space<workgroup>> {
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0], #layout_1d
+      permutation_map affine_map<(d0, d1) -> (d1)>
+      : tensor<20x64xf16>, tensor<64xf16, #gpu.address_space<workgroup>>
+      -> tensor<64xf16, #gpu.address_space<workgroup>>
+  return %0 : tensor<64xf16, #gpu.address_space<workgroup>>
+}
+
+// CHECK-DAG: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-LABEL: func @async_dma_permutation_map
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}], #[[$LAYOUT]]
+//  CHECK-SAME:     permutation_map #[[$MAP]]
+//  CHECK-SAME:     : tensor<20x64xf16>, tensor<64xf16, #gpu.address_space<workgroup>>
+//  CHECK-SAME:     -> tensor<64xf16, #gpu.address_space<workgroup>>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -200,85 +200,52 @@ func.func @coalesced_gather_dma_tensor_indices(%idx0: tensor<64xi32>, %source: t
 
 // -----
 
-#layout_2d = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_tensor(%src: tensor<20x64xf16>,
                              %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,
                              %i: index, %j: index, %c0: index)
     -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
-  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
       : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
       -> tensor<1x64xf16, #gpu.address_space<workgroup>>
   return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
 }
 
-// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-LABEL: func @async_dma_tensor
 //  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: tensor<20x64xf16>
 //  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<1x64xf16, #gpu.address_space<workgroup>>
-//       CHECK:   iree_gpu.async_dma %[[SRC]][%{{.+}}, %{{.+}}] to %[[DEST]][%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//       CHECK:   iree_gpu.async_dma %[[SRC]][%{{.+}}, %{{.+}}] to %[[DEST]][%{{.+}}, %{{.+}}], vector<1x64xf16>
 //  CHECK-SAME:     : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
 
 // -----
 
-#layout_2d_memref = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_memref(%src: memref<20x64xf16>,
                              %dest: memref<1x64xf16, #gpu.address_space<workgroup>>,
                              %i: index, %j: index, %c0: index) {
-  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d_memref
+  iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
       : memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
   return
 }
 
-// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-LABEL: func @async_dma_memref
-//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], vector<1x64xf16>
 //  CHECK-SAME:     : memref<20x64xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>
 
 // -----
-
-#layout_2d_ib = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
 
 func.func @async_dma_in_bounds(%src: tensor<20x64xf16>,
                                 %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,
                                 %i: index, %j: index, %c0: index)
     -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
-  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], #layout_2d_ib
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
       in_bounds [true, false]
       : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
       -> tensor<1x64xf16, #gpu.address_space<workgroup>>
   return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
 }
 
-// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-LABEL: func @async_dma_in_bounds
-//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], vector<1x64xf16>
 //  CHECK-SAME:     in_bounds [true, false]
 //  CHECK-SAME:     : tensor<20x64xf16>, tensor<1x64xf16, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
@@ -286,30 +253,19 @@ func.func @async_dma_in_bounds(%src: tensor<20x64xf16>,
 // -----
 
 // Test async_dma with gather (vector) source indices.
-#layout_gather = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_gather(%src: tensor<1024x64xf16>,
                              %dest: tensor<1x64xf16, #gpu.address_space<workgroup>>,
                              %indices: vector<1xindex>, %j: index, %c0: index)
     -> tensor<1x64xf16, #gpu.address_space<workgroup>> {
-  %0 = iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], #layout_gather
+  %0 = iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], vector<1x64xf16>
       : tensor<1024x64xf16> [vector<1xindex>, index],
         tensor<1x64xf16, #gpu.address_space<workgroup>>
       -> tensor<1x64xf16, #gpu.address_space<workgroup>>
   return %0 : tensor<1x64xf16, #gpu.address_space<workgroup>>
 }
 
-// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-LABEL: func @async_dma_gather
-//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], vector<1x64xf16>
 //  CHECK-SAME:     : tensor<1024x64xf16> [vector<1xindex>, index],
 //  CHECK-SAME:     tensor<1x64xf16, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     -> tensor<1x64xf16, #gpu.address_space<workgroup>>
@@ -317,59 +273,37 @@ func.func @async_dma_gather(%src: tensor<1024x64xf16>,
 // -----
 
 // Test async_dma gather with memref form.
-#layout_gather_memref = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [1, 64],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 1]
->
-
 func.func @async_dma_gather_memref(%src: memref<1024x64xf16>,
                                     %dest: memref<1x64xf16, #gpu.address_space<workgroup>>,
                                     %indices: vector<1xindex>, %j: index, %c0: index) {
-  iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], #layout_gather_memref
+  iree_gpu.async_dma %src[%indices, %j] to %dest[%c0, %c0], vector<1x64xf16>
       : memref<1024x64xf16> [vector<1xindex>, index],
         memref<1x64xf16, #gpu.address_space<workgroup>>
   return
 }
 
-// CHECK: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-LABEL: func @async_dma_gather_memref
-//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], #[[$LAYOUT]]
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}, %{{.+}}], vector<1x64xf16>
 //  CHECK-SAME:     : memref<1024x64xf16> [vector<1xindex>, index],
 //  CHECK-SAME:     memref<1x64xf16, #gpu.address_space<workgroup>>
 
 // -----
 
 // Test async_dma with decoupled ranks and permutation_map.
-#layout_1d = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1],
-  batch_tile = [1],
-  outer_tile = [1],
-  thread_tile = [64],
-  element_tile = [1],
-  subgroup_strides = [0],
-  thread_strides = [1]
->
-
 func.func @async_dma_permutation_map(%src: tensor<20x64xf16>,
                                       %dest: tensor<64xf16, #gpu.address_space<workgroup>>,
                                       %i: index, %j: index, %c0: index)
     -> tensor<64xf16, #gpu.address_space<workgroup>> {
-  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0], #layout_1d
+  %0 = iree_gpu.async_dma %src[%i, %j] to %dest[%c0], vector<64xf16>
       permutation_map affine_map<(d0, d1) -> (d1)>
       : tensor<20x64xf16>, tensor<64xf16, #gpu.address_space<workgroup>>
       -> tensor<64xf16, #gpu.address_space<workgroup>>
   return %0 : tensor<64xf16, #gpu.address_space<workgroup>>
 }
 
-// CHECK-DAG: #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1) -> (d1)>
 // CHECK-LABEL: func @async_dma_permutation_map
-//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}], #[[$LAYOUT]]
+//       CHECK:   iree_gpu.async_dma %{{.+}}[%{{.+}}, %{{.+}}] to %{{.+}}[%{{.+}}], vector<64xf16>
 //  CHECK-SAME:     permutation_map #[[$MAP]]
 //  CHECK-SAME:     : tensor<20x64xf16>, tensor<64xf16, #gpu.address_space<workgroup>>
 //  CHECK-SAME:     -> tensor<64xf16, #gpu.address_space<workgroup>>


### PR DESCRIPTION
Introduces a new `async_dma` operation that represents an (asynchronous) memory transfer from one memory in the hierarchy to another memory without intermediate staging in registers.

The motivation is to represent the direct-to-LDS feature in AMD GPUs. Compared to the existing `coalesced_gather_dma`, this operation is not as strongly specialized on the representation of subgroup-level operations in thread-level IR in the `TileAndFuse` pipeline.

In the current prototype implementation of direct-to-LDS support in `VectorDistribute`, the operation is used to represent global to LDS data movement at the workgroup level, but the operation itself should be flexible enough for other uses and other levels (e.g., thread).

The operation exists with `tensor` and `memref` semantics. With `tensor` semantics, it returns the destination tensor after data transfer, allowing for synchronization via the `iree_gpu.value_barrier`. Gathering from source is possible, but not scattering to the destination.

This is part of https://github.com/iree-org/iree/issues/23782.

Assisted-by: Claude Code and Codex