### PR TITLE
[Codegen] Duplicate operations in tile size analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -637,6 +637,27 @@ static TileSizes getIterationSpaceTileSizes(Operation *op, unsigned numLoops,
   return iterTileSizes;
 }
 
+/// Gather tile sizes into the iteration space of a linalg op by looking up
+/// both operand and result lattice states in the solver.
+static TileSizes
+getLinalgIterationSpaceTileSizes(linalg::LinalgOp linalgOp,
+                                 const DataFlowSolver &solver) {
+  TileSizes iterTileSizes =
+      getIterationSpaceTileSizes(linalgOp, linalgOp.getNumLoops(),
+                                 linalgOp.getIndexingMapsArray(), solver);
+
+  for (auto [idx, result] : llvm::enumerate(linalgOp->getResults())) {
+    const TileSizeLattice *lattice =
+        solver.lookupState<TileSizeLattice>(result);
+    TileSizes tileSizes = getTileSizesFor(result, lattice);
+    OpOperand *init = linalgOp.getDpsInitOperand(idx);
+    AffineMap map = linalgOp.getMatchingIndexingMap(init);
+    iterTileSizes.merge(tileSizes.mapToIterationSpace(map));
+  }
+
+  return iterTileSizes;
+}
+
 /// Get tile sizes for an im2col op from its result lattice. Im2col's output
 /// dimensions are the iteration domain, so the result lattice directly holds
 /// the iteration-space tile sizes.
@@ -645,6 +666,89 @@ static TileSizes getIm2colTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
   Value result = im2colOp.getResult(0);
   const TileSizeLattice *lattice = solver.lookupState<TileSizeLattice>(result);
   return getTileSizesFor(result, lattice);
