### PR TITLE
[Codegen][DMA] Skip untuned XOR swizzle fallback for BF16

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -881,6 +881,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     // Apply XOR swizzle for BF16 DMA operands whose reduction dim is
     // innermost (contiguous reads) to avoid LDS bank conflicts.
+    // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (lhsElemType.isBF16() && !transposedLhs) {
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -883,14 +883,16 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     if (lhsElemType.isBF16() && !transposedLhs) {
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
-          context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs);
+          context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
+          /*skipUntunedFallback=*/true);
       if (succeeded(lhsSwizzleAttr)) {
         lhsAttr = *lhsSwizzleAttr;
       }
     }
     if (rhsElemType.isBF16() && transposedRhs) {
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
-          context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs);
+          context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
+          /*skipUntunedFallback=*/true);
       if (succeeded(rhsSwizzleAttr)) {
         rhsAttr = *rhsSwizzleAttr;
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -11,6 +11,12 @@
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
+// RUN: | FileCheck %s --check-prefix=CHECK-DIRECT-LOAD
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
 // RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true --iree-llvmgpu-prefetch-num-stages=2 \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS-DIRECT-LOAD-2
@@ -29,6 +35,12 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=IGEMM
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-llvmgpu-use-direct-load=true \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
+// RUN: | FileCheck %s --check-prefix=IGEMM-DIRECT-LOAD
 
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
 #rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
@@ -583,3 +595,24 @@ func.func @matmul_bf16(
 // CHECK-DIRECT-LOAD-LABEL: func.func @matmul_bf16
 // CHECK-DIRECT-LOAD:       linalg.matmul {lowering_config = #iree_gpu.lowering_config
 // CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.swizzle_operand<copy_config = #iree_gpu.use_global_load_dma, swizzle = #iree_codegen.xor_shuffle<64, 8>>, #iree_gpu.use_global_load_dma]
+
+// -----
+
+// BF16 1x1 conv with DMA. The MMA intrinsic (MFMA_F32_32x32x8_BF16) is not in
+// the tuned swizzle table, so no XOR swizzle should be applied -- only plain
+// use_global_load_dma.
+func.func @conv_bf16_no_untuned_swizzle(
+    %arg0: tensor<16x96x64x40xbf16>,
+    %arg1: tensor<40x1x1x40xbf16>) -> tensor<16x96x64x40xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<16x96x64x40xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<16x96x64x40xf32>) -> tensor<16x96x64x40xf32>
+  %result = linalg.conv_2d_nhwc_fhwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1 : tensor<16x96x64x40xbf16>, tensor<40x1x1x40xbf16>)
+    outs(%fill : tensor<16x96x64x40xf32>) -> tensor<16x96x64x40xf32>
+  return %result : tensor<16x96x64x40xf32>
+}
+
+// IGEMM-DIRECT-LOAD-LABEL: func.func @conv_bf16_no_untuned_swizzle
+// IGEMM-DIRECT-LOAD:       linalg.conv_2d_nhwc_fhwc {
+// IGEMM-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma]

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -961,10 +961,11 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForUntunedChipset(
 FailureOr<XorShuffleParams>
 getXorShuffleParams(IREE::GPU::TargetAttr target,
                     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                    ArrayRef<int64_t> reductionTileSizes, int operandIndex) {
+                    ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+                    bool skipUntunedFallback) {
   FailureOr<XorShuffleParams> xorShuffleAttr =
       getXorShuffleParamsForTunedChipset(target, intrinsic, operandIndex);
-  if (failed(xorShuffleAttr)) {
+  if (failed(xorShuffleAttr) && !skipUntunedFallback) {
     xorShuffleAttr = getXorShuffleParamsForUntunedChipset(
         target, intrinsic, reductionTileSizes, operandIndex);
   }
@@ -976,9 +977,10 @@ FailureOr<Attribute>
 getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                   IREE::GPU::TargetAttr target,
                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                  ArrayRef<int64_t> reductionTileSizes, int operandIndex) {
-  FailureOr<XorShuffleParams> xorShuffleParams =
-      getXorShuffleParams(target, intrinsic, reductionTileSizes, operandIndex);
+                  ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+                  bool skipUntunedFallback) {
+  FailureOr<XorShuffleParams> xorShuffleParams = getXorShuffleParams(
+      target, intrinsic, reductionTileSizes, operandIndex, skipUntunedFallback);
   if (failed(xorShuffleParams)) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -271,7 +271,8 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForUntunedChipset(
 FailureOr<XorShuffleParams>
 getXorShuffleParams(IREE::GPU::TargetAttr target,
                     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                    ArrayRef<int64_t> reductionTileSizes, int operandIndex);
+                    ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+                    bool skipUntunedFallback = false);
 
 /// Returns the XOR shuffle attribute for the given target, intrinsic, and
 /// operand index.
@@ -279,7 +280,8 @@ FailureOr<Attribute>
 getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                   IREE::GPU::TargetAttr target,
                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                  ArrayRef<int64_t> reductionTileSizes, int operandIndex);
+                  ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+                  bool skipUntunedFallback = false);
 //===----------------------------------------------------------------------===//
 // GPU CodeGen op filter
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The untuned swizzle heuristic (`getXorShuffleParamsForUntunedChipset`) can produce XOR shuffle parameters that are incompatible with AMDGPULowerCoalescedDMAToGatherLDS  checks, causing DMA to fall back to vector.transfer_read/write.

This PR is in the same spirit of #24208, making DMA decisions explicit at heuristic selection time rather than relying on silent late-pipeline fallbacks. 

Assisted-by: Cursor (Claude)