### PR TITLE
[CI] Update iree-test-suite ref

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
+          ref: 612f93663b32ea86ea442e87be549f1056a5de1c
           path: iree-test-suites
       - name: Install ONNX ops test suite requirements
         run: |
@@ -199,7 +199,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
+          ref: 612f93663b32ea86ea442e87be549f1056a5de1c
           path: iree-test-suites
       - name: Install ONNX models test suite requirements
         run: |

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
+          ref: 612f93663b32ea86ea442e87be549f1056a5de1c
           path: iree-test-suites
           lfs: false
 
@@ -190,7 +190,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
+          ref: 612f93663b32ea86ea442e87be549f1056a5de1c
           path: iree-test-suites
           lfs: false
 

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -34,6 +34,7 @@ jobs:
             markers: "cpu"
             config-file: torch_ops_cpu_llvm_sync.json
             cache-dir: /home/nod/iree_tests_cache
+            extra-flags: ""
             runs-on:
               - self-hosted # Must come first.
               - persistent-cache
@@ -43,19 +44,23 @@ jobs:
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]
             cache-dir: /home/nod/iree_tests_cache
+            extra-flags: "--benchmark-with-rocprofv3"
           - name: amdgpu_hip_gfx1201_O3
             config-file: torch_ops_gpu_hip_gfx1201_O3.json
             runs-on: [Linux, X64, gfx1201]
             cache-dir: /home/nod/iree_tests_cache
+            extra-flags: "--benchmark-with-rocprofv3"
           - name: amdgpu_vulkan_O3
             config-file: torch_ops_gpu_vulkan_O3.json
             # TODO(#22579): Remove `shark10-ci` label. There are vulkan driver issues on other runners.
             runs-on: [Linux, X64, rdna3, shark10-ci]
             cache-dir: /home/nod/iree_tests_cache
+            extra-flags: ""
           - name: amdgpu_rocm_mi300_gfx942_O3
             config-file: torch_ops_gpu_hip_gfx942_O3.json
             runs-on: linux-mi325-1gpu-ossci-iree-org
             cache-dir: /shark-cache/data/iree-regression-cache
+            extra-flags: ""
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       LOG_FILE_PATH: /tmp/test_torch_ops_${{ matrix.name }}_logs.json
@@ -86,7 +91,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
+          ref: 612f93663b32ea86ea442e87be549f1056a5de1c
           path: iree-test-suites
           lfs: false
       - name: Install Torch ops test suite requirements
@@ -106,7 +111,8 @@ jobs:
               --durations=20 \
               --report-log=${LOG_FILE_PATH} \
               --config-files=${CONFIG_FILE_PATH} \
-              --artifact-directory=${{ matrix.cache-dir }}/torch_ops/artifacts
+              --artifact-directory=${{ matrix.cache-dir }}/torch_ops/artifacts \
+              ${{ matrix.extra-flags }}
 
   tests:
     name: "torch_models tests :: ${{ matrix.name }}"
@@ -156,7 +162,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: iree-org/iree-test-suites
-          ref: 3182e7a131551362e5e5eb20bbb18bfa6e7eb89c
+          ref: 612f93663b32ea86ea442e87be549f1056a5de1c
           path: iree-test-suites
           # Don't need lfs for torch models yet.
           lfs: false

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 6.42
+    "golden_time_ms": 5.84
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 7.87
+    "golden_time_ms": 7.16
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 32.12
+    "golden_time_ms": 29.2
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 266.2
+    "golden_time_ms": 242.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 7.7
+    "golden_time_ms": 7.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 18.0
+    "golden_time_ms": 16.4
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 11.14
+    "golden_time_ms": 10.13
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 21.0
+    "golden_time_ms": 19.1
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 27.0
+    "golden_time_ms": 24.6
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 27.1
+    "golden_time_ms": 24.6
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 173.8
+    "golden_time_ms": 158.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 187
+    "golden_time_ms": 170
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
@@ -36,5 +36,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time_ms": 165.0
+    "golden_time_ms": 150.0
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
@@ -36,5 +36,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time_ms": 8.0
+    "golden_time_ms": 7.3
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
@@ -50,5 +50,5 @@
       "value": "1xf16"
     }
   ],
-  "golden_time_ms" : 46.2
+  "golden_time_ms" : 42.0
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
@@ -34,5 +34,5 @@
     { "value": "100xf32" },
     { "value": "100xf32" }
   ],
-  "golden_time_ms": 44.28
+  "golden_time_ms": 40.23
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/vae_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/vae_benchmark_mi325.json
@@ -26,5 +26,5 @@
             "value": "1x4x128x128xf16"
         }
     ],
