### PR TITLE
Add mxfp4 gemm e2e test for unaligned case

### DIFF
--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2634,6 +2634,36 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cdna4_mxfp4_unaligned
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=large"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_cdna4_mxfp4_dt
   TEST_TYPE
     matmul

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2634,36 +2634,6 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_cdna4_mxfp4_unaligned
-  TEST_TYPE
-    matmul
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f4E2M1FN"
-    "--acc_type=f32"
-    "--mx_scale_type=f8E8M0FNU"
-    "--mx_block_size=32"
-    "--shapes=large"
-    "--transpose_rhs"
-  TEST_RUNNER
-    iree_tools_testing_e2e_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "rocm"
-  DRIVERS
-    "hip"
-  COMPILER_FLAGS
-    ${IREE_HIP_TEST_COMPILER_FLAGS}
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-cdna4"
-)
-
-iree_generated_e2e_runner_test(
-  NAME
     e2e_matmul_cdna4_mxfp4_dt
   TEST_TYPE
     matmul

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -85,6 +85,11 @@ def get_test_shapes(shapes_id: ShapesId, accumulate=True):
         return [
             TestShape(m=512, k=128, n=512, accumulate=True),
             TestShape(m=512, k=128, n=512, accumulate=False),
+            # unaligned cases.
+            TestShape(m=457, k=128, n=512, accumulate=True),
+            TestShape(m=457, k=128, n=512, accumulate=False),
+            TestShape(m=1000, k=256, n=1001, accumulate=True),
+            TestShape(m=1001, k=256, n=1000, accumulate=False),
         ]
     if shapes_id == ShapesId.CUSTOM_MNK:
         # This is used for custom shapes specified by the --mnk= flag.


### PR DESCRIPTION
Adds unaligned e2e tests for MXFP4 gemms in CI. Certain problems like the correctness issue addressed by https://github.com/iree-org/iree/pull/24273 might go undetected otherwise.