### PR TITLE
[HAL] Fix HALToStream import dims test after alias lowering

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/import_dims.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/import_dims.mlir
@@ -13,7 +13,13 @@ util.func public @importBufferViewWithConsumerDims(%view: !hal.buffer_view, %sto
   // CHECK-DAG: %[[IMPORT_SIZE:.+]] = stream.tensor.sizeof tensor<?x?xf32>{%[[C4]], %[[C8]]} : index
   // CHECK: %[[RESOURCE:.+]] = stream.tensor.import %[[VIEW]]
   // CHECK-SAME: tensor<?x?xf32>{%[[C4]], %[[C8]]} in !stream.resource<external>{%[[IMPORT_SIZE]]}
-  // CHECK: stream.async.clone %[[RESOURCE]]
+  // CHECK: %[[TENSOR:.+]] = stream.async.cast %[[RESOURCE]]
+  // CHECK-DAG: %[[STORAGE_SIZE:.+]] = stream.tensor.sizeof tensor<?x?xf32>{%[[C4]], %[[C8]]} : index
+  // CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import consume %[[STORAGE]]
+  // CHECK-SAME: tensor<?x?xf32>{%[[C4]], %[[C8]]} in !stream.resource<external>{%[[STORAGE_SIZE]]}
+  // CHECK: %[[UPDATE:.+]] = stream.async.update %[[TENSOR]], %[[STORAGE_RESOURCE]]
+  // CHECK: %[[SLICE:.+]] = stream.async.slice %[[UPDATE]]
+  // CHECK: stream.async.clone %[[SLICE]]
   %imported = hal.tensor.import %view : !hal.buffer_view -> tensor<?x?xf32>{%dim0, %dim1}
   %aliased = hal.tensor.alias %imported : tensor<?x?xf32>{%c4, %c8} to %storage : !hal.buffer
   // CHECK: util.return


### PR DESCRIPTION
The import dims test was checking that the final clone consumed the original buffer-view import directly. That made the test depend on incidental lowering shape around hal.tensor.alias instead of the behavior it was meant to protect.

Keep the assertion that consumer-refined dimensions reach the stream imports and sizes, but match the existing alias lowering through cast, update, slice, and clone. This structure is useful as it verifies the contract is maintained where previously the test did not.

Verified that this runs through the stream pipeline and melts away:
```mlir
  %0 = stream.tensor.import %arg0 : !hal.buffer_view -> tensor<?x?xf32>{%c128}
  %1 = stream.tensor.import consume %arg1 : !hal.buffer -> tensor<?x?xf32>{%c128}
  %2 = stream.cmd.execute with(%1 ..., %0 ...) {
    stream.cmd.copy %arg3[%c0], %arg2[%c0], %c128 : !stream.resource<external>{%c128} -> !stream.resource<external>{%c128}
  } => !stream.timepoint
  %3 = stream.timepoint.await %2 => %1
  util.return %3, %c128
```