### PR TITLE
[HAL] Runtime Correctness Foundations

### DIFF
--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -148,6 +148,16 @@ iree_runtime_cc_test(
     ],
 )
 
+cc_binary_benchmark(
+    name = "atomic_slist_benchmark",
+    srcs = ["atomic_slist_benchmark.cc"],
+    deps = [
+        ":atomic_slist",
+        "//runtime/src/iree/testing:benchmark_main",
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
 iree_runtime_cc_library(
     name = "atomic_freelist",
     hdrs = ["atomic_freelist.h"],

--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -453,6 +453,16 @@ iree_runtime_cc_library(
     ],
 )
 
+iree_runtime_cc_test(
+    name = "sysfs_test",
+    srcs = ["sysfs_test.cc"],
+    deps = [
+        ":sysfs",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 iree_runtime_cc_library(
     name = "time",
     srcs = ["time.c"],

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -499,6 +499,17 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    sysfs_test
+  SRCS
+    "sysfs_test.cc"
+  DEPS
+    ::sysfs
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 iree_cc_library(
   NAME
     time

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -146,6 +146,18 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_binary_benchmark(
+  NAME
+    atomic_slist_benchmark
+  SRCS
+    "atomic_slist_benchmark.cc"
+  DEPS
+    ::atomic_slist
+    benchmark
+    iree::testing::benchmark_main
+  TESTONLY
+)
+
 iree_cc_library(
   NAME
     atomic_freelist

--- a/runtime/src/iree/base/internal/atomic_slist.c
+++ b/runtime/src/iree/base/internal/atomic_slist.c
@@ -10,9 +10,17 @@
 
 #include "iree/base/attributes.h"
 
-// TODO(benvanik): add TSAN annotations when switched to atomics:
-// https://github.com/gcc-mirror/gcc/blob/master/libsanitizer/include/sanitizer/tsan_interface_atomic.h
-// https://reviews.llvm.org/D18500
+// Loads the head pointer with the given memory ordering.
+static inline iree_atomic_slist_entry_t* iree_atomic_slist_load_head(
+    iree_atomic_slist_t* list, iree_memory_order_t order) {
+  return (iree_atomic_slist_entry_t*)iree_atomic_load(&list->head, order);
+}
+
+// Stores the head pointer with release ordering (publishes prior writes).
+static inline void iree_atomic_slist_store_head(
+    iree_atomic_slist_t* list, iree_atomic_slist_entry_t* value) {
+  iree_atomic_store(&list->head, (intptr_t)value, iree_memory_order_release);
+}
 
 void iree_atomic_slist_initialize(iree_atomic_slist_t* out_list) {
   memset(out_list, 0, sizeof(*out_list));
@@ -20,7 +28,6 @@ void iree_atomic_slist_initialize(iree_atomic_slist_t* out_list) {
 }
 
 void iree_atomic_slist_deinitialize(iree_atomic_slist_t* list) {
-  // TODO(benvanik): assert empty.
   iree_slim_mutex_deinitialize(&list->mutex);
   memset(list, 0, sizeof(*list));
 }
@@ -30,37 +37,44 @@ void iree_atomic_slist_concat(iree_atomic_slist_t* list,
                               iree_atomic_slist_entry_t* tail) {
   if (IREE_UNLIKELY(!head)) return;
   iree_slim_mutex_lock(&list->mutex);
-  tail->next = list->head;
-  list->head = head;
+  tail->next = iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, head);
   iree_slim_mutex_unlock(&list->mutex);
 }
 
 void iree_atomic_slist_push(iree_atomic_slist_t* list,
                             iree_atomic_slist_entry_t* entry) {
   iree_slim_mutex_lock(&list->mutex);
-  iree_atomic_slist_push_unsafe(list, entry);
+  entry->next = iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, entry);
   iree_slim_mutex_unlock(&list->mutex);
 }
 
 void iree_atomic_slist_push_unsafe(iree_atomic_slist_t* list,
                                    iree_atomic_slist_entry_t* entry) {
-  // NOTE: no lock is held here and no atomic operation will be used when this
-  // is actually made atomic.
-  entry->next = list->head;
-  list->head = entry;
+  entry->next = iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, entry);
 }
 
 void iree_atomic_slist_discard(iree_atomic_slist_t* list) {
   iree_slim_mutex_lock(&list->mutex);
-  list->head = NULL;
+  iree_atomic_slist_store_head(list, NULL);
   iree_slim_mutex_unlock(&list->mutex);
 }
 
 iree_atomic_slist_entry_t* iree_atomic_slist_pop(iree_atomic_slist_t* list) {
+  // Fast path: check if the list is empty without taking the mutex.
+  // The relaxed load is safe because we re-check under the mutex if non-NULL.
+  // False negatives (read NULL when an entry was just pushed) are benign:
+  // the entry will be seen on the next pop call.
+  if (!iree_atomic_slist_load_head(list, iree_memory_order_relaxed)) {
+    return NULL;
+  }
   iree_slim_mutex_lock(&list->mutex);
-  iree_atomic_slist_entry_t* entry = list->head;
+  iree_atomic_slist_entry_t* entry =
+      iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
   if (entry != NULL) {
-    list->head = entry->next;
+    iree_atomic_slist_store_head(list, entry->next);
     entry->next = NULL;
   }
   iree_slim_mutex_unlock(&list->mutex);
@@ -71,19 +85,19 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
                              iree_atomic_slist_flush_order_t flush_order,
                              iree_atomic_slist_entry_t** out_head,
                              iree_atomic_slist_entry_t** out_tail) {
-  // Exchange list head with NULL to steal the entire list. The list will be in
-  // the native LIFO order of the slist.
+  // Fast path: check if the list is empty without taking the mutex.
+  if (!iree_atomic_slist_load_head(list, iree_memory_order_relaxed)) {
+    return false;
+  }
   iree_slim_mutex_lock(&list->mutex);
-  iree_atomic_slist_entry_t* head = list->head;
-  list->head = NULL;
+  iree_atomic_slist_entry_t* head =
+      iree_atomic_slist_load_head(list, iree_memory_order_relaxed);
+  iree_atomic_slist_store_head(list, NULL);
   iree_slim_mutex_unlock(&list->mutex);
   if (!head) return false;
 
   switch (flush_order) {
     case IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO: {
-      // List is already in native LIFO order. If the user wants a tail we have
-      // to scan for it, though, which we really only want to do when required
-      // as it's a linked list pointer walk.
       *out_head = head;
       if (out_tail) {
         iree_atomic_slist_entry_t* p = head;
@@ -93,9 +107,6 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
       break;
     }
     case IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_FIFO: {
-      // Reverse the list in a single scan. list_head is our tail, so scan
-      // forward to find our head. Since we have to walk the whole list anyway
-      // we can cheaply give both the head and tail to the caller.
       iree_atomic_slist_entry_t* tail = head;
       if (out_tail) *out_tail = tail;
       iree_atomic_slist_entry_t* p = head;

--- a/runtime/src/iree/base/internal/atomic_slist.h
+++ b/runtime/src/iree/base/internal/atomic_slist.h
@@ -78,9 +78,10 @@ typedef struct iree_atomic_slist_entry_t {
 // etc. That said, the Windows Interlocked* variants don't seem to. Having a
 // single heavily tested implementation seems more worthwhile than several.
 typedef iree_alignas(iree_max_align_t) struct {
-  // TODO(benvanik): spend some time golfing this. Unblocking myself for now :)
   iree_slim_mutex_t mutex;
-  iree_atomic_slist_entry_t* head;
+  // Atomic head pointer used for relaxed empty checks without taking the mutex.
+  // All mutations still hold the mutex.
+  iree_atomic_intptr_t head;
 } iree_atomic_slist_t;
 
 // Initializes an slist handle to an empty list.

--- a/runtime/src/iree/base/internal/atomic_slist_benchmark.cc
+++ b/runtime/src/iree/base/internal/atomic_slist_benchmark.cc
@@ -1,0 +1,475 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Benchmarks for iree_atomic_slist_t characterizing single-threaded operation
+// costs and multi-threaded contention behavior.
+//
+// Single-threaded baselines measure the raw cost of each operation in
+// isolation. Multi-threaded benchmarks use Google Benchmark's ->Threads(N)
+// to measure how operations scale under contention with increasing thread
+// counts on the same list.
+//
+// Key scenarios:
+//   - Push/pop/flush round-trip cost (uncontended)
+//   - Fast-path empty check cost (pop/flush on empty list)
+//   - Batch push then pop/flush throughput
+//   - Write-write contention (N threads pushing)
+//   - Mixed contention (N threads doing push+pop)
+//   - Producer/consumer (N-1 pushers, 1 popper or flusher)
+//   - Empty fast-path under contention (N threads popping/flushing empty)
+//
+// Run with:
+//   iree-bazel-run //runtime/src/iree/base/internal:atomic_slist_benchmark
+// Filter:
+//   --benchmark_filter='Contention'
+
+#include <algorithm>
+#include <thread>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "iree/base/internal/atomic_slist.h"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Test entry type
+//===----------------------------------------------------------------------===//
+
+struct bench_entry_t {
+  int value;
+  iree_atomic_slist_intrusive_ptr_t slist_next;
+};
+IREE_TYPED_ATOMIC_SLIST_WRAPPER(bench, bench_entry_t,
+                                offsetof(bench_entry_t, slist_next));
+
+// Returns the number of hardware threads, clamped to at least 1.
+static int HardwareConcurrency() {
+  int count = static_cast<int>(std::thread::hardware_concurrency());
+  return count > 0 ? count : 1;
+}
+
+// Skips benchmarks that request more threads than the machine has cores.
+// Running N threads on M << N cores produces meaningless contention noise.
+static bool ShouldSkipThreadCount(benchmark::State& state) {
+  if (state.threads() > HardwareConcurrency()) {
+    state.SkipWithMessage("thread count exceeds available cores");
+    return true;
+  }
+  return false;
+}
+
+// Thread counts to sweep for contention benchmarks. Powers of two up to 256,
+// filtered at runtime by ShouldSkipThreadCount.
+static void ThreadRange(::benchmark::Benchmark* benchmark) {
+  for (int threads = 1; threads <= 256; threads *= 2) {
+    benchmark->Threads(threads);
+  }
+}
+
+// Fixed iteration count for intrusive-entry contention benchmarks. Each push
+// needs a unique entry until the shared list is drained at teardown; otherwise
+// repeatedly pushing the same intrusive node would corrupt the list.
+static constexpr benchmark::IterationCount kContentionIterations = 10000;
+
+//===----------------------------------------------------------------------===//
+// Single-threaded baselines
+//===----------------------------------------------------------------------===//
+
+// Push then pop a single entry. Measures the uncontended round-trip cost
+// through the mutex (lock, store head, unlock) x2.
+void BM_PushPop(benchmark::State& state) {
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+  bench_entry_t entry = {42, nullptr};
+
+  for (auto _ : state) {
+    bench_slist_push(&list, &entry);
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushPop);
+
+// Pop from an empty list. Measures the fast-path relaxed load cost: should
+// return without ever touching the mutex.
+void BM_PopEmpty(benchmark::State& state) {
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PopEmpty);
+
+// Flush from an empty list. Same fast-path as pop: relaxed load of NULL head
+// returns immediately without locking.
+void BM_FlushEmpty(benchmark::State& state) {
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    bench_entry_t* head = nullptr;
+    bool flushed = bench_slist_flush(
+        &list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head, nullptr);
+    benchmark::DoNotOptimize(flushed);
+  }
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_FlushEmpty);
+
+// Push N entries then pop them all one at a time. Measures throughput of
+// sequential pop draining a populated list (N mutex acquisitions).
+// The final pop hits the fast-path empty check.
+void BM_PushNPopN(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    for (int i = 0; i < count; ++i) {
+      bench_slist_push(&list, &entries[i]);
+    }
+    for (int i = 0; i < count; ++i) {
+      bench_entry_t* popped = bench_slist_pop(&list);
+      benchmark::DoNotOptimize(popped);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * count * 2);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushNPopN)->Arg(1)->Arg(4)->Arg(16)->Arg(64)->Arg(256)->Arg(1024);
+
+// Push N entries then flush them all at once (LIFO order). Measures the
+// amortized cost: one mutex acquisition drains the entire list. The flush
+// walks the list to find the tail only when out_tail is requested.
+void BM_PushNFlushLIFO(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    for (int i = 0; i < count; ++i) {
+      bench_slist_push(&list, &entries[i]);
+    }
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    benchmark::DoNotOptimize(head);
+  }
+  state.SetItemsProcessed(state.iterations() * count);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushNFlushLIFO)
+    ->Arg(1)
+    ->Arg(4)
+    ->Arg(16)
+    ->Arg(64)
+    ->Arg(256)
+    ->Arg(1024);
+
+// Push N entries then flush them all at once (FIFO order). FIFO flush
+// reverses the list in-place, touching every entry's next pointer. This
+// shows the cost delta between LIFO (O(1) without tail) and FIFO (O(N)
+// reversal).
+void BM_PushNFlushFIFO(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    for (int i = 0; i < count; ++i) {
+      bench_slist_push(&list, &entries[i]);
+    }
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_FIFO,
+                      &head, nullptr);
+    benchmark::DoNotOptimize(head);
+  }
+  state.SetItemsProcessed(state.iterations() * count);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_PushNFlushFIFO)
+    ->Arg(1)
+    ->Arg(4)
+    ->Arg(16)
+    ->Arg(64)
+    ->Arg(256)
+    ->Arg(1024);
+
+// Concat a chain of N entries at once. Measures the cost of a single mutex
+// acquisition to prepend an entire chain (O(1) regardless of chain length).
+void BM_Concat(benchmark::State& state) {
+  const int count = static_cast<int>(state.range(0));
+  std::vector<bench_entry_t> entries(count);
+  for (int i = 0; i < count; ++i) entries[i].value = i;
+
+  bench_slist_t list;
+  bench_slist_initialize(&list);
+
+  for (auto _ : state) {
+    // Build chain: link entries[0] -> entries[1] -> ... -> entries[N-1].
+    for (int i = 0; i < count - 1; ++i) {
+      bench_slist_set_next(&entries[i], &entries[i + 1]);
+    }
+    bench_slist_set_next(&entries[count - 1], nullptr);
+
+    bench_slist_concat(&list, &entries[0], &entries[count - 1]);
+
+    // Drain so the list is empty for the next iteration.
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    benchmark::DoNotOptimize(head);
+  }
+  state.SetItemsProcessed(state.iterations() * count);
+
+  bench_slist_deinitialize(&list);
+}
+BENCHMARK(BM_Concat)->Arg(1)->Arg(4)->Arg(16)->Arg(64)->Arg(256)->Arg(1024);
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded contention: write-write
+//===----------------------------------------------------------------------===//
+
+// N threads all pushing to the same list. Measures mutex contention on the
+// write path. Each thread pushes its own entry (no data sharing beyond the
+// list head). After each iteration, entries accumulate in the list; a barrier
+// and flush between iterations would add noise, so we accept the growing list
+// and report per-operation throughput.
+void BM_ContentionPush(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  // Shared list, initialized once by thread 0.
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  // Each push uses a unique intrusive entry. The benchmark loop has a start
+  // barrier, so thread 0 setup is complete before other threads push.
+  std::vector<bench_entry_t> entries(static_cast<size_t>(state.max_iterations));
+  size_t entry_index = 0;
+
+  for (auto _ : state) {
+    (void)_;
+    entries[entry_index].value = static_cast<int>(entry_index);
+    bench_slist_push(&list, &entries[entry_index]);
+    ++entry_index;
+  }
+
+  // The benchmark loop has a stop barrier before teardown, so thread 0 drains
+  // only after all pushes have completed.
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ContentionPush)
+    ->Apply(ThreadRange)
+    ->Iterations(kContentionIterations)
+    ->UseRealTime();
+
+// N threads each doing push-then-pop cycles on the same list. Measures
+// mixed read-write contention. Each thread pushes its own entry then
+// immediately pops (which may get its own entry back, or another thread's —
+// that's fine, we're measuring contention cost not correctness).
+void BM_ContentionPushPop(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  std::vector<bench_entry_t> entries(static_cast<size_t>(state.max_iterations));
+  size_t entry_index = 0;
+
+  for (auto _ : state) {
+    (void)_;
+    entries[entry_index].value = static_cast<int>(entry_index);
+    bench_slist_push(&list, &entries[entry_index]);
+    ++entry_index;
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ContentionPushPop)
+    ->Apply(ThreadRange)
+    ->Iterations(kContentionIterations)
+    ->UseRealTime();
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded contention: empty fast-path
+//===----------------------------------------------------------------------===//
+
+// N threads all popping from an empty list. This is the critical benchmark
+// for the fast-path empty check: with the relaxed load, threads should never
+// touch the mutex and should scale perfectly. Without it, every pop would
+// contend on the mutex even though the list is always empty.
+void BM_PopEmptyContention(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  for (auto _ : state) {
+    bench_entry_t* popped = bench_slist_pop(&list);
+    benchmark::DoNotOptimize(popped);
+  }
+
+  if (state.thread_index() == 0) {
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_PopEmptyContention)->Apply(ThreadRange)->UseRealTime();
+
+// N threads all flushing an empty list. Same fast-path test as PopEmpty
+// but for the flush path.
+void BM_FlushEmptyContention(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  for (auto _ : state) {
+    bench_entry_t* head = nullptr;
+    bool flushed = bench_slist_flush(
+        &list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head, nullptr);
+    benchmark::DoNotOptimize(flushed);
+  }
+
+  if (state.thread_index() == 0) {
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_FlushEmptyContention)->Apply(ThreadRange)->UseRealTime();
+
+//===----------------------------------------------------------------------===//
+// Multi-threaded contention: producer/consumer
+//===----------------------------------------------------------------------===//
+
+// (N-1) producers pushing, 1 consumer popping. Simulates the typical
+// pattern where worker threads produce results into a shared collection
+// list and a coordinator drains them one at a time. The consumer (thread 0)
+// may frequently see an empty list, exercising the fast-path.
+//
+// For the single-thread case, the one thread does push+pop (no point in
+// having zero producers or zero consumers).
+void BM_ProducerConsumerPop(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  std::vector<bench_entry_t> entries(static_cast<size_t>(state.max_iterations));
+  size_t entry_index = 0;
+  const bool is_consumer = (state.thread_index() == 0);
+
+  for (auto _ : state) {
+    (void)_;
+    if (state.threads() == 1 || !is_consumer) {
+      entries[entry_index].value = static_cast<int>(entry_index);
+      bench_slist_push(&list, &entries[entry_index]);
+      ++entry_index;
+    }
+    if (state.threads() == 1 || is_consumer) {
+      bench_entry_t* popped = bench_slist_pop(&list);
+      benchmark::DoNotOptimize(popped);
+    }
+  }
+
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ProducerConsumerPop)
+    ->Apply(ThreadRange)
+    ->Iterations(kContentionIterations)
+    ->UseRealTime();
+
+// (N-1) producers pushing, 1 consumer flushing. Simulates the pattern where
+// a coordinator periodically drains the entire list in one shot. This is the
+// typical pattern for work-stealing schedulers and batch processing: the
+// flush amortizes mutex cost across all accumulated entries.
+void BM_ProducerConsumerFlush(benchmark::State& state) {
+  if (ShouldSkipThreadCount(state)) return;
+
+  static bench_slist_t list;
+  if (state.thread_index() == 0) {
+    bench_slist_initialize(&list);
+  }
+
+  std::vector<bench_entry_t> entries(static_cast<size_t>(state.max_iterations));
+  size_t entry_index = 0;
+  const bool is_consumer = (state.thread_index() == 0);
+
+  for (auto _ : state) {
+    (void)_;
+    if (state.threads() == 1 || !is_consumer) {
+      entries[entry_index].value = static_cast<int>(entry_index);
+      bench_slist_push(&list, &entries[entry_index]);
+      ++entry_index;
+    }
+    if (state.threads() == 1 || is_consumer) {
+      bench_entry_t* head = nullptr;
+      bool flushed = bench_slist_flush(
+          &list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head,
+          nullptr);
+      benchmark::DoNotOptimize(flushed);
+    }
+  }
+
+  if (state.thread_index() == 0) {
+    bench_entry_t* head = nullptr;
+    bench_slist_flush(&list, IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+                      &head, nullptr);
+    bench_slist_deinitialize(&list);
+  }
+}
+BENCHMARK(BM_ProducerConsumerFlush)
+    ->Apply(ThreadRange)
+    ->Iterations(kContentionIterations)
+    ->UseRealTime();
+
+}  // namespace

--- a/runtime/src/iree/base/internal/sysfs.c
+++ b/runtime/src/iree/base/internal/sysfs.c
@@ -79,6 +79,31 @@ iree_status_t iree_sysfs_read_small_file(const char* path, char* buffer,
   return iree_ok_status();
 }
 
+bool iree_sysfs_try_read_small_file(const char* path, char* buffer,
+                                    size_t buffer_size,
+                                    iree_host_size_t* out_length) {
+  IREE_ASSERT_ARGUMENT(path);
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_ASSERT_ARGUMENT(buffer_size > 0);
+  IREE_ASSERT_ARGUMENT(out_length);
+  *out_length = 0;
+
+  FILE* file = fopen(path, "r");
+  if (!file) return false;
+
+  const size_t bytes_read = fread(buffer, 1, buffer_size - 1, file);
+  if (ferror(file) || (bytes_read == buffer_size - 1 && !feof(file))) {
+    fclose(file);
+    return false;
+  }
+  fclose(file);
+
+  IREE_ASSERT(bytes_read < buffer_size);
+  buffer[bytes_read] = '\0';
+  *out_length = bytes_read;
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // Parsing utilities
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/sysfs.c
+++ b/runtime/src/iree/base/internal/sysfs.c
@@ -108,11 +108,15 @@ bool iree_sysfs_try_read_small_file(const char* path, char* buffer,
 // Parsing utilities
 //===----------------------------------------------------------------------===//
 
-iree_status_t iree_sysfs_parse_cpu_list(iree_string_view_t text,
-                                        iree_sysfs_cpu_list_callback_t callback,
-                                        void* user_data) {
-  IREE_ASSERT_ARGUMENT(callback);
+typedef enum iree_sysfs_cpu_list_parse_result_e {
+  IREE_SYSFS_CPU_LIST_PARSE_RESULT_OK = 0,
+  IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_NUMBER = 1,
+  IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_RANGE = 2,
+} iree_sysfs_cpu_list_parse_result_t;
 
+static iree_sysfs_cpu_list_parse_result_t iree_sysfs_parse_cpu_list_impl(
+    iree_string_view_t text, iree_sysfs_cpu_list_callback_t callback,
+    void* user_data) {
   text = iree_string_view_trim(text);
 
   // Split on commas and process each element.
@@ -131,8 +135,10 @@ iree_status_t iree_sysfs_parse_cpu_list(iree_string_view_t text,
       if (dash_pos == IREE_STRING_VIEW_NPOS) {
         // Single CPU: "N"
         if (!iree_string_view_atoi_uint32(segment, &start_cpu)) {
-          return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                                  "invalid CPU number in list");
+          return IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_NUMBER;
+        }
+        if (start_cpu == UINT32_MAX) {
+          return IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_RANGE;
         }
         end_cpu = start_cpu + 1;
       } else {
@@ -144,8 +150,10 @@ iree_status_t iree_sysfs_parse_cpu_list(iree_string_view_t text,
 
         if (!iree_string_view_atoi_uint32(start_str, &start_cpu) ||
             !iree_string_view_atoi_uint32(end_str, &end_cpu)) {
-          return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                                  "invalid CPU range in list");
+          return IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_RANGE;
+        }
+        if (end_cpu < start_cpu || end_cpu == UINT32_MAX) {
+          return IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_RANGE;
         }
         end_cpu += 1;  // Make exclusive.
       }
@@ -156,19 +164,40 @@ iree_status_t iree_sysfs_parse_cpu_list(iree_string_view_t text,
     offset = (comma_pos == IREE_STRING_VIEW_NPOS) ? text.size : comma_pos + 1;
   }
 
-  return iree_ok_status();
+  return IREE_SYSFS_CPU_LIST_PARSE_RESULT_OK;
 }
 
-iree_status_t iree_sysfs_parse_size_string(iree_string_view_t text,
-                                           uint64_t* out_size) {
-  IREE_ASSERT_ARGUMENT(out_size);
+iree_status_t iree_sysfs_parse_cpu_list(iree_string_view_t text,
+                                        iree_sysfs_cpu_list_callback_t callback,
+                                        void* user_data) {
+  IREE_ASSERT_ARGUMENT(callback);
+  switch (iree_sysfs_parse_cpu_list_impl(text, callback, user_data)) {
+    case IREE_SYSFS_CPU_LIST_PARSE_RESULT_OK:
+      return iree_ok_status();
+    case IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_NUMBER:
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "invalid CPU number in list");
+    case IREE_SYSFS_CPU_LIST_PARSE_RESULT_INVALID_RANGE:
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "invalid CPU range in list");
+  }
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "invalid CPU list");
+}
+
+bool iree_sysfs_try_parse_cpu_list(iree_string_view_t text,
+                                   iree_sysfs_cpu_list_callback_t callback,
+                                   void* user_data) {
+  IREE_ASSERT_ARGUMENT(callback);
+  return iree_sysfs_parse_cpu_list_impl(text, callback, user_data) ==
+         IREE_SYSFS_CPU_LIST_PARSE_RESULT_OK;
+}
+
+static bool iree_sysfs_try_parse_size_string_impl(iree_string_view_t text,
+                                                  uint64_t* out_size) {
   *out_size = 0;
 
   text = iree_string_view_trim(text);
-  if (iree_string_view_is_empty(text)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "size string is empty");
-  }
+  if (iree_string_view_is_empty(text)) return false;
 
   // Check for optional K suffix (case-insensitive).
   uint64_t scale = 1;
@@ -180,12 +209,20 @@ iree_status_t iree_sysfs_parse_size_string(iree_string_view_t text,
   // Parse the numeric part.
   text = iree_string_view_trim(text);
   uint64_t value = 0;
-  if (!iree_string_view_atoi_uint64(text, &value)) {
+  if (!iree_string_view_atoi_uint64(text, &value)) return false;
+  if (value > UINT64_MAX / scale) return false;
+
+  *out_size = value * scale;
+  return true;
+}
+
+iree_status_t iree_sysfs_parse_size_string(iree_string_view_t text,
+                                           uint64_t* out_size) {
+  IREE_ASSERT_ARGUMENT(out_size);
+  if (!iree_sysfs_try_parse_size_string_impl(text, out_size)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "invalid size string");
   }
-
-  *out_size = value * scale;
   return iree_ok_status();
 }
 
@@ -210,6 +247,20 @@ iree_status_t iree_sysfs_read_uint32(const char* path, uint32_t* out_value) {
   return iree_ok_status();
 }
 
+bool iree_sysfs_try_read_uint32(const char* path, uint32_t* out_value) {
+  IREE_ASSERT_ARGUMENT(path);
+  IREE_ASSERT_ARGUMENT(out_value);
+  *out_value = 0;
+  char buffer[64];
+  iree_host_size_t length = 0;
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
+    return false;
+  }
+  iree_string_view_t text =
+      iree_string_view_trim(iree_make_string_view(buffer, length));
+  return iree_string_view_atoi_uint32(text, out_value);
+}
+
 iree_status_t iree_sysfs_read_size(const char* path, uint64_t* out_size) {
   IREE_ASSERT_ARGUMENT(path);
   IREE_ASSERT_ARGUMENT(out_size);
@@ -220,6 +271,19 @@ iree_status_t iree_sysfs_read_size(const char* path, uint64_t* out_size) {
       iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length));
   return iree_sysfs_parse_size_string(iree_make_string_view(buffer, length),
                                       out_size);
+}
+
+bool iree_sysfs_try_read_size(const char* path, uint64_t* out_size) {
+  IREE_ASSERT_ARGUMENT(path);
+  IREE_ASSERT_ARGUMENT(out_size);
+  *out_size = 0;
+  char buffer[64];
+  iree_host_size_t length = 0;
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
+    return false;
+  }
+  return iree_sysfs_try_parse_size_string_impl(
+      iree_make_string_view(buffer, length), out_size);
 }
 
 #endif  // IREE_PLATFORM_LINUX && !IREE_PLATFORM_EMSCRIPTEN

--- a/runtime/src/iree/base/internal/sysfs.h
+++ b/runtime/src/iree/base/internal/sysfs.h
@@ -77,6 +77,12 @@ iree_status_t iree_sysfs_parse_cpu_list(iree_string_view_t text,
                                         iree_sysfs_cpu_list_callback_t callback,
                                         void* user_data);
 
+// Tries to parse a Linux CPU list without allocating an iree_status_t. Returns
+// false when the input is malformed.
+bool iree_sysfs_try_parse_cpu_list(iree_string_view_t text,
+                                   iree_sysfs_cpu_list_callback_t callback,
+                                   void* user_data);
+
 // Parses a size string with optional K suffix (case-insensitive).
 // Whitespace is trimmed before parsing.
 // Examples: "32K" -> 32768, "1024K" -> 1048576, "1024" -> 1024
@@ -94,8 +100,18 @@ iree_status_t iree_sysfs_parse_size_string(iree_string_view_t text,
 // Reads a sysfs file and parses it as a uint32.
 iree_status_t iree_sysfs_read_uint32(const char* path, uint32_t* out_value);
 
+// Tries to read a sysfs file and parse it as a uint32 without allocating an
+// iree_status_t. Returns false when the file is absent, unreadable, too large,
+// or malformed.
+bool iree_sysfs_try_read_uint32(const char* path, uint32_t* out_value);
+
 // Reads a sysfs file and parses it as a size string (e.g., "32K").
 iree_status_t iree_sysfs_read_size(const char* path, uint64_t* out_size);
+
+// Tries to read a sysfs file and parse it as a size string without allocating
+// an iree_status_t. Returns false when the file is absent, unreadable, too
+// large, or malformed.
+bool iree_sysfs_try_read_size(const char* path, uint64_t* out_size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/base/internal/sysfs.h
+++ b/runtime/src/iree/base/internal/sysfs.h
@@ -49,6 +49,14 @@ iree_status_t iree_sysfs_read_small_file(const char* path, char* buffer,
                                          size_t buffer_size,
                                          iree_host_size_t* out_length);
 
+// Tries to read a small sysfs file into the provided buffer.
+// Returns false when the file cannot be read or does not fit in |buffer|. This
+// is for optional sysfs data where missing files are expected and should not
+// allocate an iree_status_t.
+bool iree_sysfs_try_read_small_file(const char* path, char* buffer,
+                                    size_t buffer_size,
+                                    iree_host_size_t* out_length);
+
 //===----------------------------------------------------------------------===//
 // Parsing utilities
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/sysfs_test.cc
+++ b/runtime/src/iree/base/internal/sysfs_test.cc
@@ -1,0 +1,77 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/sysfs.h"
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+#if defined(IREE_PLATFORM_LINUX) && !defined(IREE_PLATFORM_EMSCRIPTEN)
+
+using namespace iree::testing::status;
+
+struct CpuRanges {
+  uint32_t start_cpus[4];
+  uint32_t end_cpus[4];
+  iree_host_size_t count;
+};
+
+static bool AppendCpuRange(uint32_t start_cpu, uint32_t end_cpu,
+                           void* user_data) {
+  CpuRanges* ranges = (CpuRanges*)user_data;
+  if (ranges->count >= IREE_ARRAYSIZE(ranges->start_cpus)) return false;
+  ranges->start_cpus[ranges->count] = start_cpu;
+  ranges->end_cpus[ranges->count] = end_cpu;
+  ++ranges->count;
+  return true;
+}
+
+TEST(SysfsTest, ParseCpuList) {
+  CpuRanges ranges = {};
+  IREE_ASSERT_OK(
+      iree_sysfs_parse_cpu_list(IREE_SV("0,2-3, 7"), AppendCpuRange, &ranges));
+
+  EXPECT_EQ(3, ranges.count);
+  EXPECT_EQ(0, ranges.start_cpus[0]);
+  EXPECT_EQ(1, ranges.end_cpus[0]);
+  EXPECT_EQ(2, ranges.start_cpus[1]);
+  EXPECT_EQ(4, ranges.end_cpus[1]);
+  EXPECT_EQ(7, ranges.start_cpus[2]);
+  EXPECT_EQ(8, ranges.end_cpus[2]);
+}
+
+TEST(SysfsTest, TryParseCpuListRejectsMalformedInput) {
+  CpuRanges ranges = {};
+  EXPECT_FALSE(iree_sysfs_try_parse_cpu_list(IREE_SV("not-a-cpu-list"),
+                                             AppendCpuRange, &ranges));
+  EXPECT_FALSE(
+      iree_sysfs_try_parse_cpu_list(IREE_SV("3-2"), AppendCpuRange, &ranges));
+  EXPECT_FALSE(iree_sysfs_try_parse_cpu_list(IREE_SV("4294967295"),
+                                             AppendCpuRange, &ranges));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_sysfs_parse_cpu_list(IREE_SV("3-2"), AppendCpuRange, &ranges));
+}
+
+TEST(SysfsTest, ParseSizeString) {
+  uint64_t size = 0;
+  IREE_ASSERT_OK(iree_sysfs_parse_size_string(IREE_SV("32K"), &size));
+  EXPECT_EQ(32768u, size);
+  IREE_ASSERT_OK(iree_sysfs_parse_size_string(IREE_SV("512"), &size));
+  EXPECT_EQ(512u, size);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_sysfs_parse_size_string(IREE_SV(""), &size));
+}
+
+#else
+
+TEST(SysfsTest, PlatformDisabled) {}
+
+#endif  // IREE_PLATFORM_LINUX && !IREE_PLATFORM_EMSCRIPTEN
+
+}  // namespace

--- a/runtime/src/iree/hal/drivers/cuda/timepoint_pool.c
+++ b/runtime/src/iree/hal/drivers/cuda/timepoint_pool.c
@@ -218,9 +218,16 @@ iree_status_t iree_hal_cuda_timepoint_pool_acquire_device_signal(
       z0, iree_hal_cuda_event_pool_acquire(timepoint_pool->device_event_pool,
                                            timepoint_count, device_events));
 
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_cuda_timepoint_pool_acquire_internal(
-              timepoint_pool, timepoint_count, out_timepoints));
+  iree_status_t status = iree_hal_cuda_timepoint_pool_acquire_internal(
+      timepoint_pool, timepoint_count, out_timepoints);
+  if (!iree_status_is_ok(status)) {
+    // Release already-acquired events back to the pool before returning.
+    for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
+      iree_hal_cuda_event_release(device_events[i]);
+    }
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
   for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
     out_timepoints[i]->kind = IREE_HAL_CUDA_TIMEPOINT_KIND_DEVICE_SIGNAL;
     out_timepoints[i]->timepoint.device_signal = device_events[i];
@@ -244,9 +251,16 @@ iree_status_t iree_hal_cuda_timepoint_pool_acquire_device_wait(
       z0, iree_hal_cuda_event_pool_acquire(timepoint_pool->device_event_pool,
                                            timepoint_count, device_events));
 
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_cuda_timepoint_pool_acquire_internal(
-              timepoint_pool, timepoint_count, out_timepoints));
+  iree_status_t status = iree_hal_cuda_timepoint_pool_acquire_internal(
+      timepoint_pool, timepoint_count, out_timepoints);
+  if (!iree_status_is_ok(status)) {
+    // Release already-acquired events back to the pool before returning.
+    for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
+      iree_hal_cuda_event_release(device_events[i]);
+    }
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
   for (iree_host_size_t i = 0; i < timepoint_count; ++i) {
     out_timepoints[i]->kind = IREE_HAL_CUDA_TIMEPOINT_KIND_DEVICE_WAIT;
     out_timepoints[i]->timepoint.device_wait = device_events[i];

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -127,7 +127,9 @@ iree_status_t iree_hal_task_device_create(
                              IREE_STRUCT_FIELD_ALIGNED(identifier.size, char, 1,
                                                        &identifier_offset)));
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(host_allocator, total_size, (void**)&device));
+      z0, iree_allocator_malloc_aligned(host_allocator, total_size,
+                                        iree_alignof(iree_hal_task_device_t),
+                                        /*offset=*/0, (void**)&device));
   memset(device, 0, total_size);
   iree_hal_resource_initialize(&iree_hal_task_device_vtable, &device->resource);
   iree_string_view_append_to_buffer(identifier, &device->identifier,
@@ -226,7 +228,7 @@ static void iree_hal_task_device_destroy(iree_hal_device_t* base_device) {
   iree_arena_block_pool_deinitialize(&device->large_block_pool);
   iree_arena_block_pool_deinitialize(&device->small_block_pool);
 
-  iree_allocator_free(host_allocator, device);
+  iree_allocator_free_aligned(host_allocator, device);
 
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 
 #include "iree/base/api.h"
+#include "iree/base/internal/debugging.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/vulkan/api.h"
 #include "iree/hal/drivers/vulkan/debug_reporter.h"
@@ -310,17 +311,24 @@ static iree_status_t iree_hal_vulkan_driver_enumerate_physical_devices(
     iree_allocator_t host_allocator, uint32_t* out_physical_device_count,
     VkPhysicalDevice** out_physical_devices) {
   uint32_t physical_device_count = 0;
-  VK_RETURN_IF_ERROR(instance_syms->vkEnumeratePhysicalDevices(
-                         instance, &physical_device_count, NULL),
-                     "vkEnumeratePhysicalDevices");
+  // Some Vulkan ICDs retain one-time internal enumeration state until process
+  // teardown. Bracket the external calls so LeakSanitizer reports stay focused
+  // on IREE-owned lifetimes.
+  IREE_LEAK_CHECK_DISABLE_PUSH();
+  VkResult query_result = instance_syms->vkEnumeratePhysicalDevices(
+      instance, &physical_device_count, NULL);
+  IREE_LEAK_CHECK_DISABLE_POP();
+  VK_RETURN_IF_ERROR(query_result, "vkEnumeratePhysicalDevices");
   VkPhysicalDevice* physical_devices = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      host_allocator, physical_device_count * sizeof(physical_devices),
+      host_allocator, physical_device_count * sizeof(*physical_devices),
       (void**)&physical_devices));
-  iree_status_t status = VK_RESULT_TO_STATUS(
-      instance_syms->vkEnumeratePhysicalDevices(
-          instance, &physical_device_count, physical_devices),
-      "vkEnumeratePhysicalDevices");
+  IREE_LEAK_CHECK_DISABLE_PUSH();
+  VkResult enumerate_result = instance_syms->vkEnumeratePhysicalDevices(
+      instance, &physical_device_count, physical_devices);
+  IREE_LEAK_CHECK_DISABLE_POP();
+  iree_status_t status =
+      VK_RESULT_TO_STATUS(enumerate_result, "vkEnumeratePhysicalDevices");
   if (iree_status_is_ok(status)) {
     *out_physical_device_count = physical_device_count;
     *out_physical_devices = physical_devices;

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -804,6 +804,7 @@ static iree_status_t iree_hal_vmvx_module_loader_try_load(
   // ensures that the data remains valid for the duration the executable is
   // loaded. Otherwise, we clone it and let the bytecode module take ownership.
   iree_allocator_t bytecode_module_allocator;
+  bool bytecode_module_data_owned = false;
   if (iree_all_bits_set(executable_params->caching_mode,
                         IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA)) {
     // Zero-copy route.
@@ -814,6 +815,7 @@ static iree_status_t iree_hal_vmvx_module_loader_try_load(
         z0, iree_allocator_clone(executable_loader->host_allocator,
                                  executable_params->executable_data,
                                  (void**)&bytecode_module_data.data));
+    bytecode_module_data_owned = true;
   }
 
   // Load the user-provided bytecode module. We pass ownership of the data (if
@@ -821,8 +823,13 @@ static iree_status_t iree_hal_vmvx_module_loader_try_load(
   iree_vm_module_t* bytecode_module = NULL;
   iree_status_t status = iree_vm_bytecode_module_create(
       executable_loader->instance, IREE_VM_BYTECODE_MODULE_FLAG_NONE,
-      executable_params->executable_data, bytecode_module_allocator,
+      bytecode_module_data, bytecode_module_allocator,
       executable_loader->host_allocator, &bytecode_module);
+  if (!iree_status_is_ok(status) && bytecode_module_data_owned) {
+    iree_allocator_free(executable_loader->host_allocator,
+                        (void*)bytecode_module_data.data);
+    bytecode_module_data_owned = false;
+  }
 
   // Executable takes ownership of the entire context (including the bytecode
   // module, which itself may own the underlying allocation).

--- a/runtime/src/iree/hal/topology_builder.c
+++ b/runtime/src/iree/hal/topology_builder.c
@@ -411,15 +411,13 @@ iree_hal_topology_edge_from_capabilities(
   // NUMA distance (queried from ACPI SLIT table via platform APIs).
   if (src_caps->numa_node != dst_caps->numa_node) {
     uint8_t slit_distance = 0;
-    iree_status_t numa_status = iree_hal_platform_query_numa_distance(
-        src_caps->numa_node, dst_caps->numa_node, &slit_distance);
     uint32_t scaled_distance;
-    if (iree_status_is_ok(numa_status)) {
+    if (iree_hal_platform_try_query_numa_distance(
+            src_caps->numa_node, dst_caps->numa_node, &slit_distance)) {
       // Normalize SLIT distance (10=same, 20=1hop, 30=2hop, ...) to 0-15 scale.
       // Subtract the "same node" base of 10, divide by 2 to compress range.
       scaled_distance = slit_distance > 10 ? (slit_distance - 10) / 2 : 0;
     } else {
-      iree_status_ignore(numa_status);
       // Platform doesn't support SLIT queries; use a conservative default
       // for cross-node distance. This will be refined by driver-specific logic
       // via refine_topology_edge.

--- a/runtime/src/iree/hal/utils/fd_file.c
+++ b/runtime/src/iree/hal/utils/fd_file.c
@@ -65,6 +65,10 @@ static iree_status_t iree_hal_platform_fd_pread(
         "file descriptor is not backed by a valid Win32 HANDLE");
   }
 
+  // Cap at INT32_MAX to prevent silent DWORD truncation for >4GB requests.
+  // Callers retry for the remaining bytes via out_bytes_read.
+  if (count > INT32_MAX) count = INT32_MAX;
+
   DWORD bytes_read = 0;
   OVERLAPPED overlapped = {0};
   overlapped.Offset = (DWORD)(offset & 0xFFFFFFFFu);
@@ -90,6 +94,10 @@ static iree_status_t iree_hal_platform_fd_pwrite(
         IREE_STATUS_INVALID_ARGUMENT,
         "file descriptor is not backed by a valid Win32 HANDLE");
   }
+
+  // Cap at INT32_MAX to prevent silent DWORD truncation for >4GB requests.
+  // Callers retry for the remaining bytes via out_bytes_written.
+  if (count > INT32_MAX) count = INT32_MAX;
 
   DWORD bytes_written = 0;
   OVERLAPPED overlapped = {0};
@@ -134,6 +142,9 @@ static iree_status_t iree_hal_platform_fd_pread(
     iree_host_size_t* out_bytes_read) {
   IREE_ASSERT_ARGUMENT(out_bytes_read);
   *out_bytes_read = 0;
+  // Cap at INT_MAX: some kernels return -EINVAL for counts exceeding this.
+  // Callers retry for the remaining bytes via out_bytes_read.
+  if (count > INT_MAX) count = INT_MAX;
   ssize_t bytes_read = pread(fd, buffer, (size_t)count, (off_t)offset);
   if (bytes_read > 0) {
     *out_bytes_read = (iree_host_size_t)bytes_read;
@@ -152,6 +163,9 @@ static iree_status_t iree_hal_platform_fd_pwrite(
     iree_host_size_t* out_bytes_written) {
   IREE_ASSERT_ARGUMENT(out_bytes_written);
   *out_bytes_written = 0;
+  // Cap at INT_MAX: some kernels return -EINVAL for counts exceeding this.
+  // Callers retry for the remaining bytes via out_bytes_written.
+  if (count > INT_MAX) count = INT_MAX;
   ssize_t bytes_written = pwrite(fd, buffer, (size_t)count, (off_t)offset);
   if (bytes_written > 0) {
     *out_bytes_written = (iree_host_size_t)bytes_written;
@@ -166,6 +180,22 @@ static iree_status_t iree_hal_platform_fd_pwrite(
 }
 
 #endif  // IREE_PLATFORM_WINDOWS
+
+#if defined(IREE_ASYNC_HAVE_FD)
+// Attempts to duplicate |fd| for optional async I/O ownership transfer.
+static bool iree_hal_platform_fd_try_dup_for_async(
+    int fd, iree_async_primitive_t* out_primitive) {
+  *out_primitive = iree_async_primitive_none();
+#if defined(IREE_PLATFORM_WINDOWS)
+  int dup_fd = _dup(fd);
+#else
+  int dup_fd = dup(fd);
+#endif  // IREE_PLATFORM_WINDOWS
+  if (dup_fd == -1) return false;
+  *out_primitive = iree_async_primitive_from_fd(dup_fd);
+  return true;
+}
+#endif  // IREE_ASYNC_HAVE_FD
 
 #endif  // IREE_FILE_IO_ENABLE
 
@@ -256,21 +286,19 @@ IREE_API_EXPORT iree_status_t iree_hal_fd_file_from_handle(
   file->fd = fd;
   file->length = length;
 
-  // If a proactor is provided, duplicate the fd and import it for async I/O.
-  // The duplicate is owned by the proactor-managed async file and closed when
-  // the async file is released.
-  //
-  // Currently only supported on platforms with native fd async primitives
-  // (POSIX). Windows IOCP requires HANDLE-based import with ReOpenFile to
-  // obtain a FILE_FLAG_OVERLAPPED handle, which needs the original share mode
-  // and access rights threaded through the import API.
   iree_status_t status = iree_ok_status();
+
 #if defined(IREE_ASYNC_HAVE_FD)
   if (proactor) {
-    iree_async_primitive_t async_primitive = iree_async_primitive_from_fd(fd);
+    // If a proactor is provided, attempt to duplicate the fd and import it for
+    // async I/O. The duplicate is owned by the proactor-managed async file and
+    // closed when the async file is released.
+    //
+    // Duplication is an optional fast-path probe: if the OS cannot produce a
+    // duplicate fd then the file remains synchronous-only. Once duplication
+    // succeeds, import failures are real construction failures and propagate.
     iree_async_primitive_t dup_primitive;
-    status = iree_async_primitive_dup(async_primitive, &dup_primitive);
-    if (iree_status_is_ok(status)) {
+    if (iree_hal_platform_fd_try_dup_for_async(fd, &dup_primitive)) {
       status =
           iree_async_file_import(proactor, dup_primitive, &file->async_file);
       if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/utils/memory_file.c
+++ b/runtime/src/iree/hal/utils/memory_file.c
@@ -219,8 +219,11 @@ static void iree_hal_memory_file_try_import_buffer(
     iree_hal_allocator_t* device_allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  const bool is_aligned = iree_host_size_has_alignment(
+      (uintptr_t)contents.data, IREE_HAL_HEAP_BUFFER_ALIGNMENT);
   iree_hal_buffer_params_t staging_buffer_params = {
-      .access = access | IREE_HAL_MEMORY_ACCESS_DISCARD,
+      .access = access | IREE_HAL_MEMORY_ACCESS_DISCARD |
+                (!is_aligned ? IREE_HAL_MEMORY_ACCESS_UNALIGNED : 0),
       .queue_affinity = queue_affinity,
       .type = IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_HOST |
               IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,

--- a/runtime/src/iree/hal/utils/platform_topology.c
+++ b/runtime/src/iree/hal/utils/platform_topology.c
@@ -22,6 +22,7 @@
 // Platform-specific implementations must define:
 // - iree_hal_platform_query_numa_node_count_impl()
 // - iree_hal_platform_query_numa_distance_impl()
+// - iree_hal_platform_try_query_numa_distance_impl()
 // - iree_hal_platform_query_pcie_same_root_impl()
 // - iree_hal_platform_query_pcie_bdf_from_path_impl()
 
@@ -29,6 +30,9 @@
 extern iree_host_size_t iree_hal_platform_query_numa_node_count_impl(void);
 
 extern iree_status_t iree_hal_platform_query_numa_distance_impl(
+    uint8_t node_a, uint8_t node_b, uint8_t* out_distance);
+
+extern bool iree_hal_platform_try_query_numa_distance_impl(
     uint8_t node_a, uint8_t node_b, uint8_t* out_distance);
 
 extern bool iree_hal_platform_query_pcie_same_root_impl(
@@ -51,6 +55,13 @@ iree_status_t iree_hal_platform_query_numa_distance(uint8_t node_a,
   IREE_ASSERT_ARGUMENT(out_distance);
   return iree_hal_platform_query_numa_distance_impl(node_a, node_b,
                                                     out_distance);
+}
+
+bool iree_hal_platform_try_query_numa_distance(uint8_t node_a, uint8_t node_b,
+                                               uint8_t* out_distance) {
+  IREE_ASSERT_ARGUMENT(out_distance);
+  return iree_hal_platform_try_query_numa_distance_impl(node_a, node_b,
+                                                        out_distance);
 }
 
 bool iree_hal_platform_query_pcie_same_root(

--- a/runtime/src/iree/hal/utils/platform_topology.h
+++ b/runtime/src/iree/hal/utils/platform_topology.h
@@ -50,6 +50,13 @@ iree_status_t iree_hal_platform_query_numa_distance(uint8_t node_a,
                                                     uint8_t node_b,
                                                     uint8_t* out_distance);
 
+// Tries to query the NUMA distance between two nodes without producing status
+// diagnostics for optional platform data. Returns false when either node is
+// outside the platform node range. Missing platform distance data is reported
+// as a conservative default distance and returns true.
+bool iree_hal_platform_try_query_numa_distance(uint8_t node_a, uint8_t node_b,
+                                               uint8_t* out_distance);
+
 //===----------------------------------------------------------------------===//
 // PCIe topology
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/utils/platform_topology_darwin.c
+++ b/runtime/src/iree/hal/utils/platform_topology_darwin.c
@@ -25,19 +25,27 @@ iree_host_size_t iree_hal_platform_query_numa_node_count_impl(void) {
   return 1;
 }
 
+bool iree_hal_platform_try_query_numa_distance_impl(uint8_t node_a,
+                                                    uint8_t node_b,
+                                                    uint8_t* out_distance) {
+  IREE_ASSERT_ARGUMENT(out_distance);
+  if (node_a != 0 || node_b != 0) return false;
+  *out_distance = 10;
+  return true;
+}
+
 iree_status_t iree_hal_platform_query_numa_distance_impl(
     uint8_t node_a, uint8_t node_b, uint8_t* out_distance) {
   IREE_ASSERT_ARGUMENT(out_distance);
 
   // macOS: only node 0 exists.
-  if (node_a != 0 || node_b != 0) {
+  if (!iree_hal_platform_try_query_numa_distance_impl(node_a, node_b,
+                                                      out_distance)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "NUMA node out of range (only node 0 exists on "
                             "macOS/Darwin)");
   }
 
-  // Same node distance.
-  *out_distance = 10;
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/utils/platform_topology_fallback.c
+++ b/runtime/src/iree/hal/utils/platform_topology_fallback.c
@@ -30,19 +30,27 @@ iree_host_size_t iree_hal_platform_query_numa_node_count_impl(void) {
   return 1;
 }
 
+bool iree_hal_platform_try_query_numa_distance_impl(uint8_t node_a,
+                                                    uint8_t node_b,
+                                                    uint8_t* out_distance) {
+  IREE_ASSERT_ARGUMENT(out_distance);
+  if (node_a != 0 || node_b != 0) return false;
+  *out_distance = 10;
+  return true;
+}
+
 iree_status_t iree_hal_platform_query_numa_distance_impl(
     uint8_t node_a, uint8_t node_b, uint8_t* out_distance) {
   IREE_ASSERT_ARGUMENT(out_distance);
 
   // Fallback: only node 0 exists.
-  if (node_a != 0 || node_b != 0) {
+  if (!iree_hal_platform_try_query_numa_distance_impl(node_a, node_b,
+                                                      out_distance)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "NUMA node out of range (only node 0 exists in "
                             "fallback implementation)");
   }
 
-  // Same node distance.
-  *out_distance = 10;
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/utils/platform_topology_sysfs.c
+++ b/runtime/src/iree/hal/utils/platform_topology_sysfs.c
@@ -28,10 +28,7 @@ iree_host_size_t iree_hal_platform_query_numa_node_count_impl(void) {
 
   char buffer[256];
   iree_host_size_t length = 0;
-  iree_status_t status =
-      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
     // Fallback: assume single NUMA node if sysfs file doesn't exist.
     return 1;
   }
@@ -78,24 +75,22 @@ iree_host_size_t iree_hal_platform_query_numa_node_count_impl(void) {
   return (iree_host_size_t)(max_node_id + 1);
 }
 
-iree_status_t iree_hal_platform_query_numa_distance_impl(
-    uint8_t node_a, uint8_t node_b, uint8_t* out_distance) {
+bool iree_hal_platform_try_query_numa_distance_impl(uint8_t node_a,
+                                                    uint8_t node_b,
+                                                    uint8_t* out_distance) {
   IREE_ASSERT_ARGUMENT(out_distance);
   *out_distance = 10;  // Default: same node.
 
   // Validate node IDs.
   iree_host_size_t node_count = iree_hal_platform_query_numa_node_count_impl();
   if (node_a >= node_count || node_b >= node_count) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "NUMA node out of range (node_a=%u, node_b=%u, "
-                            "node_count=%zu)",
-                            node_a, node_b, node_count);
+    return false;
   }
 
   // Same node: distance is 10 (standard NUMA distance for local node).
   if (node_a == node_b) {
     *out_distance = 10;
-    return iree_ok_status();
+    return true;
   }
 
   // Read distance from /sys/devices/system/node/node<A>/distance.
@@ -107,13 +102,10 @@ iree_status_t iree_hal_platform_query_numa_distance_impl(
 
   char buffer[1024];
   iree_host_size_t length = 0;
-  iree_status_t status =
-      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
-  if (!iree_status_is_ok(status)) {
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
     // Distance file doesn't exist: assume default cross-node distance.
-    iree_status_ignore(status);
     *out_distance = 20;  // Default: one hop away.
-    return iree_ok_status();
+    return true;
   }
 
   // Parse space-separated list of distances.
@@ -147,11 +139,11 @@ iree_status_t iree_hal_platform_query_numa_distance_impl(
       if (iree_string_view_atoi_uint32(number_str, &distance_value)) {
         // Clamp to uint8_t range.
         *out_distance = (uint8_t)iree_min(distance_value, 255u);
-        return iree_ok_status();
+        return true;
       } else {
         // Parse error: use default.
         *out_distance = 20;
-        return iree_ok_status();
+        return true;
       }
     }
 
@@ -160,6 +152,20 @@ iree_status_t iree_hal_platform_query_numa_distance_impl(
 
   // Didn't find node_b in the distance list: use default.
   *out_distance = 20;
+  return true;
+}
+
+iree_status_t iree_hal_platform_query_numa_distance_impl(
+    uint8_t node_a, uint8_t node_b, uint8_t* out_distance) {
+  IREE_ASSERT_ARGUMENT(out_distance);
+  if (!iree_hal_platform_try_query_numa_distance_impl(node_a, node_b,
+                                                      out_distance)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "NUMA node out of range (node_a=%u, node_b=%u, "
+                            "node_count=%zu)",
+                            node_a, node_b,
+                            iree_hal_platform_query_numa_node_count_impl());
+  }
   return iree_ok_status();
 }
 
@@ -169,7 +175,7 @@ iree_status_t iree_hal_platform_query_numa_distance_impl(
 
 // Queries the PCIe root port for a given BDF by following symbolic links.
 // Returns a hash of the root port path for same-root comparison.
-static iree_status_t iree_hal_platform_query_pcie_root_hash(
+static void iree_hal_platform_query_pcie_root_hash(
     iree_hal_platform_pcie_bdf_t bdf, uint64_t* out_hash) {
   IREE_ASSERT_ARGUMENT(out_hash);
   *out_hash = 0;
@@ -193,8 +199,6 @@ static iree_status_t iree_hal_platform_query_pcie_root_hash(
   // This is a heuristic: true root detection requires traversing PCI hierarchy.
   *out_hash = ((uint64_t)iree_hal_platform_pcie_bdf_domain(bdf) << 32) |
               (uint64_t)iree_hal_platform_pcie_bdf_bus(bdf);
-
-  return iree_ok_status();
 }
 
 bool iree_hal_platform_query_pcie_same_root_impl(
@@ -206,18 +210,8 @@ bool iree_hal_platform_query_pcie_same_root_impl(
 
   uint64_t hash_a = 0;
   uint64_t hash_b = 0;
-
-  iree_status_t status_a =
-      iree_hal_platform_query_pcie_root_hash(bdf_a, &hash_a);
-  iree_status_t status_b =
-      iree_hal_platform_query_pcie_root_hash(bdf_b, &hash_b);
-
-  if (!iree_status_is_ok(status_a) || !iree_status_is_ok(status_b)) {
-    iree_status_ignore(status_a);
-    iree_status_ignore(status_b);
-    // Fallback: assume same root if we can't determine.
-    return true;
-  }
+  iree_hal_platform_query_pcie_root_hash(bdf_a, &hash_a);
+  iree_hal_platform_query_pcie_root_hash(bdf_b, &hash_b);
 
   // Same bus implies same root (heuristic).
   return hash_a == hash_b;

--- a/runtime/src/iree/hal/utils/platform_topology_win32.c
+++ b/runtime/src/iree/hal/utils/platform_topology_win32.c
@@ -27,35 +27,40 @@ iree_host_size_t iree_hal_platform_query_numa_node_count_impl(void) {
   return 1;
 }
 
-iree_status_t iree_hal_platform_query_numa_distance_impl(
-    uint8_t node_a, uint8_t node_b, uint8_t* out_distance) {
+bool iree_hal_platform_try_query_numa_distance_impl(uint8_t node_a,
+                                                    uint8_t node_b,
+                                                    uint8_t* out_distance) {
   IREE_ASSERT_ARGUMENT(out_distance);
   *out_distance = 10;  // Default: same node.
 
-  // Validate node IDs.
   iree_host_size_t node_count = iree_hal_platform_query_numa_node_count_impl();
-  if (node_a >= node_count || node_b >= node_count) {
+  if (node_a >= node_count || node_b >= node_count) return false;
+
+  if (node_a == node_b) {
+    *out_distance = 10;
+    return true;
+  }
+
+  // Windows doesn't provide a direct NUMA distance query API like Linux SLIT.
+  // Use a fixed conservative cross-node distance.
+  *out_distance = 20;
+  return true;
+}
+
+iree_status_t iree_hal_platform_query_numa_distance_impl(
+    uint8_t node_a, uint8_t node_b, uint8_t* out_distance) {
+  IREE_ASSERT_ARGUMENT(out_distance);
+
+  if (!iree_hal_platform_try_query_numa_distance_impl(node_a, node_b,
+                                                      out_distance)) {
+    iree_host_size_t node_count =
+        iree_hal_platform_query_numa_node_count_impl();
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "NUMA node out of range (node_a=%u, node_b=%u, "
                             "node_count=%zu)",
                             node_a, node_b, node_count);
   }
 
-  // Same node: distance is 10.
-  if (node_a == node_b) {
-    *out_distance = 10;
-    return iree_ok_status();
-  }
-
-  // Query NUMA distance using GetNumaProximityNodeEx.
-  // This API returns proximity domain information, but Windows doesn't expose
-  // SLIT-style distance tables directly. We'll use a heuristic based on
-  // proximity domain equality.
-
-  // Windows doesn't provide a direct NUMA distance query API like Linux SLIT.
-  // We'll use a heuristic: nodes with the same proximity domain are closer.
-  // For simplicity, return a fixed cross-node distance.
-  *out_distance = 20;  // Default: one hop away.
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/io/file_contents.c
+++ b/runtime/src/iree/io/file_contents.c
@@ -312,6 +312,9 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_map(
   iree_io_file_contents_t* contents = NULL;
   iree_status_t status = iree_allocator_malloc(
       host_allocator, sizeof(*contents), (void**)&contents);
+  if (iree_status_is_ok(status)) {
+    contents->allocator = host_allocator;
+  }
 
   if (iree_status_is_ok(status)) {
     status =
@@ -324,7 +327,6 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_map(
   iree_io_file_handle_release(handle);
 
   if (iree_status_is_ok(status)) {
-    contents->allocator = host_allocator;
     if (iree_all_bits_set(access, IREE_IO_FILE_ACCESS_WRITE)) {
       contents->buffer = iree_io_file_mapping_contents_rw(contents->mapping);
     } else {

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -91,7 +91,9 @@ iree_status_t iree_task_executor_create(iree_task_executor_options_t options,
 
   iree_task_executor_t* executor = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(allocator, executor_size, (void**)&executor));
+      z0, iree_allocator_malloc_aligned(allocator, executor_size,
+                                        iree_alignof(iree_task_executor_t),
+                                        /*offset=*/0, (void**)&executor));
   memset(executor, 0, executor_size);
   iree_atomic_ref_count_init(&executor->ref_count);
   executor->allocator = allocator;
@@ -218,7 +220,7 @@ static void iree_task_executor_destroy(iree_task_executor_t* executor) {
   iree_slim_mutex_deinitialize(&executor->coordinator_mutex);
   iree_atomic_task_slist_deinitialize(&executor->incoming_ready_slist);
   iree_task_pool_deinitialize(&executor->transient_task_pool);
-  iree_allocator_free(executor->allocator, executor);
+  iree_allocator_free_aligned(executor->allocator, executor);
 
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/task/topology_sysfs.c
+++ b/runtime/src/iree/task/topology_sysfs.c
@@ -10,9 +10,6 @@
 // Documentation:
 // https://docs.kernel.org/admin-guide/abi-stable-files.html#abi-file-stable-sysfs-devices-system-cpu
 
-// Must define _GNU_SOURCE before includes to get CPU_* macros from sched.h.
-#define _GNU_SOURCE
-
 #include "iree/base/internal/math.h"
 #include "iree/base/internal/sysfs.h"
 #include "iree/task/topology.h"
@@ -22,7 +19,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <sched.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -286,16 +282,23 @@ iree_host_size_t iree_task_topology_query_node_count(void) {
     return 1;
   }
 
-  // Track unique cluster IDs and count them as we discover new ones.
-  cpu_set_t cluster_set;
-  CPU_ZERO(&cluster_set);
+  // Track unique cluster IDs and count them as we discover new ones. Cluster
+  // IDs are sparse sysfs values, not bounded cpu_set_t indices.
+  uint32_t cluster_ids[IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT];
   iree_host_size_t unique_clusters = 0;
   for (uint32_t cpu = 0; cpu < processor_count; ++cpu) {
     uint32_t cluster_id = 0;
     iree_status_t status = iree_sysfs_query_cluster_id(cpu, &cluster_id);
     if (iree_status_is_ok(status) && iree_sysfs_is_valid_cluster(cluster_id)) {
-      if (!CPU_ISSET(cluster_id, &cluster_set)) {
-        CPU_SET(cluster_id, &cluster_set);
+      bool cluster_seen = false;
+      for (iree_host_size_t i = 0; i < unique_clusters; ++i) {
+        if (cluster_ids[i] == cluster_id) {
+          cluster_seen = true;
+          break;
+        }
+      }
+      if (!cluster_seen && unique_clusters < IREE_ARRAYSIZE(cluster_ids)) {
+        cluster_ids[unique_clusters] = cluster_id;
         ++unique_clusters;
       }
     }
@@ -323,29 +326,39 @@ iree_task_topology_node_id_t iree_task_topology_query_current_node(void) {
 // Constructive sharing mask utilities
 //===----------------------------------------------------------------------===//
 
-// Context for building processor bitmask from CPU list.
+// Context for building a topology group mask directly from a CPU list.
+// For each CPU range in the list, we scan the topology's groups to find which
+// ones have a processor_index in the range, and set their bit in group_mask.
+// This avoids the intermediate cpu_set_t (limited to CPU_SETSIZE=1024) and
+// works for arbitrary processor IDs.
 typedef struct {
-  cpu_set_t processor_mask;
-} iree_sysfs_processor_mask_context_t;
+  const iree_task_topology_t* topology;
+  iree_task_topology_group_mask_t group_mask;
+} iree_sysfs_sharing_context_t;
 
-// Callback to accumulate processor IDs into a bitmask.
-static bool iree_sysfs_accumulate_processor_mask(uint32_t start_cpu,
+// Callback for iree_sysfs_parse_cpu_list that maps CPU ranges to group indices.
+// O(ranges_in_list x group_count) per group; both are small.
+static bool iree_sysfs_accumulate_sharing_groups(uint32_t start_cpu,
                                                  uint32_t end_cpu,
                                                  void* user_data) {
-  iree_sysfs_processor_mask_context_t* ctx =
-      (iree_sysfs_processor_mask_context_t*)user_data;
-  for (uint32_t cpu = start_cpu; cpu < end_cpu; ++cpu) {
-    CPU_SET(cpu, &ctx->processor_mask);
+  iree_sysfs_sharing_context_t* ctx = (iree_sysfs_sharing_context_t*)user_data;
+  for (iree_host_size_t i = 0; i < ctx->topology->group_count; ++i) {
+    uint32_t processor = ctx->topology->groups[i].processor_index;
+    if (processor >= start_cpu && processor < end_cpu) {
+      ctx->group_mask |= 1ull << ctx->topology->groups[i].group_index;
+    }
   }
   return true;  // Continue enumeration.
 }
 
-// Reads shared_cpu_list for a given cache index into processor bitmask.
+// Reads shared_cpu_list for a given cache index and builds a group mask
+// directly from the topology (no intermediate cpu_set_t).
 // Returns true if successful, false if the file doesn't exist or can't be
 // parsed.
-static bool iree_sysfs_read_cache_shared_cpu_list(uint32_t processor,
-                                                  uint32_t cache_index,
-                                                  cpu_set_t* out_mask) {
+static bool iree_sysfs_read_cache_shared_cpu_list(
+    uint32_t processor, uint32_t cache_index,
+    const iree_task_topology_t* topology,
+    iree_task_topology_group_mask_t* out_group_mask) {
   char path[256];
   iree_snprintf(path, sizeof(path),
                 "%s/cpu/cpu%u/cache/index%u/shared_cpu_list",
@@ -360,27 +373,28 @@ static bool iree_sysfs_read_cache_shared_cpu_list(uint32_t processor,
     return false;
   }
 
-  // Parse CPU list into bitmask.
-  iree_sysfs_processor_mask_context_t ctx;
-  CPU_ZERO(&ctx.processor_mask);
+  // Parse CPU list directly into group mask.
+  iree_sysfs_sharing_context_t ctx = {
+      .topology = topology,
+      .group_mask = 0,
+  };
   status =
       iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
-                                iree_sysfs_accumulate_processor_mask, &ctx);
-  const bool valid_bitmask = iree_status_is_ok(status);
+                                iree_sysfs_accumulate_sharing_groups, &ctx);
+  const bool valid = iree_status_is_ok(status);
   iree_status_ignore(status);
-  *out_mask = ctx.processor_mask;
-  return valid_bitmask;
+  *out_group_mask = ctx.group_mask;
+  return valid;
 }
 
-// Finds the best cache level for constructive sharing.
-// Prefers L3 Data/Unified, falls back to L2 Data/Unified.
-// Populates |out_mask| with processors sharing that cache level.
+// Finds the best cache level for constructive sharing and returns the group
+// mask directly. Prefers L3 Data/Unified, falls back to L2 Data/Unified.
 // Returns true if a mask was found, false otherwise.
-static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
-                                               cpu_set_t* out_mask) {
-  cpu_set_t l3_mask, l2_mask;
-  CPU_ZERO(&l3_mask);
-  CPU_ZERO(&l2_mask);
+static bool iree_sysfs_find_sharing_cache_mask(
+    uint32_t processor, const iree_task_topology_t* topology,
+    iree_task_topology_group_mask_t* out_group_mask) {
+  iree_task_topology_group_mask_t l3_mask = 0;
+  iree_task_topology_group_mask_t l2_mask = 0;
   bool found_l3 = false;
   bool found_l2 = false;
 
@@ -400,8 +414,8 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
       continue;
     }
 
-    cpu_set_t shared_mask;
-    if (iree_sysfs_read_cache_shared_cpu_list(processor, cache_index,
+    iree_task_topology_group_mask_t shared_mask;
+    if (iree_sysfs_read_cache_shared_cpu_list(processor, cache_index, topology,
                                               &shared_mask)) {
       if (cache.level == 3) {
         l3_mask = shared_mask;
@@ -416,10 +430,10 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
 
   // Prefer L3, fall back to L2.
   if (found_l3) {
-    *out_mask = l3_mask;
+    *out_group_mask = l3_mask;
     return true;
   } else if (found_l2) {
-    *out_mask = l2_mask;
+    *out_group_mask = l2_mask;
     return true;
   }
   return false;
@@ -429,30 +443,19 @@ static bool iree_sysfs_find_sharing_cache_mask(uint32_t processor,
 // We parse shared_cpu_list from cache/index*/shared_cpu_list to determine
 // which processors share cache levels. We prefer L3 cache sharing, falling
 // back to L2 if L3 is not available.
+//
+// The group mask is built directly from the CPU list without an intermediate
+// cpu_set_t, so there is no limit on processor IDs (unlike glibc's
+// CPU_SETSIZE=1024 which overflows on machines with >1024 logical CPUs).
 iree_status_t iree_task_topology_fixup_constructive_sharing_masks(
     iree_task_topology_t* topology) {
-  // O(n^2), but n is always <= 64 (and often <= 8).
   for (iree_host_size_t i = 0; i < topology->group_count; ++i) {
     iree_task_topology_group_t* group = &topology->groups[i];
-    uint32_t processor = group->processor_index;
 
-    // Find processors that share L3 (or L2 as fallback) cache.
-    cpu_set_t processor_sharing_mask;
-    const bool has_sharing_mask =
-        iree_sysfs_find_sharing_cache_mask(processor, &processor_sharing_mask);
-
-    // Convert processor bitmask to group bitmask.
-    // Only processors in the topology can contribute to the group mask.
+    // Find groups that share L3 (or L2 as fallback) cache with this group.
     iree_task_topology_group_mask_t group_mask = 0;
-    if (has_sharing_mask) {
-      for (iree_host_size_t j = 0; j < topology->group_count; ++j) {
-        const iree_task_topology_group_t* other_group = &topology->groups[j];
-        uint32_t other_processor = other_group->processor_index;
-        if (CPU_ISSET(other_processor, &processor_sharing_mask)) {
-          group_mask |= 1ull << other_group->group_index;
-        }
-      }
-    }
+    iree_sysfs_find_sharing_cache_mask(group->processor_index, topology,
+                                       &group_mask);
 
     group->constructive_sharing_mask = group_mask;
   }
@@ -525,13 +528,130 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
 // Cache domain enumeration
 //===----------------------------------------------------------------------===//
 
+// Context for building an index mask over a bounded core_map from a CPU list.
+typedef struct {
+  const uint32_t* core_map;
+  iree_host_size_t core_count;
+  iree_task_topology_group_mask_t core_mask;
+} iree_sysfs_core_mask_context_t;
+
+// Callback to accumulate CPU ranges into a mask of core_map indices.
+static bool iree_sysfs_accumulate_core_mask(uint32_t start_cpu,
+                                            uint32_t end_cpu, void* user_data) {
+  iree_sysfs_core_mask_context_t* ctx =
+      (iree_sysfs_core_mask_context_t*)user_data;
+  for (iree_host_size_t i = 0; i < ctx->core_count; ++i) {
+    uint32_t processor = ctx->core_map[i];
+    if (processor >= start_cpu && processor < end_cpu) {
+      ctx->core_mask |= UINT64_C(1) << i;
+    }
+  }
+  return true;  // Continue enumeration.
+}
+
+// Reads shared_cpu_list for a given cache index into a core index mask.
+// Returns true if successful, false if the file doesn't exist or can't be
+// parsed.
+static bool iree_sysfs_read_cache_shared_core_mask(
+    uint32_t processor, uint32_t cache_index, iree_host_size_t core_count,
+    const uint32_t* core_map, iree_task_topology_group_mask_t* out_mask) {
+  char path[256];
+  iree_snprintf(path, sizeof(path),
+                "%s/cpu/cpu%u/cache/index%u/shared_cpu_list",
+                iree_sysfs_get_root_path(), processor, cache_index);
+
+  char buffer[256];
+  iree_host_size_t length = 0;
+  iree_status_t status =
+      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return false;
+  }
+
+  // Parse the CPU list directly into a bounded core index mask.
+  iree_sysfs_core_mask_context_t ctx = {
+      .core_map = core_map,
+      .core_count = core_count,
+      .core_mask = 0,
+  };
+  status = iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
+                                     iree_sysfs_accumulate_core_mask, &ctx);
+  const bool valid = iree_status_is_ok(status);
+  iree_status_ignore(status);
+  *out_mask = ctx.core_mask;
+  return valid;
+}
+
+// Finds the best cache level for domain grouping and returns a core index mask.
+// Prefers L3 Data/Unified, falls back to L2 Data/Unified.
+// Returns true if a mask was found, false otherwise.
+static bool iree_sysfs_find_sharing_core_mask(
+    uint32_t processor, iree_host_size_t core_count, const uint32_t* core_map,
+    iree_task_topology_group_mask_t* out_mask) {
+  iree_task_topology_group_mask_t l3_mask = 0;
+  iree_task_topology_group_mask_t l2_mask = 0;
+  bool found_l3 = false;
+  bool found_l2 = false;
+
+  // Scan cache indices looking for L3 (preferred) and L2 (fallback).
+  for (uint32_t cache_index = 0; cache_index < IREE_SYSFS_MAX_CACHE_INDICES;
+       ++cache_index) {
+    iree_sysfs_cache_info_t cache = {0};
+    iree_status_t status =
+        iree_sysfs_query_cache_level(processor, cache_index, &cache);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      break;  // No more cache levels.
+    }
+
+    // Only consider Data or Unified caches.
+    if (!cache.is_data_cache) {
+      continue;
+    }
+
+    iree_task_topology_group_mask_t shared_mask = 0;
+    if (iree_sysfs_read_cache_shared_core_mask(
+            processor, cache_index, core_count, core_map, &shared_mask)) {
+      if (cache.level == 3) {
+        l3_mask = shared_mask;
+        found_l3 = true;
+        break;  // L3 is best, use it immediately.
+      } else if (cache.level == 2) {
+        l2_mask = shared_mask;
+        found_l2 = true;
+      }
+    }
+  }
+
+  // Prefer L3, fall back to L2.
+  if (found_l3) {
+    *out_mask = l3_mask;
+    return true;
+  } else if (found_l2) {
+    *out_mask = l2_mask;
+    return true;
+  }
+  return false;
+}
+
 // Cache domain descriptor grouping cores that share L3 cache.
 typedef struct {
-  // All cores in this domain.
-  cpu_set_t cores;
-  // Processor bitmask defining this domain.
-  cpu_set_t sharing_mask;
+  // Mask of core_map indices in this domain.
+  iree_task_topology_group_mask_t core_mask;
+  // Mask of core_map indices sharing this domain's cache.
+  iree_task_topology_group_mask_t sharing_mask;
 } iree_sysfs_cache_domain_t;
+
+// Returns the lowest processor ID in |core_mask| for deterministic sorting.
+static uint32_t iree_sysfs_find_first_domain_processor(
+    iree_task_topology_group_mask_t core_mask, iree_host_size_t core_count,
+    const uint32_t* core_map) {
+  for (iree_host_size_t i = 0; i < core_count; ++i) {
+    if (core_mask & (UINT64_C(1) << i)) return core_map[i];
+  }
+  return UINT32_MAX;
+}
 
 // Groups cores into cache domains based on L3 sharing masks.
 // Returns the number of domains found. If cache info is unavailable, returns 1
@@ -545,27 +665,26 @@ static iree_host_size_t iree_sysfs_enumerate_cache_domains(
   iree_host_size_t domain_count = 0;
   for (iree_host_size_t i = 0; i < core_count; ++i) {
     uint32_t processor = core_map[i];
-    cpu_set_t sharing_mask;
-    CPU_ZERO(&sharing_mask);
-    const bool has_mask =
-        iree_sysfs_find_sharing_cache_mask(processor, &sharing_mask);
+    iree_task_topology_group_mask_t sharing_mask = 0;
+    const bool has_mask = iree_sysfs_find_sharing_core_mask(
+        processor, core_count, core_map, &sharing_mask);
 
-    // If no cache info available, put all cores in one domain.
+    // If no cache info is available, keep the original core order.
     if (!has_mask) {
-      CPU_ZERO(&out_domains[0].cores);
+      out_domains[0].core_mask = 0;
       for (iree_host_size_t j = 0; j < core_count; ++j) {
-        CPU_SET(core_map[j], &out_domains[0].cores);
+        out_domains[0].core_mask |= UINT64_C(1) << j;
       }
-      CPU_ZERO(&out_domains[0].sharing_mask);
+      out_domains[0].sharing_mask = out_domains[0].core_mask;
       return 1;  // Single domain fallback.
     }
 
     // Check if this sharing mask matches an existing domain.
     bool found_domain = false;
     for (iree_host_size_t d = 0; d < domain_count; ++d) {
-      if (CPU_EQUAL(&out_domains[d].sharing_mask, &sharing_mask)) {
+      if (out_domains[d].sharing_mask == sharing_mask) {
         // Add to existing domain.
-        CPU_SET(processor, &out_domains[d].cores);
+        out_domains[d].core_mask |= UINT64_C(1) << i;
         found_domain = true;
         break;
       }
@@ -573,25 +692,20 @@ static iree_host_size_t iree_sysfs_enumerate_cache_domains(
 
     // Create new domain if this is a unique sharing mask.
     if (!found_domain && domain_count < max_domains) {
-      CPU_ZERO(&out_domains[domain_count].cores);
-      CPU_SET(processor, &out_domains[domain_count].cores);
+      out_domains[domain_count].core_mask = UINT64_C(1) << i;
       out_domains[domain_count].sharing_mask = sharing_mask;
       ++domain_count;
     }
   }
 
   // Sort domains by lowest core ID for deterministic ordering.
-  // Find the lowest set bit in each domain's cores cpu_set_t.
   for (iree_host_size_t i = 0; i < domain_count - 1; ++i) {
     for (iree_host_size_t j = i + 1; j < domain_count; ++j) {
-      // Find first set CPU in each domain.
-      int first_i = -1, first_j = -1;
-      for (int cpu = 0; cpu < CPU_SETSIZE && (first_i < 0 || first_j < 0);
-           ++cpu) {
-        if (first_i < 0 && CPU_ISSET(cpu, &out_domains[i].cores)) first_i = cpu;
-        if (first_j < 0 && CPU_ISSET(cpu, &out_domains[j].cores)) first_j = cpu;
-      }
-      if (first_j >= 0 && first_i >= 0 && first_j < first_i) {
+      const uint32_t first_i = iree_sysfs_find_first_domain_processor(
+          out_domains[i].core_mask, core_count, core_map);
+      const uint32_t first_j = iree_sysfs_find_first_domain_processor(
+          out_domains[j].core_mask, core_count, core_map);
+      if (first_j < first_i) {
         iree_sysfs_cache_domain_t temp = out_domains[i];
         out_domains[i] = out_domains[j];
         out_domains[j] = temp;
@@ -718,20 +832,21 @@ iree_status_t iree_task_topology_initialize_from_physical_cores(
       uint32_t new_core_map[IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT];
       iree_host_size_t new_core_count = 0;
 
-      // Track next CPU to check for each domain.
-      int domain_next_cpu[IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT];
+      // Track next core_map index to check for each domain.
+      iree_host_size_t domain_next_index[IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT];
       for (iree_host_size_t d = 0; d < domain_count; ++d) {
-        domain_next_cpu[d] = 0;
+        domain_next_index[d] = 0;
       }
 
       while (new_core_count < core_count) {
         bool assigned_any = false;
         for (iree_host_size_t d = 0; d < domain_count; ++d) {
-          // Find next set CPU in this domain.
-          for (int cpu = domain_next_cpu[d]; cpu < CPU_SETSIZE; ++cpu) {
-            if (CPU_ISSET(cpu, &domains[d].cores)) {
-              new_core_map[new_core_count++] = (uint32_t)cpu;
-              domain_next_cpu[d] = cpu + 1;  // Start after this next time.
+          // Find next set core in this domain.
+          for (iree_host_size_t core_index = domain_next_index[d];
+               core_index < core_count; ++core_index) {
+            if (domains[d].core_mask & (UINT64_C(1) << core_index)) {
+              new_core_map[new_core_count++] = core_map[core_index];
+              domain_next_index[d] = core_index + 1;
               assigned_any = true;
               break;
             }

--- a/runtime/src/iree/task/topology_sysfs.c
+++ b/runtime/src/iree/task/topology_sysfs.c
@@ -63,40 +63,34 @@ static uint32_t iree_sysfs_query_processor_count(void) {
                 iree_sysfs_get_root_path());
   char buffer[256];
   iree_host_size_t length = 0;
-  iree_status_t status =
-      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
-  if (iree_status_is_ok(status)) {
+  if (iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
     iree_sysfs_cpu_count_context_t ctx = {.max_cpu_id = 0};
-    status = iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
-                                       iree_sysfs_count_cpus_callback, &ctx);
-    if (iree_status_is_ok(status)) {
+    if (iree_sysfs_try_parse_cpu_list(iree_make_string_view(buffer, length),
+                                      iree_sysfs_count_cpus_callback, &ctx)) {
       uint32_t count = ctx.max_cpu_id + 1;
       return count;  // Convert max ID to count.
     }
   }
-  iree_status_ignore(status);
 
   // Fallback to /sys/devices/system/cpu/kernel_max.
   iree_snprintf(path, sizeof(path), "%s/cpu/kernel_max",
                 iree_sysfs_get_root_path());
   uint32_t kernel_max = 0;
-  status = iree_sysfs_read_uint32(path, &kernel_max);
-  if (iree_status_is_ok(status)) {
+  if (iree_sysfs_try_read_uint32(path, &kernel_max)) {
     return kernel_max + 1;  // kernel_max is 0-based.
   }
-  iree_status_ignore(status);
 
   return 0;  // Unknown.
 }
 
 // Reads the core ID for a specific logical processor.
-// Returns IREE_STATUS_NOT_FOUND if the file doesn't exist.
-static iree_status_t iree_sysfs_query_core_id(uint32_t processor,
-                                              uint32_t* out_core_id) {
+// Returns false if the file doesn't exist or can't be parsed.
+static bool iree_sysfs_try_query_core_id(uint32_t processor,
+                                         uint32_t* out_core_id) {
   char path[256];
   iree_snprintf(path, sizeof(path), "%s/cpu/cpu%u/topology/core_id",
                 iree_sysfs_get_root_path(), processor);
-  return iree_sysfs_read_uint32(path, out_core_id);
+  return iree_sysfs_try_read_uint32(path, out_core_id);
 }
 
 // Gets the current CPU ID using the getcpu syscall.
@@ -121,34 +115,28 @@ static inline bool iree_sysfs_is_valid_cluster(uint32_t cluster_id) {
 
 // Reads the cluster ID for a specific logical processor.
 // Tries multiple fallback sources if cluster_id is not available.
-// Returns IREE_STATUS_NOT_FOUND if no cluster info is available.
-static iree_status_t iree_sysfs_query_cluster_id(uint32_t processor,
-                                                 uint32_t* out_cluster_id) {
+// Returns false if no cluster info is available.
+static bool iree_sysfs_try_query_cluster_id(uint32_t processor,
+                                            uint32_t* out_cluster_id) {
   *out_cluster_id = UINT32_MAX;
   char path[256];
 
   // Try cluster_id first (kernel 5.16+).
   iree_snprintf(path, sizeof(path), "%s/cpu/cpu%u/topology/cluster_id",
                 iree_sysfs_get_root_path(), processor);
-  iree_status_t status = iree_sysfs_read_uint32(path, out_cluster_id);
-  if (iree_status_is_ok(status)) {
-    return status;
+  if (iree_sysfs_try_read_uint32(path, out_cluster_id)) {
+    return true;
   }
-  iree_status_ignore(status);
 
   // Fallback to physical_package_id (socket/package).
   iree_snprintf(path, sizeof(path), "%s/cpu/cpu%u/topology/physical_package_id",
                 iree_sysfs_get_root_path(), processor);
-  status = iree_sysfs_read_uint32(path, out_cluster_id);
-  if (iree_status_is_ok(status)) {
-    return status;
+  if (iree_sysfs_try_read_uint32(path, out_cluster_id)) {
+    return true;
   }
-  iree_status_ignore(status);
 
   // No cluster info available.
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "no cluster information available for CPU %u",
-                          processor);
+  return false;
 }
 
 // Reads the CPU capacity for a specific logical processor.
@@ -159,7 +147,7 @@ static uint32_t iree_sysfs_query_cpu_capacity(uint32_t processor) {
   iree_snprintf(path, sizeof(path), "%s/cpu/cpu%u/cpu_capacity",
                 iree_sysfs_get_root_path(), processor);
   uint32_t capacity = 0;
-  iree_status_ignore(iree_sysfs_read_uint32(path, &capacity));
+  iree_sysfs_try_read_uint32(path, &capacity);
   return capacity;
 }
 
@@ -178,8 +166,8 @@ typedef struct {
 } iree_sysfs_cache_info_t;
 
 // Queries cache information for a specific cache index.
-// Returns IREE_STATUS_NOT_FOUND if the cache index doesn't exist.
-static iree_status_t iree_sysfs_query_cache_level(
+// Returns false if the cache index doesn't exist or can't be parsed.
+static bool iree_sysfs_try_query_cache_level(
     uint32_t processor, uint32_t cache_index,
     iree_sysfs_cache_info_t* out_cache) {
   // Read cache type (Data, Instruction, or Unified).
@@ -189,8 +177,9 @@ static iree_status_t iree_sysfs_query_cache_level(
                 iree_sysfs_get_root_path(), processor, cache_index);
   char buffer[64];
   iree_host_size_t length = 0;
-  IREE_RETURN_IF_ERROR(
-      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length));
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
+    return false;
+  }
 
   iree_string_view_t type_str =
       iree_string_view_trim(iree_make_string_view(buffer, length));
@@ -202,17 +191,17 @@ static iree_status_t iree_sysfs_query_cache_level(
   iree_snprintf(path, sizeof(path), "%s/cpu/cpu%u/cache/index%u/level",
                 iree_sysfs_get_root_path(), processor, cache_index);
   uint32_t level = 0;
-  iree_status_ignore(iree_sysfs_read_uint32(path, &level));
+  iree_sysfs_try_read_uint32(path, &level);
   out_cache->level = level;
 
   // Read cache size (optional - ignore failures).
   iree_snprintf(path, sizeof(path), "%s/cpu/cpu%u/cache/index%u/size",
                 iree_sysfs_get_root_path(), processor, cache_index);
   uint64_t size = 0;
-  iree_status_ignore(iree_sysfs_read_size(path, &size));
+  iree_sysfs_try_read_size(path, &size);
   out_cache->size = size;
 
-  return iree_ok_status();
+  return true;
 }
 
 // Queries all cache levels for a processor and populates the group's cache
@@ -229,10 +218,7 @@ static void iree_sysfs_populate_cache_info(
   for (uint32_t cache_index = 0; cache_index < IREE_SYSFS_MAX_CACHE_INDICES;
        ++cache_index) {
     iree_sysfs_cache_info_t cache = {0};
-    iree_status_t status =
-        iree_sysfs_query_cache_level(processor, cache_index, &cache);
-    if (!iree_status_is_ok(status)) {
-      iree_status_ignore(status);
+    if (!iree_sysfs_try_query_cache_level(processor, cache_index, &cache)) {
       break;  // No more cache levels.
     }
 
@@ -288,8 +274,8 @@ iree_host_size_t iree_task_topology_query_node_count(void) {
   iree_host_size_t unique_clusters = 0;
   for (uint32_t cpu = 0; cpu < processor_count; ++cpu) {
     uint32_t cluster_id = 0;
-    iree_status_t status = iree_sysfs_query_cluster_id(cpu, &cluster_id);
-    if (iree_status_is_ok(status) && iree_sysfs_is_valid_cluster(cluster_id)) {
+    if (iree_sysfs_try_query_cluster_id(cpu, &cluster_id) &&
+        iree_sysfs_is_valid_cluster(cluster_id)) {
       bool cluster_seen = false;
       for (iree_host_size_t i = 0; i < unique_clusters; ++i) {
         if (cluster_ids[i] == cluster_id) {
@@ -302,7 +288,6 @@ iree_host_size_t iree_task_topology_query_node_count(void) {
         ++unique_clusters;
       }
     }
-    iree_status_ignore(status);
   }
 
   return unique_clusters > 0 ? unique_clusters : 1;
@@ -311,14 +296,12 @@ iree_host_size_t iree_task_topology_query_node_count(void) {
 iree_task_topology_node_id_t iree_task_topology_query_current_node(void) {
   const uint32_t current_cpu = iree_sysfs_query_current_cpu();
   uint32_t cluster_id = 0;
-  iree_status_t status = iree_sysfs_query_cluster_id(current_cpu, &cluster_id);
-  if (iree_status_is_ok(status)) {
+  if (iree_sysfs_try_query_cluster_id(current_cpu, &cluster_id)) {
     if (!iree_sysfs_is_valid_cluster(cluster_id)) {
       return 0;  // Invalid clusters are node 0.
     }
     return cluster_id;
   }
-  iree_status_ignore(status);
   return 0;  // Fallback to node 0.
 }
 
@@ -366,10 +349,7 @@ static bool iree_sysfs_read_cache_shared_cpu_list(
 
   char buffer[256];
   iree_host_size_t length = 0;
-  iree_status_t status =
-      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
     return false;
   }
 
@@ -378,11 +358,9 @@ static bool iree_sysfs_read_cache_shared_cpu_list(
       .topology = topology,
       .group_mask = 0,
   };
-  status =
-      iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
-                                iree_sysfs_accumulate_sharing_groups, &ctx);
-  const bool valid = iree_status_is_ok(status);
-  iree_status_ignore(status);
+  const bool valid =
+      iree_sysfs_try_parse_cpu_list(iree_make_string_view(buffer, length),
+                                    iree_sysfs_accumulate_sharing_groups, &ctx);
   *out_group_mask = ctx.group_mask;
   return valid;
 }
@@ -402,10 +380,7 @@ static bool iree_sysfs_find_sharing_cache_mask(
   for (uint32_t cache_index = 0; cache_index < IREE_SYSFS_MAX_CACHE_INDICES;
        ++cache_index) {
     iree_sysfs_cache_info_t cache = {0};
-    iree_status_t status =
-        iree_sysfs_query_cache_level(processor, cache_index, &cache);
-    if (!iree_status_is_ok(status)) {
-      iree_status_ignore(status);
+    if (!iree_sysfs_try_query_cache_level(processor, cache_index, &cache)) {
       break;  // No more cache levels.
     }
 
@@ -510,12 +485,9 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
 
     // Query cluster ID for affinity grouping.
     uint32_t cluster_id = 0;
-    iree_status_t cluster_status =
-        iree_sysfs_query_cluster_id(cpu_ids[i], &cluster_id);
-    if (iree_status_is_ok(cluster_status)) {
+    if (iree_sysfs_try_query_cluster_id(cpu_ids[i], &cluster_id)) {
       group->ideal_thread_affinity.group = cluster_id;
     }
-    iree_status_ignore(cluster_status);
   }
 
   iree_status_t status =
@@ -562,10 +534,7 @@ static bool iree_sysfs_read_cache_shared_core_mask(
 
   char buffer[256];
   iree_host_size_t length = 0;
-  iree_status_t status =
-      iree_sysfs_read_small_file(path, buffer, sizeof(buffer), &length);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
+  if (!iree_sysfs_try_read_small_file(path, buffer, sizeof(buffer), &length)) {
     return false;
   }
 
@@ -575,10 +544,9 @@ static bool iree_sysfs_read_cache_shared_core_mask(
       .core_count = core_count,
       .core_mask = 0,
   };
-  status = iree_sysfs_parse_cpu_list(iree_make_string_view(buffer, length),
-                                     iree_sysfs_accumulate_core_mask, &ctx);
-  const bool valid = iree_status_is_ok(status);
-  iree_status_ignore(status);
+  const bool valid =
+      iree_sysfs_try_parse_cpu_list(iree_make_string_view(buffer, length),
+                                    iree_sysfs_accumulate_core_mask, &ctx);
   *out_mask = ctx.core_mask;
   return valid;
 }
@@ -598,10 +566,7 @@ static bool iree_sysfs_find_sharing_core_mask(
   for (uint32_t cache_index = 0; cache_index < IREE_SYSFS_MAX_CACHE_INDICES;
        ++cache_index) {
     iree_sysfs_cache_info_t cache = {0};
-    iree_status_t status =
-        iree_sysfs_query_cache_level(processor, cache_index, &cache);
-    if (!iree_status_is_ok(status)) {
-      iree_status_ignore(status);
+    if (!iree_sysfs_try_query_cache_level(processor, cache_index, &cache)) {
       break;  // No more cache levels.
     }
 
@@ -760,9 +725,7 @@ iree_status_t iree_task_topology_initialize_from_physical_cores(
   for (uint32_t cpu = 0; cpu < processor_count && core_count < max_core_count;
        ++cpu) {
     uint32_t core_id = 0;
-    iree_status_t status = iree_sysfs_query_core_id(cpu, &core_id);
-    if (!iree_status_is_ok(status)) {
-      iree_status_ignore(status);
+    if (!iree_sysfs_try_query_core_id(cpu, &core_id)) {
       continue;  // Skip CPUs we can't query.
     }
 
@@ -770,16 +733,13 @@ iree_status_t iree_task_topology_initialize_from_physical_cores(
     if (node_id != IREE_TASK_TOPOLOGY_NODE_ID_ANY) {
       // Only filter if cluster info is valid and doesn't match.
       uint32_t cluster_id = 0;
-      iree_status_t cluster_status =
-          iree_sysfs_query_cluster_id(cpu, &cluster_id);
       // When invalid we skip filtering on invalid values to avoid removing all
       // cores on homogeneous systems.
-      if (iree_status_is_ok(cluster_status) &&
+      if (iree_sysfs_try_query_cluster_id(cpu, &cluster_id) &&
           iree_sysfs_is_valid_cluster(cluster_id) &&
           cluster_id != (uint32_t)node_id) {
         continue;  // Wrong cluster.
       }
-      iree_status_ignore(cluster_status);
     }
 
     // Filter by performance level on heterogeneous systems (ARM big.LITTLE).
@@ -803,13 +763,11 @@ iree_status_t iree_task_topology_initialize_from_physical_cores(
     for (iree_host_size_t i = 0; i < core_count; ++i) {
       const uint32_t existing_cpu = core_map[i];
       uint32_t existing_core_id = 0;
-      iree_status_t existing_status =
-          iree_sysfs_query_core_id(existing_cpu, &existing_core_id);
-      if (iree_status_is_ok(existing_status) && existing_core_id == core_id) {
+      if (iree_sysfs_try_query_core_id(existing_cpu, &existing_core_id) &&
+          existing_core_id == core_id) {
         core_seen = true;
         break;
       }
-      iree_status_ignore(existing_status);
     }
     if (!core_seen) {
       // First processor in this core.
@@ -882,12 +840,8 @@ iree_status_t iree_task_topology_initialize_from_physical_cores(
     group->ideal_thread_affinity.id = processor;
 
     uint32_t cluster_id = 0;
-    iree_status_t cluster_status =
-        iree_sysfs_query_cluster_id(processor, &cluster_id);
-    if (iree_status_is_ok(cluster_status)) {
+    if (iree_sysfs_try_query_cluster_id(processor, &cluster_id)) {
       group->ideal_thread_affinity.group = cluster_id;
-    } else {
-      iree_status_ignore(cluster_status);
     }
   }
 

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -65,8 +65,9 @@ iree_status_t iree_task_worker_initialize(
       iree_max(IREE_TASK_WORKER_MIN_STACK_SIZE, stack_size);
 
   // NOTE: if the thread creation fails we'll bail here and let the caller
-  // cleanup by calling deinitialize (which is safe because we zero init
-  // everything).
+  // cleanup by calling deinitialize. The guard in deinitialize checks
+  // worker->executor (set above) to distinguish initialized workers from
+  // never-initialized ones in the same allocation.
   iree_status_t status = iree_thread_create(
       iree_task_worker_thread_entry, out_worker, thread_params,
       executor->allocator, &out_worker->thread);
@@ -126,10 +127,18 @@ void iree_task_worker_await_exit(iree_task_worker_t* worker) {
 }
 
 void iree_task_worker_deinitialize(iree_task_worker_t* worker) {
+  // Skip workers that were never initialized. Their memory is zero-filled when
+  // the executor allocation is initialized, but their notifications were never
+  // initialized. Calling iree_notification_deinitialize on them would operate
+  // on a never-initialized pthread_mutex_t (undefined behavior on non-glibc).
+  // worker->executor is set at the start of iree_task_worker_initialize,
+  // before notification init, so NULL means initialize was never called.
+  if (!worker->executor) return;
+
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Must have called request_exit/await_exit, OR thread creation failed during
-  // initialization.
+  // initialization (thread is NULL but notifications are initialized).
   IREE_ASSERT_TRUE(!worker->thread || iree_task_worker_is_zombie(worker));
 
   iree_thread_release(worker->thread);


### PR DESCRIPTION
This PR tightens a set of runtime correctness paths that the later HAL work
leans on. The changes are deliberately small and independent: less lock traffic
in the empty atomic-slist fast path, safer file-backed imports, topology probing
that behaves on large systems, task teardown that tolerates partially
initialized executors, CUDA event cleanup on failure, and Vulkan physical-device
enumeration cleanup.

## Why

The later stack puts more stress on startup, device probing, queue setup, and
failure unwinding. These paths should be boring before we add new allocation,
profiling, replay, and AMDGPU machinery on top of them. The theme here is
removing avoidable hazards instead of letting them become debugging noise in
larger PRs.

## What's Here

The atomic slist pop path now avoids taking the lock when the list is already
empty. That keeps the uncontended empty fast path cheap and makes the
benchmark's ownership model explicit enough to avoid reusing intrusive entries
across concurrent producers.

File-backed import paths handle unaligned memory-file imports, cap fd-file
pread/pwrite chunk sizes, and fall back to synchronous fd import when async
import is unavailable.

Task and topology setup is more robust on machines with more than 1024 CPUs and
when optional sysfs/NUMA probes fail. Optional topology discovery now uses
ordinary values for optional outcomes instead of manufacturing expensive
statuses for expected absence.

CUDA and Vulkan touched failure paths now release acquired resources instead of
leaking on early failure.

ci-extra: all