### PR TITLE
[DispatchCreation] Refactor and add low-parallelism split reduction parameter set

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -178,8 +178,14 @@ static void addDispatchRegionCreationPreprocessingPasses(
       //        - Legacy pass to be deprecated
       .addPass(DispatchCreation::createSplitReductionPass)
       //        - Split reduction using partial reduction tiling.
-      .addPredicatedPass(dispatchOptions.enableSplitReduction,
-                         DispatchCreation::createSetSplitReductionSizesPass)
+      .addPredicatedPass(
+          dispatchOptions.enableSplitReduction,
+          [&]() {
+            SetSplitReductionSizesPassOptions options;
+            options.lowParallelism =
+                dispatchOptions.splitReductionLowParallelism;
+            return DispatchCreation::createSetSplitReductionSizesPass(options);
+          })
       .addPass([&]() {
         FormSplitReductionDispatchesPassOptions options;
         options.enableFusePad =

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -80,6 +80,14 @@ struct TransformOptions : PassPipelineOptions<TransformOptions> {
       llvm::cl::desc("Enable split reduction for dispatch creation pipeline"),
       llvm::cl::init(false),
   };
+  Option<bool> splitReductionLowParallelism{
+      *this,
+      "split-reduction-low-parallelism",
+      llvm::cl::desc("Use the low-parallelism split reduction parameter set "
+                     "(RDNA-class targets) instead of the high-parallelism "
+                     "default (CDNA-class targets)"),
+      llvm::cl::init(false),
+  };
   Option<bool> enableAggressiveReshapeMovement{
       *this,
       "aggressive-reshape-movement",

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -338,7 +338,12 @@ def SetSplitReductionSizesPass :
     Option<"splitReductionTargetSize", "split-reduction-target-size", "int64_t", "1024",
            "Target tile size for split reduction. Inner reduction "
            "dimensions are tiled first, with the tile size rounded "
-           "up until it evenly divides the iteration domain.">
+           "up until it evenly divides the iteration domain.">,
+    Option<"lowParallelism", "low-parallelism", "bool", "false",
+           "If true, use the low-parallelism split-reduction parameter set "
+           "tuned for targets with limited concurrent workgroup parallelism "
+           "(e.g. RDNA-class GPUs); otherwise use the default set tuned for "
+           "high-parallelism targets (e.g. CDNA-class GPUs).">
   ];
   let dependentDialects = [];
 }

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -131,13 +131,63 @@ getOuterReductionSizes(PartialReductionOpInterface op,
   return tileSizes;
 }
 
-/// Determines split reduction sizes for convolutions. Analyzes the convolution
-/// structure to find reduction dimensions that can be split to improve
-/// parallelism. Splitting can be applied across multiple reduction dimensions,
-/// with tile sizes varying according to the output (parallel dimension) sizes.
+/// Returns the maximum split reduction parallelism for a convolution,
+/// selected from a 2D bucket over (outputSize, reductionSize). Within each
+/// outputSize band the limit grows with the reduction size. Low-parallelism
+/// targets (e.g. RDNA-class GPUs) use a smaller limit because each split
+/// already saturates the device; default high-parallelism targets (e.g.
+/// CDNA-class) use a larger limit as the reduction grows to keep all
+/// compute units utilized.
+static std::optional<int64_t>
+getConvolutionLimitParallelLoops(int64_t outputSize, int64_t reductionSize,
+                                 int64_t startTileSize, bool lowParallelism) {
+  if (outputSize < 32 * 32) {
+    return 2048;
+  }
+
+  if (outputSize < 128 * 128) {
+    return 128;
+  }
+
+  if (outputSize < 256 * 256) {
+    if (reductionSize < 50000) {
+      return lowParallelism ? 8 : 16;
+    }
+    if (reductionSize < 200000) {
+      return lowParallelism ? 16 : 32;
+    }
+    if (reductionSize < 300000) {
+      return lowParallelism ? 16 : 64;
+    }
+    return 64;
+  }
+
+  if (outputSize < 512 * 512) {
+    if (reductionSize >= 800000) {
+      return 64;
+    }
+    if (lowParallelism && reductionSize >= 200000) {
+      return 32;
+    }
+    return 16;
+  }
+
+  if (outputSize >= 1024 * 1024 && reductionSize >= 200000) {
+    return 16;
+  }
+
+  return std::min<int64_t>(8, startTileSize);
+}
+
+/// Determines split reduction sizes for convolutions. Analyzes the
+/// convolution structure to find reduction dimensions that can be split to
+/// improve parallelism. Splitting can be applied across multiple reduction
+/// dimensions, with tile sizes varying according to the output (parallel
+/// dimension) sizes.
 static std::optional<SmallVector<int64_t>>
 getConvolutionReductionSizes(PartialReductionOpInterface op,
-                             int64_t splitReductionTargetSize) {
+                             int64_t splitReductionTargetSize,
+                             bool lowParallelism) {
   // First check if the input op is a convolution with static shapes.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
   if (!linalgOp || !linalg::isaConvolutionOpInterface(linalgOp)) {
@@ -236,7 +286,7 @@ getConvolutionReductionSizes(PartialReductionOpInterface op,
 
   // The constants below are determined based on empirical data.
   const int64_t largeParallelSize = 640000;
-  const int64_t largeReductionSize = 8192;
+  const int64_t smallReductionSize = 8192;
   const int64_t ratioThreshold = 64;
 
   // When the parallel dimension sizes are large, the workload tends to
@@ -255,8 +305,17 @@ getConvolutionReductionSizes(PartialReductionOpInterface op,
   SmallVector<int64_t> tileSizes = std::move(*maybeSizes);
   int64_t reductionSize = llvm::product_of(tileSizes);
   int64_t ratio = reductionSize / std::sqrt(parallelSize);
-  if (ratio <= ratioThreshold && reductionSize < largeReductionSize) {
+  if (ratio <= ratioThreshold && reductionSize < smallReductionSize) {
     LDBG() << "skipping op; small reduction size";
+    return std::nullopt;
+  }
+
+  // When the output size is huge and the reduction size is modest, the
+  // per-split compute work is too small to amortise the splitting overhead,
+  // so split reduction degrades performance.
+  int64_t outputSize = outputChannelSize * batchSize * imageSize * depthSize;
+  if (outputSize >= 2 * 1024 * 1024 && reductionSize < 50000) {
+    LDBG() << "skipping op; huge output with modest reduction";
     return std::nullopt;
   }
 
@@ -264,21 +323,15 @@ getConvolutionReductionSizes(PartialReductionOpInterface op,
   // For larger outputs, the workload tends to be distributed across more
   // workgroups, thereby reducing the need for extensive splitting along the
   // reduction dimensions.
-  int64_t outputSize = outputChannelSize * batchSize * imageSize * depthSize;
   int64_t startTileSize =
       isBatchFirstLayout ? tileSizes.back() : tileSizes.front();
-  int64_t limitParallelLoops;
-  if (outputSize < 32 * 32) {
-    limitParallelLoops = 2048;
-  } else if (outputSize < 128 * 128) {
-    limitParallelLoops = 128;
-  } else if (outputSize < 256 * 256) {
-    limitParallelLoops = 64;
-  } else if (outputSize < 512 * 512) {
-    limitParallelLoops = 16;
-  } else {
-    limitParallelLoops = std::min<int64_t>(8, startTileSize);
+  std::optional<int64_t> maybeLimitParallelLoops =
+      getConvolutionLimitParallelLoops(outputSize, reductionSize, startTileSize,
+                                       lowParallelism);
+  if (!maybeLimitParallelLoops) {
+    return std::nullopt;
   }
+  int64_t limitParallelLoops = maybeLimitParallelLoops.value();
 
   // Based on the limitParallelLoops, assign tile size. For batch-first layout,
   // go from the innermost dimension to the outermost; otherwise, go from the
@@ -305,15 +358,70 @@ getConvolutionReductionSizes(PartialReductionOpInterface op,
   return tileSizes;
 }
 
+/// Returns the maximum split reduction parallelism for a matmul-like
+/// operation, selected from a top-down ladder over outputSize with
+/// reduction size sub-rules in each band. Low-parallelism targets (e.g.
+/// RDNA-class GPUs) use a smaller limit because each split already
+/// saturates the device; default high-parallelism targets (e.g. CDNA-class)
+/// use a larger limit for huge reductions to keep all compute units
+/// utilized.
+static std::optional<int64_t> getMatmulLimitParallelLoops(int64_t outputSize,
+                                                          int64_t reductionSize,
+                                                          int64_t startTileSize,
+                                                          bool lowParallelism) {
+  // Tiny output or huge reduction: saturate the budget.
+  if (outputSize <= 16 * 16 || reductionSize > 1e7) {
+    return 2048;
+  }
+
+  if (outputSize <= 64 * 64) {
+    return 128;
+  }
+
+  if (outputSize <= 128 * 128) {
+    if (reductionSize > 1e6) {
+      return 128;
+    }
+    if (reductionSize < 50000) {
+      return lowParallelism ? 8 : 64;
+    }
+    return 64;
+  }
+  // outputSize > 128*128. With large reduction a low-parallelism target
+  // prefers a smaller budget once the output is wide enough to spread the
+  // splits.
+  if (reductionSize > 1e6) {
+    return lowParallelism ? 8 : 128;
+  }
+
+  if (outputSize <= 256 * 256) {
+    if (reductionSize < 150000) {
+      return lowParallelism ? 8 : 32;
+    }
+    return 32;
+  }
+
+  if (outputSize <= 512 * 512) {
+    return 16;
+  }
+
+  if (outputSize <= 900 * 900 && reductionSize >= 100000) {
+    return 16;
+  }
+
+  return std::min<int64_t>(8, startTileSize);
+}
+
 /// Determines split reduction sizes for matmul-like operations where the K
 /// dimension is significantly larger than the M or N dimensions. Splitting
 /// can be applied across multiple reduction dimensions, with tile sizes
-/// varying according to the output (parallel dimension) sizes. Note that the
-/// constant thresholds are empirically derived from limited data and may not
-/// generalize to all cases.
+/// varying according to the output (parallel dimension) sizes. Note that
+/// the constant thresholds are empirically derived from limited data and
+/// may not generalize to all cases.
 static std::optional<SmallVector<int64_t>>
 getMatmulLikeReductionSizes(PartialReductionOpInterface op,
-                            int64_t splitReductionTargetSize) {
+                            int64_t splitReductionTargetSize,
+                            bool lowParallelism) {
   // Matmul-like op should have at least 1 reduction, which is checked by the
   // contraction interface, and at least 2 parallel dimensions.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
@@ -376,7 +484,7 @@ getMatmulLikeReductionSizes(PartialReductionOpInterface op,
 
   // The constants below are determined based on empirical data.
   const int64_t largeOutputSize = 2048 * 4096;
-  const int64_t largeKSize = 18000;
+  const int64_t smallKSize = 18000;
   const int64_t ratioThreshold = 48;
 
   // When the output size is large, the workload tends to distributed across
@@ -388,8 +496,16 @@ getMatmulLikeReductionSizes(PartialReductionOpInterface op,
 
   // When the reduction size is small relative to the M/N sizes, split
   // reduction often has no effect or even degrades performance.
-  if (kSize < largeKSize && ratio < ratioThreshold) {
+  if (kSize < smallKSize && ratio < ratioThreshold) {
     LDBG() << "skipping op; small reduction size";
+    return std::nullopt;
+  }
+
+  // When the output size is moderately large and the reduction size is
+  // modest, the per-split compute work is too small to amortise the
+  // splitting overhead, so split reduction degrades performance.
+  if (outputSize >= 1024 * 1024 && outputSize < 1500 * 1024 && kSize < 200000) {
+    LDBG() << "skipping op; large output with modest reduction";
     return std::nullopt;
   }
 
@@ -398,20 +514,12 @@ getMatmulLikeReductionSizes(PartialReductionOpInterface op,
   // workgroups, thereby reducing the need for extensive splitting along the
   // reduction dimensions.
   SmallVector<int64_t> tileSizes = std::move(*maybeSizes);
-  int64_t limitParallelLoops;
-  if (outputSize <= 16 * 16 || kSize > 1e7) {
-    limitParallelLoops = 2048;
-  } else if (outputSize <= 64 * 64 || kSize > 1e6) {
-    limitParallelLoops = 128;
-  } else if (outputSize <= 128 * 128) {
-    limitParallelLoops = 64;
-  } else if (outputSize <= 256 * 256) {
-    limitParallelLoops = 32;
-  } else if (outputSize <= 512 * 512) {
-    limitParallelLoops = 16;
-  } else {
-    limitParallelLoops = std::min<int64_t>(8, tileSizes[0]);
+  std::optional<int64_t> maybeLimitParallelLoops = getMatmulLimitParallelLoops(
+      outputSize, kSize, tileSizes[0], lowParallelism);
+  if (!maybeLimitParallelLoops) {
+    return std::nullopt;
   }
+  int64_t limitParallelLoops = maybeLimitParallelLoops.value();
 
   // Based on the limitParallelLoops, assign tile size from the outermost
   // dimension to the innermost.
@@ -495,14 +603,14 @@ struct SetSplitReductionSizesPass final
 
       // --- Case 2: Generic convolution ---
       if (auto tileSizes = getConvolutionReductionSizes(
-              tilingOp, splitReductionTargetSize)) {
+              tilingOp, splitReductionTargetSize, lowParallelism)) {
         IREE::LinalgExt::setSplitReductionAttribute(tilingOp, *tileSizes);
         return;
       }
 
       // --- Case 3: Matmul-like operations ---
-      if (auto tileSizes =
-              getMatmulLikeReductionSizes(tilingOp, splitReductionTargetSize)) {
+      if (auto tileSizes = getMatmulLikeReductionSizes(
+              tilingOp, splitReductionTargetSize, lowParallelism)) {
         IREE::LinalgExt::setSplitReductionAttribute(tilingOp, *tileSizes);
         return;
       }

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -60,6 +60,7 @@ iree_lit_test_suite(
             "set_encoding_pipeline.mlir",
             "set_split_reduction_sizes_conv.mlir",
             "set_split_reduction_sizes_gemm.mlir",
+            "set_split_reduction_sizes_low_parallelism.mlir",
             "set_split_reduction_sizes_outer_reduction.mlir",
             "sink_reshapes.mlir",
             "split_reduction.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_lit_test_suite(
     "set_encoding_pipeline.mlir"
     "set_split_reduction_sizes_conv.mlir"
     "set_split_reduction_sizes_gemm.mlir"
+    "set_split_reduction_sizes_low_parallelism.mlir"
     "set_split_reduction_sizes_outer_reduction.mlir"
     "sink_reshapes.mlir"
     "split_reduction.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes))" --split-input-file %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes{low-parallelism=true}))" --split-input-file %s | FileCheck %s --check-prefix=RDNA
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
@@ -18,15 +17,13 @@ module {
 
 // CHECK-LABEL: @conv_1d_chn_chf
 //       CHECK: iree_linalg_ext.split_reduction = [1 : index, 48 : index, 32 : index]
-// RDNA-LABEL: @conv_1d_chn_chf
-//       RDNA: iree_linalg_ext.split_reduction = [2 : index, 48 : index, 32 : index]
 
 // -----
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
-util.func public @conv_1d_chn_chf_mid_red(%arg0: tensor<16x130x32x96xf32>, %arg1: tensor<16x128x32x96xf32>, %arg2: tensor<96x3x96xf32>) -> tensor<96x3x96xf32> {
+util.func public @conv_1d_chn_chf_mid_reduction(%arg0: tensor<16x130x32x96xf32>, %arg1: tensor<16x128x32x96xf32>, %arg2: tensor<96x3x96xf32>) -> tensor<96x3x96xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x130x32x96xf32>, tensor<16x128x32x96xf32>) outs(%arg2 : tensor<96x3x96xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %1 = arith.mulf %in, %in_0 : f32
@@ -36,17 +33,15 @@ util.func public @conv_1d_chn_chf_mid_red(%arg0: tensor<16x130x32x96xf32>, %arg1
   util.return %0 : tensor<96x3x96xf32>
 }
 
-// CHECK-LABEL: @conv_1d_chn_chf_mid_red
+// CHECK-LABEL: @conv_1d_chn_chf_mid_reduction
 //       CHECK: iree_linalg_ext.split_reduction = [1 : index, 64 : index, 32 : index]
-// RDNA-LABEL: @conv_1d_chn_chf_mid_red
-//       RDNA: iree_linalg_ext.split_reduction = [1 : index, 128 : index, 32 : index]
 
 // -----
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @conv_2d_chwn_chwf_large(%arg0: tensor<16x227x227x16xf32>, %arg1: tensor<16x225x225x64xf32>, %arg2: tensor<64x3x3x16xf32>) -> tensor<64x3x3x16xf32> {
+util.func public @conv_2d_chwn_chwf_large_reduction(%arg0: tensor<16x227x227x16xf32>, %arg1: tensor<16x225x225x64xf32>, %arg2: tensor<64x3x3x16xf32>) -> tensor<64x3x3x16xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x227x227x16xf32>, tensor<16x225x225x64xf32>) outs(%arg2 : tensor<64x3x3x16xf32>) {
   ^bb0(%in: f32, %in_3: f32, %out: f32):
     %12 = arith.mulf %in, %in_3 : f32
@@ -56,7 +51,7 @@ util.func public @conv_2d_chwn_chwf_large(%arg0: tensor<16x227x227x16xf32>, %arg
   util.return %0 : tensor<64x3x3x16xf32>
 }
 
-// CHECK-LABEL: @conv_2d_chwn_chwf_large
+// CHECK-LABEL: @conv_2d_chwn_chwf_large_reduction
 //       CHECK: iree_linalg_ext.split_reduction = [1 : index, 45 : index, 225 : index]
 
 // -----
@@ -64,7 +59,7 @@ util.func public @conv_2d_chwn_chwf_large(%arg0: tensor<16x227x227x16xf32>, %arg
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d3, d1 + d5, d2 + d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d0, d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @conv_2d_cnhw_cfhw_large(%arg0: tensor<16x16x227x227xf32>, %arg1: tensor<16x64x225x225xf32>, %arg2: tensor<64x3x3x16xf32>) -> tensor<64x3x3x16xf32> {
+util.func public @conv_2d_cnhw_cfhw_large_reduction(%arg0: tensor<16x16x227x227xf32>, %arg1: tensor<16x64x225x225xf32>, %arg2: tensor<64x3x3x16xf32>) -> tensor<64x3x3x16xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x16x227x227xf32>, tensor<16x64x225x225xf32>) outs(%arg2 : tensor<64x3x3x16xf32>) {
   ^bb0(%in: f32, %in_3: f32, %out: f32):
     %12 = arith.mulf %in, %in_3 : f32
@@ -74,7 +69,7 @@ util.func public @conv_2d_cnhw_cfhw_large(%arg0: tensor<16x16x227x227xf32>, %arg
   util.return %0 : tensor<64x3x3x16xf32>
 }
 
-// CHECK-LABEL: @conv_2d_cnhw_cfhw_large
+// CHECK-LABEL: @conv_2d_cnhw_cfhw_large_reduction
 //       CHECK: iree_linalg_ext.split_reduction = [1 : index, 45 : index, 225 : index]
 
 // -----

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes{low-parallelism=true}))" --split-input-file %s | FileCheck %s --check-prefix=RDNA
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
@@ -16,7 +17,29 @@ module {
 }
 
 // CHECK-LABEL: @conv_1d_chn_chf
-//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 12 : index, 32 : index]
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 48 : index, 32 : index]
+// RDNA-LABEL: @conv_1d_chn_chf
+//       RDNA: iree_linalg_ext.split_reduction = [2 : index, 48 : index, 32 : index]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+util.func public @conv_1d_chn_chf_mid_red(%arg0: tensor<16x130x32x96xf32>, %arg1: tensor<16x128x32x96xf32>, %arg2: tensor<96x3x96xf32>) -> tensor<96x3x96xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x130x32x96xf32>, tensor<16x128x32x96xf32>) outs(%arg2 : tensor<96x3x96xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %1 = arith.mulf %in, %in_0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<96x3x96xf32>
+  util.return %0 : tensor<96x3x96xf32>
+}
+
+// CHECK-LABEL: @conv_1d_chn_chf_mid_red
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 64 : index, 32 : index]
+// RDNA-LABEL: @conv_1d_chn_chf_mid_red
+//       RDNA: iree_linalg_ext.split_reduction = [1 : index, 128 : index, 32 : index]
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes))" --split-input-file %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes{low-parallelism=true}))" --split-input-file %s | FileCheck %s --check-prefix=RDNA
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -16,30 +15,6 @@ util.func public @split_matmul(%arg0: tensor<32x40960xf32>, %arg1: tensor<40960x
 
 // CHECK-LABEL: @split_matmul
 //       CHECK: iree_linalg_ext.split_reduction = [320 : index]
-
-// -----
-
-util.func public @split_balanced_matmul_low_parallelism(%arg0: tensor<128x32768xbf16>, %arg1: tensor<32768x128xbf16>, %arg2: tensor<128x128xf32>) -> tensor<128x128xf32> {
-  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x32768xbf16>, tensor<32768x128xbf16>) outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
-  util.return %0 : tensor<128x128xf32>
-}
-
-// CHECK-LABEL: @split_balanced_matmul_low_parallelism
-//       CHECK: iree_linalg_ext.split_reduction = [512 : index]
-// RDNA-LABEL: @split_balanced_matmul_low_parallelism
-//       RDNA: iree_linalg_ext.split_reduction = [4096 : index]
-
-// -----
-
-util.func public @split_mid_output_small_k_low_parallelism(%arg0: tensor<128x131072xbf16>, %arg1: tensor<131072x256xbf16>, %arg2: tensor<128x256xf32>) -> tensor<128x256xf32> {
-  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x131072xbf16>, tensor<131072x256xbf16>) outs(%arg2 : tensor<128x256xf32>) -> tensor<128x256xf32>
-  util.return %0 : tensor<128x256xf32>
-}
-
-// CHECK-LABEL: @split_mid_output_small_k_low_parallelism
-//       CHECK: iree_linalg_ext.split_reduction = [4096 : index]
-// RDNA-LABEL: @split_mid_output_small_k_low_parallelism
-//       RDNA: iree_linalg_ext.split_reduction = [16384 : index]
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_gemm.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes{low-parallelism=true}))" --split-input-file %s | FileCheck %s --check-prefix=RDNA
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -15,6 +16,30 @@ util.func public @split_matmul(%arg0: tensor<32x40960xf32>, %arg1: tensor<40960x
 
 // CHECK-LABEL: @split_matmul
 //       CHECK: iree_linalg_ext.split_reduction = [320 : index]
+
+// -----
+
+util.func public @split_balanced_matmul_low_parallelism(%arg0: tensor<128x32768xbf16>, %arg1: tensor<32768x128xbf16>, %arg2: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x32768xbf16>, tensor<32768x128xbf16>) outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  util.return %0 : tensor<128x128xf32>
+}
+
+// CHECK-LABEL: @split_balanced_matmul_low_parallelism
+//       CHECK: iree_linalg_ext.split_reduction = [512 : index]
+// RDNA-LABEL: @split_balanced_matmul_low_parallelism
+//       RDNA: iree_linalg_ext.split_reduction = [4096 : index]
+
+// -----
+
+util.func public @split_mid_output_small_k_low_parallelism(%arg0: tensor<128x131072xbf16>, %arg1: tensor<131072x256xbf16>, %arg2: tensor<128x256xf32>) -> tensor<128x256xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x131072xbf16>, tensor<131072x256xbf16>) outs(%arg2 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  util.return %0 : tensor<128x256xf32>
+}
+
+// CHECK-LABEL: @split_mid_output_small_k_low_parallelism
+//       CHECK: iree_linalg_ext.split_reduction = [4096 : index]
+// RDNA-LABEL: @split_mid_output_small_k_low_parallelism
+//       RDNA: iree_linalg_ext.split_reduction = [16384 : index]
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_low_parallelism.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_low_parallelism.mlir
@@ -1,0 +1,55 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes{low-parallelism=true}))" --split-input-file %s | FileCheck %s
+
+util.func public @split_balanced_matmul(%arg0: tensor<128x32768xbf16>, %arg1: tensor<32768x128xbf16>, %arg2: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x32768xbf16>, tensor<32768x128xbf16>) outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  util.return %0 : tensor<128x128xf32>
+}
+
+// CHECK-LABEL: @split_balanced_matmul
+//       CHECK: iree_linalg_ext.split_reduction = [4096 : index]
+
+// -----
+
+util.func public @split_mid_output_small_k(%arg0: tensor<128x131072xbf16>, %arg1: tensor<131072x256xbf16>, %arg2: tensor<128x256xf32>) -> tensor<128x256xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x131072xbf16>, tensor<131072x256xbf16>) outs(%arg2 : tensor<128x256xf32>) -> tensor<128x256xf32>
+  util.return %0 : tensor<128x256xf32>
+}
+
+// CHECK-LABEL: @split_mid_output_small_k
+//       CHECK: iree_linalg_ext.split_reduction = [16384 : index]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+util.func public @conv_1d_chn_chf(%arg0: tensor<16x50x32x96xf32>, %arg1: tensor<16x48x32x96xf32>, %arg2: tensor<96x3x96xf32>) -> tensor<96x3x96xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x50x32x96xf32>, tensor<16x48x32x96xf32>) outs(%arg2 : tensor<96x3x96xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %1 = arith.mulf %in, %in_0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<96x3x96xf32>
+  util.return %0 : tensor<96x3x96xf32>
+}
+
+// CHECK-LABEL: @conv_1d_chn_chf
+//       CHECK: iree_linalg_ext.split_reduction = [2 : index, 48 : index, 32 : index]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+util.func public @conv_1d_chn_chf_mid_reduction(%arg0: tensor<16x130x32x96xf32>, %arg1: tensor<16x128x32x96xf32>, %arg2: tensor<96x3x96xf32>) -> tensor<96x3x96xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x130x32x96xf32>, tensor<16x128x32x96xf32>) outs(%arg2 : tensor<96x3x96xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %1 = arith.mulf %in, %in_0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<96x3x96xf32>
+  util.return %0 : tensor<96x3x96xf32>
+}
+
+// CHECK-LABEL: @conv_1d_chn_chf_mid_reduction
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 128 : index, 32 : index]

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -403,6 +403,13 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
           "Enable split-reduction for certain reduction operations."),
       llvm::cl::cat(category));
   binder.opt<bool>(
+      "iree-dispatch-creation-split-reduction-low-parallelism",
+      splitReductionLowParallelism,
+      llvm::cl::desc("Use the low-parallelism split-reduction parameter set "
+                     "(RDNA-class targets) instead of the high-parallelism "
+                     "default (CDNA-class targets)."),
+      llvm::cl::cat(category));
+  binder.opt<bool>(
       "iree-dispatch-creation-enable-aggressive-reshape-movement",
       enableAggressiveReshapeMovement,
       llvm::cl::desc(

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -270,6 +270,7 @@ struct DispatchCreationOptions {
   bool enableAggressiveFusion = false;
   bool enableFuseMultiUse = true;
   bool enableSplitReduction = false;
+  bool splitReductionLowParallelism = false;
 
   // Enables data tiling in dispatch creation phase.
   bool dataTiling = false;

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -359,6 +359,8 @@ void buildIREEVMTransformPassPipeline(
     }
     dispatchTransformOptions.enableSplitReduction =
         dispatchCreationOptions.enableSplitReduction;
+    dispatchTransformOptions.splitReductionLowParallelism =
+        dispatchCreationOptions.splitReductionLowParallelism;
     dispatchTransformOptions.enableAggressiveReshapeMovement =
         dispatchCreationOptions.enableAggressiveReshapeMovement;
     dispatchTransformOptions.enablePadHandling =


### PR DESCRIPTION
Introduce a `low-parallelism` flag that selects a split reduction parameter set tuned for targets with limited concurrent workgroup parallelism (e.g. RDNA-class GPUs), distinct from the existing high-parallelism default (CDNA-class). The matmul and convolution limit-parallel-loops helpers are restructured into a single top-down output size ladder with reduction size sub-rules in each band.

Representative benchmark results:

RDNA4 (RX 9070 XT) conv:
| Speedup | Baseline (us) | This PR (us) | Saved (us) | Shape |
|--------:|--------------:|-------------:|-----------:|-------|
| 2.21x | 6234.3 | 2825.4 | 3408.9 | -n 32 -c 256 -H 25 -W 25 -k 2376 -y 3 -x 3 -F 4 |
| 1.54x | 6537.7 | 4234.0 | 2303.7 | -n 32 -c 256 -H 25 -W 25 -k 2376 -y 3 -x 3 -F 2 |
| 1.24x | 10359.2 | 8330.5 | 2028.6 | -n 12 -c 224 -H 470 -W 725 -k 224 -u 2 -v 2 -g 4 -F 4 |
| 1.62x | 5210.9 | 3220.0 | 1990.9 | -n 5 -c 224 -H 470 -W 725 -k 224 -u 2 -v 2 -g 4 -F 4 |
| 1.43x | 3660.4 | 2568.0 | 1092.4 | -n 4 -c 224 -H 470 -W 725 -k 224 -u 2 -v 2 -g 4 -F 4 |

RDNA4 1x1 conv:
| Speedup | Baseline (us) | This PR (us) | Saved (us) | Shape |
|--------:|--------------:|-------------:|-----------:|-------|
| 4.12x | 45.2 | 11.0 | 34.2 | -n 16 -c 64 -H 24 -W 16 -k 192 -F 4 |
| 2.27x | 61.3 | 27.0 | 34.3 | -n 16 -c 96 -H 48 -W 32 -k 96 -F 4 |
| 2.30x | 30.9 | 13.4 | 17.5 | -n 16 -c 48 -H 24 -W 16 -k 192 -F 4 |

CDNA4 (MI355) conv:
| Speedup | Baseline (us) | This PR (us) | Saved (us) | Shape |
|--------:|--------------:|-------------:|-----------:|-------|
| 2.60x | 48.7 | 18.7 | 30.0 | -n 16 -c 96 -H 48 -W 32 -k 96 -y 3 -x 1 -F 4 |
| 1.81x | 4198.3 | 2319.7 | 1878.6 | -n 12 -c 224 -H 470 -W 725 -k 224 -u 2 -v 2 -g 4 -F 4 |
| 1.71x | 3287.0 | 1924.0 | 1363.0 | -n 10 -c 224 -H 470 -W 725 -k 224 -u 2 -v 2 -g 4 -F 4 |
| 1.49x | 3218.2 | 2160.6 | 1057.6 | -n 12 -c 224 -H 235 -W 363 -k 224 -g 4 -F 4 |

CDNA4 1x1 conv:
| Speedup | Baseline (us) | This PR (us) | Saved (us) | Shape |
|--------:|--------------:|-------------:|-----------:|-------|
| 2.54x | 1499.0 | 589.5 | 909.5 | -n 10 -c 448 -H 118 -W 182 -k 896 -F 4 |
| 2.06x | 1703.2 | 826.4 | 876.8 | -n 12 -c 448 -H 118 -W 182 -k 896 -F 4 |