### PR TITLE
[LLVMCPU] Expand implied x86 CPU features when resolving CPU to features

### DIFF
--- a/compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.cpp
+++ b/compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.cpp
@@ -7,6 +7,7 @@
 #include "compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/TargetParser/AArch64TargetParser.h"
@@ -67,8 +68,29 @@ resolveCPUFeaturesForCPU(const llvm::Triple &triple, std::string &cpu,
     }
     llvm::SmallVector<llvm::StringRef> features;
     llvm::X86::getFeaturesForCPU(cpu, features, /*NeedPlus=*/false);
-    for (const auto &feature : features) {
-      targetCpuFeatures.AddFeature(feature);
+    // llvm::X86::getFeaturesForCPU returns only the features literally stored
+    // on the ProcInfo entry (i.e. the "leaf" features). For microarchitecture
+    // levels like x86-64-v{2,3,4}, that notably excludes the transitively
+    // implied features: e.g. x86-64-v4 lists {avx512bw, avx512cd, avx512dq,
+    // avx512vl} but not avx512f, avx2, avx, the earlier sse versions, etc.
+    // Clang's X86TargetInfo::initFeatureMap expands those implications by
+    // running each feature through llvm::X86::updateImpliedFeatures; do the
+    // same here so downstream consumers (including IREE's own hasFeature
+    // string-based checks) see the full transitive set, matching the behavior
+    // of `clang -march=<cpu>`.
+    llvm::StringMap<bool> featureMap;
+    for (llvm::StringRef feature : features) {
+      featureMap[feature] = true;
+      llvm::X86::updateImpliedFeatures(feature, /*Enabled=*/true, featureMap);
+    }
+    // Sort for a deterministic feature string.
+    llvm::SmallVector<llvm::StringRef> sortedFeatures =
+        llvm::to_vector_of<llvm::StringRef>(featureMap.keys());
+    llvm::sort(sortedFeatures);
+    for (llvm::StringRef feature : sortedFeatures) {
+      if (featureMap.lookup(feature)) {
+        targetCpuFeatures.AddFeature(feature);
+      }
     }
   } else if (triple.isRISCV64()) {
     if (!llvm::RISCV::parseCPU(cpu, triple.isRISCV64())) {

--- a/compiler/plugins/target/LLVMCPU/test/hal_target_device_attributes.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/hal_target_device_attributes.mlir
@@ -40,6 +40,36 @@
 // CHECK-INNER-TILED-FLAG-SAME: [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
 // CHECK-INNER-TILED-FLAG-SAME: enable_inner_tiled = true
 
+// Targeting an x86 microarchitecture level like x86-64-v4 must expand to the
+// full transitive set of implied CPU features (matching `clang -march=...`),
+// not just the "leaf" features directly listed in LLVM's ProcInfo table for
+// that CPU. The features listed below are a mix of leaves (+avx2, +avx512bw,
+// +sse4.2, ...) and transitively-implied features (+avx, +avx512f, earlier
+// +sse versions, ...) that must all be present. They are sorted because the
+// resolver emits features in sorted order, which `CHECK-SAME` relies on.
+//
+// RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=local --iree-hal-local-target-device-backends=llvm-cpu --iree-llvmcpu-target-triple=x86_64-linux-gnu %s \
+// RUN:              --iree-llvmcpu-target-cpu=x86-64-v4 \
+// RUN: | FileCheck %s --check-prefix=CHECK-X86-64-V4
+//
+// CHECK-X86-64-V4: #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64",
+// CHECK-X86-64-V4-SAME: cpu = "x86-64-v4"
+// CHECK-X86-64-V4-SAME: cpu_features = "
+// CHECK-X86-64-V4-SAME: +avx,
+// CHECK-X86-64-V4-SAME: +avx2,
+// CHECK-X86-64-V4-SAME: +avx512bw,
+// CHECK-X86-64-V4-SAME: +avx512cd,
+// CHECK-X86-64-V4-SAME: +avx512dq,
+// CHECK-X86-64-V4-SAME: +avx512f,
+// CHECK-X86-64-V4-SAME: +avx512vl,
+// CHECK-X86-64-V4-SAME: +fma,
+// CHECK-X86-64-V4-SAME: +sse,
+// CHECK-X86-64-V4-SAME: +sse2,
+// CHECK-X86-64-V4-SAME: +sse3,
+// CHECK-X86-64-V4-SAME: +sse4.1,
+// CHECK-X86-64-V4-SAME: +sse4.2,
+// CHECK-X86-64-V4-SAME: +ssse3
+
 module {
   util.func public @foo(%arg0: tensor<?xf32>) -> tensor<?xf32> {
     util.return %arg0 : tensor<?xf32>


### PR DESCRIPTION
When a user passes e.g. `--iree-llvmcpu-target-cpu=x86-64-v4`, IREE calls `llvm::X86::getFeaturesForCPU` to populate the cpu_features string. That LLVM API returns only the features literally stored on the ProcInfo entry -- the "leaf" features -- and does not expand transitive implications. So x86-64-v4 yielded {avx512bw, avx512cd, avx512dq, avx512vl, avx2, sse4.2, ...} but not avx512f, avx, sse4.1, ssse3, sse3, sse2, sse, fma, etc.

Clang does not have this issue because `X86TargetInfo::initFeatureMap` runs each returned feature through `llvm::X86::updateImpliedFeatures` to fixed-point before handing the set to the backend. Do the same thing here so that IREE matches `clang -march=<cpu>`. This matters because several places in IREE codegen query the cpu_features string directly (e.g. `hasFeature` in `Codegen/Utils/Utils.cpp` does a literal substring scan of the comma-separated list), so missing transitive features would cause those checks to incorrectly return false.

Extend the existing `hal_target_device_attributes.mlir` lit test with a `--iree-llvmcpu-target-cpu=x86-64-v4` invocation that FileCheck-asserts the resulting `cpu_features = "..."` string contains both the leaf features (avx2, avx512bw, sse4.2, ...) and the transitively-implied ones (avx, avx512f, sse, sse2, sse3, sse4.1, ssse3, fma, ...).

Made-with: Cursor