### PR TITLE
[CI] Ease contention on self hosted machines

### DIFF
--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -33,12 +33,8 @@ jobs:
           - name: cpu_task
             markers: "cpu"
             config-file: torch_ops_cpu_llvm_sync.json
-            cache-dir: /home/nod/iree_tests_cache
-            runs-on:
-              - self-hosted # Must come first.
-              - persistent-cache
-              - Linux
-              - X64
+            runs-on: ubuntu-24.04
+            cache-dir: /tmp/iree_tests_cache
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]


### PR DESCRIPTION
After https://github.com/iree-org/iree/pull/24194 we have no need to use a benchmarking machine for cpu jobs in torch ops. So let's just use the github action ones for torch_ops cpu and help reduce contention on self hosted machines.