### PR TITLE
[IREEGPU] Bufferize `async_dma`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "bufferize_async_dma.mlir",
             "bufferize_coalesced_gather_dma.mlir",
             "canonicalize.mlir",
             "invalid.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "bufferize_async_dma.mlir"
     "bufferize_coalesced_gather_dma.mlir"
     "canonicalize.mlir"
     "invalid.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_async_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_async_dma.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-opt %s --one-shot-bufferize="bufferize-function-boundaries" --split-input-file | FileCheck %s
+
+// Test basic tensor -> memref bufferization.
+func.func @bufferize_async_dma(%source: tensor<20x64xf16>,
+                                %dest: tensor<1x64xf16>,
+                                %i: index, %j: index, %c0: index)
+    -> tensor<1x64xf16> {
+  %0 = iree_gpu.async_dma %source[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
+      : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
+  return %0 : tensor<1x64xf16>
+}
+
+// CHECK-LABEL: func @bufferize_async_dma
+//       CHECK:   iree_gpu.async_dma {{.+}} : memref<20x64xf16{{.*}}>, memref<1x64xf16{{.*}}>
+
+// -----
+
+// Test bufferization with in_bounds attribute.
+func.func @bufferize_async_dma_in_bounds(%source: tensor<20x64xf16>,
+                                          %dest: tensor<1x64xf16>,
+                                          %i: index, %j: index, %c0: index)
+    -> tensor<1x64xf16> {
+  %0 = iree_gpu.async_dma %source[%i, %j] to %dest[%c0, %c0], vector<1x64xf16>
+      in_bounds [true, false]
+      : tensor<20x64xf16>, tensor<1x64xf16> -> tensor<1x64xf16>
+  return %0 : tensor<1x64xf16>
+}
+
+// CHECK-LABEL: func @bufferize_async_dma_in_bounds
+//       CHECK:   iree_gpu.async_dma {{.+}} in_bounds [true, false] : memref<20x64xf16{{.*}}>, memref<1x64xf16{{.*}}>
+
+// -----
+
+// Test bufferization with gather (vector) source indices.
+func.func @bufferize_async_dma_gather(%source: tensor<1024x64xf16>,
+                                       %dest: tensor<1x64xf16>,
+                                       %indices: vector<1xindex>,
+                                       %j: index, %c0: index)
+    -> tensor<1x64xf16> {
+  %0 = iree_gpu.async_dma %source[%indices, %j] to %dest[%c0, %c0], vector<1x64xf16>
+      : tensor<1024x64xf16> [vector<1xindex>, index],
+        tensor<1x64xf16> -> tensor<1x64xf16>
+  return %0 : tensor<1x64xf16>
+}
+
+// CHECK-LABEL: func @bufferize_async_dma_gather
+//       CHECK:   iree_gpu.async_dma {{.+}} : memref<1024x64xf16{{.*}}> [vector<1xindex>, index], memref<1x64xf16{{.*}}>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -516,7 +516,6 @@ struct AsyncDMAOpBufferizationInterface
       return failure();
     }
 
-    rewriter.setInsertionPoint(dmaOp);
     IREE::GPU::AsyncDMAOp::create(
         rewriter, dmaOp.getLoc(), TypeRange{}, *sourceBuffer,
         dmaOp.getSourceIndices(), *destBuffer, dmaOp.getDestIndices(),

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -461,6 +461,73 @@ struct CoalescedGatherDMAOpBufferizationInterface
   }
 };
 
