### PR TITLE
[Codegen] Support pack/unpack/linalg generic transpose in CombineLayoutTransformation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -46,8 +46,8 @@ using IREE::LinalgExt::MapStoreOp;
 static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
                                        FunctionOpInterface funcOp) {
   OpBuilder::InsertionGuard g(rewriter);
-  SmallVector<linalg::PackOp> packOps(
-      funcOp.getFunctionBody().getOps<linalg::PackOp>());
+  SmallVector<linalg::PackOp> packOps;
+  funcOp.walk([&](linalg::PackOp op) { packOps.push_back(op); });
   for (auto packOp : packOps) {
     rewriter.setInsertionPoint(packOp);
     FailureOr<linalg::LowerPackResult> result = linalg::lowerPack(
@@ -63,15 +63,15 @@ static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
       rewriter.replaceOp(result->padOp, result->padOp.getSource());
     }
   }
-  SmallVector<linalg::UnPackOp> unPackOps(
-      funcOp.getFunctionBody().getOps<linalg::UnPackOp>());
+  SmallVector<linalg::UnPackOp> unPackOps;
+  funcOp.walk([&](linalg::UnPackOp op) { unPackOps.push_back(op); });
   for (auto unPackOp : unPackOps) {
     rewriter.setInsertionPoint(unPackOp);
     (void)linalg::lowerUnPack(rewriter, unPackOp,
                               /*lowerUnpadLikeWithExtractSlice=*/false);
   }
-  SmallVector<linalg::GenericOp> genericOps(
-      funcOp.getFunctionBody().getOps<linalg::GenericOp>());
+  SmallVector<linalg::GenericOp> genericOps;
+  funcOp.walk([&](linalg::GenericOp op) { genericOps.push_back(op); });
   for (auto genericOp : genericOps) {
     if (linalg::isaTransposeOpInterface(genericOp)) {
       rewriter.setInsertionPoint(genericOp);

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -46,8 +46,8 @@ using IREE::LinalgExt::MapStoreOp;
 static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
                                        FunctionOpInterface funcOp) {
   OpBuilder::InsertionGuard g(rewriter);
-  SmallVector<linalg::PackOp> packOps;
-  funcOp.walk([&](linalg::PackOp op) { packOps.push_back(op); });
+  SmallVector<linalg::PackOp> packOps(
+      funcOp.getFunctionBody().getOps<linalg::PackOp>());
   for (auto packOp : packOps) {
     rewriter.setInsertionPoint(packOp);
     FailureOr<linalg::LowerPackResult> result = linalg::lowerPack(
@@ -63,15 +63,15 @@ static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
       rewriter.replaceOp(result->padOp, result->padOp.getSource());
     }
   }
-  SmallVector<linalg::UnPackOp> unPackOps;
-  funcOp.walk([&](linalg::UnPackOp op) { unPackOps.push_back(op); });
+  SmallVector<linalg::UnPackOp> unPackOps(
+      funcOp.getFunctionBody().getOps<linalg::UnPackOp>());
   for (auto unPackOp : unPackOps) {
     rewriter.setInsertionPoint(unPackOp);
     (void)linalg::lowerUnPack(rewriter, unPackOp,
                               /*lowerUnpadLikeWithExtractSlice=*/false);
   }
-  SmallVector<linalg::GenericOp> genericOps;
-  funcOp.walk([&](linalg::GenericOp op) { genericOps.push_back(op); });
+  SmallVector<linalg::GenericOp> genericOps(
+      funcOp.getFunctionBody().getOps<linalg::GenericOp>());
   for (auto genericOp : genericOps) {
     if (linalg::isaTransposeOpInterface(genericOp)) {
       rewriter.setInsertionPoint(genericOp);
@@ -1306,6 +1306,26 @@ struct CombineSourceLayoutTransformationPass final
     // ops like unpack into simpler supported ops.
     IRRewriter rewriter(context);
     simplifyComplexRelayoutOps(rewriter, funcOp);
+
+    // Raise transpose generics in nested regions (e.g., inside scf.for
+    // from promotion tiling). simplifyComplexRelayoutOps only walks
+    // top-level ops via Region::getOps, missing ops inside loop bodies.
+    // When a transpose generic is not raised, collectRelayoutChain stops
+    // early, causing spurious map_load creation that produces scalar
+    // memref.store ops. This deep walk is only needed in the source
+    // pass; the result pass should not raise nested generics as it can
+    // change downstream vectorization decisions on other backends.
+    {
+      OpBuilder::InsertionGuard g(rewriter);
+      SmallVector<linalg::GenericOp> nestedGenerics;
+      funcOp.walk([&](linalg::GenericOp op) { nestedGenerics.push_back(op); });
+      for (auto genericOp : nestedGenerics) {
+        if (linalg::isaTransposeOpInterface(genericOp)) {
+          rewriter.setInsertionPoint(genericOp);
+          (void)linalg::specializeGenericOp(rewriter, genericOp);
+        }
+      }
+    }
 
     // Insert identity map_load ops after load_from_buffer ops and fold
     // consumer relayout ops into them.

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -97,6 +98,27 @@ static MapStoreOp foldIdentityLikeOpIntoMapStore(RewriterBase &rewriter,
   return mapStoreOp;
 }
 
+/// Fold a transpose (given by `perm`) producer into a consumer `mapStoreOp`.
+/// The `producerInput` is the tensor that feeds the transpose, and
+/// `producerResult` is the transpose output (== mapStoreOp input).
+static MapStoreOp foldTransposePermIntoMapStore(RewriterBase &rewriter,
+                                                ArrayRef<int64_t> perm,
+                                                Value producerInput,
+                                                MapStoreOp mapStoreOp) {
+  SmallVector<int64_t> permCopy(perm);
+  rewriter.modifyOpInPlace(mapStoreOp, [&]() {
+    mapStoreOp.insertTransformationAtStart(
+        rewriter,
+        [permCopy](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
+          SmallVector<Value> indexValues(indices.begin(), indices.end());
+          return applyPermutation(indexValues, permCopy);
+        },
+        permCopy.size());
+    mapStoreOp.getInputMutable().assign(producerInput);
+  });
+  return mapStoreOp;
+}
+
 /// Fold a `transposeOp` into a consumer `mapStoreOp`, by transposing the
 /// uses of the `mapStoreOp`s transformation_region block arguments.
 static MapStoreOp foldTransposeIntoMapStore(RewriterBase &rewriter,
@@ -104,19 +126,8 @@ static MapStoreOp foldTransposeIntoMapStore(RewriterBase &rewriter,
                                             MapStoreOp mapStoreOp) {
   assert(mapStoreOp.getInput() == transposeOp->getResult(0) &&
          "expected transposeOp to be the producer of mapStoreOp");
-
-  SmallVector<int64_t> perm(transposeOp.getPermutation());
-  rewriter.modifyOpInPlace(mapStoreOp, [&]() {
-    mapStoreOp.insertTransformationAtStart(
-        rewriter,
-        [perm](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
-          SmallVector<Value> indexValues(indices.begin(), indices.end());
-          return applyPermutation(indexValues, perm);
-        },
-        perm.size());
-    mapStoreOp.getInputMutable().assign(transposeOp.getInput());
-  });
-  return mapStoreOp;
+  return foldTransposePermIntoMapStore(rewriter, transposeOp.getPermutation(),
+                                       transposeOp.getInput(), mapStoreOp);
 }
 
 /// Fold a tensor::ExpandShapeOp or tensor::CollapseShapeOp into a consumer
@@ -496,6 +507,138 @@ foldPadIntoMapStore(RewriterBase &rewriter, tensor::PadOp padOp,
   return mapStoreOp;
 }
 
+/// Given an expanded (strip-mined) shape and reassociation indices, compute the
+/// collapsed shape by multiplying sizes within each reassociation group.
+static SmallVector<int64_t>
+computeCollapsedShape(ArrayRef<int64_t> expandedShape,
+                      ArrayRef<ReassociationIndices> reassociations) {
+  SmallVector<int64_t> collapsedShape(reassociations.size(), 1);
+  for (auto [collapsedIdx, group] : llvm::enumerate(reassociations)) {
+    for (int64_t expandedIdx : group) {
+      collapsedShape[collapsedIdx] *= expandedShape[expandedIdx];
+    }
+  }
+  return collapsedShape;
+}
+
+/// Fold a `packOp` producer into a consumer `mapStoreOp`.
+/// A pack is: pad + expand_shape + transpose.
+/// For producer folding into map_store, we apply the FORWARD transforms
+/// (source indices -> packed indices) at the start of the transformation
+/// region. The map_store input is rewired to the pack's source.
+static FailureOr<MapStoreOp> foldPackIntoMapStore(RewriterBase &rewriter,
+                                                  linalg::PackOp packOp,
+                                                  MapStoreOp mapStoreOp) {
+  assert(mapStoreOp.getInput() == packOp->getResult(0) &&
+         "expected packOp to be the producer of mapStoreOp");
+  if (llvm::any_of(packOp.getStaticInnerTiles(), ShapedType::isDynamic)) {
+    return rewriter.notifyMatchFailure(packOp,
+                                       "dynamic inner tiles not supported");
+  }
+
+  PackingMetadata packingMetadata;
+  SmallVector<int64_t> packedToExpandedPerm =
+      linalg::getPackInverseDestPerm(packOp, packingMetadata);
+  // Invert permutation for consumer folding.
+  SmallVector<int64_t> expandedToPackedPerm =
+      invertPermutationVector(packedToExpandedPerm);
+
+  MLIRContext *ctx = rewriter.getContext();
+
+  auto packedType = cast<RankedTensorType>(packOp.getResult().getType());
+  SmallVector<int64_t> expandedShape(packedType.getShape());
+  applyPermutationToVector(expandedShape, packedToExpandedPerm);
+  SmallVector<OpFoldResult> expandedDims =
+      getAsIndexOpFoldResult(ctx, expandedShape);
+
+  SmallVector<int64_t> collapsedShape =
+      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
+  SmallVector<OpFoldResult> collapsedDims =
+      getAsIndexOpFoldResult(ctx, collapsedShape);
+
+  Location loc = packOp->getLoc();
+  rewriter.modifyOpInPlace(mapStoreOp, [&]() {
+    mapStoreOp.insertTransformationAtStart(
+        rewriter,
+        [&rewriter, loc, collapsedDims, expandedDims, expandedToPackedPerm](
+            ArrayRef<BlockArgument> sourceIndices) -> SmallVector<Value> {
+          SmallVector<Value> indexValues(sourceIndices.begin(),
+                                         sourceIndices.end());
+          auto linearizeOp = affine::AffineLinearizeIndexOp::create(
+              rewriter, loc, indexValues, collapsedDims, /*disjoint=*/true);
+          auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
+              rewriter, loc, linearizeOp.getResult(), expandedDims,
+              /*hasOuterBound=*/true);
+          SmallVector<Value> expandedIndices(delinearizeOp->getResults());
+          return applyPermutation(expandedIndices, expandedToPackedPerm);
+        },
+        collapsedDims.size());
+    mapStoreOp.getInputMutable().assign(packOp.getSource());
+  });
+  return mapStoreOp;
+}
+
+/// Fold an `unPackOp` producer into a consumer `mapStoreOp`.
+/// An unpack is: transpose + collapse_shape + extract_slice + copy.
+/// For producer folding, we apply: inverse transpose + expand (delinearize).
+static FailureOr<MapStoreOp> foldUnPackIntoMapStore(RewriterBase &rewriter,
+                                                    linalg::UnPackOp unPackOp,
+                                                    MapStoreOp mapStoreOp) {
+  assert(mapStoreOp.getInput() == unPackOp->getResult(0) &&
+         "expected unPackOp to be the producer of mapStoreOp");
+
+  PackingMetadata packingMetadata;
+  SmallVector<int64_t> packedToExpandedPerm =
+      linalg::getUnPackInverseSrcPerm(unPackOp, packingMetadata);
+
+  MLIRContext *ctx = rewriter.getContext();
+
+  auto packedType = cast<RankedTensorType>(unPackOp.getSourceType());
+  SmallVector<int64_t> expandedShape(packedType.getShape());
+  applyPermutationToVector(expandedShape, packedToExpandedPerm);
+  SmallVector<OpFoldResult> expandedDims =
+      getAsIndexOpFoldResult(ctx, expandedShape);
+
+  SmallVector<int64_t> collapsedShape =
+      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
+  SmallVector<OpFoldResult> collapsedDims =
+      getAsIndexOpFoldResult(ctx, collapsedShape);
+
+  Location loc = unPackOp->getLoc();
+  rewriter.modifyOpInPlace(mapStoreOp, [&]() {
+    mapStoreOp.insertTransformationAtStart(
+        rewriter,
+        [&rewriter, loc, packedToExpandedPerm, expandedDims, collapsedDims](
+            ArrayRef<BlockArgument> packedIndices) -> SmallVector<Value> {
+          SmallVector<Value> indexValues(packedIndices.begin(),
+                                         packedIndices.end());
+          SmallVector<Value> expandedIndices =
+              applyPermutation(indexValues, packedToExpandedPerm);
+          auto linearizeOp = affine::AffineLinearizeIndexOp::create(
+              rewriter, loc, expandedIndices, expandedDims,
+              /*disjoint=*/true);
+          auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
+              rewriter, loc, linearizeOp.getResult(), collapsedDims,
+              /*hasOuterBound=*/true);
+          return delinearizeOp->getResults();
+        },
+        expandedDims.size());
+    mapStoreOp.getInputMutable().assign(unPackOp.getSource());
+  });
+  return mapStoreOp;
+}
+
+/// Fold a transpose-like `genericOp` producer into a consumer `mapStoreOp`.
+/// Same as foldTransposeIntoMapStore but extracts perm from indexing maps.
+static FailureOr<MapStoreOp> foldTransposeGenericIntoMapStore(
+    RewriterBase &rewriter, linalg::GenericOp genericOp, ArrayRef<int64_t> perm,
+    MapStoreOp mapStoreOp) {
+  assert(mapStoreOp.getInput() == genericOp->getResult(0) &&
+         "expected genericOp to be the producer of mapStoreOp");
+  return foldTransposePermIntoMapStore(rewriter, perm,
+                                       genericOp.getDpsInputs()[0], mapStoreOp);
+}
+
 FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
                                        MapStoreOp mapStoreOp) {
   return llvm::TypeSwitch<Operation *, FailureOr<MapStoreOp>>(op)
@@ -514,6 +657,19 @@ FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
       .Case([&](tensor::ExtractSliceOp extractSliceOp) {
         return foldExtractSliceIntoMapStore(rewriter, extractSliceOp,
                                             mapStoreOp);
+      })
+      .Case([&](linalg::PackOp packOp) {
+        return foldPackIntoMapStore(rewriter, packOp, mapStoreOp);
+      })
+      .Case([&](linalg::UnPackOp unPackOp) {
+        return foldUnPackIntoMapStore(rewriter, unPackOp, mapStoreOp);
+      })
+      .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
+        if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
+          return foldTransposeGenericIntoMapStore(rewriter, genericOp, *perm,
+                                                  mapStoreOp);
+        }
+        return FailureOr<MapStoreOp>(failure());
       })
       .Default(failure());
 }
