### PR TITLE
[TensorExt] Fold insert_slice -> store when dest is tensor.empty

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -62,14 +62,26 @@ struct FoldInsertSliceWithTensorStoreOp
       return failure();
     }
 
-    // Only fold when dest is a load of the same target with matching
-    // offsets/sizes/strides; otherwise positions outside the partial insert
-    // lose passthrough.
-    auto loadOp = insertSliceOp.getDest()
-                      .getDefiningOp<IREE::TensorExt::DispatchTensorLoadOp>();
-    if (!loadOp || loadOp.getSource() != dispatchTensorStoreOp.getTarget() ||
-        !mlir::detail::sameOffsetsSizesAndStrides(loadOp, dispatchTensorStoreOp,
-                                                  isEqualConstantIntOrValue)) {
+    // Fold is safe when dest carries no values that need to pass through:
+    // either `tensor.empty` (uninitialized) or a `dispatch.tensor.load` of
+    // the same target with matching offsets/sizes/strides (the load/store
+    // round-trip leaves outside-insert positions unchanged).
+    auto isFoldSafe = [&] {
+      Operation *destOp = insertSliceOp.getDest().getDefiningOp();
+      if (!destOp) {
+        return false;
+      }
+      if (isa<tensor::EmptyOp>(destOp)) {
+        return true;
+      }
+      auto loadOp = dyn_cast<IREE::TensorExt::DispatchTensorLoadOp>(destOp);
+      if (!loadOp || loadOp.getSource() != dispatchTensorStoreOp.getTarget()) {
+        return false;
+      }
+      return mlir::detail::sameOffsetsSizesAndStrides(
+          loadOp, dispatchTensorStoreOp, isEqualConstantIntOrValue);
+    };
+    if (!isFoldSafe()) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -460,6 +460,35 @@ util.func public @fold_insert_slice_with_identity_load(
 
 // -----
 
+util.func public @fold_insert_slice_with_empty_dest(
+    %val: tensor<?xf32>, %n: index) -> tensor<4x1xf32> {
+  %0 = flow.dispatch.workgroups(%val, %n)
+      : (tensor<?xf32>{%n}, index) -> tensor<4x1xf32> =
+      (%arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>,
+       %arg1: index,
+       %arg2: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1xf32>>) {
+    %dest = tensor.empty() : tensor<4x1xf32>
+    %loaded = iree_tensor_ext.dispatch.tensor.load %arg0,
+        offsets = [0], sizes = [%arg1], strides = [1]
+        : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf32>>{%arg1}
+          -> tensor<?xf32>
+    %inserted = tensor.insert_slice %loaded into %dest[0, 0] [%arg1, 1] [1, 1]
+        : tensor<?xf32> into tensor<4x1xf32>
+    iree_tensor_ext.dispatch.tensor.store %inserted, %arg2,
+        offsets = [0, 0], sizes = [4, 1], strides = [1, 1]
+        : tensor<4x1xf32>
+          -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x1xf32>>
+    flow.return
+  }
+  util.return %0 : tensor<4x1xf32>
+}
+// CHECK-LABEL: @fold_insert_slice_with_empty_dest
+//   CHECK-NOT: tensor.empty
+//   CHECK-NOT: tensor.insert_slice
+//       CHECK: iree_tensor_ext.dispatch.tensor.store
+
+// -----
+
 util.func public @fuse_non_tiled_reduction_fill(%input1: tensor<1000xf32>, %input2: tensor<1000xf32>, %offset: tensor<f32>) -> tensor<f32> {
   %zero = arith.constant 0.0 : f32
   %init = tensor.empty() : tensor<f32>


### PR DESCRIPTION
This pattern currently only fires when the insert's dest is a matching `dispatch.tensor.load`. But `tensor.empty` dest is also safe because the dest values are undefined.


Follow up to https://github.com/iree-org/iree/pull/24266 and fixes lowering failures on https://github.com/iree-org/iree/pull/24214