### PR TITLE
[Stream] Preserve op affinity for tied dispatch results

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -265,6 +265,16 @@ private:
 };
 const char ValueProducerAffinityPVS::ID = 0;
 
+static bool canTieResultToExplicitOpAffinity(Operation *op) {
+  // Tied dispatch results are produced by executing work at the dispatch
+  // affinity even though they preserve the tied storage chain. Only explicit
+  // dispatch affinities are placement anchors; inferred/default op affinities
+  // can be consequences of the same tied result and must not feed back into
+  // producer placement.
+  auto dispatchOp = dyn_cast<IREE::Stream::AsyncDispatchOp>(op);
+  return dispatchOp && dispatchOp.getAffinityAttr();
+}
+
 class GlobalAffinityPVS
     : public DFX::StateWrapper<
           DFX::PotentialValuesState<IREE::Stream::AffinityAttr>,
@@ -717,12 +727,38 @@ ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
             if (!isPinned || valuePVS.isValidState()) {
               newState ^= valuePVS;
             }
+            // Tied results inherit the tied operand's placement. A dispatch
+            // with an explicit affinity also materially writes the result at
+            // that affinity, which is a real producer-placement fact. Do not
+            // use inferred/default op affinity here: it may be derived from
+            // the tied result itself and feeding it back into producer
+            // placement makes partitioning see placements that are not real
+            // anchors.
+            Operation *definingOp = result.getDefiningOp();
+            if (canTieResultToExplicitOpAffinity(definingOp)) {
+              auto affinityOp =
+                  cast<IREE::Stream::AffinityOpInterface>(definingOp);
+              auto &opPVS = solver.getElementFor<OpAffinityPVS>(
+                  *this, Position::forOperation(affinityOp),
+                  DFX::Resolution::REQUIRED);
+              LLVM_DEBUG({
+                llvm::dbgs() << "[ValueProducerAffinityPVS] value ";
+                value.printAsOperand(llvm::dbgs(), solver.getAsmState());
+                llvm::dbgs()
+                    << " affinity also using explicit tied dispatch affinity ";
+                opPVS.print(llvm::dbgs(), solver.getAsmState());
+                llvm::dbgs() << "\n";
+              });
+              if (!isPinned || opPVS.isValidState()) {
+                newState ^= opPVS;
+              }
+            }
             return WalkResult::advance();
           }
         }
 
-        // If the value is produced by the defining op then assume that the
-        // execution affinity dictates the result affinity.
+        // If the value is produced by a non-tied affinity-aware op then assume
+        // that the execution affinity dictates the result affinity.
         if (auto affinityOp =
                 dyn_cast_if_present<IREE::Stream::AffinityOpInterface>(
                     result.getDefiningOp())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -413,8 +413,14 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
     }
 
     // Sort the ops in the execution region. This is safe because we are