@@ -542,9 +698,13 @@ static MapStoreOp insertIdentityMapStore(RewriterBase &rewriter,
 }
 
 bool isSupportedSingleInputRelayoutOpForResult(Operation *op) {
-  return isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
-             tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
-             linalg::TransposeOp>(op);
+  if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
+          tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
+          linalg::TransposeOp, linalg::PackOp, linalg::UnPackOp>(op)) {
+    return true;
+  }
+  auto genericOp = dyn_cast<linalg::GenericOp>(op);
+  return genericOp && linalg::isaTransposeOpInterface(genericOp).has_value();
 }
 
 bool isSupportedSingleInputRelayoutOpForSource(Operation *op) {
@@ -989,24 +1149,30 @@ foldIdentityLikeOpIntoMapLoad(RewriterBase &rewriter, Operation *op,
   return mapLoadOp;
 }
 
+/// Fold a transpose (given by `perm`) consumer into a producer `mapLoadOp`.
+/// For consumer folding, we apply the INVERSE permutation (output indices →
+/// input indices). `consumerOp` is the op being folded (used for replacement).
+static FailureOr<MapLoadOp> foldTransposePermIntoMapLoad(RewriterBase &rewriter,
+                                                         Operation *consumerOp,
+                                                         ArrayRef<int64_t> perm,
+                                                         MapLoadOp mapLoadOp) {
+  SmallVector<int64_t> inversePerm = invertPermutationVector(perm);
+  return foldConsumerIntoMapLoadImpl(
+      rewriter, consumerOp, mapLoadOp,
+      [inversePerm](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
+        SmallVector<Value> indexValues(indices.begin(), indices.end());
+        return applyPermutation(indexValues, inversePerm);
+      });
+}
+
 /// Fold a consumer `transposeOp` into a producer `mapLoadOp`.
-/// For consumer folding, we apply the INVERSE permutation.
-/// Example: perm=[1,2,0] means output[i,j,k] = input[k,i,j] (inverse=[2,0,1]).
 static FailureOr<MapLoadOp>
 foldTransposeIntoMapLoad(RewriterBase &rewriter,
                          linalg::TransposeOp transposeOp, MapLoadOp mapLoadOp) {
   assert(transposeOp.getInput() == mapLoadOp.getResult(0) &&
          "expected mapLoadOp to be the producer of transposeOp input");
-
-  SmallVector<int64_t> inversePerm =
-      invertPermutationVector(transposeOp.getPermutation());
-
-  return foldConsumerIntoMapLoadImpl(
-      rewriter, transposeOp, mapLoadOp,
-      [inversePerm](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
-        SmallVector<Value> indexValues(indices.begin(), indices.end());
-        return applyPermutation(indexValues, inversePerm);
-      });
+  return foldTransposePermIntoMapLoad(rewriter, transposeOp,
+                                      transposeOp.getPermutation(), mapLoadOp);
 }
 
 /// Fold a consumer reshape op (expand_shape or collapse_shape) into a producer
@@ -1174,6 +1340,134 @@ static FailureOr<MapLoadOp> foldPadIntoMapLoad(RewriterBase &rewriter,
                                      indexTransformBuilder, padValue);
 }
 
+/// Fold a consumer `packOp` into a producer `mapLoadOp`.
+/// A pack is semantically: pad + expand_shape + transpose.
+/// Index transformation (inverse order, output -> source):
+///   1. Inverse transpose (undo packed permutation)
+///   2. Linearize + delinearize (undo expand_shape via reassociations)
+///   3. Subtract low pad offsets (always zero for pack)
+/// Fill value is set to the pack's padding value.
+static FailureOr<MapLoadOp> foldPackIntoMapLoad(RewriterBase &rewriter,
+                                                linalg::PackOp packOp,
+                                                MapLoadOp mapLoadOp) {
+  assert(packOp.getSource() == mapLoadOp.getResult(0) &&
+         "expected mapLoadOp to be the producer of packOp source");
+  if (llvm::any_of(packOp.getStaticInnerTiles(), ShapedType::isDynamic)) {
+    return rewriter.notifyMatchFailure(packOp,
+                                       "dynamic inner tiles not supported");
+  }
+
+  // Compute the permutation and metadata that lowerPack would use.
+  PackingMetadata packingMetadata;
+  SmallVector<int64_t> packedToExpandedPerm =
+      linalg::getPackInverseDestPerm(packOp, packingMetadata);
+
+  MLIRContext *ctx = rewriter.getContext();
+
+  auto packedType = cast<RankedTensorType>(packOp.getResult().getType());
+  SmallVector<int64_t> expandedShape(packedType.getShape());
+  applyPermutationToVector(expandedShape, packedToExpandedPerm);
+  SmallVector<OpFoldResult> expandedDims =
+      getAsIndexOpFoldResult(ctx, expandedShape);
+
+  SmallVector<int64_t> collapsedShape =
+      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
+  SmallVector<OpFoldResult> collapsedDims =
+      getAsIndexOpFoldResult(ctx, collapsedShape);
+
+  Value mapLoadPad = mapLoadOp.getPaddingValue();
+  Value packPad = packOp.getPaddingValue();
+  Value fillValue = packPad ? packPad : mapLoadPad;
+  if (!mapLoadPad.getDefiningOp<ub::PoisonOp>() && mapLoadPad != fillValue) {
+    return rewriter.notifyMatchFailure(
+        packOp, "map_load already has a non-poison padding value and it is "
+                "different from the pack padding value; folding "
+                "another pad would overwrite it");
+  }
+
+  Location loc = packOp->getLoc();
+  auto indexTransformBuilder =
+      [&rewriter, loc, packedToExpandedPerm, expandedDims, collapsedDims](
+          ArrayRef<BlockArgument> packedIndices) -> SmallVector<Value> {
+    SmallVector<Value> indexValues(packedIndices.begin(), packedIndices.end());
+    SmallVector<Value> expandedIndices =
+        applyPermutation(indexValues, packedToExpandedPerm);
+    auto linearizeOp = affine::AffineLinearizeIndexOp::create(
+        rewriter, loc, expandedIndices, expandedDims,
+        /*disjoint=*/true);
+    auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
+        rewriter, loc, linearizeOp.getResult(), collapsedDims,
+        /*hasOuterBound=*/true);
+    return delinearizeOp->getResults();
+  };
+
+  return foldConsumerIntoMapLoadImpl(rewriter, packOp, mapLoadOp,
+                                     indexTransformBuilder, fillValue);
+}
+
+/// Fold a consumer `unPackOp` into a producer `mapLoadOp`.
+/// An unpack is semantically: transpose + collapse_shape + extract_slice +
+/// copy. Index transformation (inverse order, output -> source):
+///   1. Delinearize (undo collapse_shape)
+///   2. Transpose (undo the packed permutation)
+/// No fill value needed.
+static FailureOr<MapLoadOp> foldUnPackIntoMapLoad(RewriterBase &rewriter,
+                                                  linalg::UnPackOp unPackOp,
+                                                  MapLoadOp mapLoadOp) {
+  assert(unPackOp.getSource() == mapLoadOp.getResult(0) &&
+         "expected mapLoadOp to be the producer of unPackOp source");
+
+  PackingMetadata packingMetadata;
+  SmallVector<int64_t> packedToExpandedPerm =
+      linalg::getUnPackInverseSrcPerm(unPackOp, packingMetadata);
+
+  MLIRContext *ctx = rewriter.getContext();
+
+  auto packedType = cast<RankedTensorType>(unPackOp.getSourceType());
+  SmallVector<int64_t> expandedShape(packedType.getShape());
+  applyPermutationToVector(expandedShape, packedToExpandedPerm);
+  SmallVector<OpFoldResult> expandedDims =
+      getAsIndexOpFoldResult(ctx, expandedShape);
+
+  SmallVector<int64_t> collapsedShape =
+      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
+  SmallVector<OpFoldResult> collapsedDims =
+      getAsIndexOpFoldResult(ctx, collapsedShape);
+
+  // To undo the unpack transpose (consumer fold), we apply the inverse perm.
+  SmallVector<int64_t> expandedToPackedPerm =
+      invertPermutationVector(packedToExpandedPerm);
+
+  Location loc = unPackOp->getLoc();
+  auto indexTransformBuilder =
+      [&rewriter, loc, collapsedDims, expandedDims, expandedToPackedPerm](
+          ArrayRef<BlockArgument> destIndices) -> SmallVector<Value> {
+    SmallVector<Value> indexValues(destIndices.begin(), destIndices.end());
+    auto linearizeOp = affine::AffineLinearizeIndexOp::create(
+        rewriter, loc, indexValues, collapsedDims, /*disjoint=*/true);
+    auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
+        rewriter, loc, linearizeOp.getResult(), expandedDims,
+        /*hasOuterBound=*/true);
+    SmallVector<Value> expandedIndices(delinearizeOp->getResults());
+    return applyPermutation(expandedIndices, expandedToPackedPerm);
+  };
+
+  return foldConsumerIntoMapLoadImpl(rewriter, unPackOp, mapLoadOp,
+                                     indexTransformBuilder);
+}
+
+/// Fold a consumer transpose-like `genericOp` into a producer `mapLoadOp`.
+/// Same as foldTransposeIntoMapLoad but extracts the permutation from the
+/// generic's indexing maps via isaTransposeOpInterface.
+static FailureOr<MapLoadOp>
+foldTransposeGenericIntoMapLoad(RewriterBase &rewriter,
+                                linalg::GenericOp genericOp,
+                                ArrayRef<int64_t> perm, MapLoadOp mapLoadOp) {
+  assert(genericOp->getOperand(0) == mapLoadOp.getResult(0) &&
+         "expected mapLoadOp to be the producer of genericOp input");
+  return foldTransposePermIntoMapLoad(rewriter, genericOp, perm, mapLoadOp);
+}
+
 /// Fold a consumer relayout op into a producer map_load.
 FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
                                      MapLoadOp mapLoadOp) {
@@ -1195,6 +1489,24 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
       })
       .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
         return foldPadIntoMapLoad(rewriter, padOp, mapLoadOp);
