### PR TITLE
Bump LLVM to llvm-project@d48c8411dfe6

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1798,27 +1798,32 @@ static Value createLaneParityPredicate(OpBuilder &builder, Location loc) {
                                zero);
 }
 
-// Creates a constant sparse index vector for SMFMAC operations.
+// Creates a constant sparse index for SMFMAC operations.
 //
 // The sparse index encodes which 2 positions out of each group of 4
 // K-elements are selected for 2:4 structured sparsity. Each 4-bit
 // field within selectorBits selects positions for one K-group:
 //   0x4 (0100b) -> positions {0,1};  0xE (1110b) -> positions {2,3}.
 //
-// For 16-bit source data (f16/bf16): vector<4xi8>, 2 groups per i8.
-// For 8-bit source data (i8/f8*): vector<2xi16>, 4 groups per i16.
+// gfx942 16-bit (k=32): vector<4xi8>, 2 groups per i8.
+// gfx950 16-bit / gfx942 8-bit (k=64): vector<2xi16>, 4 groups per i16.
+// gfx950 8-bit (k=128): i32 scalar, 8 groups packed into 32 bits.
 //
-// Only the first element carries active selector bits; remaining
-// elements are padding zeros.
+// For vector types, only the first element carries active selector bits;
+// remaining elements are padding zeros.
 static Value createConstSparseIndex(OpBuilder &builder, Location loc,
-                                    VectorType sparseIndexVectorType,
+                                    Type sparseIndexType,
                                     int64_t selectorBits) {
-  Type elemTy = sparseIndexVectorType.getElementType();
-  Value zero = arith::ConstantOp::create(
-      builder, loc, builder.getZeroAttr(sparseIndexVectorType));
-  Value selector = arith::ConstantOp::create(
-      builder, loc, builder.getIntegerAttr(elemTy, selectorBits));
-  return vector::InsertOp::create(builder, loc, selector, zero, 0);
+  if (auto vecTy = dyn_cast<VectorType>(sparseIndexType)) {
+    Type elemTy = vecTy.getElementType();
+    Value zero =
+        arith::ConstantOp::create(builder, loc, builder.getZeroAttr(vecTy));
+    Value selector = arith::ConstantOp::create(
+        builder, loc, builder.getIntegerAttr(elemTy, selectorBits));
+    return vector::InsertOp::create(builder, loc, selector, zero, 0);
+  }
+  return arith::ConstantOp::create(
+      builder, loc, builder.getIntegerAttr(sparseIndexType, selectorBits));
 }
 
 // Returns the number of native intrinsics chained along K per virtual
