### PR TITLE
[Tokenizer] Add explicit pair batch encoding

### DIFF
--- a/runtime/src/iree/tokenizer/postprocessor.c
+++ b/runtime/src/iree/tokenizer/postprocessor.c
@@ -57,6 +57,7 @@ iree_status_t iree_tokenizer_postprocessor_initialize(
   if (pair_template) {
     memcpy(&out_postprocessor->pair, pair_template,
            sizeof(iree_tokenizer_postprocessor_template_t));
+    out_postprocessor->has_pair = true;
   }
 
   out_postprocessor->flags = flags;
@@ -122,12 +123,34 @@ iree_host_size_t iree_tokenizer_postprocessor_emit_prefix(
   return emitted;
 }
 
+iree_host_size_t iree_tokenizer_postprocessor_emit_infix(
+    iree_tokenizer_postprocessor_encode_state_t* state,
+    iree_tokenizer_token_output_t output, iree_host_size_t output_offset) {
+  if (state->phase != IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX) return 0;
+  uint8_t base = state->active_template->prefix_count;
+  iree_host_size_t emitted = iree_tokenizer_postprocessor_emit_phase(
+      state->active_template, base, state->active_template->infix_count,
+      &state->position, output, output_offset);
+  if (state->position >= state->active_template->infix_count) {
+    state->phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B;
+    state->position = 0;
+  }
+  return emitted;
+}
+
 void iree_tokenizer_postprocessor_assign_type_ids(
     const iree_tokenizer_postprocessor_encode_state_t* state,
     iree_tokenizer_token_output_t output, iree_host_size_t offset,
     iree_host_size_t count) {
   if (!output.type_ids || count == 0) return;
-  if (state->phase != IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A) return;
+  uint8_t type_id = 0;
+  if (state->phase == IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A) {
+    type_id = state->active_template->sequence_a_type_id;
+  } else if (state->phase == IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B) {
+    type_id = state->active_template->sequence_b_type_id;
+  } else {
+    return;
+  }
   // Bounds check with overflow protection: offset + count must not exceed
   // capacity and must not overflow.
   iree_host_size_t end = 0;
@@ -135,8 +158,7 @@ void iree_tokenizer_postprocessor_assign_type_ids(
       end > output.capacity) {
     return;  // Overflow or out of bounds.
   }
-  memset(&output.type_ids[offset], state->active_template->sequence_a_type_id,
-         count);
+  memset(&output.type_ids[offset], type_id, count);
 }
 
 iree_host_size_t iree_tokenizer_postprocessor_emit_suffix(

--- a/runtime/src/iree/tokenizer/postprocessor.h
+++ b/runtime/src/iree/tokenizer/postprocessor.h
@@ -105,10 +105,13 @@ typedef struct iree_tokenizer_postprocessor_t {
   // Template for single-sequence encoding (always populated).
   iree_tokenizer_postprocessor_template_t single;
 
+  // True when pair encoding has an explicit pair template.
+  bool has_pair;
+
   // Template for pair-sequence encoding (zeroed if unsupported).
-  // When pair.prefix_count + pair.infix_count + pair.suffix_count == 0 and
-  // pair.sequence_a_type_id == 0 and pair.sequence_b_type_id == 0, pair
-  // encoding is not supported.
+  // Valid only when |has_pair| is true. An explicit empty pair template is
+  // meaningful: it encodes sequence A followed by sequence B without inserting
+  // special tokens or changing type IDs.
   iree_tokenizer_postprocessor_template_t pair;
 
   // Behavioral flags (IREE_TOKENIZER_POSTPROCESSOR_FLAG_*).
@@ -118,10 +121,7 @@ typedef struct iree_tokenizer_postprocessor_t {
 // Returns true if the postprocessor supports pair encoding.
 static inline bool iree_tokenizer_postprocessor_supports_pair(
     const iree_tokenizer_postprocessor_t* postprocessor) {
-  return iree_tokenizer_postprocessor_template_total_count(
-             &postprocessor->pair) > 0 ||
-         postprocessor->pair.sequence_a_type_id != 0 ||
-         postprocessor->pair.sequence_b_type_id != 0;
+  return postprocessor->has_pair;
 }
 
 // Initializes a postprocessor from precomputed template data.
@@ -148,13 +148,14 @@ void iree_tokenizer_postprocessor_deinitialize(
 // Phase of the postprocessor state machine during encoding.
 // Tracks which portion of the template is being emitted relative to model
 // tokens:
-//   PREFIX → SEQUENCE_A → SUFFIX → DONE
-// For pair encoding (future), the full sequence is:
-//   PREFIX → SEQUENCE_A → INFIX → SEQUENCE_B → SUFFIX → DONE
+//   Single:  PREFIX → SEQUENCE_A → SUFFIX → DONE
+//   Pair:    PREFIX → SEQUENCE_A → INFIX → SEQUENCE_B → SUFFIX → DONE
 typedef enum {
   IREE_TOKENIZER_POSTPROCESSOR_PHASE_IDLE = 0,
   IREE_TOKENIZER_POSTPROCESSOR_PHASE_PREFIX,
   IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A,
+  IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX,
+  IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B,
   IREE_TOKENIZER_POSTPROCESSOR_PHASE_SUFFIX,
   IREE_TOKENIZER_POSTPROCESSOR_PHASE_DONE,
 } iree_tokenizer_postprocessor_phase_t;
@@ -177,9 +178,9 @@ typedef struct iree_tokenizer_postprocessor_encode_state_t {
 } iree_tokenizer_postprocessor_encode_state_t;
 
 // Initializes encode state for a given postprocessor and template. If the
-// template has no special tokens (total count == 0), the state remains IDLE
-// (all operations are no-ops). The template pointer must remain valid for the
-// lifetime of the encode state.
+// template has no special tokens and assigns no non-zero sequence type IDs, the
+// state remains IDLE (all operations are no-ops). The template pointer must
+// remain valid for the lifetime of the encode state.
 static inline void iree_tokenizer_postprocessor_encode_state_initialize(
     const iree_tokenizer_postprocessor_t* postprocessor,
     const iree_tokenizer_postprocessor_template_t* active_template,
@@ -189,7 +190,8 @@ static inline void iree_tokenizer_postprocessor_encode_state_initialize(
   out_state->flags = postprocessor->flags;
   uint8_t total =
       iree_tokenizer_postprocessor_template_total_count(active_template);
-  if (total > 0) {
+  if (total > 0 || active_template->sequence_a_type_id != 0 ||
+      active_template->sequence_b_type_id != 0) {
     out_state->active_template = active_template;
     out_state->phase = active_template->prefix_count > 0
                            ? IREE_TOKENIZER_POSTPROCESSOR_PHASE_PREFIX
@@ -197,12 +199,13 @@ static inline void iree_tokenizer_postprocessor_encode_state_initialize(
   }
 }
 
-// Returns true if the postprocessor has pending tokens to emit (prefix or
-// suffix phase not yet complete). Used by the tokenizer to report pending work
-// in the streaming API.
+// Returns true if the postprocessor has pending tokens to emit (prefix, infix,
+// or suffix phase not yet complete). Used by the tokenizer to report pending
+// work in the streaming API.
 static inline bool iree_tokenizer_postprocessor_encode_state_has_pending(
     const iree_tokenizer_postprocessor_encode_state_t* state) {
   return state->phase == IREE_TOKENIZER_POSTPROCESSOR_PHASE_PREFIX ||
+         state->phase == IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX ||
          state->phase == IREE_TOKENIZER_POSTPROCESSOR_PHASE_SUFFIX;
 }
 
@@ -218,20 +221,44 @@ iree_host_size_t iree_tokenizer_postprocessor_emit_prefix(
     iree_tokenizer_postprocessor_encode_state_t* state,
     iree_tokenizer_token_output_t output, iree_host_size_t output_offset);
 
+// Emits infix special tokens into the output if in INFIX phase.
+// Transitions to SEQUENCE_B when all infix tokens are emitted.
+// No-op if the phase is not INFIX.
+// Returns the number of tokens written to output.
+iree_host_size_t iree_tokenizer_postprocessor_emit_infix(
+    iree_tokenizer_postprocessor_encode_state_t* state,
+    iree_tokenizer_token_output_t output, iree_host_size_t output_offset);
+
 // Assigns type_ids to model-produced tokens based on current sequence phase.
-// Uses sequence_a_type_id during SEQUENCE_A (sequence_b_type_id for future pair
-// encoding). No-op if type_ids output is NULL or phase is not a sequence phase.
+// Uses sequence_a_type_id during SEQUENCE_A, sequence_b_type_id during
+// SEQUENCE_B. No-op if type_ids output is NULL or phase is not a sequence
+// phase.
 void iree_tokenizer_postprocessor_assign_type_ids(
     const iree_tokenizer_postprocessor_encode_state_t* state,
     iree_tokenizer_token_output_t output, iree_host_size_t offset,
     iree_host_size_t count);
 
-// Transitions from sequence phase to SUFFIX after model finalize.
-// If suffix_count is 0, transitions directly to DONE.
+// Transitions from SEQUENCE_A → INFIX (or SEQUENCE_B if infix_count == 0)
+// after finalizing sequence A during pair encoding.
 // No-op if phase is not SEQUENCE_A.
-static inline void iree_tokenizer_postprocessor_begin_suffix(
+static inline void iree_tokenizer_postprocessor_begin_infix(
     iree_tokenizer_postprocessor_encode_state_t* state) {
   if (state->phase != IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A) return;
+  state->position = 0;
+  state->phase = state->active_template->infix_count > 0
+                     ? IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX
+                     : IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B;
+}
+
+// Transitions from sequence phase to SUFFIX after model finalize.
+// If suffix_count is 0, transitions directly to DONE.
+// No-op if phase is not SEQUENCE_A or SEQUENCE_B.
+static inline void iree_tokenizer_postprocessor_begin_suffix(
+    iree_tokenizer_postprocessor_encode_state_t* state) {
+  if (state->phase != IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A &&
+      state->phase != IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B) {
+    return;
+  }
   state->position = 0;
   state->phase = state->active_template->suffix_count > 0
                      ? IREE_TOKENIZER_POSTPROCESSOR_PHASE_SUFFIX

--- a/runtime/src/iree/tokenizer/postprocessor_fuzz.cc
+++ b/runtime/src/iree/tokenizer/postprocessor_fuzz.cc
@@ -182,7 +182,19 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                                                  seq_a_count);
     offset += seq_a_count;
 
-    // Transition to suffix and emit.
+    iree_tokenizer_postprocessor_begin_infix(&state);
+    offset += iree_tokenizer_postprocessor_emit_infix(&state, output, offset);
+
+    // Simulate sequence B model tokens.
+    iree_host_size_t seq_b_count = 4;
+    if (offset + seq_b_count > 64) seq_b_count = 64 - offset;
+    for (iree_host_size_t i = 0; i < seq_b_count; ++i) {
+      token_ids[offset + i] = (int32_t)(i + 300);
+    }
+    iree_tokenizer_postprocessor_assign_type_ids(&state, output, offset,
+                                                 seq_b_count);
+    offset += seq_b_count;
+
     iree_tokenizer_postprocessor_begin_suffix(&state);
     offset += iree_tokenizer_postprocessor_emit_suffix(&state, output, offset);
 

--- a/runtime/src/iree/tokenizer/postprocessor_test.cc
+++ b/runtime/src/iree/tokenizer/postprocessor_test.cc
@@ -130,6 +130,27 @@ TEST(Postprocessor, InitializeBertPair) {
   iree_tokenizer_postprocessor_deinitialize(&pp);
 }
 
+TEST(Postprocessor, ExplicitEmptyPairTemplateIsSupported) {
+  auto single = MakeTemplate(/*prefix=*/{}, /*infix=*/{}, /*suffix=*/{});
+  auto pair = MakeTemplate(/*prefix=*/{}, /*infix=*/{}, /*suffix=*/{},
+                           /*prefix_type_ids=*/{},
+                           /*infix_type_ids=*/{},
+                           /*suffix_type_ids=*/{},
+                           /*sequence_a_type_id=*/0,
+                           /*sequence_b_type_id=*/0);
+
+  iree_tokenizer_postprocessor_t pp;
+  IREE_ASSERT_OK(iree_tokenizer_postprocessor_initialize(
+      &single, &pair, IREE_TOKENIZER_POSTPROCESSOR_FLAG_NONE, &pp));
+
+  EXPECT_TRUE(iree_tokenizer_postprocessor_supports_pair(&pp));
+  EXPECT_EQ(iree_tokenizer_postprocessor_template_total_count(&pp.pair), 0);
+  EXPECT_EQ(pp.pair.sequence_a_type_id, 0);
+  EXPECT_EQ(pp.pair.sequence_b_type_id, 0);
+
+  iree_tokenizer_postprocessor_deinitialize(&pp);
+}
+
 TEST(Postprocessor, InitializeLlama) {
   // LLaMA 2 single: <bos> $A
   auto single = MakeTemplate(/*prefix=*/{1}, /*infix=*/{}, /*suffix=*/{});
@@ -594,6 +615,297 @@ TEST(PostprocessorEncodeState, FullBertFlow) {
   EXPECT_EQ(type_ids[4], 0);
 
   EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_DONE);
+}
+
+TEST(PostprocessorEncodeState, FullBertPairFlow) {
+  // BERT pair: [CLS]=101 $A [SEP]=102 $B [SEP]=102
+  // Pair template: prefix={101}, infix={102}, suffix={102}
+  // sequence_a_type_id=0, sequence_b_type_id=1
+  auto pair_tmpl = MakeTemplate(
+      /*prefix=*/{101}, /*infix=*/{102}, /*suffix=*/{102},
+      /*prefix_type_ids=*/{0}, /*infix_type_ids=*/{0},
+      /*suffix_type_ids=*/{1},
+      /*sequence_a_type_id=*/0, /*sequence_b_type_id=*/1);
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = pair_tmpl;
+  pp.flags = IREE_TOKENIZER_POSTPROCESSOR_FLAG_NONE;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &pair_tmpl, &state);
+
+  iree_tokenizer_token_id_t token_ids[10] = {};
+  uint8_t type_ids[10];
+  memset(type_ids, 0xFF, sizeof(type_ids));
+  iree_tokenizer_token_output_t output =
+      iree_tokenizer_make_token_output(token_ids, NULL, type_ids, 10);
+
+  iree_host_size_t offset = 0;
+
+  // Phase: PREFIX → emit [CLS]
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_PREFIX);
+  offset += iree_tokenizer_postprocessor_emit_prefix(&state, output, offset);
+  EXPECT_EQ(offset, 1u);
+  EXPECT_EQ(token_ids[0], 101);
+  EXPECT_EQ(type_ids[0], 0);  // [CLS] type_id from prefix_type_ids
+
+  // Phase: SEQUENCE_A — simulate model producing 2 tokens
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A);
+  token_ids[1] = 2000;
+  token_ids[2] = 2001;
+  iree_tokenizer_postprocessor_assign_type_ids(&state, output, offset, 2);
+  offset += 2;
+  EXPECT_EQ(type_ids[1], 0);  // sequence_a_type_id
+  EXPECT_EQ(type_ids[2], 0);
+
+  // Transition: SEQUENCE_A → INFIX
+  iree_tokenizer_postprocessor_begin_infix(&state);
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX);
+
+  // Phase: INFIX → emit [SEP] between sequences
+  offset += iree_tokenizer_postprocessor_emit_infix(&state, output, offset);
+  EXPECT_EQ(offset, 4u);
+  EXPECT_EQ(token_ids[3], 102);
+  EXPECT_EQ(type_ids[3], 0);  // infix type_id from infix_type_ids
+
+  // Phase: SEQUENCE_B — simulate model producing 2 tokens
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B);
+  token_ids[4] = 3000;
+  token_ids[5] = 3001;
+  iree_tokenizer_postprocessor_assign_type_ids(&state, output, offset, 2);
+  offset += 2;
+  EXPECT_EQ(type_ids[4], 1);  // sequence_b_type_id
+  EXPECT_EQ(type_ids[5], 1);
+
+  // Transition: SEQUENCE_B → SUFFIX
+  iree_tokenizer_postprocessor_begin_suffix(&state);
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SUFFIX);
+
+  // Phase: SUFFIX → emit trailing [SEP]
+  offset += iree_tokenizer_postprocessor_emit_suffix(&state, output, offset);
+  EXPECT_EQ(offset, 7u);
+  EXPECT_EQ(token_ids[6], 102);
+  EXPECT_EQ(type_ids[6], 1);  // suffix type_id from suffix_type_ids
+
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_DONE);
+
+  // Verify full output: [CLS] 2000 2001 [SEP] 3000 3001 [SEP]
+  EXPECT_EQ(token_ids[0], 101);
+  EXPECT_EQ(token_ids[1], 2000);
+  EXPECT_EQ(token_ids[2], 2001);
+  EXPECT_EQ(token_ids[3], 102);
+  EXPECT_EQ(token_ids[4], 3000);
+  EXPECT_EQ(token_ids[5], 3001);
+  EXPECT_EQ(token_ids[6], 102);
+
+  // Verify type_ids: 0 0 0 0 1 1 1
+  EXPECT_EQ(type_ids[0], 0);
+  EXPECT_EQ(type_ids[1], 0);
+  EXPECT_EQ(type_ids[2], 0);
+  EXPECT_EQ(type_ids[3], 0);
+  EXPECT_EQ(type_ids[4], 1);
+  EXPECT_EQ(type_ids[5], 1);
+  EXPECT_EQ(type_ids[6], 1);
+}
+
+TEST(PostprocessorEncodeState, PairBeginInfixNoInfix) {
+  // Template with no infix tokens — begin_infix transitions directly to
+  // SEQUENCE_B (used by models that only use type_ids to distinguish
+  // sequences, no [SEP] between them).
+  auto tmpl = MakeTemplate(
+      /*prefix=*/{101}, /*infix=*/{}, /*suffix=*/{102},
+      /*prefix_type_ids=*/{}, /*infix_type_ids=*/{}, /*suffix_type_ids=*/{},
+      /*sequence_a_type_id=*/0, /*sequence_b_type_id=*/1);
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+
+  // Skip to SEQUENCE_A.
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A;
+  iree_tokenizer_postprocessor_begin_infix(&state);
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B);
+}
+
+TEST(PostprocessorEncodeState, PairTypeIdsOnlyTemplateKeepsSequencePhases) {
+  // No special tokens are required for pair encoding: some templates only use
+  // type IDs to distinguish sequence A from sequence B.
+  auto tmpl = MakeTemplate(
+      /*prefix=*/{}, /*infix=*/{}, /*suffix=*/{},
+      /*prefix_type_ids=*/{}, /*infix_type_ids=*/{}, /*suffix_type_ids=*/{},
+      /*sequence_a_type_id=*/0, /*sequence_b_type_id=*/1);
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A);
+
+  uint8_t type_ids[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+  iree_tokenizer_token_id_t token_ids[4] = {};
+  iree_tokenizer_token_output_t output =
+      iree_tokenizer_make_token_output(token_ids, NULL, type_ids, 4);
+
+  iree_tokenizer_postprocessor_assign_type_ids(&state, output, 0, 2);
+  EXPECT_EQ(type_ids[0], 0);
+  EXPECT_EQ(type_ids[1], 0);
+
+  iree_tokenizer_postprocessor_begin_infix(&state);
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B);
+
+  iree_tokenizer_postprocessor_assign_type_ids(&state, output, 2, 2);
+  EXPECT_EQ(type_ids[2], 1);
+  EXPECT_EQ(type_ids[3], 1);
+}
+
+TEST(PostprocessorEncodeState, PairBeginInfixNoOpWrongPhase) {
+  auto tmpl = MakeTemplate(/*prefix=*/{101}, /*infix=*/{102}, /*suffix=*/{102});
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+
+  // In PREFIX phase — begin_infix should be a no-op.
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_PREFIX);
+  iree_tokenizer_postprocessor_begin_infix(&state);
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_PREFIX);
+}
+
+TEST(PostprocessorEncodeState, EmitInfixNoOpWrongPhase) {
+  auto tmpl = MakeTemplate(/*prefix=*/{101}, /*infix=*/{102}, /*suffix=*/{102});
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+
+  iree_tokenizer_token_id_t token_ids[4] = {};
+  iree_tokenizer_token_output_t output =
+      iree_tokenizer_make_token_output(token_ids, NULL, NULL, 4);
+
+  // In PREFIX phase — emit_infix should return 0.
+  iree_host_size_t emitted =
+      iree_tokenizer_postprocessor_emit_infix(&state, output, 0);
+  EXPECT_EQ(emitted, 0u);
+}
+
+TEST(PostprocessorEncodeState, PairBeginSuffixFromSequenceB) {
+  // Verify begin_suffix works from SEQUENCE_B (not just SEQUENCE_A).
+  auto tmpl = MakeTemplate(
+      /*prefix=*/{101}, /*infix=*/{102}, /*suffix=*/{102},
+      /*prefix_type_ids=*/{}, /*infix_type_ids=*/{}, /*suffix_type_ids=*/{},
+      /*sequence_a_type_id=*/0, /*sequence_b_type_id=*/1);
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B;
+  iree_tokenizer_postprocessor_begin_suffix(&state);
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SUFFIX);
+}
+
+TEST(PostprocessorEncodeState, PairRobertaDoubleInfix) {
+  // RoBERTa pair: <s>=0 $A </s></s>=2,2 $B </s>=2
+  // Two infix tokens (</s></s> between sequences).
+  auto tmpl = MakeTemplate(
+      /*prefix=*/{0}, /*infix=*/{2, 2}, /*suffix=*/{2},
+      /*prefix_type_ids=*/{0}, /*infix_type_ids=*/{0, 0},
+      /*suffix_type_ids=*/{0},
+      /*sequence_a_type_id=*/0, /*sequence_b_type_id=*/0);
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+
+  iree_tokenizer_token_id_t token_ids[10] = {};
+  uint8_t type_ids[10];
+  memset(type_ids, 0xFF, sizeof(type_ids));
+  iree_tokenizer_token_output_t output =
+      iree_tokenizer_make_token_output(token_ids, NULL, type_ids, 10);
+
+  iree_host_size_t offset = 0;
+
+  // PREFIX: <s>
+  offset += iree_tokenizer_postprocessor_emit_prefix(&state, output, offset);
+  EXPECT_EQ(offset, 1u);
+
+  // SEQUENCE_A: 2 tokens
+  token_ids[offset] = 500;
+  token_ids[offset + 1] = 501;
+  iree_tokenizer_postprocessor_assign_type_ids(&state, output, offset, 2);
+  offset += 2;
+
+  // INFIX: </s></s> (two tokens)
+  iree_tokenizer_postprocessor_begin_infix(&state);
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX);
+  offset += iree_tokenizer_postprocessor_emit_infix(&state, output, offset);
+  EXPECT_EQ(offset, 5u);
+  EXPECT_EQ(token_ids[3], 2);
+  EXPECT_EQ(token_ids[4], 2);
+
+  // SEQUENCE_B: 1 token
+  ASSERT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B);
+  token_ids[offset] = 600;
+  iree_tokenizer_postprocessor_assign_type_ids(&state, output, offset, 1);
+  offset += 1;
+
+  // SUFFIX: </s>
+  iree_tokenizer_postprocessor_begin_suffix(&state);
+  offset += iree_tokenizer_postprocessor_emit_suffix(&state, output, offset);
+  EXPECT_EQ(offset, 7u);
+  EXPECT_EQ(token_ids[6], 2);
+
+  EXPECT_EQ(state.phase, IREE_TOKENIZER_POSTPROCESSOR_PHASE_DONE);
+
+  // All type_ids should be 0 for RoBERTa (sequence_a_type_id=0,
+  // sequence_b_type_id=0).
+  for (int j = 0; j < 7; ++j) {
+    EXPECT_EQ(type_ids[j], 0) << "type_ids[" << j << "]";
+  }
+}
+
+TEST(PostprocessorEncodeState, HasPendingIncludesInfix) {
+  auto tmpl = MakeTemplate(/*prefix=*/{101}, /*infix=*/{102}, /*suffix=*/{102});
+
+  iree_tokenizer_postprocessor_t pp = {};
+  pp.pair = tmpl;
+
+  iree_tokenizer_postprocessor_encode_state_t state;
+  iree_tokenizer_postprocessor_encode_state_initialize(&pp, &tmpl, &state);
+
+  // PREFIX: has_pending = true
+  EXPECT_TRUE(iree_tokenizer_postprocessor_encode_state_has_pending(&state));
+
+  // SEQUENCE_A: has_pending = false (model tokens, not postprocessor tokens)
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_A;
+  EXPECT_FALSE(iree_tokenizer_postprocessor_encode_state_has_pending(&state));
+
+  // INFIX: has_pending = true
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_INFIX;
+  EXPECT_TRUE(iree_tokenizer_postprocessor_encode_state_has_pending(&state));
+
+  // SEQUENCE_B: has_pending = false
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_SEQUENCE_B;
+  EXPECT_FALSE(iree_tokenizer_postprocessor_encode_state_has_pending(&state));
+
+  // SUFFIX: has_pending = true
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_SUFFIX;
+  EXPECT_TRUE(iree_tokenizer_postprocessor_encode_state_has_pending(&state));
+
+  // DONE: has_pending = false
+  state.phase = IREE_TOKENIZER_POSTPROCESSOR_PHASE_DONE;
+  EXPECT_FALSE(iree_tokenizer_postprocessor_encode_state_has_pending(&state));
 }
 
 TEST(PostprocessorEncodeState, EmitPrefixWithOffsets) {

--- a/runtime/src/iree/tokenizer/testdata/BUILD.bazel
+++ b/runtime/src/iree/tokenizer/testdata/BUILD.bazel
@@ -17,6 +17,7 @@ iree_c_embed_data(
     testonly = True,
     srcs = [
         "bpe_bytelevel_minimal.json",
+        "wordpiece_bert_pair_minimal.json",
     ],
     c_file_output = "streaming_testdata.c",
     flatten = True,

--- a/runtime/src/iree/tokenizer/testdata/CMakeLists.txt
+++ b/runtime/src/iree/tokenizer/testdata/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_c_embed_data(
     streaming_testdata
   SRCS
     "bpe_bytelevel_minimal.json"
+    "wordpiece_bert_pair_minimal.json"
   C_FILE_OUTPUT
     "streaming_testdata.c"
   H_FILE_OUTPUT

--- a/runtime/src/iree/tokenizer/testdata/wordpiece_bert_pair_minimal.json
+++ b/runtime/src/iree/tokenizer/testdata/wordpiece_bert_pair_minimal.json
@@ -1,0 +1,117 @@
+{
+  "model": {
+    "type": "WordPiece",
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": "##",
+    "max_input_chars_per_word": 100,
+    "vocab": {
+      "[PAD]": 0,
+      "[UNK]": 100,
+      "[CLS]": 101,
+      "[SEP]": 102,
+      "[MASK]": 103,
+      "hello": 7592,
+      "world": 2088,
+      "deep": 2784,
+      "learning": 4083,
+      "is": 2003,
+      "a": 1037,
+      "the": 1996,
+      "weather": 4633,
+      "today": 2651,
+      "sunny": 11560,
+      "neural": 15755,
+      "networks": 12955,
+      "##s": 2015
+    }
+  },
+  "added_tokens": [
+    {
+      "id": 0,
+      "content": "[PAD]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    },
+    {
+      "id": 100,
+      "content": "[UNK]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    },
+    {
+      "id": 101,
+      "content": "[CLS]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    },
+    {
+      "id": 102,
+      "content": "[SEP]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    },
+    {
+      "id": 103,
+      "content": "[MASK]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": true,
+      "special": true
+    }
+  ],
+  "normalizer": {
+    "type": "BertNormalizer",
+    "clean_text": true,
+    "handle_chinese_chars": true,
+    "strip_accents": null,
+    "lowercase": true
+  },
+  "pre_tokenizer": {
+    "type": "BertPreTokenizer"
+  },
+  "post_processor": {
+    "type": "TemplateProcessing",
+    "single": [
+      {"SpecialToken": {"id": "[CLS]", "type_id": 0}},
+      {"Sequence": {"id": "A", "type_id": 0}},
+      {"SpecialToken": {"id": "[SEP]", "type_id": 0}}
+    ],
+    "pair": [
+      {"SpecialToken": {"id": "[CLS]", "type_id": 0}},
+      {"Sequence": {"id": "A", "type_id": 0}},
+      {"SpecialToken": {"id": "[SEP]", "type_id": 0}},
+      {"Sequence": {"id": "B", "type_id": 1}},
+      {"SpecialToken": {"id": "[SEP]", "type_id": 1}}
+    ],
+    "special_tokens": {
+      "[CLS]": {
+        "id": "[CLS]",
+        "ids": [101],
+        "tokens": ["[CLS]"]
+      },
+      "[SEP]": {
+        "id": "[SEP]",
+        "ids": [102],
+        "tokens": ["[SEP]"]
+      }
+    }
+  },
+  "decoder": {
+    "type": "WordPiece",
+    "prefix": "##",
+    "cleanup": true
+  }
+}

--- a/runtime/src/iree/tokenizer/testing/fuzzing_util.c
+++ b/runtime/src/iree/tokenizer/testing/fuzzing_util.c
@@ -198,6 +198,33 @@ static iree_status_t iree_fuzz_build_dummy_tokenizer(
   }
   iree_tokenizer_builder_set_decoder(&builder, decoder);
 
+  iree_tokenizer_postprocessor_template_t single_template = {0};
+  single_template.prefix_count = 1;
+  single_template.suffix_count = 1;
+  single_template.token_ids[0] = 1;
+  single_template.token_ids[1] = 2;
+
+  iree_tokenizer_postprocessor_template_t pair_template = {0};
+  pair_template.prefix_count = 1;
+  pair_template.infix_count = 1;
+  pair_template.suffix_count = 1;
+  pair_template.sequence_a_type_id = 0;
+  pair_template.sequence_b_type_id = 1;
+  pair_template.token_ids[0] = 1;
+  pair_template.token_ids[1] = 2;
+  pair_template.token_ids[2] = 2;
+  pair_template.type_ids[2] = 1;
+
+  iree_tokenizer_postprocessor_t postprocessor;
+  status = iree_tokenizer_postprocessor_initialize(
+      &single_template, &pair_template, IREE_TOKENIZER_POSTPROCESSOR_FLAG_NONE,
+      &postprocessor);
+  if (!iree_status_is_ok(status)) {
+    iree_tokenizer_builder_deinitialize(&builder);
+    return status;
+  }
+  iree_tokenizer_builder_set_postprocessor(&builder, postprocessor);
+
   // Build.
   status = iree_tokenizer_builder_build(&builder, out_tokenizer);
   iree_tokenizer_builder_deinitialize(&builder);

--- a/runtime/src/iree/tokenizer/testing/fuzzing_util.h
+++ b/runtime/src/iree/tokenizer/testing/fuzzing_util.h
@@ -55,6 +55,7 @@ extern "C" {
 //   - Special tokens: UNK=0, BOS=1, EOS=2
 //   - Whitespace segmenter
 //   - BPE model with FUSE_UNK (no merges, character-level)
+//   - BOS/EOS postprocessor with single and pair templates
 //   - Byte-level decoder
 //
 // |out_vocab_size| receives the vocab capacity (max_token_id + 1). May be NULL

--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -1065,6 +1065,140 @@ iree_status_t iree_tokenizer_decode(const iree_tokenizer_t* tokenizer,
 // Multi-Item Batch Encode/Decode
 //===----------------------------------------------------------------------===//
 
+typedef uint32_t iree_tokenizer_encode_state_reset_flags_t;
+enum iree_tokenizer_encode_state_reset_flag_bits_e {
+  IREE_TOKENIZER_ENCODE_STATE_RESET_FLAG_NONE = 0u,
+  // Preserve postprocessor phase/template while resetting the rest of the
+  // encode pipeline. Used between pair sequence A and sequence B.
+  IREE_TOKENIZER_ENCODE_STATE_RESET_FLAG_PRESERVE_POSTPROCESSOR = 1u << 0,
+};
+
+typedef uint32_t iree_tokenizer_encode_state_finalize_flags_t;
+enum iree_tokenizer_encode_state_finalize_flag_bits_e {
+  IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_NONE = 0u,
+  // Finalize normalizer/segmenter/model state without transitioning to or
+  // emitting the postprocessor suffix. Used after pair sequence A so the
+  // caller can emit the pair infix and continue with sequence B.
+  IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_OMIT_SUFFIX = 1u << 0,
+};
+
+static iree_status_t iree_tokenizer_encode_state_finalize_internal(
+    iree_tokenizer_encode_state_t* state, iree_tokenizer_token_output_t output,
+    iree_tokenizer_encode_state_finalize_flags_t finalize_flags,
+    iree_host_size_t* out_token_count);
+
+static void iree_tokenizer_encode_state_reset_internal(
+    iree_tokenizer_encode_state_t* state, iree_tokenizer_encode_flags_t flags,
+    iree_tokenizer_encode_state_reset_flags_t reset_flags) {
+  if (!state) return;
+  const iree_tokenizer_t* tokenizer = state->tokenizer;
+
+  // Deinitialize and re-initialize pipeline stage states.
+  iree_tokenizer_model_state_deinitialize(state->model_state);
+  iree_tokenizer_segmenter_state_deinitialize(state->segmenter_state);
+  iree_tokenizer_normalizer_state_deinitialize(state->normalizer_state);
+
+  // Reset ring buffer positions.
+  state->flags = flags;
+  state->read_position = 0;
+  state->write_position = 0;
+  state->segmenter_view_start = 0;
+  state->segment_count = 0;
+  state->segments_consumed = 0;
+
+  // Re-initialize pipeline stage states (storage layout unchanged).
+  if (state->normalizer_state) {
+    iree_tokenizer_normalizer_state_initialize(tokenizer->normalizer,
+                                               (void*)state->normalizer_state,
+                                               &state->normalizer_state);
+  }
+  if (state->segmenter_state) {
+    iree_tokenizer_segmenter_state_initialize(tokenizer->segmenter,
+                                              (void*)state->segmenter_state,
+                                              &state->segmenter_state);
+  }
+  if (state->model_state) {
+    iree_tokenizer_model_state_initialize(
+        tokenizer->model, (void*)state->model_state, &state->model_state);
+  }
+
+  // Reset special token match states.
+  iree_tokenizer_special_tokens_encode_state_initialize(
+      &state->special_token_match);
+  iree_tokenizer_special_tokens_encode_state_initialize(
+      &state->special_token_match_post);
+
+  if (!iree_all_bits_set(
+          reset_flags,
+          IREE_TOKENIZER_ENCODE_STATE_RESET_FLAG_PRESERVE_POSTPROCESSOR)) {
+    if (iree_all_bits_set(flags,
+                          IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS)) {
+      iree_tokenizer_postprocessor_encode_state_initialize(
+          &tokenizer->postprocessor, &tokenizer->postprocessor.single,
+          &state->postprocessor);
+    } else {
+      memset(&state->postprocessor, 0, sizeof(state->postprocessor));
+    }
+  }
+
+  state->pending_special_token = -1;
+  state->first_consumed_by_special_token = false;
+  state->in_finalize_mode = false;
+  state->has_partial_segment = false;
+}
+
+static iree_tokenizer_token_output_t iree_tokenizer_sub_token_output(
+    iree_tokenizer_token_output_t output, iree_host_size_t token_offset) {
+  iree_tokenizer_token_output_t sub_output = {
+      .capacity = output.capacity - token_offset,
+      .token_ids = output.token_ids ? &output.token_ids[token_offset] : NULL,
+      .token_offsets =
+          output.token_offsets ? &output.token_offsets[token_offset] : NULL,
+      .type_ids = output.type_ids ? &output.type_ids[token_offset] : NULL,
+  };
+  return sub_output;
+}
+
+static iree_status_t iree_tokenizer_encode_batch_feed_sequence(
+    iree_tokenizer_encode_state_t* state, iree_string_view_t text,
+    iree_tokenizer_token_output_t output,
+    iree_tokenizer_encode_state_finalize_flags_t finalize_flags,
+    iree_host_size_t* total_tokens) {
+  while (text.size > 0) {
+    if (*total_tokens >= output.capacity) {
+      return iree_make_status(
+          IREE_STATUS_RESOURCE_EXHAUSTED,
+          "batch encode: output buffer full before input was consumed "
+          "(wrote %" PRIhsz " of %" PRIhsz " capacity)",
+          *total_tokens, output.capacity);
+    }
+    iree_host_size_t bytes_consumed = 0;
+    iree_host_size_t tokens_written = 0;
+    iree_tokenizer_token_output_t sub_output =
+        iree_tokenizer_sub_token_output(output, *total_tokens);
+    iree_status_t status = iree_tokenizer_encode_state_feed(
+        state, text, sub_output, &bytes_consumed, &tokens_written);
+    *total_tokens += tokens_written;
+    if (!iree_status_is_ok(status)) return status;
+    text.data += bytes_consumed;
+    text.size -= bytes_consumed;
+  }
+
+  if (*total_tokens > output.capacity) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "batch encode: output count exceeded capacity "
+                            "(wrote %" PRIhsz " of %" PRIhsz " capacity)",
+                            *total_tokens, output.capacity);
+  }
+  iree_host_size_t final_tokens = 0;
+  iree_tokenizer_token_output_t final_output =
+      iree_tokenizer_sub_token_output(output, *total_tokens);
+  iree_status_t status = iree_tokenizer_encode_state_finalize_internal(
+      state, final_output, finalize_flags, &final_tokens);
+  *total_tokens += final_tokens;
+  return status;
+}
+
 iree_status_t iree_tokenizer_encode_batch(
     const iree_tokenizer_t* tokenizer,
     iree_tokenizer_encode_batch_item_t* items, iree_host_size_t item_count,
@@ -1096,55 +1230,90 @@ iree_status_t iree_tokenizer_encode_batch(
       effective_flags |= IREE_TOKENIZER_ENCODE_FLAG_TRACK_OFFSETS;
     }
 
+    bool has_text_pair = iree_all_bits_set(
+        item->flags, IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR);
+    iree_tokenizer_encode_batch_item_flags_t unknown_flags =
+        item->flags & ~IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+    if (unknown_flags != 0) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "batch encode item has unknown flags 0x%08x",
+                                (unsigned)unknown_flags);
+    } else if (!has_text_pair && item->text_pair.size > 0) {
+      status = iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "batch encode item has non-empty text_pair but HAS_TEXT_PAIR flag "
+          "is not set");
+    }
+
     // First item: full initialize. Subsequent items: lightweight reset.
-    if (state == NULL) {
+    if (iree_status_is_ok(status) && state == NULL) {
       status = iree_tokenizer_encode_state_initialize(
           tokenizer, state_storage, transform_buffer, offset_runs,
           effective_flags, &state);
-    } else {
+    } else if (iree_status_is_ok(status)) {
       iree_tokenizer_encode_state_reset(state, effective_flags);
     }
 
-    // Feed all text, collecting tokens.
-    iree_string_view_t text = item->text;
-    iree_host_size_t total_tokens = 0;
-
-    while (iree_status_is_ok(status) && text.size > 0) {
-      iree_host_size_t bytes_consumed = 0;
-      iree_host_size_t tokens_written = 0;
-      iree_tokenizer_token_output_t sub_output = {
-          .capacity = item->output.capacity - total_tokens,
-          .token_ids = &item->output.token_ids[total_tokens],
-          .token_offsets = item->output.token_offsets
-                               ? &item->output.token_offsets[total_tokens]
-                               : NULL,
-          .type_ids = item->output.type_ids
-                          ? &item->output.type_ids[total_tokens]
-                          : NULL,
-      };
-      status = iree_tokenizer_encode_state_feed(
-          state, text, sub_output, &bytes_consumed, &tokens_written);
-      total_tokens += tokens_written;
-      text.data += bytes_consumed;
-      text.size -= bytes_consumed;
+    // For pair encoding, re-initialize the postprocessor with the pair
+    // template. encode_state_initialize/reset always selects the single
+    // template; pair template selection is an encode_batch concern since the
+    // streaming API does not support pair encoding.
+    if (iree_status_is_ok(status) && has_text_pair &&
+        iree_all_bits_set(effective_flags,
+                          IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS)) {
+      if (!iree_tokenizer_postprocessor_supports_pair(
+              &tokenizer->postprocessor)) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "pair encoding requested but tokenizer has no pair template");
+      } else {
+        iree_tokenizer_postprocessor_encode_state_initialize(
+            &tokenizer->postprocessor, &tokenizer->postprocessor.pair,
+            &state->postprocessor);
+      }
     }
 
-    // Finalize to flush remaining tokens.
+    // Feed all text (sequence A), collecting tokens.
+    iree_host_size_t total_tokens = 0;
+
     if (iree_status_is_ok(status)) {
-      iree_host_size_t final_tokens = 0;
-      iree_tokenizer_token_output_t final_output = {
-          .capacity = item->output.capacity - total_tokens,
-          .token_ids = &item->output.token_ids[total_tokens],
-          .token_offsets = item->output.token_offsets
-                               ? &item->output.token_offsets[total_tokens]
-                               : NULL,
-          .type_ids = item->output.type_ids
-                          ? &item->output.type_ids[total_tokens]
-                          : NULL,
-      };
-      status = iree_tokenizer_encode_state_finalize(state, final_output,
-                                                    &final_tokens);
-      total_tokens += final_tokens;
+      iree_tokenizer_encode_state_finalize_flags_t finalize_flags =
+          has_text_pair ? IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_OMIT_SUFFIX
+                        : IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_NONE;
+      status = iree_tokenizer_encode_batch_feed_sequence(
+          state, item->text, item->output, finalize_flags, &total_tokens);
+    }
+
+    // Pair encoding: emit infix tokens, reset pipeline for sequence B, then
+    // feed and finalize the second text.
+    if (iree_status_is_ok(status) && has_text_pair) {
+      // Transition SEQUENCE_A → INFIX (or directly to SEQUENCE_B).
+      iree_tokenizer_postprocessor_begin_infix(&state->postprocessor);
+
+      // Emit infix special tokens (e.g., [SEP] between sequences).
+      total_tokens += iree_tokenizer_postprocessor_emit_infix(
+          &state->postprocessor, item->output, total_tokens);
+      if (iree_tokenizer_postprocessor_encode_state_has_pending(
+              &state->postprocessor)) {
+        status = iree_make_status(
+            IREE_STATUS_RESOURCE_EXHAUSTED,
+            "batch encode: output buffer full while emitting pair infix "
+            "(wrote %" PRIhsz " of %" PRIhsz " capacity)",
+            total_tokens, item->output.capacity);
+      }
+    }
+
+    if (iree_status_is_ok(status) && has_text_pair) {
+      // Reset the normalizer/segmenter/model pipeline for sequence B while
+      // preserving the postprocessor state (now in SEQUENCE_B phase).
+      // AT_INPUT_START is set because sequence B is a fresh input to the
+      // normalizer (e.g., prepend_scheme="first" applies per-sequence).
+      iree_tokenizer_encode_state_reset_internal(
+          state, effective_flags,
+          IREE_TOKENIZER_ENCODE_STATE_RESET_FLAG_PRESERVE_POSTPROCESSOR);
+      status = iree_tokenizer_encode_batch_feed_sequence(
+          state, item->text_pair, item->output,
+          IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_NONE, &total_tokens);
     }
 
     item->out_token_count = total_tokens;
@@ -1430,58 +1599,8 @@ void iree_tokenizer_encode_state_deinitialize(
 
 void iree_tokenizer_encode_state_reset(iree_tokenizer_encode_state_t* state,
                                        iree_tokenizer_encode_flags_t flags) {
-  if (!state) return;
-  const iree_tokenizer_t* tokenizer = state->tokenizer;
-
-  // Deinitialize component states (may have pending data to clear).
-  iree_tokenizer_model_state_deinitialize(state->model_state);
-  iree_tokenizer_segmenter_state_deinitialize(state->segmenter_state);
-  iree_tokenizer_normalizer_state_deinitialize(state->normalizer_state);
-
-  // Reset ring buffer positions.
-  state->flags = flags;
-  state->read_position = 0;
-  state->write_position = 0;
-  state->segmenter_view_start = 0;
-  state->segment_count = 0;
-  state->segments_consumed = 0;
-
-  // Re-initialize component states (storage layout unchanged).
-  if (state->normalizer_state) {
-    iree_tokenizer_normalizer_state_initialize(tokenizer->normalizer,
-                                               (void*)state->normalizer_state,
-                                               &state->normalizer_state);
-  }
-  if (state->segmenter_state) {
-    iree_tokenizer_segmenter_state_initialize(tokenizer->segmenter,
-                                              (void*)state->segmenter_state,
-                                              &state->segmenter_state);
-  }
-  if (state->model_state) {
-    iree_tokenizer_model_state_initialize(
-        tokenizer->model, (void*)state->model_state, &state->model_state);
-  }
-
-  // Reset special token match state.
-  iree_tokenizer_special_tokens_encode_state_initialize(
-      &state->special_token_match);
-
-  // Reset post-normalization special token match state.
-  iree_tokenizer_special_tokens_encode_state_initialize(
-      &state->special_token_match_post);
-
-  // Reset postprocessor state if ADD_SPECIAL_TOKENS is requested.
-  if (iree_all_bits_set(flags, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS)) {
-    iree_tokenizer_postprocessor_encode_state_initialize(
-        &tokenizer->postprocessor, &tokenizer->postprocessor.single,
-        &state->postprocessor);
-  } else {
-    memset(&state->postprocessor, 0, sizeof(state->postprocessor));
-  }
-
-  state->pending_special_token = -1;
-  state->first_consumed_by_special_token = false;
-  state->in_finalize_mode = false;
+  iree_tokenizer_encode_state_reset_internal(
+      state, flags, IREE_TOKENIZER_ENCODE_STATE_RESET_FLAG_NONE);
 }
 
 // Returns true if the encode pipeline has content that must be emitted before
@@ -2680,8 +2799,9 @@ iree_status_t iree_tokenizer_encode_state_feed(
   return status;
 }
 
-iree_status_t iree_tokenizer_encode_state_finalize(
+static iree_status_t iree_tokenizer_encode_state_finalize_internal(
     iree_tokenizer_encode_state_t* state, iree_tokenizer_token_output_t output,
+    iree_tokenizer_encode_state_finalize_flags_t finalize_flags,
     iree_host_size_t* out_token_count) {
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(output.token_ids);
@@ -2928,9 +3048,13 @@ iree_status_t iree_tokenizer_encode_state_finalize(
   }
 
   // Emit suffix special tokens (e.g., [SEP], </s>) after all model tokens.
-  iree_tokenizer_postprocessor_begin_suffix(&state->postprocessor);
-  total_tokens += iree_tokenizer_postprocessor_emit_suffix(
-      &state->postprocessor, output, total_tokens);
+  if (!iree_all_bits_set(
+          finalize_flags,
+          IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_OMIT_SUFFIX)) {
+    iree_tokenizer_postprocessor_begin_suffix(&state->postprocessor);
+    total_tokens += iree_tokenizer_postprocessor_emit_suffix(
+        &state->postprocessor, output, total_tokens);
+  }
 
   *out_token_count = total_tokens;
 
@@ -2946,6 +3070,14 @@ iree_status_t iree_tokenizer_encode_state_finalize(
   }
 
   return iree_ok_status();
+}
+
+iree_status_t iree_tokenizer_encode_state_finalize(
+    iree_tokenizer_encode_state_t* state, iree_tokenizer_token_output_t output,
+    iree_host_size_t* out_token_count) {
+  return iree_tokenizer_encode_state_finalize_internal(
+      state, output, IREE_TOKENIZER_ENCODE_STATE_FINALIZE_FLAG_NONE,
+      out_token_count);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/tokenizer/tokenizer.h
+++ b/runtime/src/iree/tokenizer/tokenizer.h
@@ -147,7 +147,7 @@ enum iree_tokenizer_encode_flag_bits_e {
   // Insert special tokens from the postprocessor template (prefix, suffix).
   // When set, the postprocessor's active template (single or pair) is used
   // to emit special tokens and assign type_ids to model-produced tokens.
-  // When not set, no special tokens are inserted and type_ids are all 0.
+  // When not set, no special tokens are inserted and type_ids are not written.
   IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS = 1u << 2,
   // Disable special token matching in input text. When set, sequences like
   // <|endoftext|> are tokenized as ordinary text instead of being matched
@@ -367,14 +367,38 @@ iree_status_t iree_tokenizer_decode(const iree_tokenizer_t* tokenizer,
 // Multi-Item Batch Encode/Decode
 //===----------------------------------------------------------------------===//
 
+// Per-item flags for multi-item batch encoding.
+enum iree_tokenizer_encode_batch_item_flag_bits_e {
+  IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_NONE = 0u,
+  // Indicates that |text_pair| is present and should be encoded as sequence B.
+  // This distinguishes an absent pair from an intentionally empty second
+  // sequence.
+  IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR = 1u << 0,
+};
+typedef uint32_t iree_tokenizer_encode_batch_item_flags_t;
+
 // Input/output item for multi-item batch encoding. Caller allocates arrays of
 // these items, fills in the inputs (text, output buffers), and the batch
 // function fills in out_token_count for each.
 typedef struct iree_tokenizer_encode_batch_item_t {
-  // Input: text to encode.
+  // Input: text to encode (sequence A).
   iree_string_view_t text;
+
+  // Input: optional second text for pair encoding (sequence B).
+  // Only read when |flags| contains HAS_TEXT_PAIR. When ADD_SPECIAL_TOKENS is
+  // also set, the postprocessor's pair template is used instead of the single
+  // template: the output is [prefix] text [infix] text_pair [suffix] with
+  // type_ids assigned per the template's sequence_a_type_id and
+  // sequence_b_type_id. Token offsets for sequence B are relative to
+  // |text_pair|, and special tokens use zero-length offsets.
+  iree_string_view_t text_pair;
+
+  // Input: per-item options controlling batch encoding.
+  iree_tokenizer_encode_batch_item_flags_t flags;
+
   // Input: output buffers for token IDs and optional offsets.
   iree_tokenizer_token_output_t output;
+
   // Output: actual number of tokens written.
   iree_host_size_t out_token_count;
 } iree_tokenizer_encode_batch_item_t;

--- a/runtime/src/iree/tokenizer/tokenizer_batch_encode_fuzz.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_batch_encode_fuzz.cc
@@ -51,27 +51,52 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   // First byte: number of batch items (1-16).
   size_t item_count = (data[0] % kMaxBatchItems) + 1;
-  data++;
-  size--;
+  uint8_t batch_control = data[1];
+  data += 2;
+  size -= 2;
 
   // Partition remaining bytes among items.
   // Each item gets a roughly equal share, with remainder going to last item.
-  iree_tokenizer_encode_batch_item_t items[kMaxBatchItems];
+  iree_tokenizer_encode_batch_item_t items[kMaxBatchItems] = {};
   iree_tokenizer_token_id_t token_storage[kMaxBatchItems * kMaxTokensPerItem];
+  iree_tokenizer_offset_t offset_storage[kMaxBatchItems * kMaxTokensPerItem];
+  uint8_t type_id_storage[kMaxBatchItems * kMaxTokensPerItem];
 
   size_t offset = 0;
   size_t base_item_size = size / item_count;
   for (size_t i = 0; i < item_count; ++i) {
     size_t item_size = (i == item_count - 1) ? (size - offset) : base_item_size;
 
-    items[i].text = iree_make_string_view(
-        reinterpret_cast<const char*>(data + offset), item_size);
+    const uint8_t* item_data = data + offset;
+    bool has_text_pair = item_size > 0 && (item_data[0] & 0x01) != 0;
+    if (has_text_pair) {
+      size_t payload_size = item_size - 1;
+      size_t split = payload_size == 0 ? 0 : item_data[0] % (payload_size + 1);
+      items[i].text = iree_make_string_view(
+          reinterpret_cast<const char*>(item_data + 1), split);
+      items[i].text_pair = iree_make_string_view(
+          reinterpret_cast<const char*>(item_data + 1 + split),
+          payload_size - split);
+      items[i].flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+    } else {
+      items[i].text = iree_make_string_view(
+          reinterpret_cast<const char*>(item_data), item_size);
+    }
 
     // Each item gets its own slice of the token output buffer.
     iree_tokenizer_token_id_t* item_tokens =
         &token_storage[i * kMaxTokensPerItem];
+    iree_tokenizer_offset_t* item_offsets =
+        &offset_storage[i * kMaxTokensPerItem];
+    uint8_t* item_type_ids = &type_id_storage[i * kMaxTokensPerItem];
     items[i].output = iree_tokenizer_make_token_output(item_tokens, NULL, NULL,
                                                        kMaxTokensPerItem);
+    if (iree_tokenizer_fuzz_track_offsets()) {
+      items[i].output.token_offsets = item_offsets;
+    }
+    if (batch_control & 0x02) {
+      items[i].output.type_ids = item_type_ids;
+    }
     items[i].out_token_count = 0;
 
     offset += item_size;
@@ -114,9 +139,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   //===--------------------------------------------------------------------===//
 
   iree_tokenizer_encode_flags_t flags = IREE_TOKENIZER_ENCODE_FLAG_NONE;
-  if (iree_tokenizer_fuzz_track_offsets()) {
-    flags |= IREE_TOKENIZER_ENCODE_FLAG_TRACK_OFFSETS;
+  if (batch_control & 0x01) {
+    flags |= IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS;
   }
+
+  iree_tokenizer_offset_run_t offset_runs[4096];
+  iree_tokenizer_offset_run_list_t offset_run_list = {
+      /*.capacity=*/IREE_ARRAYSIZE(offset_runs),
+      /*.values=*/offset_runs,
+  };
 
   status = iree_tokenizer_encode_batch(
       g_tokenizer, items, item_count, flags,
@@ -124,7 +155,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                           state_size),
       iree_make_byte_span(reinterpret_cast<uint8_t*>(transform_buffer),
                           buffer_size),
-      iree_tokenizer_offset_run_list_empty());
+      iree_tokenizer_fuzz_track_offsets()
+          ? offset_run_list
+          : iree_tokenizer_offset_run_list_empty());
   // RESOURCE_EXHAUSTED is expected when output buffers are too small.
   iree_status_ignore(status);
 

--- a/runtime/src/iree/tokenizer/tokenizer_huggingface_test.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_huggingface_test.cc
@@ -1017,5 +1017,474 @@ TEST(GroundTruthInvarianceTest, AllBufferSizesProduceIdenticalOutput) {
   iree_tokenizer_free(tokenizer);
 }
 
+//===----------------------------------------------------------------------===//
+// Pair Encoding Tests (BERT TemplateProcessing)
+//===----------------------------------------------------------------------===//
+
+// Helper: batch-encode a single (text, text_pair) item with ADD_SPECIAL_TOKENS.
+// Returns {token_ids, type_ids} vectors.
+struct PairEncodeResult {
+  std::vector<iree_tokenizer_token_id_t> token_ids;
+  std::vector<uint8_t> type_ids;
+};
+
+struct PairEncodeDetailedResult {
+  std::vector<iree_tokenizer_token_id_t> token_ids;
+  std::vector<uint8_t> type_ids;
+  std::vector<iree_tokenizer_offset_t> token_offsets;
+};
+
+static StatusOr<PairEncodeResult> EncodePair(iree_tokenizer_t* tokenizer,
+                                             iree_string_view_t text,
+                                             iree_string_view_t text_pair) {
+  iree_host_size_t state_size = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_tokenizer_encode_state_calculate_size(tokenizer, &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+
+  std::vector<iree_tokenizer_token_id_t> token_ids(256);
+  std::vector<uint8_t> type_ids(256, 0xFF);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = text;
+  item.text_pair = text_pair;
+  item.flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+  item.output = iree_tokenizer_make_token_output(token_ids.data(), nullptr,
+                                                 type_ids.data(), 256);
+  item.out_token_count = 0;
+
+  IREE_RETURN_IF_ERROR(iree_tokenizer_encode_batch(
+      tokenizer, &item, 1, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty()));
+
+  token_ids.resize(item.out_token_count);
+  type_ids.resize(item.out_token_count);
+  return PairEncodeResult{std::move(token_ids), std::move(type_ids)};
+}
+
+static StatusOr<PairEncodeDetailedResult> EncodePairDetailed(
+    iree_tokenizer_t* tokenizer, iree_string_view_t text,
+    iree_string_view_t text_pair, iree_host_size_t output_capacity,
+    bool track_offsets) {
+  iree_host_size_t state_size = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_tokenizer_encode_state_calculate_size(tokenizer, &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+  std::vector<iree_tokenizer_offset_run_t> offset_runs(256);
+
+  iree_host_size_t storage_capacity = output_capacity > 0 ? output_capacity : 1;
+  std::vector<iree_tokenizer_token_id_t> token_ids(storage_capacity);
+  std::vector<uint8_t> type_ids(storage_capacity, 0xFF);
+  std::vector<iree_tokenizer_offset_t> token_offsets(storage_capacity);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = text;
+  item.text_pair = text_pair;
+  item.flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+  item.output = iree_tokenizer_make_token_output(
+      token_ids.data(), track_offsets ? token_offsets.data() : nullptr,
+      type_ids.data(), output_capacity);
+
+  iree_tokenizer_offset_run_list_t offset_run_list = {
+      /*.capacity=*/offset_runs.size(),
+      /*.values=*/offset_runs.data(),
+  };
+  IREE_RETURN_IF_ERROR(iree_tokenizer_encode_batch(
+      tokenizer, &item, 1, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      track_offsets ? offset_run_list
+                    : iree_tokenizer_offset_run_list_empty()));
+
+  token_ids.resize(item.out_token_count);
+  type_ids.resize(item.out_token_count);
+  token_offsets.resize(track_offsets ? item.out_token_count : 0);
+  return PairEncodeDetailedResult{std::move(token_ids), std::move(type_ids),
+                                  std::move(token_offsets)};
+}
+
+// Helper: batch-encode single-sequence with ADD_SPECIAL_TOKENS.
+static StatusOr<std::vector<iree_tokenizer_token_id_t>> EncodeSingle(
+    iree_tokenizer_t* tokenizer, iree_string_view_t text) {
+  iree_host_size_t state_size = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_tokenizer_encode_state_calculate_size(tokenizer, &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+
+  std::vector<iree_tokenizer_token_id_t> token_ids(256);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = text;
+  item.output =
+      iree_tokenizer_make_token_output(token_ids.data(), nullptr, nullptr, 256);
+  item.out_token_count = 0;
+
+  IREE_RETURN_IF_ERROR(iree_tokenizer_encode_batch(
+      tokenizer, &item, 1, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty()));
+
+  token_ids.resize(item.out_token_count);
+  return token_ids;
+}
+
+TEST(PairEncode, BertSingleSequence) {
+  // Verify single-sequence encoding still works with the BERT pair tokenizer.
+  // Expected: [CLS]=101, "hello"=7592, [SEP]=102
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  IREE_ASSERT_OK_AND_ASSIGN(auto ids,
+                            EncodeSingle(tokenizer.get(), IREE_SV("hello")));
+
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], 101);   // [CLS]
+  EXPECT_EQ(ids[1], 7592);  // hello
+  EXPECT_EQ(ids[2], 102);   // [SEP]
+}
+
+TEST(PairEncode, BertPairSequence) {
+  // BERT pair: [CLS] query [SEP] document [SEP]
+  // Input: text="hello", text_pair="world"
+  // Expected token_ids: [101, 7592, 102, 2088, 102]
+  // Expected type_ids:  [  0,    0,   0,    1,   1]
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto result,
+      EncodePair(tokenizer.get(), IREE_SV("hello"), IREE_SV("world")));
+
+  ASSERT_EQ(result.token_ids.size(), 5u);
+  EXPECT_EQ(result.token_ids[0], 101);   // [CLS]
+  EXPECT_EQ(result.token_ids[1], 7592);  // hello
+  EXPECT_EQ(result.token_ids[2], 102);   // [SEP] (infix)
+  EXPECT_EQ(result.token_ids[3], 2088);  // world
+  EXPECT_EQ(result.token_ids[4], 102);   // [SEP] (suffix)
+
+  ASSERT_EQ(result.type_ids.size(), 5u);
+  EXPECT_EQ(result.type_ids[0], 0);  // [CLS] prefix type_id
+  EXPECT_EQ(result.type_ids[1], 0);  // sequence A type_id
+  EXPECT_EQ(result.type_ids[2], 0);  // [SEP] infix type_id
+  EXPECT_EQ(result.type_ids[3], 1);  // sequence B type_id
+  EXPECT_EQ(result.type_ids[4], 1);  // [SEP] suffix type_id
+}
+
+TEST(PairEncode, BertPairAllowsEmptySecondSequence) {
+  // Empty sequence B is still a pair: [CLS] hello [SEP] [SEP].
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto result,
+      EncodePair(tokenizer.get(), IREE_SV("hello"), iree_string_view_empty()));
+
+  ASSERT_EQ(result.token_ids.size(), 4u);
+  EXPECT_EQ(result.token_ids[0], 101);   // [CLS]
+  EXPECT_EQ(result.token_ids[1], 7592);  // hello
+  EXPECT_EQ(result.token_ids[2], 102);   // [SEP] (infix)
+  EXPECT_EQ(result.token_ids[3], 102);   // [SEP] (suffix)
+
+  ASSERT_EQ(result.type_ids.size(), 4u);
+  EXPECT_EQ(result.type_ids[0], 0);
+  EXPECT_EQ(result.type_ids[1], 0);
+  EXPECT_EQ(result.type_ids[2], 0);
+  EXPECT_EQ(result.type_ids[3], 1);
+}
+
+TEST(PairEncode, BertPairMultiWord) {
+  // Multi-word pair encoding: "deep learning" / "the weather today"
+  // Expected token_ids: [101, 2784, 4083, 102, 1996, 4633, 2651, 102]
+  // Expected type_ids:  [  0,    0,    0,   0,    1,    1,    1,   1]
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto result, EncodePair(tokenizer.get(), IREE_SV("deep learning"),
+                              IREE_SV("the weather today")));
+
+  ASSERT_EQ(result.token_ids.size(), 8u);
+  EXPECT_EQ(result.token_ids[0], 101);   // [CLS]
+  EXPECT_EQ(result.token_ids[1], 2784);  // deep
+  EXPECT_EQ(result.token_ids[2], 4083);  // learning
+  EXPECT_EQ(result.token_ids[3], 102);   // [SEP]
+  EXPECT_EQ(result.token_ids[4], 1996);  // the
+  EXPECT_EQ(result.token_ids[5], 4633);  // weather
+  EXPECT_EQ(result.token_ids[6], 2651);  // today
+  EXPECT_EQ(result.token_ids[7], 102);   // [SEP]
+
+  // Type IDs: 0 for CLS+query+infix-SEP, 1 for document+suffix-SEP.
+  for (size_t i = 0; i <= 3; ++i) {
+    EXPECT_EQ(result.type_ids[i], 0) << "type_ids[" << i << "]";
+  }
+  for (size_t i = 4; i <= 7; ++i) {
+    EXPECT_EQ(result.type_ids[i], 1) << "type_ids[" << i << "]";
+  }
+}
+
+TEST(PairEncode, BatchMixedSingleAndPair) {
+  // Batch with one single-sequence item and one pair item.
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  iree_host_size_t state_size = 0;
+  IREE_ASSERT_OK(
+      iree_tokenizer_encode_state_calculate_size(tokenizer.get(), &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+
+  // Item 0: single-sequence "hello"
+  std::vector<iree_tokenizer_token_id_t> ids0(256);
+  std::vector<uint8_t> type_ids0(256, 0xFF);
+  iree_tokenizer_encode_batch_item_t items[2] = {};
+  items[0].text = IREE_SV("hello");
+  items[0].output = iree_tokenizer_make_token_output(ids0.data(), nullptr,
+                                                     type_ids0.data(), 256);
+
+  // Item 1: pair "hello" / "world"
+  std::vector<iree_tokenizer_token_id_t> ids1(256);
+  std::vector<uint8_t> type_ids1(256, 0xFF);
+  items[1].text = IREE_SV("hello");
+  items[1].text_pair = IREE_SV("world");
+  items[1].flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+  items[1].output = iree_tokenizer_make_token_output(ids1.data(), nullptr,
+                                                     type_ids1.data(), 256);
+
+  IREE_ASSERT_OK(iree_tokenizer_encode_batch(
+      tokenizer.get(), items, 2, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty()));
+
+  // Item 0: [CLS] hello [SEP]
+  ASSERT_EQ(items[0].out_token_count, 3u);
+  EXPECT_EQ(ids0[0], 101);   // [CLS]
+  EXPECT_EQ(ids0[1], 7592);  // hello
+  EXPECT_EQ(ids0[2], 102);   // [SEP]
+  EXPECT_EQ(type_ids0[0], 0);
+  EXPECT_EQ(type_ids0[1], 0);
+  EXPECT_EQ(type_ids0[2], 0);
+
+  // Item 1: [CLS] hello [SEP] world [SEP]
+  ASSERT_EQ(items[1].out_token_count, 5u);
+  EXPECT_EQ(ids1[0], 101);   // [CLS]
+  EXPECT_EQ(ids1[1], 7592);  // hello
+  EXPECT_EQ(ids1[2], 102);   // [SEP]
+  EXPECT_EQ(ids1[3], 2088);  // world
+  EXPECT_EQ(ids1[4], 102);   // [SEP]
+  EXPECT_EQ(type_ids1[0], 0);
+  EXPECT_EQ(type_ids1[1], 0);
+  EXPECT_EQ(type_ids1[2], 0);
+  EXPECT_EQ(type_ids1[3], 1);
+  EXPECT_EQ(type_ids1[4], 1);
+}
+
+TEST(PairEncode, BatchPairThenSingleResetsPostprocessor) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  iree_host_size_t state_size = 0;
+  IREE_ASSERT_OK(
+      iree_tokenizer_encode_state_calculate_size(tokenizer.get(), &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+
+  std::vector<iree_tokenizer_token_id_t> ids0(256);
+  std::vector<uint8_t> type_ids0(256, 0xFF);
+  std::vector<iree_tokenizer_token_id_t> ids1(256);
+  std::vector<uint8_t> type_ids1(256, 0xFF);
+
+  iree_tokenizer_encode_batch_item_t items[2] = {};
+  items[0].text = IREE_SV("hello");
+  items[0].text_pair = IREE_SV("world");
+  items[0].flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+  items[0].output = iree_tokenizer_make_token_output(ids0.data(), nullptr,
+                                                     type_ids0.data(), 256);
+  items[1].text = IREE_SV("world");
+  items[1].output = iree_tokenizer_make_token_output(ids1.data(), nullptr,
+                                                     type_ids1.data(), 256);
+
+  IREE_ASSERT_OK(iree_tokenizer_encode_batch(
+      tokenizer.get(), items, 2, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty()));
+
+  ASSERT_EQ(items[0].out_token_count, 5u);
+  EXPECT_EQ(ids0[0], 101);
+  EXPECT_EQ(ids0[1], 7592);
+  EXPECT_EQ(ids0[2], 102);
+  EXPECT_EQ(ids0[3], 2088);
+  EXPECT_EQ(ids0[4], 102);
+  EXPECT_EQ(type_ids0[3], 1);
+  EXPECT_EQ(type_ids0[4], 1);
+
+  ASSERT_EQ(items[1].out_token_count, 3u);
+  EXPECT_EQ(ids1[0], 101);
+  EXPECT_EQ(ids1[1], 2088);
+  EXPECT_EQ(ids1[2], 102);
+  EXPECT_EQ(type_ids1[0], 0);
+  EXPECT_EQ(type_ids1[1], 0);
+  EXPECT_EQ(type_ids1[2], 0);
+}
+
+TEST(PairEncode, PairWithoutAddSpecialTokens) {
+  // Without ADD_SPECIAL_TOKENS, pair encoding should produce just the
+  // concatenated model tokens (no [CLS], [SEP], or type_ids assignment).
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  iree_host_size_t state_size = 0;
+  IREE_ASSERT_OK(
+      iree_tokenizer_encode_state_calculate_size(tokenizer.get(), &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+
+  std::vector<iree_tokenizer_token_id_t> token_ids(256);
+  std::vector<uint8_t> type_ids(256, 0xFF);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = IREE_SV("hello");
+  item.text_pair = IREE_SV("world");
+  item.flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+  item.output = iree_tokenizer_make_token_output(token_ids.data(), nullptr,
+                                                 type_ids.data(), 256);
+
+  IREE_ASSERT_OK(iree_tokenizer_encode_batch(
+      tokenizer.get(), &item, 1, IREE_TOKENIZER_ENCODE_FLAG_NONE,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty()));
+
+  // Without special tokens: just "hello" + "world" (no [CLS]/[SEP]).
+  // Type IDs should all be 0xFF (untouched) since the postprocessor is IDLE.
+  ASSERT_EQ(item.out_token_count, 2u);
+  EXPECT_EQ(token_ids[0], 7592);  // hello
+  EXPECT_EQ(token_ids[1], 2088);  // world
+  EXPECT_EQ(type_ids[0], 0xFF);   // Untouched (IDLE postprocessor).
+  EXPECT_EQ(type_ids[1], 0xFF);
+}
+
+TEST(PairEncode, TextPairRequiresFlag) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  iree_host_size_t state_size = 0;
+  IREE_ASSERT_OK(
+      iree_tokenizer_encode_state_calculate_size(tokenizer.get(), &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+  std::vector<iree_tokenizer_token_id_t> token_ids(16);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = IREE_SV("hello");
+  item.text_pair = IREE_SV("world");
+  item.output = iree_tokenizer_make_token_output(token_ids.data(), nullptr,
+                                                 nullptr, token_ids.size());
+
+  iree_status_t status = iree_tokenizer_encode_batch(
+      tokenizer.get(), &item, 1, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty());
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
+}
+
+TEST(PairEncode, UnknownItemFlagsRejected) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  iree_host_size_t state_size = 0;
+  IREE_ASSERT_OK(
+      iree_tokenizer_encode_state_calculate_size(tokenizer.get(), &state_size));
+  std::vector<uint8_t> state_storage(state_size);
+  std::vector<uint8_t> transform_buffer(4096);
+  std::vector<iree_tokenizer_token_id_t> token_ids(16);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = IREE_SV("hello");
+  item.flags = 0x80000000u;
+  item.output = iree_tokenizer_make_token_output(token_ids.data(), nullptr,
+                                                 nullptr, token_ids.size());
+
+  iree_status_t status = iree_tokenizer_encode_batch(
+      tokenizer.get(), &item, 1, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(state_storage.data(), state_storage.size()),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty());
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
+}
+
+TEST(PairEncode, InvalidStateStorageReturnsStatus) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  uint8_t state_storage = 0;
+  std::vector<uint8_t> transform_buffer(4096);
+  std::vector<iree_tokenizer_token_id_t> token_ids(16);
+
+  iree_tokenizer_encode_batch_item_t item = {};
+  item.text = IREE_SV("hello");
+  item.text_pair = IREE_SV("world");
+  item.flags = IREE_TOKENIZER_ENCODE_BATCH_ITEM_FLAG_HAS_TEXT_PAIR;
+  item.output = iree_tokenizer_make_token_output(token_ids.data(), nullptr,
+                                                 nullptr, token_ids.size());
+
+  iree_status_t status = iree_tokenizer_encode_batch(
+      tokenizer.get(), &item, 1, IREE_TOKENIZER_ENCODE_FLAG_ADD_SPECIAL_TOKENS,
+      iree_make_byte_span(&state_storage, 1),
+      iree_make_byte_span(transform_buffer.data(), transform_buffer.size()),
+      iree_tokenizer_offset_run_list_empty());
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
+}
+
+TEST(PairEncode, OutputBufferTooSmallAtPairBoundaries) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  for (iree_host_size_t capacity = 0; capacity < 5; ++capacity) {
+    auto result = EncodePairDetailed(tokenizer.get(), IREE_SV("hello"),
+                                     IREE_SV("world"), capacity,
+                                     /*track_offsets=*/false);
+    IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, result.status())
+        << "capacity=" << capacity;
+  }
+
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto result, EncodePairDetailed(tokenizer.get(), IREE_SV("hello"),
+                                      IREE_SV("world"), /*output_capacity=*/5,
+                                      /*track_offsets=*/false));
+  EXPECT_EQ(result.token_ids, (std::vector<iree_tokenizer_token_id_t>{
+                                  101, 7592, 102, 2088, 102}));
+}
+
+TEST(PairEncode, OffsetsAreRelativeToEachSequence) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto tokenizer,
+                            LoadTokenizer("wordpiece_bert_pair_minimal.json"));
+
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto result, EncodePairDetailed(tokenizer.get(), IREE_SV("hello"),
+                                      IREE_SV("world"), /*output_capacity=*/8,
+                                      /*track_offsets=*/true));
+
+  ASSERT_EQ(result.token_offsets.size(), 5u);
+  EXPECT_EQ(result.token_offsets[0].start, 0u);
+  EXPECT_EQ(result.token_offsets[0].end, 0u);
+  EXPECT_EQ(result.token_offsets[1].start, 0u);
+  EXPECT_EQ(result.token_offsets[1].end, 5u);
+  EXPECT_EQ(result.token_offsets[2].start, 0u);
+  EXPECT_EQ(result.token_offsets[2].end, 0u);
+  EXPECT_EQ(result.token_offsets[3].start, 0u);
+  EXPECT_EQ(result.token_offsets[3].end, 5u);
+  EXPECT_EQ(result.token_offsets[4].start, 0u);
+  EXPECT_EQ(result.token_offsets[4].end, 0u);
+}
+
 }  // namespace
 }  // namespace iree::tokenizer


### PR DESCRIPTION
Batch pair encoding needs to distinguish no pair from an intentionally empty sequence B. Add per-item flags so pair presence is explicit instead of inferred from text_pair size, reject unknown item flags, and document sequence-B offsets as relative to text_pair.

Keep the pair boundary out of persistent encode state. Sequence A finalize now uses a call-local flag to omit suffix emission, the batch path emits the pair infix, resets the normalizer/segmenter/model pipeline while preserving the postprocessor phase, and then finalizes sequence B normally.

Make pair-template support explicit in the postprocessor instead of deriving it from token counts or type IDs. This keeps empty pair templates and type-id-only pair templates valid, while unsupported pair encoding still fails before touching the encode state.

No measurable performance change. Median CPU time, parent vs this branch:

| Benchmark | Parent | This branch | Delta |
|---|---:|---:|---:|
| vocab 10000, batch 8, text 1024 | 110871 ns | 109720 ns | -1.0% |
| vocab 50000, batch 8, text 1024 | 117558 ns | 117543 ns | ~0.0% |
| vocab 10000, batch 32, text 100 | 58712 ns | 58708 ns | ~0.0% |
| vocab 50000, batch 32, text 100 | 61269 ns | 61608 ns | +0.6% |
| vocab 10000, batch 128, text 100 | 304107 ns | 303413 ns | -0.2% |
