### PR TITLE
[DispatchCreation] Block transpose fusion for OnlineAttention

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -50,11 +50,21 @@ static SmallVector<T> applyProjectedPermutation(const SmallVectorImpl<T> &input,
 }
 
 static bool wouldBroadcastAwayAttentionDimGroup(OpOperand *fusedOperand) {
-  auto attentionOp =
-      dyn_cast<IREE::LinalgExt::AttentionOp>(fusedOperand->getOwner());
-  if (!attentionOp) {
+  Operation *consumer = fusedOperand->getOwner();
+  FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
+      TypeSwitch<Operation *, FailureOr<IREE::LinalgExt::AttentionOpDetail>>(
+          consumer)
+          .Case<IREE::LinalgExt::AttentionOp,
+                IREE::LinalgExt::OnlineAttentionOp>([](auto attentionOp) {
+            return IREE::LinalgExt::AttentionOpDetail::get(
+                attentionOp.getQueryMap(), attentionOp.getKeyMap(),
+                attentionOp.getValueMap(), attentionOp.getOutputMap());
+          })
+          .Default({});
+  if (failed(maybeOpInfo)) {
     return false;
   }
+  IREE::LinalgExt::AttentionOpDetail opInfo = std::move(*maybeOpInfo);
 
   auto producer = dyn_cast_if_present<linalg::LinalgOp>(
       fusedOperand->get().getDefiningOp());
@@ -62,20 +72,13 @@ static bool wouldBroadcastAwayAttentionDimGroup(OpOperand *fusedOperand) {
     return false;
   }
 
-  FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
-      IREE::LinalgExt::AttentionOpDetail::get(
-          attentionOp.getQueryMap(), attentionOp.getKeyMap(),
-          attentionOp.getValueMap(), attentionOp.getOutputMap());
-  if (failed(maybeOpInfo)) {
-    return true;
-  }
-  IREE::LinalgExt::AttentionOpDetail opInfo = std::move(*maybeOpInfo);
-
   AffineMap producerInputMap =
       producer.getMatchingIndexingMap(producer.getDpsInputOperand(0));
   AffineMap producerResultMap =
       producer.getMatchingIndexingMap(producer.getDpsInitOperand(0));
-  AffineMap consumerInputMap = attentionOp.getMatchingIndexingMap(fusedOperand);
+  AffineMap consumerInputMap =
+      cast<IREE::LinalgExt::LinalgFusionOpInterface>(consumer)
+          .getMatchingIndexingMap(fusedOperand);
   AffineMap fusedInputMap =
       producerInputMap.compose(inversePermutation(producerResultMap))
           .compose(consumerInputMap);

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -329,6 +329,54 @@ util.func public @dont_fuse_attention_with_broadcasted_away_n_dim(
 
 // -----
 
+util.func public @dont_fuse_online_attention_with_broadcasted_away_n_dim(
+    %q: tensor<4x32x64x16xf16>,
+    %k: tensor<4x32x64x16xf16>,
+    %v: tensor<4x32x64xf16>,
+    %scale: f16) -> tensor<4x32x64x128xf16> {
+  %empty_v = tensor.empty() : tensor<4x32x64x128xf16>
+  %v_broadcast = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%v : tensor<4x32x64xf16>) outs(%empty_v : tensor<4x32x64x128xf16>) {
+  ^bb0(%in: f16, %out: f16):
+    linalg.yield %in : f16
+  } -> tensor<4x32x64x128xf16>
+  %empty_out = tensor.empty() : tensor<4x32x64x128xf16>
+  %empty_max = tensor.empty() : tensor<4x32x64xf16>
+  %empty_sum = tensor.empty() : tensor<4x32x64xf16>
+  %attention:3 = iree_linalg_ext.online_attention {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>]}
+      ins(%q, %k, %v_broadcast, %scale :
+          tensor<4x32x64x16xf16>, tensor<4x32x64x16xf16>,
+          tensor<4x32x64x128xf16>, f16)
+      outs(%empty_out, %empty_max, %empty_sum :
+           tensor<4x32x64x128xf16>, tensor<4x32x64xf16>, tensor<4x32x64xf16>) {
+  ^bb0(%score: f16):
+    iree_linalg_ext.yield %score : f16
+  } -> tensor<4x32x64x128xf16>, tensor<4x32x64xf16>, tensor<4x32x64xf16>
+  util.return %attention#0 : tensor<4x32x64x128xf16>
+}
+// CHECK-LABEL: func public @dont_fuse_online_attention_with_broadcasted_away_n_dim
+//  CHECK-SAME:     %[[Q:[a-zA-Z0-9]+]]:
+//  CHECK-SAME:     %[[K:[a-zA-Z0-9]+]]:
+//  CHECK-SAME:     %[[V:[a-zA-Z0-9]+]]:
+//  CHECK-SAME:     %[[SCALE:[a-zA-Z0-9]+]]:
+//       CHECK:   %[[V_BCAST:.+]] = linalg.generic
+//       CHECK:   %[[ATTENTION:.+]]:3 = iree_linalg_ext.online_attention
+//  CHECK-SAME:     ins(%[[Q]], %[[K]], %[[V_BCAST]], %[[SCALE]] :
+//       CHECK:   util.return %[[ATTENTION]]#0
+
+
+// -----
+
 util.func public @fuse_attention_with_broadcast_transpose(%arg0: tensor<4x?x8x128xf16>, %arg1: tensor<4x8x4x?x32x128xf16>, %arg2: tensor<4x8x4x?x128xf16>, %arg3: f16, %arg4: tensor<4x8x4x?x32x?xf16>, %arg5: tensor<4x8x4x?x32x128xf16>, %arg6: tensor<4x8x4x128x?xf16>) -> tensor<4x8x4x?x32x128xf16> {
   %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d3, d4, d1)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<4x?x8x128xf16>) outs(%arg6 : tensor<4x8x4x128x?xf16>) {
   ^bb0(%in: f16, %out: f16):


### PR DESCRIPTION
`wouldBroadcastAwayAttentionDimGroup` only checked `AttentionOp`, so the `foldTransposeControlFn` would allow a broadcasting producer to be fused into `OnlineAttentionOp` even when it drops a whole dim group (batch/M/K1/K2/N). Handle `OnlineAttentionOp` the same way as `AttentionOp`.