### PR TITLE
[CI][TorchModels] Relax mi325 goldens for two flaky llama_8b_fp16 benchmarks

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 7.48
+    "golden_time_ms": 7.87
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 29.5
+    "golden_time_ms": 32.12
 }


### PR DESCRIPTION
The revision updates golden values to `mean (~3 months) * 1.1`.

Two llama_8b_fp16 benchmarks on the mi325 runner have been failing sporadically since their goldens were last tightened (`2025-12-18` for decode_seq2048, `2025-10-29` for prefill_seq128). Analysis across 278 recorded runs on main since `2025-12-18` shows the means are stable -- this is noise hitting thresholds set inside the natural variance band, not a perf regression.

Aggregate distribution (278 main-branch runs, post last-golden-update):

| Benchmark                             |  mean  |  p95   |  max   | old g. | new g. | fail% |
| ------------------------------------- | ------ | ------ | ------ | ------ | ------ | ----- |
| decode_benchmark_seq2048_mi325.json   |  7.157 |  7.465 |  8.022 |  7.48  |  7.87  |  4.0% |
| prefill_benchmark_seq128_mi325.json   | 29.202 | 29.589 | 30.618 | 29.50  | 32.12  |  6.8% |

Weekly trend (2026-W05..W17, ~3 months). Means stay flat at `~7.1-7.3 ms` (decode) and `~29.0-29.3 ms` (prefill) throughout -- no drift upward. Failures are scattered, not clustered at the end of the window:

| Week |  n | dec mean | dec p95 | dec max | dec fail% | pre mean | pre p95 | pre max | pre fail% |
| ---- | -- | -------- | ------- | ------- | --------- | -------- | ------- | ------- | --------- |
| W05  | 11 |   7.185  |  7.497  |  7.595  |   18.2%   |  29.316  | 29.691  | 29.727  |   18.2%   |
| W06  |  4 |   7.154  |  7.156  |  7.272  |    0.0%   |  29.189  | 29.211  | 29.385  |    0.0%   |
| W07  | 10 |   7.083  |  7.195  |  7.226  |    0.0%   |  29.057  | 29.123  | 29.137  |    0.0%   |
| W08  |  7 |   7.169  |  7.276  |  7.279  |    0.0%   |  29.110  | 29.175  | 29.185  |    0.0%   |
| W09  |  4 |   7.130  |  7.134  |  7.265  |    0.0%   |  29.095  | 29.145  | 29.151  |    0.0%   |
| W10  | 10 |   7.181  |  7.380  |  7.468  |    0.0%   |  29.145  | 29.347  | 29.425  |    0.0%   |
| W11  | 19 |   7.315  |  7.779  |  8.022  |   15.8%   |  29.190  | 29.514  | 29.661  |   10.5%   |
| W12  | 16 |   7.191  |  7.362  |  7.654  |    6.2%   |  29.245  | 29.508  | 30.618  |   12.5%   |
| W13  | 34 |   7.169  |  7.366  |  7.555  |    2.9%   |  29.200  | 29.431  | 29.486  |    0.0%   |
| W14  | 41 |   7.157  |  7.395  |  7.468  |    0.0%   |  29.257  | 29.488  | 29.727  |    4.9%   |
| W15  | 40 |   7.107  |  7.448  |  7.490  |    2.5%   |  29.190  | 29.626  | 29.761  |   12.5%   |
| W16  | 52 |   7.141  |  7.306  |  7.599  |    1.9%   |  29.180  | 29.503  | 29.796  |    7.7%   |
| W17  | 29 |   7.127  |  7.318  |  7.579  |    6.9%   |  29.233  | 29.456  | 29.680  |    6.9%   |

The old goldens sit at roughly p93-p95 of the observed distribution, so ~`5-7%` of runs are expected to miss them on noise alone, which matches the observed flake rates.

Note: `decode_benchmark_seq128_mi325.json` (3.6% flake) and `sdxl/vae_benchmark_mi325.json` (5.3% flake) show the same pattern and should be relaxed in a follow-up using the same rule.

Assisted-by: Claude Code