### PR TITLE
[VectorDistribute] Distribute `vector.scan` to threads

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -795,7 +795,8 @@ static Value broadcastFromProjected(RewriterBase &rewriter, Location loc,
                                     Value source, ArrayRef<int64_t> targetShape,
                                     ArrayRef<bool> projectedDims) {
   SmallVector<int64_t> expandedShape(targetShape);
-  for (size_t i = 0; i < expandedShape.size(); ++i) {
+  for (int64_t i = 0, expandedNumDims = expandedShape.size();
+       i < expandedNumDims; ++i) {
     if (projectedDims[i]) {
       expandedShape[i] = 1;
     }
@@ -2336,7 +2337,7 @@ createSubgroupScan(PatternRewriter &rewriter, Location loc, Value value,
 /// ```
 ///
 /// To compute the scan over the block totals at the subgroup level, we simply
-/// use subgroup_reduce. For the loop over the batch/outer dimensions, we can
+/// use subgroup_scan. For the loop over the batch/outer dimensions, we can
 /// compute the scan iteratively. The loops over batch/outer do not manifest in
 /// IR, they only exist in codegen and are unrolled in IR.
 ///
@@ -2422,7 +2423,6 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
     // Initialize subgroupRunning to identity with localAccType shape.
     // This matches the accumulated_value shape from the local scan, which
     // has the scan-dim element removed from chunkShape.
-    VectorType initDistType = disInit.getType();
     Value batchOuterRunning =
         getCombiningIdentityValue(loc, rewriter, kind, localAccType);
 
@@ -2509,6 +2509,7 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
           rewriter, loc, kind, batchOuterRunning, subgroupTotal);
     }
 
+    VectorType initDistType = disInit.getType();
     // For the inclusive case we're done.
     if (inclusive) {
       Value accumulatedValue = vector::ShapeCastOp::create(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -794,6 +794,7 @@ static VectorValue broadcastToShape(RewriterBase &rewriter, Value source,
 static Value broadcastFromProjected(RewriterBase &rewriter, Location loc,
                                     Value source, ArrayRef<int64_t> targetShape,
                                     ArrayRef<bool> projectedDims) {
+  assert(targetShape.size() == projectedDims.size());
   SmallVector<int64_t> expandedShape(targetShape);
   for (int64_t i = 0, expandedNumDims = expandedShape.size();
        i < expandedNumDims; ++i) {
@@ -812,13 +813,11 @@ static Value broadcastFromProjected(RewriterBase &rewriter, Location loc,
 /// Converts a linearized element number into vector indices in row-major order.
 static SmallVector<int64_t> getVectorElementIndices(VectorType vectorType,
                                                     int64_t linearIndex) {
-  SmallVector<int64_t> indices;
-  indices.reserve(vectorType.getRank());
+  SmallVector<int64_t> indices(vectorType.getRank());
   for (int64_t d = vectorType.getRank() - 1; d >= 0; --d) {
-    indices.push_back(linearIndex % vectorType.getDimSize(d));
+    indices[d] = linearIndex % vectorType.getDimSize(d);
     linearIndex /= vectorType.getDimSize(d);
   }
-  std::reverse(indices.begin(), indices.end());
   return indices;
 }
 
@@ -2242,12 +2241,17 @@ static Value broadcastFromLastClusterLane(RewriterBase &rewriter, Location loc,
   return result;
 }
 
-/// Helper to create a `iree_gpu.subgroup_scan` op for a scalar value, using
-/// `vector::CombiningKind` to build the combiner region.
-static std::pair<Value, Value>
-createSubgroupScan(PatternRewriter &rewriter, Location loc, Value value,
-                   Value identity, vector::CombiningKind kind,
-                   int64_t clusterSize, int64_t clusterStride) {
+struct SubgroupScanResult {
+  Value scan;
+  Value total;
+};
+
+/// Helper to create an exclusive `iree_gpu.subgroup_scan` op for a scalar
+/// value, using `vector::CombiningKind` to build the combiner region.
+static SubgroupScanResult
+createExclusiveSubgroupScan(RewriterBase &rewriter, Location loc, Value value,
+                            Value identity, vector::CombiningKind kind,
+                            int64_t clusterSize, int64_t clusterStride) {
   auto scanOp = IREE::GPU::SubgroupScanOp::create(
       rewriter, loc, value.getType(), value.getType(), value, identity,
       /*inclusive=*/nullptr, rewriter.getI32IntegerAttr(clusterSize),
@@ -2383,9 +2387,8 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
           scanOp, "multi-subgroup scan not yet supported");
     }
 
-    // Get distributed operands.
+    // Get distributed source.
     VectorValue disSrc = getDistributed(rewriter, source, sig[source]);
-    VectorValue disInit = getDistributed(rewriter, init, sig[init]);
 
     // Layout tile sizes along scan dimension.
     int64_t batchSize = srcLayout.getBatchTile()[scanDim];
@@ -2420,7 +2423,7 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
     VectorType distType = disSrc.getType();
     Value result = getCombiningIdentityValue(loc, rewriter, kind, distType);
 
-    // Initialize subgroupRunning to identity with localAccType shape.
+    // Initialize batchOuterRunning to identity with localAccType shape.
     // This matches the accumulated_value shape from the local scan, which
     // has the scan-dim element removed from chunkShape.
     Value batchOuterRunning =
@@ -2437,7 +2440,7 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
           rewriter, loc, disSrc, offsets, chunkShape, strides);
 
       // Stage 1: local scan over element tile with identity init.
-      // Using identity (not user init) keeps chunkTotal pure for stage 2.
+      // Using identity (not user init) keeps localTotal pure for stage 2.
       // The user init is applied once at the end for exclusive mode.
       auto localScanOp = vector::ScanOp::create(
           rewriter, loc, kind, srcChunk, localIdentityInit, elemIdx, inclusive);
@@ -2475,8 +2478,8 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
           Value scalar =
               vector::ExtractOp::create(rewriter, loc, localTotal, idx);
           auto [scanResult, scanTotal] =
-              createSubgroupScan(rewriter, loc, scalar, scalarIdentity, kind,
-                                 threadSize, clusterStride);
+              createExclusiveSubgroupScan(rewriter, loc, scalar, scalarIdentity,
+                                          kind, threadSize, clusterStride);
           subgroupScan = vector::InsertOp::create(rewriter, loc, scanResult,
                                                   subgroupScan, idx);
           subgroupTotal = vector::InsertOp::create(rewriter, loc, scanTotal,
@@ -2488,7 +2491,8 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
         subgroupTotal = localTotal;
       }
 
-      // Carry composition: chunkBase = combine(subgroupRunning, threadIncr).
+      // Carry composition:
+      // blockIncrement = combine(batchOuterRunning, subgroupScan).
       Value blockIncrement = vector::makeArithReduction(
           rewriter, loc, kind, batchOuterRunning, subgroupScan);
 
@@ -2509,7 +2513,8 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
           rewriter, loc, kind, batchOuterRunning, subgroupTotal);
     }
 
-    VectorType initDistType = disInit.getType();
+    VectorType initDistType = VectorType::get(initLayout.getDistributedShape(),
+                                              init.getType().getElementType());
     // For the inclusive case we're done.
     if (inclusive) {
       Value accumulatedValue = vector::ShapeCastOp::create(
@@ -2536,6 +2541,7 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
     scanDimMask[batchIdx] = true;
     scanDimMask[outerIdx] = true;
     scanDimMask[elemIdx] = true;
+    VectorValue disInit = getDistributed(rewriter, init, sig[init]);
     Value broadcastedInit =
         broadcastFromProjected(rewriter, loc, disInit, distShape, scanDimMask);
     result = vector::makeArithReduction(rewriter, loc, kind, broadcastedInit,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -2374,15 +2374,18 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
                                          "expected nested layout for init");
     }
 
+    bool needsCrossThread = srcLayout.getThreadTile()[scanDim] > 1;
+    bool needsCrossSubgroup = srcLayout.getSubgroupTile()[scanDim] > 1;
     Type elemTy = source.getType().getElementType();
-    if (failed(checkBitwidthForShuffle(scanOp, elemTy, maxBitsPerShuffle,
+    if ((needsCrossThread || needsCrossSubgroup) &&
+        failed(checkBitwidthForShuffle(scanOp, elemTy, maxBitsPerShuffle,
                                        "element", rewriter))) {
       return failure();
     }
 
     // Reject multi-subgroup for now.
     // TODO: Support distribution across workgroups.
-    if (srcLayout.getSubgroupTile()[scanDim] > 1) {
+    if (needsCrossSubgroup) {
       return rewriter.notifyMatchFailure(
           scanOp, "multi-subgroup scan not yet supported");
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -808,73 +808,17 @@ static Value broadcastFromProjected(RewriterBase &rewriter, Location loc,
   return vector::BroadcastOp::create(rewriter, loc, targetType, expanded);
 }
 
-/// Broadcast every element of |source| from the last lane in a scan cluster
-/// to all lanes. The cluster is defined by |clusterSize| threads at
-/// |clusterStride| spacing within a subgroup of |subgroupSize| lanes.
-/// Handles pack/unpack for types narrower than 32 bits.
-static Value broadcastFromLastClusterLane(RewriterBase &rewriter, Location loc,
-                                          Value source, int64_t clusterSize,
-                                          int64_t clusterStride,
-                                          int64_t subgroupSize) {
-  auto vecTy = cast<VectorType>(source.getType());
-  Type elemTy = vecTy.getElementType();
-  unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
-  constexpr unsigned shuffleBitwidth = 32;
-  auto shuffleIntType = rewriter.getIntegerType(shuffleBitwidth);
-  auto equivIntType = rewriter.getIntegerType(bitwidth);
-
-  // Compute the lane ID of the last thread in the scan cluster:
-  //   lanePos = (laneId / clusterStride) % clusterSize
-  //   lastLane = laneId - lanePos * clusterStride
-  //              + (clusterSize - 1) * clusterStride
-  auto i32 = rewriter.getI32Type();
-  Value laneId = gpu::LaneIdOp::create(rewriter, loc, /*upper_bound=*/nullptr);
-  Value laneIdI32 = arith::IndexCastOp::create(rewriter, loc, i32, laneId);
-  Value strideCst = arith::ConstantOp::create(
-      rewriter, loc, i32, rewriter.getI32IntegerAttr(clusterStride));
-  Value sizeCst = arith::ConstantOp::create(
-      rewriter, loc, i32, rewriter.getI32IntegerAttr(clusterSize));
-  Value lanePos = arith::RemUIOp::create(
-      rewriter, loc,
-      arith::DivUIOp::create(rewriter, loc, laneIdI32, strideCst), sizeCst);
-  Value posTimesStride =
-      arith::MulIOp::create(rewriter, loc, lanePos, strideCst);
-  Value baseLane =
-      arith::SubIOp::create(rewriter, loc, laneIdI32, posTimesStride);
-  Value lastOffset = arith::ConstantOp::create(
-      rewriter, loc, i32,
-      rewriter.getI32IntegerAttr((clusterSize - 1) * clusterStride));
-  Value lastLane = arith::AddIOp::create(rewriter, loc, baseLane, lastOffset);
-  Value widthCst = arith::ConstantOp::create(
-      rewriter, loc, i32, rewriter.getI32IntegerAttr(subgroupSize));
-
-  // Shuffle each scalar element from the last lane.
-  Value result = source;
-  for (int64_t i = 0, n = vecTy.getNumElements(); i < n; ++i) {
-    SmallVector<int64_t> idx;
-    int64_t remaining = i;
-    for (int64_t d = vecTy.getRank() - 1; d >= 0; --d) {
-      idx.push_back(remaining % vecTy.getDimSize(d));
-      remaining /= vecTy.getDimSize(d);
-    }
-    std::reverse(idx.begin(), idx.end());
-
-    Value scalar = vector::ExtractOp::create(rewriter, loc, source, idx);
-    Value packed = scalar;
-    if (bitwidth < shuffleBitwidth) {
-      packed = arith::BitcastOp::create(rewriter, loc, equivIntType, packed);
-      packed = arith::ExtUIOp::create(rewriter, loc, shuffleIntType, packed);
-    }
-    auto shuffle = gpu::ShuffleOp::create(rewriter, loc, packed, lastLane,
-                                          widthCst, gpu::ShuffleMode::IDX);
-    Value shuffled = shuffle.getShuffleResult();
-    if (bitwidth < shuffleBitwidth) {
-      shuffled = arith::TruncIOp::create(rewriter, loc, equivIntType, shuffled);
-      shuffled = arith::BitcastOp::create(rewriter, loc, elemTy, shuffled);
-    }
-    result = vector::InsertOp::create(rewriter, loc, shuffled, result, idx);
+/// Converts a linearized element number into vector indices in row-major order.
+static SmallVector<int64_t> getVectorElementIndices(VectorType vectorType,
+                                                    int64_t linearIndex) {
+  SmallVector<int64_t> indices;
+  indices.reserve(vectorType.getRank());
+  for (int64_t d = vectorType.getRank() - 1; d >= 0; --d) {
+    indices.push_back(linearIndex % vectorType.getDimSize(d));
+    linearIndex /= vectorType.getDimSize(d);
   }
-  return result;
+  std::reverse(indices.begin(), indices.end());
+  return indices;
 }
 
 struct DistributeBroadcast final : OpDistributionPattern<vector::BroadcastOp> {
@@ -1779,18 +1723,11 @@ private:
                           rewriter, loc, rewriter.getZeroAttr(outIdxType))
                           .getResult();
 
-    SmallVector<int64_t> outShape(outValType.getShape());
-    SmallVector<int64_t> outIndices(outValType.getRank(), 0);
     int64_t outNumElements = outValType.getNumElements();
 
     for (int64_t linearIdx = 0; linearIdx < outNumElements; ++linearIdx) {
-      int64_t tmp = linearIdx;
-      for (int64_t i = static_cast<int64_t>(outIndices.size()) - 1; i >= 0;
-           --i) {
-        int64_t extent = outShape[i];
-        outIndices[i] = tmp % extent;
-        tmp /= extent;
-      }
+      SmallVector<int64_t> outIndices =
+          getVectorElementIndices(outValType, linearIdx);
 
       Value accVal =
           vector::ExtractOp::create(rewriter, loc, initVal, outIndices);
@@ -2242,6 +2179,68 @@ private:
   int64_t maxBitsPerShuffle;
 };
 
+/// Broadcast every element of |source| from the last lane in a scan cluster
+/// to all lanes. The cluster is defined by |clusterSize| threads at
+/// |clusterStride| spacing within a subgroup of |subgroupSize| lanes.
+/// Handles pack/unpack for types narrower than 32 bits.
+static Value broadcastFromLastClusterLane(RewriterBase &rewriter, Location loc,
+                                          Value source, int64_t clusterSize,
+                                          int64_t clusterStride,
+                                          int64_t subgroupSize) {
+  auto vecTy = cast<VectorType>(source.getType());
+  Type elemTy = vecTy.getElementType();
+  unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
+  constexpr unsigned shuffleBitwidth = 32;
+  auto shuffleIntType = rewriter.getIntegerType(shuffleBitwidth);
+  auto equivIntType = rewriter.getIntegerType(bitwidth);
+
+  // Compute the lane ID of the last thread in the scan cluster:
+  //   lanePos = (laneId / clusterStride) % clusterSize
+  //   lastLane = laneId - lanePos * clusterStride
+  //              + (clusterSize - 1) * clusterStride
+  auto i32 = rewriter.getI32Type();
+  Value laneId = gpu::LaneIdOp::create(rewriter, loc, /*upper_bound=*/nullptr);
+  Value laneIdI32 = arith::IndexCastOp::create(rewriter, loc, i32, laneId);
+  Value strideCst = arith::ConstantOp::create(
+      rewriter, loc, i32, rewriter.getI32IntegerAttr(clusterStride));
+  Value sizeCst = arith::ConstantOp::create(
+      rewriter, loc, i32, rewriter.getI32IntegerAttr(clusterSize));
+  Value lanePos = arith::RemUIOp::create(
+      rewriter, loc,
+      arith::DivUIOp::create(rewriter, loc, laneIdI32, strideCst), sizeCst);
+  Value posTimesStride =
+      arith::MulIOp::create(rewriter, loc, lanePos, strideCst);
+  Value baseLane =
+      arith::SubIOp::create(rewriter, loc, laneIdI32, posTimesStride);
+  Value lastOffset = arith::ConstantOp::create(
+      rewriter, loc, i32,
+      rewriter.getI32IntegerAttr((clusterSize - 1) * clusterStride));
+  Value lastLane = arith::AddIOp::create(rewriter, loc, baseLane, lastOffset);
+  Value widthCst = arith::ConstantOp::create(
+      rewriter, loc, i32, rewriter.getI32IntegerAttr(subgroupSize));
+
+  // Shuffle each scalar element from the last lane.
+  Value result = source;
+  for (int64_t i = 0, n = vecTy.getNumElements(); i < n; ++i) {
+    SmallVector<int64_t> idx = getVectorElementIndices(vecTy, i);
+    Value scalar = vector::ExtractOp::create(rewriter, loc, source, idx);
+    Value packed = scalar;
+    if (bitwidth < shuffleBitwidth) {
+      packed = arith::BitcastOp::create(rewriter, loc, equivIntType, packed);
+      packed = arith::ExtUIOp::create(rewriter, loc, shuffleIntType, packed);
+    }
+    auto shuffle = gpu::ShuffleOp::create(rewriter, loc, packed, lastLane,
+                                          widthCst, gpu::ShuffleMode::IDX);
+    Value shuffled = shuffle.getShuffleResult();
+    if (bitwidth < shuffleBitwidth) {
+      shuffled = arith::TruncIOp::create(rewriter, loc, equivIntType, shuffled);
+      shuffled = arith::BitcastOp::create(rewriter, loc, elemTy, shuffled);
+    }
+    result = vector::InsertOp::create(rewriter, loc, shuffled, result, idx);
+  }
+  return result;
+}
+
 /// Helper to create a `iree_gpu.subgroup_scan` op for a scalar value, using
 /// `vector::CombiningKind` to build the combiner region.
 static std::pair<Value, Value>
@@ -2371,11 +2370,9 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
     }
 
     Type elemTy = source.getType().getElementType();
-    unsigned elemBitwidth = elemTy.getIntOrFloatBitWidth();
-    if (elemBitwidth > maxBitsPerShuffle) {
-      return rewriter.notifyMatchFailure(
-          scanOp, llvm::formatv("element bitwidth {0} > maxBitsPerShuffle {1}",
-                                elemBitwidth, maxBitsPerShuffle));
+    if (failed(checkBitwidthForShuffle(scanOp, elemTy, maxBitsPerShuffle,
+                                       "element", rewriter))) {
+      return failure();
     }
 
     // Reject multi-subgroup for now.
@@ -2474,14 +2471,7 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
         subgroupTotal = localTotal;
 
         for (int64_t i = 0, n = totalType.getNumElements(); i < n; ++i) {
-          SmallVector<int64_t> idx;
-          int64_t remaining = i;
-          for (int64_t d = totalType.getRank() - 1; d >= 0; --d) {
-            idx.push_back(remaining % totalType.getDimSize(d));
-            remaining /= totalType.getDimSize(d);
-          }
-          std::reverse(idx.begin(), idx.end());
-
+          SmallVector<int64_t> idx = getVectorElementIndices(totalType, i);
           Value scalar =
               vector::ExtractOp::create(rewriter, loc, localTotal, idx);
           auto [scanResult, scanTotal] =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -786,6 +787,94 @@ static VectorValue broadcastToShape(RewriterBase &rewriter, Value source,
   }
   return vector::TransposeOp::create(rewriter, source.getLoc(), broadcasted,
                                      inversePerm);
+}
+
+/// Re-inserts unit dimensions at the positions indicated by |projectedDims|
+/// via shape_cast, then broadcasts to |targetShape|.
+static Value broadcastFromProjected(RewriterBase &rewriter, Location loc,
+                                    Value source, ArrayRef<int64_t> targetShape,
+                                    ArrayRef<bool> projectedDims) {
+  SmallVector<int64_t> expandedShape(targetShape);
+  for (size_t i = 0; i < expandedShape.size(); ++i) {
+    if (projectedDims[i]) {
+      expandedShape[i] = 1;
+    }
+  }
+  Type elemTy = getElementTypeOrSelf(source.getType());
+  VectorType expandedType = VectorType::get(expandedShape, elemTy);
+  Value expanded =
+      vector::ShapeCastOp::create(rewriter, loc, expandedType, source);
+  VectorType targetType = VectorType::get(targetShape, elemTy);
+  return vector::BroadcastOp::create(rewriter, loc, targetType, expanded);
+}
+
+/// Broadcast every element of |source| from the last lane in a scan cluster
+/// to all lanes. The cluster is defined by |clusterSize| threads at
+/// |clusterStride| spacing within a subgroup of |subgroupSize| lanes.
+/// Handles pack/unpack for types narrower than 32 bits.
+static Value broadcastFromLastClusterLane(RewriterBase &rewriter, Location loc,
+                                          Value source, int64_t clusterSize,
+                                          int64_t clusterStride,
+                                          int64_t subgroupSize) {
+  auto vecTy = cast<VectorType>(source.getType());
+  Type elemTy = vecTy.getElementType();
+  unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
+  constexpr unsigned shuffleBitwidth = 32;
+  auto shuffleIntType = rewriter.getIntegerType(shuffleBitwidth);
+  auto equivIntType = rewriter.getIntegerType(bitwidth);
+
+  // Compute the lane ID of the last thread in the scan cluster:
+  //   lanePos = (laneId / clusterStride) % clusterSize
+  //   lastLane = laneId - lanePos * clusterStride
+  //              + (clusterSize - 1) * clusterStride
+  auto i32 = rewriter.getI32Type();
+  Value laneId = gpu::LaneIdOp::create(rewriter, loc, /*upper_bound=*/nullptr);
+  Value laneIdI32 = arith::IndexCastOp::create(rewriter, loc, i32, laneId);
+  Value strideCst = arith::ConstantOp::create(
+      rewriter, loc, i32, rewriter.getI32IntegerAttr(clusterStride));
+  Value sizeCst = arith::ConstantOp::create(
+      rewriter, loc, i32, rewriter.getI32IntegerAttr(clusterSize));
+  Value lanePos = arith::RemUIOp::create(
+      rewriter, loc,
+      arith::DivUIOp::create(rewriter, loc, laneIdI32, strideCst), sizeCst);
+  Value posTimesStride =
+      arith::MulIOp::create(rewriter, loc, lanePos, strideCst);
+  Value baseLane =
+      arith::SubIOp::create(rewriter, loc, laneIdI32, posTimesStride);
+  Value lastOffset = arith::ConstantOp::create(
+      rewriter, loc, i32,
+      rewriter.getI32IntegerAttr((clusterSize - 1) * clusterStride));
+  Value lastLane = arith::AddIOp::create(rewriter, loc, baseLane, lastOffset);
+  Value widthCst = arith::ConstantOp::create(
+      rewriter, loc, i32, rewriter.getI32IntegerAttr(subgroupSize));
+
+  // Shuffle each scalar element from the last lane.
+  Value result = source;
+  for (int64_t i = 0, n = vecTy.getNumElements(); i < n; ++i) {
+    SmallVector<int64_t> idx;
+    int64_t remaining = i;
+    for (int64_t d = vecTy.getRank() - 1; d >= 0; --d) {
+      idx.push_back(remaining % vecTy.getDimSize(d));
+      remaining /= vecTy.getDimSize(d);
+    }
+    std::reverse(idx.begin(), idx.end());
+
+    Value scalar = vector::ExtractOp::create(rewriter, loc, source, idx);
+    Value packed = scalar;
+    if (bitwidth < shuffleBitwidth) {
+      packed = arith::BitcastOp::create(rewriter, loc, equivIntType, packed);
+      packed = arith::ExtUIOp::create(rewriter, loc, shuffleIntType, packed);
+    }
+    auto shuffle = gpu::ShuffleOp::create(rewriter, loc, packed, lastLane,
+                                          widthCst, gpu::ShuffleMode::IDX);
+    Value shuffled = shuffle.getShuffleResult();
+    if (bitwidth < shuffleBitwidth) {
+      shuffled = arith::TruncIOp::create(rewriter, loc, equivIntType, shuffled);
+      shuffled = arith::BitcastOp::create(rewriter, loc, elemTy, shuffled);
+    }
+    result = vector::InsertOp::create(rewriter, loc, shuffled, result, idx);
+  }
+  return result;
 }
 
 struct DistributeBroadcast final : OpDistributionPattern<vector::BroadcastOp> {
@@ -2153,6 +2242,349 @@ private:
   int64_t maxBitsPerShuffle;
 };
 
+/// Helper to create a `iree_gpu.subgroup_scan` op for a scalar value, using
+/// `vector::CombiningKind` to build the combiner region.
+static std::pair<Value, Value>
+createSubgroupScan(PatternRewriter &rewriter, Location loc, Value value,
+                   Value identity, vector::CombiningKind kind,
+                   int64_t clusterSize, int64_t clusterStride) {
+  auto scanOp = IREE::GPU::SubgroupScanOp::create(
+      rewriter, loc, value.getType(), value.getType(), value, identity,
+      rewriter.getI32IntegerAttr(clusterSize),
+      rewriter.getI32IntegerAttr(clusterStride));
+
+  // Build combiner region.
+  Block &block = scanOp.getCombiner().emplaceBlock();
+  block.addArguments({value.getType(), value.getType()}, {loc, loc});
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(&block);
+    Value combined = vector::makeArithReduction(
+        rewriter, loc, kind, block.getArgument(0), block.getArgument(1));
+    IREE::GPU::YieldOp::create(rewriter, loc, combined);
+  }
+
+  return {scanOp.getResult(), scanOp.getTotal()};
+}
+
+/// Distributes `vector.scan` across GPU threads.
+///
+/// The lowering proceeds in two stages:
+///   1. Thread-local scan: Each thread performs `vector.scan` on its local
+///      element tile chunks.
+///   2. Cross-thread scan: Thread chunk totals are scanned across threads
+///      within the subgroup using `iree_gpu.subgroup_scan`.
+///
+/// Cross-subgroup distribution (stages 3-4) is deferred — this pattern
+/// rejects `subgroupTile[scanDim] > 1`.
+///
+/// To distribute and parallelize the scan computation, we use an approach by
+/// Blelloch. The general idea is that we can break the computation into N
+/// blocks and then break the computation into multiple steps:
+/// 1. Local scan over the block and computation of the block total (e.g., sum
+/// of all elements).
+/// 2. Scan over all the block totals, resulting in N scan results.
+/// 3. Update all local elements of block n with the nth scan result.
+///
+/// In our case, we apply this principle repeatedly. We have multiple levels
+/// that break our computation into blocks. The first level is the thread-level,
+/// where each thread holds a number of elements. The next level is the
+/// subgroup. After that, we have to iterate over the batch and outer tile
+/// sizes. Together, this yields the intra-subgroup scan result. The
+/// thread-level is our local scan and for the subgroup and batch/outer level,
+/// we apply steps 2 and 3 from the approach.
+///
+/// This yields the following algorithm:
+/// ```
+/// source = input
+/// result = identity
+/// batchOuterRunning = identity
+/// for b in 0..batch_size[scan_dim]:
+///   for o in 0..outer_size[scan_dim]:
+///     // Extract the current local chunk
+///     srcChunk = source[b, o]
+///     // Perform thread-local scan
+///     localScan, localTotal = vector.scan(srcChunk)
+///     // Adjust local total value for exclusive case
+///     if exclusive:
+///       localTotal = combine(localTotal, srcChunk[-1])
+///
+///     if thread_tile[scan_dim] > 1:
+///       // Compute the scan over each thread's total value within the subgroup
+///       subgroupScan, subgroupTotal = subgroup_scan(localTotal)
+///     else:
+///       subgroupScan = identity
+///       subgroupTotal = localTotal
+///
+///     // Combine the two increments we need to add to this local block.
+///     increment = combine(subgroupScan, batchOuterRunning)
+///     // Broadcast the increment to the local block shape
+///     blockIncrement = broadcast(increment)
+///     localResult = combine(localScan, blockIncrement)
+///
+///     // Update the iteratively computed scan for batch/outer
+///     batchOuterRunning = combine(batchOuterRunning, subgroupTotal)
+///
+///     // Insert result
+///     result[b, o] = localResult
+///
+/// // Scan also returns the total value of all elements as a second result.
+/// // For inclusive mode, this is simply batchOuterRunning
+///
+/// // For exclusive mode, we need to add the increment and shuffle the result
+/// // from the last thread in order for each thread to have the total value
+/// // of all elements.
+/// ```
+///
+/// To compute the scan over the block totals at the subgroup level, we simply
+/// use subgroup_reduce. For the loop over the batch/outer dimensions, we can
+/// compute the scan iteratively. The loops over batch/outer do not manifest in
+/// IR, they only exist in codegen and are unrolled in IR.
+///
+/// The pattern does not yet support distribution across multiple subgroups in a
+/// workgroup, that will be added later.
+struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
+  DistributeScan(MLIRContext *context, int64_t subgroupSize,
+                 int64_t maxBitsPerShuffle, int64_t benefit = 1)
+      : OpDistributionPattern(context, benefit), subgroupSize(subgroupSize),
+        maxBitsPerShuffle(maxBitsPerShuffle) {}
+
+  LogicalResult matchAndRewrite(vector::ScanOp scanOp,
+                                DistributionSignature &sig,
+                                PatternRewriter &rewriter) const override {
+    Location loc = scanOp.getLoc();
+    VectorValue source = scanOp.getSource();
+    VectorValue init = scanOp.getInitialValue();
+    vector::CombiningKind kind = scanOp.getKind();
+    int64_t scanDim = scanOp.getReductionDim();
+    bool inclusive = scanOp.getInclusive();
+    int64_t rank = source.getType().getRank();
+
+    auto srcLayout = dyn_cast_if_present<NestedLayoutAttr>(sig[source]);
+    if (!srcLayout) {
+      return rewriter.notifyMatchFailure(scanOp, "expected nested layout attr");
+    }
+    auto initLayout = dyn_cast_if_present<NestedLayoutAttr>(sig[init]);
+    if (!initLayout) {
+      return rewriter.notifyMatchFailure(scanOp,
+                                         "expected nested layout for init");
+    }
+
+    Type elemTy = source.getType().getElementType();
+    unsigned elemBitwidth = elemTy.getIntOrFloatBitWidth();
+    if (elemBitwidth > maxBitsPerShuffle) {
+      return rewriter.notifyMatchFailure(
+          scanOp, llvm::formatv("element bitwidth {0} > maxBitsPerShuffle {1}",
+                                elemBitwidth, maxBitsPerShuffle));
+    }
+
+    // Reject multi-subgroup for now.
+    // TODO: Support distribution across workgroups.
+    if (srcLayout.getSubgroupTile()[scanDim] > 1) {
+      return rewriter.notifyMatchFailure(
+          scanOp, "multi-subgroup scan not yet supported");
+    }
+
+    // Get distributed operands.
+    VectorValue disSrc = getDistributed(rewriter, source, sig[source]);
+    VectorValue disInit = getDistributed(rewriter, init, sig[init]);
+
+    // Layout tile sizes along scan dimension.
+    int64_t batchSize = srcLayout.getBatchTile()[scanDim];
+    int64_t outerSize = srcLayout.getOuterTile()[scanDim];
+    int64_t threadSize = srcLayout.getThreadTile()[scanDim];
+    int64_t elementSize = srcLayout.getElementTile()[scanDim];
+
+    // Distributed shape is [B0..Bn, O0..On, E0..En].
+    SmallVector<int64_t> distShape = srcLayout.getDistributedShape();
+    int64_t batchIdx = scanDim;           // batch position
+    int64_t outerIdx = rank + scanDim;    // outer position
+    int64_t elemIdx = 2 * rank + scanDim; // element position
+
+    // Build identity value.
+    Value scalarIdentity =
+        getCombiningIdentityValue(loc, rewriter, kind, elemTy);
+
+    // Build the element-chunk shape for local scan:
+    // Same as distShape but with scan-dim batch and outer set to 1.
+    SmallVector<int64_t> chunkShape(distShape);
+    chunkShape[batchIdx] = 1;
+    chunkShape[outerIdx] = 1;
+    // The init for the local vector.scan is the identity broadcast to the
+    // accumulated shape (chunkShape with scan-dim element removed).
+    SmallVector<int64_t> localAccShape(chunkShape);
+    localAccShape.erase(localAccShape.begin() + elemIdx);
+    VectorType localAccType = VectorType::get(localAccShape, elemTy);
+    Value localIdentityInit =
+        getCombiningIdentityValue(loc, rewriter, kind, localAccType);
+
+    // Initialize result vector.
+    VectorType distType = disSrc.getType();
+    Value result = getCombiningIdentityValue(loc, rewriter, kind, distType);
+
+    // Initialize subgroupRunning to identity with localAccType shape.
+    // This matches the accumulated_value shape from the local scan, which
+    // has the scan-dim element removed from chunkShape.
+    VectorType initDistType = disInit.getType();
+    Value batchOuterRunning =
+        getCombiningIdentityValue(loc, rewriter, kind, localAccType);
+
+    SmallVector<int64_t> strides(distShape.size(), 1);
+
+    // Iterate over (batch, outer) chunk positions along the scan dimension.
+    // Non-scan dimensions have chunkShape == distShape so their offsets are
+    // always 0; the scan-dim batch and outer positions vary.
+    for (SmallVector<int64_t> offsets :
+         StaticTileOffsetRange(distShape, chunkShape)) {
+      Value srcChunk = vector::ExtractStridedSliceOp::create(
+          rewriter, loc, disSrc, offsets, chunkShape, strides);
+
+      // Stage 1: local scan over element tile with identity init.
+      // Using identity (not user init) keeps chunkTotal pure for stage 2.
+      // The user init is applied once at the end for exclusive mode.
+      auto localScanOp = vector::ScanOp::create(
+          rewriter, loc, kind, srcChunk, localIdentityInit, elemIdx, inclusive);
+      Value localScan = localScanOp.getDest();
+      Value localTotal = localScanOp.getAccumulatedValue();
+
+      // For exclusive scan, accumulated_value is the last dest element
+      // which misses the last source element. Combine it in to get the
+      // full chunk reduction needed for stage 2 and carry advancement.
+      if (!inclusive) {
+        SmallVector<int64_t> lastOff(distShape.size(), 0);
+        lastOff[elemIdx] = elementSize - 1;
+        SmallVector<int64_t> lastSz(chunkShape);
+        lastSz[elemIdx] = 1;
+        SmallVector<int64_t> unitStrides(distShape.size(), 1);
+        Value lastElem = vector::ExtractStridedSliceOp::create(
+            rewriter, loc, srcChunk, lastOff, lastSz, unitStrides);
+        Value lastElemFlat = vector::ShapeCastOp::create(
+            rewriter, loc, cast<VectorType>(localTotal.getType()), lastElem);
+        localTotal = vector::makeArithReduction(rewriter, loc, kind, localTotal,
+                                                lastElemFlat);
+      }
+
+      // Stage 2: cross-thread scan (if threadTile[scanDim] > 1).
+      Value subgroupScan, subgroupTotal;
+      if (threadSize > 1) {
+        int64_t clusterStride = srcLayout.getThreadStrides()[scanDim];
+        auto totalType = cast<VectorType>(localTotal.getType());
+
+        subgroupScan = localTotal;
+        subgroupTotal = localTotal;
+
+        for (int64_t i = 0, n = totalType.getNumElements(); i < n; ++i) {
+          SmallVector<int64_t> idx;
+          int64_t remaining = i;
+          for (int64_t d = totalType.getRank() - 1; d >= 0; --d) {
+            idx.push_back(remaining % totalType.getDimSize(d));
+            remaining /= totalType.getDimSize(d);
+          }
+          std::reverse(idx.begin(), idx.end());
+
+          Value scalar =
+              vector::ExtractOp::create(rewriter, loc, localTotal, idx);
+          auto [scanResult, scanTotal] =
+              createSubgroupScan(rewriter, loc, scalar, scalarIdentity, kind,
+                                 threadSize, clusterStride);
+          subgroupScan = vector::InsertOp::create(rewriter, loc, scanResult,
+                                                  subgroupScan, idx);
+          subgroupTotal = vector::InsertOp::create(rewriter, loc, scanTotal,
+                                                   subgroupTotal, idx);
+        }
+      } else {
+        subgroupScan = getCombiningIdentityValue(
+            loc, rewriter, kind, cast<VectorType>(localTotal.getType()));
+        subgroupTotal = localTotal;
+      }
+
+      // Carry composition: chunkBase = combine(subgroupRunning, threadIncr).
+      Value blockIncrement = vector::makeArithReduction(
+          rewriter, loc, kind, batchOuterRunning, subgroupScan);
+
+      // Apply carry to local scan result.
+      SmallVector<bool> elemDimMask(chunkShape.size(), false);
+      elemDimMask[elemIdx] = true;
+      Value broadcasted = broadcastFromProjected(rewriter, loc, blockIncrement,
+                                                 chunkShape, elemDimMask);
+      Value localResult = vector::makeArithReduction(rewriter, loc, kind,
+                                                     broadcasted, localScan);
+
+      // Insert partial back into result at (b, o).
+      result = vector::InsertStridedSliceOp::create(rewriter, loc, localResult,
+                                                    result, offsets, strides);
+
+      // Advance running total.
+      batchOuterRunning = vector::makeArithReduction(
+          rewriter, loc, kind, batchOuterRunning, subgroupTotal);
+    }
+
+    // For the inclusive case we're done.
+    if (inclusive) {
+      Value accumulatedValue = vector::ShapeCastOp::create(
+          rewriter, loc, initDistType, batchOuterRunning);
+      replaceOpWithDistributedValues(
+          rewriter, scanOp,
+          {cast<VectorValue>(result), cast<VectorValue>(accumulatedValue)});
+      return success();
+    }
+
+    // For the exclusive case, we need to make two adjustments: In exclusive
+    // mode, the user provides an init operand to the operation. So far, we have
+    // initialized all scans with identity, so we haven't added the provided
+    // init yet. Therefore, we need to add/combine the init to the result we
+    // have computed so far.
+    // This also implies that our running accumulation does not include that
+    // init value yet. Only the last thread in the cluster has access to the
+    // init operand for the last element, so after we have updated the result,
+    // we need to broadcast the result of the last element from the last lane to
+    // all other lanes using a shuffle.
+
+    // Apply user init for exclusive mode.
+    SmallVector<bool> scanDimMask(distShape.size(), false);
+    scanDimMask[batchIdx] = true;
+    scanDimMask[outerIdx] = true;
+    scanDimMask[elemIdx] = true;
+    Value broadcastedInit =
+        broadcastFromProjected(rewriter, loc, disInit, distShape, scanDimMask);
+    result = vector::makeArithReduction(rewriter, loc, kind, broadcastedInit,
+                                        result);
+
+    Value accumulatedValue;
+    // Extract the last element along the scan dimension.
+    SmallVector<int64_t> lastOffsets(distShape.size(), 0);
+    SmallVector<int64_t> lastSizes(distShape);
+    lastOffsets[batchIdx] = batchSize - 1;
+    lastOffsets[outerIdx] = outerSize - 1;
+    lastOffsets[elemIdx] = elementSize - 1;
+    lastSizes[batchIdx] = 1;
+    lastSizes[outerIdx] = 1;
+    lastSizes[elemIdx] = 1;
+    SmallVector<int64_t> extractStrides(distShape.size(), 1);
+    Value lastSlice = vector::ExtractStridedSliceOp::create(
+        rewriter, loc, result, lastOffsets, lastSizes, extractStrides);
+    Value perThreadAccum =
+        vector::ShapeCastOp::create(rewriter, loc, initDistType, lastSlice);
+
+    if (threadSize > 1) {
+      int64_t clusterStride = srcLayout.getThreadStrides()[scanDim];
+      accumulatedValue =
+          broadcastFromLastClusterLane(rewriter, loc, perThreadAccum,
+                                       threadSize, clusterStride, subgroupSize);
+    } else {
+      accumulatedValue = perThreadAccum;
+    }
+
+    replaceOpWithDistributedValues(
+        rewriter, scanOp,
+        {cast<VectorValue>(result), cast<VectorValue>(accumulatedValue)});
+    return success();
+  }
+
+  int64_t subgroupSize;
+  int64_t maxBitsPerShuffle;
+};
+
 /// The distribution of contract is performed by doing a local contraction where
 /// each thread performs operations on its locally distributed elements. Then,
 /// the resulting vector is interpreted in undistributed domain. The said
@@ -2998,6 +3430,8 @@ void IREE::VectorExt::populateNestedLayoutDistributionPatterns(
                                          maxBitsPerShuffle);
   patterns.add<DistributeArgCompare>(patterns.getContext(), subgroupSize,
                                      maxBitsPerShuffle);
+  patterns.add<DistributeScan>(patterns.getContext(), subgroupSize,
+                               maxBitsPerShuffle);
   patterns.add<DistributeContract>(patterns.getContext());
   patterns.add<DistributeBatchOuterToLayoutConversions>(patterns.getContext());
   patterns.add<DistributeInnerTiled>(patterns.getContext());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -2249,7 +2249,7 @@ createSubgroupScan(PatternRewriter &rewriter, Location loc, Value value,
                    int64_t clusterSize, int64_t clusterStride) {
   auto scanOp = IREE::GPU::SubgroupScanOp::create(
       rewriter, loc, value.getType(), value.getType(), value, identity,
-      rewriter.getI32IntegerAttr(clusterSize),
+      /*inclusive=*/nullptr, rewriter.getI32IntegerAttr(clusterSize),
       rewriter.getI32IntegerAttr(clusterStride));
 
   // Build combiner region.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -52,6 +52,7 @@ iree_lit_test_suite(
             "gpu_nested_layout_vector_distribution_inner_tiled.mlir",
             "gpu_nested_layout_vector_distribution_mask.mlir",
             "gpu_nested_layout_vector_distribution_multi_reduce.mlir",
+            "gpu_nested_layout_vector_distribution_scan.mlir",
             "gpu_nested_layout_vector_distribution_step.mlir",
             "gpu_pack_partial_reductions.mlir",
             "gpu_pack_to_intrinsics.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -47,6 +47,7 @@ iree_lit_test_suite(
     "gpu_nested_layout_vector_distribution_inner_tiled.mlir"
     "gpu_nested_layout_vector_distribution_mask.mlir"
     "gpu_nested_layout_vector_distribution_multi_reduce.mlir"
+    "gpu_nested_layout_vector_distribution_scan.mlir"
     "gpu_nested_layout_vector_distribution_step.mlir"
     "gpu_pack_partial_reductions.mlir"
     "gpu_pack_to_intrinsics.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_scan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_scan.mlir
@@ -1,0 +1,262 @@
+// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize --cse %s | FileCheck %s
+
+// Test 1: Single (b,o) inclusive scan.
+// Layout: subgroup=1, batch=1, outer=1, thread=4, element=4 along scan dim.
+// Full vector is 16 elements along scan dim (1*1*1*4*4).
+
+#layout_scan_1d = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [1],
+  outer_tile    = [1],
+  thread_tile   = [4],
+  element_tile  = [4],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+// CHECK-LABEL: @scan_single_bo_inclusive
+func.func @scan_single_bo_inclusive(%src: vector<16xf32>, %init: vector<f32>) -> (vector<16xf32>, vector<f32>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_1d) : vector<16xf32>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = true, reduction_dim = 0 : i64}
+    : vector<16xf32>, vector<f32>
+  return %out#0, %out#1 : vector<16xf32>, vector<f32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
+// CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16xf32> -> vector<1x1x4xf32>
+// Local inclusive scan with identity init.
+// CHECK: %[[LOCAL_SCAN:.*]], %[[LOCAL_TOTAL:.*]] = vector.scan <add>, %[[SRC_DIST]], %[[ID_VEC]] {inclusive = true, reduction_dim = 2 : i64} : vector<1x1x4xf32>, vector<1x1xf32>
+// Subgroup scan of localTotal.
+// CHECK: %[[SCALAR_TOTAL:.*]] = vector.extract %[[LOCAL_TOTAL]][0, 0] : f32 from vector<1x1xf32>
+// CHECK: %[[SUBGROUP_SCAN:.*]], %[[SUBGROUP_TOTAL:.*]] = iree_gpu.subgroup_scan(%[[SCALAR_TOTAL]], {{.*}}) cluster(size = 4)
+// Broadcast both subgroup scan results.
+// CHECK-DAG: %[[SCAN_VEC:.*]] = vector.broadcast %[[SUBGROUP_SCAN]] : f32 to vector<1x1xf32>
+// CHECK-DAG: %[[TOTAL_VEC:.*]] = vector.broadcast %[[SUBGROUP_TOTAL]] : f32 to vector<1x1xf32>
+// blockIncrement = combine(subgroupScan, batchOuterRunning), apply to localScan.
+// CHECK: %[[BLOCK_INCR:.*]] = arith.addf %[[SCAN_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR]] : vector<1x1xf32> to vector<1x1x4xf32>
+// CHECK: %[[RESULT:.*]] = arith.addf %[[BLOCK_INCR_BCAST]], %[[LOCAL_SCAN]] : vector<1x1x4xf32>
+// Accumulated value = batchOuterRunning (uniform), shape_cast to init shape.
+// CHECK: %[[BO_RUNNING:.*]] = arith.addf %[[TOTAL_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// CHECK: %[[ACC:.*]] = vector.shape_cast %[[BO_RUNNING]] : vector<1x1xf32> to vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[ACC]] : vector<f32> -> vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[RESULT]] : vector<1x1x4xf32> -> vector<16xf32>
+
+// -----
+
+// Test 2: Single (b,o) exclusive scan.
+
+#layout_scan_1d_excl = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [1],
+  outer_tile    = [1],
+  thread_tile   = [4],
+  element_tile  = [4],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+// CHECK-LABEL: @scan_single_bo_exclusive
+func.func @scan_single_bo_exclusive(%src: vector<16xf32>, %init: vector<f32>) -> (vector<16xf32>, vector<f32>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_1d_excl) : vector<16xf32>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = false, reduction_dim = 0 : i64}
+    : vector<16xf32>, vector<f32>
+  return %out#0, %out#1 : vector<16xf32>, vector<f32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
+// CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16xf32> -> vector<1x1x4xf32>
+// CHECK-DAG: %[[INIT_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<f32> -> vector<f32>
+// Local exclusive scan with identity init.
+// CHECK: %[[LOCAL_SCAN:.*]], %[[ACC_VAL:.*]] = vector.scan <add>, %[[SRC_DIST]], %[[ID_VEC]] {inclusive = false, reduction_dim = 2 : i64}
+// Fix up localTotal: combine accumulated_value with last source element.
+// CHECK: %[[LAST_ELEM:.*]] = vector.extract_strided_slice %[[SRC_DIST]] {offsets = [0, 0, 3], sizes = [1, 1, 1], strides = [1, 1, 1]}
+// CHECK: %[[LAST_FLAT:.*]] = vector.shape_cast %[[LAST_ELEM]] : vector<1x1x1xf32> to vector<1x1xf32>
+// CHECK: %[[LOCAL_TOTAL:.*]] = arith.addf %[[ACC_VAL]], %[[LAST_FLAT]] : vector<1x1xf32>
+// Subgroup scan of fixed-up localTotal.
+// CHECK: %[[SCALAR_TOTAL:.*]] = vector.extract %[[LOCAL_TOTAL]][0, 0] : f32 from vector<1x1xf32>
+// CHECK: %[[SUBGROUP_SCAN:.*]], %{{.*}} = iree_gpu.subgroup_scan(%[[SCALAR_TOTAL]], {{.*}}) cluster(size = 4)
+// blockIncrement = combine(subgroupScan, batchOuterRunning), apply to localScan.
+// CHECK: %[[SCAN_VEC:.*]] = vector.broadcast %[[SUBGROUP_SCAN]] : f32 to vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR:.*]] = arith.addf %[[SCAN_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR]] : vector<1x1xf32> to vector<1x1x4xf32>
+// CHECK: %[[LOCAL_RESULT:.*]] = arith.addf %[[BLOCK_INCR_BCAST]], %[[LOCAL_SCAN]] : vector<1x1x4xf32>
+// Application of user init via broadcast + combine.
+// CHECK: %[[INIT_BCAST:.*]] = vector.broadcast %[[INIT_DIST]] : vector<f32> to vector<1x1x4xf32>
+// CHECK: %[[RESULT:.*]] = arith.addf %[[INIT_BCAST]], %[[LOCAL_RESULT]] : vector<1x1x4xf32>
+// Accumulated value: extract last element from result, broadcast from last thread.
+// CHECK: %[[LAST_ACC:.*]] = vector.extract %[[RESULT]][0, 0, 3] : f32 from vector<1x1x4xf32>
+// CHECK: %[[SHUFFLED:.*]], %{{.*}} = gpu.shuffle idx %[[LAST_ACC]], %{{.*}}, %{{.*}} : f32
+// CHECK: %[[ACC_BCAST:.*]] = vector.broadcast %[[SHUFFLED]] : f32 to vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[ACC_BCAST]] : vector<f32> -> vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[RESULT]] : vector<1x1x4xf32> -> vector<16xf32>
+
+// -----
+
+// Test 3: Multi (b,o) inclusive scan.
+// Layout: batch=2 along scan dim -> two (b,o) iterations.
+
+#layout_scan_multi = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [2],
+  outer_tile    = [1],
+  thread_tile   = [4],
+  element_tile  = [4],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+// CHECK-LABEL: @scan_multi_bo_inclusive
+func.func @scan_multi_bo_inclusive(%src: vector<32xf32>, %init: vector<f32>) -> (vector<32xf32>, vector<f32>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_multi) : vector<32xf32>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = true, reduction_dim = 0 : i64}
+    : vector<32xf32>, vector<f32>
+  return %out#0, %out#1 : vector<32xf32>, vector<f32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
+// CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<32xf32> -> vector<2x1x4xf32>
+// First (b=0): extract srcChunk, local scan, subgroup scan.
+// CHECK: %[[CHUNK0:.*]] = vector.extract %[[SRC_DIST]][0, 0] : vector<4xf32> from vector<2x1x4xf32>
+// CHECK: %[[CHUNK0_RS:.*]] = vector.shape_cast %[[CHUNK0]] : vector<4xf32> to vector<1x1x4xf32>
+// CHECK: %[[SCAN0:.*]], %[[TOTAL0:.*]] = vector.scan <add>, %[[CHUNK0_RS]], %[[ID_VEC]] {inclusive = true, reduction_dim = 2 : i64} : vector<1x1x4xf32>, vector<1x1xf32>
+// CHECK: %[[SCALAR0:.*]] = vector.extract %[[TOTAL0]][0, 0] : f32 from vector<1x1xf32>
+// CHECK: %[[SG_SCAN0:.*]], %[[SG_TOTAL0:.*]] = iree_gpu.subgroup_scan(%[[SCALAR0]], {{.*}}) cluster(size = 4)
+// Broadcast both subgroup scan results.
+// CHECK-DAG: %[[SG_SCAN0_VEC:.*]] = vector.broadcast %[[SG_SCAN0]] : f32 to vector<1x1xf32>
+// CHECK-DAG: %[[SG_TOTAL0_VEC:.*]] = vector.broadcast %[[SG_TOTAL0]] : f32 to vector<1x1xf32>
+// blockIncrement = combine(subgroupScan, batchOuterRunning), apply to localScan.
+// CHECK: %[[BLOCK_INCR0:.*]] = arith.addf %[[SG_SCAN0_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR0_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR0]] : vector<1x1xf32> to vector<1x1x4xf32>
+// CHECK: %[[LOCAL_RESULT0:.*]] = arith.addf %[[BLOCK_INCR0_BCAST]], %[[SCAN0]] : vector<1x1x4xf32>
+// CHECK: %[[RES0:.*]] = vector.insert_strided_slice %[[LOCAL_RESULT0]], %{{.*}} {offsets = [0, 0, 0], strides = [1, 1, 1]}
+// Advance batchOuterRunning.
+// CHECK: %[[BO_RUNNING1:.*]] = arith.addf %[[SG_TOTAL0_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// Second (b=1): extract srcChunk, local scan, subgroup scan.
+// CHECK: %[[CHUNK1:.*]] = vector.extract %[[SRC_DIST]][1, 0] : vector<4xf32> from vector<2x1x4xf32>
+// CHECK: %[[CHUNK1_RS:.*]] = vector.shape_cast %[[CHUNK1]] : vector<4xf32> to vector<1x1x4xf32>
+// CHECK: %[[SCAN1:.*]], %[[TOTAL1:.*]] = vector.scan <add>, %[[CHUNK1_RS]], %[[ID_VEC]] {inclusive = true, reduction_dim = 2 : i64} : vector<1x1x4xf32>, vector<1x1xf32>
+// CHECK: %[[SCALAR1:.*]] = vector.extract %[[TOTAL1]][0, 0] : f32 from vector<1x1xf32>
+// CHECK: %[[SG_SCAN1:.*]], %[[SG_TOTAL1:.*]] = iree_gpu.subgroup_scan(%[[SCALAR1]], {{.*}}) cluster(size = 4)
+// Broadcast both subgroup scan results.
+// CHECK-DAG: %[[SG_SCAN1_VEC:.*]] = vector.broadcast %[[SG_SCAN1]] : f32 to vector<1x1xf32>
+// CHECK-DAG: %[[SG_TOTAL1_VEC:.*]] = vector.broadcast %[[SG_TOTAL1]] : f32 to vector<1x1xf32>
+// blockIncrement = combine(subgroupScan, batchOuterRunning), apply to localScan.
+// CHECK: %[[BLOCK_INCR1:.*]] = arith.addf %[[BO_RUNNING1]], %[[SG_SCAN1_VEC]] : vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR1_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR1]] : vector<1x1xf32> to vector<1x1x4xf32>
+// CHECK: %[[LOCAL_RESULT1:.*]] = arith.addf %[[BLOCK_INCR1_BCAST]], %[[SCAN1]] : vector<1x1x4xf32>
+// CHECK: %[[RESULT:.*]] = vector.insert_strided_slice %[[LOCAL_RESULT1]], %[[RES0]] {offsets = [1, 0, 0], strides = [1, 1, 1]}
+// Accumulated value = final batchOuterRunning.
+// CHECK: %[[FINAL_BO_RUNNING:.*]] = arith.addf %[[BO_RUNNING1]], %[[SG_TOTAL1_VEC]] : vector<1x1xf32>
+// CHECK: %[[ACC:.*]] = vector.shape_cast %[[FINAL_BO_RUNNING]] : vector<1x1xf32> to vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[ACC]] : vector<f32> -> vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[RESULT]] : vector<2x1x4xf32> -> vector<32xf32>
+
+// -----
+
+// Test 4: Multi (b,o) exclusive scan.
+
+#layout_scan_multi_excl = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [2],
+  outer_tile    = [1],
+  thread_tile   = [4],
+  element_tile  = [4],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+// CHECK-LABEL: @scan_multi_bo_exclusive
+func.func @scan_multi_bo_exclusive(%src: vector<32xf32>, %init: vector<f32>) -> (vector<32xf32>, vector<f32>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_multi_excl) : vector<32xf32>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = false, reduction_dim = 0 : i64}
+    : vector<32xf32>, vector<f32>
+  return %out#0, %out#1 : vector<32xf32>, vector<f32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
+// CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<32xf32> -> vector<2x1x4xf32>
+// CHECK-DAG: %[[INIT_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<f32> -> vector<f32>
+// First (b=0): extract srcChunk, local exclusive scan.
+// CHECK: %[[CHUNK0:.*]] = vector.extract %[[SRC_DIST]][0, 0] : vector<4xf32> from vector<2x1x4xf32>
+// CHECK: %[[CHUNK0_RS:.*]] = vector.shape_cast %[[CHUNK0]] : vector<4xf32> to vector<1x1x4xf32>
+// CHECK: %[[SCAN0:.*]], %[[ACC0:.*]] = vector.scan <add>, %[[CHUNK0_RS]], %[[ID_VEC]] {inclusive = false, reduction_dim = 2 : i64}
+// Fix up localTotal: combine accumulated_value with last source element.
+// CHECK: %[[LAST0:.*]] = vector.extract_strided_slice %[[CHUNK0_RS]] {offsets = [0, 0, 3], sizes = [1, 1, 1], strides = [1, 1, 1]}
+// CHECK: %[[LAST0_FLAT:.*]] = vector.shape_cast %[[LAST0]] : vector<1x1x1xf32> to vector<1x1xf32>
+// CHECK: %[[LOCAL_TOTAL0:.*]] = arith.addf %[[ACC0]], %[[LAST0_FLAT]] : vector<1x1xf32>
+// Subgroup scan.
+// CHECK: %[[SCALAR0:.*]] = vector.extract %[[LOCAL_TOTAL0]][0, 0] : f32 from vector<1x1xf32>
+// CHECK: %[[SG_SCAN0:.*]], %[[SG_TOTAL0:.*]] = iree_gpu.subgroup_scan(%[[SCALAR0]], {{.*}}) cluster(size = 4)
+// Broadcast both subgroup scan results.
+// CHECK-DAG: %[[SG_SCAN0_VEC:.*]] = vector.broadcast %[[SG_SCAN0]] : f32 to vector<1x1xf32>
+// CHECK-DAG: %[[SG_TOTAL0_VEC:.*]] = vector.broadcast %[[SG_TOTAL0]] : f32 to vector<1x1xf32>
+// blockIncrement = combine(subgroupScan, batchOuterRunning), apply to localScan.
+// CHECK: %[[BLOCK_INCR0:.*]] = arith.addf %[[SG_SCAN0_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR0_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR0]] : vector<1x1xf32> to vector<1x1x4xf32>
+// CHECK: %[[LOCAL_RESULT0:.*]] = arith.addf %[[BLOCK_INCR0_BCAST]], %[[SCAN0]] : vector<1x1x4xf32>
+// CHECK: %[[RES0:.*]] = vector.insert_strided_slice %[[LOCAL_RESULT0]], %{{.*}} {offsets = [0, 0, 0], strides = [1, 1, 1]}
+// Advance batchOuterRunning.
+// CHECK: %[[BO_RUNNING1:.*]] = arith.addf %[[SG_TOTAL0_VEC]], %[[ID_VEC]] : vector<1x1xf32>
+// Second (b=1): extract srcChunk, local exclusive scan.
+// CHECK: %[[CHUNK1:.*]] = vector.extract %[[SRC_DIST]][1, 0] : vector<4xf32> from vector<2x1x4xf32>
+// CHECK: %[[CHUNK1_RS:.*]] = vector.shape_cast %[[CHUNK1]] : vector<4xf32> to vector<1x1x4xf32>
+// CHECK: %[[SCAN1:.*]], %[[ACC1:.*]] = vector.scan <add>, %[[CHUNK1_RS]], %[[ID_VEC]] {inclusive = false, reduction_dim = 2 : i64}
+// Fix up localTotal for second chunk.
+// CHECK: %[[LAST1:.*]] = vector.extract_strided_slice %[[CHUNK1_RS]] {offsets = [0, 0, 3], sizes = [1, 1, 1], strides = [1, 1, 1]}
+// CHECK: %[[LAST1_FLAT:.*]] = vector.shape_cast %[[LAST1]] : vector<1x1x1xf32> to vector<1x1xf32>
+// CHECK: %[[LOCAL_TOTAL1:.*]] = arith.addf %[[ACC1]], %[[LAST1_FLAT]] : vector<1x1xf32>
+// Subgroup scan.
+// CHECK: %[[SCALAR1:.*]] = vector.extract %[[LOCAL_TOTAL1]][0, 0] : f32 from vector<1x1xf32>
+// CHECK: %[[SG_SCAN1:.*]], %{{.*}} = iree_gpu.subgroup_scan(%[[SCALAR1]], {{.*}}) cluster(size = 4)
+// blockIncrement = combine(subgroupScan, batchOuterRunning), apply to localScan.
+// CHECK: %[[SG_SCAN1_VEC:.*]] = vector.broadcast %[[SG_SCAN1]] : f32 to vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR1:.*]] = arith.addf %[[BO_RUNNING1]], %[[SG_SCAN1_VEC]] : vector<1x1xf32>
+// CHECK: %[[BLOCK_INCR1_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR1]] : vector<1x1xf32> to vector<1x1x4xf32>
+// CHECK: %[[LOCAL_RESULT1:.*]] = arith.addf %[[BLOCK_INCR1_BCAST]], %[[SCAN1]] : vector<1x1x4xf32>
+// CHECK: %[[PRE_INIT:.*]] = vector.insert_strided_slice %[[LOCAL_RESULT1]], %[[RES0]] {offsets = [1, 0, 0], strides = [1, 1, 1]}
+// Application of user init.
+// CHECK: %[[INIT_BCAST:.*]] = vector.broadcast %[[INIT_DIST]] : vector<f32> to vector<2x1x4xf32>
+// CHECK: %[[RESULT:.*]] = arith.addf %[[INIT_BCAST]], %[[PRE_INIT]] : vector<2x1x4xf32>
+// Accumulated value: extract last element from result, broadcast from last thread.
+// CHECK: %[[LAST_ACC:.*]] = vector.extract %[[RESULT]][1, 0, 3] : f32 from vector<2x1x4xf32>
+// CHECK: %[[SHUFFLED:.*]], %{{.*}} = gpu.shuffle idx %[[LAST_ACC]], %{{.*}}, %{{.*}} : f32
+// CHECK: %[[ACC_BCAST:.*]] = vector.broadcast %[[SHUFFLED]] : f32 to vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[ACC_BCAST]] : vector<f32> -> vector<f32>
+// CHECK: iree_vector_ext.to_simd %[[RESULT]] : vector<2x1x4xf32> -> vector<32xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_scan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_scan.mlir
@@ -260,3 +260,129 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[ACC_BCAST:.*]] = vector.broadcast %[[SHUFFLED]] : f32 to vector<f32>
 // CHECK: iree_vector_ext.to_simd %[[ACC_BCAST]] : vector<f32> -> vector<f32>
 // CHECK: iree_vector_ext.to_simd %[[RESULT]] : vector<2x1x4xf32> -> vector<32xf32>
+
+// -----
+
+// Test 5: 2D inclusive scan along dim 1.
+
+#layout_scan_2d_dim1 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 1],
+  outer_tile    = [1, 1],
+  thread_tile   = [1, 4],
+  element_tile  = [1, 4],
+
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 1]
+>
+
+// CHECK-LABEL: @scan_2d_dim1_inclusive
+func.func @scan_2d_dim1_inclusive(%src: vector<2x16xf32>, %init: vector<2xf32>) -> (vector<2x16xf32>, vector<2xf32>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_2d_dim1) : vector<2x16xf32>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = true, reduction_dim = 1 : i64}
+    : vector<2x16xf32>, vector<2xf32>
+  return %out#0, %out#1 : vector<2x16xf32>, vector<2xf32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<2x1x1x1x1xf32>
+// CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<2x16xf32> -> vector<2x1x1x1x1x4xf32>
+// CHECK: %[[LOCAL_SCAN:.*]], %[[LOCAL_TOTAL:.*]] = vector.scan <add>, %[[SRC_DIST]], %[[ID_VEC]] {inclusive = true, reduction_dim = 5 : i64} : vector<2x1x1x1x1x4xf32>, vector<2x1x1x1x1xf32>
+// CHECK: %[[SCALAR0:.*]] = vector.extract %[[LOCAL_TOTAL]][0, 0, 0, 0, 0] : f32 from vector<2x1x1x1x1xf32>
+// CHECK: iree_gpu.subgroup_scan(%[[SCALAR0]], {{.*}}) cluster(size = 4)
+// CHECK: %[[SCALAR1:.*]] = vector.extract %[[LOCAL_TOTAL]][1, 0, 0, 0, 0] : f32 from vector<2x1x1x1x1xf32>
+// CHECK: iree_gpu.subgroup_scan(%[[SCALAR1]], {{.*}}) cluster(size = 4)
+// CHECK: iree_vector_ext.to_simd %{{.*}} : vector<2x1x1xf32> -> vector<2xf32>
+// CHECK: iree_vector_ext.to_simd %{{.*}} : vector<2x1x1x1x1x4xf32> -> vector<2x16xf32>
+
+// -----
+
+// Test 6: Exclusive f16 scan exercises shuffle pack/unpack for sub-32-bit types.
+
+#layout_scan_1d_f16_excl = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [1],
+  outer_tile    = [1],
+  thread_tile   = [4],
+  element_tile  = [4],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+// CHECK-LABEL: @scan_single_bo_exclusive_f16
+func.func @scan_single_bo_exclusive_f16(%src: vector<16xf16>, %init: vector<f16>) -> (vector<16xf16>, vector<f16>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_1d_f16_excl) : vector<16xf16>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = false, reduction_dim = 0 : i64}
+    : vector<16xf16>, vector<f16>
+  return %out#0, %out#1 : vector<16xf16>, vector<f16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC_F16:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf16>
+// CHECK-DAG: %[[SRC_DIST_F16:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16xf16> -> vector<1x1x4xf16>
+// CHECK: %[[LOCAL_SCAN_F16:.*]], %[[ACC_VAL_F16:.*]] = vector.scan <add>, %[[SRC_DIST_F16]], %[[ID_VEC_F16]] {inclusive = false, reduction_dim = 2 : i64}
+// CHECK: arith.addf %{{.*}}, %{{.*}} : vector<1x1x4xf16>
+// CHECK: %[[LAST_ACC_F16:.*]] = vector.extract %{{.*}}[0, 0, 3] : f16 from vector<1x1x4xf16>
+// CHECK: %[[PACKED:.*]] = arith.bitcast %[[LAST_ACC_F16]] : f16 to i16
+// CHECK: %[[EXTENDED:.*]] = arith.extui %[[PACKED]] : i16 to i32
+// CHECK: %[[SHUFFLED_F16:.*]], %{{.*}} = gpu.shuffle idx %[[EXTENDED]], %{{.*}}, %{{.*}} : i32
+// CHECK: %[[TRUNCATED:.*]] = arith.trunci %[[SHUFFLED_F16]] : i32 to i16
+// CHECK: %[[UNPACKED:.*]] = arith.bitcast %[[TRUNCATED]] : i16 to f16
+// CHECK: vector.broadcast %[[UNPACKED]] : f16 to vector<f16>
+// CHECK: iree_vector_ext.to_simd %{{.*}} : vector<1x1x4xf16> -> vector<16xf16>
+
+// -----
+
+// Test 7: thread_tile = [1] covers the single-thread scan path.
+
+#layout_scan_1d_thread_tile_1 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [1],
+  outer_tile    = [1],
+  thread_tile   = [1],
+  element_tile  = [4],
+
+  subgroup_strides = [0],
+  thread_strides   = [0]
+>
+
+// CHECK-LABEL: @scan_thread_tile_1_inclusive
+func.func @scan_thread_tile_1_inclusive(%src: vector<4xf32>, %init: vector<f32>) -> (vector<4xf32>, vector<f32>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_1d_thread_tile_1) : vector<4xf32>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = true, reduction_dim = 0 : i64}
+    : vector<4xf32>, vector<f32>
+  return %out#0, %out#1 : vector<4xf32>, vector<f32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: %[[ID_VEC_T1:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
+// CHECK-DAG: %[[SRC_DIST_T1:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<4xf32> -> vector<1x1x4xf32>
+// CHECK: %[[LOCAL_SCAN_T1:.*]], %[[LOCAL_TOTAL_T1:.*]] = vector.scan <add>, %[[SRC_DIST_T1]], %[[ID_VEC_T1]] {inclusive = true, reduction_dim = 2 : i64} : vector<1x1x4xf32>, vector<1x1xf32>
+// CHECK-NOT: iree_gpu.subgroup_scan
+// CHECK: arith.addf %[[LOCAL_SCAN_T1]], %{{.*}} : vector<1x1x4xf32>
+// CHECK: %[[BO_RUNNING_T1:.*]] = arith.addf %[[LOCAL_TOTAL_T1]], %[[ID_VEC_T1]] : vector<1x1xf32>
+// CHECK: vector.shape_cast %[[BO_RUNNING_T1]] : vector<1x1xf32> to vector<f32>
+// CHECK-NOT: gpu.shuffle
+// CHECK: iree_vector_ext.to_simd %{{.*}} : vector<1x1x4xf32> -> vector<4xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_scan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_scan.mlir
@@ -84,7 +84,6 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
 // CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16xf32> -> vector<1x1x4xf32>
-// CHECK-DAG: %[[INIT_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<f32> -> vector<f32>
 // Local exclusive scan with identity init.
 // CHECK: %[[LOCAL_SCAN:.*]], %[[ACC_VAL:.*]] = vector.scan <add>, %[[SRC_DIST]], %[[ID_VEC]] {inclusive = false, reduction_dim = 2 : i64}
 // Fix up localTotal: combine accumulated_value with last source element.
@@ -100,6 +99,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[BLOCK_INCR_BCAST:.*]] = vector.broadcast %[[BLOCK_INCR]] : vector<1x1xf32> to vector<1x1x4xf32>
 // CHECK: %[[LOCAL_RESULT:.*]] = arith.addf %[[BLOCK_INCR_BCAST]], %[[LOCAL_SCAN]] : vector<1x1x4xf32>
 // Application of user init via broadcast + combine.
+// CHECK: %[[INIT_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<f32> -> vector<f32>
 // CHECK: %[[INIT_BCAST:.*]] = vector.broadcast %[[INIT_DIST]] : vector<f32> to vector<1x1x4xf32>
 // CHECK: %[[RESULT:.*]] = arith.addf %[[INIT_BCAST]], %[[LOCAL_RESULT]] : vector<1x1x4xf32>
 // Accumulated value: extract last element from result, broadcast from last thread.
@@ -212,7 +212,6 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK-DAG: %[[ID_VEC:.*]] = arith.constant dense<0.000000e+00> : vector<1x1xf32>
 // CHECK-DAG: %[[SRC_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<32xf32> -> vector<2x1x4xf32>
-// CHECK-DAG: %[[INIT_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<f32> -> vector<f32>
 // First (b=0): extract srcChunk, local exclusive scan.
 // CHECK: %[[CHUNK0:.*]] = vector.extract %[[SRC_DIST]][0, 0] : vector<4xf32> from vector<2x1x4xf32>
 // CHECK: %[[CHUNK0_RS:.*]] = vector.shape_cast %[[CHUNK0]] : vector<4xf32> to vector<1x1x4xf32>
@@ -252,6 +251,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[LOCAL_RESULT1:.*]] = arith.addf %[[BLOCK_INCR1_BCAST]], %[[SCAN1]] : vector<1x1x4xf32>
 // CHECK: %[[PRE_INIT:.*]] = vector.insert_strided_slice %[[LOCAL_RESULT1]], %[[RES0]] {offsets = [1, 0, 0], strides = [1, 1, 1]}
 // Application of user init.
+// CHECK: %[[INIT_DIST:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<f32> -> vector<f32>
 // CHECK: %[[INIT_BCAST:.*]] = vector.broadcast %[[INIT_DIST]] : vector<f32> to vector<2x1x4xf32>
 // CHECK: %[[RESULT:.*]] = arith.addf %[[INIT_BCAST]], %[[PRE_INIT]] : vector<2x1x4xf32>
 // Accumulated value: extract last element from result, broadcast from last thread.


### PR DESCRIPTION
Implementation of vector distribution of `vector.scan` to threads. Currently limited to threads in a single wave/subgroup, distribution across subgroups in a workgroup will come as a follow-up PR to ease review. 

In contrast to reduction operations which produce a uniform result, scans have one result per input element plus a second result for the overall outcome. Therefore, the distribution is different from e.g. `multi_reduction`. 

This PR builds on top of the `subgroup_scan` operation introduced in https://github.com/iree-org/iree/pull/24188. More details on the algorithm can be found in the pattern documentation.

This is part of https://github.com/iree-org/iree/issues/24186.

Assisted-by: Claude Code and Codex