### PR TITLE
[Codegen][GPU] Root non-unique scatter before update producers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -65,6 +65,42 @@ func.func @forall_fuse_then_hoist(%3: tensor<128x128xf16>, %4: tensor<128x128xf1
 
 // -----
 
+#translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [4, 1, 1] subgroup_size = 4>
+
+func.func @non_unique_scatter_keeps_forall_update(
+    %arg0: tensor<4x8xf32>, %arg1: tensor<4xi32>,
+    %arg2: tensor<16x8xf32>) -> tensor<16x8xf32>
+    attributes {translation_info = #translation_info} {
+  %empty = tensor.empty() : tensor<4x8xf32>
+  %updates = scf.forall (%i) in (4) shared_outs(%out = %empty)
+      -> (tensor<4x8xf32>) {
+    %src = tensor.extract_slice %arg0[%i, 0] [1, 8] [1, 1]
+        : tensor<4x8xf32> to tensor<1x8xf32>
+    %dst = tensor.extract_slice %out[%i, 0] [1, 8] [1, 1]
+        : tensor<4x8xf32> to tensor<1x8xf32>
+    %copy = linalg.copy ins(%src : tensor<1x8xf32>)
+        outs(%dst : tensor<1x8xf32>) -> tensor<1x8xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %copy into %out[%i, 0] [1, 8] [1, 1]
+          : tensor<1x8xf32> into tensor<4x8xf32>
+    }
+  } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+  %scatter = iree_linalg_ext.scatter dimension_map = [0]
+      unique_indices(false)
+      ins(%updates, %arg1 : tensor<4x8xf32>, tensor<4xi32>)
+      outs(%arg2 : tensor<16x8xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32):
+    iree_linalg_ext.yield %arg3 : f32
+  } -> tensor<16x8xf32>
+  return %scatter : tensor<16x8xf32>
+}
+
+// CHECK-LABEL: func.func @non_unique_scatter_keeps_forall_update(
+//       CHECK:   %[[UPDATES:.+]] = scf.forall
+//       CHECK:   iree_linalg_ext.scatter {{.*}}unique_indices(false) ins(%[[UPDATES]]
+
+// -----
+
 #translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #map = affine_map<(d0) -> (d0 * 2)>

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -49,6 +49,12 @@ struct FuseTilableForallConsumers final
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
   LogicalResult matchAndRewrite(TilingInterface tilableOp,
                                 PatternRewriter &rewriter) const override {
+    auto scatterOp = dyn_cast<IREE::LinalgExt::ScatterOp>(*tilableOp);
+    if (scatterOp && !scatterOp.getUniqueIndices()) {
+      return rewriter.notifyMatchFailure(
+          tilableOp, "non-unique scatter indices are not consumer-fusible");
+    }
+
     // Currently consumer fusion requires DPS, and we don't want to fuse through
     // inits anyway.
     auto dpsOp = dyn_cast<DestinationStyleOpInterface>(*tilableOp);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -1628,15 +1628,18 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
     return failure();
   }
 
-  // TODO: Support non-unique indices.
-  if (!scatter.getUniqueIndices()) {
-    return failure();
-  }
-
   // Various problem parameters.
   int64_t loopDepth = scatter.getLoopIteratorTypes().size();
   int64_t elemBits = scatter.getOriginalType().getElementTypeBitWidth();
   SmallVector<int64_t> loopBounds = scatter.getStaticLoopRanges();
+  int64_t numBatch = scatter.getBatchRank();
+  bool hasUniqueIndices = scatter.getUniqueIndices();
+
+  // Duplicate indices make the batch dimensions reduction-like. Scalar scatters
+  // have no inner parallel slice dimensions to distribute safely.
+  if (!hasUniqueIndices && numBatch == loopDepth) {
+    return failure();
+  }
 
   // Configurations we need to decide.
   int64_t flatWorkgroupSize = target.getPreferredSubgroupSize();
@@ -1667,7 +1670,8 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
     // Floordiv to overestimate the required number of threads.
     int64_t residualThreads = flatWorkgroupSize / residualInnerSize;
     workgroupTileSizes.back() = residualInnerSize * vectorSize;
-    for (int64_t i = loopDepth - 2, e = 0; i >= e; --i) {
+    int64_t firstParallelDim = hasUniqueIndices ? 0 : numBatch;
+    for (int64_t i = loopDepth - 2, e = firstParallelDim; i >= e; --i) {
       if (residualThreads <= 1) {
         break;
       }
@@ -1680,7 +1684,15 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
     }
   }
 
