### PR TITLE
[LinalgExt] Fix ArgCompareOp::generateResultTileValue for producer fusion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -800,6 +800,7 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
    "getResultTilePosition",
    "getTiledImplementation",
    "generateResultTileValue",
+   "getIterationDomainTileFromResultTile",
    "getIterationDomain"]
   >,
   DeclareOpInterfaceMethods<PartialReductionOpInterface,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1939,11 +1939,53 @@ LogicalResult ArgCompareOp::getResultTilePosition(
   return success();
 }
 
+LogicalResult ArgCompareOp::getIterationDomainTileFromResultTile(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes,
+    SmallVectorImpl<OpFoldResult> &iterDomainOffsets,
+    SmallVectorImpl<OpFoldResult> &iterDomainSizes) {
+  // Result tiles are in the output coordinate space (reduction dim removed).
+  // Re-insert the reduction dimension as the full range to get input-rank
+  // coordinates for the iteration domain.
+  int64_t reductionDim = getDimension();
+  OpFoldResult zero = builder.getIndexAttr(0);
+  OpFoldResult reductionDimSize =
+      getDim(builder, getLoc(), getInputValue(), reductionDim);
+  int64_t inputRank = offsets.size() + 1;
+  iterDomainOffsets.reserve(inputRank);
+  iterDomainSizes.reserve(inputRank);
+  int64_t outIdx = 0;
+  for (int64_t i = 0; i < inputRank; ++i) {
+    if (i == reductionDim) {
+      iterDomainOffsets.push_back(zero);
+      iterDomainSizes.push_back(reductionDimSize);
+    } else {
+      iterDomainOffsets.push_back(offsets[outIdx]);
+      iterDomainSizes.push_back(sizes[outIdx]);
+      ++outIdx;
+    }
+  }
+  return success();
+}
+
 FailureOr<TilingResult>
 ArgCompareOp::generateResultTileValue(OpBuilder &builder, unsigned resultNumber,
                                       ArrayRef<OpFoldResult> offsets,
                                       ArrayRef<OpFoldResult> sizes) {
-  return getTiledImplementation(builder, offsets, sizes);
+  SmallVector<OpFoldResult> mappedOffsets, mappedSizes;
+  if (failed(getIterationDomainTileFromResultTile(
+          builder, resultNumber, offsets, sizes, mappedOffsets, mappedSizes))) {
+    return failure();
+  }
+  FailureOr<TilingResult> tilingResult =
+      getTiledImplementation(builder, mappedOffsets, mappedSizes);
+  if (failed(tilingResult)) {
+    return failure();
+  }
+  return TilingResult{
+      tilingResult->tiledOps,
+      SmallVector<Value>{tilingResult->tiledValues[resultNumber]},
+      tilingResult->generatedSlices};
 }
 
 LogicalResult ArgCompareOp::generateScalarImplementation(OpBuilder &b,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -4283,6 +4283,162 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
+// Test producer fusion for arg_compare (generateResultTileValue).
+// Tiles the consumer linalg.generic on the parallel (non-reduction) dim and
+// fuses the arg_compare producer into the loop. The fused arg_compare must
+// receive the full reduction-dim extent on its input slice.
+func.func @arg_compare_producer_fusion(
+    %input: tensor<16x32xf32>, %outv: tensor<32xf32>,
+    %outi: tensor<32xi32>, %out: tensor<32xi32>
+) -> tensor<32xi32> {
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%input : tensor<16x32xf32>)
+    outs(%outv, %outi : tensor<32xf32>, tensor<32xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<32xf32>, tensor<32xi32>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%res#1 : tensor<32xi32>) outs(%out : tensor<32xi32>) {
+    ^bb0(%in: i32, %o: i32):
+      %2 = arith.addi %in, %in : i32
+      linalg.yield %2 : i32
+  } -> tensor<32xi32>
+  return %1 : tensor<32xi32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %producer = transform.structured.match ops{["iree_linalg_ext.arg_compare"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %consumer = transform.structured.match ops{["linalg.generic"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %tiled, %loops = transform.structured.tile_using_forall %consumer tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused, %_ = transform.structured.fuse_into_containing_op %producer into %loops : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+// CHECK-LABEL: func @arg_compare_producer_fusion
+//  CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<16x32xf32>
+//       CHECK:   scf.forall (%[[IV:.+]]) in (2)
+//  CHECK-SAME:       shared_outs(%[[OUTS:.+]] =
+//       CHECK:     %[[LINEAR_IDX:.+]] = affine.apply
+//  CHECK-SAME:         %[[IV]]
+//       CHECK:     %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[INPUT]][0, %[[LINEAR_IDX]]] [16, 16] [1, 1]
+//       CHECK:     %[[ARGCMP:.+]]:2 = iree_linalg_ext.arg_compare
+//  CHECK-SAME:       dimension(0)
+//  CHECK-SAME:       ins(%[[INPUT_SLICE]]
+//       CHECK:     %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUTS]][%[[LINEAR_IDX]]] [16] [1]
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[ARGCMP]]#1 :
+//  CHECK-SAME:         outs(%[[OUT_SLICE]] :
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[GENERIC]] into %[[OUTS]][%[[LINEAR_IDX]]] [16] [1]
+
+// -----
+
+// Test producer fusion with reduction dim on the last axis (dimension(1)).
+func.func @arg_compare_producer_fusion_dim1(
+    %input: tensor<32x16xf32>, %outv: tensor<32xf32>,
+    %outi: tensor<32xi32>, %out: tensor<32xf32>
+) -> tensor<32xf32> {
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input : tensor<32x16xf32>)
+    outs(%outv, %outi : tensor<32xf32>, tensor<32xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<32xf32>, tensor<32xi32>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%res#0 : tensor<32xf32>) outs(%out : tensor<32xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %2 = arith.addf %in, %in : f32
+      linalg.yield %2 : f32
+  } -> tensor<32xf32>
+  return %1 : tensor<32xf32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %producer = transform.structured.match ops{["iree_linalg_ext.arg_compare"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %consumer = transform.structured.match ops{["linalg.generic"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %tiled, %loops = transform.structured.tile_using_forall %consumer tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused, %_ = transform.structured.fuse_into_containing_op %producer into %loops : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+// CHECK-LABEL: func @arg_compare_producer_fusion_dim1
+//  CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<32x16xf32>
+//       CHECK:   scf.forall (%[[IV:.+]]) in (2)
+//  CHECK-SAME:       shared_outs(%[[OUTS:.+]] =
+//       CHECK:     %[[LINEAR_IDX:.+]] = affine.apply
+//  CHECK-SAME:         %[[IV]]
+//       CHECK:     %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[INPUT]][%[[LINEAR_IDX]], 0] [16, 16] [1, 1]
+//       CHECK:     %[[ARGCMP:.+]]:2 = iree_linalg_ext.arg_compare
+//  CHECK-SAME:       dimension(1)
+//  CHECK-SAME:       ins(%[[INPUT_SLICE]]
+//       CHECK:     %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUTS]][%[[LINEAR_IDX]]] [16] [1]
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[ARGCMP]]#0 :
+//  CHECK-SAME:         outs(%[[OUT_SLICE]] :
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[GENERIC]] into %[[OUTS]][%[[LINEAR_IDX]]] [16] [1]
+
+// -----
+
+// Test producer fusion consuming result #0 (value result) with dim 0 reduction.
+func.func @arg_compare_producer_fusion_result0(
+    %input: tensor<16x32xf32>, %outv: tensor<32xf32>,
+    %outi: tensor<32xi32>, %out: tensor<32xf32>
+) -> tensor<32xf32> {
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%input : tensor<16x32xf32>)
+    outs(%outv, %outi : tensor<32xf32>, tensor<32xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<32xf32>, tensor<32xi32>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%res#0 : tensor<32xf32>) outs(%out : tensor<32xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %2 = arith.addf %in, %in : f32
+      linalg.yield %2 : f32
+  } -> tensor<32xf32>
+  return %1 : tensor<32xf32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %producer = transform.structured.match ops{["iree_linalg_ext.arg_compare"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %consumer = transform.structured.match ops{["linalg.generic"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %tiled, %loops = transform.structured.tile_using_forall %consumer tile_sizes [16] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused, %_ = transform.structured.fuse_into_containing_op %producer into %loops : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+// CHECK-LABEL: func @arg_compare_producer_fusion_result0
+//  CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<16x32xf32>
+//       CHECK:   scf.forall (%[[IV:.+]]) in (2)
+//  CHECK-SAME:       shared_outs(%[[OUTS:.+]] =
+//       CHECK:     %[[LINEAR_IDX:.+]] = affine.apply
+//  CHECK-SAME:         %[[IV]]
+//       CHECK:     %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[INPUT]][0, %[[LINEAR_IDX]]] [16, 16] [1, 1]
+//       CHECK:     %[[ARGCMP:.+]]:2 = iree_linalg_ext.arg_compare
+//  CHECK-SAME:       dimension(0)
+//  CHECK-SAME:       ins(%[[INPUT_SLICE]]
+//       CHECK:     %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUTS]][%[[LINEAR_IDX]]] [16] [1]
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[ARGCMP]]#0 :
+//  CHECK-SAME:         outs(%[[OUT_SLICE]] :
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[GENERIC]] into %[[OUTS]][%[[LINEAR_IDX]]] [16] [1]
+
+// -----
+
 func.func @concat_dynamic(%arg0 : tensor<?x64xi32>, %arg1 : tensor<?x64xi32>) -> tensor<?x128xi32> {
   %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<?x64xi32>, tensor<?x64xi32>) -> tensor<?x128xi32>
   return %0 : tensor<?x128xi32>


### PR DESCRIPTION
This PR fixes `ArgCompareOp::generateResultTileValue` to correctly map output-rank coordinates to input-rank coordinates by re-inserting the reduction dimension, enabling producer fusion with downstream consumers.  

Assisted-by:  [Claude Code](https://claude.ai/code)