### PR TITLE
Fix release due to missing directory

### DIFF
--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -182,6 +182,7 @@ def build_main_dist():
         "bin",
         "lib",
         "include",
+        "share",
     ]
     dist_archive = os.path.join(
         BINDIST_DIR,


### PR DESCRIPTION
Iree-profile-render is a Python script that loads its modules from share/iree/profile/render/ at runtime. The tarball packaging in build_dist.py only included bin/, lib/, and include/ — leaving share/ out. The script lands in bin/ but its Python module support files are absent, causing ModuleNotFoundError: No module named 'render' on any invocation including --help.

Fix: Added "share" to dist_entries in build_dist.py. The next release build will include the share/iree/profile/render/ directory in the tarball and the CI validation step will pass.