+      })
+      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
+        return foldPackIntoMapLoad(rewriter, packOp, mapLoadOp);
+      })
+      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unPackOp) {
+        return foldUnPackIntoMapLoad(rewriter, unPackOp, mapLoadOp);
+      })
+      .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
+        if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
+          return foldTransposeGenericIntoMapLoad(rewriter, genericOp, *perm,
+                                                 mapLoadOp);
+        }
+        if (linalg::isaBroadcastOpInterface(genericOp)) {
+          return foldBroadcastIntoMapLoad(
+              rewriter, cast<linalg::LinalgOp>(genericOp.getOperation()),
+              mapLoadOp);
+        }
+        return FailureOr<MapLoadOp>(failure());
       })
       .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
         return foldBroadcastIntoMapLoad(rewriter, linalgOp, mapLoadOp);
@@ -1306,26 +1618,6 @@ struct CombineSourceLayoutTransformationPass final
     // ops like unpack into simpler supported ops.
     IRRewriter rewriter(context);
     simplifyComplexRelayoutOps(rewriter, funcOp);
-
-    // Raise transpose generics in nested regions (e.g., inside scf.for
-    // from promotion tiling). simplifyComplexRelayoutOps only walks
-    // top-level ops via Region::getOps, missing ops inside loop bodies.
-    // When a transpose generic is not raised, collectRelayoutChain stops
-    // early, causing spurious map_load creation that produces scalar
-    // memref.store ops. This deep walk is only needed in the source
-    // pass; the result pass should not raise nested generics as it can
-    // change downstream vectorization decisions on other backends.
-    {
-      OpBuilder::InsertionGuard g(rewriter);
-      SmallVector<linalg::GenericOp> nestedGenerics;
-      funcOp.walk([&](linalg::GenericOp op) { nestedGenerics.push_back(op); });
-      for (auto genericOp : nestedGenerics) {
-        if (linalg::isaTransposeOpInterface(genericOp)) {
-          rewriter.setInsertionPoint(genericOp);
-          (void)linalg::specializeGenericOp(rewriter, genericOp);
-        }
-      }
-    }
 
     // Insert identity map_load ops after load_from_buffer ops and fold
     // consumer relayout ops into them.

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -526,6 +526,10 @@ static FailureOr<MapStoreOp> foldUnpackIntoMapStore(RewriterBase &rewriter,
          "expected unPackOp to be the producer of mapStoreOp");
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(unPackOp);
+  // lowerUnpadLikeWithExtractSlice=false ensures "like unpad" unpacks go
+  // through the full transpose → collapse_shape → extract_slice chain instead
+  // of being lowered to a single rank-reducing extract_slice, which
+  // foldExtractSliceIntoMapStore does not support.
   auto result = linalg::lowerUnPack(rewriter, unPackOp,
                                     /*lowerUnpadLikeWithExtractSlice=*/false);
   if (failed(result)) {
@@ -1336,6 +1340,10 @@ static FailureOr<MapLoadOp> foldUnpackIntoMapLoad(RewriterBase &rewriter,
          "expected mapLoadOp to be the producer of unPackOp input");
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(unPackOp);
+  // lowerUnpadLikeWithExtractSlice=false ensures "like unpad" unpacks go
+  // through the full transpose → collapse_shape → extract_slice chain instead
+  // of being lowered to a single rank-reducing extract_slice, which
+  // foldExtractSliceIntoMapLoad does not support.
   auto result = linalg::lowerUnPack(rewriter, unPackOp,
                                     /*lowerUnpadLikeWithExtractSlice=*/false);
   if (failed(result)) {

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -473,6 +473,97 @@ static FailureOr<MapStoreOp> foldTransposeGenericIntoMapStore(
                                        genericOp.getDpsInputs()[0], mapStoreOp);
 }
 
+/// Decompose a `packOp` and fold all resulting ops into the consumer
+/// `mapStoreOp` in one shot. lowerPack produces: source → [pad] →
+/// expand_shape → transpose. We fold transpose then expand_shape into the
+/// map_store. Identity pads are removed; non-identity pads are left for
+/// FoldPadOpIntoMapStorePattern to handle on the next greedy iteration.
+static FailureOr<MapStoreOp> foldPackIntoMapStore(RewriterBase &rewriter,
+                                                  linalg::PackOp packOp,
+                                                  MapStoreOp mapStoreOp) {
+  assert(mapStoreOp.getInput() == packOp->getResult(0) &&
+         "expected packOp to be the producer of mapStoreOp");
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(packOp);
+  auto result = linalg::lowerPack(rewriter, packOp,
+                                  /*lowerPadLikeWithInsertSlice=*/false);
+  if (failed(result)) {
+    return failure();
+  }
+
+  // After lowerPack the chain is: source → [pad] → expand_shape → transpose.
+  // The map_store input is now transpose.result.
+  mapStoreOp =
+      foldTransposeIntoMapStore(rewriter, result->transposeOp, mapStoreOp);
+
+  auto foldResult =
+      foldExpandShapeIntoMapStore(rewriter, result->expandShapeOp, mapStoreOp);
+  if (failed(foldResult)) {
+    return failure();
+  }
+  mapStoreOp = *foldResult;
+
+  if (result->padOp) {
+    if (areAllConstantIntValue(result->padOp.getMixedLowPad(), 0) &&
+        areAllConstantIntValue(result->padOp.getMixedHighPad(), 0)) {
+      rewriter.replaceOp(result->padOp, result->padOp.getSource());
+    }
+    // Non-identity pad left for FoldPadOpIntoMapStorePattern.
+  }
+
+  return mapStoreOp;
+}
+
+/// Decompose an `unPackOp` and fold all resulting ops into the consumer
+/// `mapStoreOp` in one shot. lowerUnPack (with lowerUnpadLikeWithExtractSlice
+/// = false) produces: source → transpose → collapse_shape → extract_slice →
+/// copy. We fold copy, extract_slice, collapse_shape, then transpose into the
+/// map_store from innermost to outermost.
+static FailureOr<MapStoreOp> foldUnpackIntoMapStore(RewriterBase &rewriter,
+                                                    linalg::UnPackOp unPackOp,
+                                                    MapStoreOp mapStoreOp) {
+  assert(mapStoreOp.getInput() == unPackOp->getResult(0) &&
+         "expected unPackOp to be the producer of mapStoreOp");
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(unPackOp);
+  auto result = linalg::lowerUnPack(rewriter, unPackOp,
+                                    /*lowerUnpadLikeWithExtractSlice=*/false);
+  if (failed(result)) {
+    return failure();
+  }
+
+  // After lowerUnPack the chain is:
+  //   source → transpose → collapse_shape → extract_slice → copy
+  // The map_store input is now copy.result.
+  // Fold from innermost (closest to map_store) to outermost.
+
+  // 1. Fold copy (identity-like) into map_store.
+  mapStoreOp =
+      foldIdentityLikeOpIntoMapStore(rewriter, result->copyOp, mapStoreOp);
+
+  // 2. Fold extract_slice into map_store.
+  auto extractFold = foldExtractSliceIntoMapStore(
+      rewriter, result->extractSliceOp, mapStoreOp);
+  if (failed(extractFold)) {
+    return failure();
+  }
+  mapStoreOp = *extractFold;
+
+  // 3. Fold collapse_shape into map_store.
+  auto collapseFold = foldCollapseShapeIntoMapStore(
+      rewriter, result->collapseShapeOp, mapStoreOp);
+  if (failed(collapseFold)) {
+    return failure();
+  }
+  mapStoreOp = *collapseFold;
+
+  // 4. Fold transpose into map_store.
+  mapStoreOp =
+      foldTransposeIntoMapStore(rewriter, result->transposeOp, mapStoreOp);
+
+  return mapStoreOp;
+}
+
 FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
                                        MapStoreOp mapStoreOp) {
   return llvm::TypeSwitch<Operation *, FailureOr<MapStoreOp>>(op)
@@ -492,17 +583,11 @@ FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
         return foldExtractSliceIntoMapStore(rewriter, extractSliceOp,
                                             mapStoreOp);
       })
-      .Case([&](linalg::PackOp packOp) -> FailureOr<MapStoreOp> {
-        if (failed(linalg::lowerPack(rewriter, packOp))) {
-          return failure();
-        }
-        return mapStoreOp;
+      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
+        return foldPackIntoMapStore(rewriter, packOp, mapStoreOp);
       })
-      .Case([&](linalg::UnPackOp unPackOp) -> FailureOr<MapStoreOp> {
-        if (failed(linalg::lowerUnPack(rewriter, unPackOp))) {
-          return failure();
-        }
-        return mapStoreOp;
+      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unPackOp) {
+        return foldUnpackIntoMapStore(rewriter, unPackOp, mapStoreOp);
       })
       .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
         if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
@@ -1188,6 +1273,113 @@ foldTransposeGenericIntoMapLoad(RewriterBase &rewriter,
   return foldTransposePermIntoMapLoad(rewriter, genericOp, perm, mapLoadOp);
 }
 