-  int64_t numBatch = scatter.getBatchRank();
+  if (!hasUniqueIndices) {
+    // Keep the duplicate-index batch dimensions serial while still tiling the
+    // inner slice dimensions across workgroups and threads.
+    for (int64_t i = 0; i < numBatch; ++i) {
+      workgroupTileSizes[i] = 0;
+      threadTileSizes[i] = 0;
+    }
+  }
+
   // Currently bufferization will fail if the only dimension distributed to
   // workgroups is the batch dims because the workgroup level slice will fold
   // away and cause a mismatch. To work around this we ensure that at least one

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2615,19 +2615,28 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
     }
 
     if (auto scatterOp = dyn_cast<IREE::LinalgExt::ScatterOp>(op)) {
-      Value indices = scatterOp.getIndices();
-      if (!indices.getDefiningOp()) {
-        continue;
-      }
-
-      // Mark scatter's backward slices(inclusive) as to skip.
       BackwardSliceOptions options;
       options.inclusive = true;
       SetVector<Operation *> slices;
-      [[maybe_unused]] LogicalResult result =
-          getBackwardSlice(indices, &slices, options);
-      assert(result.succeeded());
-      genericToSkip.insert(slices.begin(), slices.end());
+      auto markBackwardSlice = [&](Value value) {
+        if (!value.getDefiningOp()) {
+          return;
+        }
+        slices.clear();
+        [[maybe_unused]] LogicalResult result =
+            getBackwardSlice(value, &slices, options);
+        assert(result.succeeded());
+        genericToSkip.insert(slices.begin(), slices.end());
+      };
+
+      // Mark scatter index producers as auxiliary to the scatter.
+      markBackwardSlice(scatterOp.getIndices());
+      if (!scatterOp.getUniqueIndices()) {
+        // Non-unique scatter updates are reduction-like writes into the
+        // original tensor. The scatter must be the root instead of letting an
+        // update producer capture the distribution strategy.
+        markBackwardSlice(scatterOp.getUpdates());
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -616,6 +616,45 @@ func.func @scatter_as_root_op(%arg0: tensor<4x?xi64>,
 
 // -----
 
+func.func @non_unique_scatter_as_root_op(%arg0: tensor<4x?x32xf16>,
+                                         %arg1: tensor<4x?xi64>,
+                                         %arg2: tensor<?x32xf16>)
+    -> tensor<?x32xf16> {
+  %i1 = arith.constant 1 : index
+  %0 = tensor.dim %arg0, %i1 : tensor<4x?x32xf16>
+  %1 = tensor.empty(%0) : tensor<4x?xi32>
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg1 : tensor<4x?xi64>) outs(%1 : tensor<4x?xi32>) {
+  ^bb0(%in: i64, %out: i32):
+    %3 = arith.trunci %in : i64 to i32
+    linalg.yield %3 : i32
+  } -> tensor<4x?xi32>
+  %3 = iree_linalg_ext.scatter dimension_map = [0] unique_indices(false)
+      ins(%arg0, %2 : tensor<4x?x32xf16>, tensor<4x?xi32>)
+      outs(%arg2 : tensor<?x32xf16>) {
+  ^bb0(%arg3: f16, %arg4: f16):
+    iree_linalg_ext.yield %arg3 : f16
+  } -> tensor<?x32xf16>
+  return %3 : tensor<?x32xf16>
+}
+
+// CHECK-LABEL: func.func @non_unique_scatter_as_root_op(
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64
+
+// Verify that the index producer does not get a lowering config.
+// CHECK:      linalg.generic
+// CHECK-SAME: ins(%arg1 : tensor<4x?xi64>)
+// CHECK-NOT:  lowering_config =
+
+// Verify that the non-unique scatter is the root.
+// CHECK:      iree_linalg_ext.scatter {lowering_config = #iree_gpu.lowering_config<{{.*}}thread = [0, 0, 8], workgroup = [0, 0, 16]
+// CHECK-SAME: unique_indices(false)
+
+// -----
+
 func.func @set_encoding_gpu(%0 : tensor<1234x567xi8>) -> tensor<10x9x8x4x4x4x2x8xi8> {
   %c0_i8 = arith.constant 0 : i8
   %22 = tensor.empty() : tensor<10x9x128x64xi8>


### PR DESCRIPTION
Non-unique scatter cannot be treated as an ordinary consumer of a tiled update producer. Duplicate indices make the batch dimensions reduction-like, so fusing the scatter through a forall update producer asks the scatter tiling interface for an operand-tile mapping it explicitly cannot provide.

Keep that legality boundary in the generic forall consumer-fusion pattern, and make LLVMGPU root selection treat non-unique scatter update producers as auxiliary to the scatter root. That keeps the scatter in charge of the distribution strategy instead of leaving it as a global write outside the workgroup-distributed region.

Also allow scatter lowering config for non-unique scatters that have inner parallel slice dimensions. The duplicate-index batch dimensions are left serial with zero tile sizes while the inner slice dimensions can still be tiled across workgroups and threads; scalar or fully reduction-shaped scatters fall back to the existing default path.

Add regression coverage for both the no-fusion legality boundary and the LLVMGPU root/config selection. Verified with the Common/GPU and LLVMGPU/ROCDL lit suites under ASAN, plus a local Toy Llama ROCm/gfx1100 compile repro.