### PR TITLE
[DispatchCreation] Allow elementwise producers in gather fusion, capped by extract sites

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/DispatchCreation/FusionUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -29,6 +30,13 @@ namespace mlir::iree_compiler::DispatchCreation {
 
 #define GEN_PASS_DEF_ELEMENTWISEOPFUSIONPASS
 #include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+static llvm::cl::opt<unsigned> clGatherRematMaxExtractSites(
+    "iree-dispatch-creation-gather-remat-max-extract-sites",
+    llvm::cl::desc("Developer flag: maximum number of `tensor.extract` "
+                   "sites in a `linalg.generic` consumer that target "
+                   "`linalg.generic` producers."),
+    llvm::cl::Hidden, llvm::cl::init(4));
 
 namespace {
 struct ElementwiseOpFusionPass final
@@ -127,8 +135,21 @@ struct GatherFusionPattern final : OpRewritePattern<tensor::ExtractOp> {
     }
 
     // Check if the producerOp is fusible.
-    // Allow any single-result elementwise generic op.
-    if (producerOp.getNumResults() != 1 || !isElementwise(producerOp)) {
+    // Allow bit extend ops or transpose ops or any single-result elementwise
+    // generic op gated by the number of extract sites in the consumer.
+    bool isBitExtend = IREE::LinalgExt::isBitExtendOp(producerOp);
+    bool isTranspose = IREE::LinalgExt::isaTransposeOpInterface(producerOp);
+    unsigned numConsumerRematCandidateSites = 0;
+    consumerOp.getRegion().walk([&](tensor::ExtractOp extract) {
+      if (isa_and_nonnull<linalg::GenericOp>(
+              extract.getTensor().getDefiningOp())) {
+        ++numConsumerRematCandidateSites;
+      }
+    });
+    bool consumerHasMoreExtractSites =
+        numConsumerRematCandidateSites > clGatherRematMaxExtractSites;
+    if (producerOp.getNumResults() != 1 || !isElementwise(producerOp) ||
+        (!isBitExtend && !isTranspose && consumerHasMoreExtractSites)) {
       return rewriter.notifyMatchFailure(producerOp,
                                          "producer op is not fusible");
     }

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -136,9 +136,14 @@ struct GatherFusionPattern final : OpRewritePattern<tensor::ExtractOp> {
 
     // Check if the producerOp is fusible.
     // Allow bit extend ops or transpose ops or any single-result elementwise
-    // generic op gated by the number of extract sites in the consumer.
+    // generic op gated by the number of extract sites in the consumer and by
+    // the presence of non-extract users on the producer.
     bool isBitExtend = IREE::LinalgExt::isBitExtendOp(producerOp);
     bool isTranspose = IREE::LinalgExt::isaTransposeOpInterface(producerOp);
+    bool producerHasOnlyExtractUsers =
+        llvm::all_of(producerOp.getResult(0).getUsers(), [](Operation *user) {
+          return isa<tensor::ExtractOp>(user);
+        });
     unsigned numConsumerRematCandidateSites = 0;
     consumerOp.getRegion().walk([&](tensor::ExtractOp extract) {
       if (isa_and_nonnull<linalg::GenericOp>(
@@ -149,7 +154,8 @@ struct GatherFusionPattern final : OpRewritePattern<tensor::ExtractOp> {
     bool consumerHasMoreExtractSites =
         numConsumerRematCandidateSites > clGatherRematMaxExtractSites;
     if (producerOp.getNumResults() != 1 || !isElementwise(producerOp) ||
-        (!isBitExtend && !isTranspose && consumerHasMoreExtractSites)) {
+        (!isBitExtend && !isTranspose &&
+         (!producerHasOnlyExtractUsers || consumerHasMoreExtractSites))) {
       return rewriter.notifyMatchFailure(producerOp,
                                          "producer op is not fusible");
     }

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -18,8 +18,10 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/DispatchCreation/FusionUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -29,6 +31,37 @@ namespace mlir::iree_compiler::DispatchCreation {
 
 #define GEN_PASS_DEF_ELEMENTWISEOPFUSIONPASS
 #include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+static llvm::cl::opt<unsigned> clGatherRematMaxBodyOps(
+    "iree-dispatch-creation-gather-remat-max-body-ops",
+    llvm::cl::desc("developer flag: maximum number of 'real' ops a "
+                   "linalg.generic body can have for it to be eligible to be "
+                   "rematerialised at tensor.extract sites in a consumer via "
+                   "GatherFusionPattern. Producers with bodies above this "
+                   "threshold remain unfused via this pattern. Set to 0 to "
+                   "disable this remat path entirely."),
+    llvm::cl::Hidden, llvm::cl::init(4));
+
+// Counts ops in `genericOp`'s body that we treat as "real work" for the
+// purposes of remat at `tensor.extract` sites. The body is cloned at every
+// extract site, so each body op is a duplication source. Op kinds that are
+// free at codegen / fold away are excluded:
+//   - linalg.yield: the terminator, replaced by the inlined yield's operand.
+//   - linalg.index: lowers to a thread / loop induction variable.
+//   - arith.constant: hoisted / folded.
+// Everything else (arith / math / cmp / select / extf-truncf / side-input
+// `tensor.extract`, etc.) counts as 1.
+static unsigned countRematerializableBodyOps(linalg::GenericOp genericOp) {
+  unsigned count = 0;
+  Block &body = genericOp.getRegion().front();
+  for (Operation &op : body.without_terminator()) {
+    if (isa<linalg::IndexOp, arith::ConstantOp>(&op)) {
+      continue;
+    }
+    ++count;
+  }
+  return count;
+}
 
 namespace {
 struct ElementwiseOpFusionPass final
@@ -127,11 +160,14 @@ struct GatherFusionPattern final : OpRewritePattern<tensor::ExtractOp> {
     }
 
     // Check if the producerOp is fusible.
-    // Allow bit extend ops or transpose ops.
+    // Allow bit extend ops, transpose ops, or any cheap elementwise op.
     bool isBitExtend = IREE::LinalgExt::isBitExtendOp(producerOp);
     bool isTranspose = IREE::LinalgExt::isaTransposeOpInterface(producerOp);
+    bool isCheapElementwise =
+        isElementwise(producerOp) &&
+        countRematerializableBodyOps(producerOp) <= clGatherRematMaxBodyOps;
     if (producerOp.getNumResults() != 1 || !isElementwise(producerOp) ||
-        (!isBitExtend && !isTranspose)) {
+        (!isBitExtend && !isTranspose && !isCheapElementwise)) {
       return rewriter.notifyMatchFailure(producerOp,
                                          "producer op is not fusible");
     }

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -18,10 +18,8 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/DispatchCreation/FusionUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -31,37 +29,6 @@ namespace mlir::iree_compiler::DispatchCreation {
 
 #define GEN_PASS_DEF_ELEMENTWISEOPFUSIONPASS
 #include "iree/compiler/DispatchCreation/Passes.h.inc"
-
-static llvm::cl::opt<unsigned> clGatherRematMaxBodyOps(
-    "iree-dispatch-creation-gather-remat-max-body-ops",
-    llvm::cl::desc("developer flag: maximum number of 'real' ops a "
-                   "linalg.generic body can have for it to be eligible to be "
-                   "rematerialised at tensor.extract sites in a consumer via "
-                   "GatherFusionPattern. Producers with bodies above this "
-                   "threshold remain unfused via this pattern. Set to 0 to "
-                   "disable this remat path entirely."),
-    llvm::cl::Hidden, llvm::cl::init(4));
-
-// Counts ops in `genericOp`'s body that we treat as "real work" for the
-// purposes of remat at `tensor.extract` sites. The body is cloned at every
-// extract site, so each body op is a duplication source. Op kinds that are
-// free at codegen / fold away are excluded:
-//   - linalg.yield: the terminator, replaced by the inlined yield's operand.
-//   - linalg.index: lowers to a thread / loop induction variable.
-//   - arith.constant: hoisted / folded.
-// Everything else (arith / math / cmp / select / extf-truncf / side-input
-// `tensor.extract`, etc.) counts as 1.
-static unsigned countRematerializableBodyOps(linalg::GenericOp genericOp) {
-  unsigned count = 0;
-  Block &body = genericOp.getRegion().front();
-  for (Operation &op : body.without_terminator()) {
-    if (isa<linalg::IndexOp, arith::ConstantOp>(&op)) {
-      continue;
-    }
-    ++count;
-  }
-  return count;
-}
 
 namespace {
 struct ElementwiseOpFusionPass final
@@ -160,14 +127,8 @@ struct GatherFusionPattern final : OpRewritePattern<tensor::ExtractOp> {
     }
 
     // Check if the producerOp is fusible.
-    // Allow bit extend ops, transpose ops, or any cheap elementwise op.
-    bool isBitExtend = IREE::LinalgExt::isBitExtendOp(producerOp);
-    bool isTranspose = IREE::LinalgExt::isaTransposeOpInterface(producerOp);
-    bool isCheapElementwise =
-        isElementwise(producerOp) &&
-        countRematerializableBodyOps(producerOp) <= clGatherRematMaxBodyOps;
-    if (producerOp.getNumResults() != 1 || !isElementwise(producerOp) ||
-        (!isBitExtend && !isTranspose && !isCheapElementwise)) {
+    // Allow any single-result elementwise generic op.
+    if (producerOp.getNumResults() != 1 || !isElementwise(producerOp)) {
       return rewriter.notifyMatchFailure(producerOp,
                                          "producer op is not fusible");
     }

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -861,3 +861,42 @@ util.func public @dont_fuse_many_site_elementwise_into_gather(
 //       CHECK:   %[[PROD:.+]] = linalg.generic
 //       CHECK:   linalg.generic
 //   CHECK-COUNT-5:     tensor.extract %[[PROD]]
+
+// -----
+
+util.func public @dont_fuse_mixed_user_elementwise_into_gather(
+    %a: tensor<256x256xf32>, %b: tensor<256x256xf32>,
+    %gather_out: tensor<256xf32>)
+    -> (tensor<256x256xf32>, tensor<256xf32>) {
+  %empty = tensor.empty() : tensor<256x256xf32>
+  %prod = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%a, %b : tensor<256x256xf32>, tensor<256x256xf32>)
+      outs(%empty : tensor<256x256xf32>) {
+  ^bb0(%x: f32, %y: f32, %_: f32):
+    %m = arith.mulf %x, %y : f32
+    linalg.yield %m : f32
+  } -> tensor<256x256xf32>
+  %gather_cons = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%gather_out : tensor<256xf32>) {
+  ^bb0(%_: f32):
+    %i0 = linalg.index 0 : index
+    %e = tensor.extract %prod[%i0, %i0] : tensor<256x256xf32>
+    linalg.yield %e : f32
+  } -> tensor<256xf32>
+  util.return %prod, %gather_cons
+      : tensor<256x256xf32>, tensor<256xf32>
+}
+// CHECK-LABEL: @dont_fuse_mixed_user_elementwise_into_gather(
+// `%prod` stays as its own generic; the gather consumer still extracts
+// from it rather than inlining its body since `%prod` is used by a
+// non-extract gather.
+//       CHECK:   %[[PROD:.+]] = linalg.generic
+//       CHECK:     arith.mulf
+//       CHECK:   linalg.generic
+//       CHECK:     tensor.extract %[[PROD]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -810,3 +810,54 @@ util.func public @fuse_elementwise_into_gather(
 //       CHECK:       linalg.yield %[[MUL]] : f16
 //       CHECK:   util.return %[[RESULT]]
 //   CHECK-NOT:   linalg.generic
+
+// -----
+
+// A non-bit-extend / non-transpose elementwise producer is structurally
+// rematerialisable, but rematerialising it at every gather site would
+// duplicate the body and grow the consumer's operand set linearly in
+// the number of sites. This test therefore checks that we don't rematerialise
+// in such case where the number of tensor.extract sites are beyond the
+// default count 4.
+util.func public @dont_fuse_many_site_elementwise_into_gather(
+    %arg0: tensor<256x256xf32>, %arg1: tensor<256x256xf32>,
+    %out: tensor<256xf32>) -> tensor<256xf32> {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %empty = tensor.empty() : tensor<256x256xf32>
+  %prod = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0, %arg1 : tensor<256x256xf32>, tensor<256x256xf32>)
+      outs(%empty : tensor<256x256xf32>) {
+  ^bb0(%a: f32, %b: f32, %_: f32):
+    %m = arith.mulf %a, %b : f32
+    linalg.yield %m : f32
+  } -> tensor<256x256xf32>
+  %cons = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%out : tensor<256xf32>) {
+  ^bb0(%_: f32):
+    %i0 = linalg.index 0 : index
+    %e0 = tensor.extract %prod[%i0, %i0] : tensor<256x256xf32>
+    %e1 = tensor.extract %prod[%i0, %c1] : tensor<256x256xf32>
+    %e2 = tensor.extract %prod[%i0, %c2] : tensor<256x256xf32>
+    %e3 = tensor.extract %prod[%i0, %c3] : tensor<256x256xf32>
+    %e4 = tensor.extract %prod[%i0, %c4] : tensor<256x256xf32>
+    %s01 = arith.addf %e0, %e1 : f32
+    %s23 = arith.addf %e2, %e3 : f32
+    %s0123 = arith.addf %s01, %s23 : f32
+    %r = arith.addf %s0123, %e4 : f32
+    linalg.yield %r : f32
+  } -> tensor<256xf32>
+  util.return %cons : tensor<256xf32>
+}
+// CHECK-LABEL: @dont_fuse_many_site_elementwise_into_gather(
+//       CHECK:   %[[PROD:.+]] = linalg.generic
+//       CHECK:   linalg.generic
+//   CHECK-COUNT-5:     tensor.extract %[[PROD]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -1,4 +1,18 @@
-// RUN: iree-opt --iree-dispatch-creation-elementwise-op-fusion --split-input-file --mlir-print-local-scope  %s | FileCheck %s
+// The default RUN line exercises the pass with
+// `--iree-dispatch-creation-gather-remat-max-body-ops` at its default (4).
+// The second RUN line forces the cap to 0, which disables the
+// cheap-elementwise admission added for issue #24149 while leaving the
+// original bit-extend / transpose admissions untouched. Tests whose
+// expected output differs between the two modes carry both default check
+// directives and DISABLED-prefixed ones; everything else is implicitly
+// only checked under the default RUN.
+
+// RUN: iree-opt --iree-dispatch-creation-elementwise-op-fusion \
+// RUN:     --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --iree-dispatch-creation-elementwise-op-fusion \
+// RUN:     --iree-dispatch-creation-gather-remat-max-body-ops=0 \
+// RUN:     --split-input-file --mlir-print-local-scope %s \
+// RUN:     | FileCheck %s --check-prefix=DISABLED
 
 util.func public @transpose_attention(%arg0: tensor<4x64x32x128xf16>, %arg1: tensor<4x64x32x128xf16>, %arg2: tensor<4x64x32x128xf16>, %arg3: f16) -> tensor<4x64x4096xf16> {
   %0 = tensor.empty() : tensor<4x32x64x128xf16>
@@ -158,6 +172,16 @@ util.func public @fuse_generic_gather(
 // CHECK-NEXT:    %[[EXTRACTED:.*]] = tensor.extract %[[TENSOR0:.+]][%[[INDEX0]], %[[INDEX1]]] : tensor<128256x4096xf16>
 // CHECK-NEXT:    %[[RES:[a-zA-Z0-9]+]] = arith.extf %[[EXTRACTED]] : f16 to f32
 // CHECK-NEXT:    linalg.yield %[[RES]] : f32
+
+// The bit-extend admission in `GatherFusionPattern` is independent of
+// `iree-dispatch-creation-gather-remat-max-body-ops`, so this pair must
+// still fuse with `=0`. Scoping guarantee on the cap.
+// DISABLED-LABEL: util.func public @fuse_generic_gather(
+//       DISABLED:   %[[INDEX0:[a-zA-Z0-9]+]] = arith.index_cast %in : i64 to index
+//       DISABLED:   %[[INDEX1:[a-zA-Z0-9]+]] = linalg.index 2 : index
+//  DISABLED-NEXT:   %[[EXTRACTED:.*]] = tensor.extract %{{.+}}[%[[INDEX0]], %[[INDEX1]]] : tensor<128256x4096xf16>
+//  DISABLED-NEXT:   %[[RES:[a-zA-Z0-9]+]] = arith.extf %[[EXTRACTED]] : f16 to f32
+//  DISABLED-NEXT:   linalg.yield %[[RES]] : f32
 
 
 // -----
@@ -757,3 +781,112 @@ util.func public @fuse_transpose_with_index_flip(%arg0: tensor<64x3x3x64xbf16>) 
 //       CHECK:       %[[EXTRACT:.+]] = tensor.extract %[[ARG0]][%[[IDX0]], %[[SUB0]], %[[SUB1]], %[[IDX1]]] : tensor<64x3x3x64xbf16>
 //       CHECK:       linalg.yield %[[EXTRACT]] : bf16
 //       CHECK:   util.return %[[RESULT]]
+
+// -----
+
+// Tests a producer that is neither bit-extend nor transpose, feeding a consumer
+// that extracts from it at a permuted index.
+util.func public @fuse_cheap_elementwise_into_gather(
+    %q: tensor<32x8x2x64xf16>, %cos: tensor<32x8x2x64xf16>,
+    %out: tensor<32x8x2x64xf16>) -> tensor<32x8x2x64xf16> {
+  %c1 = arith.constant 1 : index
+  %empty = tensor.empty() : tensor<32x8x2x64xf16>
+  %prod = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%q, %cos : tensor<32x8x2x64xf16>, tensor<32x8x2x64xf16>)
+      outs(%empty : tensor<32x8x2x64xf16>) {
+  ^bb0(%a: f16, %b: f16, %_: f16):
+    %add = arith.addf %a, %b : f16
+    %mul = arith.mulf %a, %add : f16
+    linalg.yield %mul : f16
+  } -> tensor<32x8x2x64xf16>
+  %cons = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      outs(%out : tensor<32x8x2x64xf16>) {
+  ^bb0(%_: f16):
+    %i0 = linalg.index 0 : index
+    %i1 = linalg.index 1 : index
+    %i2 = linalg.index 2 : index
+    %i3 = linalg.index 3 : index
+    %swapped = arith.subi %c1, %i2 : index
+    %ext = tensor.extract %prod[%i0, %i1, %swapped, %i3] : tensor<32x8x2x64xf16>
+    linalg.yield %ext : f16
+  } -> tensor<32x8x2x64xf16>
+  util.return %cons : tensor<32x8x2x64xf16>
+}
+// CHECK-LABEL: @fuse_cheap_elementwise_into_gather(
+//  CHECK-SAME:   %[[Q:[A-Za-z0-9]+]]: tensor<32x8x2x64xf16>
+//  CHECK-SAME:   %[[COS:[A-Za-z0-9]+]]: tensor<32x8x2x64xf16>
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:   %[[RESULT:.+]] = linalg.generic
+//       CHECK:     ^bb0(%{{.+}}: f16):
+//   CHECK-DAG:       %[[I0:.+]] = linalg.index 0 : index
+//   CHECK-DAG:       %[[I1:.+]] = linalg.index 1 : index
+//   CHECK-DAG:       %[[I2:.+]] = linalg.index 2 : index
+//   CHECK-DAG:       %[[I3:.+]] = linalg.index 3 : index
+//       CHECK:       %[[SWAP:.+]] = arith.subi %[[C1]], %[[I2]] : index
+//   CHECK-DAG:       %[[EQ:.+]] = tensor.extract %[[Q]][%[[I0]], %[[I1]], %[[SWAP]], %[[I3]]]
+//   CHECK-DAG:       %[[EC:.+]] = tensor.extract %[[COS]][%[[I0]], %[[I1]], %[[SWAP]], %[[I3]]]
+//       CHECK:       %[[ADD:.+]] = arith.addf %[[EQ]], %[[EC]] : f16
+//       CHECK:       %[[MUL:.+]] = arith.mulf %[[EQ]], %[[ADD]] : f16
+//       CHECK:       linalg.yield %[[MUL]] : f16
+//       CHECK:   util.return %[[RESULT]]
+//   CHECK-NOT:   linalg.generic
+
+// Under --iree-dispatch-creation-gather-remat-max-body-ops=0 the
+// cheap-elementwise admission is disabled, so the producer survives with
+// its full two-op body and the consumer keeps its tensor.extract on it.
+// DISABLED-LABEL: @fuse_cheap_elementwise_into_gather(
+//       DISABLED:   %[[PROD:.+]] = linalg.generic
+//       DISABLED:   %[[CONS:.+]] = linalg.generic
+//       DISABLED:     tensor.extract %[[PROD]]
+//       DISABLED:   util.return %[[CONS]]
+
+// -----
+
+// Tests a producer whose body contains more "real" ops than the configured
+// threshold (default 4). The producer is elementwise but expensive enough
+// that rematerialising it at every `tensor.extract` site in the consumer
+// would duplicate substantial compute.
+util.func public @dont_fuse_expensive_elementwise_into_gather(
+    %arg0: tensor<256x256xf32>, %arg1: tensor<256x256xf32>,
+    %out: tensor<256x256xf32>) -> tensor<256x256xf32> {
+  %c1 = arith.constant 1 : index
+  %empty = tensor.empty() : tensor<256x256xf32>
+  %prod = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0, %arg1 : tensor<256x256xf32>, tensor<256x256xf32>)
+      outs(%empty : tensor<256x256xf32>) {
+  ^bb0(%a: f32, %b: f32, %_: f32):
+    %0 = arith.mulf %a, %b : f32
+    %1 = arith.addf %0, %a : f32
+    %2 = arith.subf %1, %b : f32
+    %3 = arith.mulf %2, %2 : f32
+    %4 = arith.addf %3, %0 : f32
+    linalg.yield %4 : f32
+  } -> tensor<256x256xf32>
+  %cons = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      outs(%out : tensor<256x256xf32>) {
+  ^bb0(%_: f32):
+    %i0 = linalg.index 0 : index
+    %i1 = linalg.index 1 : index
+    %swapped = arith.subi %c1, %i1 : index
+    %ext = tensor.extract %prod[%i0, %swapped] : tensor<256x256xf32>
+    linalg.yield %ext : f32
+  } -> tensor<256x256xf32>
+  util.return %cons : tensor<256x256xf32>
+}
+// CHECK-LABEL: @dont_fuse_expensive_elementwise_into_gather(
+//       CHECK:   %[[PROD:.+]] = linalg.generic
+//       CHECK:   %[[CONS:.+]] = linalg.generic
+//       CHECK:     tensor.extract %[[PROD]]
+//       CHECK:   util.return %[[CONS]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -1,18 +1,4 @@
-// The default RUN line exercises the pass with
-// `--iree-dispatch-creation-gather-remat-max-body-ops` at its default (4).
-// The second RUN line forces the cap to 0, which disables the
-// cheap-elementwise admission added for issue #24149 while leaving the
-// original bit-extend / transpose admissions untouched. Tests whose
-// expected output differs between the two modes carry both default check
-// directives and DISABLED-prefixed ones; everything else is implicitly
-// only checked under the default RUN.
-
-// RUN: iree-opt --iree-dispatch-creation-elementwise-op-fusion \
-// RUN:     --split-input-file --mlir-print-local-scope %s | FileCheck %s
-// RUN: iree-opt --iree-dispatch-creation-elementwise-op-fusion \
-// RUN:     --iree-dispatch-creation-gather-remat-max-body-ops=0 \
-// RUN:     --split-input-file --mlir-print-local-scope %s \
-// RUN:     | FileCheck %s --check-prefix=DISABLED
+// RUN: iree-opt --iree-dispatch-creation-elementwise-op-fusion --split-input-file --mlir-print-local-scope  %s | FileCheck %s
 
 util.func public @transpose_attention(%arg0: tensor<4x64x32x128xf16>, %arg1: tensor<4x64x32x128xf16>, %arg2: tensor<4x64x32x128xf16>, %arg3: f16) -> tensor<4x64x4096xf16> {
   %0 = tensor.empty() : tensor<4x32x64x128xf16>
@@ -172,16 +158,6 @@ util.func public @fuse_generic_gather(
 // CHECK-NEXT:    %[[EXTRACTED:.*]] = tensor.extract %[[TENSOR0:.+]][%[[INDEX0]], %[[INDEX1]]] : tensor<128256x4096xf16>
 // CHECK-NEXT:    %[[RES:[a-zA-Z0-9]+]] = arith.extf %[[EXTRACTED]] : f16 to f32
 // CHECK-NEXT:    linalg.yield %[[RES]] : f32
-
-// The bit-extend admission in `GatherFusionPattern` is independent of
-// `iree-dispatch-creation-gather-remat-max-body-ops`, so this pair must
-// still fuse with `=0`. Scoping guarantee on the cap.
-// DISABLED-LABEL: util.func public @fuse_generic_gather(
-//       DISABLED:   %[[INDEX0:[a-zA-Z0-9]+]] = arith.index_cast %in : i64 to index
-//       DISABLED:   %[[INDEX1:[a-zA-Z0-9]+]] = linalg.index 2 : index
-//  DISABLED-NEXT:   %[[EXTRACTED:.*]] = tensor.extract %{{.+}}[%[[INDEX0]], %[[INDEX1]]] : tensor<128256x4096xf16>
-//  DISABLED-NEXT:   %[[RES:[a-zA-Z0-9]+]] = arith.extf %[[EXTRACTED]] : f16 to f32
-//  DISABLED-NEXT:   linalg.yield %[[RES]] : f32
 
 
 // -----
@@ -784,9 +760,7 @@ util.func public @fuse_transpose_with_index_flip(%arg0: tensor<64x3x3x64xbf16>) 
 
 // -----
 
-// Tests a producer that is neither bit-extend nor transpose, feeding a consumer
-// that extracts from it at a permuted index.
-util.func public @fuse_cheap_elementwise_into_gather(
+util.func public @fuse_elementwise_into_gather(
     %q: tensor<32x8x2x64xf16>, %cos: tensor<32x8x2x64xf16>,
     %out: tensor<32x8x2x64xf16>) -> tensor<32x8x2x64xf16> {
   %c1 = arith.constant 1 : index
@@ -818,9 +792,9 @@ util.func public @fuse_cheap_elementwise_into_gather(
   } -> tensor<32x8x2x64xf16>
   util.return %cons : tensor<32x8x2x64xf16>
 }
-// CHECK-LABEL: @fuse_cheap_elementwise_into_gather(
-//  CHECK-SAME:   %[[Q:[A-Za-z0-9]+]]: tensor<32x8x2x64xf16>
-//  CHECK-SAME:   %[[COS:[A-Za-z0-9]+]]: tensor<32x8x2x64xf16>
+// CHECK-LABEL: @fuse_elementwise_into_gather(
+//  CHECK-SAME:   %[[A1:[A-Za-z0-9]+]]: tensor<32x8x2x64xf16>
+//  CHECK-SAME:   %[[A2:[A-Za-z0-9]+]]: tensor<32x8x2x64xf16>
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:   %[[RESULT:.+]] = linalg.generic
 //       CHECK:     ^bb0(%{{.+}}: f16):
@@ -829,64 +803,10 @@ util.func public @fuse_cheap_elementwise_into_gather(
 //   CHECK-DAG:       %[[I2:.+]] = linalg.index 2 : index
 //   CHECK-DAG:       %[[I3:.+]] = linalg.index 3 : index
 //       CHECK:       %[[SWAP:.+]] = arith.subi %[[C1]], %[[I2]] : index
-//   CHECK-DAG:       %[[EQ:.+]] = tensor.extract %[[Q]][%[[I0]], %[[I1]], %[[SWAP]], %[[I3]]]
-//   CHECK-DAG:       %[[EC:.+]] = tensor.extract %[[COS]][%[[I0]], %[[I1]], %[[SWAP]], %[[I3]]]
+//   CHECK-DAG:       %[[EQ:.+]] = tensor.extract %[[A1]][%[[I0]], %[[I1]], %[[SWAP]], %[[I3]]]
+//   CHECK-DAG:       %[[EC:.+]] = tensor.extract %[[A2]][%[[I0]], %[[I1]], %[[SWAP]], %[[I3]]]
 //       CHECK:       %[[ADD:.+]] = arith.addf %[[EQ]], %[[EC]] : f16
 //       CHECK:       %[[MUL:.+]] = arith.mulf %[[EQ]], %[[ADD]] : f16
 //       CHECK:       linalg.yield %[[MUL]] : f16
 //       CHECK:   util.return %[[RESULT]]
 //   CHECK-NOT:   linalg.generic
-
-// Under --iree-dispatch-creation-gather-remat-max-body-ops=0 the
-// cheap-elementwise admission is disabled, so the producer survives with
-// its full two-op body and the consumer keeps its tensor.extract on it.
-// DISABLED-LABEL: @fuse_cheap_elementwise_into_gather(
-//       DISABLED:   %[[PROD:.+]] = linalg.generic
-//       DISABLED:   %[[CONS:.+]] = linalg.generic
-//       DISABLED:     tensor.extract %[[PROD]]
-//       DISABLED:   util.return %[[CONS]]
-
-// -----
-
-// Tests a producer whose body contains more "real" ops than the configured
-// threshold (default 4). The producer is elementwise but expensive enough
-// that rematerialising it at every `tensor.extract` site in the consumer
-// would duplicate substantial compute.
-util.func public @dont_fuse_expensive_elementwise_into_gather(
-    %arg0: tensor<256x256xf32>, %arg1: tensor<256x256xf32>,
-    %out: tensor<256x256xf32>) -> tensor<256x256xf32> {
-  %c1 = arith.constant 1 : index
-  %empty = tensor.empty() : tensor<256x256xf32>
-  %prod = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-                       affine_map<(d0, d1) -> (d0, d1)>,
-                       affine_map<(d0, d1) -> (d0, d1)>],
-      iterator_types = ["parallel", "parallel"]}
-      ins(%arg0, %arg1 : tensor<256x256xf32>, tensor<256x256xf32>)
-      outs(%empty : tensor<256x256xf32>) {
-  ^bb0(%a: f32, %b: f32, %_: f32):
-    %0 = arith.mulf %a, %b : f32
-    %1 = arith.addf %0, %a : f32
-    %2 = arith.subf %1, %b : f32
-    %3 = arith.mulf %2, %2 : f32
-    %4 = arith.addf %3, %0 : f32
-    linalg.yield %4 : f32
-  } -> tensor<256x256xf32>
-  %cons = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
-      iterator_types = ["parallel", "parallel"]}
-      outs(%out : tensor<256x256xf32>) {
-  ^bb0(%_: f32):
-    %i0 = linalg.index 0 : index
-    %i1 = linalg.index 1 : index
-    %swapped = arith.subi %c1, %i1 : index
-    %ext = tensor.extract %prod[%i0, %swapped] : tensor<256x256xf32>
-    linalg.yield %ext : f32
-  } -> tensor<256x256xf32>
-  util.return %cons : tensor<256x256xf32>
-}
-// CHECK-LABEL: @dont_fuse_expensive_elementwise_into_gather(
-//       CHECK:   %[[PROD:.+]] = linalg.generic
-//       CHECK:   %[[CONS:.+]] = linalg.generic
-//       CHECK:     tensor.extract %[[PROD]]
-//       CHECK:   util.return %[[CONS]]


### PR DESCRIPTION
In the issue #24149 we see instances of `memref<32 × 9007199254740991 × 2 × 64 × f16>` and consequentially when `GPUCheckResourceUsage` tried to compute the size it led to the overflow in `int` and yielded negative result.

The above happened because `PadDynamicAlloc` rewrote a workgroup-scoped tensor's dynamic dim to its static upper bound.

On investigating I found that what could've been a thread-scoped tensor, ends up being a workgroup-scoped tensor because of `GatherFusionPattern`'s predicate - which currently admits only bit-extend or transpose producers, so a trivial elementwise producer (like RoPE's q * cos) is bailed out on.

This PR thus tries to relax the stringent predicate and allows any single-result elementwise op gated on `tensor.extract` site count (I can ideally remove `isBitExtendOp` and `isTransposeOp` but I want to first ensure that there is no regression).

My concern :-
```
--------------------------------------------------------------------
INPUT
--------------------------------------------------------------------
%prod = linalg.generic  // has N ops with M inputs
%cons = linalg.generic  // has K tensor.extract ops
--------------------------------------------------------------------
OUTPUT
--------------------------------------------------------------------
%out = linalg.generic   // (M * K + N) ops per thread <-- can blow op pretty fast
```
I initially tried thinking of a better cost model to prevent fusion in the case I tried highligthing above - where we have multiple `tensor.extract` in consumer and a larger producer body.
But the options I could think of involved having to hardcode a threshold value.
I'll await for CI's result and see if the relaxation causes any issue. I'm open to adapting to any suggestions meanwhile. :)

In most cases it should lead to a perf optimization besides resolving the negative shared memory issue highlighted above.

Fixes: https://github.com/iree-org/iree/issues/24149
