### PR TITLE
[TensorExt] Fix insert_slice -> dispatch.tensor.store folder

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/BUILD.bazel
@@ -27,9 +27,11 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:ViewLikeInterface",
     ],
 )
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     MLIRSCFDialect
     MLIRTensorDialect
     MLIRTransformUtils
+    MLIRViewLikeInterface
     iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/Affine/ViewLikeInterfaceUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 namespace mlir::iree_compiler::IREE::TensorExt {
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/ViewLikeInterfaceUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 namespace mlir::iree_compiler::IREE::TensorExt {
 
@@ -57,6 +58,17 @@ struct FoldInsertSliceWithTensorStoreOp
     auto insertSliceOp =
         dispatchTensorStoreOp.getValue().getDefiningOp<tensor::InsertSliceOp>();
     if (!insertSliceOp) {
+      return failure();
+    }
+
+    // Only fold when dest is a load of the same target with matching
+    // offsets/sizes/strides; otherwise positions outside the partial insert
+    // lose passthrough.
+    auto loadOp = insertSliceOp.getDest()
+                      .getDefiningOp<IREE::TensorExt::DispatchTensorLoadOp>();
+    if (!loadOp || loadOp.getSource() != dispatchTensorStoreOp.getTarget() ||
+        !mlir::detail::sameOffsetsSizesAndStrides(loadOp, dispatchTensorStoreOp,
+                                                  isEqualConstantIntOrValue)) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -396,6 +396,70 @@ util.func public @subtensor_insert(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32
 
 // -----
 
+// Don't fold when insert_slice's dest is a load of a different target.
+util.func public @no_fold_insert_slice_with_unrelated_load(
+    %input: tensor<4x1x4xf32>, %val: tensor<?xf32>, %n: index) -> tensor<4x1xf32> {
+  %0 = flow.dispatch.workgroups(%input, %val, %n)
+      : (tensor<4x1x4xf32>, tensor<?xf32>{%n}, index) -> tensor<4x1xf32> =
+      (%arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x4xf32>>,
+       %arg1: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>,
+       %arg2: index,
+       %arg3: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x1xf32>>) {
+    %dest = iree_tensor_ext.dispatch.tensor.load %arg0,
+        offsets = [0, 0, 0], sizes = [4, 1, 1], strides = [1, 1, 1]
+        : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x1x4xf32>>
+          -> tensor<4x1xf32>
+    %loaded = iree_tensor_ext.dispatch.tensor.load %arg1,
+        offsets = [0], sizes = [%arg2], strides = [1]
+        : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%arg2}
+          -> tensor<?xf32>
+    %inserted = tensor.insert_slice %loaded into %dest[0, 0] [%arg2, 1] [1, 1]
+        : tensor<?xf32> into tensor<4x1xf32>
+    iree_tensor_ext.dispatch.tensor.store %inserted, %arg3,
+        offsets = [0, 0], sizes = [4, 1], strides = [1, 1]
+        : tensor<4x1xf32>
+          -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x1xf32>>
+    flow.return
+  }
+  util.return %0 : tensor<4x1xf32>
+}
+// CHECK-LABEL: @no_fold_insert_slice_with_unrelated_load
+//       CHECK: tensor.insert_slice
+
+// -----
+
+// Fold when dest is an identity load of the store target.
+util.func public @fold_insert_slice_with_identity_load(
+    %val: tensor<?xf32>, %n: index) -> tensor<4x1xf32> {
+  %0 = flow.dispatch.workgroups(%val, %n)
+      : (tensor<?xf32>{%n}, index) -> tensor<4x1xf32> =
+      (%arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>,
+       %arg1: index,
+       %arg2: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x1xf32>>) {
+    %dest = iree_tensor_ext.dispatch.tensor.load %arg2,
+        offsets = [0, 0], sizes = [4, 1], strides = [1, 1]
+        : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x1xf32>>
+          -> tensor<4x1xf32>
+    %loaded = iree_tensor_ext.dispatch.tensor.load %arg0,
+        offsets = [0], sizes = [%arg1], strides = [1]
+        : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%arg1}
+          -> tensor<?xf32>
+    %inserted = tensor.insert_slice %loaded into %dest[0, 0] [%arg1, 1] [1, 1]
+        : tensor<?xf32> into tensor<4x1xf32>
+    iree_tensor_ext.dispatch.tensor.store %inserted, %arg2,
+        offsets = [0, 0], sizes = [4, 1], strides = [1, 1]
+        : tensor<4x1xf32>
+          -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x1xf32>>
+    flow.return
+  }
+  util.return %0 : tensor<4x1xf32>
+}
+// CHECK-LABEL: @fold_insert_slice_with_identity_load
+//   CHECK-NOT: tensor.insert_slice
+//       CHECK: iree_tensor_ext.dispatch.tensor.store
+
+// -----
+
 util.func public @fuse_non_tiled_reduction_fill(%input1: tensor<1000xf32>, %input2: tensor<1000xf32>, %offset: tensor<f32>) -> tensor<f32> {
   %zero = arith.constant 0.0 : f32
   %init = tensor.empty() : tensor<f32>


### PR DESCRIPTION
The fold drops insert_slice's dest, so positions written by the store but not by the insert lose passthrough. Only fold when dest is a dispatch.tensor.load of the same target with matching offsets, sizes, and strides.