+/// Decompose a consumer `packOp` and fold all resulting ops into the producer
+/// `mapLoadOp` in one shot. lowerPack produces: source → [pad] →
+/// expand_shape → transpose. We fold pad, expand_shape, then transpose into
+/// the map_load from outermost to innermost.
+static FailureOr<MapLoadOp> foldPackIntoMapLoad(RewriterBase &rewriter,
+                                                linalg::PackOp packOp,
+                                                MapLoadOp mapLoadOp) {
+  assert(packOp.getSource() == mapLoadOp.getResult(0) &&
+         "expected mapLoadOp to be the producer of packOp input");
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(packOp);
+  auto result = linalg::lowerPack(rewriter, packOp,
+                                  /*lowerPadLikeWithInsertSlice=*/false);
+  if (failed(result)) {
+    return failure();
+  }
+
+  // After lowerPack the chain is: map_load → [pad] → expand_shape → transpose.
+  // Fold from outermost (closest to map_load) to innermost.
+
+  // 1. Handle pad.
+  if (result->padOp) {
+    if (areAllConstantIntValue(result->padOp.getMixedLowPad(), 0) &&
+        areAllConstantIntValue(result->padOp.getMixedHighPad(), 0)) {
+      rewriter.replaceOp(result->padOp, result->padOp.getSource());
+    } else {
+      auto padFold = foldPadIntoMapLoad(rewriter, result->padOp, mapLoadOp);
+      if (failed(padFold)) {
+        return failure();
+      }
+      mapLoadOp = *padFold;
+    }
+  }
+
+  // 2. Fold expand_shape into map_load.
+  auto expandFold =
+      foldExpandShapeIntoMapLoad(rewriter, result->expandShapeOp, mapLoadOp);
+  if (failed(expandFold)) {
+    return failure();
+  }
+  mapLoadOp = *expandFold;
+
+  // 3. Fold transpose into map_load.
+  auto transposeFold =
+      foldTransposeIntoMapLoad(rewriter, result->transposeOp, mapLoadOp);
+  if (failed(transposeFold)) {
+    return failure();
+  }
+  mapLoadOp = *transposeFold;
+  return mapLoadOp;
+}
+
+/// Decompose a consumer `unPackOp` and fold all resulting ops into the producer
+/// `mapLoadOp` in one shot. lowerUnPack (with lowerUnpadLikeWithExtractSlice
+/// = false) produces: source → transpose → collapse_shape → extract_slice →
+/// copy. We fold from outermost (closest to map_load) to innermost.
+static FailureOr<MapLoadOp> foldUnpackIntoMapLoad(RewriterBase &rewriter,
+                                                  linalg::UnPackOp unPackOp,
+                                                  MapLoadOp mapLoadOp) {
+  assert(unPackOp.getSource() == mapLoadOp.getResult(0) &&
+         "expected mapLoadOp to be the producer of unPackOp input");
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(unPackOp);
+  auto result = linalg::lowerUnPack(rewriter, unPackOp,
+                                    /*lowerUnpadLikeWithExtractSlice=*/false);
+  if (failed(result)) {
+    return failure();
+  }
+
+  // After lowerUnPack the chain is:
+  //   map_load → transpose → collapse_shape → extract_slice → copy
+  // Fold from outermost (closest to map_load) to innermost.
+
+  // 1. Fold transpose into map_load.
+  auto transposeFold =
+      foldTransposeIntoMapLoad(rewriter, result->transposeOp, mapLoadOp);
+  if (failed(transposeFold)) {
+    return failure();
+  }
+  mapLoadOp = *transposeFold;
+
+  // 2. Fold collapse_shape into map_load.
+  auto collapseFold = foldCollapseShapeIntoMapLoad(
+      rewriter, result->collapseShapeOp, mapLoadOp);
+  if (failed(collapseFold)) {
+    return failure();
+  }
+  mapLoadOp = *collapseFold;
+
+  // 3. Fold extract_slice into map_load.
+  auto extractFold =
+      foldExtractSliceIntoMapLoad(rewriter, result->extractSliceOp, mapLoadOp);
+  if (failed(extractFold)) {
+    return failure();
+  }
+  mapLoadOp = *extractFold;
+
+  // 4. Fold copy (identity-like) into map_load.
+  auto copyFold =
+      foldIdentityLikeOpIntoMapLoad(rewriter, result->copyOp, mapLoadOp);
+  if (failed(copyFold)) {
+    return failure();
+  }
+  mapLoadOp = *copyFold;
+  return mapLoadOp;
+}
+
 /// Fold a consumer relayout op into a producer map_load.
 FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
                                      MapLoadOp mapLoadOp) {
@@ -1210,19 +1402,12 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
       .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
         return foldPadIntoMapLoad(rewriter, padOp, mapLoadOp);
       })
-      .Case<linalg::PackOp>([&](linalg::PackOp packOp) -> FailureOr<MapLoadOp> {
-        if (failed(linalg::lowerPack(rewriter, packOp))) {
-          return failure();
-        }
-        return mapLoadOp;
+      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
+        return foldPackIntoMapLoad(rewriter, packOp, mapLoadOp);
       })
-      .Case<linalg::UnPackOp>(
-          [&](linalg::UnPackOp unPackOp) -> FailureOr<MapLoadOp> {
-            if (failed(linalg::lowerUnPack(rewriter, unPackOp))) {
-              return failure();
-            }
-            return mapLoadOp;
-          })
+      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unPackOp) {
+        return foldUnpackIntoMapLoad(rewriter, unPackOp, mapLoadOp);
+      })
       .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
         if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
           return foldTransposeGenericIntoMapLoad(rewriter, genericOp, *perm,

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -37,51 +37,6 @@ using IREE::LinalgExt::MapLoadOp;
 using IREE::LinalgExt::MapStoreOp;
 
 //===----------------------------------------------------------------------===//
-// Preprocessing Utilities
-//===----------------------------------------------------------------------===//
-
-/// Convert complex ops into simpler ops by decomposing or raising to a named
-/// op.
-///  - `PackOp`s and `UnPackOp`s are decomposed.
-///  - Transpose `linalg::GenericOp`s are raised to `linalg::TransposeOp`s.
-static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
-                                       FunctionOpInterface funcOp) {
-  OpBuilder::InsertionGuard g(rewriter);
-  SmallVector<linalg::PackOp> packOps(
-      funcOp.getFunctionBody().getOps<linalg::PackOp>());
-  for (auto packOp : packOps) {
-    rewriter.setInsertionPoint(packOp);
-    FailureOr<linalg::LowerPackResult> result = linalg::lowerPack(
-        rewriter, packOp, /*lowerPadLikeWithInsertSlice=*/false);
-    // For aligned pack ops, the pad will be a no-op, and can be folded away.
-    // Fold it here so it does not complicate the index transformation folding
-    // later on.
-    if (failed(result) || !result->padOp) {
-      continue;
-    }
-    if (areAllConstantIntValue(result->padOp.getMixedLowPad(), 0) &&
-        areAllConstantIntValue(result->padOp.getMixedHighPad(), 0)) {
-      rewriter.replaceOp(result->padOp, result->padOp.getSource());
-    }
-  }
-  SmallVector<linalg::UnPackOp> unPackOps(
-      funcOp.getFunctionBody().getOps<linalg::UnPackOp>());
-  for (auto unPackOp : unPackOps) {
-    rewriter.setInsertionPoint(unPackOp);
-    (void)linalg::lowerUnPack(rewriter, unPackOp,
-                              /*lowerUnpadLikeWithExtractSlice=*/false);
-  }
-  SmallVector<linalg::GenericOp> genericOps(
-      funcOp.getFunctionBody().getOps<linalg::GenericOp>());
-  for (auto genericOp : genericOps) {
-    if (linalg::isaTransposeOpInterface(genericOp)) {
-      rewriter.setInsertionPoint(genericOp);
-      (void)linalg::specializeGenericOp(rewriter, genericOp);
-    }
-  }
-}
-
-//===----------------------------------------------------------------------===//
 // Combining Layout Transformation Ops
 //===----------------------------------------------------------------------===//
 
@@ -507,127 +462,6 @@ foldPadIntoMapStore(RewriterBase &rewriter, tensor::PadOp padOp,
   return mapStoreOp;
 }
 
-/// Given an expanded (strip-mined) shape and reassociation indices, compute the
-/// collapsed shape by multiplying sizes within each reassociation group.
-static SmallVector<int64_t>
-computeCollapsedShape(ArrayRef<int64_t> expandedShape,
-                      ArrayRef<ReassociationIndices> reassociations) {
-  SmallVector<int64_t> collapsedShape(reassociations.size(), 1);
-  for (auto [collapsedIdx, group] : llvm::enumerate(reassociations)) {
-    for (int64_t expandedIdx : group) {
-      collapsedShape[collapsedIdx] *= expandedShape[expandedIdx];
-    }
-  }
-  return collapsedShape;
-}
-
-/// Fold a `packOp` producer into a consumer `mapStoreOp`.
-/// A pack is: pad + expand_shape + transpose.
-/// For producer folding into map_store, we apply the FORWARD transforms
-/// (source indices -> packed indices) at the start of the transformation
-/// region. The map_store input is rewired to the pack's source.
-static FailureOr<MapStoreOp> foldPackIntoMapStore(RewriterBase &rewriter,
-                                                  linalg::PackOp packOp,
-                                                  MapStoreOp mapStoreOp) {
-  assert(mapStoreOp.getInput() == packOp->getResult(0) &&
-         "expected packOp to be the producer of mapStoreOp");
-  if (llvm::any_of(packOp.getStaticInnerTiles(), ShapedType::isDynamic)) {
-    return rewriter.notifyMatchFailure(packOp,
-                                       "dynamic inner tiles not supported");
-  }
-
-  PackingMetadata packingMetadata;
-  SmallVector<int64_t> packedToExpandedPerm =
-      linalg::getPackInverseDestPerm(packOp, packingMetadata);
-  // Invert permutation for consumer folding.
-  SmallVector<int64_t> expandedToPackedPerm =
-      invertPermutationVector(packedToExpandedPerm);
-
-  MLIRContext *ctx = rewriter.getContext();
-
-  auto packedType = cast<RankedTensorType>(packOp.getResult().getType());
-  SmallVector<int64_t> expandedShape(packedType.getShape());
-  applyPermutationToVector(expandedShape, packedToExpandedPerm);
-  SmallVector<OpFoldResult> expandedDims =
-      getAsIndexOpFoldResult(ctx, expandedShape);
-
-  SmallVector<int64_t> collapsedShape =
-      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
-  SmallVector<OpFoldResult> collapsedDims =
-      getAsIndexOpFoldResult(ctx, collapsedShape);
-
-  Location loc = packOp->getLoc();
-  rewriter.modifyOpInPlace(mapStoreOp, [&]() {
-    mapStoreOp.insertTransformationAtStart(
-        rewriter,
-        [&rewriter, loc, collapsedDims, expandedDims, expandedToPackedPerm](
-            ArrayRef<BlockArgument> sourceIndices) -> SmallVector<Value> {
-          SmallVector<Value> indexValues(sourceIndices.begin(),
-                                         sourceIndices.end());
-          auto linearizeOp = affine::AffineLinearizeIndexOp::create(
-              rewriter, loc, indexValues, collapsedDims, /*disjoint=*/true);
-          auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
-              rewriter, loc, linearizeOp.getResult(), expandedDims,
-              /*hasOuterBound=*/true);
-          SmallVector<Value> expandedIndices(delinearizeOp->getResults());
-          return applyPermutation(expandedIndices, expandedToPackedPerm);
-        },
-        collapsedDims.size());
-    mapStoreOp.getInputMutable().assign(packOp.getSource());
-  });
-  return mapStoreOp;
-}
-
-/// Fold an `unPackOp` producer into a consumer `mapStoreOp`.
-/// An unpack is: transpose + collapse_shape + extract_slice + copy.
-/// For producer folding, we apply: inverse transpose + expand (delinearize).
-static FailureOr<MapStoreOp> foldUnPackIntoMapStore(RewriterBase &rewriter,
-                                                    linalg::UnPackOp unPackOp,
-                                                    MapStoreOp mapStoreOp) {
-  assert(mapStoreOp.getInput() == unPackOp->getResult(0) &&
-         "expected unPackOp to be the producer of mapStoreOp");
-
-  PackingMetadata packingMetadata;
-  SmallVector<int64_t> packedToExpandedPerm =
-      linalg::getUnPackInverseSrcPerm(unPackOp, packingMetadata);
-
-  MLIRContext *ctx = rewriter.getContext();
-
-  auto packedType = cast<RankedTensorType>(unPackOp.getSourceType());
-  SmallVector<int64_t> expandedShape(packedType.getShape());
-  applyPermutationToVector(expandedShape, packedToExpandedPerm);
-  SmallVector<OpFoldResult> expandedDims =
-      getAsIndexOpFoldResult(ctx, expandedShape);
-
-  SmallVector<int64_t> collapsedShape =
-      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
-  SmallVector<OpFoldResult> collapsedDims =
-      getAsIndexOpFoldResult(ctx, collapsedShape);
-
-  Location loc = unPackOp->getLoc();
-  rewriter.modifyOpInPlace(mapStoreOp, [&]() {
-    mapStoreOp.insertTransformationAtStart(
-        rewriter,
-        [&rewriter, loc, packedToExpandedPerm, expandedDims, collapsedDims](
-            ArrayRef<BlockArgument> packedIndices) -> SmallVector<Value> {
-          SmallVector<Value> indexValues(packedIndices.begin(),
-                                         packedIndices.end());
-          SmallVector<Value> expandedIndices =
-              applyPermutation(indexValues, packedToExpandedPerm);
-          auto linearizeOp = affine::AffineLinearizeIndexOp::create(
-              rewriter, loc, expandedIndices, expandedDims,
-              /*disjoint=*/true);
-          auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
-              rewriter, loc, linearizeOp.getResult(), collapsedDims,
-              /*hasOuterBound=*/true);
-          return delinearizeOp->getResults();
-        },
-        expandedDims.size());
-    mapStoreOp.getInputMutable().assign(unPackOp.getSource());
-  });
-  return mapStoreOp;
-}
-
 /// Fold a transpose-like `genericOp` producer into a consumer `mapStoreOp`.
 /// Same as foldTransposeIntoMapStore but extracts perm from indexing maps.
 static FailureOr<MapStoreOp> foldTransposeGenericIntoMapStore(
@@ -658,11 +492,17 @@ FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
         return foldExtractSliceIntoMapStore(rewriter, extractSliceOp,
                                             mapStoreOp);
       })