-    // still unaliased and SSA values imply ordering.
-    mlir::sortTopologically(block);
+    // still unaliased and SSA values imply ordering. If sorting cannot satisfy
+    // all dependencies then partitioning introduced a cycle and the outlined
+    // schedule would fail SSA dominance verification.
+    if (!mlir::sortTopologically(block)) {
+      return mlir::emitError(loc)
+             << "failed to schedule execution partitions without cyclic "
+                "dependencies";
+    }
 
     LLVM_DEBUG({
       llvm::dbgs() << "\nPartitions constructed:\n";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -67,6 +67,7 @@ iree_lit_test_suite(
             "schedule_allocation_parameters.mlir",
             "schedule_concurrency.mlir",
             "schedule_execution.mlir",
+            "schedule_execution_invalid.mlir",
             "schedule_execution_scf.mlir",
             "schedule_execution_timeline_aware.mlir",
             "specialize_dispatches.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_lit_test_suite(
     "schedule_allocation_parameters.mlir"
     "schedule_concurrency.mlir"
     "schedule_execution.mlir"
+    "schedule_execution_invalid.mlir"
     "schedule_execution_scf.mlir"
     "schedule_execution_timeline_aware.mlir"
     "specialize_dispatches.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/annotate_affinities.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/annotate_affinities.mlir
@@ -1732,6 +1732,61 @@ util.func public @stream_yield_consumer_affinity_tied(%size: index) -> !stream.r
 
 // -----
 
+// Tests that update result placement follows the tied target storage and does
+// not acquire the update op's execution affinity as a producer placement.
+
+// CHECK-LABEL: @stream_update_tied_result_affinity
+util.func public @stream_update_tied_result_affinity(%size: index) -> !stream.resource<transient> {
+  %c0 = arith.constant 0 : index
+  %target = stream.async.constant on(#hal.device.promise<@dev_a>) : !stream.resource<transient>{%size} = dense<0> : tensor<8xi32>
+  %update = stream.async.constant on(#hal.device.promise<@dev_b>) : !stream.resource<transient>{%size} = dense<1> : tensor<8xi32>
+  // CHECK: stream.async.update on(#hal.device.promise<@dev_b>)
+  // CHECK-SAME{LITERAL}: stream.affinities = [#hal.device.promise<@dev_b>]
+  // CHECK-SAME{LITERAL}: stream.affinities.operands = [[#hal.device.promise<@dev_a>], [#hal.device.promise<@dev_b>]]
+  // CHECK-SAME{LITERAL}: stream.affinities.results = [[#hal.device.promise<@dev_a>]]
+  // CHECK-SAME{LITERAL}: stream.affinities.results.usage = [[#hal.device.promise<@dev_a>]]
+  %result = stream.async.update on(#hal.device.promise<@dev_b>) %update, %target[%c0 to %size] : !stream.resource<transient>{%size} -> %target as !stream.resource<transient>{%size}
+  util.return %result : !stream.resource<transient>
+}
+
+// -----
+
+// Tests that loop-carried tied dispatch results preserve both the tied
+// operand's storage placement and the dispatch's execution placement.
+
+// CHECK-LABEL: @scf_for_tied_dispatch_result_affinity
+util.func public @scf_for_tied_dispatch_result_affinity(%size: index) -> !stream.resource<transient> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %input = stream.async.constant on(#hal.device.promise<@dev_a>) : !stream.resource<transient>{%size} = dense<0> : tensor<8xi32>
+  // CHECK: scf.for
+  %loop0 = scf.for %i = %c0 to %c2 step %c1 iter_args(%arg0 = %input) -> !stream.resource<transient> {
+    // CHECK: stream.async.dispatch on(#hal.device.promise<@dev_b>)
+    // CHECK-SAME{LITERAL}: stream.affinities = [#hal.device.promise<@dev_b>]
+    // CHECK-SAME{LITERAL}: stream.affinities.operands = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    // CHECK-SAME{LITERAL}: stream.affinities.operands.usage = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    // CHECK-SAME{LITERAL}: stream.affinities.results = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    // CHECK-SAME{LITERAL}: stream.affinities.results.usage = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    %result0 = stream.async.dispatch on(#hal.device.promise<@dev_b>) @executable::@dispatch(%arg0[%c0 to %size for %size]) : (!stream.resource<transient>{%size}) -> %arg0{%size}
+    scf.yield %result0 : !stream.resource<transient>
+  }
+  // CHECK: scf.for
+  %loop1 = scf.for %i = %c0 to %c2 step %c1 iter_args(%arg1 = %loop0) -> !stream.resource<transient> {
+    // CHECK: stream.async.dispatch on(#hal.device.promise<@dev_b>)
+    // CHECK-SAME{LITERAL}: stream.affinities = [#hal.device.promise<@dev_b>]
+    // CHECK-SAME{LITERAL}: stream.affinities.operands = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    // CHECK-SAME{LITERAL}: stream.affinities.operands.usage = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    // CHECK-SAME{LITERAL}: stream.affinities.results = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    // CHECK-SAME{LITERAL}: stream.affinities.results.usage = [[#hal.device.promise<@dev_a>, #hal.device.promise<@dev_b>]]
+    %result1 = stream.async.dispatch on(#hal.device.promise<@dev_b>) @executable::@dispatch(%arg1[%c0 to %size for %size]) : (!stream.resource<transient>{%size}) -> %arg1{%size}
+    scf.yield %result1 : !stream.resource<transient>
+  }
+  util.return %loop1 : !stream.resource<transient>
+}
+
+// -----
+
 // Tests that pinning a value will always result in a valid analysis result even
 // if we couldn't exhaustively analyze the value. Here %arg0 has producers (in
 // the callers) and consumers (in the callers after return) we don't know about

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution_invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution_invalid.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-stream-schedule-execution))" --verify-diagnostics %s
+
+// Tests that scheduling fails directly when partition outlining would produce
+// cyclic SSA dependencies. The key shape is an interleaved device-0/device-1
+// stream where a value produced by the final device-0 partition is needed by an
+// earlier device-0 partition through the device-1 side path.
+
+module @module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
+  util.global private @__device_0 : !hal.device
+  util.global private @__device_1 : !hal.device
+
+  // expected-error @+1 {{failed to schedule execution partitions without cyclic dependencies}}
+  util.func public @cyclic_partition_dependencies(
+      %input: !stream.resource<external>,
+      %constant0: !stream.resource<constant>,
+      %constant1: !stream.resource<constant>,
+      %fence: !hal.fence) -> !hal.buffer_view {
+    %timepoint = stream.timepoint.immediate => !stream.timepoint
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %to_device_1 = stream.async.transfer %input : !stream.resource<external>{%c8} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_1>) !stream.resource<transient>{%c8}
+    %base = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@base(%constant0[%c0 to %c512 for %c512], %input[%c0 to %c8 for %c8]) : (!stream.resource<constant>{%c512}, !stream.resource<external>{%c8}) -> !stream.resource<transient>{%c512}
+    %barrier0 = stream.async.barrier on(#hal.device.affinity<@__device_0>) %base : !stream.resource<transient>{%c512}
+    %barrier1 = stream.async.barrier on(#hal.device.affinity<@__device_0>) %base : !stream.resource<transient>{%c512}
+    %device_1_mid = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@device_1_mid(%to_device_1[%c0 to %c512 for %c512], %base[%c0 to %c512 for %c512]) : (!stream.resource<transient>{%c512}, !stream.resource<transient>{%c512}) -> !stream.resource<transient>{%c512}
+    %device_0_mid = stream.async.dispatch @ex::@device_0_mid(%constant1[%c0 to %c1024 for %c1024], %base[%c0 to %c1024 for %c1024], %base[%c0 to %c4 for %c4]) : (!stream.resource<constant>{%c1024}, !stream.resource<transient>{%c1024}, !stream.resource<transient>{%c4}) -> !stream.resource<transient>{%c512}
+    %barrier2 = stream.async.barrier on(#hal.device.affinity<@__device_0>) %device_0_mid : !stream.resource<transient>{%c512}
+    %from_device_1 = stream.async.transfer %device_1_mid : !stream.resource<transient>{%c512} from(#hal.device.affinity<@__device_1>) -> !stream.resource<transient>{%c512}
+    %barrier3 = stream.async.barrier on(#hal.device.affinity<@__device_0>) %from_device_1 : !stream.resource<transient>{%c512}
+    %device_0_join = stream.async.dispatch @ex::@device_0_join(%base[%c0 to %c512 for %c512], %barrier3[%c0 to %c512 for %c512]) : (!stream.resource<transient>{%c512}, !stream.resource<transient>{%c512}) -> !stream.resource<transient>{%c512}
+    %device_1_tail = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@device_1_tail(%device_1_mid[%c0 to %c512 for %c512]) : (!stream.resource<transient>{%c512}) -> !stream.resource<transient>{%c1024}
+    %device_0_tail = stream.async.dispatch @ex::@device_0_tail(%base[%c0 to %c512 for %c512], %constant1[%c0 to %c512 for %c512], %device_0_join[%c0 to %c4 for %c4]) : (!stream.resource<transient>{%c1024}, !stream.resource<constant>{%c512}, !stream.resource<transient>{%c4}) -> !stream.resource<transient>{%c256}
+    %device_1_result = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@device_1_result(%device_1_tail[%c0 to %c256 for %c256], %constant0[%c0 to %c512 for %c512]) : (!stream.resource<transient>{%c256}, !stream.resource<constant>{%c512}) -> !stream.resource<transient>{%c512}
+    %barrier4 = stream.async.barrier on(#hal.device.affinity<@__device_0>) %device_0_tail : !stream.resource<transient>{%c512}
+    %result = stream.async.dispatch @ex::@result(%device_0_tail[%c0 to %c512 for %c512], %device_1_result[%c0 to %c512 for %c512]) : (!stream.resource<transient>{%c512}, !stream.resource<transient>{%c512}) -> !stream.resource<external>{%c512}
+    stream.timepoint.chain_external %timepoint => (%fence : !hal.fence)
+    %buffer_view = stream.tensor.export %result : tensor<1x1x256xf16> in !stream.resource<external>{%c512} -> !hal.buffer_view
+    util.return %buffer_view : !hal.buffer_view
+  }
+}


### PR DESCRIPTION
Tied results inherit placement from their tied operand, but affinity-aware ops such as stream.async.dispatch also produce values under their own execution affinity. Only following the tied operand drops explicit dispatch placement from loop-carried resources and makes sequential loops depend on the backwards tied chain.

Now we include the op affinity in tied-result producer affinity while still unioning the tied operand so storage placement and multi-device propagation are preserved.

The scf.for regression exercises loop-carried tied dispatches that run on one device while reusing storage initialized on another, covering both placement facts in the resulting affinity set.