### PR TITLE
[Codegen][DMA] Fix OOB clamping for subview sources

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -146,14 +146,21 @@ computeTransferSegments(int64_t totalElements, int64_t elementBits,
   return segments;
 }
 
+/// Walk a memref value through ViewLikeOpInterface ops to find the root
+/// buffer that backs it.
+static Value getRootSource(Value val) {
+  while (auto viewOp = val.getDefiningOp<ViewLikeOpInterface>()) {
+    val = viewOp.getViewSource();
+  }
+  return val;
+}
+
 /// Trace a memref value through view-like ops to find a SwizzleHintOp.
 /// Returns the swizzle attribute if it is an XOR swizzle (which is
 /// self-inverse), std::nullopt otherwise.
 static std::optional<IREE::Codegen::SwizzleAttrInterface>
 getDestSwizzleAttr(Value dest) {
-  while (auto viewOp = dest.getDefiningOp<mlir::ViewLikeOpInterface>()) {
-    dest = viewOp.getViewSource();
-  }
+  dest = getRootSource(dest);
   if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
     auto swizzle = hintOp.getSwizzle();
     // Only XOR swizzle is self-inverse (swizzle(swizzle(x)) = x), so it can
@@ -497,19 +504,25 @@ private:
           auto [srcIndices, dstIndices] = generateGatherIndices(
               rewriter, loc, srcDimOffsets, dstDimOffsets, indices);
 
-          // Raw buffer OOB clamping is 1D (linear): it returns 0 only when the
-          // byte offset >= total buffer size. For non-outermost dimensions,
+          // Raw buffer OOB clamping is 1D (linear): it returns 0 only when
+          // the byte offset >= total buffer size. For non-outermost dims,
           // an OOB index wraps into the next row instead of returning 0.
-          // Fix: when any non-outermost source index exceeds its dimension,
-          // replace the outermost index with sourceShape[0] to force the
-          // linearized offset past the buffer end → hardware returns 0.
+          // When the source is a view of a larger buffer, the outermost
+          // dim also needs checking because an OOB dim-0 index may still
+          // land in valid parent memory.
+          // Fix: when any checked source index exceeds its dimension,
+          // replace srcIndices[0] with the root buffer's dim-0 size to
+          // force the linearized offset past the buffer end.
           auto sourceType = cast<MemRefType>(source.getType());
           if (inBoundsAttr && hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+            Value rootSource = getRootSource(source);
+            bool isSubview = (rootSource != source);
             ArrayRef<int64_t> sourceShape = sourceType.getShape();
-            Value anyNonOutermostOOB = arith::ConstantOp::create(
+            Value anyOOB = arith::ConstantOp::create(
                 rewriter, loc, rewriter.getBoolAttr(false));
 
-            for (int64_t dim = 1; dim < sourceType.getRank(); ++dim) {
+            int64_t startDim = isSubview ? 0 : 1;
+            for (int64_t dim = startDim; dim < sourceType.getRank(); ++dim) {
               if (dim >= static_cast<int64_t>(inBoundsAttr->size())) {
                 break;
               }
@@ -531,19 +544,19 @@ private:
                                                   arith::CmpIPredicate::uge,
                                                   srcIndices[dim], dimSize);
 
-              anyNonOutermostOOB = arith::OrIOp::create(
-                  rewriter, loc, anyNonOutermostOOB, isOOB);
+              anyOOB = arith::OrIOp::create(rewriter, loc, anyOOB, isOOB);
             }
 
+            auto rootType = cast<MemRefType>(rootSource.getType());
             Value oobOuterIdx;
-            if (ShapedType::isDynamic(sourceShape[0])) {
-              oobOuterIdx = memref::DimOp::create(rewriter, loc, source, 0);
+            if (ShapedType::isDynamic(rootType.getShape()[0])) {
+              oobOuterIdx = memref::DimOp::create(rewriter, loc, rootSource, 0);
             } else {
-              oobOuterIdx =
-                  arith::ConstantIndexOp::create(rewriter, loc, sourceShape[0]);
+              oobOuterIdx = arith::ConstantIndexOp::create(
+                  rewriter, loc, rootType.getShape()[0]);
             }
-            srcIndices[0] = arith::SelectOp::create(
-                rewriter, loc, anyNonOutermostOOB, oobOuterIdx, srcIndices[0]);
+            srcIndices[0] = arith::SelectOp::create(rewriter, loc, anyOOB,
+                                                    oobOuterIdx, srcIndices[0]);
           }
 
           amdgpu::GatherToLDSOp::create(rewriter, loc, source, srcIndices, dest,
@@ -705,15 +718,16 @@ void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
     auto [srcIndices, dstIndices] =
         generateGatherIndices(b, loc, srcDimOffsets, dstDimOffsets, indices);
 
-    // OOB handling: replicate the fast path's outermost-index-replacement
-    // trick for non-outermost dimensions.
+    // OOB handling: same logic as the fast path.
     auto sourceType = cast<MemRefType>(source.getType());
     if (inBoundsAttr && hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+      Value rootSource = getRootSource(source);
+      bool isSubview = (rootSource != source);
       ArrayRef<int64_t> sourceShape = sourceType.getShape();
-      Value anyNonOutermostOOB =
-          arith::ConstantOp::create(b, loc, b.getBoolAttr(false));
+      Value anyOOB = arith::ConstantOp::create(b, loc, b.getBoolAttr(false));
 
-      for (int64_t dim = 1; dim < sourceType.getRank(); ++dim) {
+      int64_t startDim = isSubview ? 0 : 1;
+      for (int64_t dim = startDim; dim < sourceType.getRank(); ++dim) {
         if (dim >= static_cast<int64_t>(inBoundsAttr->size())) {
           break;
         }
@@ -731,18 +745,19 @@ void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
 
         Value isOOB = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::uge,
                                             srcIndices[dim], dimSize);
-        anyNonOutermostOOB =
-            arith::OrIOp::create(b, loc, anyNonOutermostOOB, isOOB);
+        anyOOB = arith::OrIOp::create(b, loc, anyOOB, isOOB);
       }
 
+      auto rootType = cast<MemRefType>(rootSource.getType());
       Value oobOuterIdx;
-      if (ShapedType::isDynamic(sourceShape[0])) {
-        oobOuterIdx = memref::DimOp::create(b, loc, source, 0);
+      if (ShapedType::isDynamic(rootType.getShape()[0])) {
+        oobOuterIdx = memref::DimOp::create(b, loc, rootSource, 0);
       } else {
-        oobOuterIdx = arith::ConstantIndexOp::create(b, loc, sourceShape[0]);
+        oobOuterIdx =
+            arith::ConstantIndexOp::create(b, loc, rootType.getShape()[0]);
       }
-      srcIndices[0] = arith::SelectOp::create(b, loc, anyNonOutermostOOB,
-                                              oobOuterIdx, srcIndices[0]);
+      srcIndices[0] =
+          arith::SelectOp::create(b, loc, anyOOB, oobOuterIdx, srcIndices[0]);
     }
 
     // Determine in_bounds for vector.transfer_read.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -155,6 +155,66 @@ static Value getRootSource(Value val) {
   return val;
 }
 
+/// Applies OOB clamping to source indices for fat_raw_buffer sources.
+///
+/// Raw buffer OOB clamping is 1D (linear): it returns 0 only when the byte
+/// offset >= total buffer size. For non-outermost dims, an OOB index wraps
+/// into the next row instead of returning 0. When the source is a view of a
+/// larger buffer, the outermost dim also needs checking because an OOB dim-0
+/// index may still land in valid parent memory.
+///
+/// Fix: when any checked source index exceeds its dimension, replace
+/// srcIndices[0] with the root buffer's dim-0 size to force the linearized
+/// offset past the buffer end.
+static void applyOOBClamping(OpBuilder &builder, Location loc, Value source,
+                             SmallVector<Value> &srcIndices,
+                             ArrayAttr inBoundsAttr) {
+  auto sourceType = cast<MemRefType>(source.getType());
+  if (!hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+    return;
+  }
+
+  Value rootSource = getRootSource(source);
+  ArrayRef<int64_t> sourceShape = sourceType.getShape();
+  Value anyOOB =
+      arith::ConstantOp::create(builder, loc, builder.getBoolAttr(false));
+
+  // For view-like sources (subview, etc.), dim 0 must also be checked because
+  // an OOB dim-0 index may still land in valid parent memory.
+  int64_t startDim =
+      source.getDefiningOp<ViewLikeOpInterface>() != nullptr ? 0 : 1;
+  for (int64_t dim = startDim; dim < sourceType.getRank(); ++dim) {
+    if (dim >= static_cast<int64_t>(inBoundsAttr.size())) {
+      break;
+    }
+    if (cast<BoolAttr>(inBoundsAttr[dim]).getValue()) {
+      continue;
+    }
+
+    Value dimSize;
+    if (ShapedType::isDynamic(sourceShape[dim])) {
+      dimSize = memref::DimOp::create(builder, loc, source, dim);
+    } else {
+      dimSize = arith::ConstantIndexOp::create(builder, loc, sourceShape[dim]);
+    }
+
+    Value isOOB = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::uge,
+                                        srcIndices[dim], dimSize);
+    anyOOB = arith::OrIOp::create(builder, loc, anyOOB, isOOB);
+  }
+
+  auto rootType = cast<MemRefType>(rootSource.getType());
+  Value oobOuterIdx;
+  if (ShapedType::isDynamic(rootType.getShape()[0])) {
+    oobOuterIdx = memref::DimOp::create(builder, loc, rootSource, 0);
+  } else {
+    oobOuterIdx =
+        arith::ConstantIndexOp::create(builder, loc, rootType.getShape()[0]);
+  }
+  srcIndices[0] =
+      arith::SelectOp::create(builder, loc, anyOOB, oobOuterIdx, srcIndices[0]);
+}
+
 /// Trace a memref value through view-like ops to find a SwizzleHintOp.
 /// Returns the swizzle attribute if it is an XOR swizzle (which is
 /// self-inverse), std::nullopt otherwise.
@@ -504,59 +564,8 @@ private:
           auto [srcIndices, dstIndices] = generateGatherIndices(
               rewriter, loc, srcDimOffsets, dstDimOffsets, indices);
 
-          // Raw buffer OOB clamping is 1D (linear): it returns 0 only when
-          // the byte offset >= total buffer size. For non-outermost dims,
-          // an OOB index wraps into the next row instead of returning 0.
-          // When the source is a view of a larger buffer, the outermost
-          // dim also needs checking because an OOB dim-0 index may still
-          // land in valid parent memory.
-          // Fix: when any checked source index exceeds its dimension,
-          // replace srcIndices[0] with the root buffer's dim-0 size to
-          // force the linearized offset past the buffer end.
-          auto sourceType = cast<MemRefType>(source.getType());
-          if (inBoundsAttr && hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
-            Value rootSource = getRootSource(source);
-            bool isSubview = (rootSource != source);
-            ArrayRef<int64_t> sourceShape = sourceType.getShape();
-            Value anyOOB = arith::ConstantOp::create(
-                rewriter, loc, rewriter.getBoolAttr(false));
-
-            int64_t startDim = isSubview ? 0 : 1;
-            for (int64_t dim = startDim; dim < sourceType.getRank(); ++dim) {
-              if (dim >= static_cast<int64_t>(inBoundsAttr->size())) {
-                break;
-              }
-              bool dimInBounds =
-                  cast<BoolAttr>((*inBoundsAttr)[dim]).getValue();
-              if (dimInBounds) {
-                continue;
-              }
-
-              Value dimSize;
-              if (ShapedType::isDynamic(sourceShape[dim])) {
-                dimSize = memref::DimOp::create(rewriter, loc, source, dim);
-              } else {
-                dimSize = arith::ConstantIndexOp::create(rewriter, loc,
-                                                         sourceShape[dim]);
-              }
-
-              Value isOOB = arith::CmpIOp::create(rewriter, loc,
-                                                  arith::CmpIPredicate::uge,
-                                                  srcIndices[dim], dimSize);
-
-              anyOOB = arith::OrIOp::create(rewriter, loc, anyOOB, isOOB);
-            }
-
-            auto rootType = cast<MemRefType>(rootSource.getType());
-            Value oobOuterIdx;
-            if (ShapedType::isDynamic(rootType.getShape()[0])) {
-              oobOuterIdx = memref::DimOp::create(rewriter, loc, rootSource, 0);
-            } else {
-              oobOuterIdx = arith::ConstantIndexOp::create(
-                  rewriter, loc, rootType.getShape()[0]);
-            }
-            srcIndices[0] = arith::SelectOp::create(rewriter, loc, anyOOB,
-                                                    oobOuterIdx, srcIndices[0]);
+          if (inBoundsAttr) {
+            applyOOBClamping(rewriter, loc, source, srcIndices, *inBoundsAttr);
           }
 
           amdgpu::GatherToLDSOp::create(rewriter, loc, source, srcIndices, dest,
@@ -718,46 +727,8 @@ void LowerCoalescedGatherDMAFallbackPattern::emitFallbackTransfers(
     auto [srcIndices, dstIndices] =
         generateGatherIndices(b, loc, srcDimOffsets, dstDimOffsets, indices);
 
-    // OOB handling: same logic as the fast path.
-    auto sourceType = cast<MemRefType>(source.getType());
-    if (inBoundsAttr && hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
-      Value rootSource = getRootSource(source);
-      bool isSubview = (rootSource != source);
-      ArrayRef<int64_t> sourceShape = sourceType.getShape();
-      Value anyOOB = arith::ConstantOp::create(b, loc, b.getBoolAttr(false));
-
-      int64_t startDim = isSubview ? 0 : 1;
-      for (int64_t dim = startDim; dim < sourceType.getRank(); ++dim) {
-        if (dim >= static_cast<int64_t>(inBoundsAttr->size())) {
-          break;
-        }
-        bool dimInBounds = cast<BoolAttr>((*inBoundsAttr)[dim]).getValue();
-        if (dimInBounds) {
-          continue;
-        }
-
-        Value dimSize;
-        if (ShapedType::isDynamic(sourceShape[dim])) {
-          dimSize = memref::DimOp::create(b, loc, source, dim);
-        } else {
-          dimSize = arith::ConstantIndexOp::create(b, loc, sourceShape[dim]);
-        }
-
-        Value isOOB = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::uge,
-                                            srcIndices[dim], dimSize);
-        anyOOB = arith::OrIOp::create(b, loc, anyOOB, isOOB);
-      }
-
-      auto rootType = cast<MemRefType>(rootSource.getType());
-      Value oobOuterIdx;
-      if (ShapedType::isDynamic(rootType.getShape()[0])) {
-        oobOuterIdx = memref::DimOp::create(b, loc, rootSource, 0);
-      } else {
-        oobOuterIdx =
-            arith::ConstantIndexOp::create(b, loc, rootType.getShape()[0]);
-      }
-      srcIndices[0] =
-          arith::SelectOp::create(b, loc, anyOOB, oobOuterIdx, srcIndices[0]);
+    if (inBoundsAttr) {
+      applyOOBClamping(b, loc, source, srcIndices, *inBoundsAttr);
     }
 
     // Determine in_bounds for vector.transfer_read.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1279,7 +1279,7 @@ func.func @gather_dma_inner_dim_oob_64x62(
 // -----
 
 // Test: OOB check when source is a subview of a larger fat_raw_buffer.
-// Parent: 8x128, subview: 4x128. in_bounds = [false, true].
+// Parent: 8x128, subview at [2, 0]: 4x128. in_bounds = [false, true].
 // Because the source is a view of a larger buffer, dim 0 must also be
 // bounds-checked: an OOB dim-0 index in the subview still lands in valid
 // parent memory. The sentinel index uses the root buffer's dim-0 size (8),
@@ -1309,9 +1309,9 @@ func.func @gather_dma_subview_oob(
     hal.executable.target = #executable_target_rocm_hsaco_fb_subview,
     translation_info = #translation_32_subview} {
   // CHECK: %[[SUBVIEW:.+]] = memref.subview %[[PARENT]]
-  %subview = memref.subview %parent[0, 0][4, 128][1, 1]
+  %subview = memref.subview %parent[2, 0][4, 128][1, 1]
     : memref<8x128xf32, #amdgpu.address_space<fat_raw_buffer>>
-      to memref<4x128xf32, strided<[128, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+      to memref<4x128xf32, strided<[128, 1], offset: 256>, #amdgpu.address_space<fat_raw_buffer>>
   // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
   scf.forall (%lane) in (32) {
     // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
@@ -1338,7 +1338,7 @@ func.func @gather_dma_subview_oob(
     // CHECK-NOT: amdgpu.gather_to_lds
     // CHECK-NOT: iree_gpu.coalesced_gather_dma
     iree_gpu.coalesced_gather_dma %subview into %dest lane(%lane) in_bounds [false, true] :
-      memref<4x128xf32, strided<[128, 1]>, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<4x128xf32, strided<[128, 1], offset: 256>, #amdgpu.address_space<fat_raw_buffer>>,
       memref<4x128xf32, #gpu.address_space<workgroup>>, index
   } {mapping = [#gpu.thread<linear_dim_0>]}
   return

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -1278,6 +1278,74 @@ func.func @gather_dma_inner_dim_oob_64x62(
 
 // -----
 
+// Test: OOB check when source is a subview of a larger fat_raw_buffer.
+// Parent: 8x128, subview: 4x128. in_bounds = [false, true].
+// Because the source is a view of a larger buffer, dim 0 must also be
+// bounds-checked: an OOB dim-0 index in the subview still lands in valid
+// parent memory. The sentinel index uses the root buffer's dim-0 size (8),
+// not the subview's (4), to guarantee the linearized offset exceeds the
+// total buffer size.
+
+#executable_target_rocm_hsaco_fb_subview = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_32_subview = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+// CHECK-LABEL: func.func @gather_dma_subview_oob
+// CHECK-SAME:    %[[PARENT:[a-zA-Z0-9]+]]: memref<8x128xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<4x128xf32, #gpu.address_space<workgroup>>
+func.func @gather_dma_subview_oob(
+    %parent: memref<8x128xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<4x128xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_subview,
+    translation_info = #translation_32_subview} {
+  // CHECK: %[[SUBVIEW:.+]] = memref.subview %[[PARENT]]
+  %subview = memref.subview %parent[0, 0][4, 128][1, 1]
+    : memref<8x128xf32, #amdgpu.address_space<fat_raw_buffer>>
+      to memref<4x128xf32, strided<[128, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+  // CHECK: scf.forall (%[[LANE_ID:[a-zA-Z0-9]+]]) in (32)
+  scf.forall (%lane) in (32) {
+    // CHECK: %[[C4:[a-zA-Z0-9_]+]] = arith.constant 4
+    // CHECK: %[[LANE_OFFSET:[a-zA-Z0-9_]+]] = arith.muli %[[LANE_ID]], %[[C4]]
+    //
+    // Transfer 1: linearOffset = 0
+    // CHECK: %[[C0:.+]] = arith.constant 0 : index
+    // CHECK: %[[SRC_LIN0:.+]] = arith.addi %[[C0]], %[[LANE_OFFSET]]
+    // CHECK: %[[SRC_DELIN0:.+]]:2 = affine.delinearize_index %[[SRC_LIN0]] into (4, 128)
+    // CHECK: %[[DST_DELIN0:.+]]:2 = affine.delinearize_index %[[C0]] into (4, 128)
+    //
+    // Dim 0 is checked because source is a subview of a larger buffer.
+    // CHECK: %[[FALSE:.+]] = arith.constant false
+    // CHECK: %[[C4_DIM:.+]] = arith.constant 4 : index
+    // CHECK: %[[CMP:.+]] = arith.cmpi uge, %[[SRC_DELIN0]]#0, %[[C4_DIM]] : index
+    // CHECK: %[[OOB:.+]] = arith.ori %[[FALSE]], %[[CMP]] : i1
+    // Sentinel uses root buffer dim-0 size (8), not subview dim-0 (4).
+    // CHECK: %[[C8_OOB:.+]] = arith.constant 8 : index
+    // CHECK: %[[FIXED:.+]] = arith.select %[[OOB]], %[[C8_OOB]], %[[SRC_DELIN0]]#0
+    // CHECK: amdgpu.gather_to_lds %[[SUBVIEW]][%[[FIXED]], %[[SRC_DELIN0]]#1], %[[DST]][%[[DST_DELIN0]]#0, %[[DST_DELIN0]]#1] : vector<4xf32>
+    //
+    // Transfers 2-4: same pattern
+    // CHECK-COUNT-3: amdgpu.gather_to_lds {{.+}} : vector<4xf32>
+    // CHECK-NOT: amdgpu.gather_to_lds
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %subview into %dest lane(%lane) in_bounds [false, true] :
+      memref<4x128xf32, strided<[128, 1]>, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<4x128xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
 // Fallback tests: these use dma_sizes = [128] (128-bit only) with f32 elements,
 // meaning the fast path (gather_to_lds) needs 128 elements per transfer
 // (32 lanes * 4 elements/lane). All tests below have fewer contiguous elements,


### PR DESCRIPTION
When the DMA source is a subview of a larger `fat_raw_buffer`, an OOB index on dim 0 of the subview can still land in valid parent memory, bypassing the hardware's linear OOB clamping. 

Fix: check all dimensions (including dim 0) when the source is a subview, and use the root buffer's dim-0 size as the OOB sentinel to guarantee the linearized offset exceeds the total buffer size.

Assisted-by: Cursor (Claude)