-      .Case([&](linalg::PackOp packOp) {
-        return foldPackIntoMapStore(rewriter, packOp, mapStoreOp);
+      .Case([&](linalg::PackOp packOp) -> FailureOr<MapStoreOp> {
+        if (failed(linalg::lowerPack(rewriter, packOp))) {
+          return failure();
+        }
+        return mapStoreOp;
       })
-      .Case([&](linalg::UnPackOp unPackOp) {
-        return foldUnPackIntoMapStore(rewriter, unPackOp, mapStoreOp);
+      .Case([&](linalg::UnPackOp unPackOp) -> FailureOr<MapStoreOp> {
+        if (failed(linalg::lowerUnPack(rewriter, unPackOp))) {
+          return failure();
+        }
+        return mapStoreOp;
       })
       .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
         if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
@@ -920,11 +760,6 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
     return failure();
   }
 
-  // Apply some preprocessing to convert complex layout transformation
-  // ops like pack and unpack into simpler supported ops.
-  IRRewriter rewriter(ctx);
-  simplifyComplexRelayoutOps(rewriter, funcOp);
-
   // Resolve dims aggressively and canonicalize to simplify the IR.
   // This improves pattern matching and makes it easier for subsequent
   // rewrites/proofs to recognize identity/no-op cases.
@@ -951,6 +786,7 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
   }
 
   // Clean up any identity map_store ops after combining.
+  IRRewriter rewriter(ctx);
   funcOp->walk([&](MapStoreOp mapStoreOp) {
     if (mapStoreOp.isIdentity()) {
       rewriter.replaceOp(mapStoreOp, mapStoreOp.getInput());
@@ -1340,122 +1176,6 @@ static FailureOr<MapLoadOp> foldPadIntoMapLoad(RewriterBase &rewriter,
                                      indexTransformBuilder, padValue);
 }
 
-/// Fold a consumer `packOp` into a producer `mapLoadOp`.
-/// A pack is semantically: pad + expand_shape + transpose.
-/// Index transformation (inverse order, output -> source):
-///   1. Inverse transpose (undo packed permutation)
-///   2. Linearize + delinearize (undo expand_shape via reassociations)
-///   3. Subtract low pad offsets (always zero for pack)
-/// Fill value is set to the pack's padding value.
-static FailureOr<MapLoadOp> foldPackIntoMapLoad(RewriterBase &rewriter,
-                                                linalg::PackOp packOp,
-                                                MapLoadOp mapLoadOp) {
-  assert(packOp.getSource() == mapLoadOp.getResult(0) &&
-         "expected mapLoadOp to be the producer of packOp source");
-  if (llvm::any_of(packOp.getStaticInnerTiles(), ShapedType::isDynamic)) {
-    return rewriter.notifyMatchFailure(packOp,
-                                       "dynamic inner tiles not supported");
-  }
-
-  // Compute the permutation and metadata that lowerPack would use.
-  PackingMetadata packingMetadata;
-  SmallVector<int64_t> packedToExpandedPerm =
-      linalg::getPackInverseDestPerm(packOp, packingMetadata);
-
-  MLIRContext *ctx = rewriter.getContext();
-
-  auto packedType = cast<RankedTensorType>(packOp.getResult().getType());
-  SmallVector<int64_t> expandedShape(packedType.getShape());
-  applyPermutationToVector(expandedShape, packedToExpandedPerm);
-  SmallVector<OpFoldResult> expandedDims =
-      getAsIndexOpFoldResult(ctx, expandedShape);
-
-  SmallVector<int64_t> collapsedShape =
-      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
-  SmallVector<OpFoldResult> collapsedDims =
-      getAsIndexOpFoldResult(ctx, collapsedShape);
-
-  Value mapLoadPad = mapLoadOp.getPaddingValue();
-  Value packPad = packOp.getPaddingValue();
-  Value fillValue = packPad ? packPad : mapLoadPad;
-  if (!mapLoadPad.getDefiningOp<ub::PoisonOp>() && mapLoadPad != fillValue) {
-    return rewriter.notifyMatchFailure(
-        packOp, "map_load already has a non-poison padding value and it is "
-                "different from the pack padding value; folding "
-                "another pad would overwrite it");
-  }
-
-  Location loc = packOp->getLoc();
-  auto indexTransformBuilder =
-      [&rewriter, loc, packedToExpandedPerm, expandedDims, collapsedDims](
-          ArrayRef<BlockArgument> packedIndices) -> SmallVector<Value> {
-    SmallVector<Value> indexValues(packedIndices.begin(), packedIndices.end());
-    SmallVector<Value> expandedIndices =
-        applyPermutation(indexValues, packedToExpandedPerm);
-    auto linearizeOp = affine::AffineLinearizeIndexOp::create(
-        rewriter, loc, expandedIndices, expandedDims,
-        /*disjoint=*/true);
-    auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
-        rewriter, loc, linearizeOp.getResult(), collapsedDims,
-        /*hasOuterBound=*/true);
-    return delinearizeOp->getResults();
-  };
-
-  return foldConsumerIntoMapLoadImpl(rewriter, packOp, mapLoadOp,
-                                     indexTransformBuilder, fillValue);
-}
-
-/// Fold a consumer `unPackOp` into a producer `mapLoadOp`.
-/// An unpack is semantically: transpose + collapse_shape + extract_slice +
-/// copy. Index transformation (inverse order, output -> source):
-///   1. Delinearize (undo collapse_shape)
-///   2. Transpose (undo the packed permutation)
-/// No fill value needed.
-static FailureOr<MapLoadOp> foldUnPackIntoMapLoad(RewriterBase &rewriter,
-                                                  linalg::UnPackOp unPackOp,
-                                                  MapLoadOp mapLoadOp) {
-  assert(unPackOp.getSource() == mapLoadOp.getResult(0) &&
-         "expected mapLoadOp to be the producer of unPackOp source");
-
-  PackingMetadata packingMetadata;
-  SmallVector<int64_t> packedToExpandedPerm =
-      linalg::getUnPackInverseSrcPerm(unPackOp, packingMetadata);
-
-  MLIRContext *ctx = rewriter.getContext();
-
-  auto packedType = cast<RankedTensorType>(unPackOp.getSourceType());
-  SmallVector<int64_t> expandedShape(packedType.getShape());
-  applyPermutationToVector(expandedShape, packedToExpandedPerm);
-  SmallVector<OpFoldResult> expandedDims =
-      getAsIndexOpFoldResult(ctx, expandedShape);
-
-  SmallVector<int64_t> collapsedShape =
-      computeCollapsedShape(expandedShape, packingMetadata.reassociations);
-  SmallVector<OpFoldResult> collapsedDims =
-      getAsIndexOpFoldResult(ctx, collapsedShape);
-
-  // To undo the unpack transpose (consumer fold), we apply the inverse perm.
-  SmallVector<int64_t> expandedToPackedPerm =
-      invertPermutationVector(packedToExpandedPerm);
-
-  Location loc = unPackOp->getLoc();
-  auto indexTransformBuilder =
-      [&rewriter, loc, collapsedDims, expandedDims, expandedToPackedPerm](
-          ArrayRef<BlockArgument> destIndices) -> SmallVector<Value> {
-    SmallVector<Value> indexValues(destIndices.begin(), destIndices.end());
-    auto linearizeOp = affine::AffineLinearizeIndexOp::create(
-        rewriter, loc, indexValues, collapsedDims, /*disjoint=*/true);
-    auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
-        rewriter, loc, linearizeOp.getResult(), expandedDims,
-        /*hasOuterBound=*/true);
-    SmallVector<Value> expandedIndices(delinearizeOp->getResults());
-    return applyPermutation(expandedIndices, expandedToPackedPerm);
-  };
-
-  return foldConsumerIntoMapLoadImpl(rewriter, unPackOp, mapLoadOp,
-                                     indexTransformBuilder);
-}
-
 /// Fold a consumer transpose-like `genericOp` into a producer `mapLoadOp`.
 /// Same as foldTransposeIntoMapLoad but extracts the permutation from the
 /// generic's indexing maps via isaTransposeOpInterface.
@@ -1490,12 +1210,19 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
       .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
         return foldPadIntoMapLoad(rewriter, padOp, mapLoadOp);
       })
