### PR TITLE
[CI] Ease contention on rdna4 machine

### DIFF
--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -33,13 +33,7 @@ jobs:
           - name: cpu_task
             markers: "cpu"
             config-file: torch_ops_cpu_llvm_sync.json
-            cache-dir: /home/nod/iree_tests_cache
-            runs-on:
-              - self-hosted # Must come first.
-              - persistent-cache
-              - Linux
-              - X64
-              - rdna3 # We only have one rdna4 machine but three rdna3 machines
+            runs-on: ubuntu-24.04
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -39,6 +39,7 @@ jobs:
               - persistent-cache
               - Linux
               - X64
+              - rdna3 # We only have one rdna4 machine but three rdna3 machines
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]


### PR DESCRIPTION
Torch_ops cpu job had the possibility of using the only rdna4 machine. Looking at the number of jobs per machine, the gfx1201 machine (shark-75) on https://github.com/hanhanW/iree-ci-monitor#self-hosted-runners-last-7d has the most number of jobs assigned to it.

<img width="484" height="472" alt="image" src="https://github.com/user-attachments/assets/26798be3-9e17-45e6-b9f9-7b1ef40e2e55" />

I think this may speed up some jobs that truly depend on gfx1201.

Alternatively, since we stopped benchmarking on CPU (due to noise) we can move this to a github runner (but we would lose caching of the azure files).
