### PR TITLE
[CI][TorchModels] Relax mi325 golden for flaky llama_8b_fp16 decode_seq128 benchmark

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 6.05
+    "golden_time_ms": 6.42
 }


### PR DESCRIPTION
The revision updates the golden value to `mean (~3 months) 5.836 * 1.1 = 6.42`.

`llama_8b_fp16/decode_benchmark_seq128_mi325.json` on the mi325 runner has been failing sporadically since its golden was last tightened (`2025-11-07`, set 5.5 -> 6.05 per the `min(val*1.1, val+5ms)` rule). Analysis across 532 recorded runs on main since `2025-11-07` shows the mean is stable -- this is noise hitting a threshold set inside the natural variance band, not a perf regression.

Aggregate distribution (532 main-branch runs, post last-golden-update):

| Benchmark                          | mean  | p50   | p95   | max   | old g. | new g. | fail% |
| ---------------------------------- | ----- | ----- | ----- | ----- | ------ | ------ | ----- |
| decode_benchmark_seq128_mi325.json | 5.836 | 5.809 | 6.073 | 7.723 | 6.05   | 6.42   | 6.0%  |

Weekly trend (2026-W04..W17, ~3 months). The mean stays flat at `~5.77-5.97 ms` throughout -- no drift upward. Failures are scattered, not clustered at the end of the window (the W12 tail spike comes from a handful of cluster-wide anomalies on 2026-03-17..19 that affected every benchmark):

| Week     | n  | mean  | p50   | p95   | max   | fail% |
| -------- | -- | ----- | ----- | ----- | ----- | ----- |
| 2026-W04 | 1  | 5.956 | 5.956 | 5.956 | 5.956 | 0.0%  |
| 2026-W05 | 44 | 5.842 | 5.830 | 6.166 | 6.214 | 11.4% |
| 2026-W06 | 17 | 5.942 | 5.915 | 6.185 | 6.229 | 23.5% |
| 2026-W07 | 33 | 5.793 | 5.798 | 5.920 | 5.990 | 0.0%  |
| 2026-W08 | 34 | 5.822 | 5.818 | 6.020 | 6.072 | 5.9%  |
| 2026-W09 | 14 | 5.767 | 5.755 | 5.915 | 5.916 | 0.0%  |
| 2026-W10 | 42 | 5.799 | 5.801 | 6.014 | 6.120 | 4.8%  |
| 2026-W11 | 77 | 5.859 | 5.846 | 6.039 | 6.190 | 5.2%  |
| 2026-W12 | 59 | 5.969 | 5.826 | 7.178 | 7.723 | 15.3% |
| 2026-W13 | 39 | 5.847 | 5.819 | 6.041 | 6.130 | 5.1%  |
| 2026-W14 | 41 | 5.818 | 5.818 | 5.995 | 6.197 | 2.4%  |
| 2026-W15 | 40 | 5.767 | 5.746 | 5.980 | 6.264 | 5.0%  |
| 2026-W16 | 52 | 5.781 | 5.785 | 5.942 | 5.975 | 0.0%  |
| 2026-W17 | 39 | 5.798 | 5.789 | 6.011 | 6.058 | 2.6%  |

The old golden (6.05) sits near p95 of the observed distribution (p95 = 6.073), so ~5-6% of runs are expected to miss it on noise alone, which matches the observed 6.0% flake rate.