### PR TITLE
[Runtime/Python] Support BF16 and FP8 buffer view host conversion

### DIFF
--- a/runtime/bindings/python/numpy_interop.cc
+++ b/runtime/bindings/python/numpy_interop.cc
@@ -36,6 +36,8 @@ static const char* ConvertHalElementTypeToDtypeName(iree_hal_element_type_t t) {
       return "uint64";
     case IREE_HAL_ELEMENT_TYPE_FLOAT_16:
       return "float16";
+    case IREE_HAL_ELEMENT_TYPE_BFLOAT_16:
+      return "bfloat16";
     case IREE_HAL_ELEMENT_TYPE_FLOAT_32:
       return "float32";
     case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
@@ -44,6 +46,16 @@ static const char* ConvertHalElementTypeToDtypeName(iree_hal_element_type_t t) {
       return "complex64";
     case IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_128:
       return "complex128";
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_8_E5M2:
+      return "float8_e5m2";
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_8_E4M3_FN:
+      return "float8_e4m3fn";
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_8_E5M2_FNUZ:
+      return "float8_e5m2fnuz";
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_8_E4M3_FNUZ:
+      return "float8_e4m3fnuz";
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_8_E8M0_FNU:
+      return "float8_e8m0fnu";
     default:
       throw py::value_error("Unsupported VM Buffer -> numpy dtype mapping");
   }

--- a/runtime/bindings/python/tests/array_interop_test.py
+++ b/runtime/bindings/python/tests/array_interop_test.py
@@ -175,6 +175,40 @@ class DeviceHalTest(unittest.TestCase):
         self.assertEqual(repr(ary), "<IREE DeviceArray: shape=[3, 4], dtype=bool>")
         np.testing.assert_array_equal(ary.to_host(), init_ary)
 
+    def testBFloat16(self):
+        dtype = np.dtype("bfloat16")
+        init_ary = np.arange(12, dtype=dtype).reshape(3, 4)
+        ary = iree.runtime.asdevicearray(self.device, init_ary)
+        self.assertEqual(ary.dtype, init_ary.dtype)
+        result = ary.to_host()
+        self.assertEqual(result.dtype, init_ary.dtype)
+        np.testing.assert_array_equal(result, init_ary)
+
+    def testFloat8ElementTypes(self):
+        float8_cases = [
+            (iree.runtime.HalElementType.FLOAT_8_E5M2, "float8_e5m2"),
+            (iree.runtime.HalElementType.FLOAT_8_E4M3_FN, "float8_e4m3fn"),
+            (
+                iree.runtime.HalElementType.FLOAT_8_E5M2_FNUZ,
+                "float8_e5m2fnuz",
+            ),
+            (
+                iree.runtime.HalElementType.FLOAT_8_E4M3_FNUZ,
+                "float8_e4m3fnuz",
+            ),
+            (iree.runtime.HalElementType.FLOAT_8_E8M0_FNU, "float8_e8m0fnu"),
+        ]
+        for hal_element_type, dtype_name in float8_cases:
+            with self.subTest(dtype=dtype_name):
+                init_ary = np.arange(12, dtype=np.dtype(dtype_name)).reshape(3, 4)
+                ary = iree.runtime.asdevicearray(self.device, init_ary)
+                self.assertEqual(ary.dtype, init_ary.dtype)
+                result = ary.to_host()
+                self.assertEqual(result.dtype, init_ary.dtype)
+                np.testing.assert_array_equal(
+                    result.view(np.uint8), init_ary.view(np.uint8)
+                )
+
     def testCopyToHostImportPath(self):
         """_copy_to_host import path must preserve values on local-task."""
         init_ary = np.arange(12, dtype=np.float32).reshape(3, 4)


### PR DESCRIPTION
When running Gemma decode with BF16/FP8 output buffers, such as KV cache tensors, calling `DeviceArray.to_host()` fails because the Python runtime cannot map the HAL buffer view element type back to a NumPy dtype:

```text
ValueError: Unsupported VM Buffer -> numpy dtype mapping
```

The missing piece is the Python runtime dtype mapping used when transferring a `DeviceArray` back to host.

This PR updates the Python runtime NumPy interop path to map IREE HAL BF16/FP8 element types to their registered NumPy dtype names:

- `BFLOAT_16`
- `FLOAT_8_E5M2`
- `FLOAT_8_E4M3_FN`
- `FLOAT_8_E5M2_FNUZ`
- `FLOAT_8_E4M3_FNUZ`
- `FLOAT_8_E8M0_FNU`