### PR TITLE
[CI][TorchModels] Relax mi325 golden for flaky llama_8b_fp8 prefill_seq2048_data_tiling benchmark

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 187
+    "golden_time_ms": 192.02
 }


### PR DESCRIPTION
The revision updates the golden value to `mean (~3 months) 174.560 * 1.1 = 192.02`.

`llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json` on the mi325 runner has been failing sporadically since its golden was last tightened (`2025-12-18`, set 221.65 -> 187 in #22936). Analysis covers the 518 main-branch runs recorded from `2026-01-25` through `2026-04-24` (~3 months of data; GHA artifact retention caps the window at 90 days). The mean is stable at ~174 ms throughout -- this is noise hitting a threshold set inside the natural variance band, not a perf regression.

Aggregate distribution (518 main-branch runs):

| Benchmark | mean | p50 | p95 | max | old g. | new g. | fail% |
| -------------------------------------------------- | ------- | ------- | ------- | ------- | ------ | ------ | ----- |
| prefill_benchmark_seq2048_mi325_data_tiling.json   | 174.560 | 173.790 | 180.353 | 216.810 | 187    | 192.02 | 2.5%  |

Weekly trend (2026-W04..W17). The mean stays flat at `~171-177 ms` throughout -- no drift upward. Failures are scattered with a large spike in W12 that comes from a handful of cluster-wide anomalies on 2026-03-17..19 that affected many benchmarks (max 216.810 in that week is the tail):

| Week     | n  | mean    | p50     | p95     | max     | fail% |
| -------- | -- | ------- | ------- | ------- | ------- | ----- |
| 2026-W04 | 1  | 174.368 | 174.368 | 174.368 | 174.368 | 0.0%  |
| 2026-W05 | 44 | 175.700 | 174.273 | 184.494 | 192.362 | 4.5%  |
| 2026-W06 | 17 | 176.282 | 175.486 | 183.929 | 189.059 | 5.9%  |
| 2026-W07 | 36 | 174.015 | 173.932 | 177.992 | 183.767 | 0.0%  |
| 2026-W08 | 25 | 173.580 | 173.295 | 178.628 | 180.345 | 0.0%  |
| 2026-W09 | 7  | 173.830 | 173.730 | 176.076 | 176.725 | 0.0%  |
| 2026-W10 | 42 | 173.354 | 173.249 | 176.043 | 176.650 | 0.0%  |
| 2026-W11 | 76 | 170.936 | 170.975 | 173.696 | 176.477 | 0.0%  |
| 2026-W12 | 59 | 176.889 | 172.465 | 210.999 | 216.810 | 13.6% |
| 2026-W13 | 39 | 173.738 | 173.342 | 177.225 | 182.475 | 0.0%  |
| 2026-W14 | 41 | 174.435 | 174.524 | 178.072 | 186.751 | 0.0%  |
| 2026-W15 | 40 | 175.429 | 174.598 | 182.975 | 194.661 | 2.5%  |
| 2026-W16 | 52 | 176.275 | 175.549 | 183.435 | 200.439 | 1.9%  |
| 2026-W17 | 39 | 176.400 | 176.887 | 178.957 | 179.066 | 0.0%  |

The old golden (187) sits just above p95 of the observed distribution (p95 = 180.353) but well below the observed max (216.810), so the steady-state noise rate is ~2-6% and jumps sharply on bad-host weeks (W6: 5.9%, W12: 13.6%). The new golden (192.02 = mean * 1.1) pushes the threshold above p95 plus normal headroom, bringing the expected flake rate under the 1% target.

Assisted-by: Claude Code