+/// Bufferization of iree_gpu.async_dma. Bufferizes to itself with memref
+/// operands and no result.
+struct AsyncDMAOpBufferizationInterface
+    : BufferizableOpInterface::ExternalModel<AsyncDMAOpBufferizationInterface,
+                                             IREE::GPU::AsyncDMAOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    auto dmaOp = cast<IREE::GPU::AsyncDMAOp>(op);
+    return opOperand.get() == dmaOp.getSource();
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    auto dmaOp = cast<IREE::GPU::AsyncDMAOp>(op);
+    return opOperand.get() == dmaOp.getDest();
+  }
+
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *op, OpOperand &opOperand,
+                    const AnalysisState &state) const {
+    auto dmaOp = cast<IREE::GPU::AsyncDMAOp>(op);
+    if (opOperand.get() == dmaOp.getDest() && dmaOp.hasTensorSemantics()) {
+      return {{dmaOp.getResult(), BufferRelation::Equivalent}};
+    }
+    return {};
+  }
+
+  bool mustBufferizeInPlace(Operation *op, OpOperand &opOperand,
+                            const AnalysisState &state) const {
+    auto dmaOp = cast<IREE::GPU::AsyncDMAOp>(op);
+    return opOperand.get() == dmaOp.getDest();
+  }
+
+  bool isWritable(Operation *op, Value value,
+                  const AnalysisState &state) const {
+    return true;
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
+    auto dmaOp = cast<IREE::GPU::AsyncDMAOp>(op);
+    if (!dmaOp.hasTensorSemantics()) {
+      return failure();
+    }
+
+    FailureOr<Value> sourceBuffer =
+        getBuffer(rewriter, dmaOp.getSource(), options, state);
+    FailureOr<Value> destBuffer =
+        getBuffer(rewriter, dmaOp.getDest(), options, state);
+
+    if (failed(sourceBuffer) || failed(destBuffer)) {
+      return failure();
+    }
+
+    rewriter.setInsertionPoint(dmaOp);
+    IREE::GPU::AsyncDMAOp::create(
+        rewriter, dmaOp.getLoc(), TypeRange{}, *sourceBuffer,
+        dmaOp.getSourceIndices(), *destBuffer, dmaOp.getDestIndices(),
+        dmaOp.getTransferTypeAttr(), dmaOp.getPermutationMapAttr(),
+        dmaOp.getInBoundsAttr());
+
+    replaceOpWithBufferizedValues(rewriter, dmaOp, *destBuffer);
+    return success();
+  }
+};
+
 /// AMD Specific Ops
 
 static bool hasStorageBufferMemSpace(BaseMemRefType m) {
@@ -573,20 +640,22 @@ struct BufferResourceCastOpBufferizationInterface
 } // namespace
 
 void registerIREEGPUBufferizationInterfaces(DialectRegistry &registry) {
-  registry.addExtension(
-      +[](MLIRContext *context, IREE::GPU::IREEGPUDialect *dialect) {
-        IREE::GPU::BarrierRegionOp::attachInterface<
-            BarrierRegionOpBufferizationInterface>(*context);
-        IREE::GPU::ValueBarrierOp::attachInterface<
-            ValueBarrierOpBufferizationInterface>(*context);
-        IREE::GPU::YieldOp::attachInterface<YieldOpBufferizationInterface>(
-            *context);
-        IREE::GPU::CoalescedGatherDMAOp::attachInterface<
-            CoalescedGatherDMAOpBufferizationInterface>(*context);
+  registry.addExtension(+[](MLIRContext *context,
+                            IREE::GPU::IREEGPUDialect *dialect) {
+    IREE::GPU::BarrierRegionOp::attachInterface<
+        BarrierRegionOpBufferizationInterface>(*context);
+    IREE::GPU::ValueBarrierOp::attachInterface<
+        ValueBarrierOpBufferizationInterface>(*context);
+    IREE::GPU::YieldOp::attachInterface<YieldOpBufferizationInterface>(
+        *context);
+    IREE::GPU::CoalescedGatherDMAOp::attachInterface<
+        CoalescedGatherDMAOpBufferizationInterface>(*context);
+    IREE::GPU::AsyncDMAOp::attachInterface<AsyncDMAOpBufferizationInterface>(
+        *context);
 
-        IREE::GPU::BufferResourceCastOp::attachInterface<
-            BufferResourceCastOpBufferizationInterface>(*context);
-      });
+    IREE::GPU::BufferResourceCastOp::attachInterface<
+        BufferResourceCastOpBufferizationInterface>(*context);
+  });
 }
 
 } // namespace mlir::iree_compiler


### PR DESCRIPTION
Implements bufferization for `iree_gpu.async_dma` through an external model interface implementation. 

This is part of https://github.com/iree-org/iree/issues/23782.

Assisted-by: Claude Code and Codex