### PR TITLE
[LinalgExt] Refactor IGEMM detail computation and update layout decisions

### DIFF
--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -278,7 +278,7 @@ def test_igemm_conv_details():
     d0, d1, d2, d3, d4 = [AffineDimExpr.get(i) for i in range(5)]
     assert maps[0] == AffineMap.get(5, 0, [d1, d4]), f"Filter map mismatch: {maps[0]}"
     assert maps[1] == AffineMap.get(
-        5, 0, [d0, d2, d3, d4]
+        5, 0, [d0, d4, d2, d3]
     ), f"Input map mismatch: {maps[1]}"
     assert maps[2] == AffineMap.get(
         5, 0, [d0, d1, d2, d3]
@@ -291,7 +291,12 @@ def test_igemm_conv_details():
         '"parallel"',
         '"reduction"',
     ]
-    assert details.im2col_output_perm == [0, 1, 2, 3]
+    assert details.im2col_output_perm == [
+        0,
+        3,
+        1,
+        2,
+    ], f"im2col output perm mismatch: {details.im2col_output_perm}"
     assert details.filter_reassoc_indices == [[0], [1, 2, 3]]
     assert details.is_output_channel_first
     assert details.conv_to_igemm_dim_map == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 4, 6: 4}
@@ -324,19 +329,27 @@ def test_igemm_conv_details():
     assert (
         details is not None
     ), "IGEMM details should be valid for generic 1D conv weight backward"
-    assert details.igemm_loop_bounds == [96, 3, 96, 98304]
+    assert details.igemm_loop_bounds == [96, 3, 96, 16, 6144]
     assert len(details.igemm_contraction_maps) == 3
     maps = [map_attr.value for map_attr in details.igemm_contraction_maps]
-    d0, d1, d2, d3 = [AffineDimExpr.get(i) for i in range(4)]
-    assert maps[0] == AffineMap.get(4, 0, [d3, d0]), f"Map 0 mismatch: {maps[0]}"
-    assert maps[1] == AffineMap.get(4, 0, [d1, d3, d2]), f"Map 1 mismatch: {maps[1]}"
-    assert maps[2] == AffineMap.get(4, 0, [d0, d1, d2]), f"Map 2 mismatch: {maps[2]}"
+    d0, d1, d2, d3, d4 = [AffineDimExpr.get(i) for i in range(5)]
+    assert maps[0] == AffineMap.get(5, 0, [d3, d4, d0]), f"Map 0 mismatch: {maps[0]}"
+    assert maps[1] == AffineMap.get(
+        5, 0, [d3, d1, d4, d2]
+    ), f"Map 1 mismatch: {maps[1]}"
+    assert maps[2] == AffineMap.get(5, 0, [d0, d1, d2]), f"Map 2 mismatch: {maps[2]}"
     iter_types = [str(attr) for attr in details.igemm_loop_iterators]
-    assert iter_types == ['"parallel"', '"parallel"', '"parallel"', '"reduction"']
-    assert details.im2col_output_perm == [1, 2, 0]
-    assert details.filter_reassoc_indices == [[0, 1, 2], [3]]
+    assert iter_types == [
+        '"parallel"',
+        '"parallel"',
+        '"parallel"',
+        '"reduction"',
+        '"reduction"',
+    ]
+    assert details.im2col_output_perm == [2, 1, 3, 0]
+    assert details.filter_reassoc_indices == [[0], [1, 2], [3]]
     assert details.is_output_channel_first