@@ -1869,7 +1874,7 @@ int64_t VirtualMMAAttr::getIntrinsicsK() const {
 struct VDMFMAConfig {
   int64_t m, n, nativeK;
   int64_t unrollFactor;
-  VectorType sparseIndexVectorType;
+  Type sparseIndexType;
   int64_t evenSparseIndex;
   int64_t oddSparseIndex;
   int64_t aSliceWidth;
@@ -1987,9 +1992,9 @@ static LogicalResult buildVDMFMAOps(OpBuilder &builder, Location loc,
 
   Value sparseIndex = arith::SelectOp::create(
       builder, loc, isOddLane,
-      createConstSparseIndex(builder, loc, config.sparseIndexVectorType,
+      createConstSparseIndex(builder, loc, config.sparseIndexType,
                              config.oddSparseIndex),
-      createConstSparseIndex(builder, loc, config.sparseIndexVectorType,
+      createConstSparseIndex(builder, loc, config.sparseIndexType,
                              config.evenSparseIndex));
 
   Value lhs = inputs[0];
@@ -2104,7 +2109,7 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
                         /*n=*/16,
                         /*nativeK=*/32,
                         /*unrollFactor=*/getIntrinsicsK(),
-                        /*sparseIndexVectorType=*/
+                        /*sparseIndexType=*/
                         VectorType::get({4}, builder.getIntegerType(8)),
                         /*evenSparseIndex=*/0x44,
                         /*oddSparseIndex=*/0xEE,
@@ -2123,7 +2128,7 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
                         /*n=*/16,
                         /*nativeK=*/64,
                         /*unrollFactor=*/getIntrinsicsK(),
-                        /*sparseIndexVectorType=*/
+                        /*sparseIndexType=*/
                         VectorType::get({2}, builder.getIntegerType(16)),
                         /*evenSparseIndex=*/0x4444,
                         /*oddSparseIndex=*/0xEEEE,
@@ -2131,6 +2136,7 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
     return buildVDMFMAOps(builder, loc, config, inputs, outputs[0], results);
   }
   // CDNA4/gfx950 F16/BF16: wider native smfmac K=64, unroll=1.
+  // gfx950 16-bit variant requires vector<2xi16> sparse indices.
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x64x1_F16:
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x64x1_BF16: {
     if (getColMajor()) {
@@ -2140,14 +2146,18 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
                         /*n=*/16,
                         /*nativeK=*/64,
                         /*unrollFactor=*/getIntrinsicsK(),
-                        /*sparseIndexVectorType=*/
-                        VectorType::get({4}, builder.getIntegerType(8)),
-                        /*evenSparseIndex=*/0x44,
-                        /*oddSparseIndex=*/0xEE,
+                        /*sparseIndexType=*/
+                        VectorType::get({2}, builder.getIntegerType(16)),
+                        /*evenSparseIndex=*/0x4444,
+                        /*oddSparseIndex=*/0xEEEE,
                         /*aSliceWidth=*/8};
     return buildVDMFMAOps(builder, loc, config, inputs, outputs[0], results);
   }
   // CDNA4/gfx950 I8 + IEEE fp8: wider native smfmac K=128, unroll=1.
+  // gfx950 8-bit variant requires i32 sparse indices (no internal set
+  // structure; hardware ignores CBSZ/ABID and uses first set only).
+  // 8 groups of 4-bit selectors packed into 32 bits: even=0x44444444,
+  // odd=0xEEEEEEEE.
   case VirtualMMAIntrinsic::VDMFMA_I32_8x16x128x1_I8:
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x128x1_F8E5M2:
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x128x1_F8E5M2_F8E4M3FN:
@@ -2160,10 +2170,9 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
                         /*n=*/16,
                         /*nativeK=*/128,
                         /*unrollFactor=*/getIntrinsicsK(),
-                        /*sparseIndexVectorType=*/
-                        VectorType::get({2}, builder.getIntegerType(16)),
-                        /*evenSparseIndex=*/0x4444,
-                        /*oddSparseIndex=*/0xEEEE,
+                        /*sparseIndexType=*/builder.getI32Type(),
+                        /*evenSparseIndex=*/0x44444444,
+                        /*oddSparseIndex=*/static_cast<int64_t>(0xEEEEEEEE),
                         /*aSliceWidth=*/16};
     return buildVDMFMAOps(builder, loc, config, inputs, outputs[0], results);
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1813,7 +1813,7 @@ static Value createLaneParityPredicate(OpBuilder &builder, Location loc) {
 // remaining elements are padding zeros.
 static Value createConstSparseIndex(OpBuilder &builder, Location loc,
                                     Type sparseIndexType,
-                                    int64_t selectorBits) {
+                                    uint32_t selectorBits) {
   if (auto vecTy = dyn_cast<VectorType>(sparseIndexType)) {
     Type elemTy = vecTy.getElementType();
     Value zero =
@@ -1875,8 +1875,8 @@ struct VDMFMAConfig {
   int64_t m, n, nativeK;
   int64_t unrollFactor;
   Type sparseIndexType;
-  int64_t evenSparseIndex;
-  int64_t oddSparseIndex;
+  uint32_t evenSparseIndex;
+  uint32_t oddSparseIndex;
   int64_t aSliceWidth;
 };
 
@@ -2136,7 +2136,6 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
     return buildVDMFMAOps(builder, loc, config, inputs, outputs[0], results);
   }
   // CDNA4/gfx950 F16/BF16: wider native smfmac K=64, unroll=1.
-  // gfx950 16-bit variant requires vector<2xi16> sparse indices.
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x64x1_F16:
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x64x1_BF16: {
     if (getColMajor()) {
@@ -2154,10 +2153,6 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
     return buildVDMFMAOps(builder, loc, config, inputs, outputs[0], results);
   }
   // CDNA4/gfx950 I8 + IEEE fp8: wider native smfmac K=128, unroll=1.
-  // gfx950 8-bit variant requires i32 sparse indices (no internal set
-  // structure; hardware ignores CBSZ/ABID and uses first set only).
-  // 8 groups of 4-bit selectors packed into 32 bits: even=0x44444444,
-  // odd=0xEEEEEEEE.
   case VirtualMMAIntrinsic::VDMFMA_I32_8x16x128x1_I8:
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x128x1_F8E5M2:
   case VirtualMMAIntrinsic::VDMFMA_F32_8x16x128x1_F8E5M2_F8E4M3FN:
@@ -2172,7 +2167,7 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
                         /*unrollFactor=*/getIntrinsicsK(),
                         /*sparseIndexType=*/builder.getI32Type(),
                         /*evenSparseIndex=*/0x44444444,
-                        /*oddSparseIndex=*/static_cast<int64_t>(0xEEEEEEEE),
+                        /*oddSparseIndex=*/0xEEEEEEEE,
                         /*aSliceWidth=*/16};
     return buildVDMFMAOps(builder, loc, config, inputs, outputs[0], results);
   }


### PR DESCRIPTION
Carries fixes from  upstream LLVM commit ef739b97b108 ([AMDGPU] Correct gfx950 smfmac
    sparse index verifier, llvm/llvm-project#193541) tightened verification
    of amdgpu.sparse_mfma sparse index types based on m/k/element-type:
    
      - gfx942 16-bit (k=32):               vector<4xi8>
      - gfx950 16-bit / gfx942 8-bit (k=64): vector<2xi16>
      - gfx950 8-bit (k=128):               i32 (hardware ignores CBSZ/ABID)
    
    The two CDNA4 (gfx950) x1 VDMFMA lowerings were using the wrong types:
    - VDMFMA_F32_8x16x64x1_{F16,BF16}: was vector<4xi8>, now vector<2xi16>
      with selector bits 0x4444/0xEEEE (4 groups per i16 element).
    - VDMFMA_{I32,F32}_8x16x128x1_*: was vector<2xi16>, now i32 scalar
      with all 8 groups packed: 0x44444444/0xEEEEEEEE.
    
    Also generalizes VDMFMAConfig::sparseIndexType from VectorType to Type
    and updates createConstSparseIndex to handle both the vector and scalar
    i32 cases.


Carrying local patch for stablehlo because of llvm-project@1823355d06b8
- https://github.com/iree-org/stablehlo/commit/fb869da27148c08c7f24602c3007fd5832a14cf3