### PR TITLE
[HAL][LocalTask] Add task_topology_group_count device creation parameter

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
@@ -7,7 +7,7 @@
 # Default implementations for HAL types that use the host resources.
 # These are generally just wrappers around host heap memory and host threads.
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -53,5 +53,20 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:queue_emulation",
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/task",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "task_driver_test",
+    srcs = ["task_driver_test.cc"],
+    tags = ["driver=local-task"],
+    deps = [
+        "//runtime/src/iree/async/util:proactor_pool",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/local_task/registration",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
@@ -50,4 +50,21 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    task_driver_test
+  SRCS
+    "task_driver_test.cc"
+  DEPS
+    iree::async::util::proactor_pool
+    iree::base
+    iree::base::threading
+    iree::hal
+    iree::hal::drivers::local_task::registration
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "driver=local-task"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/hal/drivers/local_task/task_driver.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_driver.c
@@ -9,6 +9,8 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "iree/task/api.h"
+
 #define IREE_HAL_TASK_DEVICE_ID_DEFAULT 0
 
 typedef struct iree_hal_task_driver_t {
@@ -143,16 +145,72 @@ static iree_status_t iree_hal_task_driver_dump_device_info(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_task_driver_parse_topology_override(
+    iree_host_size_t param_count, const iree_string_pair_t* params,
+    bool* out_has_override, iree_host_size_t* out_group_count) {
+  *out_has_override = false;
+  *out_group_count = 0;
+  for (iree_host_size_t i = 0; i < param_count; ++i) {
+    if (!iree_string_view_equal(params[i].key,
+                                IREE_SV("task_topology_group_count"))) {
+      continue;
+    }
+    uint32_t group_count = 0;
+    if (!iree_string_view_atoi_uint32(params[i].value, &group_count) ||
+        group_count == 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "device parameter task_topology_group_count must be a non-zero "
+          "unsigned integer");
+    }
+    *out_has_override = true;
+    *out_group_count = group_count;
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_task_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_host_size_t param_count, const iree_string_pair_t* params,
     const iree_hal_device_create_params_t* create_params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_task_driver_t* driver = iree_hal_task_driver_cast(base_driver);
-  return iree_hal_task_device_create(
-      driver->identifier, &driver->default_params, driver->queue_count,
-      driver->queue_executors, driver->loader_count, driver->loaders,
+  bool has_topology_override = false;
+  iree_host_size_t group_count = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_task_driver_parse_topology_override(
+      param_count, params, &has_topology_override, &group_count));
+  if (!has_topology_override) {
+    return iree_hal_task_device_create(
+        driver->identifier, &driver->default_params, driver->queue_count,
+        driver->queue_executors, driver->loader_count, driver->loaders,
+        driver->device_allocator, create_params, host_allocator, out_device);
+  }
+
+  iree_task_executor_options_t options;
+  IREE_RETURN_IF_ERROR(
+      iree_task_executor_options_initialize_from_flags(&options));
+  iree_task_topology_t topology;
+  iree_task_topology_initialize_from_group_count(group_count, &topology);
+
+  iree_task_executor_t* executor = NULL;
+  iree_status_t status =
+      iree_task_executor_create(options, &topology, host_allocator, &executor);
+  iree_task_topology_deinitialize(&topology);
+  if (!iree_status_is_ok(status)) {
+    return status;
+  }
+
+  // The device retains the executor through each per-queue retain in
+  // iree_hal_task_queue_initialize, so the post-create release here balances
+  // the create above. On failure the device's destroy path also releases any
+  // retains taken by partially-initialized queues.
+  iree_task_executor_t* executors[1] = {executor};
+  status = iree_hal_task_device_create(
+      driver->identifier, &driver->default_params, IREE_ARRAYSIZE(executors),
+      executors, driver->loader_count, driver->loaders,
       driver->device_allocator, create_params, host_allocator, out_device);
+  iree_task_executor_release(executor);
+  return status;
 }
 
 static iree_status_t iree_hal_task_driver_create_device_by_path(

--- a/runtime/src/iree/hal/drivers/local_task/task_driver_test.cc
+++ b/runtime/src/iree/hal/drivers/local_task/task_driver_test.cc
@@ -1,0 +1,199 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Local-task driver-specific tests.
+//
+// These tests live outside the cross-driver CTS suite because they exercise
+// behavior that is unique to the local-task driver: parsing the
+// task_topology_group_count creation parameter and using it to override the
+// driver's default executor topology.  hal.dispatch:concurrency is queried as
+// a black-box check that the override took effect.
+
+#include "iree/async/util/proactor_pool.h"
+#include "iree/base/api.h"
+#include "iree/base/threading/numa.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/local_task/registration/driver_module.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::local_task {
+namespace {
+
+class TaskDriverTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_status_t status = iree_hal_local_task_driver_module_register(
+        iree_hal_driver_registry_default());
+    if (iree_status_is_already_exists(status)) {
+      iree_status_ignore(status);
+      status = iree_ok_status();
+    }
+    IREE_ASSERT_OK(status);
+
+    IREE_ASSERT_OK(iree_hal_driver_registry_try_create(
+        iree_hal_driver_registry_default(), IREE_SV("local-task"),
+        iree_allocator_system(), &driver_));
+
+    IREE_ASSERT_OK(iree_async_proactor_pool_create(
+        iree_numa_node_count(), /*node_ids=*/NULL,
+        iree_async_proactor_pool_options_default(), iree_allocator_system(),
+        &proactor_pool_));
+  }
+
+  void TearDown() override {
+    iree_async_proactor_pool_release(proactor_pool_);
+    iree_hal_driver_release(driver_);
+  }
+
+  iree_hal_device_create_params_t MakeCreateParams() const {
+    iree_hal_device_create_params_t create_params =
+        iree_hal_device_create_params_default();
+    create_params.proactor_pool = proactor_pool_;
+    return create_params;
+  }
+
+  // Returns the task executor worker count for |device| as reported by the
+  // device, which equals the topology group count used to construct it.
+  static int64_t QueryDispatchConcurrency(iree_hal_device_t* device) {
+    int64_t value = 0;
+    IREE_EXPECT_OK(iree_hal_device_query_i64(device, IREE_SV("hal.dispatch"),
+                                             IREE_SV("concurrency"), &value));
+    return value;
+  }
+
+  iree_hal_driver_t* driver_ = nullptr;
+  iree_async_proactor_pool_t* proactor_pool_ = nullptr;
+};
+
+// With no creation parameters the driver returns a device backed by the
+// default queue executors and reports a non-zero worker count.
+TEST_F(TaskDriverTest, DefaultDeviceHasPositiveDispatchConcurrency) {
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  IREE_ASSERT_OK(iree_hal_driver_create_default_device(
+      driver_, &create_params, iree_allocator_system(), &device));
+
+  EXPECT_GT(QueryDispatchConcurrency(device), 0);
+
+  iree_hal_device_release(device);
+}
+
+// task_topology_group_count overrides the executor topology when creating a
+// device by id.  Parameterized over a small set of group counts to also cover
+// the single-worker degenerate case.
+class TaskDriverGroupCountTest : public TaskDriverTest,
+                                 public ::testing::WithParamInterface<int> {};
+
+TEST_P(TaskDriverGroupCountTest, ByIdRespectsGroupCountOverride) {
+  const int group_count = GetParam();
+  const std::string value = std::to_string(group_count);
+  const iree_string_pair_t params[] = {
+      {{IREE_SV("task_topology_group_count")},
+       {iree_make_string_view(value.data(), value.size())}},
+  };
+
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  IREE_ASSERT_OK(iree_hal_driver_create_device_by_id(
+      driver_, IREE_HAL_DEVICE_ID_DEFAULT, IREE_ARRAYSIZE(params), params,
+      &create_params, iree_allocator_system(), &device));
+
+  EXPECT_EQ(QueryDispatchConcurrency(device), group_count);
+
+  iree_hal_device_release(device);
+}
+
+TEST_P(TaskDriverGroupCountTest, ByPathRespectsGroupCountOverride) {
+  const int group_count = GetParam();
+  const std::string value = std::to_string(group_count);
+  const iree_string_pair_t params[] = {
+      {{IREE_SV("task_topology_group_count")},
+       {iree_make_string_view(value.data(), value.size())}},
+  };
+
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  IREE_ASSERT_OK(iree_hal_driver_create_device_by_path(
+      driver_, IREE_SV("local-task"), iree_string_view_empty(),
+      IREE_ARRAYSIZE(params), params, &create_params, iree_allocator_system(),
+      &device));
+
+  EXPECT_EQ(QueryDispatchConcurrency(device), group_count);
+
+  iree_hal_device_release(device);
+}
+
+// Mirrors the call site in callers that build a URI string and hand it to
+// iree_hal_driver_create_device_by_uri: the URI's query string must round-trip
+// through iree_uri_split_params and reach the driver's parameter parser.
+TEST_P(TaskDriverGroupCountTest, ByUriRespectsGroupCountOverride) {
+  const int group_count = GetParam();
+  const std::string uri =
+      "local-task://?task_topology_group_count=" + std::to_string(group_count);
+
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  IREE_ASSERT_OK(iree_hal_driver_create_device_by_uri(
+      driver_, iree_make_string_view(uri.data(), uri.size()), &create_params,
+      iree_allocator_system(), &device));
+
+  EXPECT_EQ(QueryDispatchConcurrency(device), group_count);
+
+  iree_hal_device_release(device);
+}
+
+INSTANTIATE_TEST_SUITE_P(GroupCounts, TaskDriverGroupCountTest,
+                         ::testing::Values(1, 2, 4));
+
+// Zero is rejected because a zero-worker executor would mean no dispatch
+// concurrency at all; if a caller wants donor-thread-only execution they must
+// not pass the parameter.
+TEST_F(TaskDriverTest, RejectsZeroGroupCount) {
+  const iree_string_pair_t params[] = {
+      {{IREE_SV("task_topology_group_count")}, {IREE_SV("0")}},
+  };
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  iree_status_t status = iree_hal_driver_create_device_by_id(
+      driver_, IREE_HAL_DEVICE_ID_DEFAULT, IREE_ARRAYSIZE(params), params,
+      &create_params, iree_allocator_system(), &device);
+  EXPECT_TRUE(iree_status_is_invalid_argument(status));
+  iree_status_ignore(status);
+  EXPECT_EQ(device, nullptr);
+}
+
+TEST_F(TaskDriverTest, RejectsNonNumericGroupCount) {
+  const iree_string_pair_t params[] = {
+      {{IREE_SV("task_topology_group_count")}, {IREE_SV("not-a-number")}},
+  };
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  iree_status_t status = iree_hal_driver_create_device_by_id(
+      driver_, IREE_HAL_DEVICE_ID_DEFAULT, IREE_ARRAYSIZE(params), params,
+      &create_params, iree_allocator_system(), &device);
+  EXPECT_TRUE(iree_status_is_invalid_argument(status));
+  iree_status_ignore(status);
+  EXPECT_EQ(device, nullptr);
+}
+
+// Unknown keys are silently ignored so that the same parameter list can be
+// passed across driver kinds.  This matches the convention used by other HAL
+// drivers (see hip_driver.c).
+TEST_F(TaskDriverTest, IgnoresUnknownParam) {
+  const iree_string_pair_t params[] = {
+      {{IREE_SV("not_a_real_local_task_param")}, {IREE_SV("anything")}},
+  };
+  iree_hal_device_create_params_t create_params = MakeCreateParams();
+  iree_hal_device_t* device = nullptr;
+  IREE_ASSERT_OK(iree_hal_driver_create_device_by_id(
+      driver_, IREE_HAL_DEVICE_ID_DEFAULT, IREE_ARRAYSIZE(params), params,
+      &create_params, iree_allocator_system(), &device));
+  iree_hal_device_release(device);
+}
+
+}  // namespace
+}  // namespace iree::hal::local_task


### PR DESCRIPTION
iree_hal_driver_create_device_by_uri parses the query string of a device URI into iree_string_pair_t parameters and forwards them to the driver through create_device_by_path. The local-task driver previously ignored those parameters and always returned a device backed by the executors built at driver-module registration time, so a URI like "local-task://?task_topology_group_count=16" silently produced a device with whatever worker count the process-wide flags had selected.

Parses task_topology_group_count in iree_hal_task_driver_create_device_by_id (reached via both create_by_id and create_by_path/create_by_uri). When present, constructs a fresh task executor with the requested group count and uses it for the new device; the default-executor path is unchanged when the parameter is absent. Zero and non-numeric values are rejected with INVALID_ARGUMENT.

Adds task_driver_test.cc covering
- iree_hal_driver_create_device_by_uri with the literal URI form callers use, asserting hal.dispatch:concurrency matches the requested count;
- the underlying create_by_id and create_by_path overrides at counts {1, 2, 4};
- the default (no-parameter) path;
- rejection of "0" and non-numeric values; and
- graceful handling of unknown parameter keys, matching the convention used by other HAL drivers (e.g. hip_driver.c).

Assisted-by: Claude Code