-      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
-        return foldPackIntoMapLoad(rewriter, packOp, mapLoadOp);
+      .Case<linalg::PackOp>([&](linalg::PackOp packOp) -> FailureOr<MapLoadOp> {
+        if (failed(linalg::lowerPack(rewriter, packOp))) {
+          return failure();
+        }
+        return mapLoadOp;
       })
-      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unPackOp) {
-        return foldUnPackIntoMapLoad(rewriter, unPackOp, mapLoadOp);
-      })
+      .Case<linalg::UnPackOp>(
+          [&](linalg::UnPackOp unPackOp) -> FailureOr<MapLoadOp> {
+            if (failed(linalg::lowerUnPack(rewriter, unPackOp))) {
+              return failure();
+            }
+            return mapLoadOp;
+          })
       .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
         if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
           return foldTransposeGenericIntoMapLoad(rewriter, genericOp, *perm,
@@ -1613,11 +1340,6 @@ struct CombineSourceLayoutTransformationPass final
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     FunctionOpInterface funcOp = getOperation();
-
-    // Apply some preprocessing to convert complex layout transformation
-    // ops like unpack into simpler supported ops.
-    IRRewriter rewriter(context);
-    simplifyComplexRelayoutOps(rewriter, funcOp);
 
     // Insert identity map_load ops after load_from_buffer ops and fold
     // consumer relayout ops into them.

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -74,17 +74,6 @@ static MapStoreOp foldTransposePermIntoMapStore(RewriterBase &rewriter,
   return mapStoreOp;
 }
 
-/// Fold a `transposeOp` into a consumer `mapStoreOp`, by transposing the
-/// uses of the `mapStoreOp`s transformation_region block arguments.
-static MapStoreOp foldTransposeIntoMapStore(RewriterBase &rewriter,
-                                            linalg::TransposeOp transposeOp,
-                                            MapStoreOp mapStoreOp) {
-  assert(mapStoreOp.getInput() == transposeOp->getResult(0) &&
-         "expected transposeOp to be the producer of mapStoreOp");
-  return foldTransposePermIntoMapStore(rewriter, transposeOp.getPermutation(),
-                                       transposeOp.getInput(), mapStoreOp);
-}
-
 /// Fold a tensor::ExpandShapeOp or tensor::CollapseShapeOp into a consumer
 /// `mapStoreOp`, by linearizing and then delinearizing the source indices
 /// of the `mapStoreOp`s index transformation.
@@ -462,27 +451,30 @@ foldPadIntoMapStore(RewriterBase &rewriter, tensor::PadOp padOp,
   return mapStoreOp;
 }
 
-/// Fold a transpose-like `genericOp` producer into a consumer `mapStoreOp`.
-/// Same as foldTransposeIntoMapStore but extracts perm from indexing maps.
-static FailureOr<MapStoreOp> foldTransposeGenericIntoMapStore(
-    RewriterBase &rewriter, linalg::GenericOp genericOp, ArrayRef<int64_t> perm,
-    MapStoreOp mapStoreOp) {
-  assert(mapStoreOp.getInput() == genericOp->getResult(0) &&
-         "expected genericOp to be the producer of mapStoreOp");
-  return foldTransposePermIntoMapStore(rewriter, perm,
-                                       genericOp.getDpsInputs()[0], mapStoreOp);
-}
-
 /// Decompose a `packOp` and fold all resulting ops into the consumer
 /// `mapStoreOp` in one shot. lowerPack produces: source → [pad] →
 /// expand_shape → transpose. We fold transpose then expand_shape into the
-/// map_store. Identity pads are removed; non-identity pads are left for
-/// FoldPadOpIntoMapStorePattern to handle on the next greedy iteration.
-static FailureOr<MapStoreOp> foldPackIntoMapStore(RewriterBase &rewriter,
-                                                  linalg::PackOp packOp,
-                                                  MapStoreOp mapStoreOp) {
+/// map_store. Identity pads are removed; non-identity pads are folded directly
+/// using `foldPadIntoMapStore` when a `padDistributionConfigFn` is provided.
+///
+/// The behavior depends on whether a `padDistributionConfigFn` is supplied:
+/// - If provided: always decompose and fold (non-identity pads are folded
+///   directly via `foldPadIntoMapStore`).
+/// - If not provided and the pack has no padding semantics: decompose and fold
+///   (the pad from decomposition, if any, is a no-op and can be folded away).
+/// - If not provided and the pack has padding semantics: return failure.
+FailureOr<MapStoreOp>
+foldPackIntoMapStore(RewriterBase &rewriter, linalg::PackOp packOp,
+                     MapStoreOp mapStoreOp,
+                     PadDistributionConfigFn padDistributionConfigFn) {
   assert(mapStoreOp.getInput() == packOp->getResult(0) &&
          "expected packOp to be the producer of mapStoreOp");
+  if (!padDistributionConfigFn && packOp.getPaddingValue()) {
+    return rewriter.notifyMatchFailure(
+        packOp, "pack has padding semantics but no PadDistributionConfigFn "
+                "was provided");
+  }
+
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(packOp);
   auto result = linalg::lowerPack(rewriter, packOp,
@@ -493,8 +485,9 @@ static FailureOr<MapStoreOp> foldPackIntoMapStore(RewriterBase &rewriter,
 
   // After lowerPack the chain is: source → [pad] → expand_shape → transpose.
   // The map_store input is now transpose.result.
-  mapStoreOp =
-      foldTransposeIntoMapStore(rewriter, result->transposeOp, mapStoreOp);
+  mapStoreOp = foldTransposePermIntoMapStore(
+      rewriter, result->transposeOp.getPermutation(),
+      result->transposeOp.getInput(), mapStoreOp);
 
   auto foldResult =
       foldExpandShapeIntoMapStore(rewriter, result->expandShapeOp, mapStoreOp);
@@ -507,8 +500,14 @@ static FailureOr<MapStoreOp> foldPackIntoMapStore(RewriterBase &rewriter,
     if (areAllConstantIntValue(result->padOp.getMixedLowPad(), 0) &&
         areAllConstantIntValue(result->padOp.getMixedHighPad(), 0)) {
       rewriter.replaceOp(result->padOp, result->padOp.getSource());
+    } else {
+      auto padFold = foldPadIntoMapStore(rewriter, result->padOp, mapStoreOp,
+                                         padDistributionConfigFn);
+      if (failed(padFold)) {
+        return failure();
+      }
+      mapStoreOp = *padFold;
     }
-    // Non-identity pad left for FoldPadOpIntoMapStorePattern.
   }
 
   return mapStoreOp;
@@ -562,8 +561,9 @@ static FailureOr<MapStoreOp> foldUnpackIntoMapStore(RewriterBase &rewriter,
   mapStoreOp = *collapseFold;
 
   // 4. Fold transpose into map_store.
-  mapStoreOp =
-      foldTransposeIntoMapStore(rewriter, result->transposeOp, mapStoreOp);
+  mapStoreOp = foldTransposePermIntoMapStore(
+      rewriter, result->transposeOp.getPermutation(),
+      result->transposeOp.getInput(), mapStoreOp);
 
   return mapStoreOp;
 }
@@ -575,7 +575,10 @@ FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
         return foldIdentityLikeOpIntoMapStore(rewriter, copyOp, mapStoreOp);
       })
       .Case([&](linalg::TransposeOp transposeOp) {
-        return foldTransposeIntoMapStore(rewriter, transposeOp, mapStoreOp);
+        FailureOr<MapStoreOp> res = foldTransposePermIntoMapStore(
+            rewriter, transposeOp.getPermutation(), transposeOp.getInput(),
+            mapStoreOp);
+        return res;
       })
       .Case([&](tensor::ExpandShapeOp expandOp) {
         return foldExpandShapeIntoMapStore(rewriter, expandOp, mapStoreOp);
@@ -588,15 +591,17 @@ FailureOr<MapStoreOp> foldIntoMapStore(RewriterBase &rewriter, Operation *op,
                                             mapStoreOp);
       })
       .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
-        return foldPackIntoMapStore(rewriter, packOp, mapStoreOp);
+        return foldPackIntoMapStore(rewriter, packOp, mapStoreOp,
+                                    /*padDistributionConfigFn=*/nullptr);
       })
       .Case<linalg::UnPackOp>([&](linalg::UnPackOp unPackOp) {
         return foldUnpackIntoMapStore(rewriter, unPackOp, mapStoreOp);
       })
       .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
         if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
-          return foldTransposeGenericIntoMapStore(rewriter, genericOp, *perm,
-                                                  mapStoreOp);
+          FailureOr<MapStoreOp> res = foldTransposePermIntoMapStore(
+              rewriter, perm.value(), genericOp.getDpsInputs()[0], mapStoreOp);
+          return res;
         }
         return FailureOr<MapStoreOp>(failure());
       })
@@ -1265,18 +1270,6 @@ static FailureOr<MapLoadOp> foldPadIntoMapLoad(RewriterBase &rewriter,
                                      indexTransformBuilder, padValue);
 }
 
-/// Fold a consumer transpose-like `genericOp` into a producer `mapLoadOp`.
-/// Same as foldTransposeIntoMapLoad but extracts the permutation from the
-/// generic's indexing maps via isaTransposeOpInterface.
-static FailureOr<MapLoadOp>
-foldTransposeGenericIntoMapLoad(RewriterBase &rewriter,
-                                linalg::GenericOp genericOp,
-                                ArrayRef<int64_t> perm, MapLoadOp mapLoadOp) {
-  assert(genericOp->getOperand(0) == mapLoadOp.getResult(0) &&
-         "expected mapLoadOp to be the producer of genericOp input");
-  return foldTransposePermIntoMapLoad(rewriter, genericOp, perm, mapLoadOp);
-}
-
 /// Decompose a consumer `packOp` and fold all resulting ops into the producer
 /// `mapLoadOp` in one shot. lowerPack produces: source → [pad] →
 /// expand_shape → transpose. We fold pad, expand_shape, then transpose into
