### PR TITLE
[DispatchCreation] Preserve attention K1/N unit dims

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
@@ -264,6 +265,37 @@ struct FoldUnitDimsFromExtractOp : OpRewritePattern<tensor::ExtractOp> {
 
 } // namespace
 
+template <typename AttentionOpTy>
+static SmallVector<unsigned>
+getAllowedAttentionUnitDims(AttentionOpTy attentionOp) {
+  SetVector<unsigned> allowedUnitDims;
+  allowedUnitDims.insert_range(
+      llvm::seq<unsigned>(0, attentionOp.getNumLoops()));
+  FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
+      IREE::LinalgExt::AttentionOpDetail::get(
+          attentionOp.getQueryMap(), attentionOp.getKeyMap(),
+          attentionOp.getValueMap(), attentionOp.getOutputMap());
+  if (failed(maybeOpInfo)) {
+    return {};
+  }
+
+  SmallVector<int64_t> loopRanges = attentionOp.getStaticLoopRanges();
+  llvm::SmallDenseSet<unsigned> preservedUnitDims;
+  auto preserveInnermostUnitDim = [&](ArrayRef<int64_t> dims) {
+    if (dims.empty()) {
+      return;
+    }
+    if (llvm::all_of(dims, [&](int64_t dim) { return loopRanges[dim] == 1; })) {
+      preservedUnitDims.insert(dims.back());
+    }
+  };
+  preserveInnermostUnitDim(maybeOpInfo->getK1Dims());
+  preserveInnermostUnitDim(maybeOpInfo->getNDims());
+
+  allowedUnitDims.set_subtract(preservedUnitDims);
+  return allowedUnitDims.takeVector();
+}
+
 static linalg::ControlDropUnitDims getControlDropUnitDimsOptions() {
   linalg::ControlDropUnitDims options;
   auto defaultFn = options.controlFn;
@@ -272,6 +304,12 @@ static linalg::ControlDropUnitDims getControlDropUnitDimsOptions() {
     // Ignore operations already in dispatches.
     if (!IREE::Flow::isNonNullAndOutsideDispatch(op)) {
       return SmallVector<unsigned>{};
+    }
+    if (auto attentionOp = dyn_cast<IREE::LinalgExt::AttentionOp>(op)) {
+      return getAllowedAttentionUnitDims(attentionOp);
+    }
+    if (auto attentionOp = dyn_cast<IREE::LinalgExt::OnlineAttentionOp>(op)) {
+      return getAllowedAttentionUnitDims(attentionOp);
     }
     if (isa<IREE::LinalgExt::LinalgExtOp>(op)) {
       return IREE::LinalgExt::defaultControlDropUnitDims(op);

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -224,6 +224,102 @@ util.func public @attention_mask_single_m_dim(%arg0 : tensor<32x1x128xf16>, %arg
 
 // -----
 
+util.func public @attention_preserve_unit_k1_and_n_dims(
+    %arg0: tensor<1x2x4x1xf16>,
+    %arg1: tensor<1x2x4x1xf16>,
+    %arg2: tensor<1x2x4x1xf16>,
+    %arg3: f16) -> tensor<1x2x4x1xf16> {
+  %0 = tensor.empty() : tensor<1x2x4x1xf16>
+  %1 = iree_linalg_ext.attention {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d3)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>]}
+    ins(%arg0, %arg1, %arg2, %arg3
+      : tensor<1x2x4x1xf16>, tensor<1x2x4x1xf16>, tensor<1x2x4x1xf16>, f16)
+    outs(%0 : tensor<1x2x4x1xf16>) {
+  ^bb0(%arg4: f32):
+    iree_linalg_ext.yield %arg4 : f32
+  } -> tensor<1x2x4x1xf16>
+  util.return %1 : tensor<1x2x4x1xf16>
+}
+// CHECK-LABEL: func public @attention_preserve_unit_k1_and_n_dims
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf16>
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf16>
+//  CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf16>
+//  CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]: f16
+//       CHECK:   %[[ATTN:.+]] = iree_linalg_ext.attention
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> ()>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+//  CHECK-SAME:     ins({{.+}} : tensor<2x4x1xf16>, tensor<2x4x1xf16>, tensor<2x4x1xf16>, f16)
+//  CHECK-SAME:     outs({{.+}} : tensor<2x4x1xf16>)
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ATTN]]
+//  CHECK-SAME:     tensor<2x4x1xf16> into tensor<1x2x4x1xf16>
+//       CHECK:   util.return %[[EXPAND]]
+
+// -----
+
+util.func public @online_attention_preserve_unit_k1_and_n_dims(
+    %arg0: tensor<1x2x4x1xf16>,
+    %arg1: tensor<1x2x4x1xf16>,
+    %arg2: tensor<1x2x4x1xf16>,
+    %arg3: f32,
+    %arg4: tensor<1x2x4x1xf32>,
+    %arg5: tensor<1x2x4xf32>,
+    %arg6: tensor<1x2x4xf32>) -> (tensor<1x2x4x1xf32>, tensor<1x2x4xf32>, tensor<1x2x4xf32>) {
+  %result:3 = iree_linalg_ext.online_attention {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d3)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+      affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>]}
+    ins(%arg0, %arg1, %arg2, %arg3
+      : tensor<1x2x4x1xf16>, tensor<1x2x4x1xf16>,
+        tensor<1x2x4x1xf16>, f32)
+    outs(%arg4, %arg5, %arg6
+      : tensor<1x2x4x1xf32>, tensor<1x2x4xf32>, tensor<1x2x4xf32>) {
+  ^bb0(%score: f32):
+    iree_linalg_ext.yield %score : f32
+  } -> tensor<1x2x4x1xf32>, tensor<1x2x4xf32>, tensor<1x2x4xf32>
+  util.return %result#0, %result#1, %result#2
+    : tensor<1x2x4x1xf32>, tensor<1x2x4xf32>, tensor<1x2x4xf32>
+}
+// CHECK-LABEL: func public @online_attention_preserve_unit_k1_and_n_dims
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf16>
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf16>
+//  CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf16>
+//  CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]: f32
+//  CHECK-SAME:    %[[ARG4:[a-zA-Z0-9]+]]: tensor<1x2x4x1xf32>
+//  CHECK-SAME:    %[[ARG5:[a-zA-Z0-9]+]]: tensor<1x2x4xf32>
+//  CHECK-SAME:    %[[ARG6:[a-zA-Z0-9]+]]: tensor<1x2x4xf32>
+//       CHECK:   %[[ATTN:.+]]:3 = iree_linalg_ext.online_attention
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> ()>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+//  CHECK-SAME:     ins({{.+}} : tensor<2x4x1xf16>, tensor<2x4x1xf16>, tensor<2x4x1xf16>, f32)
+//  CHECK-SAME:     outs({{.+}} : tensor<2x4x1xf32>, tensor<2x4xf32>, tensor<2x4xf32>)
+//       CHECK:   %[[EXPAND0:.+]] = tensor.expand_shape %[[ATTN]]#0
+//  CHECK-SAME:     tensor<2x4x1xf32> into tensor<1x2x4x1xf32>
+//       CHECK:   %[[EXPAND1:.+]] = tensor.expand_shape %[[ATTN]]#1
+//  CHECK-SAME:     tensor<2x4xf32> into tensor<1x2x4xf32>
+//       CHECK:   %[[EXPAND2:.+]] = tensor.expand_shape %[[ATTN]]#2
+//  CHECK-SAME:     tensor<2x4xf32> into tensor<1x2x4xf32>
+//       CHECK:   util.return %[[EXPAND0]], %[[EXPAND1]], %[[EXPAND2]]
+
+// -----
+
 util.func @collapse_of_expand_0(%arg0: tensor<?x128xf16>, %arg1: index) -> tensor<4x?x128xf16> {
   %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3, 4]] output_shape [4, %arg1, 1, 1, 128] : tensor<?x128xf16> into tensor<4x?x1x1x128xf16>
   %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x1x128xf16> into tensor<4x?x128xf16>


### PR DESCRIPTION
Adds a check to FoldUnitExtentDims to prevent fully erasing attention K1/N dimensions. This fixes a crash in the LLVMGPU lowering. Note that code gen _can_ handle erasing all M unit dims (e.g. for llama decode) but K1/N have issues.


Fixes https://github.com/iree-org/iree/issues/24213