### PR TITLE
[LLVMCPU] Apply binding subspan byte offsets to base pointers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/Matchers.h"
 
 static llvm::cl::opt<bool> clVerboseDebugInfo(
     "iree-codegen-llvm-verbose-debug-info",
@@ -794,6 +795,14 @@ MemRefDescriptor HALDispatchABI::loadBinding(Operation *forOp, int64_t ordinal,
   // Load the base buffer pointer in the appropriate type (f32*, etc).
   Value basePtrValue = loadBindingPtr(forOp, ordinal, builder);
 
+  // Apply the subspan byte offset to the base pointer. The memref descriptor
+  // offset below is the memref layout offset, not the HAL binding byte offset.
+  if (baseOffsetValue && !matchPattern(baseOffsetValue, m_Zero())) {
+    basePtrValue =
+        LLVM::GEPOp::create(builder, loc, basePtrValue.getType(),
+                            builder.getI8Type(), basePtrValue, baseOffsetValue);
+  }
+
   // NOTE: if we wanted to check the range was in bounds here would be the
   // place to do it.
 
@@ -817,19 +826,8 @@ MemRefDescriptor HALDispatchABI::loadBinding(Operation *forOp, int64_t ordinal,
     desc.setAlignedPtr(builder, loc, basePtrValue);
     auto llvmIndexType = typeConverter->convertType(builder.getIndexType());
     if (ShapedType::isDynamic(offset)) {
-      // The offset in the subspan is byteoffset. It is converted to element
-      // offset here. It is assumed that the byte offset is a multiple of
-      // the element type byte width.
-      int32_t elementBitWidth =
-          IREE::Util::getTypeBitWidth(memRefType.getElementType());
-      Value elementWidthVal = LLVM::ConstantOp::create(
-          builder, loc, llvmIndexType, elementBitWidth);
-      Value eight = LLVM::ConstantOp::create(builder, loc, llvmIndexType, 8);
-      Value bitOffset =
-          LLVM::MulOp::create(builder, loc, baseOffsetValue, eight);
-      Value elementOffsetVal =
-          LLVM::UDivOp::create(builder, loc, bitOffset, elementWidthVal);
-      desc.setOffset(builder, loc, elementOffsetVal);
+      desc.setOffset(builder, loc,
+                     LLVM::ConstantOp::create(builder, loc, llvmIndexType, 0));
     } else {
       desc.setConstantOffset(builder, loc, offset);
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
@@ -19,7 +19,10 @@ func.func @binding_ptrs() {
   %c128 = arith.constant 128 : index
   %memref = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%c72) : memref<?x2xf32, strided<[2, 1], offset: 18>>{%c128}
 
-  // CHECK: %[[OFFSET_PTR0:.+]] = llvm.getelementptr %[[BASE_PTR]][18]
+  // The HAL subspan byte offset is applied to the binding base pointer. The
+  // memref layout offset is then applied by the memref load lowering.
+  // CHECK: %[[BYTE_PTR:.+]] = llvm.getelementptr %[[BASE_PTR]][72] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK: %[[OFFSET_PTR0:.+]] = llvm.getelementptr %[[BYTE_PTR]][18]
   // CHECK: %[[OFFSET_D0:.+]] = llvm.mul %[[C5]], %[[C2]]
   // CHECK: %[[INDEX1:.+]] = llvm.add %[[OFFSET_D0]], %[[C1]]
   // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds|nuw %[[OFFSET_PTR0]][%[[INDEX1]]]
@@ -27,6 +30,43 @@ func.func @binding_ptrs() {
   %c1 = arith.constant 1 : index
   %c5 = arith.constant 5 : index
   %value = memref.load %memref[%c5, %c1] : memref<?x2xf32, strided<[2, 1], offset: 18>>
+
+  // CHECK: llvm.call @sink(%[[VALUE]])
+  llvm.call @sink(%value) : (f32) -> ()
+  return
+}
+llvm.func @sink(%arg0: f32) {
+  llvm.return
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK-LABEL: llvm.func @binding_ptrs_static_shape_dynamic_offset
+func.func @binding_ptrs_static_shape_dynamic_offset() {
+  // CHECK: %[[STATE:.+]] = llvm.load %arg1
+  // CHECK: %[[CONSTANT_BASEPTR:.+]] = llvm.extractvalue %[[STATE]][9]
+  // CHECK: %[[OFFSET:.+]] = llvm.load %[[CONSTANT_BASEPTR]]
+  // CHECK: %[[OFFSET_ZEXT:.+]] = llvm.zext %[[OFFSET]]
+  %offset = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+
+  // CHECK: %[[STATE1:.+]] = llvm.load %arg1
+  // CHECK: %[[BINDING_PTRS:.+]] = llvm.extractvalue %[[STATE1]][10]
+  // CHECK: %[[ARRAY_PTR:.+]] = llvm.getelementptr %[[BINDING_PTRS]][1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+  // CHECK: %[[BASE_PTR:.+]] = llvm.load %[[ARRAY_PTR]] : !llvm.ptr -> !llvm.ptr
+  %memref = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%offset) : memref<8xf32>
+
+  // Static-shape memrefs use MemRefDescriptor::fromStaticShape; the subspan
+  // byte offset must still adjust the base pointer before descriptor creation.
+  // CHECK: %[[BYTE_PTR:.+]] = llvm.getelementptr %[[BASE_PTR]][%[[OFFSET_ZEXT]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+  // CHECK: %[[OFFSET_PTR:.+]] = llvm.getelementptr inbounds|nuw %[[BYTE_PTR]][3]
+  // CHECK: %[[VALUE:.+]] = llvm.load %[[OFFSET_PTR]]
+  %c3 = arith.constant 3 : index
+  %value = memref.load %memref[%c3] : memref<8xf32>
 
   // CHECK: llvm.call @sink(%[[VALUE]])
   llvm.call @sink(%value) : (f32) -> ()
@@ -46,8 +86,6 @@ llvm.func @sink(%arg0: f32) {
 // CHECK-LABEL: llvm.func @binding_ptrs_dynamic
 func.func @binding_ptrs_dynamic() {
   // CHECK-DAG: %[[C1:.+]] = llvm.mlir.constant(1 :
-  // CHECK-DAG: %[[C8:.+]] = llvm.mlir.constant(8 :
-  // CHECK-DAG: %[[C32:.+]] = llvm.mlir.constant(32 :
   // CHECK-DAG: %[[C7:.+]] = llvm.mlir.constant(7 :
   // CHECK-DAG: %[[C5:.+]] = llvm.mlir.constant(5 :
   // CHECK-DAG: %[[C3:.+]] = llvm.mlir.constant(3 :
@@ -78,16 +116,16 @@ func.func @binding_ptrs_dynamic() {
   // CHECK: %[[BASE_PTR:.+]] = llvm.load %[[ARRAY_PTR]] : !llvm.ptr -> !llvm.ptr
   %memref = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%offset) : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>{%dim0, %dim1, %dim2}
 
-  // CHECK: %[[BASE_BIT_OFFSET:.+]] = llvm.mul %[[OFFSET_ZEXT]], %[[C8]]
-  // CHECK: %[[BASE_OFFSET:.+]] = llvm.udiv %[[BASE_BIT_OFFSET]], %[[C32]]
+  // The dynamic subspan offset is a byte offset on the binding base pointer.
+  // The dynamic memref descriptor offset is therefore zero.
+  // CHECK: %[[BYTE_PTR:.+]] = llvm.getelementptr %[[BASE_PTR]][%[[OFFSET_ZEXT]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
   // CHECK: %[[STRIDE1:.+]] = llvm.mul %[[DIM2_ZEXT]], %[[C1]]
   // CHECK: %[[STRIDE2:.+]] = llvm.mul %[[STRIDE1]], %[[DIM1_ZEXT]]
-  // CHECK: %[[OFFSET_PTR0:.+]] = llvm.getelementptr %[[BASE_PTR]][%[[BASE_OFFSET]]]
   // CHECK: %[[INDEX2:.+]] = llvm.mul %[[STRIDE2]], %[[C7]]
   // CHECK: %[[INDEX1:.+]] = llvm.mul %[[STRIDE1]], %[[C5]]
   // CHECK: %[[T1:.+]] = llvm.add %[[INDEX2]], %[[INDEX1]]
   // CHECK: %[[T2:.+]] = llvm.add %[[T1]], %[[C3]]
-  // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds|nuw %[[OFFSET_PTR0]][%[[T2]]]
+  // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds|nuw %[[BYTE_PTR]][%[[T2]]]
   // CHECK: %[[VALUE:.+]] = llvm.load %[[OFFSET_PTR1]]
   %c3 = arith.constant 3 : index
   %c5 = arith.constant 5 : index
@@ -111,9 +149,6 @@ llvm.func @sink(%arg0: f32) {
 
 // CHECK-LABEL: llvm.func @binding_ptrs_sub_byte_dynamic
 func.func @binding_ptrs_sub_byte_dynamic() {
-  // CHECK-DAG: %[[C8:.+]] = llvm.mlir.constant(8 :
-  // CHECK-DAG: %[[C4:.+]] = llvm.mlir.constant(4 :
-
   // CHECK: %[[STATE:.+]] = llvm.load %arg1
   // CHECK: %[[CONSTANT_BASEPTR:.+]] = llvm.extractvalue %[[STATE]][9]
   // CHECK: %[[OFFSET:.+]] = llvm.load %[[CONSTANT_BASEPTR]]
@@ -127,10 +162,9 @@ func.func @binding_ptrs_sub_byte_dynamic() {
   // CHECK: %[[BASE_PTR:.+]] = llvm.load %[[ARRAY_PTR]] : !llvm.ptr -> !llvm.ptr
   %memref = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%offset) : memref<?xi4, strided<[1], offset: ?>>{%dim0}
 
-  // CHECK: %[[BASE_BIT_OFFSET:.+]] = llvm.mul %[[OFFSET_ZEXT]], %[[C8]]
-  // CHECK: %[[BASE_OFFSET:.+]] = llvm.udiv %[[BASE_BIT_OFFSET]], %[[C4]]
-  // CHECK: %[[OFFSET_PTR0:.+]] = llvm.getelementptr %[[BASE_PTR]][%[[BASE_OFFSET]]]
-  // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds|nuw %[[OFFSET_PTR0]][7]
+  // The byte offset stays byte-granular even for sub-byte element types.
+  // CHECK: %[[BYTE_PTR:.+]] = llvm.getelementptr %[[BASE_PTR]][%[[OFFSET_ZEXT]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+  // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds|nuw %[[BYTE_PTR]][7]
   // CHECK: %[[VALUE:.+]] = llvm.load %[[OFFSET_PTR1]]
   %c7 = arith.constant 7 : index
   %value = memref.load %memref[%c7] : memref<?xi4, strided<[1], offset: ?>>


### PR DESCRIPTION
hal.interface.binding.subspan offsets are byte offsets into the HAL binding range. LLVMCPU lowering previously treated those offsets as memref descriptor offsets, converting bytes to element offsets for dynamic descriptors and letting static-shape descriptors bypass the offset entirely.

That was only accidentally correct when the generated dispatch used dynamic memrefs with element-aligned offsets. It broke for static-shaped descriptors produced from packed dispatch-local resources, and it could not faithfully represent byte-granular or sub-byte element addressing.

Now we apply the byte offset with an i8 GEP to the loaded binding base pointer before constructing the memref descriptor and leave the descriptor offset for the memref layout offset; dynamic descriptors that only carried the HAL subspan offset now start at zero.

This was caught once binding optimization packed things like an i32 scratch buffer and an f32 workspace/output buffer into one binding, then the kernel used stream.binding.subspan/hal.interface.binding.subspan offsets to recover each logical view. LLVMCPU lowered those logical views as if they all started at the binding base. Once the kernel did real work across those aliased/misbased views the address computations went sideways hard enough to crash instead of just producing a quiet wrong answer.

The accompanying lowering cases document the previously missing static-shape and byte-granular forms.

Note that alignment remains governed by InterfaceBindingSubspanOp::calculateAlignment(), which computes the effective alignment of the adjusted binding pointer from the binding base alignment and byte-offset alignment; producers must still align typed subspans to at least their natural element alignment.