### PR TITLE
[HAL] Propagate tensor import dims from consistent consumers

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -62,6 +62,131 @@ OpFoldResult TensorImportOp::fold(FoldAdaptor operands) {
   return {};
 }
 
+namespace {
+
+static bool isConstantValue(Value value) {
+  Attribute constantAttr;
+  return matchPattern(value, m_Constant(&constantAttr));
+}
+
+static bool tryMatchConstantValue(Value value, Attribute &constantAttr) {
+  return matchPattern(value, m_Constant(&constantAttr));
+}
+
+static Value getConstantAvailableAt(PatternRewriter &rewriter,
+                                    TensorImportOp importOp, Value value) {
+  Operation *constantOp = value.getDefiningOp();
+  assert(constantOp && "expected constant to have defining op");
+  if (constantOp->getBlock() == importOp->getBlock() &&
+      constantOp->isBeforeInBlock(importOp)) {
+    return value;
+  }
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(importOp);
+  Operation *clonedOp = rewriter.clone(*constantOp);
+  return clonedOp->getResult(0);
+}
+
+struct DimEvidence {
+  // First constant dimension value observed from shape-aware consumers.
+  Value constantValue;
+  // Constant attribute used to compare equivalent dimension values.
+  Attribute constantAttr;
+  // Whether any shape-aware consumer provided a constant dimension.
+  bool hasConstant = false;
+  // Whether any shape-aware consumer kept the dimension dynamic.
+  bool hasNonConstant = false;
+  // Whether shape-aware consumers provided different constant dimensions.
+  bool hasConflict = false;
+};
+
+struct PropagateImportDimsFromConsumers
+    : public OpRewritePattern<TensorImportOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(TensorImportOp importOp,
+                                PatternRewriter &rewriter) const override {
+    ValueRange targetDims = importOp.getTargetDims();
+    if (targetDims.empty()) {
+      return failure();
+    }
+    if (llvm::all_of(targetDims, isConstantValue)) {
+      return failure();
+    }
+
+    SmallVector<DimEvidence> evidence(targetDims.size());
+    for (OpOperand &use : importOp.getTarget().getUses()) {
+      Operation *userOp = use.getOwner();
+      if (userOp->getBlock() != importOp->getBlock()) {
+        // Region-local users may only refine the imported shape on one
+        // control-flow path. Keep the import dims unchanged unless all evidence
+        // comes from the import's block.
+        return failure();
+      }
+
+      auto shapeAwareUser = dyn_cast<IREE::Util::ShapeAwareOpInterface>(userOp);
+      if (!shapeAwareUser) {
+        continue;
+      }
+
+      ValueRange userDims =
+          shapeAwareUser.getOperandDynamicDims(use.getOperandNumber());
+      if (userDims.size() != targetDims.size()) {
+        return failure();
+      }
+
+      for (auto [index, userDim] : llvm::enumerate(userDims)) {
+        if (isConstantValue(targetDims[index])) {
+          continue;
+        }
+
+        Attribute constantAttr;
+        if (!tryMatchConstantValue(userDim, constantAttr)) {
+          evidence[index].hasNonConstant = true;
+          continue;
+        }
+
+        DimEvidence &dimEvidence = evidence[index];
+        if (!dimEvidence.hasConstant) {
+          dimEvidence.constantValue = userDim;
+          dimEvidence.constantAttr = constantAttr;
+          dimEvidence.hasConstant = true;
+        } else if (dimEvidence.constantAttr != constantAttr) {
+          dimEvidence.hasConflict = true;
+        }
+      }
+    }
+
+    bool anyResolved = false;
+    SmallVector<Value> resolvedDims(targetDims.begin(), targetDims.end());
+    for (auto [index, dimEvidence] : llvm::enumerate(evidence)) {
+      if (isConstantValue(targetDims[index]) || !dimEvidence.hasConstant ||
+          dimEvidence.hasNonConstant || dimEvidence.hasConflict) {
+        continue;
+      }
+      resolvedDims[index] =
+          getConstantAvailableAt(rewriter, importOp, dimEvidence.constantValue);
+      anyResolved = true;
+    }
+    if (!anyResolved) {
+      return failure();
+    }
+
+    rewriter.modifyOpInPlace(importOp, [&]() {
+      importOp.getTargetDimsMutable().assign(resolvedDims);
+    });
+    return success();
+  }
+};
+
+} // namespace
+
+void TensorImportOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                 MLIRContext *context) {
+  results.insert<PropagateImportDimsFromConsumers>(context);
+}
+
 OpFoldResult TensorExportOp::fold(FoldAdaptor operands) {
   if (auto importOp = getSource().getDefiningOp<TensorImportOp>()) {
     // Cannot fold through an import with byte_offset — it's a subview.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -183,6 +183,7 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
   let hasVerifier = 1;
 
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_folding.mlir
@@ -53,6 +53,77 @@ util.func public @foldTensorExportImport(%arg0: tensor<5xi32>) -> tensor<5xi32> 
 
 // -----
 
+// CHECK-LABEL: @propagateImportDimsFromConsumers
+// CHECK-SAME: (%[[BV:.+]]: !hal.buffer_view, %[[BUF:.+]]: !hal.buffer)
+util.func public @propagateImportDimsFromConsumers(%bv: !hal.buffer_view, %buf: !hal.buffer) -> tensor<?x?xf32> {
+  %d0 = hal.buffer_view.dim<%bv : !hal.buffer_view>[0] : index
+  %d1 = hal.buffer_view.dim<%bv : !hal.buffer_view>[1] : index
+  // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+  // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+  // CHECK: hal.tensor.import %[[BV]] : !hal.buffer_view -> tensor<?x?xf32>{%[[C4]], %[[C8]]}
+  %t = hal.tensor.import %bv : !hal.buffer_view -> tensor<?x?xf32>{%d0, %d1}
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %aliased = hal.tensor.alias %t : tensor<?x?xf32>{%c4, %c8} to %buf : !hal.buffer
+  util.return %aliased : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @propagateImportDimsPartial
+// CHECK-SAME: (%[[BV:.+]]: !hal.buffer_view, %[[BUF:.+]]: !hal.buffer)
+util.func public @propagateImportDimsPartial(%bv: !hal.buffer_view, %buf: !hal.buffer) -> tensor<?x?xf32> {
+  // CHECK-DAG: %[[D0:.+]] = hal.buffer_view.dim<%[[BV]] : !hal.buffer_view>[0] : index
+  // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+  %d0 = hal.buffer_view.dim<%bv : !hal.buffer_view>[0] : index
+  %d1 = hal.buffer_view.dim<%bv : !hal.buffer_view>[1] : index
+  // CHECK: hal.tensor.import %[[BV]] : !hal.buffer_view -> tensor<?x?xf32>{%[[D0]], %[[C8]]}
+  %t = hal.tensor.import %bv : !hal.buffer_view -> tensor<?x?xf32>{%d0, %d1}
+  %c8 = arith.constant 8 : index
+  %aliased = hal.tensor.alias %t : tensor<?x?xf32>{%d0, %c8} to %buf : !hal.buffer
+  util.return %aliased : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @propagateImportDimsConflictingConsumers
+// CHECK-SAME: (%[[BV:.+]]: !hal.buffer_view, %[[BUF0:.+]]: !hal.buffer, %[[BUF1:.+]]: !hal.buffer)
+util.func public @propagateImportDimsConflictingConsumers(%bv: !hal.buffer_view, %buf0: !hal.buffer, %buf1: !hal.buffer) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  // CHECK-DAG: %[[D0:.+]] = hal.buffer_view.dim<%[[BV]] : !hal.buffer_view>[0] : index
+  // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+  %d0 = hal.buffer_view.dim<%bv : !hal.buffer_view>[0] : index
+  %d1 = hal.buffer_view.dim<%bv : !hal.buffer_view>[1] : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c8 = arith.constant 8 : index
+  // CHECK: hal.tensor.import %[[BV]] : !hal.buffer_view -> tensor<?x?xf32>{%[[D0]], %[[C8]]}
+  %t = hal.tensor.import %bv : !hal.buffer_view -> tensor<?x?xf32>{%d0, %d1}
+  %aliased0 = hal.tensor.alias %t : tensor<?x?xf32>{%c4, %c8} to %buf0 : !hal.buffer
+  %aliased1 = hal.tensor.alias %t : tensor<?x?xf32>{%c5, %c8} to %buf1 : !hal.buffer
+  util.return %aliased0, %aliased1 : tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @doNotPropagateImportDimsFromNestedConsumer
+// CHECK-SAME: (%[[BV:.+]]: !hal.buffer_view, %[[BUF:.+]]: !hal.buffer, %[[COND:.+]]: i1)
+util.func public @doNotPropagateImportDimsFromNestedConsumer(%bv: !hal.buffer_view, %buf: !hal.buffer, %cond: i1) -> tensor<?xf32> {
+  // CHECK-DAG: %[[D0:.+]] = hal.buffer_view.dim<%[[BV]] : !hal.buffer_view>[0] : index
+  %d0 = hal.buffer_view.dim<%bv : !hal.buffer_view>[0] : index
+  // CHECK: hal.tensor.import %[[BV]] : !hal.buffer_view -> tensor<?xf32>{%[[D0]]}
+  %t = hal.tensor.import %bv : !hal.buffer_view -> tensor<?xf32>{%d0}
+  %r = scf.if %cond -> tensor<?xf32> {
+    %c4 = arith.constant 4 : index
+    %aliased = hal.tensor.alias %t : tensor<?xf32>{%c4} to %buf : !hal.buffer
+    scf.yield %aliased : tensor<?xf32>
+  } else {
+    scf.yield %t : tensor<?xf32>
+  }
+  util.return %r : tensor<?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @FoldConsecutiveTransientsSameStorage
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<4xf32>, %[[STORAGE:.+]]: !hal.buffer)
 util.func public @FoldConsecutiveTransientsSameStorage(%arg0: tensor<4xf32>, %storage: !hal.buffer) -> tensor<4xf32> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         # keep sorted
         [
             "abi_ops.mlir",
+            "import_dims.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "abi_ops.mlir"
+    "import_dims.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/import_dims.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/import_dims.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt --split-input-file --canonicalize --iree-stream-conversion --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @importBufferViewWithConsumerDims
+// CHECK-SAME: (%[[VIEW:.+]]: !hal.buffer_view, %[[STORAGE:.+]]: !hal.buffer)
+// CHECK-SAME: -> (!stream.resource<*>, index)
+util.func public @importBufferViewWithConsumerDims(%view: !hal.buffer_view, %storage: !hal.buffer) -> tensor<?x?xf32> {
+  %dim0 = hal.buffer_view.dim<%view : !hal.buffer_view>[0] : index
+  %dim1 = hal.buffer_view.dim<%view : !hal.buffer_view>[1] : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
+  // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+  // CHECK-DAG: %[[IMPORT_SIZE:.+]] = stream.tensor.sizeof tensor<?x?xf32>{%[[C4]], %[[C8]]} : index
+  // CHECK: %[[RESOURCE:.+]] = stream.tensor.import %[[VIEW]]
+  // CHECK-SAME: tensor<?x?xf32>{%[[C4]], %[[C8]]} in !stream.resource<external>{%[[IMPORT_SIZE]]}
+  // CHECK: stream.async.clone %[[RESOURCE]]
+  %imported = hal.tensor.import %view : !hal.buffer_view -> tensor<?x?xf32>{%dim0, %dim1}
+  %aliased = hal.tensor.alias %imported : tensor<?x?xf32>{%c4, %c8} to %storage : !hal.buffer
+  // CHECK: util.return
+  util.return %aliased : tensor<?x?xf32>
+}


### PR DESCRIPTION
hal.tensor.import from a buffer view can start with target_dims derived from hal.buffer_view.dim even when direct shape-aware consumers later expose stricter constant dimensions for the same tensor value. HAL-to-Stream uses the import target_dims for buffer-view shape assertions and stream.tensor.sizeof, so leaving these operands dynamic keeps otherwise fixed-size resources opaque to downstream reuse and memoization analysis.

Add a conservative canonicalizer that replaces dynamic import dims with constants only when direct same-block shape-aware consumers provide unambiguous per-dimension evidence. Region-local evidence is ignored because it may only hold on one control-flow path, and the import is left unchanged if any shape-aware consumer reports a mismatched dynamic-dim space. Conflicting constants or nonconstant evidence keep the affected dimension dynamic while still allowing independent agreed dimensions to resolve.