### PR TITLE
[Python] Fix duplicate enum builder registrations in Python bindings

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -105,6 +105,7 @@ declare_mlir_dialect_python_bindings(
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/IREECodegenBinding.td
   GEN_ENUM_BINDINGS
+  GEN_ENUM_BINDINGS_TD_FILE dialects/IREECodegenEnumBinding.td
   SOURCES dialects/iree_codegen.py
   DIALECT_NAME iree_codegen
 )
@@ -114,6 +115,7 @@ declare_mlir_dialect_python_bindings(
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
   TD_FILE dialects/IREEGPUBinding.td
   GEN_ENUM_BINDINGS
+  GEN_ENUM_BINDINGS_TD_FILE dialects/IREEGPUEnumBinding.td
   SOURCES dialects/iree_gpu.py
   DIALECT_NAME iree_gpu
 )

--- a/compiler/bindings/python/iree/compiler/dialects/IREECodegenEnumBinding.td
+++ b/compiler/bindings/python/iree/compiler/dialects/IREECodegenEnumBinding.td
@@ -1,0 +1,15 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Enum-only binding that excludes IREECodegenOps.td to avoid pulling in
+// LinalgBase.td and its duplicate linalg enum builder registrations.
+
+#ifndef PYTHON_BINDINGS_IREECODEGEN_ENUMS
+#define PYTHON_BINDINGS_IREECODEGEN_ENUMS
+
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td"
+
+#endif // PYTHON_BINDINGS_IREECODEGEN_ENUMS

--- a/compiler/bindings/python/iree/compiler/dialects/IREEGPUEnumBinding.td
+++ b/compiler/bindings/python/iree/compiler/dialects/IREEGPUEnumBinding.td
@@ -1,0 +1,15 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Enum-only binding that excludes IREEGPUOps.td to avoid pulling in
+// StructuredOpsUtils.td and its duplicate IteratorType builder registration.
+
+#ifndef PYTHON_BINDINGS_IREEGPU_ENUMS
+#define PYTHON_BINDINGS_IREEGPU_ENUMS
+
+include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td"
+
+#endif // PYTHON_BINDINGS_IREEGPU_ENUMS


### PR DESCRIPTION
Motivated by the warning issues when importing `iree_codegen` or `iree_gpu` Python dialects from tuner side, 10 `RuntimeWarning's are emitted:                                                                                                                                              
  
  ```                                                                                                                                                          
  RuntimeWarning: Attribute builder for 'BinaryFn' is already registered                                                                                    
  RuntimeWarning: Attribute builder for 'IteratorType' is already registered                                                                                
  ``` 

This PR fixes duplicate Python attribute builder registration warnings in assertion-enabled builds by using separate, minimal `.td` files for enum binding generation.  

Assisted-by:  [Claude Code](https://claude.ai/code)