-    assert details.conv_to_igemm_dim_map == {0: 0, 1: 1, 2: 2, 3: 3, 4: 3, 5: 3}
+    assert details.conv_to_igemm_dim_map == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 4}
 
     # Test with a non-conv operation.
     module_str = """

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -7,6 +7,30 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx942 \
 // RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-igemm-pad-convolution=true --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=PAD-CONV-GFX942
 
+#map = affine_map<(d0, d1, d2, d3) -> (d0 + d2, d1 + d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> ()>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+func.func @conv_integer_like_extra_scalar_input(%arg0: tensor<5x5xi8>, %arg1: tensor<2x2xi8>, %arg2: i32, %arg3: tensor<4x4xi32>) -> tensor<4x4xi32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%arg0, %arg1, %arg2 : tensor<5x5xi8>, tensor<2x2xi8>, i32) outs(%arg3 : tensor<4x4xi32>) {
+  ^bb0(%in: i8, %in_0: i8, %in_1: i32, %out: i32):
+    %1 = arith.extui %in : i8 to i32
+    %2 = arith.subi %1, %in_1 : i32
+    %3 = arith.extui %in_0 : i8 to i32
+    %4 = arith.muli %2, %3 : i32
+    %5 = arith.addi %out, %4 : i32
+    linalg.yield %5 : i32
+  } -> tensor<4x4xi32>
+  return %0 : tensor<4x4xi32>
+}
+
+// CHECK-LABEL: func.func @conv_integer_like_extra_scalar_input
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
+//   CHECK-NOT:   use_igemm_convolution = true
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+
+// -----
+
 func.func @nhwc_conv_mfma(%3: tensor<2x34x34x128xf32>, %4: tensor<3x3x128x64xf32>) -> tensor<2x32x32x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %5 = tensor.empty() : tensor<2x32x32x64xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -233,10 +233,12 @@ public:
         computeInputKPerm(inputMap, filterMap, convDims);
 
     // Build unified offsets and output_sizes for the im2col op.
-    // Canonical output dim order: [batch dims, M (1 dim), K dims].
+    // Canonical output dim order: [batch, M, inputChannel K, filterLoop K].
     // At conv-to-im2col time all offsets are zero.
 
-    // Identify which original filter dims are parallel (depth + outputChannel).
+    // Classify each original filter dim as parallel, inputChannel, or
+    // filterLoop. The canonical im2col output order places inputChannel K
+    // dims before filterLoop K dims.
     llvm::SmallDenseSet<int64_t, 4> parallelFilterDims;
     for (auto iterDim :
          llvm::concat<const unsigned>(convDims.depth, convDims.outputChannel)) {
@@ -246,26 +248,45 @@ public:
         parallelFilterDims.insert(maybeDim.value());
       }
     }
-
-    // Collect K output dim inner sizes from filter reassociation indices.
-    // Each reduction group (group not entirely composed of parallel dims)
-    // becomes one K output dim whose inner sizes are the original filter
-    // dim sizes in that group.
-    SmallVector<SmallVector<int64_t>> kInnerSizes;
-    for (const auto &indices : filterReassocIndices) {
-      bool isParallel =
-          indices.size() == 1 && parallelFilterDims.contains(indices[0]);
-      if (!isParallel) {
-        SmallVector<int64_t> innerSizes;
-        for (int64_t idx : indices) {
-          innerSizes.push_back(filterShape[idx]);
-        }
-        kInnerSizes.push_back(innerSizes);
+    llvm::SmallDenseSet<int64_t, 4> inputChannelFilterDims;
+    for (unsigned iterDim : convDims.inputChannel) {
+      std::optional<int64_t> maybeDim = filterMap.getResultPosition(
+          getAffineDimExpr(iterDim, filterMap.getContext()));
+      if (maybeDim) {
+        inputChannelFilterDims.insert(maybeDim.value());
       }
     }
 
-    int64_t numOutputDims =
-        batchPos.size() + mShape.size() + kInnerSizes.size();
+    // Collect K output dim inner sizes from filter reassociation indices,
+    // separated into inputChannel and filterLoop groups. The canonical
+    // im2col output order is: [batch, M, inputChannel K, filterLoop K].
+    SmallVector<SmallVector<int64_t>> inputChannelInnerSizes;
+    SmallVector<SmallVector<int64_t>> filterLoopInnerSizes;
+    for (const auto &indices : filterReassocIndices) {
+      bool isParallel =
+          indices.size() == 1 && parallelFilterDims.contains(indices[0]);
+      if (isParallel) {
+        continue;
+      }
+      SmallVector<int64_t> innerSizes;
+      for (int64_t idx : indices) {
+        innerSizes.push_back(filterShape[idx]);
+      }
+      // Classify as inputChannel if all filter dims in the group are
+      // inputChannel dims; otherwise classify as filterLoop.
+      bool isInputChannel = llvm::all_of(indices, [&](int64_t idx) {
+        return inputChannelFilterDims.contains(idx);
+      });
+      if (isInputChannel) {
+        inputChannelInnerSizes.push_back(innerSizes);
+      } else {
+        filterLoopInnerSizes.push_back(innerSizes);
+      }
+    }
+
+    int64_t numOutputDims = batchPos.size() + mShape.size() +
+                            inputChannelInnerSizes.size() +
+                            filterLoopInnerSizes.size();
     SmallVector<OpFoldResult> offsets(numOutputDims, rewriter.getIndexAttr(0));
     SmallVector<SmallVector<OpFoldResult>> outputSizes;
     // Batch dims: each has a single inner size.
@@ -276,8 +297,11 @@ public:
     for (int64_t m : mShape) {
       outputSizes.push_back({rewriter.getIndexAttr(m)});
     }
-    // K dims: inner sizes from filter reassociation.
-    for (const auto &innerSizes : kInnerSizes) {
+    // InputChannel K dims first, then filterLoop K dims.
+    for (const auto &innerSizes : inputChannelInnerSizes) {
+      outputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
+    }
+    for (const auto &innerSizes : filterLoopInnerSizes) {
       outputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
     }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -43,25 +43,25 @@ util.func public @conv_2d_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<
   util.return %0 : tensor<1x16x14x14xf32>
 }
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d4)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d3, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d2, d3)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_nchw_fchw(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x16x14x14xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x36x14x14xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4, 3, 3]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 3, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x4x16x16xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x36x14x14xf32>) -> tensor<1x36x14x14xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2, 3]] : tensor<16x4x3x3xf32> into tensor<16x36xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x36xf32>, tensor<1x14x14x36xf32>)
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x36xf32>, tensor<1x36x14x14xf32>)
 // CHECK-SAME:   outs(%[[ARG2]] : tensor<1x16x14x14xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
@@ -192,16 +192,16 @@ util.func public @conv_nhwc_hwfc(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3
   util.return %0 : tensor<1x14x14x16xf32>
 }
 
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4, d5)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d3, d5)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d4, d5)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d1, d5)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d1)>
 // CHECK:      util.func public @conv_nhwc_hwfc(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x16x4xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x9x4xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [3, 3], [4]]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4], [3, 3]]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x9x4xf32>) -> tensor<1x14x14x9x4xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1], [2], [3]] : tensor<3x3x16x4xf32> into tensor<9x16x4xf32>
@@ -261,28 +261,28 @@ util.func public @conv_1d_ncw_fcw_transpose_maps(%arg0: tensor<1x8x130xf32>, %ar
   util.return %0 : tensor<1x16x128xf32>
 }
 
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1)>
 // CHECK:      util.func public @conv_1d_ncw_fcw_transpose_maps(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x8x130xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x8x3xf32>
 // CHECK:      %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x16x128xf32>
 // CHECK:      %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY]] : tensor<1x16x128xf32>) -> tensor<1x16x128xf32>
-// CHECK:      %[[EMPTY2:.+]] = tensor.empty() : tensor<1x128x24xf32>
+// CHECK:      %[[EMPTY2:.+]] = tensor.empty() : tensor<1x24x128xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
 // CHECK-SAME:   offsets = [0, 0, 0] output_sizes = {{\[}}[1], [128], [8, 3]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2] k_pos = [1]
-// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 2, 1]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x8x130xf32>)
-// CHECK-SAME:   outs(%[[EMPTY2]] : tensor<1x128x24xf32>) -> tensor<1x128x24xf32>
+// CHECK-SAME:   outs(%[[EMPTY2]] : tensor<1x24x128xf32>) -> tensor<1x24x128xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<16x8x3xf32> into tensor<16x24xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x24xf32>, tensor<1x128x24xf32>)
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x24xf32>, tensor<1x24x128xf32>)
 // CHECK-SAME:   outs(%[[FILL]] : tensor<1x16x128xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
@@ -305,25 +305,24 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tens
 }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d0)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4, d3)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_chwn_chwf(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x288xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x24x16x288xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<288x3x3x288xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<3x3x6144x288xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<6144x3x3x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
 // CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[288], [3], [3], [16, 24, 16]]
 // CHECK-SAME:   batch_pos = [3] m_pos = [1, 2] k_pos = [0]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [3, 1, 2, 0]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x18x288xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<3x3x6144x288xf32>) -> tensor<3x3x6144x288xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<6144x3x3x288xf32>) -> tensor<6144x3x3x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<16x24x16x288xf32> into tensor<6144x288xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<6144x288xf32>, tensor<3x3x6144x288xf32>)
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<6144x288xf32>, tensor<6144x3x3x288xf32>)
 // CHECK-SAME:   outs(%[[ARG2]] : tensor<288x3x3x288xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
@@ -386,16 +385,16 @@ util.func public @conv_nhwc_hwfc_nobatch(%arg0: tensor<16x16x4xf32>, %arg1: tens
   util.return %0 : tensor<14x14x16xf32>
 }
 
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d2, d4)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d3, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d0, d4)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d0)>
 // CHECK:      util.func public @conv_nhwc_hwfc_nobatch(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x16x4xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x16x4xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<14x14x9x4xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[14], [14], [3, 3], [4]]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[14], [14], [4], [3, 3]]
 // CHECK-SAME:   batch_pos = [] m_pos = [0, 1] k_pos = [2]
 // CHECK-SAME:   input_k_perm = [0, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x16x4xf32>)
@@ -465,11 +464,11 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK:      util.func public @conv_2d_nhwc_chwf(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4, 3, 3]]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4], [3, 3]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [2, 0, 1]
+// CHECK-SAME:   input_k_perm = [2, 0, 1] output_perm = [0, 1, 2, 4, 3]
 // CHECK-SAME:   ins({{.*}} : tensor<1x16x16x4xf32>)
-// CHECK-SAME:   outs({{.*}} : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
+// CHECK-SAME:   outs({{.*}} : tensor<1x14x14x9x4xf32>) -> tensor<1x14x14x9x4xf32>
 
 // -----
 
@@ -489,11 +488,11 @@ util.func public @conv_1d_nhc_chf(%arg0: tensor<1x3x2xf32>, %arg1: tensor<2x2x2x
 // CHECK:      util.func public @conv_1d_nhc_chf(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [2]
-// CHECK-SAME:   offsets = [0, 0, 0] output_sizes = {{\[}}[1], [2], [2, 2]]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [2], [2], [2]]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [1, 0]
+// CHECK-SAME:   input_k_perm = [1, 0] output_perm = [0, 1, 3, 2]
 // CHECK-SAME:   ins({{.*}} : tensor<1x3x2xf32>)
-// CHECK-SAME:   outs({{.*}} : tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
+// CHECK-SAME:   outs({{.*}} : tensor<1x2x2x2xf32>) -> tensor<1x2x2x2xf32>
 
 // -----
 
@@ -515,9 +514,9 @@ util.func public @conv_2d_no_input_channel(%arg0: tensor<61x93x16x64xbf16>, %arg
 // CHECK:      util.func public @conv_2d_no_input_channel(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [59, 91]
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[64], [16], [3], [3], [59, 91]]
-// CHECK-SAME:   batch_pos = [3, 2] m_pos = [0, 1] k_pos = []
-// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [2, 3, 4, 1, 0]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[16], [64], [3], [3], [59, 91]]
+// CHECK-SAME:   batch_pos = [2, 3] m_pos = [0, 1] k_pos = []
+// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [2, 3, 4, 0, 1]
 // CHECK-SAME:   ins({{.*}} : tensor<61x93x16x64xbf16>)
 // CHECK-SAME:   outs({{.*}} : tensor<3x3x5369x16x64xbf16>) -> tensor<3x3x5369x16x64xbf16>
 // CHECK:        tensor.collapse_shape %{{.*}} {{\[}}[0, 1], [2], [3]] : tensor<59x91x16x56xbf16> into tensor<5369x16x56xbf16>
@@ -569,18 +568,18 @@ util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<2x7x4x10x10xf32>, %arg1: ten
 }
 //                                            n   g   f   h   w   c
 // CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5)>
-// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4, d5)>
+// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d3, d4)>
 // CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_ngchw_fgchw(
 // CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x7x4x10x10xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<16x7x4x3x3xf32>]]
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x7x16x8x8xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x8x8x36xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x36x8x8xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[2], [7], [8], [8], [4, 3, 3]]
 // CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 4, 2, 3]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[RHS_T]])
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]
@@ -611,17 +610,17 @@ util.func public @conv_2d_ngchw_fgchw_gnfhw(%arg0: tensor<2x7x4x10x10xf32>, %arg
   util.return %0 : tensor<7x2x16x8x8xf32>
 }
 //                                            g   n   f   h   w   c
-// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d5)>
-// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4, d5)>
-// CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
+// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5)>
+// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d3, d4)>
+// CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_ngchw_fgchw_gnfhw(
 // CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x7x4x10x10xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<16x7x4x3x3xf32>]]
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<7x2x16x8x8xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x8x8x36xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x36x8x8xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 4, 2, 3]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[RHS_T]])
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -306,6 +306,7 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tens
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d0)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d1, d2, d3)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_chwn_chwf(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x288xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x24x16x288xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgInterfaces",
+        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Support",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
     MLIRIR
     MLIRLinalgDialect
     MLIRLinalgInterfacesIncGenLib
+    MLIRLinalgTransforms
     MLIRLinalgUtils
     MLIRMemRefDialect
     MLIRSupport

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
@@ -16,6 +17,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -424,50 +426,486 @@ bool isGatherlikeOp(Operation *op) {
 // IGEMM details for generic convolutions
 //===---------------------------------------------------------------------===//
 
+/// Classification of IGEMM dims from the image/im2col perspective.
+/// Batch includes both batch and depth (group) dims. M is output spatial
+/// dims. InputChannel and FilterLoop are the two subcategories of reduction
+/// dims. The canonical im2col output order is:
+///   [Batch, M, InputChannel, FilterLoop].
+enum class Im2colDimKind {
+  Batch,
+  M,
+  InputChannel,
+  FilterLoop,
+};
+
 /// Computes the output permutation for the im2col tensor to match the
 /// dimension order of the input tensor.
 static SmallVector<int64_t> computeIm2colOutputPermutation(
-    AffineMap inputMap, AffineMap inputMapGEMM,
+    AffineMap inputMapGEMM, const linalg::ConvolutionDimensions &convDims,
     const DenseMap<int64_t, AffineExpr> &convToIgemmDimMap) {
-  llvm::SetVector<int64_t> capturedDims;
-  SmallVector<int64_t> colTensorDimsInConvInputOrder;
-  for (int64_t dim = 0; dim < inputMap.getNumResults(); ++dim) {
-    llvm::SetVector<int64_t> convDimsForInputDim;
-    AffineExpr dimExpr = inputMap.getResult(dim);
-    dimExpr.walk([&](AffineExpr expr) {
-      if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
-        convDimsForInputDim.insert(dimExpr.getPosition());
-      }
-    });
-    for (int64_t convDim : convDimsForInputDim) {
-      if (capturedDims.contains(convDim)) {
-        continue;
-      }
-      capturedDims.insert(convDim);
-      auto iGEMMDim = cast<AffineDimExpr>(convToIgemmDimMap.at(convDim));
-      int64_t colTensorDim = inputMapGEMM.getResultPosition(iGEMMDim).value();
-      colTensorDimsInConvInputOrder.push_back(colTensorDim);
+  llvm::SmallDenseSet<unsigned, 4> batchDimSet(convDims.batch.begin(),
+                                               convDims.batch.end());
+  llvm::SmallDenseSet<unsigned, 4> depthDimSet(convDims.depth.begin(),
+                                               convDims.depth.end());
+  llvm::SmallDenseSet<unsigned, 4> outputImageDimSet(
+      convDims.outputImage.begin(), convDims.outputImage.end());
+  llvm::SmallDenseSet<unsigned, 4> inputChannelDimSet(
+      convDims.inputChannel.begin(), convDims.inputChannel.end());
+  llvm::SmallDenseSet<unsigned, 4> filterLoopDimSet(
+      convDims.filterLoop.begin(), convDims.filterLoop.end());
+
+  DenseMap<int64_t, SmallVector<int64_t>> igemmDimToConvDims;
+  for (const auto &[convDim, igemmExpr] : convToIgemmDimMap) {
+    int64_t igemmDim = cast<AffineDimExpr>(igemmExpr).getPosition();
+    igemmDimToConvDims[igemmDim].push_back(convDim);
+  }
+
+  auto classifyIgemmDim =
+      [&](int64_t igemmDim) -> Im2colDimKind {
+    ArrayRef<int64_t> convDimGroup = igemmDimToConvDims[igemmDim];
+    if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
+          return batchDimSet.contains(convDim) || depthDimSet.contains(convDim);
+        })) {
+      return Im2colDimKind::Batch;
+    }
+    if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
+          return outputImageDimSet.contains(convDim);
+        })) {
+      return Im2colDimKind::M;
+    }
+    if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
+          return inputChannelDimSet.contains(convDim);
+        })) {
+      return Im2colDimKind::InputChannel;
+    }
+    if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
+          return filterLoopDimSet.contains(convDim);
+        })) {
+      return Im2colDimKind::FilterLoop;
+    }
+    // Mixed inputChannel + filterLoop after collapse: classify as FilterLoop
+    // since inputChannel dims are absorbed into the filter loop group.
+    assert(llvm::all_of(convDimGroup, [&](int64_t convDim) {
+          return inputChannelDimSet.contains(convDim) ||
+                 filterLoopDimSet.contains(convDim);
+        }) && "unexpected IGEMM input dim classification");
+    return Im2colDimKind::FilterLoop;
+  };
+
+  SmallVector<int64_t> batchPositions;
+  SmallVector<int64_t> mPositions;
+  SmallVector<int64_t> inputChannelPositions;
+  SmallVector<int64_t> filterLoopPositions;
+  for (auto [actualPos, expr] : llvm::enumerate(inputMapGEMM.getResults())) {
+    int64_t igemmDim = cast<AffineDimExpr>(expr).getPosition();
+    switch (classifyIgemmDim(igemmDim)) {
+    case Im2colDimKind::Batch:
+      batchPositions.push_back(actualPos);
+      break;
+    case Im2colDimKind::M:
+      mPositions.push_back(actualPos);
+      break;
+    case Im2colDimKind::InputChannel:
+      inputChannelPositions.push_back(actualPos);
+      break;
+    case Im2colDimKind::FilterLoop:
+      filterLoopPositions.push_back(actualPos);
+      break;
     }
   }
-  llvm::SetVector<int64_t> capturedOutputPermDims;
-  SmallVector<int64_t> im2colOutputPerm;
-  // Iterate over the dimensions in reverse order, removing duplicates. The
-  // reverse order is used to ensure that we capture the innermost occurrences
-  // of each dimension when there are duplicates, because the innermost
-  // dimension has impact on contiguity of memory accesses.
-  for (int64_t dim : llvm::reverse(colTensorDimsInConvInputOrder)) {
-    if (capturedOutputPermDims.contains(dim)) {
-      continue;
+
+  SmallVector<int64_t> outputPerm(inputMapGEMM.getNumResults(), -1);
+  int64_t canonicalPos = 0;
+  auto assignPositions = [&](ArrayRef<int64_t> actualPositions) {
+    for (int64_t actualPos : actualPositions) {
+      outputPerm[actualPos] = canonicalPos++;
     }
-    capturedOutputPermDims.insert(dim);
-    im2colOutputPerm.push_back(dim);
-  }
-  std::reverse(im2colOutputPerm.begin(), im2colOutputPerm.end());
-  return im2colOutputPerm;
+  };
+  assignPositions(batchPositions);
+  assignPositions(mPositions);
+  assignPositions(inputChannelPositions);
+  assignPositions(filterLoopPositions);
+  return outputPerm;
 }
 
-FailureOr<IGEMMGenericConvDetails>
-getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
+/// Remaps the result expressions of an affine map by substituting each
+/// AffineDimExpr with the corresponding expression from 'dims'.
+static SmallVector<AffineExpr> remapMapResults(AffineMap map,
+                                               ArrayRef<AffineExpr> dims) {
+  SmallVector<AffineExpr> results;
+  results.reserve(map.getNumResults());
+  for (AffineExpr expr : map.getResults()) {
+    results.push_back(dims[cast<AffineDimExpr>(expr).getPosition()]);
+  }
+  return results;
+}
+
+/// Inserts filter loop dims into the input dim order adjacent to their
+/// corresponding input channel dims. Each filter loop dim is placed before
+/// the next input channel dim, or after the previous one if no next channel
+/// dim exists. When no input channel dims exist at all, filter loop dims are
+/// grouped after the last spatial dim.
+static void insertFilterLoopDims(
+    SmallVectorImpl<unsigned> &inputDimOrder,
+    const linalg::ConvolutionDimensions &convDims,
+    const llvm::SmallDenseSet<unsigned, 4> &inputChannelDimSet,
+    const llvm::SmallDenseSet<unsigned, 4> &filterLoopDimSet) {
+  llvm::SmallDenseSet<unsigned, 4> outputImageDimSet(
+      convDims.outputImage.begin(), convDims.outputImage.end());
+  auto findDimIndex = [&](ArrayRef<unsigned> dims, unsigned dim) -> int64_t {
+    auto it = llvm::find(dims, dim);
+    return it == dims.end() ? -1 : std::distance(dims.begin(), it);
+  };
+
+  auto findNextInputChannelIndex = [&](ArrayRef<unsigned> dims,
+                                       int64_t start) -> int64_t {
+    for (int64_t idx = start; idx < static_cast<int64_t>(dims.size()); ++idx) {
+      if (inputChannelDimSet.contains(dims[idx])) {
+        return idx;
+      }
+    }
+    return -1;
+  };
+
+  auto findPrevInputChannelIndex = [&](ArrayRef<unsigned> dims,
+                                       int64_t start) -> int64_t {
+    for (int64_t idx = start; idx >= 0; --idx) {
+      if (inputChannelDimSet.contains(dims[idx])) {
+        return idx;
+      }
+    }
+    return -1;
+  };
+
+  auto findInsertIndexAfterChannel = [&](ArrayRef<unsigned> dims,
+                                         int64_t channelIndex) -> int64_t {
+    int64_t insertIndex = channelIndex + 1;
+    while (insertIndex < static_cast<int64_t>(dims.size()) &&
+           filterLoopDimSet.contains(dims[insertIndex])) {
+      ++insertIndex;
+    }
+    return insertIndex;
+  };
+
+  for (auto [outputImageDim, filterLoopDim] :
+       llvm::zip_equal(convDims.outputImage, convDims.filterLoop)) {
+    int64_t outputImageIndex = findDimIndex(inputDimOrder, outputImageDim);
+    assert(outputImageIndex >= 0 && "expected output image dim in input order");
+
+    int64_t nextChannelIndex =
+        findNextInputChannelIndex(inputDimOrder, outputImageIndex + 1);
+    if (nextChannelIndex >= 0) {
+      inputDimOrder.insert(inputDimOrder.begin() + nextChannelIndex,
+                           filterLoopDim);
+      continue;
+    }
+
+    int64_t prevChannelIndex =
+        findPrevInputChannelIndex(inputDimOrder, outputImageIndex);
+    if (prevChannelIndex >= 0) {
+      int64_t insertIndex =
+          findInsertIndexAfterChannel(inputDimOrder, prevChannelIndex);
+      inputDimOrder.insert(inputDimOrder.begin() + insertIndex, filterLoopDim);
+      continue;
+    }
+
+    // No input channel dims found in either direction. Insert after the last
+    // spatial/filter-loop dim so all filter loop dims are grouped together
+    // at the end of the spatial region (enabling collapse).
+    int64_t lastSpatialIndex = -1;
+    for (int64_t idx = 0; idx < static_cast<int64_t>(inputDimOrder.size());
+         ++idx) {
+      if (outputImageDimSet.contains(inputDimOrder[idx]) ||
+          filterLoopDimSet.contains(inputDimOrder[idx])) {
+        lastSpatialIndex = idx;
+      }
+    }
+    int64_t insertIndex = lastSpatialIndex + 1;
+    inputDimOrder.insert(inputDimOrder.begin() + insertIndex,
+                         filterLoopDim);
+  }
+}
+
+/// Builds the result expressions for the image-side GEMM map in expanded
+/// (uncollapsed) form. Walks the original input map, replaces convolved
+/// spatial expressions with their spatial dim, skips filter loop dims
+/// (inserted separately by insertFilterLoopDims), and maps each dim through
+/// convToIgemmDimMap.
+static SmallVector<AffineExpr> buildExpandedInputGEMMResults(
+    AffineMap inputMap, const linalg::ConvolutionDimensions &convDims,
+    const DenseMap<int64_t, AffineExpr> &convToIgemmDimMap) {
+  llvm::SmallDenseSet<unsigned, 4> inputChannelDimSet(
+      convDims.inputChannel.begin(), convDims.inputChannel.end());
+  llvm::SmallDenseSet<unsigned, 4> filterLoopDimSet(
+      convDims.filterLoop.begin(), convDims.filterLoop.end());
+
+  // Build the base dim list in the order implied by the original input map.
+  // For convolved spatial expressions like `ow + kw`, keep only the spatial
+  // dim in the base list and insert the filter-loop dims separately below.
+  llvm::SetVector<unsigned> seenDims;
+  SmallVector<unsigned> inputDimOrder;
+  for (AffineExpr inputExpr : inputMap.getResults()) {
+    auto spatialIt = llvm::find_if(convDims.outputImage, [&](unsigned dim) {
+      return inputExpr.isFunctionOfDim(dim);
+    });
+    if (spatialIt != convDims.outputImage.end()) {
+      if (seenDims.insert(*spatialIt)) {
+        inputDimOrder.push_back(*spatialIt);
+      }
+      continue;
+    }
+
+    unsigned dim = cast<AffineDimExpr>(inputExpr).getPosition();
+    if (filterLoopDimSet.contains(dim) || !seenDims.insert(dim)) {
+      continue;
+    }
+    inputDimOrder.push_back(dim);
+  }
+  insertFilterLoopDims(inputDimOrder, convDims, inputChannelDimSet,
+                       filterLoopDimSet);
+
+  SmallVector<AffineExpr> inputDims;
+  inputDims.reserve(inputDimOrder.size());
+  for (unsigned dim : inputDimOrder) {
+    inputDims.push_back(convToIgemmDimMap.at(dim));
+  }
+  return inputDims;
+}
+
+// Permutes reduction dims in the loop space so their order matches the
+// image-side map. Since reduction dims are always at the end of the source
+// dims, this is just a permutation among the reduction positions.
+static IGEMMGenericConvDetails canonicalizeReductionOrder(
+    IGEMMGenericConvDetails details) {
+  int64_t inputMapIndex = details.isOutputChannelFirst ? 1 : 0;
+  AffineMap inputMapGEMM = details.igemmContractionMaps[inputMapIndex];
+  int64_t rank = inputMapGEMM.getNumDims();
+  MLIRContext *ctx = inputMapGEMM.getContext();
+
+  // Collect reduction positions in loop order (ascending).
+  SmallVector<int64_t> reductionPositions;
+  llvm::SmallDenseSet<int64_t, 4> reductionDimSet;
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (details.igemmLoopIterators[dim] == utils::IteratorType::reduction) {
+      reductionPositions.push_back(dim);
+      reductionDimSet.insert(dim);
+    }
+  }
+
+  // Walk the image-side map to get reduction dims in image-side order.
+  SmallVector<int64_t> imageReductionOrder;
+  for (AffineExpr expr : inputMapGEMM.getResults()) {
+    int64_t dim = cast<AffineDimExpr>(expr).getPosition();
+    if (reductionDimSet.contains(dim)) {
+      imageReductionOrder.push_back(dim);
+    }
+  }
+
+  // Build remapping: imageReductionOrder[i] -> reductionPositions[i].
+  // This places reduction dims in the image-side order while keeping them
+  // in the same tail positions of the loop space.
+  DenseMap<int64_t, int64_t> reductionRemap;
+  bool isIdentity = true;
+  for (auto [i, imageRedDim] : llvm::enumerate(imageReductionOrder)) {
+    reductionRemap[imageRedDim] = reductionPositions[i];
+    if (imageRedDim != reductionPositions[i]) {
+      isIdentity = false;
+    }
+  }
+
+  // Remap a dim expr, only touching reduction dims.
+  auto remapExpr = [&](AffineExpr expr) -> AffineExpr {
+    int64_t dim = cast<AffineDimExpr>(expr).getPosition();
+    auto it = reductionRemap.find(dim);
+    if (it != reductionRemap.end()) {
+      return getAffineDimExpr(it->second, ctx);
+    }
+    return expr;
+  };
+
+  if (!isIdentity) {
+    // Apply remapping to all indexing maps.
+    for (AffineMap &map : details.igemmContractionMaps) {
+      SmallVector<AffineExpr> newResults;
+      for (AffineExpr expr : map.getResults()) {
+        newResults.push_back(remapExpr(expr));
+      }
+      map = AffineMap::get(rank, map.getNumSymbols(), newResults, ctx);
+    }
+    // Permute loop bounds and iterators at the reduction positions.
+    SmallVector<int64_t> newBounds = details.igemmLoopBounds;
+    SmallVector<utils::IteratorType> newIterators = details.igemmLoopIterators;
+    for (auto [i, imageRedDim] : llvm::enumerate(imageReductionOrder)) {
+      newBounds[reductionPositions[i]] = details.igemmLoopBounds[imageRedDim];
+      newIterators[reductionPositions[i]] =
+          details.igemmLoopIterators[imageRedDim];
+    }
+    details.igemmLoopBounds = newBounds;
+    details.igemmLoopIterators = newIterators;
+    // Update convToIgemmDimMap.
+    for (auto &[convDim, igemmExpr] : details.convToIgemmDimMap) {
+      igemmExpr = remapExpr(igemmExpr);
+    }
+  }
+
+  return details;
+}
+
+/// Translates iteration-space reassociation indices into operand-space
+/// reassociation indices using the given affine map. Each iteration group
+/// is mapped to the corresponding operand dim positions.
+static SmallVector<ReassociationIndices> getOperandReassociation(
+    AffineMap map, ArrayRef<ReassociationIndices> iterationReassociation) {
+  DenseMap<int64_t, int64_t> iterationToOperandDim;
+  for (auto [idx, expr] : llvm::enumerate(map.getResults())) {
+    iterationToOperandDim[cast<AffineDimExpr>(expr).getPosition()] = idx;
+  }
+
+  SmallVector<ReassociationIndices> operandReassociation;
+  for (ReassociationIndicesRef group : iterationReassociation) {
+    ReassociationIndices operandGroup;
+    for (int64_t iterationDim : group) {
+      auto it = iterationToOperandDim.find(iterationDim);
+      if (it != iterationToOperandDim.end()) {
+        operandGroup.push_back(it->second);
+      }
+    }
+    if (operandGroup.empty()) {
+      continue;
+    }
+    assert(llvm::is_sorted(operandGroup) &&
+           "expected operand dims to preserve iteration order");
+    assert((operandGroup.size() <= 1 ||
+            operandGroup.back() - operandGroup.front() + 1 ==
+                static_cast<int64_t>(operandGroup.size())) &&
+           "expected operand dims to be contiguous");
+    operandReassociation.push_back(std::move(operandGroup));
+  }
+  llvm::sort(operandReassociation, [](ReassociationIndicesRef lhs,
+                                      ReassociationIndicesRef rhs) {
+    return lhs.front() < rhs.front();
+  });
+  return operandReassociation;
+}
+
+/// Collapses loop bounds by multiplying together bounds in each group.
+static SmallVector<int64_t> collapseLoopBounds(
+    ArrayRef<int64_t> loopBounds,
+    ArrayRef<ReassociationIndices> reassociation) {
+  SmallVector<int64_t> collapsedLoopBounds;
+  collapsedLoopBounds.reserve(reassociation.size());
+  for (ReassociationIndicesRef group : reassociation) {
+    int64_t collapsedSize = 1;
+    for (int64_t dim : group) {
+      collapsedSize *= loopBounds[dim];
+    }
+    collapsedLoopBounds.push_back(collapsedSize);
+  }
+  return collapsedLoopBounds;
+}
+
+/// Collapses iterator types by taking the type of the first dim in each group.
+static SmallVector<utils::IteratorType> collapseIteratorTypes(
+    ArrayRef<utils::IteratorType> iteratorTypes,
+    ArrayRef<ReassociationIndices> reassociation) {
+  SmallVector<utils::IteratorType> collapsedIteratorTypes;
+  collapsedIteratorTypes.reserve(reassociation.size());
+  for (ReassociationIndicesRef group : reassociation) {
+    collapsedIteratorTypes.push_back(iteratorTypes[group.front()]);
+  }
+  return collapsedIteratorTypes;
+}
+
+/// Collapses iteration dimensions in a set of affine maps according to the
+/// given reassociation indices. Adjacent iteration dims that map to the same
+/// collapsed dim produce a single result dim in the output map.
+static SmallVector<AffineMap> collapseAffineMaps(
+    ArrayRef<AffineMap> maps, ArrayRef<ReassociationIndices> reassociation) {
+  assert(!maps.empty() && "expected non-empty maps");
+  int64_t numDims = maps.front().getNumDims();
+  SmallVector<int64_t> iterationToCollapsedDim(numDims, -1);
+  for (auto [collapsedDim, group] : llvm::enumerate(reassociation)) {
+    for (int64_t dim : group) {
+      iterationToCollapsedDim[dim] = collapsedDim;
+    }
+  }
+
+  SmallVector<AffineMap> collapsedMaps;
+  collapsedMaps.reserve(maps.size());
+  for (AffineMap map : maps) {
+    SmallVector<AffineExpr> collapsedResults;
+    for (AffineExpr expr : map.getResults()) {
+      int64_t collapsedDim =
+          iterationToCollapsedDim[cast<AffineDimExpr>(expr).getPosition()];
+      AffineExpr collapsedExpr =
+          getAffineDimExpr(collapsedDim, map.getContext());
+      if (collapsedResults.empty() ||
+          collapsedResults.back() != collapsedExpr) {
+        collapsedResults.push_back(collapsedExpr);
+      }
+    }
+    collapsedMaps.push_back(AffineMap::get(reassociation.size(),
+                                           map.getNumSymbols(),
+                                           collapsedResults, map.getContext()));
+  }
+  return collapsedMaps;
+}
+
+/// Updates convToIgemmDimMap to refer to collapsed iteration dims.
+static DenseMap<int64_t, AffineExpr> collapseConvToIgemmDimMap(
+    const DenseMap<int64_t, AffineExpr> &convToIgemmDimMap,
+    ArrayRef<ReassociationIndices> reassociation) {
+  SmallVector<int64_t> iterationToCollapsedDim;
+  for (auto [collapsedDim, group] : llvm::enumerate(reassociation)) {
+    iterationToCollapsedDim.resize(
+        std::max<int64_t>(iterationToCollapsedDim.size(), group.back() + 1), -1);
+    for (int64_t dim : group) {
+      iterationToCollapsedDim[dim] = collapsedDim;
+    }
+  }
+
+  DenseMap<int64_t, AffineExpr> collapsedMap;
+  MLIRContext *ctx = convToIgemmDimMap.begin()->second.getContext();
+  for (const auto &[convDim, igemmExpr] : convToIgemmDimMap) {
+    int64_t expandedDim = cast<AffineDimExpr>(igemmExpr).getPosition();
+    collapsedMap[convDim] =
+        getAffineDimExpr(iterationToCollapsedDim[expandedDim], ctx);
+  }
+  return collapsedMap;
+}
+
+/// Identifies groups of adjacent reduction dims that can be collapsed.
+/// Two adjacent reduction dims can be collapsed if they appear as a
+/// preserved sequence in all indexing maps (checked via
+/// areDimSequencesPreserved).
+static SmallVector<ReassociationIndices> getCollapsibleIGEMMIterationGroups(
+    ArrayRef<AffineMap> maps, ArrayRef<utils::IteratorType> iteratorTypes) {
+  SmallVector<ReassociationIndices> reassociation;
+  int64_t rank = iteratorTypes.size();
+  for (int64_t dim = 0; dim < rank;) {
+    ReassociationIndices group = {dim};
+    while (iteratorTypes[dim] == utils::IteratorType::reduction &&
+           group.back() + 1 < rank &&
+           iteratorTypes[group.back() + 1] == utils::IteratorType::reduction) {
+      ReassociationIndices candidate = group;
+      candidate.push_back(group.back() + 1);
+      if (!linalg::areDimSequencesPreserved(maps, {candidate})) {
+        break;
+      }
+      group.push_back(group.back() + 1);
+    }
+    reassociation.push_back(std::move(group));
+    dim = reassociation.back().back() + 1;
+  }
+  return reassociation;
+}
+
+/// Builds the fully expanded (uncollapsed) IGEMM details for a convolution.
+/// The expanded form has an identity mapping from conv loop dims to IGEMM
+/// loop dims. Reduction dims are then canonicalized to match the image-side
+/// order to enable subsequent collapsing.
+static FailureOr<IGEMMGenericConvDetails>
+getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
   MLIRContext *ctx = linalgOp->getContext();
   if (failed(convDimsOrFailure)) {
@@ -495,7 +933,6 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   Value output = linalgOp.getDpsInits()[0];
   auto inputType = cast<ShapedType>(input.getType());
   auto filterType = cast<ShapedType>(filter.getType());
-  auto outputType = cast<ShapedType>(output.getType());
 
   if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
     LDBG() << "[unimplemented] expected 'filterType' and 'inputType' to have "
@@ -508,18 +945,11 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     LDBG() << "[unimplemented] expected no pooling operations.";
     return failure();
   }
-  auto filterShape = filterType.getShape();
-  auto outputShape = outputType.getShape();
+
   auto indexingMaps = linalgOp.getIndexingMapsArray();
+  auto inputMap = indexingMaps[0];
   auto filterMap = indexingMaps[1];
   auto outputMap = indexingMaps[2];
-
-  SmallVector<int64_t> reductionDims;
-  for (auto iter : llvm::enumerate(linalgOp.getIteratorTypesArray())) {
-    if (linalg::isReductionIterator(iter.value())) {
-      reductionDims.push_back(iter.index());
-    }
-  }
 
   bool isOutputChannelFirst = false;
   auto outputChannelPos = convDims.outputChannel;
@@ -537,150 +967,29 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     isOutputChannelFirst = true;
   }
 
-  SmallVector<int64_t> filterkPos;
-  for (auto reductionDim : reductionDims) {
-    std::optional<int64_t> maybeDim = filterMap.getResultPosition(
-        getAffineDimExpr(reductionDim, filterMap.getContext()));
-    filterkPos.push_back(maybeDim.value());
-  }
-  // Group together adjacent reduction dimensions in the filter.
-  // First we want to sort the dims as the look up from the filterMap
-  // can place the dims in arbitarty order.
-  std::sort(filterkPos.begin(), filterkPos.end());
-  SmallVector<ReassociationIndices> collapsedFilterReductionDim;
-  int64_t prevFilterIndex = filterkPos[0];
-  int64_t currCollapsedIndex = 0;
-  collapsedFilterReductionDim.push_back({filterkPos[0]});
-  SmallVector<int64_t> kShape = {filterShape[filterkPos[0]]};
-  for (auto currPos : llvm::ArrayRef(filterkPos).drop_front()) {
-    if (prevFilterIndex == currPos - 1) {
-      collapsedFilterReductionDim[currCollapsedIndex].push_back(currPos);
-    } else {
-      collapsedFilterReductionDim.push_back({currPos});
-      ++currCollapsedIndex;
-    }
-    prevFilterIndex = currPos;
-  }
+  int64_t loopRank = linalgOp.getNumLoops();
+  SmallVector<AffineExpr> dims(loopRank);
+  bindDimsList<AffineExpr>(ctx, dims);
 
-  auto parallel = utils::IteratorType::parallel;
-  auto reduction = utils::IteratorType::reduction;
-
-  // Parallel filter dims, in order.
-  SmallVector<int64_t> filterNdims;
-  for (auto iterDim :
-       llvm::concat<const unsigned>(convDims.depth, convDims.outputChannel)) {
-    std::optional<int64_t> maybeDim = filterMap.getResultPosition(
-        getAffineDimExpr(iterDim, filterMap.getContext()));
-    filterNdims.push_back(maybeDim.value());
+  DenseMap<int64_t, AffineExpr> convToIgemmDimMap;
+  for (int64_t dim = 0; dim < loopRank; ++dim) {
+    convToIgemmDimMap[dim] = dims[dim];
   }
-  std::sort(filterNdims.begin(), filterNdims.end());
 
   SmallVector<ReassociationIndices> filterReassocIndices;
-  SmallVector<utils::IteratorType> filterIterators;
-  // Interleave the parallel dims with the reduction dims.
-  int64_t filterNdimPos = 0;
-  for (auto collapsedDim : collapsedFilterReductionDim) {
-    for (int i = filterNdimPos; i < filterNdims.size(); i++) {
-      if (filterNdims[i] < collapsedDim[0]) {
-        filterReassocIndices.push_back({filterNdims[i]});
-        filterIterators.push_back(parallel);
-        filterNdimPos = i + 1;
-      } else {
-        break;
-      }
-    }
-    filterIterators.push_back(reduction);
-    filterReassocIndices.push_back(collapsedDim);
-  }
-  // Insert any leftover parallel dims in the end.
-  for (int i = filterNdimPos; i < filterNdims.size(); i++) {
-    filterReassocIndices.push_back({filterNdims[i]});
-    filterIterators.push_back(parallel);
-  }
-  SmallVector<int64_t> reshapedFilterShape(filterReassocIndices.size(), 1);
-  for (auto [idx, indices] : llvm::enumerate(filterReassocIndices)) {
-    for (auto index : indices) {
-      reshapedFilterShape[idx] *= filterShape[index];
-    }
+  filterReassocIndices.reserve(filterMap.getNumResults());
+  for (int64_t idx = 0; idx < filterMap.getNumResults(); ++idx) {
+    filterReassocIndices.push_back({idx});
   }
 
-  int64_t numParallelDims = convDims.depth.size() + convDims.batch.size() +
-                            convDims.outputImage.size() +
-                            convDims.outputChannel.size();
-  int64_t numKDims = collapsedFilterReductionDim.size();
-  SmallVector<utils::IteratorType> genericIterators(numParallelDims, parallel);
-  genericIterators.insert(genericIterators.end(), numKDims, reduction);
-
-  SmallVector<AffineExpr> dims(numParallelDims + numKDims);
-  bindDimsList<AffineExpr>(ctx, dims);
-  // Build the result map with dims in canonical order.
-  auto resultMap = AffineMap::get(
-      numParallelDims + numKDims, 0,
-      SmallVector<AffineExpr>(dims.begin(), dims.begin() + numParallelDims),
+  auto inputMapGEMM = AffineMap::get(
+      loopRank, 0,
+      buildExpandedInputGEMMResults(inputMap, convDims, convToIgemmDimMap),
       ctx);
-
-  // Build a mapping from original conv output map dimensions to their canonical
-  // dimensions, as used by the IGEMM maps.
-  DenseMap<int64_t, AffineExpr> convToIgemmDimMap;
-  for (auto [idx, expr] : llvm::enumerate(outputMap.getResults())) {
-    auto convDimIdx = cast<AffineDimExpr>(expr).getPosition();
-    convToIgemmDimMap[convDimIdx] = getAffineDimExpr(idx, ctx);
-  }
-
-  // Lambda to remap conv dim indices to igemm dimensions.
-  auto remapDims = [&](ArrayRef<unsigned> dims) -> SmallVector<AffineExpr> {
-    SmallVector<AffineExpr> mapped;
-    for (unsigned d : dims) {
-      mapped.push_back(convToIgemmDimMap.at(d));
-    }
-    return mapped;
-  };
-
-  // Prepare the input map.
-  SmallVector<AffineExpr> inputDims;
-  // Add the batch dims.
-  inputDims.append(remapDims(convDims.batch));
-  // Add the depth (group) dims.
-  inputDims.append(remapDims(convDims.depth));
-  // Add the M dims.
-  inputDims.append(remapDims(convDims.outputImage));
-  // Add the reduction dims at the end.
-  inputDims.append(dims.begin() + numParallelDims, dims.end());
-  auto inputMapGEMM =
-      AffineMap::get(numParallelDims + numKDims, 0, inputDims, ctx);
-
-  // Prepare filter map and add mapping for reduction dimensions.
-  int64_t currKPos = numParallelDims;
-  SmallVector<AffineExpr> filterDims;
-  for (const auto &[iter, indices] :
-       llvm::zip_equal(filterIterators, filterReassocIndices)) {
-    if (iter == reduction) {
-      for (int64_t reInd : indices) {
-        int64_t convDimIdx =
-            cast<AffineDimExpr>(filterMap.getResult(reInd)).getPosition();
-        convToIgemmDimMap[convDimIdx] = dims[currKPos];
-      }
-      filterDims.push_back(dims[currKPos++]);
-    } else {
-      assert(iter == parallel && "expected a parallel dim");
-      assert(indices.size() == 1 && "expected a single reassociation index");
-      int64_t filterInputIdx = indices.front();
-      auto convDim = cast<AffineDimExpr>(filterMap.getResult(filterInputIdx));
-      filterDims.push_back(convToIgemmDimMap.at(convDim.getPosition()));
-    }
-  }
   auto filterMapGEMM =
-      AffineMap::get(numParallelDims + numKDims, 0, filterDims, ctx);
-
-  // Compute the output permutation for the im2col tensor to match the
-  // dimension order of the input tensor.
-  SmallVector<int64_t> im2colOutputPerm = computeIm2colOutputPermutation(
-      indexingMaps[0], inputMapGEMM, convToIgemmDimMap);
-  SmallVector<AffineExpr> colTensorResultExprs(inputMapGEMM.getResults());
-  applyPermutationToVector(colTensorResultExprs, im2colOutputPerm);
-  inputMapGEMM =
-      AffineMap::get(inputMapGEMM.getNumDims(), 0, colTensorResultExprs,
-                     inputMapGEMM.getContext());
+      AffineMap::get(loopRank, 0, remapMapResults(filterMap, dims), ctx);
+  auto resultMap =
+      AffineMap::get(loopRank, 0, remapMapResults(outputMap, dims), ctx);
 
   SmallVector<AffineMap> indexingGEMMMaps;
   if (isOutputChannelFirst) {
@@ -691,33 +1000,86 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     indexingGEMMMaps.push_back(filterMapGEMM);
   }
   indexingGEMMMaps.push_back(resultMap);
+
+  SmallVector<int64_t> igemmLoopBounds =
+      linalgOp.getStaticLoopRanges();
+
+  SmallVector<utils::IteratorType> igemmLoopIterators;
+  for (utils::IteratorType iteratorType : linalgOp.getIteratorTypesArray()) {
+    igemmLoopIterators.push_back(iteratorType);
+  }
+
   IGEMMGenericConvDetails igemmDetails;
-  igemmDetails.im2colOutputPerm = im2colOutputPerm;
   igemmDetails.igemmContractionMaps = indexingGEMMMaps;
   igemmDetails.igemmOperands = isOutputChannelFirst
                                    ? SmallVector<Value>({filter, input})
                                    : SmallVector<Value>({input, filter});
   igemmDetails.igemmOperands.push_back(output);
-  SmallVector<int64_t> igemmLoopBounds;
-  for (auto [idx, expr] : llvm::enumerate(outputMap.getResults())) {
-    igemmLoopBounds.push_back(outputShape[idx]);
-  }
-  SmallVector<utils::IteratorType> igemmLoopIterators(numParallelDims,
-                                                      parallel);
-
-  for (auto iter : llvm::enumerate(filterIterators)) {
-    if (iter.value() == reduction) {
-      igemmLoopBounds.push_back(reshapedFilterShape[iter.index()]);
-      igemmLoopIterators.push_back(reduction);
-    }
-  }
   igemmDetails.igemmLoopBounds = igemmLoopBounds;
   igemmDetails.filterReassocIndices = filterReassocIndices;
   igemmDetails.isOutputChannelFirst = isOutputChannelFirst;
   igemmDetails.convDims = convDims;
   igemmDetails.convToIgemmDimMap = convToIgemmDimMap;
   igemmDetails.igemmLoopIterators = igemmLoopIterators;
-  return igemmDetails;
+  return canonicalizeReductionOrder(std::move(igemmDetails));
+}
+
+/// Collapses adjacent same-kind dims in the expanded IGEMM details.
+/// Produces the final collapsed contraction maps, loop bounds, iterator
+/// types, filter reassociation indices, and im2col output permutation.
+static IGEMMGenericConvDetails collapseIGEMMGenericConvDetails(
+    const IGEMMGenericConvDetails &expandedDetails) {
+  SmallVector<ReassociationIndices> iterationReassociation =
+      getCollapsibleIGEMMIterationGroups(expandedDetails.igemmContractionMaps,
+                                         expandedDetails.igemmLoopIterators);
+  if (llvm::all_of(iterationReassociation, [](ReassociationIndicesRef group) {
+        return group.size() == 1;
+      })) {
+    IGEMMGenericConvDetails result = expandedDetails;
+    int64_t inputMapIndex = result.isOutputChannelFirst ? 1 : 0;
+    result.im2colOutputPerm = computeIm2colOutputPermutation(
+        result.igemmContractionMaps[inputMapIndex], result.convDims,
+        result.convToIgemmDimMap);
+    return result;
+  }
+
+  IGEMMGenericConvDetails collapsedDetails = expandedDetails;
+  collapsedDetails.igemmContractionMaps =
+      collapseAffineMaps(expandedDetails.igemmContractionMaps,
+                         iterationReassociation);
+  collapsedDetails.igemmLoopBounds = collapseLoopBounds(
+      expandedDetails.igemmLoopBounds, iterationReassociation);
+  collapsedDetails.igemmLoopIterators =
+      collapseIteratorTypes(expandedDetails.igemmLoopIterators,
+                            iterationReassociation);
+  collapsedDetails.convToIgemmDimMap = collapseConvToIgemmDimMap(
+      expandedDetails.convToIgemmDimMap, iterationReassociation);
+
+  AffineMap expandedFilterMap =
+      expandedDetails.igemmContractionMaps[expandedDetails.isOutputChannelFirst
+                                               ? 0
+                                               : 1];
+  collapsedDetails.filterReassocIndices =
+      getOperandReassociation(expandedFilterMap, iterationReassociation);
+
+  int64_t inputMapIndex = expandedDetails.isOutputChannelFirst ? 1 : 0;
+  AffineMap collapsedInputMap =
+      collapsedDetails.igemmContractionMaps[inputMapIndex];
+  collapsedDetails.im2colOutputPerm =
+      computeIm2colOutputPermutation(
+          collapsedInputMap, collapsedDetails.convDims,
+          collapsedDetails.convToIgemmDimMap);
+  return collapsedDetails;
+}
+
+FailureOr<IGEMMGenericConvDetails>
+getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
+  FailureOr<IGEMMGenericConvDetails> expandedDetails =
+      getExpandedIGEMMGenericConvDetails(linalgOp);
+  if (failed(expandedDetails)) {
+    return failure();
+  }
+  return collapseIGEMMGenericConvDetails(*expandedDetails);
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -451,8 +451,8 @@ static SmallVector<int64_t> computeIm2colOutputPermutation(
       convDims.outputImage.begin(), convDims.outputImage.end());
   llvm::SmallDenseSet<unsigned, 4> inputChannelDimSet(
       convDims.inputChannel.begin(), convDims.inputChannel.end());
-  llvm::SmallDenseSet<unsigned, 4> filterLoopDimSet(
-      convDims.filterLoop.begin(), convDims.filterLoop.end());
+  llvm::SmallDenseSet<unsigned, 4> filterLoopDimSet(convDims.filterLoop.begin(),
+                                                    convDims.filterLoop.end());
 
   DenseMap<int64_t, SmallVector<int64_t>> igemmDimToConvDims;
   for (const auto &[convDim, igemmExpr] : convToIgemmDimMap) {
@@ -460,8 +460,7 @@ static SmallVector<int64_t> computeIm2colOutputPermutation(
     igemmDimToConvDims[igemmDim].push_back(convDim);
   }
 
-  auto classifyIgemmDim =
-      [&](int64_t igemmDim) -> Im2colDimKind {
+  auto classifyIgemmDim = [&](int64_t igemmDim) -> Im2colDimKind {
     ArrayRef<int64_t> convDimGroup = igemmDimToConvDims[igemmDim];
     if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
           return batchDimSet.contains(convDim) || depthDimSet.contains(convDim);
@@ -485,10 +484,12 @@ static SmallVector<int64_t> computeIm2colOutputPermutation(
     }
     // Mixed inputChannel + filterLoop after collapse: classify as FilterLoop
     // since inputChannel dims are absorbed into the filter loop group.
-    assert(llvm::all_of(convDimGroup, [&](int64_t convDim) {
-          return inputChannelDimSet.contains(convDim) ||
-                 filterLoopDimSet.contains(convDim);
-        }) && "unexpected IGEMM input dim classification");
+    assert(llvm::all_of(convDimGroup,
+                        [&](int64_t convDim) {
+                          return inputChannelDimSet.contains(convDim) ||
+                                 filterLoopDimSet.contains(convDim);
+                        }) &&
+           "unexpected IGEMM input dim classification");
     return Im2colDimKind::FilterLoop;
   };
 
@@ -545,11 +546,11 @@ static SmallVector<AffineExpr> remapMapResults(AffineMap map,
 /// the next input channel dim, or after the previous one if no next channel
 /// dim exists. When no input channel dims exist at all, filter loop dims are
 /// grouped after the last spatial dim.
-static void insertFilterLoopDims(
-    SmallVectorImpl<unsigned> &inputDimOrder,
-    const linalg::ConvolutionDimensions &convDims,
-    const llvm::SmallDenseSet<unsigned, 4> &inputChannelDimSet,
-    const llvm::SmallDenseSet<unsigned, 4> &filterLoopDimSet) {
+static void
+insertFilterLoopDims(SmallVectorImpl<unsigned> &inputDimOrder,
+                     const linalg::ConvolutionDimensions &convDims,
+                     const llvm::SmallDenseSet<unsigned, 4> &inputChannelDimSet,
+                     const llvm::SmallDenseSet<unsigned, 4> &filterLoopDimSet) {
   llvm::SmallDenseSet<unsigned, 4> outputImageDimSet(
       convDims.outputImage.begin(), convDims.outputImage.end());
   auto findDimIndex = [&](ArrayRef<unsigned> dims, unsigned dim) -> int64_t {
@@ -621,8 +622,7 @@ static void insertFilterLoopDims(
       }
     }
     int64_t insertIndex = lastSpatialIndex + 1;
-    inputDimOrder.insert(inputDimOrder.begin() + insertIndex,
-                         filterLoopDim);
+    inputDimOrder.insert(inputDimOrder.begin() + insertIndex, filterLoopDim);
   }
 }
 
@@ -636,8 +636,8 @@ static SmallVector<AffineExpr> buildExpandedInputGEMMResults(
     const DenseMap<int64_t, AffineExpr> &convToIgemmDimMap) {
   llvm::SmallDenseSet<unsigned, 4> inputChannelDimSet(
       convDims.inputChannel.begin(), convDims.inputChannel.end());
-  llvm::SmallDenseSet<unsigned, 4> filterLoopDimSet(
-      convDims.filterLoop.begin(), convDims.filterLoop.end());
+  llvm::SmallDenseSet<unsigned, 4> filterLoopDimSet(convDims.filterLoop.begin(),
+                                                    convDims.filterLoop.end());
 
   // Build the base dim list in the order implied by the original input map.
   // For convolved spatial expressions like `ow + kw`, keep only the spatial
@@ -675,8 +675,8 @@ static SmallVector<AffineExpr> buildExpandedInputGEMMResults(
 // Permutes reduction dims in the loop space so their order matches the
 // image-side map. Since reduction dims are always at the end of the source
 // dims, this is just a permutation among the reduction positions.
-static IGEMMGenericConvDetails canonicalizeReductionOrder(
-    IGEMMGenericConvDetails details) {
+static IGEMMGenericConvDetails
+canonicalizeReductionOrder(IGEMMGenericConvDetails details) {
   int64_t inputMapIndex = details.isOutputChannelFirst ? 1 : 0;
   AffineMap inputMapGEMM = details.igemmContractionMaps[inputMapIndex];
   int64_t rank = inputMapGEMM.getNumDims();
@@ -754,8 +754,9 @@ static IGEMMGenericConvDetails canonicalizeReductionOrder(
 /// Translates iteration-space reassociation indices into operand-space
 /// reassociation indices using the given affine map. Each iteration group
 /// is mapped to the corresponding operand dim positions.
-static SmallVector<ReassociationIndices> getOperandReassociation(
-    AffineMap map, ArrayRef<ReassociationIndices> iterationReassociation) {
+static SmallVector<ReassociationIndices>
+getOperandReassociation(AffineMap map,
+                        ArrayRef<ReassociationIndices> iterationReassociation) {
   DenseMap<int64_t, int64_t> iterationToOperandDim;
   for (auto [idx, expr] : llvm::enumerate(map.getResults())) {
     iterationToOperandDim[cast<AffineDimExpr>(expr).getPosition()] = idx;
@@ -781,17 +782,17 @@ static SmallVector<ReassociationIndices> getOperandReassociation(
            "expected operand dims to be contiguous");
     operandReassociation.push_back(std::move(operandGroup));
   }
-  llvm::sort(operandReassociation, [](ReassociationIndicesRef lhs,
-                                      ReassociationIndicesRef rhs) {
-    return lhs.front() < rhs.front();
-  });
+  llvm::sort(operandReassociation,
+             [](ReassociationIndicesRef lhs, ReassociationIndicesRef rhs) {
+               return lhs.front() < rhs.front();
+             });
   return operandReassociation;
 }
 
 /// Collapses loop bounds by multiplying together bounds in each group.
-static SmallVector<int64_t> collapseLoopBounds(
-    ArrayRef<int64_t> loopBounds,
-    ArrayRef<ReassociationIndices> reassociation) {
+static SmallVector<int64_t>
+collapseLoopBounds(ArrayRef<int64_t> loopBounds,
+                   ArrayRef<ReassociationIndices> reassociation) {
   SmallVector<int64_t> collapsedLoopBounds;
   collapsedLoopBounds.reserve(reassociation.size());
   for (ReassociationIndicesRef group : reassociation) {
@@ -805,9 +806,9 @@ static SmallVector<int64_t> collapseLoopBounds(
 }
 
 /// Collapses iterator types by taking the type of the first dim in each group.
-static SmallVector<utils::IteratorType> collapseIteratorTypes(
-    ArrayRef<utils::IteratorType> iteratorTypes,
-    ArrayRef<ReassociationIndices> reassociation) {
+static SmallVector<utils::IteratorType>
+collapseIteratorTypes(ArrayRef<utils::IteratorType> iteratorTypes,
+                      ArrayRef<ReassociationIndices> reassociation) {
   SmallVector<utils::IteratorType> collapsedIteratorTypes;
   collapsedIteratorTypes.reserve(reassociation.size());
   for (ReassociationIndicesRef group : reassociation) {
@@ -819,8 +820,9 @@ static SmallVector<utils::IteratorType> collapseIteratorTypes(
 /// Collapses iteration dimensions in a set of affine maps according to the
 /// given reassociation indices. Adjacent iteration dims that map to the same
 /// collapsed dim produce a single result dim in the output map.
-static SmallVector<AffineMap> collapseAffineMaps(
-    ArrayRef<AffineMap> maps, ArrayRef<ReassociationIndices> reassociation) {
+static SmallVector<AffineMap>
+collapseAffineMaps(ArrayRef<AffineMap> maps,
+                   ArrayRef<ReassociationIndices> reassociation) {
   assert(!maps.empty() && "expected non-empty maps");
   int64_t numDims = maps.front().getNumDims();
   SmallVector<int64_t> iterationToCollapsedDim(numDims, -1);
@@ -858,7 +860,8 @@ static DenseMap<int64_t, AffineExpr> collapseConvToIgemmDimMap(
   SmallVector<int64_t> iterationToCollapsedDim;
   for (auto [collapsedDim, group] : llvm::enumerate(reassociation)) {
     iterationToCollapsedDim.resize(
-        std::max<int64_t>(iterationToCollapsedDim.size(), group.back() + 1), -1);
+        std::max<int64_t>(iterationToCollapsedDim.size(), group.back() + 1),
+        -1);
     for (int64_t dim : group) {
       iterationToCollapsedDim[dim] = collapsedDim;
     }
@@ -1001,8 +1004,7 @@ getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   }
   indexingGEMMMaps.push_back(resultMap);
 
-  SmallVector<int64_t> igemmLoopBounds =
-      linalgOp.getStaticLoopRanges();
+  SmallVector<int64_t> igemmLoopBounds = linalgOp.getStaticLoopRanges();
 
   SmallVector<utils::IteratorType> igemmLoopIterators;
   for (utils::IteratorType iteratorType : linalgOp.getIteratorTypesArray()) {
@@ -1044,31 +1046,27 @@ static IGEMMGenericConvDetails collapseIGEMMGenericConvDetails(
   }
 
   IGEMMGenericConvDetails collapsedDetails = expandedDetails;
-  collapsedDetails.igemmContractionMaps =
-      collapseAffineMaps(expandedDetails.igemmContractionMaps,
-                         iterationReassociation);
+  collapsedDetails.igemmContractionMaps = collapseAffineMaps(
+      expandedDetails.igemmContractionMaps, iterationReassociation);
   collapsedDetails.igemmLoopBounds = collapseLoopBounds(
       expandedDetails.igemmLoopBounds, iterationReassociation);
-  collapsedDetails.igemmLoopIterators =
-      collapseIteratorTypes(expandedDetails.igemmLoopIterators,
-                            iterationReassociation);
+  collapsedDetails.igemmLoopIterators = collapseIteratorTypes(
+      expandedDetails.igemmLoopIterators, iterationReassociation);
   collapsedDetails.convToIgemmDimMap = collapseConvToIgemmDimMap(
       expandedDetails.convToIgemmDimMap, iterationReassociation);
 
   AffineMap expandedFilterMap =
-      expandedDetails.igemmContractionMaps[expandedDetails.isOutputChannelFirst
-                                               ? 0
-                                               : 1];
+      expandedDetails
+          .igemmContractionMaps[expandedDetails.isOutputChannelFirst ? 0 : 1];
   collapsedDetails.filterReassocIndices =
       getOperandReassociation(expandedFilterMap, iterationReassociation);
 
   int64_t inputMapIndex = expandedDetails.isOutputChannelFirst ? 1 : 0;
   AffineMap collapsedInputMap =
       collapsedDetails.igemmContractionMaps[inputMapIndex];
-  collapsedDetails.im2colOutputPerm =
-      computeIm2colOutputPermutation(
-          collapsedInputMap, collapsedDetails.convDims,
-          collapsedDetails.convToIgemmDimMap);
+  collapsedDetails.im2colOutputPerm = computeIm2colOutputPermutation(
+      collapsedInputMap, collapsedDetails.convDims,
+      collapsedDetails.convToIgemmDimMap);
   return collapsedDetails;
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -911,13 +911,15 @@ static SmallVector<ReassociationIndices> getCollapsibleIGEMMIterationGroups(
 /// order to enable subsequent collapsing.
 static FailureOr<IGEMMGenericConvDetails>
 getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
+  // The failure conditions for these checks differ slightly, so check both.
   if (!linalg::isaConvolutionOpInterface(linalgOp)) {
     return failure();
   }
 
   auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
-  assert(succeeded(convDimsOrFailure) &&
-         "expected to infer convolution dims after isaConvolutionOpInterface");
+  if (failed(convDimsOrFailure)) {
+    return failure();
+  }
   const mlir::linalg::ConvolutionDimensions &convDims = *convDimsOrFailure;
   MLIRContext *ctx = linalgOp->getContext();
   LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -655,6 +655,8 @@ static SmallVector<AffineExpr> buildExpandedInputGEMMResults(
       continue;
     }
 
+    // isaConvolutionOpInterface guarantees input map results without output
+    // image dims are affine dim expressions.
     unsigned dim = cast<AffineDimExpr>(inputExpr).getPosition();
     if (filterLoopDimSet.contains(dim) || !seenDims.insert(dim)) {
       continue;
@@ -673,8 +675,8 @@ static SmallVector<AffineExpr> buildExpandedInputGEMMResults(
 }
 
 // Permutes reduction dims in the loop space so their order matches the
-// image-side map. Since reduction dims are always at the end of the source
-// dims, this is just a permutation among the reduction positions.
+// image-side map. This only remaps among the existing reduction positions;
+// reduction dims do not need to be at the end of the loop space.
 static IGEMMGenericConvDetails
 canonicalizeReductionOrder(IGEMMGenericConvDetails details) {
   int64_t inputMapIndex = details.isOutputChannelFirst ? 1 : 0;
@@ -909,12 +911,15 @@ static SmallVector<ReassociationIndices> getCollapsibleIGEMMIterationGroups(
 /// order to enable subsequent collapsing.
 static FailureOr<IGEMMGenericConvDetails>
 getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
-  auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
-  MLIRContext *ctx = linalgOp->getContext();
-  if (failed(convDimsOrFailure)) {
+  if (!linalg::isaConvolutionOpInterface(linalgOp)) {
     return failure();
   }
+
+  auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
+  assert(succeeded(convDimsOrFailure) &&
+         "expected to infer convolution dims after isaConvolutionOpInterface");
   const mlir::linalg::ConvolutionDimensions &convDims = *convDimsOrFailure;
+  MLIRContext *ctx = linalgOp->getContext();
   LLVM_DEBUG({
     llvm::dbgs() << "conv: " << linalgOp;
     llvm::dbgs() << "\nconv batch dim: ";

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -858,7 +858,7 @@ collapseAffineMaps(ArrayRef<AffineMap> maps,
 /// Updates convToIgemmDimMap to refer to collapsed iteration dims.
 static DenseMap<int64_t, AffineExpr> collapseConvToIgemmDimMap(
     const DenseMap<int64_t, AffineExpr> &convToIgemmDimMap,
-    ArrayRef<ReassociationIndices> reassociation) {
+    ArrayRef<ReassociationIndices> reassociation, MLIRContext *ctx) {
   SmallVector<int64_t> iterationToCollapsedDim;
   for (auto [collapsedDim, group] : llvm::enumerate(reassociation)) {
     iterationToCollapsedDim.resize(
@@ -870,7 +870,6 @@ static DenseMap<int64_t, AffineExpr> collapseConvToIgemmDimMap(
   }
 
   DenseMap<int64_t, AffineExpr> collapsedMap;
-  MLIRContext *ctx = convToIgemmDimMap.begin()->second.getContext();
   for (const auto &[convDim, igemmExpr] : convToIgemmDimMap) {
     int64_t expandedDim = cast<AffineDimExpr>(igemmExpr).getPosition();
     collapsedMap[convDim] =
@@ -916,7 +915,8 @@ getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     return failure();
   }
 
-  auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
+  FailureOr<linalg::ConvolutionDimensions> convDimsOrFailure =
+      linalg::inferConvolutionDims(linalgOp);
   if (failed(convDimsOrFailure)) {
     return failure();
   }
@@ -962,8 +962,8 @@ getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   auto outputMap = indexingMaps[2];
 
   bool isOutputChannelFirst = false;
-  auto outputChannelPos = convDims.outputChannel;
-  auto outputImagePos = convDims.outputImage;
+  ArrayRef<unsigned> outputChannelPos = convDims.outputChannel;
+  ArrayRef<unsigned> outputImagePos = convDims.outputImage;
 
   std::optional<int64_t> outputChannelLastDim = outputMap.getResultPosition(
       getAffineDimExpr(outputChannelPos.back(), outputMap.getContext()));
@@ -1013,10 +1013,8 @@ getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
 
   SmallVector<int64_t> igemmLoopBounds = linalgOp.getStaticLoopRanges();
 
-  SmallVector<utils::IteratorType> igemmLoopIterators;
-  for (utils::IteratorType iteratorType : linalgOp.getIteratorTypesArray()) {
-    igemmLoopIterators.push_back(iteratorType);
-  }
+  SmallVector<utils::IteratorType> igemmLoopIterators =
+      llvm::to_vector(linalgOp.getIteratorTypesArray());
 
   IGEMMGenericConvDetails igemmDetails;
   igemmDetails.igemmContractionMaps = indexingGEMMMaps;
@@ -1036,8 +1034,9 @@ getExpandedIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
 /// Collapses adjacent same-kind dims in the expanded IGEMM details.
 /// Produces the final collapsed contraction maps, loop bounds, iterator
 /// types, filter reassociation indices, and im2col output permutation.
-static IGEMMGenericConvDetails collapseIGEMMGenericConvDetails(
-    const IGEMMGenericConvDetails &expandedDetails) {
+static IGEMMGenericConvDetails
+collapseIGEMMGenericConvDetails(const IGEMMGenericConvDetails &expandedDetails,
+                                MLIRContext *ctx) {
   SmallVector<ReassociationIndices> iterationReassociation =
       getCollapsibleIGEMMIterationGroups(expandedDetails.igemmContractionMaps,
                                          expandedDetails.igemmLoopIterators);
@@ -1060,7 +1059,7 @@ static IGEMMGenericConvDetails collapseIGEMMGenericConvDetails(
   collapsedDetails.igemmLoopIterators = collapseIteratorTypes(
       expandedDetails.igemmLoopIterators, iterationReassociation);
   collapsedDetails.convToIgemmDimMap = collapseConvToIgemmDimMap(
-      expandedDetails.convToIgemmDimMap, iterationReassociation);
+      expandedDetails.convToIgemmDimMap, iterationReassociation, ctx);
 
   AffineMap expandedFilterMap =
       expandedDetails
@@ -1084,7 +1083,8 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   if (failed(expandedDetails)) {
     return failure();
   }
-  return collapseIGEMMGenericConvDetails(*expandedDetails);
+  return collapseIGEMMGenericConvDetails(*expandedDetails,
+                                         linalgOp->getContext());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -176,8 +176,8 @@ struct IGEMMGenericConvDetails {
   SmallVector<Value> igemmOperands;
   /// The inferred convolution dimensions.
   mlir::linalg::ConvolutionDimensions convDims;
-  /// Mapping from dimensions in 'convDims' to dimensions in
-  /// 'igemmContractionMaps'. This only includes parallel dimensions.
+  /// Mapping from all loop dimensions of the convolution (both parallel
+  /// and reduction) to dimensions in 'igemmContractionMaps'.
   DenseMap<int64_t, AffineExpr> convToIgemmDimMap;
   /// The reassociation indices used to computer the collapse shape of the
   /// filter in IGEMM transformation.


### PR DESCRIPTION
Refactors getIGEMMGenericConvDetails into three stages:

1. Build fully expanded IGEMM details where every conv loop dim maps 1:1 to an IGEMM dim (no collapsing). The image-side GEMM map is constructed following the original input tensor's layout order, with filter loop dims inserted adjacent to their corresponding input channel dims.
2. Canonicalize reduction dim labeling so their order in the loop space matches the order they appear in the image-side map, which is a prerequisite for collapsing.
3. Collapse adjacent same-kind dims that are collapsible across all indexing maps, producing the final collapsed GEMM maps, loop bounds, filter reassociation, and im2col output permutation.

This makes a few improvements over the old path:
 - Better separation of concerns in the computation of the IGEMM details, because we have 3 separate phases that don't need to care what the other phases do.
 - Improved reduction order for layout mismatches between image and filter (e.g., `nhwc x nchw`), because we canonicalize to the image's order, which makes vectorized loads from global memory possible in some cases where we otherwise had artificially strided access patterns.
 - The layout of the GEMM actually matches the layout of the convolution now. Before this PR, the layout of the im2col op's result would generally be in the "canonical" order, meaning there was an implicit transpose happening in the im2col access pattern. It is better to explicitly model this transpose in the GEMM indexing maps, where it is easier to target optimizations like transpose_load.

This refactoring will also make it easier to make a couple of follow-up changes, which will come as separate PRs:
 - Redefine the classification of `Batch` vs `M` dims in the im2col op semantics. The current definition is inconsistent with what the corresponding dims actually mean in the GEMM because convolution batch dims are actually M dims in the GEMM, but we classify them as batch in the im2col op. This will be a simple reclassification in phase 1 now.
 - Flatten parallel dimensions as well as reduction dimensions. This will be very simple now, since we will just need to update phase 3.