+}
+
+static std::optional<TileSizes>
+getUseOperandTileSizes(OpOperand &use, const DataFlowSolver &solver) {
+  Operation *user = use.getOwner();
+
+  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(user)) {
+    TileSizes iterTileSizes =
+        getLinalgIterationSpaceTileSizes(linalgOp, solver);
+    AffineMap map = linalgOp.getMatchingIndexingMap(&use);
+    TileSizes operandTileSizes = iterTileSizes.mapFromIterationSpace(map);
+    if (!operandTileSizes.isDefined()) {
+      return std::nullopt;
+    }
+    return operandTileSizes;
+  }
+
+  if (auto toLayoutOp = dyn_cast<ToLayoutOp>(user)) {
+    Value result = toLayoutOp.getResult();
+    const TileSizeLattice *lattice =
+        solver.lookupState<TileSizeLattice>(result);
+    TileSizes tileSizes = getTileSizesFor(result, lattice);
+    if (!tileSizes.isDefined()) {
+      return std::nullopt;
+    }
+    return tileSizes;
+  }
+
+  return std::nullopt;
+}
+
+static LogicalResult
+materializeDuplicatableLinalgOp(linalg::LinalgOp linalgOp,
+                                const DataFlowSolver &solver) {
+  if (linalgOp->getNumResults() != 1) {
+    return failure();
+  }
+  if (linalgOp->hasAttr(kVectorTileSizesAttrName)) {
+    return success();
+  }
+  Value result = linalgOp->getResult(0);
+  if (!isDuplicatable(result)) {
+    return failure();
+  }
+
+  SmallVector<std::pair<TileSizes, SmallVector<OpOperand *>>> useGroups;
+  for (OpOperand &use : result.getUses()) {
+    std::optional<TileSizes> maybeTileSizes =
+        getUseOperandTileSizes(use, solver);
+    if (!maybeTileSizes || !maybeTileSizes->isDefined()) {
+      continue;
+    }
+    auto it = llvm::find_if(
+        useGroups, [&](auto &entry) { return entry.first == *maybeTileSizes; });
+    if (it == useGroups.end()) {
+      useGroups.emplace_back(*maybeTileSizes, SmallVector<OpOperand *>{&use});
+    } else {
+      it->second.push_back(&use);
+    }
+  }
+
+  if (useGroups.empty()) {
+    return success();
+  }
+
+  auto setTileSizeAttr = [](Operation *op, TileSizes tileSizes) {
+    op->setAttr(kVectorTileSizesAttrName,
+                DenseI64ArrayAttr::get(op->getContext(), tileSizes.getDims()));
+  };
+
+  setTileSizeAttr(linalgOp, useGroups.front().first);
+
+  OpBuilder builder(linalgOp);
+  builder.setInsertionPointAfter(linalgOp);
+  for (auto &useGroup : llvm::drop_begin(useGroups)) {
+    Operation *cloned = builder.clone(*linalgOp.getOperation());
+    setTileSizeAttr(cloned, useGroup.first);
+    Value clonedResult = cloned->getResult(0);
+    for (OpOperand *use : useGroup.second) {
+      use->set(clonedResult);
+    }
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -670,8 +774,24 @@ public:
       return signalPassFailure();
     }
 
+    SmallVector<linalg::LinalgOp> duplicatableLinalgOps;
+    funcOp.walk([&](linalg::LinalgOp linalgOp) {
+      if (linalgOp->getNumResults() == 1 &&
+          isDuplicatable(linalgOp->getResult(0))) {
+        duplicatableLinalgOps.push_back(linalgOp);
+      }
+    });
+    for (linalg::LinalgOp linalgOp : duplicatableLinalgOps) {
+      if (failed(materializeDuplicatableLinalgOp(linalgOp, solver))) {
+        return signalPassFailure();
+      }
+    }
+
     auto materialize = [](Operation *op, TileSizes tileSizes) -> LogicalResult {
       if (tileSizes.isOverdefined()) {
+        if (op->hasAttr(kVectorTileSizesAttrName)) {
+          return success();
+        }
         op->emitOpError()
             << "tile size analysis did not determine a valid tile size";
         return failure();
@@ -706,9 +826,8 @@ public:
         return WalkResult(materialize(op, tileSizes));
       }
       if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
-        SmallVector<AffineMap> indexingMaps = linalgOp.getIndexingMapsArray();
-        TileSizes tileSizes = getIterationSpaceTileSizes(
-            op, linalgOp.getNumLoops(), indexingMaps, solver);
+        TileSizes tileSizes =
+            getLinalgIterationSpaceTileSizes(linalgOp, solver);
         assert(!tileSizes.isDefined() ||
                tileSizes.rank() == linalgOp.getNumLoops());
         return WalkResult(materialize(op, tileSizes));

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -736,17 +736,18 @@ materializeDuplicatableLinalgOp(linalg::LinalgOp linalgOp,
                 DenseI64ArrayAttr::get(op->getContext(), tileSizes.getDims()));
   };
 
-  setTileSizeAttr(linalgOp, useGroups.front().first);
-
   OpBuilder builder(linalgOp);
   builder.setInsertionPointAfter(linalgOp);
-  for (auto &useGroup : llvm::drop_begin(useGroups)) {
+  for (auto &useGroup : useGroups) {
     Operation *cloned = builder.clone(*linalgOp.getOperation());
     setTileSizeAttr(cloned, useGroup.first);
     Value clonedResult = cloned->getResult(0);
     for (OpOperand *use : useGroup.second) {
       use->set(clonedResult);
     }
+  }
+  if (result.use_empty()) {
+    linalgOp->erase();
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -247,6 +247,44 @@ func.func @scf_if_propagation(%arg0: tensor<512xf32>, %cond: i1) -> tensor<512xf
 
 // -----
 
+// Duplicatable linalg ops are specialized per use at materialization time.
+// One linalg.fill feeding two consumers with different logical vector tile
+// sizes should be duplicated and each clone should keep the tile size of its
+// corresponding use.
+
+#layout_fill_consumer_32 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1], batch_tile = [1, 2], outer_tile = [1, 1],
+  thread_tile = [16, 4], element_tile = [1, 4],
+  subgroup_strides = [0, 0], thread_strides = [1, 16]>
+
+#layout_fill_consumer_24 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1], batch_tile = [1, 3], outer_tile = [1, 1],
+  thread_tile = [16, 2], element_tile = [1, 4],
+  subgroup_strides = [0, 0], thread_strides = [1, 16]>
+
+// CHECK-LABEL: @result_and_fill_specialization
+func.func @result_and_fill_specialization() -> (tensor<16x24xf32>, tensor<16x24xf32>) {
+  %empty = tensor.empty() : tensor<16x24xf32>
+  %zero = arith.constant 0.0 : f32
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<16x24xf32>
+  // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG: %[[FILL24:.+]] = linalg.fill
+  // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 16, 24>
+  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK-DAG: %[[FILL32:.+]] = linalg.fill
+  // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 16, 32>
+  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK-DAG: %[[LAYOUT32:.+]] = iree_vector_ext.to_layout %[[FILL32]] to layout(#{{.+}}) : tensor<16x24xf32>
+  // CHECK-DAG: %[[LAYOUT24:.+]] = iree_vector_ext.to_layout %[[FILL24]] to layout(#{{.+}}) : tensor<16x24xf32>
+  // CHECK: return %[[LAYOUT32]], %[[LAYOUT24]] : tensor<16x24xf32>, tensor<16x24xf32>
+  %laid_out_32 = iree_vector_ext.to_layout %fill to layout(#layout_fill_consumer_32) : tensor<16x24xf32>
+  %laid_out_24 = iree_vector_ext.to_layout %fill to layout(#layout_fill_consumer_24) : tensor<16x24xf32>
+  return %laid_out_32, %laid_out_24 : tensor<16x24xf32>, tensor<16x24xf32>
+}
+
+// -----
+
 #layout_pack = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1], batch_tile = [1, 32], outer_tile = [1, 1],
   thread_tile = [1, 1], element_tile = [8, 8],

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -285,6 +285,46 @@ func.func @result_and_fill_specialization() -> (tensor<16x24xf32>, tensor<16x24x
 
 // -----
 
+#layout_fill_consumer_32 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1], batch_tile = [1, 2], outer_tile = [1, 1],
+  thread_tile = [16, 4], element_tile = [1, 4],
+  subgroup_strides = [0, 0], thread_strides = [1, 16]>
+
+#layout_fill_consumer_24 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1], batch_tile = [1, 3], outer_tile = [1, 1],
+  thread_tile = [16, 2], element_tile = [1, 4],
+  subgroup_strides = [0, 0], thread_strides = [1, 16]>
+
+// CHECK-LABEL: @result_and_fill_specialization_with_unclassified_scf_yield_uses
+func.func @result_and_fill_specialization_with_unclassified_scf_yield_uses(%cond: i1) -> (tensor<16x24xf32>, tensor<16x24xf32>) {
+  %empty = tensor.empty() : tensor<16x24xf32>
+  %zero = arith.constant 0.0 : f32
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<16x24xf32>
+  // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[FILL_ORIG:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK: %[[FILL32:.+]] = linalg.fill
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 16, 32>
+  // CHECK-SAME: ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK: %[[LAYOUT32:.+]] = iree_vector_ext.to_layout %[[FILL32]] to layout(#{{.+}}) : tensor<16x24xf32>
+  %laid_out_32 = iree_vector_ext.to_layout %fill to layout(#layout_fill_consumer_32) : tensor<16x24xf32>
+  // CHECK: %[[IF:.+]] = scf.if
+  %if = scf.if %cond -> tensor<16x24xf32> {
+    // CHECK: scf.yield %[[FILL_ORIG]]
+    scf.yield %fill : tensor<16x24xf32>
+  } else {
+    // CHECK: scf.yield %[[FILL_ORIG]]
+    scf.yield %fill : tensor<16x24xf32>
+  }
+  // CHECK-NOT: iree_codegen.vector_tile_sizes = array<i64: 16, 24>
+  // CHECK: %[[LAYOUT24:.+]] = iree_vector_ext.to_layout %[[IF]] to layout(#{{.+}}) : tensor<16x24xf32>
+  // CHECK: return %[[LAYOUT32]], %[[LAYOUT24]] : tensor<16x24xf32>, tensor<16x24xf32>
+  %laid_out_24 = iree_vector_ext.to_layout %if to layout(#layout_fill_consumer_24) : tensor<16x24xf32>
+  return %laid_out_32, %laid_out_24 : tensor<16x24xf32>, tensor<16x24xf32>
+}
+
+// -----
+
 #layout_pack = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1], batch_tile = [1, 32], outer_tile = [1, 1],
   thread_tile = [1, 1], element_tile = [8, 8],


### PR DESCRIPTION
The tile size analysis considers some operations such as `linalg.fill` as duplicatable to avoid poisoning the tile size analysis in case such easy-to-duplicate operations are used by multiple users with different tile sizes after CSE.

So far, that duplication was never materialized. Now, the materialization pass after analysis clones duplicatable operation with the requested tile-size attributes.

This PR also fixes missing tile-size attributes on operations that have their tile size fully defined by the analysis on the result. So far, the materialization only considered operands, now it also uses result information.

This is part of https://github.com/iree-org/iree/issues/24221.

Assisted-by: Codex