### PR TITLE
[LLVMCPU] Lower explicit workgroup-local allocs through dispatch ABI

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CreateDispatchConfig.cpp
@@ -54,12 +54,18 @@ void CreateDispatchConfigPass::runOnOperation() {
     }
 
     Location loc = funcOp.getLoc();
+    auto applyExportMetadata = [&](IREE::Codegen::DispatchConfigOp configOp) {
+      if (auto localMemoryAttr = exportOp.getWorkgroupLocalMemoryAttr()) {
+        configOp.setWorkgroupLocalMemoryAttr(localMemoryAttr);
+      }
+    };
     Block *exportBlock = exportOp.getWorkgroupCountBody();
     if (!exportBlock || exportBlock->getNumArguments() == 0) {
       // No count region — create a dispatch_config with a stub {1,1,1} body.
       builder.setInsertionPointAfter(funcOp);
       auto configOp = IREE::Codegen::DispatchConfigOp::create(
           builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
+      applyExportMetadata(configOp);
       Block *block = builder.createBlock(&configOp.getBody());
       builder.setInsertionPointToStart(block);
       auto c1 = arith::ConstantIndexOp::create(builder, loc, 1);
@@ -72,6 +78,7 @@ void CreateDispatchConfigPass::runOnOperation() {
     builder.setInsertionPointAfter(funcOp);
     auto configOp = IREE::Codegen::DispatchConfigOp::create(
         builder, loc, FlatSymbolRefAttr::get(funcOp.getNameAttr()));
+    applyExportMetadata(configOp);
     builder.cloneRegionBefore(exportOp.getWorkgroupCount(), configOp.getBody(),
                               configOp.getBody().end());
     Block *configBlock = &configOp.getBody().front();

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateDispatchConfig.cpp
@@ -94,6 +94,9 @@ void PropagateDispatchConfigPass::runOnOperation() {
     if (auto subgroupSize = configOp.getSubgroupSize()) {
       exportOp.setSubgroupSizeAttr(builder.getIndexAttr(subgroupSize.value()));
     }
+    if (auto localMemoryAttr = configOp.getWorkgroupLocalMemoryAttr()) {
+      exportOp.setWorkgroupLocalMemoryAttr(localMemoryAttr);
+    }
 
     configOp.erase();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/create_dispatch_config.mlir
@@ -85,6 +85,26 @@ hal.executable private @no_count_region {
 
 // -----
 
+// Export metadata is preserved on the dispatch_config.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @export_metadata {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "">) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        attributes {workgroup_local_memory = 4096 : index}
+    builtin.module {
+      func.func @entry_point() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @export_metadata
+//       CHECK:   iree_codegen.dispatch_config @entry_point workgroup_local_memory = 4096
+
+// -----
+
 // Test that dispatch_config placed after its function.
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_config.mlir
@@ -18,7 +18,8 @@ hal.executable private @basic_exe {
         return
       }
       iree_codegen.dispatch_config @matmul
-          workgroup_size = [64, 16, 1] subgroup_size = 64 {
+          workgroup_size = [64, 16, 1] subgroup_size = 64
+          workgroup_local_memory = 4096 {
         ^bb0(%device: !hal.device, %w0: index, %w1: index):
           %c1 = arith.constant 1 : index
           %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%w0]
@@ -33,7 +34,10 @@ hal.executable private @basic_exe {
 //       CHECK:       %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:       %[[X:.+]] = affine.apply
 //       CHECK:       hal.return %[[X]], %[[W1]], %[[C1]]
-//       CHECK:     } attributes {subgroup_size = 64 : index, workgroup_size = [64 : index, 16 : index, 1 : index]}
+//       CHECK:     } attributes {
+//  CHECK-SAME:       subgroup_size = 64 : index
+//  CHECK-SAME:       workgroup_local_memory = 4096 : index
+//  CHECK-SAME:       workgroup_size = [64 : index, 16 : index, 1 : index]
 //       CHECK:   builtin.module
 //       CHECK:     func.func @matmul()
 //   CHECK-NOT:     iree_codegen.dispatch_config

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -67,6 +67,8 @@ constexpr StringLiteral kUkernelAttrName = "iree_codegen.ukernel";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
 constexpr StringLiteral kVectorTileSizesAttrName =
     "iree_codegen.vector_tile_sizes";
+constexpr StringLiteral kWorkgroupLocalMemoryRangeAttrName =
+    "iree_codegen.local_memory_range";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -67,8 +67,6 @@ constexpr StringLiteral kUkernelAttrName = "iree_codegen.ukernel";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
 constexpr StringLiteral kVectorTileSizesAttrName =
     "iree_codegen.vector_tile_sizes";
-constexpr StringLiteral kWorkgroupLocalMemoryRangeAttrName =
-    "iree_codegen.local_memory_range";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -73,6 +73,8 @@ constexpr StringLiteral kUkernelAttrName = "iree_codegen.ukernel";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
 constexpr StringLiteral kVectorTileSizesAttrName =
     "iree_codegen.vector_tile_sizes";
+constexpr StringLiteral kWorkgroupLocalMemoryRangeAttrName =
+    "iree_codegen.local_memory_range";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -73,8 +73,6 @@ constexpr StringLiteral kUkernelAttrName = "iree_codegen.ukernel";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
 constexpr StringLiteral kVectorTileSizesAttrName =
     "iree_codegen.vector_tile_sizes";
-constexpr StringLiteral kWorkgroupLocalMemoryRangeAttrName =
-    "iree_codegen.local_memory_range";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -135,12 +135,12 @@ def WorkgroupLocalMemoryAttr :
     Memory space attribute indicating that an allocation uses per-workgroup
     local memory supplied by the target runtime instead of the thread stack.
 
-    LLVMCPU dispatch lowering rewrites `memref.alloc` operations marked with
-    this memory space to use the HAL dispatch ABI local-memory pointer. Matching
-    `memref.dealloc` operations are erased because the storage is owned by the
-    dispatch frame. The allocation layout is assigned before final LLVM
-    conversion and exported as the dispatch `workgroup_local_memory`
-    requirement.
+    LLVMCPU dispatch lowering packs `memref.alloc` operations marked with this
+    memory space into one byte allocation and rewrites the original allocations
+    to `memref.view` slices. The packed allocation is lowered to the HAL
+    dispatch ABI local-memory pointer. Matching `memref.dealloc` operations are
+    erased because the storage is owned by the dispatch frame. The aggregate
+    byte size is exported as the dispatch `workgroup_local_memory` requirement.
 
     Example:
     ```mlir

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -122,6 +122,35 @@ def LocalMappingAttr :
 }
 
 //===---------------------------------------------------------------------===//
+// iree_codegen.workgroup_local memory space attribute
+//===---------------------------------------------------------------------===//
+
+def WorkgroupLocalMemoryAttr :
+    AttrDef<IREECodegen_Dialect, "WorkgroupLocalMemory"> {
+  let mnemonic = "workgroup_local";
+  let parameters = (ins);
+  let assemblyFormat = "";
+
+  let description = [{
+    Memory space attribute indicating that an allocation uses per-workgroup
+    local memory supplied by the target runtime instead of the thread stack.
+
+    LLVMCPU dispatch lowering rewrites `memref.alloc` operations marked with
+    this memory space to use the HAL dispatch ABI local-memory pointer. Matching
+    `memref.dealloc` operations are erased because the storage is owned by the
+    dispatch frame. The allocation layout is assigned before final LLVM
+    conversion and exported as the dispatch `workgroup_local_memory`
+    requirement.
+
+    Example:
+    ```mlir
+      %scratch = memref.alloc()
+        : memref<64x1536xf32, #iree_codegen.workgroup_local>
+    ```
+  }];
+}
+
+//===---------------------------------------------------------------------===//
 // iree_codegen.simple_target
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -174,12 +174,12 @@ def WorkgroupLocalMemoryAttr :
     Memory space attribute indicating that an allocation uses per-workgroup
     local memory supplied by the target runtime instead of the thread stack.
 
-    LLVMCPU dispatch lowering rewrites `memref.alloc` operations marked with
-    this memory space to use the HAL dispatch ABI local-memory pointer. Matching
-    `memref.dealloc` operations are erased because the storage is owned by the
-    dispatch frame. The allocation layout is assigned before final LLVM
-    conversion and exported as the dispatch `workgroup_local_memory`
-    requirement.
+    LLVMCPU dispatch lowering packs `memref.alloc` operations marked with this
+    memory space into one byte allocation and rewrites the original allocations
+    to `memref.view` slices. The packed allocation is lowered to the HAL
+    dispatch ABI local-memory pointer. Matching `memref.dealloc` operations are
+    erased because the storage is owned by the dispatch frame. The aggregate
+    byte size is exported as the dispatch `workgroup_local_memory` requirement.
 
     Example:
     ```mlir

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -161,6 +161,35 @@ def LocalMappingAttr :
 }
 
 //===---------------------------------------------------------------------===//
+// iree_codegen.workgroup_local memory space attribute
+//===---------------------------------------------------------------------===//
+
+def WorkgroupLocalMemoryAttr :
+    AttrDef<IREECodegen_Dialect, "WorkgroupLocalMemory"> {
+  let mnemonic = "workgroup_local";
+  let parameters = (ins);
+  let assemblyFormat = "";
+
+  let description = [{
+    Memory space attribute indicating that an allocation uses per-workgroup
+    local memory supplied by the target runtime instead of the thread stack.
+
+    LLVMCPU dispatch lowering rewrites `memref.alloc` operations marked with
+    this memory space to use the HAL dispatch ABI local-memory pointer. Matching
+    `memref.dealloc` operations are erased because the storage is owned by the
+    dispatch frame. The allocation layout is assigned before final LLVM
+    conversion and exported as the dispatch `workgroup_local_memory`
+    requirement.
+
+    Example:
+    ```mlir
+      %scratch = memref.alloc()
+        : memref<64x1536xf32, #iree_codegen.workgroup_local>
+    ```
+  }];
+}
+
+//===---------------------------------------------------------------------===//
 // iree_codegen.simple_target
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -504,7 +504,8 @@ void DispatchConfigOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                              FlatSymbolRefAttr functionRef) {
   DispatchConfigOp::build(odsBuilder, odsState, functionRef,
                           /*workgroup_size=*/nullptr,
-                          /*subgroup_size=*/nullptr);
+                          /*subgroup_size=*/nullptr,
+                          /*workgroup_local_memory=*/nullptr);
 }
 
 LogicalResult DispatchConfigOp::verify() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -503,7 +503,8 @@ void DispatchConfigOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                              FlatSymbolRefAttr functionRef) {
   DispatchConfigOp::build(odsBuilder, odsState, functionRef,
                           /*workgroup_size=*/nullptr,
-                          /*subgroup_size=*/nullptr);
+                          /*subgroup_size=*/nullptr,
+                          /*workgroup_local_memory=*/nullptr);
 }
 
 LogicalResult DispatchConfigOp::verify() {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -695,7 +695,8 @@ def IREECodegen_DispatchConfigOp :
     Example:
     ```mlir
     iree_codegen.dispatch_config @matmul
-        workgroup_size = [64, 16, 1] subgroup_size = 64 {
+        workgroup_size = [64, 16, 1] subgroup_size = 64
+        workgroup_local_memory = 4096 {
       ^bb0(%w0: index, %w1: index, %w2: index, %w3: index):
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 256)>()[%w2]
         %c1 = arith.constant 1 : index
@@ -707,7 +708,8 @@ def IREECodegen_DispatchConfigOp :
   let arguments = (ins
     FlatSymbolRefAttr:$function_ref,
     OptionalAttr<DenseI64ArrayAttr>:$workgroup_size,
-    OptionalAttr<I64Attr>:$subgroup_size
+    OptionalAttr<I64Attr>:$subgroup_size,
+    OptionalAttr<IndexAttr>:$workgroup_local_memory
   );
   let regions = (region SizedRegion<1>:$body);
 
@@ -719,6 +721,7 @@ def IREECodegen_DispatchConfigOp :
     $function_ref
     (`workgroup_size` `=` $workgroup_size^)?
     (`subgroup_size` `=` $subgroup_size^)?
+    (`workgroup_local_memory` `=` $workgroup_local_memory^)?
     $body attr-dict
   }];
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -696,7 +696,8 @@ def IREECodegen_DispatchConfigOp :
     Example:
     ```mlir
     iree_codegen.dispatch_config @matmul
-        workgroup_size = [64, 16, 1] subgroup_size = 64 {
+        workgroup_size = [64, 16, 1] subgroup_size = 64
+        workgroup_local_memory = 4096 {
       ^bb0(%w0: index, %w1: index, %w2: index, %w3: index):
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 256)>()[%w2]
         %c1 = arith.constant 1 : index
@@ -708,7 +709,8 @@ def IREECodegen_DispatchConfigOp :
   let arguments = (ins
     FlatSymbolRefAttr:$function_ref,
     OptionalAttr<DenseI64ArrayAttr>:$workgroup_size,
-    OptionalAttr<I64Attr>:$subgroup_size
+    OptionalAttr<I64Attr>:$subgroup_size,
+    OptionalAttr<IndexAttr>:$workgroup_local_memory
   );
   let regions = (region SizedRegion<1>:$body);
 
@@ -720,6 +722,7 @@ def IREECodegen_DispatchConfigOp :
     $function_ref
     (`workgroup_size` `=` $workgroup_size^)?
     (`subgroup_size` `=` $subgroup_size^)?
+    (`workgroup_local_memory` `=` $workgroup_local_memory^)?
     $body attr-dict
   }];
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -144,6 +144,17 @@ func.func private @translation_info_vmvx_pipeline() attributes {
 
 // -----
 
+func.func @workgroup_local_memory_space(
+    %arg0: memref<64x64xf32, #iree_codegen.workgroup_local>)
+    -> memref<64x64xf32, #iree_codegen.workgroup_local> {
+  return %arg0 : memref<64x64xf32, #iree_codegen.workgroup_local>
+}
+// CHECK-LABEL: func.func @workgroup_local_memory_space(
+// CHECK-SAME:    memref<64x64xf32, #iree_codegen.workgroup_local>
+// CHECK-SAME:    -> memref<64x64xf32, #iree_codegen.workgroup_local>
+
+// -----
+
 // Test constraints op with knobs and dims.
 func.func @constraints_op(%arg0: index, %arg1: index) {
   iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -361,7 +361,8 @@ func.func @smt_lookup_sparse(%arg0: index) {
 // -----
 
 iree_codegen.dispatch_config @matmul
-    workgroup_size = [64, 16, 1] subgroup_size = 64 {
+    workgroup_size = [64, 16, 1] subgroup_size = 64
+    workgroup_local_memory = 4096 {
   ^bb0(%w0: index, %w1: index):
     %c1 = arith.constant 1 : index
     iree_codegen.yield %w0, %w1, %c1 : index, index, index
@@ -369,6 +370,7 @@ iree_codegen.dispatch_config @matmul
 // CHECK-LABEL: iree_codegen.dispatch_config @matmul
 // CHECK-SAME:    workgroup_size = [64, 16, 1]
 // CHECK-SAME:    subgroup_size = 64
+// CHECK-SAME:    workgroup_local_memory = 4096
 // CHECK:       ^bb0(%[[W0:.+]]: index, %[[W1:.+]]: index):
 // CHECK:         %[[C1:.+]] = arith.constant 1 : index
 // CHECK:         iree_codegen.yield %[[W0]], %[[W1]], %[[C1]] : index, index, index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -331,7 +331,8 @@ func.func @smt_lookup_sparse(%arg0: index) {
 // -----
 
 iree_codegen.dispatch_config @matmul
-    workgroup_size = [64, 16, 1] subgroup_size = 64 {
+    workgroup_size = [64, 16, 1] subgroup_size = 64
+    workgroup_local_memory = 4096 {
   ^bb0(%w0: index, %w1: index):
     %c1 = arith.constant 1 : index
     iree_codegen.yield %w0, %w1, %c1 : index, index, index
@@ -339,6 +340,7 @@ iree_codegen.dispatch_config @matmul
 // CHECK-LABEL: iree_codegen.dispatch_config @matmul
 // CHECK-SAME:    workgroup_size = [64, 16, 1]
 // CHECK-SAME:    subgroup_size = 64
+// CHECK-SAME:    workgroup_local_memory = 4096
 // CHECK:       ^bb0(%[[W0:.+]]: index, %[[W1:.+]]: index):
 // CHECK:         %[[C1:.+]] = arith.constant 1 : index
 // CHECK:         iree_codegen.yield %[[W0]], %[[W1]], %[[C1]] : index, index, index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -114,6 +114,17 @@ func.func private @workgroup_scope_attr_linearize() attributes {
 
 // -----
 
+func.func @workgroup_local_memory_space(
+    %arg0: memref<64x64xf32, #iree_codegen.workgroup_local>)
+    -> memref<64x64xf32, #iree_codegen.workgroup_local> {
+  return %arg0 : memref<64x64xf32, #iree_codegen.workgroup_local>
+}
+// CHECK-LABEL: func.func @workgroup_local_memory_space(
+// CHECK-SAME:    memref<64x64xf32, #iree_codegen.workgroup_local>
+// CHECK-SAME:    -> memref<64x64xf32, #iree_codegen.workgroup_local>
+
+// -----
+
 // Test constraints op with knobs and dims.
 func.func @constraints_op(%arg0: index, %arg1: index) {
   iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "LLVMCPU2DScalableTo1DScalable.cpp",
         "LLVMCPUAssignConstantOrdinals.cpp",
         "LLVMCPUAssignImportOrdinals.cpp",
+        "LLVMCPUAssignWorkgroupLocalMemory.cpp",
         "LLVMCPUCheckIRBeforeLLVMConversion.cpp",
         "LLVMCPUEmitVectorizationRemarks.cpp",
         "LLVMCPULinkExecutables.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     "LLVMCPU2DScalableTo1DScalable.cpp"
     "LLVMCPUAssignConstantOrdinals.cpp"
     "LLVMCPUAssignImportOrdinals.cpp"
+    "LLVMCPUAssignWorkgroupLocalMemory.cpp"
     "LLVMCPUCheckIRBeforeLLVMConversion.cpp"
     "LLVMCPUEmitVectorizationRemarks.cpp"
     "LLVMCPULinkExecutables.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -349,6 +349,11 @@ struct ConvertWorkgroupLocalAllocOp
             memRefType.getMemorySpace())) {
       return failure();
     }
+    if (!memRefType.getElementType().isInteger(8)) {
+      return allocOp.emitOpError(
+          "workgroup local memory allocations must be packed into an i8 "
+          "allocation before LLVM conversion");
+    }
     if (!memRefType.hasStaticShape()) {
       return allocOp.emitOpError(
           "workgroup local memory allocations must have static shape");
@@ -362,27 +367,14 @@ struct ConvertWorkgroupLocalAllocOp
           "workgroup local memory allocations must have static layout");
     }
 
-    auto rangeAttr = allocOp->getAttrOfType<DenseI64ArrayAttr>(
-        kWorkgroupLocalMemoryRangeAttrName);
-    if (!rangeAttr || rangeAttr.size() != 2 || rangeAttr[0] < 0 ||
-        rangeAttr[1] < 0) {
-      return allocOp.emitOpError(
-          "missing valid iree_codegen.local_memory_range annotation");
-    }
-
     Location loc = allocOp.getLoc();
     Value basePtr = abi.loadWorkgroupLocalMemoryPtr(allocOp, rewriter);
-    Value byteOffset = LLVM::ConstantOp::create(
-        rewriter, loc, rewriter.getI64Type(), rangeAttr[0]);
-    Value offsetPtr = LLVM::GEPOp::create(
-        rewriter, loc, basePtr.getType(), rewriter.getI8Type(), basePtr,
-        byteOffset, LLVM::GEPNoWrapFlags::inbounds);
 
     MemRefType strippedType =
         MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
                         memRefType.getLayout());
     auto desc = MemRefDescriptor::fromStaticShape(
-        rewriter, loc, *getTypeConverter(), strippedType, offsetPtr);
+        rewriter, loc, *getTypeConverter(), strippedType, basePtr);
     rewriter.replaceOp(allocOp, {desc});
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
@@ -328,6 +329,83 @@ struct ConvertHALInterfaceBindingSubspanOp
                         operands.getByteOffset(), memRefType,
                         operands.getDynamicDims(), rewriter);
     rewriter.replaceOp(subspanOp, {memRefDesc});
+    return success();
+  }
+};
+
+/// Rewrites memref.alloc with #iree_codegen.workgroup_local memory space to a
+/// memref descriptor backed by HAL dispatch workgroup local memory.
+struct ConvertWorkgroupLocalAllocOp
+    : ConvertOpToLLVMWithABIPattern<memref::AllocOp> {
+  ConvertWorkgroupLocalAllocOp(HALDispatchABI &abi,
+                               LLVMTypeConverter &typeConverter)
+      : ConvertOpToLLVMWithABIPattern(abi, typeConverter, /*benefit=*/2) {}
+
+  LogicalResult
+  matchAndRewrite(memref::AllocOp allocOp, memref::AllocOpAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MemRefType memRefType = allocOp.getType();
+    if (!isa_and_nonnull<IREE::Codegen::WorkgroupLocalMemoryAttr>(
+            memRefType.getMemorySpace())) {
+      return failure();
+    }
+    if (!memRefType.hasStaticShape()) {
+      return allocOp.emitOpError(
+          "workgroup local memory allocations must have static shape");
+    }
+    SmallVector<int64_t> strides;
+    int64_t offset = 0;
+    if (failed(memRefType.getStridesAndOffset(strides, offset)) ||
+        ShapedType::isDynamic(offset) ||
+        llvm::any_of(strides, ShapedType::isDynamic)) {
+      return allocOp.emitOpError(
+          "workgroup local memory allocations must have static layout");
+    }
+
+    auto rangeAttr = allocOp->getAttrOfType<DenseI64ArrayAttr>(
+        kWorkgroupLocalMemoryRangeAttrName);
+    if (!rangeAttr || rangeAttr.size() != 2 || rangeAttr[0] < 0 ||
+        rangeAttr[1] < 0) {
+      return allocOp.emitOpError(
+          "missing valid iree_codegen.local_memory_range annotation");
+    }
+
+    Location loc = allocOp.getLoc();
+    Value basePtr = abi.loadWorkgroupLocalMemoryPtr(allocOp, rewriter);
+    Value byteOffset = LLVM::ConstantOp::create(
+        rewriter, loc, rewriter.getI64Type(), rangeAttr[0]);
+    Value offsetPtr = LLVM::GEPOp::create(
+        rewriter, loc, basePtr.getType(), rewriter.getI8Type(), basePtr,
+        byteOffset, LLVM::GEPNoWrapFlags::inbounds);
+
+    MemRefType strippedType =
+        MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
+                        memRefType.getLayout());
+    auto desc = MemRefDescriptor::fromStaticShape(
+        rewriter, loc, *getTypeConverter(), strippedType, offsetPtr);
+    rewriter.replaceOp(allocOp, {desc});
+    return success();
+  }
+};
+
+/// Erases deallocations for #iree_codegen.workgroup_local memory. The storage
+/// is owned by the HAL dispatch frame and released when the dispatch returns.
+struct ConvertWorkgroupLocalDeallocOp
+    : ConvertOpToLLVMWithABIPattern<memref::DeallocOp> {
+  ConvertWorkgroupLocalDeallocOp(HALDispatchABI &abi,
+                                 LLVMTypeConverter &typeConverter)
+      : ConvertOpToLLVMWithABIPattern(abi, typeConverter, /*benefit=*/2) {}
+
+  LogicalResult
+  matchAndRewrite(memref::DeallocOp deallocOp, memref::DeallocOpAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto memRefType = dyn_cast<MemRefType>(deallocOp.getMemref().getType());
+    if (!memRefType ||
+        !isa_and_nonnull<IREE::Codegen::WorkgroupLocalMemoryAttr>(
+            memRefType.getMemorySpace())) {
+      return failure();
+    }
+    rewriter.eraseOp(deallocOp);
     return success();
   }
 };
@@ -1052,6 +1130,11 @@ void ConvertToLLVMPass::runOnOperation() {
   options.dataLayout = llvm::DataLayout(dataLayoutStr);
   options.overrideIndexBitwidth(options.dataLayout.getPointerSizeInBits());
   LLVMTypeConverter typeConverter(&getContext(), options, &dataLayoutAnalysis);
+  typeConverter.addTypeAttributeConversion(
+      [](BaseMemRefType, IREE::Codegen::WorkgroupLocalMemoryAttr attr)
+          -> TypeConverter::AttributeConversionResult {
+        return IntegerAttr::get(IntegerType::get(attr.getContext(), 64), 0);
+      });
 
   RewritePatternSet patterns(&getContext());
 
@@ -1123,6 +1206,8 @@ void ConvertToLLVMPass::runOnOperation() {
     ConvertHALInterfaceWorkgroupCountOp,
     ConvertHALInterfaceConstantLoadOp,
     ConvertHALInterfaceBindingSubspanOp,
+    ConvertWorkgroupLocalAllocOp,
+    ConvertWorkgroupLocalDeallocOp,
     ConvertHALInstrumentWorkgroupOp,
     ConvertHALInstrumentValueOp,
     ConvertHALInstrumentMemoryLoadOp,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignWorkgroupLocalMemory.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignWorkgroupLocalMemory.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/MathExtras.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
@@ -27,16 +28,20 @@ constexpr int64_t kMinWorkgroupLocalAlignment = 16;
 struct LLVMCPUAssignWorkgroupLocalMemoryPass
     : impl::LLVMCPUAssignWorkgroupLocalMemoryPassBase<
           LLVMCPUAssignWorkgroupLocalMemoryPass> {
-  using impl::LLVMCPUAssignWorkgroupLocalMemoryPassBase<
-      LLVMCPUAssignWorkgroupLocalMemoryPass>::
-      LLVMCPUAssignWorkgroupLocalMemoryPassBase;
+  using Base::Base;
   void runOnOperation() override;
 };
 
-static bool hasWorkgroupLocalMemorySpace(memref::AllocOp allocOp) {
-  return isa_and_nonnull<IREE::Codegen::WorkgroupLocalMemoryAttr>(
-      allocOp.getType().getMemorySpace());
-}
+struct LocalAllocLayout {
+  memref::AllocOp allocOp;
+  int64_t byteOffset = 0;
+  int64_t elementFootprint = 0;
+};
+
+struct AllocationSize {
+  int64_t elementFootprint = 0;
+  int64_t byteSize = 0;
+};
 
 static bool hasWorkgroupLocalMemorySpace(Type type) {
   auto memRefType = dyn_cast<BaseMemRefType>(type);
@@ -56,6 +61,18 @@ static LogicalResult checkedMul(int64_t lhs, int64_t rhs, int64_t &result) {
     return failure();
   }
   return success();
+}
+
+static LogicalResult checkedAlignTo(int64_t value, int64_t alignment,
+                                    int64_t &result) {
+  assert(value >= 0);
+  assert(alignment > 0);
+  int64_t remainder = value % alignment;
+  if (remainder == 0) {
+    result = value;
+    return success();
+  }
+  return checkedAdd(value, alignment - remainder, result);
 }
 
 static FailureOr<int64_t>
@@ -109,7 +126,8 @@ computeStaticElementFootprint(memref::AllocOp allocOp) {
   return footprint;
 }
 
-static FailureOr<int64_t> computeAllocationByteSize(memref::AllocOp allocOp) {
+static FailureOr<AllocationSize>
+computeAllocationSize(memref::AllocOp allocOp) {
   MemRefType type = allocOp.getType();
   FailureOr<int64_t> elementFootprint = computeStaticElementFootprint(allocOp);
   if (failed(elementFootprint)) {
@@ -136,7 +154,10 @@ static FailureOr<int64_t> computeAllocationByteSize(memref::AllocOp allocOp) {
     allocOp.emitOpError("workgroup local memory allocation size overflow");
     return failure();
   }
-  return totalBytes;
+  AllocationSize allocationSize;
+  allocationSize.elementFootprint = *elementFootprint;
+  allocationSize.byteSize = totalBytes;
+  return allocationSize;
 }
 
 static FailureOr<int64_t> computeAlignment(memref::AllocOp allocOp) {
@@ -163,7 +184,8 @@ static FailureOr<int64_t> computeAlignment(memref::AllocOp allocOp) {
 }
 
 static LogicalResult
-rejectUnsupportedWorkgroupLocalMemoryUses(mlir::FunctionOpInterface funcOp) {
+collectWorkgroupLocalAllocs(mlir::FunctionOpInterface funcOp,
+                            SmallVectorImpl<memref::AllocOp> &localAllocs) {
   if (llvm::any_of(
           funcOp.getArgumentTypes(),
           [](Type type) { return hasWorkgroupLocalMemorySpace(type); }) ||
@@ -175,12 +197,31 @@ rejectUnsupportedWorkgroupLocalMemoryUses(mlir::FunctionOpInterface funcOp) {
   }
 
   WalkResult result = funcOp.walk([&](Operation *op) -> WalkResult {
-    if (auto allocaOp = dyn_cast<memref::AllocaOp>(op)) {
-      if (hasWorkgroupLocalMemorySpace(allocaOp.getType())) {
-        allocaOp.emitOpError(
-            "workgroup local memory is only supported for memref.alloc");
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        if (llvm::any_of(block.getArgumentTypes(), [](Type type) {
+              return hasWorkgroupLocalMemorySpace(type);
+            })) {
+          op->emitOpError(
+              "workgroup local memory is only supported for memref.alloc "
+              "results");
+          return WalkResult::interrupt();
+        }
+      }
+    }
+
+    for (Value result : op->getResults()) {
+      if (!hasWorkgroupLocalMemorySpace(result.getType())) {
+        continue;
+      }
+      auto allocOp = dyn_cast<memref::AllocOp>(op);
+      if (!allocOp || result != allocOp.getMemref()) {
+        op->emitOpError(
+            "workgroup local memory is only supported for memref.alloc "
+            "results");
         return WalkResult::interrupt();
       }
+      localAllocs.push_back(allocOp);
     }
     return WalkResult::advance();
   });
@@ -194,35 +235,30 @@ void LLVMCPUAssignWorkgroupLocalMemoryPass::runOnOperation() {
   if (funcOp.getFunctionBody().empty()) {
     return;
   }
-  if (failed(rejectUnsupportedWorkgroupLocalMemoryUses(funcOp))) {
-    return signalPassFailure();
-  }
 
   SmallVector<memref::AllocOp> localAllocs;
-  funcOp.walk([&](memref::AllocOp allocOp) {
-    if (hasWorkgroupLocalMemorySpace(allocOp)) {
-      localAllocs.push_back(allocOp);
-    }
-  });
+  if (failed(collectWorkgroupLocalAllocs(funcOp, localAllocs))) {
+    return signalPassFailure();
+  }
   if (localAllocs.empty()) {
     return;
   }
 
-  std::optional<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
-  if (!exportOp) {
+  IREE::Codegen::DispatchConfigOp configOp = getDispatchConfigOp(funcOp);
+  if (!configOp) {
     localAllocs.front().emitOpError(
-        "workgroup local memory allocations are only supported in HAL "
-        "executable exports");
+        "workgroup local memory allocations require an "
+        "iree_codegen.dispatch_config op");
     return signalPassFailure();
   }
-  if (exportOp.value()->hasAttr(exportOp->getWorkgroupLocalMemoryAttrName())) {
-    exportOp.value()->emitOpError(
-        "already has a workgroup local memory requirement");
+  if (configOp.getWorkgroupLocalMemoryAttr()) {
+    configOp.emitOpError("already has a workgroup local memory requirement");
     return signalPassFailure();
   }
 
-  OpBuilder builder(funcOp.getContext());
   int64_t currentOffset = 0;
+  SmallVector<LocalAllocLayout> layouts;
+  layouts.reserve(localAllocs.size());
   Block &entryBlock = funcOp.getFunctionBody().front();
   for (auto allocOp : localAllocs) {
     if (allocOp->getBlock() != &entryBlock) {
@@ -231,13 +267,9 @@ void LLVMCPUAssignWorkgroupLocalMemoryPass::runOnOperation() {
           "block");
       return signalPassFailure();
     }
-    if (allocOp->hasAttr(kWorkgroupLocalMemoryRangeAttrName)) {
-      allocOp.emitOpError("already has a workgroup local memory assignment");
-      return signalPassFailure();
-    }
 
-    FailureOr<int64_t> byteSize = computeAllocationByteSize(allocOp);
-    if (failed(byteSize)) {
+    FailureOr<AllocationSize> allocationSize = computeAllocationSize(allocOp);
+    if (failed(allocationSize)) {
       return signalPassFailure();
     }
 
@@ -245,25 +277,61 @@ void LLVMCPUAssignWorkgroupLocalMemoryPass::runOnOperation() {
     if (failed(alignment)) {
       return signalPassFailure();
     }
-    uint64_t alignedOffset = llvm::alignTo(static_cast<uint64_t>(currentOffset),
-                                           static_cast<uint64_t>(*alignment));
-    if (alignedOffset >
-        static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    if (failed(checkedAlignTo(currentOffset, *alignment, currentOffset))) {
       allocOp.emitOpError("workgroup local memory allocation size overflow");
       return signalPassFailure();
     }
-    currentOffset = static_cast<int64_t>(alignedOffset);
-    allocOp->setAttr(kWorkgroupLocalMemoryRangeAttrName,
-                     builder.getDenseI64ArrayAttr({currentOffset, *byteSize}));
+    layouts.push_back(LocalAllocLayout{
+        /*allocOp=*/allocOp,
+        /*byteOffset=*/currentOffset,
+        /*elementFootprint=*/allocationSize->elementFootprint,
+    });
 
-    if (failed(checkedAdd(currentOffset, *byteSize, currentOffset))) {
+    if (failed(checkedAdd(currentOffset, allocationSize->byteSize,
+                          currentOffset))) {
       allocOp.emitOpError("workgroup local memory allocation size overflow");
       return signalPassFailure();
     }
   }
 
-  exportOp.value()->setAttr(exportOp->getWorkgroupLocalMemoryAttrName(),
-                            builder.getIndexAttr(currentOffset));
+  OpBuilder builder(funcOp.getContext());
+  builder.setInsertionPointToStart(&entryBlock);
+  Attribute memorySpace = localAllocs.front().getType().getMemorySpace();
+  MemRefType packedType = MemRefType::get({currentOffset}, builder.getI8Type(),
+                                          AffineMap(), memorySpace);
+  Value packedAlloc =
+      memref::AllocOp::create(builder, funcOp.getLoc(), packedType);
+  for (const LocalAllocLayout &layout : layouts) {
+    memref::AllocOp allocOp = layout.allocOp;
+    MemRefType allocType = allocOp.getType();
+    MemRefType viewType = allocType;
+    if (!allocType.getLayout().isIdentity()) {
+      viewType =
+          MemRefType::get({layout.elementFootprint}, allocType.getElementType(),
+                          AffineMap(), allocType.getMemorySpace());
+    }
+    builder.setInsertionPoint(allocOp);
+    Value byteOffset = arith::ConstantIndexOp::create(builder, allocOp.getLoc(),
+                                                      layout.byteOffset);
+    Value view = memref::ViewOp::create(builder, allocOp.getLoc(), viewType,
+                                        packedAlloc, byteOffset, ValueRange{});
+    if (viewType != allocType) {
+      SmallVector<int64_t> strides;
+      int64_t offset = 0;
+      if (failed(allocType.getStridesAndOffset(strides, offset))) {
+        allocOp.emitOpError(
+            "workgroup local memory allocations must have static layout");
+        return signalPassFailure();
+      }
+      view = memref::ReinterpretCastOp::create(builder, allocOp.getLoc(),
+                                               allocType, view, offset,
+                                               allocType.getShape(), strides);
+    }
+    allocOp.replaceAllUsesWith(view);
+    allocOp.erase();
+  }
+
+  configOp.setWorkgroupLocalMemoryAttr(builder.getIndexAttr(currentOffset));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignWorkgroupLocalMemory.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignWorkgroupLocalMemory.cpp
@@ -1,0 +1,269 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <limits>
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MathExtras.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_LLVMCPUASSIGNWORKGROUPLOCALMEMORYPASS
+#include "iree/compiler/Codegen/LLVMCPU/Passes.h.inc"
+
+namespace {
+
+constexpr int64_t kMinWorkgroupLocalAlignment = 16;
+
+struct LLVMCPUAssignWorkgroupLocalMemoryPass
+    : impl::LLVMCPUAssignWorkgroupLocalMemoryPassBase<
+          LLVMCPUAssignWorkgroupLocalMemoryPass> {
+  using impl::LLVMCPUAssignWorkgroupLocalMemoryPassBase<
+      LLVMCPUAssignWorkgroupLocalMemoryPass>::
+      LLVMCPUAssignWorkgroupLocalMemoryPassBase;
+  void runOnOperation() override;
+};
+
+static bool hasWorkgroupLocalMemorySpace(memref::AllocOp allocOp) {
+  return isa_and_nonnull<IREE::Codegen::WorkgroupLocalMemoryAttr>(
+      allocOp.getType().getMemorySpace());
+}
+
+static bool hasWorkgroupLocalMemorySpace(Type type) {
+  auto memRefType = dyn_cast<BaseMemRefType>(type);
+  return memRefType && isa_and_nonnull<IREE::Codegen::WorkgroupLocalMemoryAttr>(
+                           memRefType.getMemorySpace());
+}
+
+static LogicalResult checkedAdd(int64_t lhs, int64_t rhs, int64_t &result) {
+  if (llvm::AddOverflow(lhs, rhs, result)) {
+    return failure();
+  }
+  return success();
+}
+
+static LogicalResult checkedMul(int64_t lhs, int64_t rhs, int64_t &result) {
+  if (llvm::MulOverflow(lhs, rhs, result)) {
+    return failure();
+  }
+  return success();
+}
+
+static FailureOr<int64_t>
+computeStaticElementFootprint(memref::AllocOp allocOp) {
+  MemRefType type = allocOp.getType();
+  if (!type.hasStaticShape()) {
+    allocOp.emitOpError(
+        "workgroup local memory allocations must have static shape");
+    return failure();
+  }
+
+  SmallVector<int64_t> strides;
+  int64_t offset = 0;
+  if (failed(type.getStridesAndOffset(strides, offset))) {
+    allocOp.emitOpError(
+        "workgroup local memory allocations must have static layout");
+    return failure();
+  }
+  if (ShapedType::isDynamic(offset) ||
+      llvm::any_of(strides, ShapedType::isDynamic)) {
+    allocOp.emitOpError(
+        "workgroup local memory allocations must have static layout");
+    return failure();
+  }
+  if (offset < 0 ||
+      llvm::any_of(strides, [](int64_t stride) { return stride < 0; })) {
+    allocOp.emitOpError(
+        "workgroup local memory allocations must have non-negative layout");
+    return failure();
+  }
+
+  if (llvm::is_contained(type.getShape(), 0)) {
+    return 0;
+  }
+
+  int64_t maxElementOffset = offset;
+  for (auto [dim, stride] : llvm::zip_equal(type.getShape(), strides)) {
+    int64_t contribution = 0;
+    if (failed(checkedMul(dim - 1, stride, contribution)) ||
+        failed(checkedAdd(maxElementOffset, contribution, maxElementOffset))) {
+      allocOp.emitOpError("workgroup local memory allocation size overflow");
+      return failure();
+    }
+  }
+
+  int64_t footprint = 0;
+  if (failed(checkedAdd(maxElementOffset, 1, footprint))) {
+    allocOp.emitOpError("workgroup local memory allocation size overflow");
+    return failure();
+  }
+  return footprint;
+}
+
+static FailureOr<int64_t> computeAllocationByteSize(memref::AllocOp allocOp) {
+  MemRefType type = allocOp.getType();
+  FailureOr<int64_t> elementFootprint = computeStaticElementFootprint(allocOp);
+  if (failed(elementFootprint)) {
+    return failure();
+  }
+
+  DataLayout dataLayout = DataLayout::closest(allocOp);
+  llvm::TypeSize elementByteSize =
+      dataLayout.getTypeSize(type.getElementType());
+  if (elementByteSize.isScalable()) {
+    allocOp.emitOpError("workgroup local memory allocations must have "
+                        "fixed-size element types");
+    return failure();
+  }
+  if (elementByteSize.getFixedValue() >
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    allocOp.emitOpError("workgroup local memory allocation size overflow");
+    return failure();
+  }
+  int64_t elementBytes = static_cast<int64_t>(elementByteSize.getFixedValue());
+
+  int64_t totalBytes = 0;
+  if (failed(checkedMul(*elementFootprint, elementBytes, totalBytes))) {
+    allocOp.emitOpError("workgroup local memory allocation size overflow");
+    return failure();
+  }
+  return totalBytes;
+}
+
+static FailureOr<int64_t> computeAlignment(memref::AllocOp allocOp) {
+  if (std::optional<uint64_t> explicitAlignment = allocOp.getAlignment()) {
+    if (*explicitAlignment >
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      allocOp.emitOpError(
+          "workgroup local memory allocation alignment overflow");
+      return failure();
+    }
+    return std::max(static_cast<int64_t>(*explicitAlignment),
+                    kMinWorkgroupLocalAlignment);
+  }
+  DataLayout dataLayout = DataLayout::closest(allocOp);
+  uint64_t abiAlignment =
+      dataLayout.getTypeABIAlignment(allocOp.getType().getElementType());
+  if (abiAlignment >
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    allocOp.emitOpError("workgroup local memory allocation alignment overflow");
+    return failure();
+  }
+  return std::max(static_cast<int64_t>(abiAlignment),
+                  kMinWorkgroupLocalAlignment);
+}
+
+static LogicalResult
+rejectUnsupportedWorkgroupLocalMemoryUses(mlir::FunctionOpInterface funcOp) {
+  if (llvm::any_of(
+          funcOp.getArgumentTypes(),
+          [](Type type) { return hasWorkgroupLocalMemorySpace(type); }) ||
+      llvm::any_of(funcOp.getResultTypes(), [](Type type) {
+        return hasWorkgroupLocalMemorySpace(type);
+      })) {
+    return funcOp.emitOpError(
+        "workgroup local memory is only supported for memref.alloc results");
+  }
+
+  WalkResult result = funcOp.walk([&](Operation *op) -> WalkResult {
+    if (auto allocaOp = dyn_cast<memref::AllocaOp>(op)) {
+      if (hasWorkgroupLocalMemorySpace(allocaOp.getType())) {
+        allocaOp.emitOpError(
+            "workgroup local memory is only supported for memref.alloc");
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+} // namespace
+
+void LLVMCPUAssignWorkgroupLocalMemoryPass::runOnOperation() {
+  mlir::FunctionOpInterface funcOp = getOperation();
+  if (funcOp.getFunctionBody().empty()) {
+    return;
+  }
+  if (failed(rejectUnsupportedWorkgroupLocalMemoryUses(funcOp))) {
+    return signalPassFailure();
+  }
+
+  SmallVector<memref::AllocOp> localAllocs;
+  funcOp.walk([&](memref::AllocOp allocOp) {
+    if (hasWorkgroupLocalMemorySpace(allocOp)) {
+      localAllocs.push_back(allocOp);
+    }
+  });
+  if (localAllocs.empty()) {
+    return;
+  }
+
+  std::optional<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
+  if (!exportOp) {
+    localAllocs.front().emitOpError(
+        "workgroup local memory allocations are only supported in HAL "
+        "executable exports");
+    return signalPassFailure();
+  }
+  if (exportOp.value()->hasAttr(exportOp->getWorkgroupLocalMemoryAttrName())) {
+    exportOp.value()->emitOpError(
+        "already has a workgroup local memory requirement");
+    return signalPassFailure();
+  }
+
+  OpBuilder builder(funcOp.getContext());
+  int64_t currentOffset = 0;
+  Block &entryBlock = funcOp.getFunctionBody().front();
+  for (auto allocOp : localAllocs) {
+    if (allocOp->getBlock() != &entryBlock) {
+      allocOp.emitOpError(
+          "workgroup local memory allocations must be in the function entry "
+          "block");
+      return signalPassFailure();
+    }
+    if (allocOp->hasAttr(kWorkgroupLocalMemoryRangeAttrName)) {
+      allocOp.emitOpError("already has a workgroup local memory assignment");
+      return signalPassFailure();
+    }
+
+    FailureOr<int64_t> byteSize = computeAllocationByteSize(allocOp);
+    if (failed(byteSize)) {
+      return signalPassFailure();
+    }
+
+    FailureOr<int64_t> alignment = computeAlignment(allocOp);
+    if (failed(alignment)) {
+      return signalPassFailure();
+    }
+    uint64_t alignedOffset = llvm::alignTo(static_cast<uint64_t>(currentOffset),
+                                           static_cast<uint64_t>(*alignment));
+    if (alignedOffset >
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      allocOp.emitOpError("workgroup local memory allocation size overflow");
+      return signalPassFailure();
+    }
+    currentOffset = static_cast<int64_t>(alignedOffset);
+    allocOp->setAttr(kWorkgroupLocalMemoryRangeAttrName,
+                     builder.getDenseI64ArrayAttr({currentOffset, *byteSize}));
+
+    if (failed(checkedAdd(currentOffset, *byteSize, currentOffset))) {
+      allocOp.emitOpError("workgroup local memory allocation size overflow");
+      return signalPassFailure();
+    }
+  }
+
+  exportOp.value()->setAttr(exportOp->getWorkgroupLocalMemoryAttrName(),
+                            builder.getIndexAttr(currentOffset));
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignWorkgroupLocalMemory.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignWorkgroupLocalMemory.cpp
@@ -75,6 +75,10 @@ static LogicalResult checkedAlignTo(int64_t value, int64_t alignment,
   return checkedAdd(value, alignment - remainder, result);
 }
 
+static bool hasZeroElementShape(MemRefType type) {
+  return llvm::is_contained(type.getShape(), 0);
+}
+
 static FailureOr<int64_t>
 computeStaticElementFootprint(memref::AllocOp allocOp) {
   MemRefType type = allocOp.getType();
@@ -104,7 +108,7 @@ computeStaticElementFootprint(memref::AllocOp allocOp) {
     return failure();
   }
 
-  if (llvm::is_contained(type.getShape(), 0)) {
+  if (hasZeroElementShape(type)) {
     return 0;
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -63,7 +63,7 @@ checkStackAllocationSize(mlir::FunctionOpInterface funcOp) {
     return success();
   }
 
-  int cumSize = 0;
+  int64_t cumSize = 0;
   const unsigned assumedVscale = clAssumedVscaleValue;
   for (auto allocaOp : allocaOps) {
     if (allocaOp->getBlock() != &funcOp.getFunctionBody().front()) {
@@ -71,7 +71,7 @@ checkStackAllocationSize(mlir::FunctionOpInterface funcOp) {
           "all stack allocations need to be hoisted to the entry block of the "
           "function");
     }
-    int allocaSize = 1;
+    int64_t allocaSize = 1;
     auto allocaType = cast<ShapedType>(allocaOp.getType());
     for (auto dimSize : allocaType.getShape()) {
       if (ShapedType::isDynamic(dimSize)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -579,6 +579,7 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
       .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createCleanupBufferAllocViewPass)
+      .addPass(createLLVMCPUAssignWorkgroupLocalMemoryPass)
       // Checking stack allocation before converting to CF dialect is easier.
       .addPass([&]() {
         return createLLVMCPUCheckIRBeforeLLVMConversionPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -569,6 +569,7 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
       .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createCleanupBufferAllocViewPass)
+      .addPass(createLLVMCPUAssignWorkgroupLocalMemoryPass)
       // Checking stack allocation before converting to CF dialect is easier.
       .addPass([&]() {
         return createLLVMCPUCheckIRBeforeLLVMConversionPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -51,6 +51,24 @@ def LLVMCPUAssignImportOrdinalsPass :
   let summary = "Assigns executable import ordinals across all LLVMCPU variants.";
 }
 
+def LLVMCPUAssignWorkgroupLocalMemoryPass :
+    InterfacePass<"iree-llvmcpu-assign-workgroup-local-memory",
+                  "mlir::FunctionOpInterface"> {
+  let summary =
+      "Assigns HAL workgroup local memory layout for marked memref.alloc ops.";
+  let description = [{
+    Scans entry-block memref.alloc operations whose memory space is
+    #iree_codegen.workgroup_local, computes a static byte layout using the
+    target data layout, and annotates each alloc with its byte range in the
+    dispatch workgroup local memory buffer.
+
+    The pass also sets the corresponding hal.executable.export
+    workgroup_local_memory attribute so the runtime provides enough local
+    memory for the converted dispatch. Existing local-memory assignments and
+    predeclared export requirements are rejected instead of being overwritten.
+  }];
+}
+
 def LLVMCPUCheckIRBeforeLLVMConversionPass :
     InterfacePass<"iree-llvmcpu-check-ir-before-llvm-conversion", "mlir::FunctionOpInterface"> {
   let summary = "Checks CPU backend specific IR constraints (like no allocas)";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -59,13 +59,13 @@ def LLVMCPUAssignWorkgroupLocalMemoryPass :
   let description = [{
     Scans entry-block memref.alloc operations whose memory space is
     #iree_codegen.workgroup_local, computes a static byte layout using the
-    target data layout, and annotates each alloc with its byte range in the
-    dispatch workgroup local memory buffer.
+    target data layout, and rewrites each alloc to a memref.view into one packed
+    byte allocation in the same memory space.
 
-    The pass also sets the corresponding hal.executable.export
-    workgroup_local_memory attribute so the runtime provides enough local
-    memory for the converted dispatch. Existing local-memory assignments and
-    predeclared export requirements are rejected instead of being overwritten.
+    The pass also sets the corresponding iree_codegen.dispatch_config
+    workgroup_local_memory attribute so propagation to hal.executable.export
+    follows the normal dispatch metadata path. Existing local-memory
+    requirements are rejected instead of being overwritten.
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "apply_scale_lowering.mlir",
             "assign_constant_ordinals.mlir",
             "assign_import_ordinals.mlir",
+            "assign_workgroup_local_memory.mlir",
             "check_ir_before_llvm_conversion.mlir",
             "check_ir_before_llvm_conversion_not_fail_unbound.mlir",
             "convert_to_llvm.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "apply_scale_lowering.mlir"
     "assign_constant_ordinals.mlir"
     "assign_import_ordinals.mlir"
+    "assign_workgroup_local_memory.mlir"
     "check_ir_before_llvm_conversion.mlir"
     "check_ir_before_llvm_conversion_not_fail_unbound.mlir"
     "convert_to_llvm.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_workgroup_local_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_workgroup_local_memory.mlir
@@ -11,17 +11,23 @@
 
 // CHECK-LABEL: hal.executable private @single_local_alloc
 // CHECK:       hal.executable.export public @dispatch
-// CHECK-SAME:    workgroup_local_memory = 1024 : index
 hal.executable private @single_local_alloc {
   hal.executable.variant public @embedded target(#executable_target) {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
     builtin.module {
       // CHECK-LABEL: func.func @dispatch
       func.func @dispatch() {
-        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 1024>}
+        // CHECK: %[[PACKED:.+]] = memref.alloc() : memref<1024xi8, #iree_codegen.workgroup_local>
+        // CHECK: %[[C0:.+]] = arith.constant 0 : index
+        // CHECK: memref.view %[[PACKED]][%[[C0]]][] : memref<1024xi8, #iree_codegen.workgroup_local> to memref<16x16xf32, #iree_codegen.workgroup_local>
         %0 = memref.alloc() : memref<16x16xf32, #iree_codegen.workgroup_local>
         memref.dealloc %0 : memref<16x16xf32, #iree_codegen.workgroup_local>
         return
+      }
+      // CHECK: iree_codegen.dispatch_config @dispatch workgroup_local_memory = 1024
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -40,20 +46,28 @@ hal.executable private @single_local_alloc {
 
 // CHECK-LABEL: hal.executable private @packing_and_alignment
 // CHECK:       hal.executable.export public @dispatch
-// CHECK-SAME:    workgroup_local_memory = 80 : index
 hal.executable private @packing_and_alignment {
   hal.executable.variant public @embedded target(#executable_target) {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
     builtin.module {
       // CHECK-LABEL: func.func @dispatch
       func.func @dispatch() {
-        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 3>}
+        // CHECK: %[[PACKED:.+]] = memref.alloc() : memref<80xi8, #iree_codegen.workgroup_local>
+        // CHECK: %[[C0:.+]] = arith.constant 0 : index
+        // CHECK: memref.view %[[PACKED]][%[[C0]]][] : memref<80xi8, #iree_codegen.workgroup_local> to memref<3xi4, #iree_codegen.workgroup_local>
         %0 = memref.alloc() : memref<3xi4, #iree_codegen.workgroup_local>
-        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 16, 16>}
+        // CHECK: %[[C16:.+]] = arith.constant 16 : index
+        // CHECK: memref.view %[[PACKED]][%[[C16]]][] : memref<80xi8, #iree_codegen.workgroup_local> to memref<4xf32, #iree_codegen.workgroup_local>
         %1 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
-        // CHECK: memref.alloc() {alignment = 64 : i64, iree_codegen.local_memory_range = array<i64: 64, 16>}
+        // CHECK: %[[C64:.+]] = arith.constant 64 : index
+        // CHECK: memref.view %[[PACKED]][%[[C64]]][] : memref<80xi8, #iree_codegen.workgroup_local> to memref<4xf32, #iree_codegen.workgroup_local>
         %2 = memref.alloc() {alignment = 64 : i64} : memref<4xf32, #iree_codegen.workgroup_local>
         return
+      }
+      // CHECK: iree_codegen.dispatch_config @dispatch workgroup_local_memory = 80
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -72,16 +86,23 @@ hal.executable private @packing_and_alignment {
 
 // CHECK-LABEL: hal.executable private @strided_layout
 // CHECK:       hal.executable.export public @dispatch
-// CHECK-SAME:    workgroup_local_memory = 32 : index
 hal.executable private @strided_layout {
   hal.executable.variant public @embedded target(#executable_target) {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
     builtin.module {
       // CHECK-LABEL: func.func @dispatch
       func.func @dispatch() {
-        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 32>}
+        // CHECK: %[[PACKED:.+]] = memref.alloc() : memref<32xi8, #iree_codegen.workgroup_local>
+        // CHECK: %[[C0:.+]] = arith.constant 0 : index
+        // CHECK: %[[VIEW:.+]] = memref.view %[[PACKED]][%[[C0]]][] : memref<32xi8, #iree_codegen.workgroup_local> to memref<8xf32, #iree_codegen.workgroup_local>
+        // CHECK: memref.reinterpret_cast %[[VIEW]] to offset: [1], sizes: [4], strides: [2] : memref<8xf32, #iree_codegen.workgroup_local> to memref<4xf32, strided<[2], offset: 1>, #iree_codegen.workgroup_local>
         %0 = memref.alloc() : memref<4xf32, strided<[2], offset: 1>, #iree_codegen.workgroup_local>
         return
+      }
+      // CHECK: iree_codegen.dispatch_config @dispatch workgroup_local_memory = 32
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -100,18 +121,24 @@ hal.executable private @strided_layout {
 
 // CHECK-LABEL: hal.executable private @mixed_allocs
 // CHECK:       hal.executable.export public @dispatch
-// CHECK-SAME:    workgroup_local_memory = 4096 : index
 hal.executable private @mixed_allocs {
   hal.executable.variant public @embedded target(#executable_target) {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
     builtin.module {
       // CHECK-LABEL: func.func @dispatch
       func.func @dispatch() {
-        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 4096>}
+        // CHECK: %[[PACKED:.+]] = memref.alloc() : memref<4096xi8, #iree_codegen.workgroup_local>
+        // CHECK: %[[C0:.+]] = arith.constant 0 : index
+        // CHECK: memref.view %[[PACKED]][%[[C0]]][] : memref<4096xi8, #iree_codegen.workgroup_local> to memref<1024xf32, #iree_codegen.workgroup_local>
         %0 = memref.alloc() : memref<1024xf32, #iree_codegen.workgroup_local>
         // CHECK: memref.alloca() : memref<16xf32>
         %1 = memref.alloca() : memref<16xf32>
         return
+      }
+      // CHECK: iree_codegen.dispatch_config @dispatch workgroup_local_memory = 4096
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -136,6 +163,10 @@ hal.executable private @dynamic_shape_rejected {
         // expected-error @+1 {{workgroup local memory allocations must have static shape}}
         %0 = memref.alloc(%size) : memref<?xf32, #iree_codegen.workgroup_local>
         return
+      }
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -162,29 +193,9 @@ hal.executable private @dynamic_layout_rejected {
         %0 = memref.alloc()[%c1] : memref<4xf32, strided<[?], offset: 0>, #iree_codegen.workgroup_local>
         return
       }
-    }
-  }
-}
-
-// -----
-
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>
-]>
-#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
-  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-  native_vector_size = 64 : index,
-  target_triple = "x86_64-unknown-linux-gnu"
-}>
-
-hal.executable private @preassigned_alloc_rejected {
-  hal.executable.variant public @embedded target(#executable_target) {
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
-    builtin.module {
-      func.func @dispatch() {
-        // expected-error @+1 {{already has a workgroup local memory assignment}}
-        %0 = memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 16>} : memref<4xf32, #iree_codegen.workgroup_local>
-        return
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -201,14 +212,18 @@ hal.executable private @preassigned_alloc_rejected {
   target_triple = "x86_64-unknown-linux-gnu"
 }>
 
-hal.executable private @preexisting_export_requirement_rejected {
+hal.executable private @preexisting_config_requirement_rejected {
   hal.executable.variant public @embedded target(#executable_target) {
-    // expected-error @+1 {{already has a workgroup local memory requirement}}
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {workgroup_local_memory = 16 : index}
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
     builtin.module {
       func.func @dispatch() {
         %0 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
         return
+      }
+      // expected-error @+1 {{already has a workgroup local memory requirement}}
+      iree_codegen.dispatch_config @dispatch workgroup_local_memory = 16 {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }
@@ -230,35 +245,11 @@ hal.executable private @private_helper_alloc_rejected {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
     builtin.module {
       func.func private @helper() {
-        // expected-error @+1 {{workgroup local memory allocations are only supported in HAL executable exports}}
+        // expected-error @+1 {{workgroup local memory allocations require an iree_codegen.dispatch_config op}}
         %0 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
         return
       }
       func.func @dispatch() {
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>
-]>
-#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
-  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n8:16:32:64-S128",
-  native_vector_size = 64 : index,
-  target_triple = "x86_64-unknown-linux-gnu"
-}>
-
-hal.executable private @alloca_rejected {
-  hal.executable.variant public @embedded target(#executable_target) {
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
-    builtin.module {
-      func.func @dispatch() {
-        // expected-error @+1 {{workgroup local memory is only supported for memref.alloc}}
-        %0 = memref.alloca() : memref<4xf32, #iree_codegen.workgroup_local>
         return
       }
     }
@@ -276,6 +267,30 @@ hal.executable private @alloca_rejected {
   target_triple = "x86_64-unknown-linux-gnu"
 }>
 
+hal.executable private @alloca_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch() {
+        // expected-error @+1 {{workgroup local memory is only supported for memref.alloc results}}
+        %0 = memref.alloca() : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
 hal.executable private @non_entry_alloc_rejected {
   hal.executable.variant public @embedded target(#executable_target) {
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
@@ -286,6 +301,10 @@ hal.executable private @non_entry_alloc_rejected {
         // expected-error @+1 {{workgroup local memory allocations must be in the function entry block}}
         %0 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
         return
+      }
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_workgroup_local_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_workgroup_local_memory.mlir
@@ -84,6 +84,39 @@ hal.executable private @packing_and_alignment {
   target_triple = "x86_64-unknown-linux-gnu"
 }>
 
+// CHECK-LABEL: hal.executable private @zero_sized_local_alloc
+hal.executable private @zero_sized_local_alloc {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      // CHECK-LABEL: func.func @dispatch
+      func.func @dispatch() {
+        // CHECK: %[[PACKED:.+]] = memref.alloc() : memref<0xi8, #iree_codegen.workgroup_local>
+        // CHECK: %[[C0:.+]] = arith.constant 0 : index
+        // CHECK: memref.view %[[PACKED]][%[[C0]]][] : memref<0xi8, #iree_codegen.workgroup_local> to memref<0xf32, #iree_codegen.workgroup_local>
+        %0 = memref.alloc() : memref<0xf32, #iree_codegen.workgroup_local>
+        return
+      }
+      // CHECK: iree_codegen.dispatch_config @dispatch workgroup_local_memory = 0
+      iree_codegen.dispatch_config @dispatch {
+        %c1 = arith.constant 1 : index
+        iree_codegen.yield %c1, %c1, %c1 : index, index, index
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
 // CHECK-LABEL: hal.executable private @strided_layout
 // CHECK:       hal.executable.export public @dispatch
 hal.executable private @strided_layout {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_workgroup_local_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_workgroup_local_memory.mlir
@@ -1,0 +1,341 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmcpu-assign-workgroup-local-memory)))))" --split-input-file --verify-diagnostics %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+// CHECK-LABEL: hal.executable private @single_local_alloc
+// CHECK:       hal.executable.export public @dispatch
+// CHECK-SAME:    workgroup_local_memory = 1024 : index
+hal.executable private @single_local_alloc {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      // CHECK-LABEL: func.func @dispatch
+      func.func @dispatch() {
+        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 1024>}
+        %0 = memref.alloc() : memref<16x16xf32, #iree_codegen.workgroup_local>
+        memref.dealloc %0 : memref<16x16xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+// CHECK-LABEL: hal.executable private @packing_and_alignment
+// CHECK:       hal.executable.export public @dispatch
+// CHECK-SAME:    workgroup_local_memory = 80 : index
+hal.executable private @packing_and_alignment {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      // CHECK-LABEL: func.func @dispatch
+      func.func @dispatch() {
+        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 3>}
+        %0 = memref.alloc() : memref<3xi4, #iree_codegen.workgroup_local>
+        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 16, 16>}
+        %1 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
+        // CHECK: memref.alloc() {alignment = 64 : i64, iree_codegen.local_memory_range = array<i64: 64, 16>}
+        %2 = memref.alloc() {alignment = 64 : i64} : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+// CHECK-LABEL: hal.executable private @strided_layout
+// CHECK:       hal.executable.export public @dispatch
+// CHECK-SAME:    workgroup_local_memory = 32 : index
+hal.executable private @strided_layout {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      // CHECK-LABEL: func.func @dispatch
+      func.func @dispatch() {
+        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 32>}
+        %0 = memref.alloc() : memref<4xf32, strided<[2], offset: 1>, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+// CHECK-LABEL: hal.executable private @mixed_allocs
+// CHECK:       hal.executable.export public @dispatch
+// CHECK-SAME:    workgroup_local_memory = 4096 : index
+hal.executable private @mixed_allocs {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      // CHECK-LABEL: func.func @dispatch
+      func.func @dispatch() {
+        // CHECK: memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 4096>}
+        %0 = memref.alloc() : memref<1024xf32, #iree_codegen.workgroup_local>
+        // CHECK: memref.alloca() : memref<16xf32>
+        %1 = memref.alloca() : memref<16xf32>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @dynamic_shape_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch(%size: index) {
+        // expected-error @+1 {{workgroup local memory allocations must have static shape}}
+        %0 = memref.alloc(%size) : memref<?xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @dynamic_layout_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch() {
+        %c1 = arith.constant 1 : index
+        // expected-error @+1 {{workgroup local memory allocations must have static layout}}
+        %0 = memref.alloc()[%c1] : memref<4xf32, strided<[?], offset: 0>, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @preassigned_alloc_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch() {
+        // expected-error @+1 {{already has a workgroup local memory assignment}}
+        %0 = memref.alloc() {iree_codegen.local_memory_range = array<i64: 0, 16>} : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @preexisting_export_requirement_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    // expected-error @+1 {{already has a workgroup local memory requirement}}
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {workgroup_local_memory = 16 : index}
+    builtin.module {
+      func.func @dispatch() {
+        %0 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @private_helper_alloc_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func private @helper() {
+        // expected-error @+1 {{workgroup local memory allocations are only supported in HAL executable exports}}
+        %0 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+      func.func @dispatch() {
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @alloca_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch() {
+        // expected-error @+1 {{workgroup local memory is only supported for memref.alloc}}
+        %0 = memref.alloca() : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @non_entry_alloc_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch() {
+        cf.br ^bb1
+      ^bb1:
+        // expected-error @+1 {{workgroup local memory allocations must be in the function entry block}}
+        %0 = memref.alloc() : memref<4xf32, #iree_codegen.workgroup_local>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+hal.executable private @signature_local_memory_rejected {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      // expected-error @+1 {{workgroup local memory is only supported for memref.alloc results}}
+      func.func @dispatch(%arg0: memref<4xf32, #iree_codegen.workgroup_local>) {
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  native_vector_size = 64 : index,
+  target_triple = "x86_64-unknown-linux-gnu"
+}>
+
+// CHECK-LABEL: hal.executable private @no_local_allocs
+// CHECK:       hal.executable.export public @dispatch
+// CHECK-NOT:   workgroup_local_memory
+hal.executable private @no_local_allocs {
+  hal.executable.variant public @embedded target(#executable_target) {
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout)
+    builtin.module {
+      func.func @dispatch() {
+        %0 = memref.alloca() : memref<16xf32>
+        return
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
@@ -68,9 +68,12 @@ func.func @complex_alloca() {
 
 // -----
 
-func.func @workgroup_local_alloc_not_counted() {
+// Workgroup-local allocs are backed by HAL dispatch local memory, not stack
+// slots. Only the memref.alloca below contributes to the stack allocation
+// limit.
+func.func @workgroup_local_alloc_not_counted_as_stack() {
   %0 = memref.alloc() : memref<16384xf32, #iree_codegen.workgroup_local>
   %1 = memref.alloca() : memref<1024xf32>
   return
 }
-// CHECK-LABEL: func @workgroup_local_alloc_not_counted(
+// CHECK-LABEL: func @workgroup_local_alloc_not_counted_as_stack(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
@@ -65,3 +65,12 @@ func.func @complex_alloca() {
   return
 }
 // CHECK-LABEL: func @complex_alloca(
+
+// -----
+
+func.func @workgroup_local_alloc_not_counted() {
+  %0 = memref.alloc() : memref<16384xf32, #iree_codegen.workgroup_local>
+  %1 = memref.alloca() : memref<1024xf32>
+  return
+}
+// CHECK-LABEL: func @workgroup_local_alloc_not_counted(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
@@ -116,7 +116,9 @@ module attributes {
 // -----
 
 func.func @workgroup_local_alloc() {
-  %0 = memref.alloc() {iree_codegen.local_memory_range = array<i64: 128, 1024>} : memref<16x16xf32, #iree_codegen.workgroup_local>
+  %base = memref.alloc() : memref<1152xi8, #iree_codegen.workgroup_local>
+  %c128 = arith.constant 128 : index
+  %0 = memref.view %base[%c128][] : memref<1152xi8, #iree_codegen.workgroup_local> to memref<16x16xf32, #iree_codegen.workgroup_local>
   %c0 = arith.constant 0 : index
   %val = memref.load %0[%c0, %c0] : memref<16x16xf32, #iree_codegen.workgroup_local>
   llvm.call @sink_f32(%val) : (f32) -> ()
@@ -130,7 +132,7 @@ llvm.func @sink_f32(%arg0: f32) {
 // CHECK-LABEL: llvm.func @workgroup_local_alloc(
 // CHECK:       %[[WG_STATE:.+]] = llvm.load %arg2
 // CHECK:       %[[LOCAL_MEM:.+]] = llvm.extractvalue %[[WG_STATE]][5]
-// CHECK:       %[[LOCAL_PTR:.+]] = llvm.getelementptr inbounds %[[LOCAL_MEM]][128] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK:       %[[LOCAL_PTR:.+]] = llvm.getelementptr %[[LOCAL_MEM]][128] : (!llvm.ptr) -> !llvm.ptr, i8
 // CHECK-NOT:   llvm.alloca
 // CHECK:       llvm.call @sink_f32
 // CHECK-NOT:   free

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
@@ -112,3 +112,26 @@ module attributes {
 
 // CHECK-LABEL:   llvm.func @negative_no_gather_lowering(
 // CHECK: llvm.intr.masked.gather {{.*}} : (vector<64x!llvm.ptr>, vector<64xi1>, vector<64xf32>) -> vector<64xf32>
+
+// -----
+
+func.func @workgroup_local_alloc() {
+  %0 = memref.alloc() {iree_codegen.local_memory_range = array<i64: 128, 1024>} : memref<16x16xf32, #iree_codegen.workgroup_local>
+  %c0 = arith.constant 0 : index
+  %val = memref.load %0[%c0, %c0] : memref<16x16xf32, #iree_codegen.workgroup_local>
+  llvm.call @sink_f32(%val) : (f32) -> ()
+  memref.dealloc %0 : memref<16x16xf32, #iree_codegen.workgroup_local>
+  return
+}
+llvm.func @sink_f32(%arg0: f32) {
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @workgroup_local_alloc(
+// CHECK:       %[[WG_STATE:.+]] = llvm.load %arg2
+// CHECK:       %[[LOCAL_MEM:.+]] = llvm.extractvalue %[[WG_STATE]][5]
+// CHECK:       %[[LOCAL_PTR:.+]] = llvm.getelementptr inbounds %[[LOCAL_MEM]][128] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NOT:   llvm.alloca
+// CHECK:       llvm.call @sink_f32
+// CHECK-NOT:   free
+// CHECK:       llvm.return


### PR DESCRIPTION
Add #iree_codegen.workgroup_local as a codegen memory-space attribute for authored LLVMCPU dispatch allocations that should use HAL workgroup local memory instead of the thread stack.

This deliberately matches the GPU-side semantic split: workgroup/shared memory is represented as memref.alloc in a workgroup memory space, while memref.alloca remains private stack scratch. LLVMCPU uses an IREE-specific memory-space attribute instead of #gpu.address_space<workgroup>, but keeps the same alloc/dealloc ownership model.

The assignment pass is intentionally narrow: it only handles entry-block memref.alloc operations in HAL executable exports, computes byte ranges with the target data layout and ABI alignment, rejects dynamic or unsupported layouts, and refuses to overwrite existing local-memory assignments or predeclared export requirements.

ConvertToLLVM consumes the assigned range by building memref descriptors from the HAL workgroup local-memory pointer. Matching memref.dealloc operations are erased because the storage is owned by the dispatch frame.