### PR TITLE
Legalize vector.{de,}interleave into 1-dimensional vectors.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULegalizeNDVectors.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULegalizeNDVectors.cpp
@@ -714,8 +714,8 @@ struct ConvertVectorBitcast final
 /// split into flat 1-D vectors by the type converter; create a 1-D interleave
 /// for each corresponding pair.
 struct ConvertVectorInterleave final
-    : public OpConversionPattern<vector::InterleaveOp> {
-  using OpConversionPattern::OpConversionPattern;
+    : OpConversionPattern<vector::InterleaveOp> {
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(vector::InterleaveOp op, OneToNOpAdaptor adaptor,
@@ -726,15 +726,14 @@ struct ConvertVectorInterleave final
     }
 
     Location loc = op.getLoc();
-    SmallVector<Value> lhsValues(adaptor.getLhs());
-    SmallVector<Value> rhsValues(adaptor.getRhs());
 
     VectorType resultType = op.getResultVectorType();
     auto result1DType = VectorType::get({resultType.getShape().back()},
                                         resultType.getElementType());
 
     SmallVector<Value> results;
-    for (auto [lhs, rhs] : llvm::zip_equal(lhsValues, rhsValues)) {
+    for (auto [lhs, rhs] :
+         llvm::zip_equal(adaptor.getLhs(), adaptor.getRhs())) {
       results.push_back(
           vector::InterleaveOp::create(rewriter, loc, result1DType, lhs, rhs));
     }
@@ -748,8 +747,8 @@ struct ConvertVectorInterleave final
 /// for each and group results so that all res1 values come first, then all
 /// res2 values.
 struct ConvertVectorDeinterleave final
-    : public OpConversionPattern<vector::DeinterleaveOp> {
-  using OpConversionPattern::OpConversionPattern;
+    : OpConversionPattern<vector::DeinterleaveOp> {
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(vector::DeinterleaveOp op, OneToNOpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULegalizeNDVectors.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULegalizeNDVectors.cpp
@@ -743,6 +743,37 @@ struct ConvertVectorInterleave final
   }
 };
 
+/// Convert vector.deinterleave on n-D vectors. The source is already split
+/// into flat 1-D vectors by the type converter; create a 1-D deinterleave
+/// for each and group results so that all res1 values come first, then all
+/// res2 values.
+struct ConvertVectorDeinterleave final
+    : public OpConversionPattern<vector::DeinterleaveOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(vector::DeinterleaveOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    VectorType srcType = op.getSourceVectorType();
+    if (srcType.getRank() <= 1) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    SmallVector<Value> srcValues(adaptor.getSource());
+
+    SmallVector<Value> res1Values;
+    SmallVector<Value> res2Values;
+    for (Value src : srcValues) {
+      auto deinterleave = vector::DeinterleaveOp::create(rewriter, loc, src);
+      res1Values.push_back(deinterleave.getRes1());
+      res2Values.push_back(deinterleave.getRes2());
+    }
+    rewriter.replaceOpWithMultiple(op, {res1Values, res2Values});
+    return success();
+  }
+};
+
 /// Convert any ReturnLike op with 1:N type-converted operands.
 struct ConvertReturnLike final
     : public OpTraitConversionPattern<OpTrait::ReturnLike> {
@@ -778,13 +809,13 @@ struct LLVMGPULegalizeNDVectorsPass final
     populateAnyFunctionOpInterfaceTypeConversionPattern(patterns,
                                                         typeConverter);
     patterns.add<UnrollElementwiseOps, ConvertReturnLike>(typeConverter, ctx);
-    patterns
-        .add<ConvertVectorExtract, ConvertVectorInsert, ConvertVectorTranspose,
-             ConvertVectorShapeCast, ConvertVectorExtractStridedSlice,
-             ConvertVectorInsertStridedSlice, ConvertArithConstant,
-             ConvertUBPoison, ConvertVectorToElements,
-             ConvertVectorFromElements, ConvertVectorBroadcast,
-             ConvertVectorBitcast, ConvertVectorInterleave>(typeConverter, ctx);
+    patterns.add<
+        ConvertVectorExtract, ConvertVectorInsert, ConvertVectorTranspose,
+        ConvertVectorShapeCast, ConvertVectorExtractStridedSlice,
+        ConvertVectorInsertStridedSlice, ConvertArithConstant, ConvertUBPoison,
+        ConvertVectorToElements, ConvertVectorFromElements,
+        ConvertVectorBroadcast, ConvertVectorBitcast, ConvertVectorInterleave,
+        ConvertVectorDeinterleave>(typeConverter, ctx);
 
     // Some nvgpu ops abuse n-D vector types to represent a "struct of
     // vectors". These ops are legal despite having n-D vectors — the

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULegalizeNDVectors.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULegalizeNDVectors.cpp
@@ -710,6 +710,39 @@ struct ConvertVectorBitcast final
   }
 };
 
+/// Convert vector.interleave on n-D vectors. The lhs and rhs are already
+/// split into flat 1-D vectors by the type converter; create a 1-D interleave
+/// for each corresponding pair.
+struct ConvertVectorInterleave final
+    : public OpConversionPattern<vector::InterleaveOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(vector::InterleaveOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    VectorType srcType = op.getSourceVectorType();
+    if (srcType.getRank() <= 1) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    SmallVector<Value> lhsValues(adaptor.getLhs());
+    SmallVector<Value> rhsValues(adaptor.getRhs());
+
+    VectorType resultType = op.getResultVectorType();
+    auto result1DType = VectorType::get({resultType.getShape().back()},
+                                        resultType.getElementType());
+
+    SmallVector<Value> results;
+    for (auto [lhs, rhs] : llvm::zip_equal(lhsValues, rhsValues)) {
+      results.push_back(
+          vector::InterleaveOp::create(rewriter, loc, result1DType, lhs, rhs));
+    }
+    rewriter.replaceOpWithMultiple(op, {results});
+    return success();
+  }
+};
+
 /// Convert any ReturnLike op with 1:N type-converted operands.
 struct ConvertReturnLike final
     : public OpTraitConversionPattern<OpTrait::ReturnLike> {
@@ -745,12 +778,13 @@ struct LLVMGPULegalizeNDVectorsPass final
     populateAnyFunctionOpInterfaceTypeConversionPattern(patterns,
                                                         typeConverter);
     patterns.add<UnrollElementwiseOps, ConvertReturnLike>(typeConverter, ctx);
-    patterns.add<
-        ConvertVectorExtract, ConvertVectorInsert, ConvertVectorTranspose,
-        ConvertVectorShapeCast, ConvertVectorExtractStridedSlice,
-        ConvertVectorInsertStridedSlice, ConvertArithConstant, ConvertUBPoison,
-        ConvertVectorToElements, ConvertVectorFromElements,
-        ConvertVectorBroadcast, ConvertVectorBitcast>(typeConverter, ctx);
+    patterns
+        .add<ConvertVectorExtract, ConvertVectorInsert, ConvertVectorTranspose,
+             ConvertVectorShapeCast, ConvertVectorExtractStridedSlice,
+             ConvertVectorInsertStridedSlice, ConvertArithConstant,
+             ConvertUBPoison, ConvertVectorToElements,
+             ConvertVectorFromElements, ConvertVectorBroadcast,
+             ConvertVectorBitcast, ConvertVectorInterleave>(typeConverter, ctx);
 
     // Some nvgpu ops abuse n-D vector types to represent a "struct of
     // vectors". These ops are legal despite having n-D vectors — the

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/legalize_nd_vectors.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/legalize_nd_vectors.mlir
@@ -315,6 +315,20 @@ func.func @interleave_2d(%a: vector<2x3xf32>, %b: vector<2x3xf32>) -> vector<2x6
 
 // -----
 
+// vector.deinterleave on a 2-D vector: each 1-D vector is deinterleaved individually.
+func.func @deinterleave_2d(%v: vector<2x6xf32>) -> (vector<2x3xf32>, vector<2x3xf32>) {
+  %0, %1 = vector.deinterleave %v : vector<2x6xf32> -> vector<2x3xf32>
+  return %0, %1 : vector<2x3xf32>, vector<2x3xf32>
+}
+// CHECK-LABEL: func.func @deinterleave_2d
+//  CHECK-SAME:   (%[[V0:.+]]: vector<6xf32>, %[[V1:.+]]: vector<6xf32>)
+//  CHECK-SAME:   -> (vector<3xf32>, vector<3xf32>, vector<3xf32>, vector<3xf32>)
+//       CHECK:   %[[E0:.+]], %[[O0:.+]] = vector.deinterleave %[[V0]] : vector<6xf32> -> vector<3xf32>
+//       CHECK:   %[[E1:.+]], %[[O1:.+]] = vector.deinterleave %[[V1]] : vector<6xf32> -> vector<3xf32>
+//       CHECK:   return %[[E0]], %[[E1]], %[[O0]], %[[O1]] : vector<3xf32>, vector<3xf32>, vector<3xf32>, vector<3xf32>
+
+// -----
+
 util.func @util_func_addf_2d(%arg0: vector<2x4xf32>, %arg1: vector<2x4xf32>) -> vector<2x4xf32> {
   %0 = arith.addf %arg0, %arg1 : vector<2x4xf32>
   util.return %0 : vector<2x4xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/legalize_nd_vectors.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/legalize_nd_vectors.mlir
@@ -301,6 +301,20 @@ func.func @linearize_2d_vector_unroll(%v0: vector<2x2xindex>, %v1: vector<2x2xin
 
 // -----
 
+// vector.interleave on a 2-D vector: each pair of 1-D vectors is interleaved individually.
+func.func @interleave_2d(%a: vector<2x3xf32>, %b: vector<2x3xf32>) -> vector<2x6xf32> {
+  %0 = vector.interleave %a, %b : vector<2x3xf32> -> vector<2x6xf32>
+  return %0 : vector<2x6xf32>
+}
+// CHECK-LABEL: func.func @interleave_2d
+//  CHECK-SAME:   (%[[A0:.+]]: vector<3xf32>, %[[A1:.+]]: vector<3xf32>, %[[B0:.+]]: vector<3xf32>, %[[B1:.+]]: vector<3xf32>)
+//  CHECK-SAME:   -> (vector<6xf32>, vector<6xf32>)
+//       CHECK:   %[[R0:.+]] = vector.interleave %[[A0]], %[[B0]] : vector<3xf32> -> vector<6xf32>
+//       CHECK:   %[[R1:.+]] = vector.interleave %[[A1]], %[[B1]] : vector<3xf32> -> vector<6xf32>
+//       CHECK:   return %[[R0]], %[[R1]] : vector<6xf32>, vector<6xf32>
+
+// -----
+
 util.func @util_func_addf_2d(%arg0: vector<2x4xf32>, %arg1: vector<2x4xf32>) -> vector<2x4xf32> {
   %0 = arith.addf %arg0, %arg1 : vector<2x4xf32>
   util.return %0 : vector<2x4xf32>


### PR DESCRIPTION
This commit adds two patterns that were missing vector 1-dimensional legalization. These patterns will convert vector.interleave and vector.deinterleave from multi-dimensional vectors into 1-dimensional vectors.

Assisted-By: Claude Opus 4.6