### PR TITLE
[VectorDistribute] Analysis to propagate promotion information

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -87,6 +87,7 @@ iree_compiler_cc_library(
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",
         "GPUPromoteMatmulOperands.cpp",
+        "GPUPromotionAnalysis.cpp",
         "GPUReduceBankConflicts.cpp",
         "GPUReuseSharedMemoryAllocs.cpp",
         "GPUTensorAlloc.cpp",
@@ -104,6 +105,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "GPUPatterns.h",
+        "GPUPromotionAnalysis.h",
         "GPUVectorDistribution.h",
         "Passes.h",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -89,6 +89,7 @@ iree_compiler_cc_library(
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",
         "GPUPromoteMatmulOperands.cpp",
+        "GPUPromotionAnalysis.cpp",
         "GPUReduceBankConflicts.cpp",
         "GPUReuseSharedMemoryAllocs.cpp",
         "GPUTensorAlloc.cpp",
@@ -107,6 +108,7 @@ iree_compiler_cc_library(
     hdrs = [
         "GPUNestedLayoutUtils.h",
         "GPUPatterns.h",
+        "GPUPromotionAnalysis.h",
         "GPUVectorDistribution.h",
         "Passes.h",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
     CommonGPUPasses
   HDRS
     "GPUPatterns.h"
+    "GPUPromotionAnalysis.h"
     "GPUVectorDistribution.h"
     "Passes.h"
   SRCS
@@ -80,6 +81,7 @@ iree_cc_library(
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"
     "GPUPromoteMatmulOperands.cpp"
+    "GPUPromotionAnalysis.cpp"
     "GPUReduceBankConflicts.cpp"
     "GPUReuseSharedMemoryAllocs.cpp"
     "GPUTensorAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_cc_library(
   HDRS
     "GPUNestedLayoutUtils.h"
     "GPUPatterns.h"
+    "GPUPromotionAnalysis.h"
     "GPUVectorDistribution.h"
     "Passes.h"
   SRCS
@@ -83,6 +84,7 @@ iree_cc_library(
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"
     "GPUPromoteMatmulOperands.cpp"
+    "GPUPromotionAnalysis.cpp"
     "GPUReduceBankConflicts.cpp"
     "GPUReuseSharedMemoryAllocs.cpp"
     "GPUTensorAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.cpp
@@ -1,0 +1,217 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h"
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
+
+namespace mlir::iree_compiler {
+
+using namespace mlir::dataflow;
+
+//===----------------------------------------------------------------------===//
+// Lattice value
+//===----------------------------------------------------------------------===//
+
+struct PromotionTypeLatticeValue {
+  enum class State { None, Concrete, Overdefined };
+  State state = State::None;
+  Attribute promotionType; // valid when state == Concrete
+
+  PromotionTypeLatticeValue() = default;
+  explicit PromotionTypeLatticeValue(Attribute type)
+      : state(State::Concrete), promotionType(type) {}
+
+  bool isDefined() const { return state == State::Concrete; }
+  bool isOverdefined() const { return state == State::Overdefined; }
+
+  bool operator==(const PromotionTypeLatticeValue &rhs) const {
+    return state == rhs.state && promotionType == rhs.promotionType;
+  }
+
+  static PromotionTypeLatticeValue meet(const PromotionTypeLatticeValue &lhs,
+                                        const PromotionTypeLatticeValue &rhs) {
+    if (lhs.isOverdefined() || rhs.isOverdefined()) {
+      return getOverdefined();
+    }
+    if (!lhs.isDefined()) {
+      return rhs;
+    }
+    if (!rhs.isDefined()) {
+      return lhs;
+    }
+    // Both concrete.
+    if (lhs.promotionType == rhs.promotionType) {
+      return lhs;
+    }
+    return getOverdefined();
+  }
+
+  // Required by Lattice<T> but unused in backward analysis.
+  static PromotionTypeLatticeValue join(const PromotionTypeLatticeValue &lhs,
+                                        const PromotionTypeLatticeValue &rhs) {
+    return meet(lhs, rhs);
+  }
+
+  static PromotionTypeLatticeValue getOverdefined() {
+    PromotionTypeLatticeValue val;
+    val.state = State::Overdefined;
+    return val;
+  }
+
+  void print(raw_ostream &os) const {
+    switch (state) {
+    case State::None:
+      os << "None";
+      break;
+    case State::Concrete:
+      os << promotionType;
+      break;
+    case State::Overdefined:
+      os << "Overdefined";
+      break;
+    }
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Lattice
+//===----------------------------------------------------------------------===//
+
+struct PromotionTypeLattice : public Lattice<PromotionTypeLatticeValue> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PromotionTypeLattice)
+  using Lattice::Lattice;
+};
+
+//===----------------------------------------------------------------------===//
+// Analysis
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Returns true for ops through which promotion type should propagate.
+static bool isPropagatable(Operation *op) {
+  if (op->hasTrait<OpTrait::Elementwise>()) {
+    return true;
+  }
+  return isa<vector::TransposeOp, vector::ShapeCastOp, vector::BroadcastOp,
+             IREE::VectorExt::ToLayoutOp>(op);
+}
+
+class PromotionTypeAnalysis
+    : public SparseBackwardDataFlowAnalysis<PromotionTypeLattice> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  void setToExitState(PromotionTypeLattice *lattice) override {
+    // Exit state = None (no promotion type known at exits).
+    propagateIfChanged(lattice, lattice->meet(PromotionTypeLatticeValue()));
+  }
+
+  LogicalResult
+  visitOperation(Operation *op, ArrayRef<PromotionTypeLattice *> operands,
+                 ArrayRef<const PromotionTypeLattice *> results) override {
+    // Anchor: to_layout with promotion_type discardable attribute.
+    if (auto toLayout = dyn_cast<IREE::VectorExt::ToLayoutOp>(op)) {
+      if (Attribute pt = toLayout->getAttr(kPromotionTypeAttr)) {
+        propagateIfChanged(operands[0],
+                           operands[0]->meet(PromotionTypeLatticeValue(pt)));
+        return success();
+      }
+    }
+
+    // Propagate through supported ops: the result's promotion type
+    // applies to all operands.
+    if (isPropagatable(op)) {
+      for (const PromotionTypeLattice *result : results) {
+        for (PromotionTypeLattice *operand : operands) {
+          meet(operand, *result);
+        }
+      }
+      return success();
+    }
+
+    // For unsupported ops: don't propagate (operands stay at exit state).
+    return success();
+  }
+
+  // Required overrides for pure virtual methods in the base class. No-ops
+  // because promotion types only propagate through op data flow, not through
+  // control flow edges or call sites.
+  void visitBranchOperand(OpOperand &operand) override {}
+  void visitCallOperand(OpOperand &operand) override {}
+  void
+  visitNonControlFlowArguments(RegionSuccessor &successor,
+                               ArrayRef<BlockArgument> arguments) override {}
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Public API
+//===----------------------------------------------------------------------===//
+
+PromotionTypeMap analyzePromotionTypes(Operation *root) {
+  DataFlowSolver solver;
+  SymbolTableCollection symbolTable;
+  loadBaselineAnalyses(solver);
+  solver.load<PromotionTypeAnalysis>(symbolTable);
+  if (failed(solver.initializeAndRun(root))) {
+    return PromotionTypeMap();
+  }
+
+  PromotionTypeMap result;
+  root->walk([&](Operation *op) {
+    for (Value res : op->getResults()) {
+      const auto *lattice = solver.lookupState<PromotionTypeLattice>(res);
+      if (!lattice) {
+        continue;
+      }
+      const PromotionTypeLatticeValue &val = lattice->getValue();
+      if (val.isDefined()) {
+        result[res] = val.promotionType;
+      }
+    }
+  });
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Test pass
+//===----------------------------------------------------------------------===//
+
+#define GEN_PASS_DEF_TESTGPUPROMOTIONANALYSISPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+struct TestGPUPromotionAnalysisPass final
+    : impl::TestGPUPromotionAnalysisPassBase<TestGPUPromotionAnalysisPass> {
+  void runOnOperation() override {
+    Operation *root = getOperation();
+    PromotionTypeMap promotionTypes = analyzePromotionTypes(root);
+
+    root->walk([&](Operation *op) {
+      for (OpResult result : op->getOpResults()) {
+        auto it = promotionTypes.find(result);
+        if (it != promotionTypes.end()) {
+          op->emitRemark("promotion type of result #")
+              << result.getResultNumber() << " is " << it->second;
+        }
+      }
+    });
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.cpp
@@ -1,0 +1,219 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h"
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
+
+namespace mlir::iree_compiler {
+
+using namespace mlir::dataflow;
+
+//===----------------------------------------------------------------------===//
+// Lattice value
+//===----------------------------------------------------------------------===//
+
+struct PromotionTypeLatticeValue {
+  enum class State { None, Concrete, Overdefined };
+  State state = State::None;
+  Attribute promotionType; // valid when state == Concrete
+
+  PromotionTypeLatticeValue() = default;
+  explicit PromotionTypeLatticeValue(Attribute type)
+      : state(State::Concrete), promotionType(type) {}
+
+  bool isDefined() const { return state == State::Concrete; }
+  bool isOverdefined() const { return state == State::Overdefined; }
+
+  bool operator==(const PromotionTypeLatticeValue &rhs) const {
+    return state == rhs.state && promotionType == rhs.promotionType;
+  }
+
+  static PromotionTypeLatticeValue meet(const PromotionTypeLatticeValue &lhs,
+                                        const PromotionTypeLatticeValue &rhs) {
+    if (lhs.isOverdefined() || rhs.isOverdefined()) {
+      return getOverdefined();
+    }
+    if (!lhs.isDefined()) {
+      return rhs;
+    }
+    if (!rhs.isDefined()) {
+      return lhs;
+    }
+    // Both concrete.
+    if (lhs.promotionType == rhs.promotionType) {
+      return lhs;
+    }
+    return getOverdefined();
+  }
+
+  // Required by Lattice<T> but unused in backward analysis.
+  static PromotionTypeLatticeValue join(const PromotionTypeLatticeValue &lhs,
+                                        const PromotionTypeLatticeValue &rhs) {
+    return meet(lhs, rhs);
+  }
+
+  static PromotionTypeLatticeValue getOverdefined() {
+    PromotionTypeLatticeValue val;
+    val.state = State::Overdefined;
+    return val;
+  }
+
+  void print(raw_ostream &os) const {
+    switch (state) {
+    case State::None:
+      os << "None";
+      break;
+    case State::Concrete:
+      os << promotionType;
+      break;
+    case State::Overdefined:
+      os << "Overdefined";
+      break;
+    }
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Lattice
+//===----------------------------------------------------------------------===//
+
+struct PromotionTypeLattice : public Lattice<PromotionTypeLatticeValue> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PromotionTypeLattice)
+  using Lattice::Lattice;
+};
+
+//===----------------------------------------------------------------------===//
+// Analysis
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Returns true for ops through which promotion type should propagate.
+static bool isPropagatable(Operation *op) {
+  if (op->hasTrait<OpTrait::Elementwise>()) {
+    return true;
+  }
+  return isa<vector::TransposeOp, vector::ShapeCastOp, vector::BroadcastOp,
+             IREE::VectorExt::ToLayoutOp>(op);
+}
+
+class PromotionTypeAnalysis
+    : public SparseBackwardDataFlowAnalysis<PromotionTypeLattice> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PromotionTypeAnalysis)
+
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  void setToExitState(PromotionTypeLattice *lattice) override {
+    // Exit state = None (no promotion type known at exits).
+    propagateIfChanged(lattice, lattice->meet(PromotionTypeLatticeValue()));
+  }
+
+  LogicalResult
+  visitOperation(Operation *op, ArrayRef<PromotionTypeLattice *> operands,
+                 ArrayRef<const PromotionTypeLattice *> results) override {
+    // Anchor: to_layout with a requested shared memory conversion.
+    if (auto toLayout = dyn_cast<IREE::VectorExt::ToLayoutOp>(op)) {
+      if (Attribute pt = toLayout.getSharedMemoryConversionAttr()) {
+        propagateIfChanged(operands[0],
+                           operands[0]->meet(PromotionTypeLatticeValue(pt)));
+        return success();
+      }
+    }
+
+    // Propagate through supported ops: the result's promotion type
+    // applies to all operands.
+    if (isPropagatable(op)) {
+      for (const PromotionTypeLattice *result : results) {
+        for (PromotionTypeLattice *operand : operands) {
+          meet(operand, *result);
+        }
+      }
+      return success();
+    }
+
+    // For unsupported ops: don't propagate (operands stay at exit state).
+    return success();
+  }
+
+  // Required overrides for pure virtual methods in the base class. No-ops
+  // because promotion types only propagate through op data flow, not through
+  // control flow edges or call sites.
+  void visitBranchOperand(OpOperand &operand) override {}
+  void visitCallOperand(OpOperand &operand) override {}
+  void
+  visitNonControlFlowArguments(RegionSuccessor &successor,
+                               ArrayRef<BlockArgument> arguments) override {}
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Public API
+//===----------------------------------------------------------------------===//
+
+PromotionTypeMap analyzePromotionTypes(Operation *root) {
+  DataFlowSolver solver;
+  SymbolTableCollection symbolTable;
+  loadBaselineAnalyses(solver);
+  solver.load<PromotionTypeAnalysis>(symbolTable);
+  if (failed(solver.initializeAndRun(root))) {
+    return PromotionTypeMap();
+  }
+
+  PromotionTypeMap result;
+  root->walk([&](Operation *op) {
+    for (Value res : op->getResults()) {
+      const auto *lattice = solver.lookupState<PromotionTypeLattice>(res);
+      if (!lattice) {
+        continue;
+      }
+      const PromotionTypeLatticeValue &val = lattice->getValue();
+      if (val.isDefined()) {
+        result[res] = val.promotionType;
+      }
+    }
+  });
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Test pass
+//===----------------------------------------------------------------------===//
+
+#define GEN_PASS_DEF_TESTGPUPROMOTIONANALYSISPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+struct TestGPUPromotionAnalysisPass final
+    : impl::TestGPUPromotionAnalysisPassBase<TestGPUPromotionAnalysisPass> {
+  void runOnOperation() override {
+    Operation *root = getOperation();
+    PromotionTypeMap promotionTypes = analyzePromotionTypes(root);
+
+    root->walk([&](Operation *op) {
+      for (OpResult result : op->getOpResults()) {
+        auto it = promotionTypes.find(result);
+        if (it != promotionTypes.end()) {
+          op->emitRemark("promotion type of result #")
+              << result.getResultNumber() << " is " << it->second;
+        }
+      }
+    });
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_COMMON_GPU_GPUPROMOTIONANALYSIS_H_
+#define IREE_COMPILER_CODEGEN_COMMON_GPU_GPUPROMOTIONANALYSIS_H_
+
+#include "llvm/ADT/DenseMap.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir::iree_compiler {
+
+/// Discardable attribute name on `to_layout` ops that carries the promotion
+/// type (e.g., UseGlobalLoadDMAAttr).
+inline constexpr llvm::StringLiteral kPromotionTypeAttr =
+    "iree_gpu.promotion_type";
+
+/// Result of promotion type analysis. Maps SSA values to their inferred
+/// promotion type attribute (e.g., UseGlobalLoadDMAAttr). Only values with a
+/// concrete (non-overdefined) promotion type are included.
+using PromotionTypeMap = llvm::DenseMap<Value, Attribute>;
+
+/// Run backward promotion type analysis on `root`. Propagates promotion types
+/// from `iree_gpu.promotion_type` discardable attributes on `to_layout` ops
+/// backward through elementwise, transpose, broadcast, and shape_cast ops.
+///
+/// Returns a map from SSA values to their inferred promotion type. Values with
+/// conflicting promotion types (overdefined) are not included.
+PromotionTypeMap analyzePromotionTypes(Operation *root);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_COMMON_GPU_GPUPROMOTIONANALYSIS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h
@@ -1,0 +1,31 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_COMMON_GPU_GPUPROMOTIONANALYSIS_H_
+#define IREE_COMPILER_CODEGEN_COMMON_GPU_GPUPROMOTIONANALYSIS_H_
+
+#include "llvm/ADT/DenseMap.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir::iree_compiler {
+
+/// Result of promotion type analysis. Maps SSA values to their inferred
+/// promotion type attribute (e.g., UseGlobalLoadDMAAttr). Only values with a
+/// concrete (non-overdefined) promotion type are included.
+using PromotionTypeMap = llvm::DenseMap<Value, Attribute>;
+
+/// Run backward promotion type analysis on `root`. Propagates promotion types
+/// from `shared_memory_conversion` attributes on `to_layout` ops
+/// backward through elementwise, transpose, broadcast, and shape_cast ops.
+///
+/// Returns a map from SSA values to their inferred promotion type. Values with
+/// conflicting promotion types (overdefined) are not included.
+PromotionTypeMap analyzePromotionTypes(Operation *root);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_COMMON_GPU_GPUPROMOTIONANALYSIS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -480,4 +480,10 @@ def ExpandGPUOpsPass :
   ];
 }
 
+def TestGPUPromotionAnalysisPass :
+    InterfacePass<"iree-codegen-test-gpu-promotion-analysis",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Test the GPU promotion type backward analysis.";
+}
+
 #endif // IREE_CODEGEN_COMMON_GPU_PASSES

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -493,4 +493,10 @@ def ExpandGPUOpsPass :
   ];
 }
 
+def TestGPUPromotionAnalysisPass :
+    InterfacePass<"iree-codegen-test-gpu-promotion-analysis",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Test the GPU promotion type backward analysis.";
+}
+
 #endif // IREE_CODEGEN_COMMON_GPU_PASSES

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -57,6 +57,7 @@ iree_lit_test_suite(
             "gpu_pad_operands.mlir",
             "gpu_pipeline.mlir",
             "gpu_promote_matmul_operands.mlir",
+            "gpu_promotion_analysis.mlir",
             "gpu_reorder_workgroups.mlir",
             "gpu_reorder_workgroups_static.mlir",
             "gpu_reuse_shared_memory_allocs.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -59,6 +59,7 @@ iree_lit_test_suite(
             "gpu_pad_operands.mlir",
             "gpu_pipeline.mlir",
             "gpu_promote_matmul_operands.mlir",
+            "gpu_promotion_analysis.mlir",
             "gpu_reorder_workgroups.mlir",
             "gpu_reorder_workgroups_static.mlir",
             "gpu_reuse_shared_memory_allocs.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_lit_test_suite(
     "gpu_pad_operands.mlir"
     "gpu_pipeline.mlir"
     "gpu_promote_matmul_operands.mlir"
+    "gpu_promotion_analysis.mlir"
     "gpu_reorder_workgroups.mlir"
     "gpu_reorder_workgroups_static.mlir"
     "gpu_reuse_shared_memory_allocs.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -54,6 +54,7 @@ iree_lit_test_suite(
     "gpu_pad_operands.mlir"
     "gpu_pipeline.mlir"
     "gpu_promote_matmul_operands.mlir"
+    "gpu_promotion_analysis.mlir"
     "gpu_reorder_workgroups.mlir"
     "gpu_reorder_workgroups_static.mlir"
     "gpu_reuse_shared_memory_allocs.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promotion_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promotion_analysis.mlir
@@ -1,0 +1,99 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(any(iree-codegen-test-gpu-promotion-analysis))" --split-input-file %s --verify-diagnostics
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @direct_propagation(%src: memref<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#layout)
+      {iree_gpu.promotion_type = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @through_elementwise(%src: memref<16x16xf16>, %other: vector<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %mul = arith.mulf %read, %other : vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %mul to layout(#layout)
+      {iree_gpu.promotion_type = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @through_transpose(%src: memref<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %transpose = vector.transpose %read, [1, 0] : vector<16x16xf16> to vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %transpose to layout(#layout)
+      {iree_gpu.promotion_type = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @through_scf_for(%src: memref<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %init = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %loop = scf.for %iv = %c0 to %c4 step %c1 iter_args(%arg = %init) -> vector<16x16xf16> {
+    // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+    %update = arith.addf %arg, %arg : vector<16x16xf16>
+    scf.yield %update : vector<16x16xf16>
+  }
+  %out = iree_vector_ext.to_layout %loop to layout(#layout)
+      {iree_gpu.promotion_type = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promotion_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promotion_analysis.mlir
@@ -1,0 +1,99 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(any(iree-codegen-test-gpu-promotion-analysis))" --split-input-file %s --verify-diagnostics
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @direct_propagation(%src: memref<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#layout)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @through_elementwise(%src: memref<16x16xf16>, %other: vector<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %mul = arith.mulf %read, %other : vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %mul to layout(#layout)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @through_transpose(%src: memref<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %transpose = vector.transpose %read, [1, 0] : vector<16x16xf16> to vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %transpose to layout(#layout)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [16, 16],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @through_scf_for(%src: memref<16x16xf16>) -> vector<16x16xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %cst = arith.constant 0.0 : f16
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %init = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+  %loop = scf.for %iv = %c0 to %c4 step %c1 iter_args(%arg = %init) -> vector<16x16xf16> {
+    // expected-remark @below {{promotion type of result #0 is #iree_gpu.use_global_load_dma}}
+    %update = arith.addf %arg, %arg : vector<16x16xf16>
+    scf.yield %update : vector<16x16xf16>
+  }
+  %out = iree_vector_ext.to_layout %loop to layout(#layout)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -428,6 +428,8 @@ struct ToLayoutOpVectorizationModel
     auto newLayoutOp = IREE::VectorExt::ToLayoutOp::create(
         rewriter, loc, readOp, toLayoutOp.getLayout(),
         toLayoutOp.getSharedMemoryConversion());
+    newLayoutOp->setDiscardableAttrs(
+        toLayoutOp->getDiscardableAttrDictionary());
     // Create the write back to a tensor.
     ShapedType tensorTy = toLayoutOp.getType();
     auto resType =


### PR DESCRIPTION
Add a sparse backward dataflow analysis to propagate promotion types from `to_layout` operations on operands to compute ops backward to the origin of the operand, e.g., a read from memory. 

The motivation is to use this analysis from transformation passes to find loads from memory that should be promoted, e.g., using direct-to-LDS and then transform the load accordingly.

The lattice of the analysis has three states: an undefined (initial) state, a defined state with a concrete promotion type stored as attribute and an overdefined (top) state. If two defined lattice values with different promotion types meet, the resulting lattice value is overdefined.

This is part of https://github.com/iree-org/iree/issues/23782.

Assisted-by: Claude Code and Codex