-    "golden_time_ms": 67.9
+    "golden_time_ms": 61.73
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1100_O3.json
@@ -18,12 +18,12 @@
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {
-    "AB/8192x8192xf32_bench": 211.36675303181013,
-    "AB/1024x1024xf32_bench": 0.473261977629155,
-    "AB/256x256xf32_bench": 0.13523232175050667,
-    "AB/128x128xf32_bench": 0.10226182854380102,
-    "AB/2048x2048xf32_bench": 3.35047472617589,
-    "AB/4096x4096xf32_bench": 26.499415814344378,
-    "AB/512x512xf32_bench": 0.16945170770798412
+    "AB/128x128xf32_bench": 0.10,
+    "AB/256x256xf32_bench": 0.15,
+    "AB/512x512xf32_bench": 0.20,
+    "AB/1024x1024xf32_bench": 0.41,
+    "AB/2048x2048xf32_bench": 2.84,
+    "AB/4096x4096xf32_bench": 21.11,
+    "AB/8192x8192xf32_bench": 168.08
   }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx1201_O3.json
@@ -18,12 +18,12 @@
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {
-    "AB/128x128xf32_bench": 0.07,
+    "AB/128x128xf32_bench": 0.10,
     "AB/256x256xf32_bench" : 0.10,
     "AB/512x512xf32_bench" : 0.16,
-    "AB/1024x1024xf32_bench": 0.59,
-    "AB/2048x2048xf32_bench" : 3.61,
-    "AB/4096x4096xf32_bench": 27.46,
-    "AB/8192x8192xf32_bench": 232.44
+    "AB/1024x1024xf32_bench": 0.39,
+    "AB/2048x2048xf32_bench" : 2.96,
+    "AB/4096x4096xf32_bench": 25.4,
+    "AB/8192x8192xf32_bench": 456.52
   }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_hip_gfx942_O3.json
@@ -17,12 +17,12 @@
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {
-    "AB/8192x8192xf32_bench": 10.345919956763586,
-    "AB/1024x1024xf32_bench": 0.12306747736492638,
-    "AB/256x256xf32_bench": 0.06101156551354003,
-    "AB/128x128xf32_bench": 0.052202587451140196,
-    "AB/2048x2048xf32_bench": 0.2345012331137894,
-    "AB/4096x4096xf32_bench": 1.423236482683913,
-    "AB/512x512xf32_bench": 0.07336693902980182
+    "AB/128x128xf32_bench": 0.10,
+    "AB/256x256xf32_bench": 0.10,
+    "AB/512x512xf32_bench": 0.10,
+    "AB/1024x1024xf32_bench": 0.10,
+    "AB/2048x2048xf32_bench": 0.22,
+    "AB/4096x4096xf32_bench": 1.27,
+    "AB/8192x8192xf32_bench": 9.17
   }
 }

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_O3.json
@@ -28,12 +28,12 @@
   "expected_compile_failures": [],
   "expected_run_failures": [],
   "golden_times_ms": {
-    "AB/8192x8192xf32_bench": 107.60851647438749,
-    "AB/1024x1024xf32_bench": 0.4509026762196051,
-    "AB/256x256xf32_bench": 0.1743873563575457,
-    "AB/128x128xf32_bench": 0.148048073505022,
-    "AB/2048x2048xf32_bench": 1.5943956199949283,
-    "AB/4096x4096xf32_bench": 10.252960922347533,
-    "AB/512x512xf32_bench": 0.23526767679662958
+    "AB/128x128xf32_bench": 0.10,
+    "AB/256x256xf32_bench" : 0.14,
+    "AB/512x512xf32_bench" : 0.17,
+    "AB/1024x1024xf32_bench": 0.26,
+    "AB/2048x2048xf32_bench" : 1.00,
+    "AB/4096x4096xf32_bench": 7.38,
+    "AB/8192x8192xf32_bench": 120.2
   }
 }


### PR DESCRIPTION
* Enables benchmarking in torch_ops
* Adds tolerance_factor to torch_ops and torch_models
* Update/Remove deprecated flags

Changes in IREE:
* Updates golden times in torch_models to be divided by 1.1 (to account for tolerance_factor)
* Updates golden times in torch_ops by looking at the current timings.
* For benchmark AB/8192x8192xf32_bench in torch_ops_gpu_hip_gfx1201_O3.json there's a regression that has been narrowed down to https://github.com/llvm/llvm-project/pull/184138. Reverting it fixes this one, but further impact has not been studied yet.
* For benchmarking torch_ops use rocprofv3