@@ -1320,8 +1313,9 @@ static FailureOr<MapLoadOp> foldPackIntoMapLoad(RewriterBase &rewriter,
   mapLoadOp = *expandFold;
 
   // 3. Fold transpose into map_load.
-  auto transposeFold =
-      foldTransposeIntoMapLoad(rewriter, result->transposeOp, mapLoadOp);
+  auto transposeFold = foldTransposePermIntoMapLoad(
+      rewriter, result->transposeOp, result->transposeOp.getPermutation(),
+      mapLoadOp);
   if (failed(transposeFold)) {
     return failure();
   }
@@ -1355,8 +1349,9 @@ static FailureOr<MapLoadOp> foldUnpackIntoMapLoad(RewriterBase &rewriter,
   // Fold from outermost (closest to map_load) to innermost.
 
   // 1. Fold transpose into map_load.
-  auto transposeFold =
-      foldTransposeIntoMapLoad(rewriter, result->transposeOp, mapLoadOp);
+  auto transposeFold = foldTransposePermIntoMapLoad(
+      rewriter, result->transposeOp, result->transposeOp.getPermutation(),
+      mapLoadOp);
   if (failed(transposeFold)) {
     return failure();
   }
@@ -1396,7 +1391,8 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
         return foldIdentityLikeOpIntoMapLoad(rewriter, copyOp, mapLoadOp);
       })
       .Case<linalg::TransposeOp>([&](linalg::TransposeOp transposeOp) {
-        return foldTransposeIntoMapLoad(rewriter, transposeOp, mapLoadOp);
+        return foldTransposePermIntoMapLoad(
+            rewriter, transposeOp, transposeOp.getPermutation(), mapLoadOp);
       })
       .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expandOp) {
         return foldExpandShapeIntoMapLoad(rewriter, expandOp, mapLoadOp);
@@ -1418,8 +1414,8 @@ FailureOr<MapLoadOp> foldIntoMapLoad(RewriterBase &rewriter, Operation *op,
       })
       .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
         if (auto perm = linalg::isaTransposeOpInterface(genericOp)) {
-          return foldTransposeGenericIntoMapLoad(rewriter, genericOp, *perm,
-                                                 mapLoadOp);
+          return foldTransposePermIntoMapLoad(rewriter, genericOp, perm.value(),
+                                              mapLoadOp);
         }
         if (linalg::isaBroadcastOpInterface(genericOp)) {
           return foldBroadcastIntoMapLoad(

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
@@ -89,6 +90,17 @@ FailureOr<IREE::LinalgExt::MapStoreOp>
 foldPadIntoMapStore(RewriterBase &rewriter, tensor::PadOp padOp,
                     IREE::LinalgExt::MapStoreOp mapStoreOp,
                     PadDistributionConfigFn padDistributionConfigFn);
+
+/// Fold a linalg.pack op into a iree_linalg_ext.map_store op by decomposing
+/// the pack into [pad] → expand_shape → transpose and folding each piece.
+/// If a `padDistributionConfigFn` is provided, packs with padding semantics
+/// are supported (the pad is folded via `foldPadIntoMapStore`). Without it,
+/// only packs without padding semantics are folded; packs that require padding
+/// return failure.
+FailureOr<IREE::LinalgExt::MapStoreOp>
+foldPackIntoMapStore(RewriterBase &rewriter, linalg::PackOp packOp,
+                     IREE::LinalgExt::MapStoreOp mapStoreOp,
+                     PadDistributionConfigFn padDistributionConfigFn);
 
 /// Combines any layout/indexing transformation ops at the ends of a dispatch.
 /// Finds `iree_codegen.store_to_buffer` ops in the `funcOp`, and combines any

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -134,9 +134,9 @@ struct FoldRelayoutOpIntoMapStorePattern
     if (!op) {
       return failure();
     }
-    // Folding tensor.pad is handled by a separate pattern.
+    // Folding tensor.pad and linalg.pack are handled by separate patterns.
     if (!isSupportedSingleInputRelayoutOpForResult(op) ||
-        isa<tensor::PadOp>(op)) {
+        isa<tensor::PadOp, linalg::PackOp>(op)) {
       return failure();
     }
     if (failed(foldIntoMapStore(rewriter, op, mapStoreOp))) {
@@ -172,12 +172,39 @@ private:
   PadDistributionConfigFn padDistributionConfigFn;
 };
 
+struct FoldPackOpIntoMapStorePattern
+    : OpRewritePattern<IREE::LinalgExt::MapStoreOp> {
+  FoldPackOpIntoMapStorePattern(MLIRContext *context,
+                                PadDistributionConfigFn configFn = nullptr,
+                                PatternBenefit benefit = 1)
+      : OpRewritePattern<IREE::LinalgExt::MapStoreOp>(context, benefit),
+        padDistributionConfigFn(configFn) {}
+
+  LogicalResult matchAndRewrite(IREE::LinalgExt::MapStoreOp mapStoreOp,
+                                PatternRewriter &rewriter) const override {
+    auto packOp = mapStoreOp.getInput().getDefiningOp<linalg::PackOp>();
+    if (!packOp) {
+      return failure();
+    }
+    if (failed(foldPackIntoMapStore(rewriter, packOp, mapStoreOp,
+                                    padDistributionConfigFn))) {
+      return failure();
+    }
+    return success();
+  }
+
+private:
+  PadDistributionConfigFn padDistributionConfigFn;
+};
+
 } // namespace
 
 void populateCombineRelayoutOpPatterns(
     RewritePatternSet &patterns,
     PadDistributionConfigFn padDistributionConfigFn) {
   patterns.add<FoldRelayoutOpIntoMapStorePattern>(patterns.getContext());
+  patterns.add<FoldPackOpIntoMapStorePattern>(patterns.getContext(),
+                                              padDistributionConfigFn);
   if (padDistributionConfigFn) {
     patterns.add<FoldPadOpIntoMapStorePattern>(patterns.getContext(),
                                                padDistributionConfigFn);

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_result_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_result_layout_transformation.mlir
@@ -90,6 +90,37 @@ func.func @fold_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16
 
 // -----
 
+func.func @fold_transpose_generic_op(%source : tensor<2x4x16xf32>, %result : memref<4x16x2xf32>) {
+  %init = tensor.empty() : tensor<4x16x2xf32>
+  %transposed = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d2, d0, d1)>,
+      affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+    ],
+    iterator_types = ["parallel", "parallel", "parallel"]
+  } ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<4x16x2xf32>
+  iree_codegen.store_to_buffer %transposed, %result : tensor<4x16x2xf32> into memref<4x16x2xf32>
+  return
+}
+// The transpose generic is specialized to linalg.transpose by
+// simplifyComplexRelayoutOps, then folded into map_store.
+// DISPATCH-SCOPE-LABEL: @fold_transpose_generic_op
+//  DISPATCH-SCOPE-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  DISPATCH-SCOPE-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   DISPATCH-SCOPE-DAG:   %[[TRUE:.+]] = arith.constant true
+//       DISPATCH-SCOPE:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
+//       DISPATCH-SCOPE:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_store
+//  DISPATCH-SCOPE-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  DISPATCH-SCOPE-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       DISPATCH-SCOPE:     iree_linalg_ext.yield %[[IDX1]], %[[IDX2]], %[[IDX0]], %[[TRUE]]
+//       DISPATCH-SCOPE:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
+//       DISPATCH-SCOPE:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<4x16x2xf32> into memref<4x16x2xf32>
+
+// -----
+
 func.func @fold_extract_slice_op(%source : tensor<64xf32>, %result : memref<63xf32>) {
   %slice = tensor.extract_slice %source[0] [63] [1] : tensor<64xf32> to tensor<63xf32>
   iree_codegen.store_to_buffer %slice, %result : tensor<63xf32> into memref<63xf32>
@@ -229,7 +260,7 @@ func.func @fold_unpack_op(%source : tensor<?x?x128x128xf32>, %result : memref<?x
 //   DISPATCH-SCOPE-DAG:   %[[SRC_D1:.+]] = tensor.dim %[[SOURCE]], %[[C1]] : tensor<?x?x128x128xf32>
 //   DISPATCH-SCOPE-DAG:   %[[COLLAPSE_SIZE0:.+]] = affine.apply #[[$MAP]]()[%[[SRC_D0]]]
 //   DISPATCH-SCOPE-DAG:   %[[COLLAPSE_SIZE1:.+]] = affine.apply #[[$MAP]]()[%[[SRC_D1]]]
-//       DISPATCH-SCOPE:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty(%[[RES_D0]], %[[RES_D1]]) : tensor<?x?xf32>
+//   DISPATCH-SCOPE-DAG:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty(%[[RES_D0]], %[[RES_D1]]) : tensor<?x?xf32>
 //       DISPATCH-SCOPE:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_store
 //  DISPATCH-SCOPE-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
 //  DISPATCH-SCOPE-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
@@ -256,16 +287,10 @@ func.func @fold_pack_op(%source : tensor<250x250xf32>, %result : memref<2x2x128x
   iree_codegen.store_to_buffer %unpack, %result : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
   return
 }
-//       DISPATCH-SCOPE: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 1)>
-//       DISPATCH-SCOPE: #[[$MAP1:.+]] = affine_map<(d0) -> (256, d0 + 64)>
 // DISPATCH-SCOPE-LABEL: @fold_pack_op
 //  DISPATCH-SCOPE-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
 //  DISPATCH-SCOPE-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
 //   DISPATCH-SCOPE-DAG:   %[[TRUE:.+]] = arith.constant true
-//   DISPATCH-SCOPE-DAG:   %[[PAD_VAL:.+]] = arith.constant 0.000000e+00 : f32
-//   DISPATCH-SCOPE-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//   DISPATCH-SCOPE-DAG:   %[[C250:.+]] = arith.constant 250 : index
-//   DISPATCH-SCOPE-DAG:   %[[C256:.+]] = arith.constant 256 : index
 //       DISPATCH-SCOPE:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<2x2x128x128xf32>
 //       DISPATCH-SCOPE:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_store
 //  DISPATCH-SCOPE-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
@@ -277,37 +302,6 @@ func.func @fold_pack_op(%source : tensor<250x250xf32>, %result : memref<2x2x128x
 //       DISPATCH-SCOPE:     iree_linalg_ext.yield %[[DELINEARIZE0]]#0, %[[DELINEARIZE1]]#0, %[[DELINEARIZE0]]#1, %[[DELINEARIZE1]]#1, %[[TRUE]]
 //       DISPATCH-SCOPE:   } : tensor<250x250xf32> into tensor<2x2x128x128xf32> -> tensor<2x2x128x128xf32>
 //       DISPATCH-SCOPE:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
-
-// High padding for dimension 0
-
-//       DISPATCH-SCOPE:   scf.forall (%[[WG_LOOP0_IV0:.+]], %[[WG_LOOP0_IV1:.+]]) = (250, 0) to (256, 256) step (1, 64) {
-//   DISPATCH-SCOPE-DAG:     %[[WG_TILE0_UB0:.+]] = affine.min #[[$MAP]](%[[WG_LOOP0_IV0]])
-//   DISPATCH-SCOPE-DAG:     %[[WG_TILE0_UB1:.+]] = affine.min #[[$MAP1]](%[[WG_LOOP0_IV1]])
-//       DISPATCH-SCOPE:     scf.for %[[HIGH0_IDX0:.+]] = %[[WG_LOOP0_IV0]] to %[[WG_TILE0_UB0]] step %[[C1]] {
-//       DISPATCH-SCOPE:       scf.for %[[HIGH0_IDX1:.+]] = %[[WG_LOOP0_IV1]] to %[[WG_TILE0_UB1]] step %[[C1]] {
-//   DISPATCH-SCOPE-DAG:         %[[EXPANDED_HIGH0_IDX0:.+]]:2 = affine.delinearize_index %[[HIGH0_IDX0]] into (2, 128)
-//   DISPATCH-SCOPE-DAG:         %[[EXPANDED_HIGH0_IDX1:.+]]:2 = affine.delinearize_index %[[HIGH0_IDX1]] into (2, 128)
-//       DISPATCH-SCOPE:         memref.store %[[PAD_VAL]], %[[RESULT]]
-//  DISPATCH-SCOPE-SAME:           [%[[EXPANDED_HIGH0_IDX0]]#0, %[[EXPANDED_HIGH0_IDX1]]#0, %[[EXPANDED_HIGH0_IDX0]]#1, %[[EXPANDED_HIGH0_IDX1]]#1]
-//  DISPATCH-SCOPE-SAME:           : memref<2x2x128x128xf32>
-//  DISPATCH-SCOPE:            }
-//  DISPATCH-SCOPE:          }
-//  DISPATCH-SCOPE:        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
-
-// High padding for dimension 1
-
-//       DISPATCH-SCOPE:   scf.forall (%[[WG_LOOP1_IV0:.+]], %[[WG_LOOP1_IV1:.+]]) = (0, 250) to (256, 256) step (1, 64) {
-//   DISPATCH-SCOPE-DAG:     %[[WG_TILE1_UB0:.+]] = affine.min #[[$MAP]](%[[WG_LOOP1_IV0]])
-//       DISPATCH-SCOPE:     scf.for %[[HIGH1_IDX0:.+]] = %[[WG_LOOP1_IV0]] to %[[WG_TILE1_UB0]] step %[[C1]] {
-//       DISPATCH-SCOPE:       scf.for %[[HIGH1_IDX1:.+]] = %[[C250]] to %[[C256]] step %[[C1]] {
-//   DISPATCH-SCOPE-DAG:         %[[EXPANDED_HIGH1_IDX0:.+]]:2 = affine.delinearize_index %[[HIGH1_IDX0]] into (2, 128)
-//   DISPATCH-SCOPE-DAG:         %[[EXPANDED_HIGH1_IDX1:.+]]:2 = affine.delinearize_index %[[HIGH1_IDX1]] into (2, 128)
-//       DISPATCH-SCOPE:         memref.store %[[PAD_VAL]], %[[RESULT]]
-//  DISPATCH-SCOPE-SAME:           [%[[EXPANDED_HIGH1_IDX0]]#0, %[[EXPANDED_HIGH1_IDX1]]#0, %[[EXPANDED_HIGH1_IDX0]]#1, %[[EXPANDED_HIGH1_IDX1]]#1]
-//  DISPATCH-SCOPE-SAME:           : memref<2x2x128x128xf32>
-//  DISPATCH-SCOPE:            }
-//  DISPATCH-SCOPE:          }
-//  DISPATCH-SCOPE:        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -470,3 +470,60 @@ func.func @fold_broadcast_pad_expand_shape(%buffer : memref<2x64xf32>, %batch : 
 //       FOLD:     iree_linalg_ext.yield %[[BATCH]], {{.*}}, %[[CST]] : index, index, f32
 //       FOLD:   } : tensor<2x64xf32> into tensor<1x4x16x4x2x16xf32> -> tensor<1x4x16x4x2x16xf32>
 //       FOLD:   linalg.copy
+
+// -----
+
+// Transpose generic inside a nested region (scf.for) must be raised to
+// linalg.transpose so the relayout chain extends to the copy with
+// lowering_config, preventing map_load creation.
+#map_in  = affine_map<(d0, d1, d2) -> (d1, d0, d2)>
+#map_out = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @nested_transpose_generic_blocks_mapload(
+    %buffer : memref<8x4xf32>) -> tensor<2x2x4xf32> {
+  %cst = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %source = iree_codegen.load_from_buffer %buffer
+      : memref<8x4xf32> -> tensor<8x4xf32>
+  %out_init = tensor.empty() : tensor<2x2x4xf32>
+  %result = scf.for %iv = %c0 to %c2 step %c1
+      iter_args(%arg = %out_init) -> tensor<2x2x4xf32> {
+    %slice = tensor.extract_slice %source[%iv, 0] [3, 4] [1, 1]
+        : tensor<8x4xf32> to tensor<3x4xf32>
+    %padded = tensor.pad %slice low[0, 0] high[1, 0] {
+    ^bb0(%a: index, %b: index):
+      tensor.yield %cst : f32
+    } : tensor<3x4xf32> to tensor<4x4xf32>
+    %expanded = tensor.expand_shape %padded [[0, 1], [2]]
+        output_shape [2, 2, 4]
+        : tensor<4x4xf32> into tensor<2x2x4xf32>
+    %empty = tensor.empty() : tensor<2x2x4xf32>
+    %transposed = linalg.generic {
+        indexing_maps = [#map_in, #map_out],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%expanded : tensor<2x2x4xf32>)
+        outs(%empty : tensor<2x2x4xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<2x2x4xf32>
+    %dest = tensor.extract_slice %arg[0, 0, 0] [2, 2, 4] [1, 1, 1]
+        : tensor<2x2x4xf32> to tensor<2x2x4xf32>
+    %copied = linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
+        ins(%transposed : tensor<2x2x4xf32>)
+        outs(%dest : tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+    %inserted = tensor.insert_slice %copied into %arg[0, 0, 0] [2, 2, 4] [1, 1, 1]
+        : tensor<2x2x4xf32> into tensor<2x2x4xf32>
+    scf.yield %inserted : tensor<2x2x4xf32>
+  }
+  return %result : tensor<2x2x4xf32>
+}
+// The transpose generic is raised to linalg.transpose inside the loop.
+// The chain {extract_slice, pad, expand_shape, linalg.transpose, linalg.copy}
+// includes linalg.copy with lowering_config, so isComplexRelayoutChain returns
+// false and no map_load is created.
+// CHECK-LABEL: @nested_transpose_generic_blocks_mapload
+//       CHECK:   scf.for
+//       CHECK:     linalg.transpose
+//       CHECK:     linalg.copy
+//   CHECK-NOT:   iree_linalg_ext.map_load

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -473,6 +473,103 @@ func.func @fold_broadcast_pad_expand_shape(%buffer : memref<2x64xf32>, %batch : 
 
 // -----
 
+func.func @pack(%buffer : memref<8x4xf32>) -> tensor<2x2x4x2xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<8x4xf32> -> tensor<8x4xf32>
+  %dest = tensor.empty() : tensor<2x2x4x2xf32>
+  %packed = linalg.pack %source
+      inner_dims_pos = [0, 1] inner_tiles = [4, 2]
+      into %dest : tensor<8x4xf32> -> tensor<2x2x4x2xf32>
+  return %packed : tensor<2x2x4x2xf32>
+}
+// In CHECK mode, the pack is a simple relayout chain (no lowering_config),
+// so it is not folded into map_load.
+// In FOLD mode, the pack is directly folded into map_load.
+// CHECK-LABEL: @pack
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.pack
+//   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @pack
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<2x2x4x2xf32>
+//   FOLD-NOT:   linalg.pack
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
+//       FOLD:     %[[LIN:.+]] = affine.linearize_index disjoint [%[[IDX0]], %[[IDX2]], %[[IDX1]], %[[IDX3]]] by (2, 4, 2, 2)
+//       FOLD:     %[[DELIN:.+]]:2 = affine.delinearize_index %[[LIN]] into (8, 4)
+//       FOLD:     iree_linalg_ext.yield %[[DELIN]]#0, %[[DELIN]]#1, {{.*}} : index, index, f32
+//       FOLD:   } : tensor<8x4xf32> into tensor<2x2x4x2xf32> -> tensor<2x2x4x2xf32>
+
+// -----
+
+func.func @unpack(%buffer : memref<2x2x4x2xf32>) -> tensor<8x4xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<2x2x4x2xf32> -> tensor<2x2x4x2xf32>
+  %dest = tensor.empty() : tensor<8x4xf32>
+  %unpacked = linalg.unpack %source
+      inner_dims_pos = [0, 1] inner_tiles = [4, 2]
+      into %dest : tensor<2x2x4x2xf32> -> tensor<8x4xf32>
+  return %unpacked : tensor<8x4xf32>
+}
+// In CHECK mode, the unpack is a simple relayout chain (no lowering_config),
+// so it is not folded into map_load.
+// In FOLD mode, the unpack is directly folded into map_load.
+// CHECK-LABEL: @unpack
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.unpack
+//   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @unpack
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<8x4xf32>
+//   FOLD-NOT:   linalg.unpack
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       FOLD:     %[[DELIN0:.+]]:2 = affine.delinearize_index %[[IDX0]] into (2, 4)
+//       FOLD:     %[[DELIN1:.+]]:2 = affine.delinearize_index %[[IDX1]] into (2, 2)
+//       FOLD:     iree_linalg_ext.yield %[[DELIN0]]#0, %[[DELIN1]]#0, %[[DELIN0]]#1, %[[DELIN1]]#1, {{.*}} : index, index, index, index, f32
+//       FOLD:   } : tensor<2x2x4x2xf32> into tensor<8x4xf32> -> tensor<8x4xf32>
+
+// -----
+
+#map_transpose_in  = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
+#map_transpose_out = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @transpose_generic(%buffer : memref<2x4x16xf32>) -> tensor<4x16x2xf32> {
+  %source = iree_codegen.load_from_buffer %buffer : memref<2x4x16xf32> -> tensor<2x4x16xf32>
+  %init = tensor.empty() : tensor<4x16x2xf32>
+  %transposed = linalg.generic {
+    indexing_maps = [#map_transpose_in, #map_transpose_out],
+    iterator_types = ["parallel", "parallel", "parallel"]
+  } ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<4x16x2xf32>
+  return %transposed : tensor<4x16x2xf32>
+}
+// In CHECK mode, the generic stays as-is (simple chain, no lowering_config).
+// In FOLD mode, the transpose generic is directly folded into map_load.
+// CHECK-LABEL: @transpose_generic
+//  CHECK-SAME:   %[[BUFFER:.+]]:
+//       CHECK:   iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   linalg.generic
+//   CHECK-NOT:   iree_linalg_ext.map_load
+// FOLD-LABEL: @transpose_generic
+//  FOLD-SAME:   %[[BUFFER:.+]]:
+//       FOLD:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       FOLD:   %[[DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
+//   FOLD-NOT:   linalg.generic
+//   FOLD-NOT:   linalg.transpose
+//       FOLD:   %[[MAP_LOAD:.+]] = iree_linalg_ext.map_load
+//  FOLD-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  FOLD-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       FOLD:     iree_linalg_ext.yield %[[IDX2]], %[[IDX0]], %[[IDX1]], {{.*}} : index, index, index, f32
+//       FOLD:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
+
+// -----
+
 // Transpose generic inside a nested region (scf.for) must be raised to
 // linalg.transpose so the relayout chain extends to the copy with
 // lowering_config, preventing map_load creation.

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -518,12 +518,12 @@ func.func @nested_transpose_generic_blocks_mapload(
   }
   return %result : tensor<2x2x4xf32>
 }
-// The transpose generic is raised to linalg.transpose inside the loop.
-// The chain {extract_slice, pad, expand_shape, linalg.transpose, linalg.copy}
-// includes linalg.copy with lowering_config, so isComplexRelayoutChain returns
-// false and no map_load is created.
+// The transpose generic inside the loop is recognized as a relayout chain
+// member. The chain {extract_slice, pad, expand_shape, generic(transpose),
+// copy{lowering_config}} includes an op with lowering_config, so
+// isComplexRelayoutChain returns false and no map_load is created.
 // CHECK-LABEL: @nested_transpose_generic_blocks_mapload
 //       CHECK:   scf.for
-//       CHECK:     linalg.transpose
+//       CHECK:     linalg.generic
 //       CHECK:     linalg.copy
 //   CHECK-NOT:   iree_linalg_ext.map_load


### PR DESCRIPTION
When performing writes to LDS for unaligned gemm operands, we lower the preceding `tensor.extract_slice` -> `tensor.pad` -> `linalg.copy` to a masked `vector.transfer_read` in a `scf.for` loop

However, when this chain of ops inside the lds promotion `scf.for` loops includes a `linalg.generic (transpose)` we produce scalar writes with `memref.map_load`.

This happens because the raising of the linalg.generic to a linalg.transpose is erroneously not firing prior to vectorization in `CombineSourceLayoutTransformationPass` due to `simplifyComplexRelayoutOps` not recognizing linalg.generic (transpose) when inside a for loop. 

This change removes `simplifyComplexRelayoutOps` entirely and performs the folding of unpack/pack ops and linalg.generic (transpose) ops directly without relying on a preliminary simplification of these ops prior to folding.

